### PR TITLE
fix: Fix update-repo ready for further testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/generator
 
-go 1.23
+go 1.23.6
 
 require github.com/go-git/go-git/v5 v5.13.2
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -393,7 +393,9 @@ func updateApi(ctx context.Context, apiRepo *gitrepo.Repo, languageRepo *gitrepo
 
 	// Note that as we've updated the state, we'll definitely have something to commit, even if no
 	// generated code changed. This avoids us regenerating no-op changes again and again, and reflects
-	// that we really are at the latest state.
+	// that we really are at the latest state. We could skip the build step here if there are no changes
+	// prior to updating the state, but it's probably not worth the additional complexity (and it does
+	// no harm to check the code is still "healthy").
 	var msg = createCommitMessage(commits)
 	if err := commitAll(ctx, languageRepo, msg); err != nil {
 		return err
@@ -423,7 +425,7 @@ func createCommitMessage(commits []object.Commit) string {
 	for i := len(commits) - 1; i >= 0; i-- {
 		commit := commits[i]
 		messageLines := strings.Split(commit.Message, "\n")
-		sourceLinkLines = append(sourceLinkLines, fmt.Sprintf("Source-Link: https://github.com/googleapis/googleapis/%s", commit.Hash.String()))
+		sourceLinkLines = append(sourceLinkLines, fmt.Sprintf("Source-Link: https://github.com/googleapis/googleapis/commits/%s", commit.Hash.String()))
 		for _, line := range messageLines {
 			if strings.HasPrefix(line, PiperPrefix) {
 				piperRevIdLines = append(piperRevIdLines, line)


### PR DESCRIPTION
We now always clone repos fully instead of with depth=1 - the latter breaks anything that uses the commit log. (We can potentially add a flag for that later.)

The change to filtering in GetApiCommits mirrors what we do in .NET; this is a much, much faster way of finding the commits that actually change directories. We don't even try to handle multi-parent commits, but I don't think that's required at the moment.