### PR TITLE
chore: Update the current .NET generation test job timeout

### DIFF
--- a/.kokoro/continuous.cfg
+++ b/.kokoro/continuous.cfg
@@ -3,6 +3,7 @@
 # proto-message: BuildConfig
 
 build_file: "librarian/.kokoro/update-dotnet.sh"
+timeout_mins: 360
 
 container_properties {
     docker_image: "us-central1-docker.pkg.dev/kokoro-container-bakery/kokoro/ubuntu/ubuntu2204/full:current"


### PR DESCRIPTION
When this is running regularly, we'd normally expect to see very few APIs change on each run - but right now there's effectively a backlog.