### PR TITLE
feat: Use an environment variable for the GitHub access token

### DIFF
--- a/internal/command/configure.go
+++ b/internal/command/configure.go
@@ -35,8 +35,8 @@ var CmdConfigure = &Command{
 		if !supportedLanguages[flagLanguage] {
 			return fmt.Errorf("invalid -language flag specified: %q", flagLanguage)
 		}
-		if flagPush && flagGitHubToken == "" {
-			return fmt.Errorf("-github-token must be provided if -push is set to true")
+		if err := validatePush(); err != nil {
+			return err
 		}
 
 		startOfRun := time.Now()

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -35,8 +35,10 @@ var CmdCreateReleasePR = &Command{
 	Name:  "create-release-pr",
 	Short: "Generate a PR for release",
 	Run: func(ctx context.Context) error {
-		err := checkFlags()
-		if err != nil {
+		if err := checkFlags(); err != nil {
+			return err
+		}
+		if err := validatePush(); err != nil {
 			return err
 		}
 		languageRepo, inputDirectory, err := setupReleasePrFolders(ctx)

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -18,6 +18,10 @@ import (
 	"flag"
 )
 
+// Environment variables are specified here as they're used for the same sort of purpose as flags...
+const gitHubTokenEnvironmentVariable string = "LIBRARIAN_GITHUB_TOKEN"
+const defaultRepositoryEnvironmentVariable string = "LIBRARIAN_REPOSITORY"
+
 var (
 	flagAPIPath      string
 	flagAPIRoot      string
@@ -25,7 +29,6 @@ var (
 	flagBuild        bool
 	flagGitUserEmail string
 	flagGitUserName  string
-	flagGitHubToken  string
 	flagImage        string
 	flagLanguage     string
 	flagLibraryID    string
@@ -51,10 +54,6 @@ func addFlagBranch(fs *flag.FlagSet) {
 
 func addFlagBuild(fs *flag.FlagSet) {
 	fs.BoolVar(&flagBuild, "build", false, "whether to build the generated code")
-}
-
-func addFlagGitHubToken(fs *flag.FlagSet) {
-	fs.StringVar(&flagGitHubToken, "github-token", "", "GitHub access token")
 }
 
 func addFlagGitUserEmail(fs *flag.FlagSet) {

--- a/internal/command/updateapis.go
+++ b/internal/command/updateapis.go
@@ -38,8 +38,8 @@ var CmdUpdateApis = &Command{
 		if !supportedLanguages[flagLanguage] {
 			return fmt.Errorf("invalid -language flag specified: %q", flagLanguage)
 		}
-		if flagPush && flagGitHubToken == "" {
-			return fmt.Errorf("-github-token must be provided if -push is set to true")
+		if err := validatePush(); err != nil {
+			return err
 		}
 
 		startOfRun := time.Now()

--- a/internal/command/updateimagetag.go
+++ b/internal/command/updateimagetag.go
@@ -35,8 +35,8 @@ var CmdUpdateImageTag = &Command{
 		if !supportedLanguages[flagLanguage] {
 			return fmt.Errorf("invalid -language flag specified: %q", flagLanguage)
 		}
-		if flagPush && flagGitHubToken == "" {
-			return errors.New("-github-token must be provided if -push is set to true")
+		if err := validatePush(); err != nil {
+			return err
 		}
 		if flagTag == "" {
 			return errors.New("-tag is not provided")


### PR DESCRIPTION
This means we can still log command line arguments without accidentally logging the access token (which is sensitive).