### PR TITLE
chore: Remove ResetHard from gitrepo

### DIFF
--- a/internal/command/updateapis.go
+++ b/internal/command/updateapis.go
@@ -52,7 +52,7 @@ var CmdUpdateApis = &Command{
 		}
 
 		var apiRepo *gitrepo.Repo
-		hardResetApiRepo := true
+		cleanWorkingTreePostGeneration := true
 		if flagAPIRoot == "" {
 			apiRepo, err = cloneGoogleapis(ctx, tmpRoot)
 			if err != nil {
@@ -74,8 +74,8 @@ var CmdUpdateApis = &Command{
 				return err
 			}
 			if !clean {
-				hardResetApiRepo = false
-				slog.Warn("API repo has modifications, so will not be reset after generation")
+				cleanWorkingTreePostGeneration = false
+				slog.Warn("API repo has modifications, so will not be cleaned after generation")
 			}
 		}
 
@@ -143,9 +143,9 @@ var CmdUpdateApis = &Command{
 			}
 		}
 
-		// Reset the API repo in case it was changed, but not if it was already dirty before the command.
-		if hardResetApiRepo {
-			gitrepo.ResetHard(ctx, apiRepo)
+		// Clean  the API repo in case it was changed, but not if it was already dirty before the command.
+		if cleanWorkingTreePostGeneration {
+			gitrepo.CleanWorkingTree(apiRepo)
 		}
 
 		if !flagPush {

--- a/internal/command/updateimagetag.go
+++ b/internal/command/updateimagetag.go
@@ -191,7 +191,7 @@ func regenerateLibrary(ctx context.Context, apiRepo *gitrepo.Repo, languageRepo 
 	if err := os.CopyFS(languageRepo.Dir, os.DirFS(outputDir)); err != nil {
 		return err
 	}
-	if err := gitrepo.ResetHard(ctx, apiRepo); err != nil {
+	if err := gitrepo.CleanWorkingTree(apiRepo); err != nil {
 		return err
 	}
 	return nil

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -170,15 +170,6 @@ func IsClean(ctx context.Context, repo *Repo) (bool, error) {
 	return status.IsClean(), nil
 }
 
-// ResetHard Resets state to remote
-func ResetHard(ctx context.Context, repo *Repo) error {
-	worktree, err := repo.repo.Worktree()
-	if err != nil {
-		return err
-	}
-	return worktree.Reset(&git.ResetOptions{Mode: git.HardReset})
-}
-
 func PrintStatus(ctx context.Context, repo *Repo) error {
 	worktree, err := repo.repo.Worktree()
 	if err != nil {


### PR DESCRIPTION
The callers of this are really only interested in cleaning the working tree, so let's do that instead.