### PR TITLE
feat: Add a "title" line to the commit message when updating APIs

### DIFF
--- a/internal/command/commitmessage.go
+++ b/internal/command/commitmessage.go
@@ -97,6 +97,7 @@ func ParseCommit(commit object.Commit) *CommitMessage {
 		case "test":
 		case "tests":
 		case "deps":
+		case "regen":
 			// Conventional commit type we know about, but don't keep.
 			// TODO: Maybe we should keep deps?
 			slice = nil

--- a/internal/command/updateapis.go
+++ b/internal/command/updateapis.go
@@ -221,7 +221,7 @@ func updateLibrary(ctx context.Context, apiRepo *gitrepo.Repo, languageRepo *git
 	// that we really are at the latest state. We could skip the build step here if there are no changes
 	// prior to updating the state, but it's probably not worth the additional complexity (and it does
 	// no harm to check the code is still "healthy").
-	var msg = createCommitMessage(commits)
+	var msg = createCommitMessage(library.Id, commits)
 	if err := commitAll(ctx, languageRepo, msg); err != nil {
 		return err
 	}
@@ -240,9 +240,15 @@ func updateLibrary(ctx context.Context, apiRepo *gitrepo.Repo, languageRepo *git
 	return nil
 }
 
-func createCommitMessage(commits []object.Commit) string {
+func createCommitMessage(libraryID string, commits []object.Commit) string {
 	const PiperPrefix = "PiperOrigin-RevId: "
 	var builder strings.Builder
+
+	// Start the commit with a line on its own saying what's being regenerated.
+	builder.WriteString(fmt.Sprintf("regen: Regenerate %s at API commit %s", libraryID, commits[0].Hash.String()[0:7]))
+	builder.WriteString("\n")
+	builder.WriteString("\n")
+
 	piperRevIdLines := []string{}
 	sourceLinkLines := []string{}
 	// Consume the commits in reverse order, so that they're in normal chronological order,


### PR DESCRIPTION
Having a blank line between the first line of a commit message and the rest improves the display in some tooling, and this "title" will be more useful when looking at a repo history than "whatever the first line of the first commit happened to be".