### PR TITLE
feat: Allow LastGeneratedCommit to be empty in update-apis

### DIFF
--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -293,7 +293,7 @@ func getHashForPathOrEmpty(commit *object.Commit, path string) (string, error) {
 		return "", err
 	}
 	treeEntry, err := tree.FindEntry(path)
-	if err == object.ErrEntryNotFound {
+	if err == object.ErrEntryNotFound || err == object.ErrDirectoryNotFound {
 		return "", nil
 	}
 	if err != nil {


### PR DESCRIPTION
This is a pre-requisite for the configure command to leave the repo "ungenerated" in the resulting PR; once the PR has been merged, the next regular generation cycle will generate it.