### PR TITLE
chore: Remove context parameter wherever possible

### DIFF
--- a/internal/command/clone.go
+++ b/internal/command/clone.go
@@ -15,7 +15,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 
@@ -24,13 +23,13 @@ import (
 
 const googleapisURL = "https://github.com/googleapis/googleapis"
 
-func cloneGoogleapis(ctx context.Context, tmpRoot string) (*gitrepo.Repo, error) {
+func cloneGoogleapis(tmpRoot string) (*gitrepo.Repo, error) {
 	repoPath := filepath.Join(tmpRoot, "googleapis")
-	return gitrepo.CloneOrOpen(ctx, repoPath, googleapisURL)
+	return gitrepo.CloneOrOpen(repoPath, googleapisURL)
 }
 
-func cloneLanguageRepo(ctx context.Context, language, tmpRoot string) (*gitrepo.Repo, error) {
+func cloneLanguageRepo(language, tmpRoot string) (*gitrepo.Repo, error) {
 	languageRepoURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-%s", language)
 	repoPath := filepath.Join(tmpRoot, fmt.Sprintf("google-cloud-%s", language))
-	return gitrepo.CloneOrOpen(ctx, repoPath, languageRepoURL)
+	return gitrepo.CloneOrOpen(repoPath, languageRepoURL)
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -154,8 +154,8 @@ func createTmpWorkingRoot(t time.Time) (string, error) {
 }
 
 // No commit is made if there are no file modifications.
-func commitAll(ctx context.Context, repo *gitrepo.Repo, msg string) error {
-	status, err := gitrepo.AddAll(ctx, repo)
+func commitAll(repo *gitrepo.Repo, msg string) error {
+	status, err := gitrepo.AddAll(repo)
 	if err != nil {
 		return err
 	}
@@ -164,10 +164,10 @@ func commitAll(ctx context.Context, repo *gitrepo.Repo, msg string) error {
 		return nil
 	}
 
-	return gitrepo.Commit(ctx, repo, msg, flagGitUserName, flagGitUserEmail)
+	return gitrepo.Commit(repo, msg, flagGitUserName, flagGitUserEmail)
 }
 
-func push(ctx context.Context, repo *gitrepo.Repo, startOfRun time.Time, title string, description string) (*gitrepo.PullRequestMetadata, error) {
+func pushAndCreatePullRequest(ctx context.Context, repo *gitrepo.Repo, startOfRun time.Time, title string, description string) (*gitrepo.PullRequestMetadata, error) {
 	if !flagPush {
 		return nil, nil
 	}
@@ -175,7 +175,7 @@ func push(ctx context.Context, repo *gitrepo.Repo, startOfRun time.Time, title s
 	// This should already have been validated to be non-empty by validatePush
 	gitHubAccessToken := os.Getenv(gitHubTokenEnvironmentVariable)
 	branch := fmt.Sprintf("librarian-%s", formatTimestamp(startOfRun))
-	err := gitrepo.PushBranch(ctx, repo, branch, gitHubAccessToken)
+	err := gitrepo.PushBranch(repo, branch, gitHubAccessToken)
 	if err != nil {
 		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
 		return nil, err

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -86,6 +86,7 @@ func addFlagPush(fs *flag.FlagSet) {
 func addFlagReleaseID(fs *flag.FlagSet) {
 	fs.StringVar(&flagReleaseID, "release-id", "", "The ID of a release PR")
 }
+
 func addFlagRepoRoot(fs *flag.FlagSet) {
 	fs.StringVar(&flagRepoRoot, "repo-root", "", "Repository root. When this is not specified, the language repo will be cloned.")
 }

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -61,7 +61,7 @@ var CmdGenerate = &Command{
 		slog.Info(fmt.Sprintf("Code will be generated in %s", outputDir))
 
 		image := deriveImage(nil)
-		if err := container.GenerateRaw(ctx, image, apiRoot, outputDir, flagAPIPath); err != nil {
+		if err := container.GenerateRaw(image, apiRoot, outputDir, flagAPIPath); err != nil {
 			return err
 		}
 

--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -65,11 +65,11 @@ var CmdRelease = &Command{
 		if err != nil {
 			return err
 		}
-		languageRepo, err := gitrepo.Open(ctx, repoRoot)
+		languageRepo, err := gitrepo.Open(repoRoot)
 		if err != nil {
 			return err
 		}
-		clean, err := gitrepo.IsClean(ctx, languageRepo)
+		clean, err := gitrepo.IsClean(languageRepo)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ var CmdRelease = &Command{
 		}
 
 		for _, release := range releases {
-			if err := buildTestPackageRelease(ctx, flagImage, outputRoot, languageRepo, release); err != nil {
+			if err := buildTestPackageRelease(flagImage, outputRoot, languageRepo, release); err != nil {
 				return err
 			}
 		}
@@ -106,8 +106,8 @@ var CmdRelease = &Command{
 	},
 }
 
-func buildTestPackageRelease(ctx context.Context, image, outputRoot string, languageRepo *gitrepo.Repo, release LibraryRelease) error {
-	if err := gitrepo.Checkout(ctx, languageRepo, release.CommitHash); err != nil {
+func buildTestPackageRelease(image, outputRoot string, languageRepo *gitrepo.Repo, release LibraryRelease) error {
+	if err := gitrepo.Checkout(languageRepo, release.CommitHash); err != nil {
 		return err
 	}
 	if err := container.BuildLibrary(image, languageRepo.Dir, release.LibraryID); err != nil {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -15,7 +15,6 @@
 package container
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -24,7 +23,7 @@ import (
 	"strings"
 )
 
-func GenerateRaw(ctx context.Context, image, apiRoot, output, apiPath string) error {
+func GenerateRaw(image, apiRoot, output, apiPath string) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -50,7 +49,7 @@ func GenerateRaw(ctx context.Context, image, apiRoot, output, apiPath string) er
 	return runDocker(image, mounts, containerArgs)
 }
 
-func GenerateLibrary(ctx context.Context, image, apiRoot, output, generatorInput, libraryID string) error {
+func GenerateLibrary(image, apiRoot, output, generatorInput, libraryID string) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -81,7 +80,7 @@ func GenerateLibrary(ctx context.Context, image, apiRoot, output, generatorInput
 	return runDocker(image, mounts, containerArgs)
 }
 
-func Clean(ctx context.Context, image, repoRoot, libraryID string) error {
+func Clean(image, repoRoot, libraryID string) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -142,7 +141,7 @@ func BuildLibrary(image, repoRoot, libraryId string) error {
 	return runDocker(image, mounts, containerArgs)
 }
 
-func Configure(ctx context.Context, image, apiRoot, apiPath, generatorInput string) error {
+func Configure(image, apiRoot, apiPath, generatorInput string) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -50,22 +50,22 @@ type PullRequestMetadata struct {
 //
 // Otherwise, it clones the repository from the given URL (repoURL) and saves it
 // to the specified directory path (dirpath).
-func CloneOrOpen(ctx context.Context, dirpath, repoURL string) (*Repo, error) {
+func CloneOrOpen(dirpath, repoURL string) (*Repo, error) {
 	slog.Info(fmt.Sprintf("Cloning %q to %q", repoURL, dirpath))
 
 	_, err := os.Stat(dirpath)
 	if err == nil {
-		return Open(ctx, dirpath)
+		return Open(dirpath)
 	}
 	if os.IsNotExist(err) {
-		return Clone(ctx, dirpath, repoURL)
+		return Clone(dirpath, repoURL)
 	}
 	return nil, err
 }
 
 // Clone downloads a copy of a Git repository from repoURL and saves it to the
 // specified directory at dirpath.
-func Clone(ctx context.Context, dirpath, repoURL string) (*Repo, error) {
+func Clone(dirpath, repoURL string) (*Repo, error) {
 	options := &git.CloneOptions{
 		URL:           repoURL,
 		ReferenceName: plumbing.HEAD,
@@ -90,7 +90,7 @@ func Clone(ctx context.Context, dirpath, repoURL string) (*Repo, error) {
 }
 
 // Open provides access to a Git repository that exists at dirpath.
-func Open(ctx context.Context, dirpath string) (*Repo, error) {
+func Open(dirpath string) (*Repo, error) {
 	repo, err := git.PlainOpen(dirpath)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func Open(ctx context.Context, dirpath string) (*Repo, error) {
 	}, nil
 }
 
-func AddAll(ctx context.Context, repo *Repo) (git.Status, error) {
+func AddAll(repo *Repo) (git.Status, error) {
 	worktree, err := repo.repo.Worktree()
 	if err != nil {
 		return git.Status{}, err
@@ -114,7 +114,7 @@ func AddAll(ctx context.Context, repo *Repo) (git.Status, error) {
 }
 
 // returns an error if there is nothing to commit
-func Commit(ctx context.Context, repo *Repo, msg string, userName, userEmail string) error {
+func Commit(repo *Repo, msg string, userName, userEmail string) error {
 	worktree, err := repo.repo.Worktree()
 	if err != nil {
 		return err
@@ -150,7 +150,7 @@ func Commit(ctx context.Context, repo *Repo, msg string, userName, userEmail str
 	return nil
 }
 
-func HeadHash(ctx context.Context, repo *Repo) (string, error) {
+func HeadHash(repo *Repo) (string, error) {
 	headRef, err := repo.repo.Head()
 	if err != nil {
 		return "", err
@@ -158,7 +158,7 @@ func HeadHash(ctx context.Context, repo *Repo) (string, error) {
 	return headRef.String(), nil
 }
 
-func IsClean(ctx context.Context, repo *Repo) (bool, error) {
+func IsClean(repo *Repo) (bool, error) {
 	worktree, err := repo.repo.Worktree()
 	if err != nil {
 		return false, err
@@ -171,7 +171,7 @@ func IsClean(ctx context.Context, repo *Repo) (bool, error) {
 	return status.IsClean(), nil
 }
 
-func PrintStatus(ctx context.Context, repo *Repo) error {
+func PrintStatus(repo *Repo) error {
 	worktree, err := repo.repo.Worktree()
 	if err != nil {
 		return err
@@ -368,7 +368,7 @@ func GetCommitsForReleaseID(repo *Repo, releaseID string) ([]object.Commit, erro
 }
 
 // Creates a branch with the given name in the default remote.
-func PushBranch(ctx context.Context, repo *Repo, remoteBranch string, accessToken string) error {
+func PushBranch(repo *Repo, remoteBranch string, accessToken string) error {
 	headRef, err := repo.repo.Head()
 	if err != nil {
 		return err
@@ -501,7 +501,7 @@ func getRepoMetadata(remotes []*git.Remote) (string, string, error) {
 	return organization, repoName, nil
 }
 
-func Checkout(ctx context.Context, repo *Repo, commit string) error {
+func Checkout(repo *Repo, commit string) error {
 	worktree, err := repo.repo.Worktree()
 	if err != nil {
 		return err


### PR DESCRIPTION
We still need the context to interact with the GitHub client, but that's all.

Fixes #113