### PR TITLE
refactor: Refactor command implementations to reduce duplication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/librarian
 
-go 1.23.6
+go 1.23.8
 
 require github.com/go-git/go-git/v5 v5.14.0
 

--- a/internal/command/clone.go
+++ b/internal/command/clone.go
@@ -23,13 +23,13 @@ import (
 
 const googleapisURL = "https://github.com/googleapis/googleapis"
 
-func cloneGoogleapis(tmpRoot string) (*gitrepo.Repo, error) {
-	repoPath := filepath.Join(tmpRoot, "googleapis")
+func cloneGoogleapis(workRoot string) (*gitrepo.Repo, error) {
+	repoPath := filepath.Join(workRoot, "googleapis")
 	return gitrepo.CloneOrOpen(repoPath, googleapisURL)
 }
 
-func cloneLanguageRepo(language, tmpRoot string) (*gitrepo.Repo, error) {
+func cloneLanguageRepo(language, workRoot string) (*gitrepo.Repo, error) {
 	languageRepoURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-%s", language)
-	repoPath := filepath.Join(tmpRoot, fmt.Sprintf("google-cloud-%s", language))
+	repoPath := filepath.Join(workRoot, fmt.Sprintf("google-cloud-%s", language))
 	return gitrepo.CloneOrOpen(repoPath, languageRepoURL)
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -26,6 +27,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/googleapis/librarian/internal/container"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -36,9 +38,41 @@ const releaseIDEnvVarName = "RELEASE_ID"
 type Command struct {
 	Name  string
 	Short string
-	Run   func(ctx context.Context) error
+	// Obtains a language repo where appropriate, cloning or using
+	// flags where necessary. May return a nil pointer if the command
+	// does not use a language repo.
+	maybeGetLanguageRepo func(workRoot string) (*gitrepo.Repo, error)
+	// Executes the command with the given pre-populated context.
+	execute func(*CommandContext) error
 
 	flags *flag.FlagSet
+}
+
+// Information used when executing a command. This is set up by RunCommand,
+// then passed into Command.execute.
+type CommandContext struct {
+	// Context for operations requiring cancellation etc
+	ctx context.Context
+	// The time at which the command started executing, to be used as a consistent
+	// timestamp for anything which needs one.
+	startTime time.Time
+	// Temporary directory created under /tmp by default (but can be specified via a flag)
+	// All files created by Librarian live under this directory unless otherwise a location
+	// (e.g. a repo root) is specified via a flag.
+	workRoot string
+	// The language repo for the command, where appropriate.
+	languageRepo *gitrepo.Repo
+	// The pipeline configuration, loaded from the language repo if there is one.
+	// (This is nil if languageRepo is nil.)
+	pipelineConfig *statepb.PipelineConfig
+	// The pipeline state, loaded from the language repo if there is one.
+	// (This is nil if languageRepo is nil.)
+	pipelineState *statepb.PipelineState
+	// The image to use for container operations, derived from flagImage and
+	// pipelineState
+	image string
+	// Environment information for container commands, or nil if languageRepo is nil
+	containerEnv *container.ContainerEnvironment
 }
 
 func (c *Command) Parse(args []string) error {
@@ -56,6 +90,74 @@ func Lookup(name string) (*Command, error) {
 		return nil, fmt.Errorf("invalid command: %q", name)
 	}
 	return cmd, nil
+}
+
+func cloneOrOpenLanguageRepo(workRoot string) (*gitrepo.Repo, error) {
+	var languageRepo *gitrepo.Repo
+	if flagRepoRoot == "" {
+		return cloneLanguageRepo(flagLanguage, workRoot)
+	}
+	repoRoot, err := filepath.Abs(flagRepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	languageRepo, err = gitrepo.Open(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	clean, err := gitrepo.IsClean(languageRepo)
+	if err != nil {
+		return nil, err
+	}
+	if !clean {
+		return nil, errors.New("language repo must be clean")
+	}
+	return languageRepo, nil
+}
+
+func RunCommand(c *Command, ctx context.Context) error {
+	if err := validateLanguage(); err != nil {
+		return err
+	}
+	startTime := time.Now()
+	workRoot, err := createWorkRoot(startTime)
+	if err != nil {
+		return err
+	}
+	languageRepo, err := c.maybeGetLanguageRepo(workRoot)
+	if err != nil {
+		return err
+	}
+	var state *statepb.PipelineState = nil
+	var config *statepb.PipelineConfig = nil
+	var containerEnv *container.ContainerEnvironment = nil
+	if languageRepo != nil {
+		state, err = loadPipelineState(languageRepo)
+		if err != nil {
+			return err
+		}
+		config, err = loadPipelineConfig(languageRepo)
+		if err != nil {
+			return err
+		}
+		containerEnv, err = container.NewEnvironment(ctx, workRoot, flagSecretsProject, config)
+		if err != nil {
+			return err
+		}
+	}
+	image := deriveImage(state)
+
+	cmdContext := &CommandContext{
+		ctx:            ctx,
+		startTime:      startTime,
+		workRoot:       workRoot,
+		languageRepo:   languageRepo,
+		pipelineConfig: config,
+		pipelineState:  state,
+		containerEnv:   containerEnv,
+		image:          image,
+	}
+	return c.execute(cmdContext)
 }
 
 func deriveImage(state *statepb.PipelineState) string {
@@ -92,7 +194,7 @@ func findLibrary(state *statepb.PipelineState, apiPath string) string {
 	return ""
 }
 
-func loadState(languageRepo *gitrepo.Repo) (*statepb.PipelineState, error) {
+func loadPipelineState(languageRepo *gitrepo.Repo) (*statepb.PipelineState, error) {
 	path := filepath.Join(languageRepo.Dir, "generator-input", "pipeline-state.json")
 	bytes, err := os.ReadFile(path)
 	if err != nil {
@@ -107,7 +209,7 @@ func loadState(languageRepo *gitrepo.Repo) (*statepb.PipelineState, error) {
 	return state, nil
 }
 
-func loadConfig(languageRepo *gitrepo.Repo) (*statepb.PipelineConfig, error) {
+func loadPipelineConfig(languageRepo *gitrepo.Repo) (*statepb.PipelineConfig, error) {
 	path := filepath.Join(languageRepo.Dir, "generator-input", "pipeline-config.json")
 	bytes, err := os.ReadFile(path)
 	if err != nil {
@@ -122,10 +224,10 @@ func loadConfig(languageRepo *gitrepo.Repo) (*statepb.PipelineConfig, error) {
 	return config, nil
 }
 
-func saveState(languageRepo *gitrepo.Repo, state *statepb.PipelineState) error {
-	path := filepath.Join(languageRepo.Dir, "generator-input", "pipeline-state.json")
+func savePipelineState(ctx *CommandContext) error {
+	path := filepath.Join(ctx.languageRepo.Dir, "generator-input", "pipeline-state.json")
 	// Marshal the protobuf message as JSON...
-	unformatted, err := protojson.Marshal(state)
+	unformatted, err := protojson.Marshal(ctx.pipelineState)
 	if err != nil {
 		return err
 	}
@@ -146,7 +248,7 @@ func formatTimestamp(t time.Time) string {
 	return t.Format(yyyyMMddHHmmss)
 }
 
-func createTmpWorkingRoot(t time.Time) (string, error) {
+func createWorkRoot(t time.Time) (string, error) {
 	if flagWorkRoot != "" {
 		slog.Info(fmt.Sprintf("Using specified working directory: %s", flagWorkRoot))
 		return flagWorkRoot, nil
@@ -184,20 +286,21 @@ func commitAll(repo *gitrepo.Repo, msg string) error {
 	return gitrepo.Commit(repo, msg, flagGitUserName, flagGitUserEmail)
 }
 
-func pushAndCreatePullRequest(ctx context.Context, repo *gitrepo.Repo, startOfRun time.Time, title string, description string) (*gitrepo.PullRequestMetadata, error) {
+// Push the contents of the language repo and create a new pull request.
+func pushAndCreatePullRequest(ctx *CommandContext, title string, description string) (*gitrepo.PullRequestMetadata, error) {
 	if !flagPush {
 		return nil, nil
 	}
 
 	// This should already have been validated to be non-empty by validatePush
 	gitHubAccessToken := os.Getenv(gitHubTokenEnvironmentVariable)
-	branch := fmt.Sprintf("librarian-%s", formatTimestamp(startOfRun))
-	err := gitrepo.PushBranch(repo, branch, gitHubAccessToken)
+	branch := fmt.Sprintf("librarian-%s", formatTimestamp(ctx.startTime))
+	err := gitrepo.PushBranch(ctx.languageRepo, branch, gitHubAccessToken)
 	if err != nil {
 		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
 		return nil, err
 	}
-	pr, err := gitrepo.CreatePullRequest(ctx, repo, branch, gitHubAccessToken, title, description)
+	pr, err := gitrepo.CreatePullRequest(ctx.ctx, ctx.languageRepo, branch, gitHubAccessToken, title, description)
 	if pr != nil {
 		return pr, err
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -48,7 +48,7 @@ func GenerateRaw(image, apiRoot, output, apiPath string) error {
 	return runDocker("generate-raw", image, mounts, commandArgs, nil)
 }
 
-func GenerateLibrary(image, apiRoot, output, generatorInput, libraryID string) error {
+func GenerateLibrary(image, apiRoot, output, generatorInput, libraryID string, containerEnv *ContainerEnvironment) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -75,10 +75,10 @@ func GenerateLibrary(image, apiRoot, output, generatorInput, libraryID string) e
 		fmt.Sprintf("%s:/output", output),
 		fmt.Sprintf("%s:/generator-input", generatorInput),
 	}
-	return runDocker("generate-library", image, mounts, commandArgs, nil)
+	return runDocker("generate-library", image, mounts, commandArgs, containerEnv)
 }
 
-func Clean(image, repoRoot, libraryID string) error {
+func Clean(image, repoRoot, libraryID string, containerEnv *ContainerEnvironment) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -94,7 +94,7 @@ func Clean(image, repoRoot, libraryID string) error {
 	if libraryID != "" {
 		commandArgs = append(commandArgs, fmt.Sprintf("--library-id=%s", libraryID))
 	}
-	return runDocker("clean", image, mounts, commandArgs, nil)
+	return runDocker("clean", image, mounts, commandArgs, containerEnv)
 }
 
 func BuildRaw(image, generatorOutput, apiPath string) error {
@@ -117,7 +117,7 @@ func BuildRaw(image, generatorOutput, apiPath string) error {
 	return runDocker("build-raw", image, mounts, commandArgs, nil)
 }
 
-func BuildLibrary(image, repoRoot, libraryId string) error {
+func BuildLibrary(image, repoRoot, libraryId string, containerEnv *ContainerEnvironment) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -133,7 +133,7 @@ func BuildLibrary(image, repoRoot, libraryId string) error {
 	if libraryId != "" {
 		commandArgs = append(commandArgs, fmt.Sprintf("--library-id=%s", libraryId))
 	}
-	return runDocker("build-library", image, mounts, commandArgs, nil)
+	return runDocker("build-library", image, mounts, commandArgs, containerEnv)
 }
 
 func Configure(image, apiRoot, apiPath, generatorInput string) error {
@@ -161,7 +161,7 @@ func Configure(image, apiRoot, apiPath, generatorInput string) error {
 	return runDocker("configure", image, mounts, commandArgs, nil)
 }
 
-func PrepareLibraryRelease(image, languageRepo, inputsDirectory, libId, releaseVersion string) error {
+func PrepareLibraryRelease(image, languageRepo, inputsDirectory, libId, releaseVersion string, containerEnv *ContainerEnvironment) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -176,7 +176,7 @@ func PrepareLibraryRelease(image, languageRepo, inputsDirectory, libId, releaseV
 		fmt.Sprintf("%s:/inputs", inputsDirectory),
 	}
 
-	return runDocker("prepare-library-release", image, mounts, commandArgs, nil)
+	return runDocker("prepare-library-release", image, mounts, commandArgs, containerEnv)
 }
 
 func IntegrationTestLibrary(image, languageRepo, libId string, containerEnv *ContainerEnvironment) error {
@@ -194,7 +194,7 @@ func IntegrationTestLibrary(image, languageRepo, libId string, containerEnv *Con
 	return runDocker("integration-test-library", image, mounts, commandArgs, containerEnv)
 }
 
-func PackageLibrary(image, languageRepo, libId, outputDir string) error {
+func PackageLibrary(image, languageRepo, libId, outputDir string, containerEnv *ContainerEnvironment) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -209,7 +209,7 @@ func PackageLibrary(image, languageRepo, libId, outputDir string) error {
 		fmt.Sprintf("%s:/output", outputDir),
 	}
 
-	return runDocker("package-library", image, mounts, commandArgs, nil)
+	return runDocker("package-library", image, mounts, commandArgs, containerEnv)
 }
 
 func runDocker(commandName, image string, mounts []string, commandArgs []string, containerEnv *ContainerEnvironment) error {

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -30,7 +30,7 @@ func Run(ctx context.Context, arg ...string) error {
 	if err := cmd.Parse(arg[1:]); err != nil {
 		return err
 	}
-	return cmd.Run(ctx)
+	return command.RunCommand(cmd, ctx)
 }
 
 func parseArgs(args []string) (*command.Command, error) {


### PR DESCRIPTION
All commands create a work-root and do language validation; many also obtain a language repo by opening/cloning. This change puts all common information into a CommandContext struct, setting it up in one place and then passing it into an execute function.

Further refactoring may be desirable for container execution, to set up the image and environment aspects within a single struct that is then passed into all the container functions.

Fixes #117.