### PR TITLE
feat: Create env-vars.txt in the work-root by default

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googleapis/librarian/internal/container"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
+	"github.com/googleapis/librarian/internal/utils"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -172,6 +173,15 @@ func RunCommand(c *Command, ctx context.Context) error {
 		image:          image,
 	}
 	return c.execute(cmdContext)
+}
+
+func appendResultEnvironmentVariable(ctx *CommandContext, name, value string) error {
+	envFile := flagEnvFile
+	if envFile == "" {
+		envFile = filepath.Join(ctx.workRoot, "env-vars.txt")
+	}
+
+	return utils.AppendToFile(envFile, fmt.Sprintf("%s=%s\n", name, value))
 }
 
 func deriveImage(state *statepb.PipelineState) string {

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -55,7 +55,10 @@ var CmdCreateReleasePR = &Command{
 		}
 
 		releaseID := fmt.Sprintf("release-%s", formatTimestamp(ctx.startTime))
-		utils.AppendToFile(flagEnvFile, fmt.Sprintf("%s=%s\n", releaseIDEnvVarName, releaseID))
+		if err := appendResultEnvironmentVariable(ctx, releaseIDEnvVarName, releaseID); err != nil {
+			return err
+		}
+
 		prDescription, err := generateReleaseCommitForEachLibrary(ctx, inputDirectory, releaseID)
 		if err != nil {
 			return err
@@ -106,7 +109,9 @@ func generateReleasePr(ctx *CommandContext, title, prDescription string, errorsI
 		}
 	}
 	if prMetadata != nil {
-		utils.AppendToFile(flagEnvFile, fmt.Sprintf("%s=%d\n", prNumberEnvVarName, prMetadata.Number))
+		if err := appendResultEnvironmentVariable(ctx, prNumberEnvVarName, strconv.Itoa(prMetadata.Number)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -63,7 +63,7 @@ func addFlagBuild(fs *flag.FlagSet) {
 }
 
 func addFlagEnvFile(fs *flag.FlagSet) {
-	fs.StringVar(&flagEnvFile, "env-file", "/tmp/env-vars.txt", "full path to the file where the environment variables are stored.  Defaults to /tmp/env-vars.txt")
+	fs.StringVar(&flagEnvFile, "env-file", "", "full path to the file where the environment variables are stored. Defaults to env-vars.txt within the work-root")
 }
 
 func addFlagGitUserEmail(fs *flag.FlagSet) {


### PR DESCRIPTION
(Aside from anything else, this avoids creating a large /tmp/env-vars.txt file with the result of several runs, when testing locally!)