### PR TITLE
refactor: Colocate flag initialization functions with other command data

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -46,7 +46,11 @@ type Command struct {
 	maybeGetLanguageRepo func(workRoot string) (*gitrepo.Repo, error)
 	// Executes the command with the given pre-populated context.
 	execute func(*CommandContext) error
+	// Functions to execute when initializing the flag set for the command.
+	flagFunctions []func(fs *flag.FlagSet)
 
+	// The flag set used to parse the flags and construct usage messages.
+	// This is populated for each command in init().
 	flags *flag.FlagSet
 }
 
@@ -353,95 +357,9 @@ func init() {
 	for _, c := range Commands {
 		c.flags = flag.NewFlagSet(c.Name, flag.ContinueOnError)
 		c.flags.Usage = constructUsage(c.flags, c.Name)
-	}
-
-	fs := CmdConfigure.flags
-	for _, fn := range []func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagAPIPath,
-		addFlagAPIRoot,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagLanguage,
-		addFlagPush,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-	} {
-		fn(fs)
-	}
-
-	fs = CmdGenerate.flags
-	for _, fn := range []func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagAPIPath,
-		addFlagAPIRoot,
-		addFlagLanguage,
-		addFlagBuild,
-	} {
-		fn(fs)
-	}
-
-	fs = CmdUpdateApis.flags
-	for _, fn := range []func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagAPIRoot,
-		addFlagBranch,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagLanguage,
-		addFlagLibraryID,
-		addFlagPush,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-	} {
-		fn(fs)
-	}
-
-	fs = CmdCreateReleasePR.flags
-	for _, fn := range []func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagSecretsProject,
-		addFlagWorkRoot,
-		addFlagLanguage,
-		addFlagPush,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagRepoRoot,
-		addFlagSkipBuild,
-		addFlagEnvFile,
-		addFlagRepoUrl,
-	} {
-		fn(fs)
-	}
-
-	fs = CmdUpdateImageTag.flags
-	for _, fn := range []func(fs *flag.FlagSet){
-		addFlagWorkRoot,
-		addFlagAPIRoot,
-		addFlagBranch,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagLanguage,
-		addFlagPush,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-		addFlagTag,
-	} {
-		fn(fs)
-	}
-
-	fs = CmdRelease.flags
-	for _, fn := range []func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagLanguage,
-		addFlagRepoRoot,
-		addFlagReleaseID,
-	} {
-		fn(fs)
+		for _, fn := range c.flagFunctions {
+			fn(c.flags)
+		}
 	}
 }
 

--- a/internal/command/configure.go
+++ b/internal/command/configure.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -36,8 +37,20 @@ type ConfigurationPrContent struct {
 }
 
 var CmdConfigure = &Command{
-	Name:                 "configure",
-	Short:                "Configure a new API in a given language",
+	Name:  "configure",
+	Short: "Configure a new API in a given language",
+	flagFunctions: []func(fs *flag.FlagSet){
+		addFlagImage,
+		addFlagWorkRoot,
+		addFlagAPIPath,
+		addFlagAPIRoot,
+		addFlagGitUserEmail,
+		addFlagGitUserName,
+		addFlagLanguage,
+		addFlagPush,
+		addFlagRepoRoot,
+		addFlagRepoUrl,
+	},
 	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
 	execute: func(ctx *CommandContext) error {
 		if err := validatePush(); err != nil {

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -40,8 +41,21 @@ type ReleasePrDescription struct {
 }
 
 var CmdCreateReleasePR = &Command{
-	Name:                 "create-release-pr",
-	Short:                "Generate a PR for release",
+	Name:  "create-release-pr",
+	Short: "Generate a PR for release",
+	flagFunctions: []func(fs *flag.FlagSet){
+		addFlagImage,
+		addFlagSecretsProject,
+		addFlagWorkRoot,
+		addFlagLanguage,
+		addFlagPush,
+		addFlagGitUserEmail,
+		addFlagGitUserName,
+		addFlagRepoRoot,
+		addFlagSkipBuild,
+		addFlagEnvFile,
+		addFlagRepoUrl,
+	},
 	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
 	execute: func(ctx *CommandContext) error {
 		if err := validatePush(); err != nil {

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -27,6 +28,14 @@ import (
 var CmdGenerate = &Command{
 	Name:  "generate",
 	Short: "Generate client library code for an API",
+	flagFunctions: []func(fs *flag.FlagSet){
+		addFlagImage,
+		addFlagWorkRoot,
+		addFlagAPIPath,
+		addFlagAPIRoot,
+		addFlagLanguage,
+		addFlagBuild,
+	},
 	// Currently we never clone a language repo, and always do raw generation.
 	maybeGetLanguageRepo: func(workRoot string) (*gitrepo.Repo, error) {
 		return nil, nil

--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -37,6 +38,13 @@ type LibraryRelease struct {
 var CmdRelease = &Command{
 	Name:  "release",
 	Short: "Release libraries from a merged release PR",
+	flagFunctions: []func(fs *flag.FlagSet){
+		addFlagImage,
+		addFlagWorkRoot,
+		addFlagLanguage,
+		addFlagRepoRoot,
+		addFlagReleaseID,
+	},
 	maybeGetLanguageRepo: func(workRoot string) (*gitrepo.Repo, error) {
 		if err := validateRequiredFlag("repo-root", flagRepoRoot); err != nil {
 			return nil, err

--- a/internal/command/updateapis.go
+++ b/internal/command/updateapis.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -28,8 +29,21 @@ import (
 )
 
 var CmdUpdateApis = &Command{
-	Name:                 "update-apis",
-	Short:                "Update a language repo by regenerating configured APIs with new API specifications",
+	Name:  "update-apis",
+	Short: "Update a language repo by regenerating configured APIs with new API specifications",
+	flagFunctions: []func(fs *flag.FlagSet){
+		addFlagImage,
+		addFlagWorkRoot,
+		addFlagAPIRoot,
+		addFlagBranch,
+		addFlagGitUserEmail,
+		addFlagGitUserName,
+		addFlagLanguage,
+		addFlagLibraryID,
+		addFlagPush,
+		addFlagRepoRoot,
+		addFlagRepoUrl,
+	},
 	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
 	execute: func(ctx *CommandContext) error {
 		if err := validatePush(); err != nil {

--- a/internal/command/updateimagetag.go
+++ b/internal/command/updateimagetag.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -27,8 +28,20 @@ import (
 )
 
 var CmdUpdateImageTag = &Command{
-	Name:                 "update-image-tag",
-	Short:                "Update the image tag used by a language repo, and regenerating all APIs at the existing commit",
+	Name:  "update-image-tag",
+	Short: "Update the image tag used by a language repo, and regenerating all APIs at the existing commit",
+	flagFunctions: []func(fs *flag.FlagSet){
+		addFlagWorkRoot,
+		addFlagAPIRoot,
+		addFlagBranch,
+		addFlagGitUserEmail,
+		addFlagGitUserName,
+		addFlagLanguage,
+		addFlagPush,
+		addFlagRepoRoot,
+		addFlagRepoUrl,
+		addFlagTag,
+	},
 	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
 	execute: func(ctx *CommandContext) error {
 		if err := validatePush(); err != nil {


### PR DESCRIPTION
(I've been peeved by this split every time we've added a new command...)

I'd like to be able to express - for each flag per command - whether the flag is optional or required, but that's a bigger change, and not worth doing just yet.