### PR TITLE
fix: fix logic to handle PR that is already merged

### DIFF
--- a/.louhi/check_pr_status.go
+++ b/.louhi/check_pr_status.go
@@ -54,7 +54,7 @@ func checkPRStatus(prNumber int, repoOwner string, repoName string, statusCheck 
 			}
 		} else if statusCheck == "mergeable" {
 			if pr.GetMergeable() || pr.GetMerged() {
-				slog.Info("PR is mergable")
+				slog.Info("PR is mergable or already merged", "mergeable status", pr.GetMergeable(), "merged status", pr.GetMerged())
 				return
 			} else {
 				slog.Info("PR is not mergable, will try again", "mergeable status", pr.GetMergeable(), "merged status", pr.GetMerged())

--- a/.louhi/check_pr_status.go
+++ b/.louhi/check_pr_status.go
@@ -53,11 +53,11 @@ func checkPRStatus(prNumber int, repoOwner string, repoName string, statusCheck 
 				time.Sleep(pollInterval)
 			}
 		} else if statusCheck == "mergeable" {
-			if pr.GetMergeable() {
+			if pr.GetMergeable() || pr.GetMerged() {
 				slog.Info("PR is mergable")
 				return
 			} else {
-				slog.Info("PR is not mergable, will try again", "mergeable status", pr.GetMerged())
+				slog.Info("PR is not mergable, will try again", "mergeable status", pr.GetMergeable(), "merged status", pr.GetMerged())
 				time.Sleep(pollInterval)
 			}
 		}


### PR DESCRIPTION
In case someone merges PR before we the check gets invoked, it shouldn't block