### PR TITLE
fix: various release command fixes

### DIFF
--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -98,7 +98,7 @@ func buildTestPackageRelease(ctx *CommandContext, outputRoot string, release Lib
 		return err
 	}
 	outputDir := filepath.Join(outputRoot, release.LibraryID)
-	if err := os.Mkdir(outputRoot, 0755); err != nil {
+	if err := os.Mkdir(outputDir, 0755); err != nil {
 		return err
 	}
 	if err := container.PackageLibrary(containerConfig, languageRepo.Dir, release.LibraryID, outputDir); err != nil {
@@ -111,7 +111,7 @@ func publishPackages(config *container.ContainerConfig, outputRoot string, relea
 	for _, release := range releases {
 		slog.Info(fmt.Sprintf("Would create GitHub release for %s", release.LibraryID))
 	}
-	slog.Info(fmt.Sprintf("Would public packages with image %s and output root %s", config.Image, outputRoot))
+	slog.Info(fmt.Sprintf("Would publish packages with image %s and output root %s", config.Image, outputRoot))
 	return errors.New("publishing releases isn't implemented yet")
 }
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -172,7 +172,6 @@ func IntegrationTestLibrary(config *ContainerConfig, languageRepo, libId string)
 
 func PackageLibrary(config *ContainerConfig, languageRepo, libId, outputDir string) error {
 	commandArgs := []string{
-		"integration-test-library",
 		"--repo-root=/repo",
 		"--output=/output",
 		fmt.Sprintf("--library-id=%s", libId),

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -328,7 +328,7 @@ func GetCommitsForPathsSinceTag(repo *Repo, paths []string, tagName string) ([]o
 // Librarian-Release-Id: <release-id>. These commits are expected to be contiguous, from head,
 // with all commits having a single parent.
 func GetCommitsForReleaseID(repo *Repo, releaseID string) ([]object.Commit, error) {
-	releaseIDLine := fmt.Sprintf("Librarian-Release-Id: %s", releaseID)
+	releaseIDLine := fmt.Sprintf("Librarian-Release-ID: %s", releaseID)
 	commits := []object.Commit{}
 
 	headRef, err := repo.repo.Head()
@@ -349,6 +349,8 @@ func GetCommitsForReleaseID(repo *Repo, releaseID string) ([]object.Commit, erro
 		if !gotReleaseID {
 			break
 		}
+
+		commits = append(commits, *candidateCommit)
 
 		if candidateCommit.NumParents() != 1 {
 			return nil, fmt.Errorf("aborted finding release PR commits; commit %s has multiple parents", candidateCommit.Hash.String())


### PR DESCRIPTION
- Fix typo in "what we'd do next" message
- Fix casing of Librarian-Release-ID when finding commits
- Fix adding of commits to the list of commits to release
- Fix output subdirectory creation