### PR TITLE
fix: make repo-root not required and allow repo-url override for release job

### DIFF
--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -43,16 +43,10 @@ var CmdRelease = &Command{
 		addFlagWorkRoot,
 		addFlagLanguage,
 		addFlagRepoRoot,
+		addFlagRepoUrl,
 		addFlagReleaseID,
 	},
-	maybeGetLanguageRepo: func(workRoot string) (*gitrepo.Repo, error) {
-		if err := validateRequiredFlag("repo-root", flagRepoRoot); err != nil {
-			return nil, err
-		}
-		// This will always open the repo root, because we've just validated
-		// that the flag has been specified.
-		return cloneOrOpenLanguageRepo(workRoot)
-	},
+	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
 	execute: func(ctx *CommandContext) error {
 		if err := validateRequiredFlag("release-id", flagReleaseID); err != nil {
 			return err


### PR DESCRIPTION
this is so kokoro does not need to check out repo as well as has the ability to point to different repo than default