### PR TITLE
feat: add final steps of the release command

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -368,3 +368,7 @@ func constructUsage(fs *flag.FlagSet, name string) func() {
 		fmt.Fprintf(fs.Output(), "\n\n")
 	}
 }
+
+func formatReleaseTag(libraryID, version string) string {
+	return libraryID + "-" + version
+}

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -153,7 +153,7 @@ func generateReleaseCommitForEachLibrary(ctx *CommandContext, inputDirectory str
 		if library.CurrentVersion == "" {
 			previousReleaseTag = ""
 		} else {
-			previousReleaseTag = library.Id + "-" + library.CurrentVersion
+			previousReleaseTag = formatReleaseTag(library.Id, library.CurrentVersion)
 		}
 		allSourcePaths := append(ctx.pipelineState.CommonLibrarySourcePaths, library.SourcePaths...)
 		commits, err := gitrepo.GetCommitsForPathsSinceTag(languageRepo, allSourcePaths, previousReleaseTag)

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -43,6 +43,7 @@ var (
 	flagSecretsProject string
 	flagSkipBuild      bool
 	flagTag            string
+	flagTagRepoUrl     string
 	flagWorkRoot       string
 )
 
@@ -112,6 +113,10 @@ func addFlagSkipBuild(fs *flag.FlagSet) {
 
 func addFlagTag(fs *flag.FlagSet) {
 	fs.StringVar(&flagTag, "tag", "", "new tag for the language-specific container image.")
+}
+
+func addFlagTagRepoUrl(fs *flag.FlagSet) {
+	fs.StringVar(&flagTagRepoUrl, "tag-repo-url", "", "Repository URL to tag and create releases in. Requires when push is true.")
 }
 
 func addFlagWorkRoot(fs *flag.FlagSet) {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -184,6 +184,19 @@ func PackageLibrary(config *ContainerConfig, languageRepo, libId, outputDir stri
 	return runDocker(config, "package-library", mounts, commandArgs)
 }
 
+func PublishLibrary(config *ContainerConfig, outputDir, libId, libVersion string) error {
+	commandArgs := []string{
+		"--package-output=/output",
+		fmt.Sprintf("--library-id=%s", libId),
+		fmt.Sprintf("--version=%s", libId),
+	}
+	mounts := []string{
+		fmt.Sprintf("%s:/output", outputDir),
+	}
+
+	return runDocker(config, "publish-library", mounts, commandArgs)
+}
+
 func runDocker(config *ContainerConfig, commandName string, mounts []string, commandArgs []string) error {
 	if config.Image == "" {
 		return fmt.Errorf("image cannot be empty")


### PR DESCRIPTION
This requires:
- Checking the push flag
- Publishing libraries using a new publish-library container command
- Creating releases/tags in GitHub, which requires a new flag (tag-repo-url)