### PR TITLE
feat: Support library-id flag in create-release-pr

### DIFF
--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -48,6 +48,7 @@ var CmdCreateReleasePR = &Command{
 		addFlagSecretsProject,
 		addFlagWorkRoot,
 		addFlagLanguage,
+		addFlagLibraryID,
 		addFlagPush,
 		addFlagGitUserEmail,
 		addFlagGitUserName,
@@ -76,6 +77,10 @@ var CmdCreateReleasePR = &Command{
 		prDescription, err := generateReleaseCommitForEachLibrary(ctx, inputDirectory, releaseID)
 		if err != nil {
 			return err
+		}
+
+		if flagLibraryID != "" && len(prDescription.Releases) != 1 {
+			return fmt.Errorf("library-id flag specified as '%s' but %d releases were created", flagLibraryID, len(prDescription.Releases))
 		}
 
 		// Need to handle four situations:
@@ -144,6 +149,10 @@ func generateReleaseCommitForEachLibrary(ctx *CommandContext, inputDirectory str
 	var releases []string
 
 	for _, library := range libraries {
+		// If we've specified a single library to release, skip all the others.
+		if flagLibraryID != "" && library.Id != flagLibraryID {
+			continue
+		}
 		if library.ReleaseAutomationLevel == statepb.AutomationLevel_AUTOMATION_LEVEL_BLOCKED {
 			slog.Info(fmt.Sprintf("Skipping release-blocked library: '%s'", library.Id))
 			continue


### PR DESCRIPTION
This restricts the command to only releasing the specified library, and causes the command to fail if that library *isn't* then released (either because there are no changes, or potentially because there's a typo in the library name, or because the integration tests failed; at the moment it's up to the user to figure out which).

Currently this does *not* force a library to be released if it wouldn't otherwise be. We could potentially add that functionality if it proves desirable. (Otherwise users will have to create "no-op" commits that affect a path specified for the library.)