### PR TITLE
refactor: Separate GitHub operations from plain Git operations

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -322,15 +322,13 @@ func pushAndCreatePullRequest(ctx *CommandContext, title string, description str
 		return nil, err
 	}
 
-	// This should already have been validated to be non-empty by validatePush
-	gitHubAccessToken := os.Getenv(gitHubTokenEnvironmentVariable)
 	branch := fmt.Sprintf("librarian-%s", formatTimestamp(ctx.startTime))
-	err = gitrepo.PushBranch(ctx.languageRepo, branch, gitHubAccessToken)
+	err = gitrepo.PushBranch(ctx.languageRepo, branch, githubrepo.GetAccessToken())
 	if err != nil {
 		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
 		return nil, err
 	}
-	pr, err := githubrepo.CreatePullRequest(ctx.ctx, gitHubRepo, branch, gitHubAccessToken, title, description)
+	pr, err := githubrepo.CreatePullRequest(ctx.ctx, gitHubRepo, branch, title, description)
 	if pr != nil {
 		return pr, err
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/googleapis/librarian/internal/container"
+	"github.com/googleapis/librarian/internal/githubrepo"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 	"github.com/googleapis/librarian/internal/utils"
@@ -311,20 +312,25 @@ func commitAll(repo *gitrepo.Repo, msg string) error {
 }
 
 // Push the contents of the language repo and create a new pull request.
-func pushAndCreatePullRequest(ctx *CommandContext, title string, description string) (*gitrepo.PullRequestMetadata, error) {
+func pushAndCreatePullRequest(ctx *CommandContext, title string, description string) (*githubrepo.PullRequestMetadata, error) {
 	if !flagPush {
 		return nil, nil
+	}
+
+	gitHubRepo, err := gitrepo.GetGitHubRepoFromRemote(ctx.languageRepo)
+	if err != nil {
+		return nil, err
 	}
 
 	// This should already have been validated to be non-empty by validatePush
 	gitHubAccessToken := os.Getenv(gitHubTokenEnvironmentVariable)
 	branch := fmt.Sprintf("librarian-%s", formatTimestamp(ctx.startTime))
-	err := gitrepo.PushBranch(ctx.languageRepo, branch, gitHubAccessToken)
+	err = gitrepo.PushBranch(ctx.languageRepo, branch, gitHubAccessToken)
 	if err != nil {
 		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
 		return nil, err
 	}
-	pr, err := gitrepo.CreatePullRequest(ctx.ctx, ctx.languageRepo, branch, gitHubAccessToken, title, description)
+	pr, err := githubrepo.CreatePullRequest(ctx.ctx, gitHubRepo, branch, gitHubAccessToken, title, description)
 	if pr != nil {
 		return pr, err
 	}

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -125,8 +125,7 @@ func generateReleasePr(ctx *CommandContext, title, prDescription string, errorsI
 		return err
 	}
 	if errorsInGeneration {
-		gitHubAccessToken := os.Getenv(gitHubTokenEnvironmentVariable)
-		err = githubrepo.AddLabelToPullRequest(ctx.ctx, gitHubRepo, prMetadata.Number, "do-not-merge", gitHubAccessToken)
+		err = githubrepo.AddLabelToPullRequest(ctx.ctx, gitHubRepo, prMetadata.Number, "do-not-merge")
 		if err != nil {
 			slog.Warn(fmt.Sprintf("Received error trying to add label to PR: '%s'", err))
 			return err

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/container"
+	"github.com/googleapis/librarian/internal/githubrepo"
 	"github.com/googleapis/librarian/internal/utils"
 
 	"github.com/Masterminds/semver/v3"
@@ -114,6 +115,10 @@ func generateReleasePr(ctx *CommandContext, title, prDescription string, errorsI
 		slog.Info(fmt.Sprintf("Push not specified; would have created release PR with the following description:\n%s", prDescription))
 		return nil
 	}
+	gitHubRepo, err := gitrepo.GetGitHubRepoFromRemote(ctx.languageRepo)
+	if err != nil {
+		return err
+	}
 	prMetadata, err := pushAndCreatePullRequest(ctx, title, prDescription)
 	if err != nil {
 		slog.Warn(fmt.Sprintf("Received error trying to create release PR: '%s'", err))
@@ -121,7 +126,7 @@ func generateReleasePr(ctx *CommandContext, title, prDescription string, errorsI
 	}
 	if errorsInGeneration {
 		gitHubAccessToken := os.Getenv(gitHubTokenEnvironmentVariable)
-		err = gitrepo.AddLabelToPullRequest(ctx.ctx, ctx.languageRepo, prMetadata.Number, "do-not-merge", gitHubAccessToken)
+		err = githubrepo.AddLabelToPullRequest(ctx.ctx, gitHubRepo, prMetadata.Number, "do-not-merge", gitHubAccessToken)
 		if err != nil {
 			slog.Warn(fmt.Sprintf("Received error trying to add label to PR: '%s'", err))
 			return err

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -18,11 +18,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
+
+	"github.com/googleapis/librarian/internal/githubrepo"
 )
 
 // Environment variables are specified here as they're used for the same sort of purpose as flags...
-const gitHubTokenEnvironmentVariable string = "LIBRARIAN_GITHUB_TOKEN"
+// ... but see also githubrepo.go
 const defaultRepositoryEnvironmentVariable string = "LIBRARIAN_REPOSITORY"
 
 var (
@@ -137,7 +138,7 @@ var supportedLanguages = map[string]bool{
 }
 
 func validatePush() error {
-	if flagPush && os.Getenv(gitHubTokenEnvironmentVariable) == "" {
+	if flagPush && githubrepo.GetAccessToken() == "" {
 		return errors.New("no GitHub token supplied for push")
 	}
 	return nil

--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/googleapis/librarian/internal/container"
+	"github.com/googleapis/librarian/internal/githubrepo"
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
@@ -133,11 +134,16 @@ func createRepoReleases(ctx *CommandContext, releases []LibraryRelease) error {
 	accessToken := os.Getenv(gitHubTokenEnvironmentVariable)
 	repoUrl := flagTagRepoUrl
 
+	gitHubRepo, err := githubrepo.ParseUrl(repoUrl)
+	if err != nil {
+		return err
+	}
+
 	for _, release := range releases {
 		tag := formatReleaseTag(release.LibraryID, release.Version)
 		title := fmt.Sprintf("Release %s version %s", release.LibraryID, release.Version)
 		prerelease := strings.HasPrefix(release.Version, "0.") || strings.Contains(release.Version, "-")
-		repoRelease, err := gitrepo.CreateRelease(ctx.ctx, repoUrl, accessToken, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
+		repoRelease, err := githubrepo.CreateRelease(ctx.ctx, gitHubRepo, accessToken, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
 		if err != nil {
 			return err
 		}

--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -131,7 +131,6 @@ func publishPackages(config *container.ContainerConfig, outputRoot string, relea
 }
 
 func createRepoReleases(ctx *CommandContext, releases []LibraryRelease) error {
-	accessToken := os.Getenv(gitHubTokenEnvironmentVariable)
 	repoUrl := flagTagRepoUrl
 
 	gitHubRepo, err := githubrepo.ParseUrl(repoUrl)
@@ -143,7 +142,7 @@ func createRepoReleases(ctx *CommandContext, releases []LibraryRelease) error {
 		tag := formatReleaseTag(release.LibraryID, release.Version)
 		title := fmt.Sprintf("Release %s version %s", release.LibraryID, release.Version)
 		prerelease := strings.HasPrefix(release.Version, "0.") || strings.Contains(release.Version, "-")
-		repoRelease, err := githubrepo.CreateRelease(ctx.ctx, gitHubRepo, accessToken, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
+		repoRelease, err := githubrepo.CreateRelease(ctx.ctx, gitHubRepo, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
 		if err != nil {
 			return err
 		}

--- a/internal/githubrepo/githubrepo.go
+++ b/internal/githubrepo/githubrepo.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package githubrepo provides operations on GitHub repos, abstracting away go-github
+// (at least somewhat) to only the operations Librarian needs.
+package githubrepo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v69/github"
+)
+
+type GitHubRepo struct {
+	Owner string
+	Name  string
+}
+
+type PullRequestMetadata struct {
+	Number int
+}
+
+// Creates a pull request in the remote repo. At the moment this requires a single remote to be
+// configured, which must have a GitHub HTTPS URL. We assume a base branch of "main".
+func CreatePullRequest(ctx context.Context, repo GitHubRepo, remoteBranch string, accessToken string, title string, body string) (*PullRequestMetadata, error) {
+	if body == "" {
+		body = "Regenerated all changed APIs. See individual commits for details."
+	}
+	gitHubClient := github.NewClient(nil).WithAuthToken(accessToken)
+	newPR := &github.NewPullRequest{
+		Title:               &title,
+		Head:                &remoteBranch,
+		Base:                github.Ptr("main"),
+		Body:                github.Ptr(body),
+		MaintainerCanModify: github.Ptr(true),
+	}
+	pr, _, err := gitHubClient.PullRequests.Create(ctx, repo.Owner, repo.Name, newPR)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("PR created: %s\n", pr.GetHTMLURL())
+	pullRequestMetadata := &PullRequestMetadata{Number: pr.GetNumber()}
+	return pullRequestMetadata, nil
+}
+
+func CreateRelease(ctx context.Context, repo GitHubRepo, accessToken, tag, commit, title, description string, prerelease bool) (*github.RepositoryRelease, error) {
+	gitHubClient := github.NewClient(nil).WithAuthToken(accessToken)
+
+	release := &github.RepositoryRelease{
+		TagName:         &tag,
+		TargetCommitish: &commit,
+		Name:            &title,
+		Body:            &description,
+		Draft:           github.Ptr(false),
+		MakeLatest:      github.Ptr("true"),
+		Prerelease:      &prerelease,
+		// TODO: Check whether this is what we want
+		GenerateReleaseNotes: github.Ptr(false),
+	}
+	release, _, err := gitHubClient.Repositories.CreateRelease(ctx, repo.Owner, repo.Name, release)
+	return release, err
+}
+
+func AddLabelToPullRequest(ctx context.Context, repo GitHubRepo, prNumber int, label string, accessToken string) error {
+	gitHubClient := github.NewClient(nil).WithAuthToken(accessToken)
+
+	labels := []string{label}
+
+	_, _, err := gitHubClient.Issues.AddLabelsToIssue(ctx, repo.Owner, repo.Name, prNumber, labels)
+	if err != nil {
+		return fmt.Errorf("failed to add label: %w", err)
+	}
+	return nil
+}
+
+// Parses a GitHub URL (anything to do with a repository) to determine
+// the GitHub repo details (owner and name)
+func ParseUrl(remoteUrl string) (GitHubRepo, error) {
+	if !strings.HasPrefix(remoteUrl, "https://github.com/") {
+		return GitHubRepo{}, fmt.Errorf("remote '%s' is not a GitHub remote", remoteUrl)
+	}
+	remotePath := remoteUrl[len("https://github.com/"):]
+	pathParts := strings.Split(remotePath, "/")
+	organization := pathParts[0]
+	repoName := pathParts[1]
+	repoName = strings.TrimSuffix(repoName, ".git")
+	return GitHubRepo{Owner: organization, Name: repoName}, nil
+}


### PR DESCRIPTION
This should make it easier to keep track of what uses the GitHub API vs what's just Git.