### PR TITLE
feat: Handle update-apis in the same way as configure/create-release-pr

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/googleapis/librarian/internal/container"
-	"github.com/googleapis/librarian/internal/githubrepo"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 	"github.com/googleapis/librarian/internal/utils"
@@ -319,30 +318,6 @@ func commitAll(repo *gitrepo.Repo, msg string) error {
 	}
 
 	return gitrepo.Commit(repo, msg, flagGitUserName, flagGitUserEmail)
-}
-
-// Push the contents of the language repo and create a new pull request.
-func pushAndCreatePullRequest(ctx *CommandContext, title string, description string) (*githubrepo.PullRequestMetadata, error) {
-	if !flagPush {
-		return nil, nil
-	}
-
-	gitHubRepo, err := gitrepo.GetGitHubRepoFromRemote(ctx.languageRepo)
-	if err != nil {
-		return nil, err
-	}
-
-	branch := fmt.Sprintf("librarian-%s", formatTimestamp(ctx.startTime))
-	err = gitrepo.PushBranch(ctx.languageRepo, branch, githubrepo.GetAccessToken())
-	if err != nil {
-		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
-		return nil, err
-	}
-	pr, err := githubrepo.CreatePullRequest(ctx.ctx, gitHubRepo, branch, title, description)
-	if pr != nil {
-		return pr, err
-	}
-	return nil, err
 }
 
 // Log details of an error which prevents a single API or library from being configured/released, but without

--- a/internal/command/pullrequest.go
+++ b/internal/command/pullrequest.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/gitrepo"
+)
+
+// A PullRequestContent builds up the content of a pull request.
+// Each entry in "Successes" represents a commit from a successful
+// operation; each entry in "Errors" represents an unsuccessful
+// operation which would otherwise have created a commit.
+type PullRequestContent struct {
+	Successes []string
+	Errors    []string
+}
+
+// Add details to a PullRequestContent of a partial error which prevents a
+// single API or library from being configured/regenerated/released,
+// but without halting the overall process. A warning is logged locally with the error details,
+// but we don't include detailed errors in the PR, as this could reveal sensitive information.
+// The action should describe what failed, e.g. "configuring", "building", "generating".
+func addErrorToPullRequest(pr *PullRequestContent, id string, err error, action string) {
+	slog.Warn(fmt.Sprintf("Error while %s %s: %s", action, id, err))
+	pr.Errors = append(pr.Errors, fmt.Sprintf("Error while %s %s", action, id))
+}
+
+// Adds a success entry to a PullRequestContent.
+func addSuccessToPullRequest(pr *PullRequestContent, text string) {
+	pr.Successes = append(pr.Successes, text)
+}
+
+// Creates a GitHub pull request based on the given content, with a title prefix (e.g. "feat: API regeneration")
+// using a branch with a name of the form "librarian-{branchtype}-{timestamp}".
+// If content is empty, the pull request is not created and no error is returned.
+// If content only contains errors, the pull request is not created and an error is returned (to highlight that everything failed)
+// If content contains any successes, a pull request is created and no error is returned (if the creation is successful) even if the content includes errors.
+func createPullRequest(ctx *CommandContext, content *PullRequestContent, titlePrefix, branchType string) (*githubrepo.PullRequestMetadata, error) {
+	anySuccesses := len(content.Successes) > 0
+	anyErrors := len(content.Errors) > 0
+
+	var description string
+	if !anySuccesses && !anyErrors {
+		slog.Error("No new APIs to configure.")
+		return nil, nil
+	} else if !anySuccesses && anyErrors {
+		slog.Error("No PR to create, but errors were logged. Aborting.")
+		return nil, errors.New("errors encountered but no PR to create")
+	} else if anySuccesses && !anyErrors {
+		description = strings.Join(content.Successes, "\n")
+	} else {
+		errorsText := strings.Join(content.Errors, "\n")
+		releasesText := strings.Join(content.Successes, "\n")
+		description = fmt.Sprintf("Errors:\n==================\n%s\n\n\nChanges Included:\n==================\n%s\n", errorsText, releasesText)
+	}
+
+	if !flagPush {
+		slog.Info(fmt.Sprintf("Push not specified; would have created PR with the following description:\n%s", description))
+		return nil, nil
+	}
+
+	title := fmt.Sprintf("%s: %s", titlePrefix, formatTimestamp(ctx.startTime))
+
+	gitHubRepo, err := gitrepo.GetGitHubRepoFromRemote(ctx.languageRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	branch := fmt.Sprintf("librarian-%s-%s", branchType, formatTimestamp(ctx.startTime))
+	err = gitrepo.PushBranch(ctx.languageRepo, branch, githubrepo.GetAccessToken())
+	if err != nil {
+		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
+		return nil, err
+	}
+	return githubrepo.CreatePullRequest(ctx.ctx, gitHubRepo, branch, title, description)
+}

--- a/internal/command/updateimagetag.go
+++ b/internal/command/updateimagetag.go
@@ -121,12 +121,11 @@ var CmdUpdateImageTag = &Command{
 			return err
 		}
 
-		if !flagPush {
-			slog.Info("Pushing not specified; update complete.")
-			return nil
-		}
-
-		_, err := pushAndCreatePullRequest(ctx, "chore: update generation image tag", "")
+		// The PullRequestContent for update-image-tag is slightly different to others, but we
+		// can massage it into a similar state.
+		prContent := new(PullRequestContent)
+		addSuccessToPullRequest(prContent, "Regenerated all libraries with new image tag.")
+		_, err := createPullRequest(ctx, prContent, "chore: update generation image tag", "update-image-tag")
 		return err
 	},
 }

--- a/internal/githubrepo/githubrepo.go
+++ b/internal/githubrepo/githubrepo.go
@@ -32,6 +32,7 @@ type GitHubRepo struct {
 }
 
 type PullRequestMetadata struct {
+	Repo   GitHubRepo
 	Number int
 }
 
@@ -57,7 +58,7 @@ func CreatePullRequest(ctx context.Context, repo GitHubRepo, remoteBranch string
 	}
 
 	fmt.Printf("PR created: %s\n", pr.GetHTMLURL())
-	pullRequestMetadata := &PullRequestMetadata{Number: pr.GetNumber()}
+	pullRequestMetadata := &PullRequestMetadata{Repo: repo, Number: pr.GetNumber()}
 	return pullRequestMetadata, nil
 }
 
@@ -79,12 +80,12 @@ func CreateRelease(ctx context.Context, repo GitHubRepo, tag, commit, title, des
 	return release, err
 }
 
-func AddLabelToPullRequest(ctx context.Context, repo GitHubRepo, prNumber int, label string) error {
+func AddLabelToPullRequest(ctx context.Context, prMetadata PullRequestMetadata, label string) error {
 	gitHubClient := createClient()
 
 	labels := []string{label}
 
-	_, _, err := gitHubClient.Issues.AddLabelsToIssue(ctx, repo.Owner, repo.Name, prNumber, labels)
+	_, _, err := gitHubClient.Issues.AddLabelsToIssue(ctx, prMetadata.Repo.Owner, prMetadata.Repo.Name, prMetadata.Number, labels)
 	if err != nil {
 		return fmt.Errorf("failed to add label: %w", err)
 	}


### PR DESCRIPTION
Generation/build errors should be reported, but should not prevent other libraries from being generated.

Refactored the existing code to remove duplication.