### PR TITLE
chore: restate errors in the log when a PR is not going to be created

### DIFF
--- a/internal/command/pullrequest.go
+++ b/internal/command/pullrequest.go
@@ -62,7 +62,10 @@ func createPullRequest(ctx *CommandContext, content *PullRequestContent, titlePr
 		slog.Error("No new APIs to configure.")
 		return nil, nil
 	} else if !anySuccesses && anyErrors {
-		slog.Error("No PR to create, but errors were logged. Aborting.")
+		slog.Error("No PR to create, but errors were logged (and restated below). Aborting.")
+		for _, error := range content.Errors {
+			slog.Error(error)
+		}
 		return nil, errors.New("errors encountered but no PR to create")
 	} else if anySuccesses && !anyErrors {
 		description = strings.Join(content.Successes, "\n")


### PR DESCRIPTION
The log may be very large; having a line-per-error summary at the bottom is handy.