### PR TITLE
feat: Upper-case first letter of lines in release notes

### DIFF
--- a/internal/command/commitmessage.go
+++ b/internal/command/commitmessage.go
@@ -87,19 +87,26 @@ func ParseCommit(commit object.Commit) *CommitMessage {
 		case "feat":
 			slice = &features
 		case "doc":
+			slice = &docs
 		case "docs":
 			slice = &docs
-		case "fixes":
+		case "fix":
 			slice = &fixes
+		// Conventional commit type we know about, but don't keep.
+		// TODO: Maybe we should keep deps?
 		case "refactor":
+			slice = nil
 		case "tools":
+			slice = nil
 		case "chore":
+			slice = nil
 		case "test":
+			slice = nil
 		case "tests":
+			slice = nil
 		case "deps":
+			slice = nil
 		case "regen":
-			// Conventional commit type we know about, but don't keep.
-			// TODO: Maybe we should keep deps?
 			slice = nil
 		default:
 			// Not a conventional commit line (that we recognise, anyway) - ignore it


### PR DESCRIPTION
Additionally, bug fixes for:

- Redundant blank lines before the metadata in release notes
- The conventional commit type of "fix" instead of "fixes"
- Failing to take account of Go's switch/case not falling through to following cases

Fixes b/416167983 and b/416164401