### PR TITLE
fix: Fix refined build

### DIFF
--- a/internal/githubrepo/githubrepo.go
+++ b/internal/githubrepo/githubrepo.go
@@ -152,7 +152,7 @@ func CreateGitHubRepoFromRepository(repo *github.Repository) GitHubRepo {
 }
 
 func GetRawContent(ctx context.Context, repo GitHubRepo, path, ref string) ([]byte, error) {
-	gitHubClient := createClient()
+	gitHubClient := github.NewClient(nil)
 	options := &github.RepositoryContentGetOptions{
 		Ref: ref,
 	}


### PR DESCRIPTION
- Fetch the pipeline state from an anonymous GitHub client (we don't need credentials). If we want to be able to use private repos later, we could potentially use credentials only if we have any.
- Use BuildLibrary instead of BuildRaw for the refined build
- Copy the library into the cloned language repo before building, for refined builds. (If we later support generate for an existing language repo, we'll need to document the behavior carefully, as in other cases generate doesn't modify any existing code.)