### PR TITLE
fix: update Docker image to match existing version in go.mod + create cloudbuild.yaml file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24 AS build
+FROM golang:1.23.8 AS build
 
 WORKDIR /src
 
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build ./cmd/librarian
 # while in Docker. Note that for this to work, *this*
 # docker image should be run with
 #  -v /var/run/docker.sock:/var/run/docker.sock
-FROM golang:1.24
+FROM golang:1.23.8
 WORKDIR /app
 
 # From https://docs.docker.com/engine/install/debian/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'us-docker.pkg.dev/cloud-sdk-production-pipeline/test-cloud-sdk-production-pipeline/librarian', '.']
+
+images:
+  - 'us-docker.pkg.dev/cloud-sdk-production-pipeline/test-cloud-sdk-production-pipeline/librarian:latest'


### PR DESCRIPTION
note, the cloudbuild.yaml file is a placeholder for when we onboard to AR exit gates