### PR TITLE
feat: Make merge-release-pr a one-stop-merging-shop

### DIFF
--- a/internal/command/mergereleasepr.go
+++ b/internal/command/mergereleasepr.go
@@ -21,12 +21,22 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v69/github"
 	"github.com/googleapis/librarian/internal/githubrepo"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 )
+
+// The label used to avoid users merging the PR themselves.
+const DoNotMergeLabel = "do-not-merge"
+const DoNotMergeAppId = 91138
+const ConventionalCommitsAppId = 37172
+
+// The label used to indicate "I've noticed a problem with this PR; I won't check it again
+// until you've done something".
+const MergeBlockedLabel = "merge-blocked-see-comments"
 
 var CmdMergeReleasePR = &Command{
 	Name:  "merge-release-pr",
@@ -67,40 +77,198 @@ func mergeReleasePRImpl(ctx *CommandContext) error {
 		return err
 	}
 
-	pr, err := githubrepo.GetPullRequest(ctx.ctx, prRepo, prNumber)
+	prMetadata := githubrepo.PullRequestMetadata{Repo: prRepo, Number: prNumber}
+
+	if err := waitForPullRequestReadiness(ctx, prMetadata); err != nil {
+		return err
+	}
+
+	if err := mergePullRequest(ctx, prMetadata); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitForPullRequestReadiness(ctx *CommandContext, prMetadata githubrepo.PullRequestMetadata) error {
+	// TODO: time out here, or let Kokoro do so?
+	// TODO: make polling frequency configurable?
+
+	const pollDelaySeconds = 60
+	for {
+		ready, err := waitForPullRequestReadinessSingleIteration(ctx, prMetadata)
+		if ready || err != nil {
+			return err
+		}
+		slog.Info("Sleeping before next iteration")
+		time.Sleep(time.Duration(pollDelaySeconds) * time.Second)
+	}
+}
+
+// A single iteration of the loop in waitForPullRequestReadiness,
+// in a separate function to make it easy to indicate an "early out".
+// Returns true for "PR is ready to merge", false for "keep polling".
+// If this function returns false (with no error) the reason will have been logged.
+// Checks performed:
+// - The PR must not be merged
+// - The PR must not have the label with the name specified in MergeBlockedLabel
+// - The PR must have the label with the name specified in DoNotMergeLabel
+// - The PR must be mergeable
+// - All status checks must pass, other than conventional commits and the do-not-merge check
+// - All commits in the PR must contain Librarian-Release-Id (for this release), Librarian-Release-Library and Librarian-Release-Version metadata
+// - No commit in the PR must start its release notes with "FIXME"
+// - There must be no commits in the head of the repo which affect libraries released by the PR
+// - There must be at least one approving reviews from a member/owner of the repo, and no reviews from members/owners requesting changes
+func waitForPullRequestReadinessSingleIteration(ctx *CommandContext, prMetadata githubrepo.PullRequestMetadata) (bool, error) {
+	slog.Info("Checking pull request for readiness")
+	pr, err := githubrepo.GetPullRequest(ctx.ctx, prMetadata.Repo, prMetadata.Number)
+	if err != nil {
+		return false, err
+	}
+
+	// If the PR has been merged by someone else, abort this command. (We can skip this step in the flow, if we still want to release.)
+	if pr.GetMerged() {
+		return false, errors.New("pull request already merged")
+	}
+
+	// If we've already blocked this PR, and the user hasn't cleared the label yet, don't check anything else.
+	gotDoNotMergeLabel := false
+	for _, label := range pr.Labels {
+		if label.GetName() == MergeBlockedLabel {
+			slog.Info(fmt.Sprintf("PR still has '%s' label; skipping other checks", MergeBlockedLabel))
+			return false, nil
+		}
+		if label.GetName() == DoNotMergeLabel {
+			gotDoNotMergeLabel = true
+		}
+	}
+
+	// We expect to remove the do-not-merge label ourselves (and we'll fail otherwise).
+	if !gotDoNotMergeLabel {
+		return false, reportBlockingReason(ctx, prMetadata, fmt.Sprintf("Label '%s' has been removed already", DoNotMergeLabel))
+	}
+
+	// If the PR isn't mergeable, that requires user action.
+	if !pr.GetMergeable() {
+		// This will log the reason.
+		return false, reportBlockingReason(ctx, prMetadata, "PR is not mergeable (e.g. there are conflicting commit)")
+	}
+
+	// Check that all the statuses have passed.
+	checkRuns, err := githubrepo.GetPullRequestCheckRuns(ctx.ctx, pr)
+	if err != nil {
+		return false, err
+	}
+	for _, checkRun := range checkRuns {
+		// Skip the do-not-merge check and conventional commits checks
+		// (Once b/416489721 has been fixed, we can remove the conventional commits check)
+		if checkRun.GetApp().GetID() == DoNotMergeAppId || checkRun.GetApp().GetID() == ConventionalCommitsAppId {
+			continue
+		}
+
+		// For now, we assume that every other check must be complete and successful.
+		// We can't get at the required status checks with the current access token;
+		// we can rethink this if it turns out to be too conservative.
+		if checkRun.GetStatus() != "completed" {
+			slog.Info(fmt.Sprintf("Check '%s' is not complete", *checkRun.Name))
+			return false, nil
+		}
+		if checkRun.GetConclusion() != "success" {
+			return false, reportBlockingReason(ctx, prMetadata, fmt.Sprintf("Check '%s' failed", *checkRun.Name))
+		}
+	}
+
+	// Check the commits in the pull request. If this returns false,
+	// the reason will already be logged (so we don't need to log it again).
+	commitStatus, err := checkPullRequestCommits(ctx, prMetadata, pr)
+	if err != nil {
+		return false, err
+	}
+	if !commitStatus {
+		return false, err
+	}
+
+	// Check for approval
+	approved, err := checkPullRequestApproval(ctx, prMetadata)
+	if err != nil {
+		return false, err
+	}
+	if !approved {
+		slog.Info("PR not yet approved")
+		return false, nil
+	}
+
+	slog.Info("All checks passed, ready to merge.")
+	return true, nil
+}
+
+func mergePullRequest(ctx *CommandContext, prMetadata githubrepo.PullRequestMetadata) error {
+	slog.Info("Merging release PR")
+	if err := githubrepo.RemoveLabelFromPullRequest(ctx.ctx, prMetadata.Repo, prMetadata.Number, "do-not-merge"); err != nil {
+		return err
+	}
+	mergeResult, err := githubrepo.MergePullRequest(ctx.ctx, prMetadata.Repo, prMetadata.Number, github.MergeMethodRebase)
 	if err != nil {
 		return err
 	}
 
+	if err := appendResultEnvironmentVariable(ctx, mergedReleaseCommitEnvVarName, *mergeResult.SHA); err != nil {
+		return err
+	}
+	slog.Info("Release PR merged")
+	return nil
+}
+
+// For each commit in the pull request, check:
+// - We still have the Librarian metadata (release ID, library, version)
+// - None of the paths which affect the library have been modified since the base of the PR
+//
+// Returns true if all the commits are fine, or false if a problem was detected, in which
+// case it will have been reported on the PR, and the merge-blocking label applied.
+func checkPullRequestCommits(ctx *CommandContext, prMetadata githubrepo.PullRequestMetadata, pr *github.PullRequest) (bool, error) {
 	baseRepo := githubrepo.CreateGitHubRepoFromRepository(pr.Base.Repo)
 	baseHeadState, err := fetchRemotePipelineState(ctx.ctx, baseRepo, *pr.Base.Ref)
 	if err != nil {
-		return err
+		return false, err
 	}
 	baselineState, err := fetchRemotePipelineState(ctx.ctx, baseRepo, flagBaselineCommit)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	prCommits, err := githubrepo.GetDiffCommits(ctx.ctx, prRepo, flagBaselineCommit, *pr.Head.SHA)
+	prCommits, err := githubrepo.GetDiffCommits(ctx.ctx, prMetadata.Repo, flagBaselineCommit, *pr.Head.SHA)
 	if err != nil {
-		return err
+		return false, err
 	}
+
 	releases, err := parseRemoteCommitsForReleases(prCommits, flagReleaseID)
 	if err != nil {
-		return err
+		// This indicates that at least one commit is invalid - either it has missing
+		// metadata, or it's for the wrong release. Report that reason, then return
+		// a non-error from this function (we don't want to abort the process here).
+		if err := reportBlockingReason(ctx, prMetadata, err.Error()); err != nil {
+			return false, err
+		}
+
+		return false, nil
 	}
+
+	for _, release := range releases {
+		if strings.HasPrefix(release.ReleaseNotes, "FIXME") {
+			return false, reportBlockingReason(ctx, prMetadata, fmt.Sprintf("Release notes for '%s' need fixing", release.LibraryID))
+		}
+	}
+
 	// Fetch the commits in the base repo since the baseline commit, but then fetch each individually
 	// so we can tell which files were affected.
 	baseCommits, err := githubrepo.GetDiffCommits(ctx.ctx, baseRepo, flagBaselineCommit, *pr.Base.Ref)
 	if err != nil {
-		return err
+		return false, err
 	}
 	fullBaseCommits := []*github.RepositoryCommit{}
 	for _, baseCommit := range baseCommits {
 		fullCommit, err := githubrepo.GetCommit(ctx.ctx, baseRepo, *baseCommit.SHA)
 		if err != nil {
-			return err
+			return false, err
 		}
 		fullBaseCommits = append(fullBaseCommits, fullCommit)
 	}
@@ -115,38 +283,65 @@ func mergeReleasePRImpl(ctx *CommandContext) error {
 		}
 	}
 
-	if len(suspectReleases) > 0 {
-		// For clarity, we add warnings to both the PR and the log.
-		var builder strings.Builder
-		intro := "At least one library being released may have changed since release PR creation:"
-		builder.WriteString(intro + "\n\n")
-		slog.Warn(intro)
-		for _, suspectRelease := range suspectReleases {
-			line := fmt.Sprintf("%s: %s", suspectRelease.LibraryID, suspectRelease.Reason)
-			builder.WriteString(line + "\n")
-			slog.Warn(line)
-		}
-		description := builder.String()
-		if err := githubrepo.AddCommentToPullRequest(ctx.ctx, prRepo, prNumber, description); err != nil {
-			return err
-		}
-		return errors.New("did not merge release PR due to suspected-changed libraries")
-	} else {
-		slog.Info("No intervening commits detected; merging release PR")
-		if err := githubrepo.RemoveLabelFromPullRequest(ctx.ctx, prRepo, prNumber, "do-not-merge"); err != nil {
-			return err
-		}
-		mergeResult, err := githubrepo.MergePullRequest(ctx.ctx, prRepo, prNumber, github.MergeMethodRebase)
-		if err != nil {
-			return err
+	if len(suspectReleases) == 0 {
+		return true, nil
+	}
+
+	var builder strings.Builder
+	builder.WriteString("At least one library being released may have changed since release PR creation:\n\n")
+	for _, suspectRelease := range suspectReleases {
+		builder.WriteString(fmt.Sprintf("%s: %s\n", suspectRelease.LibraryID, suspectRelease.Reason))
+	}
+	return false, reportBlockingReason(ctx, prMetadata, builder.String())
+}
+
+// Checks that the pull request has at least one approved review, and no "changes requested" reviews.
+func checkPullRequestApproval(ctx *CommandContext, prMetadata githubrepo.PullRequestMetadata) (bool, error) {
+	reviews, err := githubrepo.GetPullRequestReviews(ctx.ctx, prMetadata)
+	if err != nil {
+		return false, err
+	}
+
+	// Collect all latest non-pending reviews from members/owners of the repository.
+	latestReviews := make(map[int64]*github.PullRequestReview)
+	for _, review := range reviews {
+		association := review.GetAuthorAssociation()
+		if association != "MEMBER" && association != "OWNER" {
+			continue
 		}
 
-		if err := appendResultEnvironmentVariable(ctx, mergedReleaseCommitEnvVarName, *mergeResult.SHA); err != nil {
-			return err
+		if review.GetState() == "PENDING" {
+			continue
 		}
-		slog.Info("Release PR merged")
-		return nil
+
+		userID := review.GetUser().GetID()
+		// Need to ensure review is the latest for the user
+		if current, exists := latestReviews[userID]; !exists || review.GetSubmittedAt().After(current.GetSubmittedAt().Time) {
+			latestReviews[userID] = review
+		}
 	}
+
+	approved := false
+	for _, review := range latestReviews {
+		if review.GetState() == "APPROVED" {
+			approved = true
+		} else if review.GetState() == "CHANGES_REQUESTED" {
+			return false, nil
+		}
+	}
+	return approved, nil
+}
+
+func reportBlockingReason(ctx *CommandContext, prMetadata githubrepo.PullRequestMetadata, description string) error {
+	slog.Warn(fmt.Sprintf("Adding '%s' label to PR and a comment with a description of '%s'", MergeBlockedLabel, description))
+	comment := fmt.Sprintf("%s\n\nAfter resolving the issue, please remove the '%s' label.", description, MergeBlockedLabel)
+	if err := githubrepo.AddCommentToPullRequest(ctx.ctx, prMetadata.Repo, prMetadata.Number, comment); err != nil {
+		return err
+	}
+	if err := githubrepo.AddLabelToPullRequest(ctx.ctx, prMetadata, MergeBlockedLabel); err != nil {
+		return err
+	}
+	return nil
 }
 
 func checkRelease(release LibraryRelease, baseHeadState, baselineState *statepb.PipelineState, baseCommits []*github.RepositoryCommit) *SuspectRelease {

--- a/internal/githubrepo/githubrepo.go
+++ b/internal/githubrepo/githubrepo.go
@@ -133,6 +133,25 @@ func GetPullRequest(ctx context.Context, repo GitHubRepo, prNumber int) (*github
 	return pr, err
 }
 
+func GetPullRequestCheckRuns(ctx context.Context, pullRequest *github.PullRequest) ([]*github.CheckRun, error) {
+	gitHubClient := createClient()
+	prHead := pullRequest.Head
+	options := &github.ListCheckRunsOptions{}
+	checkRuns, _, err := gitHubClient.Checks.ListCheckRunsForRef(ctx, *prHead.User.Login, *prHead.Repo.Name, *prHead.Ref, options)
+	if checkRuns == nil {
+		return nil, err
+	}
+	return checkRuns.CheckRuns, err
+}
+
+func GetPullRequestReviews(ctx context.Context, prMetadata PullRequestMetadata) ([]*github.PullRequestReview, error) {
+	gitHubClient := createClient()
+	// TODO: Implement pagination or use go-github-paginate
+	listOptions := &github.ListOptions{PerPage: 100}
+	reviews, _, err := gitHubClient.PullRequests.ListReviews(ctx, prMetadata.Repo.Owner, prMetadata.Repo.Name, prMetadata.Number, listOptions)
+	return reviews, err
+}
+
 // Parses a GitHub URL (anything to do with a repository) to determine
 // the GitHub repo details (owner and name)
 func ParseUrl(remoteUrl string) (GitHubRepo, error) {


### PR DESCRIPTION
This now polls (once per minute) for all the conditions we want to enforce until it's ready to merge, then merges. See the comment on waitForPullRequestReadinessSingleIteration for details of the conditions that are enforced.