### PR TITLE
feat: Improve PR and commit messages

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -279,7 +279,7 @@ func savePipelineState(ctx *CommandContext) error {
 }
 
 func formatTimestamp(t time.Time) string {
-	const yyyyMMddHHmmss = "20060102T150405" // Expected format by time library
+	const yyyyMMddHHmmss = "20060102T150405Z" // Expected format by time library
 	return t.Format(yyyyMMddHHmmss)
 }
 

--- a/internal/command/configure.go
+++ b/internal/command/configure.go
@@ -88,7 +88,7 @@ var CmdConfigure = &Command{
 			}
 		}
 
-		_, err = createPullRequest(ctx, &prContent, "feat: API configuration", "config")
+		_, err = createPullRequest(ctx, &prContent, "feat: API configuration", "", "config")
 		return err
 	},
 }

--- a/internal/command/createreleaseartifacts.go
+++ b/internal/command/createreleaseartifacts.go
@@ -136,7 +136,7 @@ func parseCommitMessageForRelease(message, hash string) (*LibraryRelease, error)
 	// Remove the expected "title and blank line" (as we'll have a release title).
 	// We're fairly conservative about this - if the commit message has been manually
 	// changed, we'll leave it as it is.
-	if len(messageLines) > 0 && strings.HasPrefix(messageLines[0], "Release library:") {
+	if len(messageLines) > 0 && strings.HasPrefix(messageLines[0], "chore: Release library ") {
 		messageLines = messageLines[1:]
 		if len(messageLines) > 0 && messageLines[0] == "" {
 			messageLines = messageLines[1:]

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -97,7 +97,7 @@ var CmdCreateReleasePR = &Command{
 			return err
 		}
 
-		prMetadata, err := createPullRequest(ctx, prContent, "chore: Library release", "release")
+		prMetadata, err := createPullRequest(ctx, prContent, "chore: Library release", fmt.Sprintf("Librarian-Release-ID: %s", releaseID), "release")
 		if err != nil {
 			return err
 		}
@@ -106,7 +106,7 @@ var CmdCreateReleasePR = &Command{
 		// with no PR: we may have finished with no changes, or we may not be pushing.)
 		if prMetadata != nil {
 			// We always add the do-not-merge label so that Librarian can merge later.
-			err = githubrepo.AddLabelToPullRequest(ctx.ctx, *prMetadata, "do-not-merge")
+			err = githubrepo.AddLabelToPullRequest(ctx.ctx, *prMetadata, DoNotMergeLabel)
 			if err != nil {
 				slog.Warn(fmt.Sprintf("Received error trying to add label to PR: '%s'", err))
 				return err
@@ -210,7 +210,7 @@ func generateReleaseCommitForEachLibrary(ctx *CommandContext, inputDirectory str
 			return nil, err
 		}
 
-		releaseDescription := fmt.Sprintf("Release library: %s version %s", library.Id, releaseVersion)
+		releaseDescription := fmt.Sprintf("chore: Release library %s version %s", library.Id, releaseVersion)
 		addSuccessToPullRequest(pr, releaseDescription)
 		// Metadata for easy extraction later.
 		metadata := fmt.Sprintf("Librarian-Release-Library: %s\nLibrarian-Release-Version: %s\nLibrarian-Release-ID: %s", library.Id, releaseVersion, releaseID)

--- a/internal/command/updateapis.go
+++ b/internal/command/updateapis.go
@@ -104,7 +104,7 @@ var CmdUpdateApis = &Command{
 		if cleanWorkingTreePostGeneration {
 			gitrepo.CleanWorkingTree(apiRepo)
 		}
-		_, err := createPullRequest(ctx, prContent, "feat: API regeneration", "regen")
+		_, err := createPullRequest(ctx, prContent, "feat: API regeneration", "", "regen")
 		return err
 	},
 }

--- a/internal/command/updateimagetag.go
+++ b/internal/command/updateimagetag.go
@@ -126,7 +126,7 @@ var CmdUpdateImageTag = &Command{
 		// can massage it into a similar state.
 		prContent := new(PullRequestContent)
 		addSuccessToPullRequest(prContent, "Regenerated all libraries with new image tag.")
-		_, err := createPullRequest(ctx, prContent, "chore: update generation image tag", "update-image-tag")
+		_, err := createPullRequest(ctx, prContent, "chore: update generation image tag", "", "update-image-tag")
 		return err
 	},
 }


### PR DESCRIPTION
- Use Markdown lists to represent items in PRs
- Add the Release-ID to release PR descriptions
- Format timestamps with a trailing Z for UTC
- Use conventional commit messages for release commits