### PR TITLE
feat: add cloudbuild config for publishing image via AR Exit Gate

### DIFF
--- a/cloudbuild-exitgate.yaml
+++ b/cloudbuild-exitgate.yaml
@@ -1,0 +1,6 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian', '.']
+
+images:
+  - 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian'


### PR DESCRIPTION
The new file cloudbuild-exitgate.yaml is based on cloudbuild.yaml. The difference is that the new file points to images-dev repo