### PR TITLE
fix: Handle release PRs being rebased

### DIFF
--- a/internal/command/mergereleasepr.go
+++ b/internal/command/mergereleasepr.go
@@ -309,7 +309,10 @@ func checkPullRequestCommits(ctx *CommandContext, prMetadata githubrepo.PullRequ
 		return false, err
 	}
 
-	prCommits, err := githubrepo.GetDiffCommits(ctx.ctx, prMetadata.Repo, flagBaselineCommit, *pr.Head.SHA)
+	// Fetch the commits which are in the PR, compared with the base (the target of the merge).
+	// In most cases pr.Base.SHA will be the same as flagBaselineCommit, but the PR may have been rebased -
+	// and we always only want the commits in the PR, not any that it's been rebased on top of.
+	prCommits, err := githubrepo.GetDiffCommits(ctx.ctx, prMetadata.Repo, *pr.Base.SHA, *pr.Head.SHA)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Previously, this would have failed as there would be commits without the release ID in the set of commits being checked.

Fixes b/418769658.