### PR TITLE
feat: Overhaul how pipeline state and config are loaded

### DIFF
--- a/internal/command/configure.go
+++ b/internal/command/configure.go
@@ -47,7 +47,8 @@ var CmdConfigure = &Command{
 		addFlagRepoUrl,
 		addFlagSecretsProject,
 	},
-	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
+	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
+	maybeLoadStateAndConfig: loadRepoStateAndConfig,
 	execute: func(ctx *CommandContext) error {
 		if err := validatePush(); err != nil {
 			return err
@@ -230,7 +231,7 @@ func configureApi(ctx *CommandContext, outputRoot, apiRoot, apiPath string, prCo
 	}
 
 	// Reload (and then resave, to reformat) the state, so we can find the newly-configured library
-	state, err := loadPipelineState(languageRepo)
+	state, err := loadRepoPipelineState(languageRepo)
 	if err != nil {
 		return err
 	}

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -54,7 +54,8 @@ var CmdCreateReleasePR = &Command{
 		addFlagEnvFile,
 		addFlagRepoUrl,
 	},
-	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
+	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
+	maybeLoadStateAndConfig: loadRepoStateAndConfig,
 	execute: func(ctx *CommandContext) error {
 		if err := validateSkipIntegrationTests(); err != nil {
 			return err

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -15,6 +15,8 @@
 package command
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -24,6 +26,7 @@ import (
 	"github.com/googleapis/librarian/internal/container"
 	"github.com/googleapis/librarian/internal/githubrepo"
 	"github.com/googleapis/librarian/internal/gitrepo"
+	"github.com/googleapis/librarian/internal/statepb"
 )
 
 var CmdGenerate = &Command{
@@ -36,13 +39,16 @@ var CmdGenerate = &Command{
 		addFlagAPIRoot,
 		addFlagLanguage,
 		addFlagBuild,
+		addFlagRepoRoot,
 		addFlagRepoUrl,
 		addFlagSecretsProject,
 	},
 	// By default don't clone a language repo, we will clone later only if library exists in language repo.
-	maybeGetLanguageRepo: func(workRoot string) (*gitrepo.Repo, error) {
-		return nil, nil
-	},
+	maybeGetLanguageRepo: openOrCloneLanguageRepoIfLibraryExists,
+	// Currently, we don't load any repo state and config in the initial path.
+	// We should do so by moving the clone part to maybeGetLanguageRepo - because then we'll be set up
+	// with the right image etc.
+	maybeLoadStateAndConfig: loadRepoStateAndConfig,
 	execute: func(ctx *CommandContext) error {
 		if err := validateRequiredFlag("api-path", flagAPIPath); err != nil {
 			return err
@@ -88,50 +94,66 @@ var CmdGenerate = &Command{
 // If refined generation is used, the context's languageRepo field will be populated and the
 // library ID will be returned; otherwise, an empty string will be returned.
 func runGenerateCommand(ctx *CommandContext, outputDir string) (string, error) {
-	libraryID, err := checkIfLibraryExistsInLanguageRepo(ctx)
-	if err != nil {
-		return "", err
-	}
 	apiRoot, err := filepath.Abs(flagAPIRoot)
 	if err != nil {
 		return "", err
 	}
-	if libraryID != "" {
-		ctx.languageRepo, err = cloneOrOpenLanguageRepo(ctx.workRoot)
-		if err != nil {
-			slog.Warn("Unable to checkout language repo ", "error", err)
-			return "", err
+
+	// If we've got a language repo, it's because we've already found a library for the
+	// specified API, configured in the repo.
+	if ctx.languageRepo != nil {
+		libraryID := findLibraryIDByApiPath(ctx.pipelineState, flagAPIPath)
+		if libraryID == "" {
+			return "", errors.New("bug in Librarian: Library not found during generation, despite being found in earlier steps")
 		}
 		generatorInput := filepath.Join(ctx.languageRepo.Dir, "generator-input")
-		slog.Info("Performing refined generation for library ID", "libraryID", libraryID)
+		slog.Info(fmt.Sprintf("Performing refined generation for library %s", libraryID))
 		return libraryID, container.GenerateLibrary(ctx.containerConfig, apiRoot, outputDir, generatorInput, libraryID)
 	} else {
-		slog.Info("No matching library found performing raw generation", "flagAPIPath", flagAPIPath)
+		slog.Info(fmt.Sprintf("No matching library found (or no repo specified); performing raw generation for %s", flagAPIPath))
 		return "", container.GenerateRaw(ctx.containerConfig, apiRoot, outputDir, flagAPIPath)
 	}
 }
 
-// Checks if the library with the given API path exists in the remote pipeline state
-// If library exists, returns the library ID, otherwise returns an empty string
-func checkIfLibraryExistsInLanguageRepo(ctx *CommandContext) (string, error) {
-	if flagRepoUrl == "" {
-		slog.Warn("repo url is not specified, cannot check if library exists")
-		return "", nil
+// Checks if the library with the given API path exists in the repo specified either
+// by a URL or a local path, and opens or clones it if so.
+func openOrCloneLanguageRepoIfLibraryExists(workRoot string) (*gitrepo.Repo, error) {
+	if flagRepoUrl == "" && flagRepoRoot == "" {
+		slog.Warn("repo url and root are not specified, cannot check if library exists")
+		return nil, nil
 	}
-	languageRepoMetadata, err := githubrepo.ParseUrl(flagRepoUrl)
-	if err != nil {
-		slog.Warn("failed to parse", "repo url:", flagRepoUrl, "error", err)
-		return "", err
+
+	if flagRepoRoot != "" && flagRepoUrl != "" {
+		return nil, errors.New("do not specify both repo-root and repo-url")
 	}
-	pipelineState, err := fetchRemotePipelineState(ctx.ctx, languageRepoMetadata, "HEAD")
-	if err != nil {
-		slog.Warn("failed to get pipeline state file", "error", err)
-		return "", err
-	}
-	if pipelineState != nil {
-		return findLibraryIDByApiPath(pipelineState, flagAPIPath), nil
+
+	// Attempt to load the pipeline state either locally or from the repo URL
+	var pipelineState *statepb.PipelineState
+	var err error
+	if flagRepoRoot != "" {
+		pipelineState, err = loadPipelineStateFile(filepath.Join(flagRepoRoot, "generator-input", pipelineStateFile))
 	} else {
-		slog.Warn("Pipeline state file is null")
+		var languageRepoMetadata githubrepo.GitHubRepo
+		languageRepoMetadata, err = githubrepo.ParseUrl(flagRepoUrl)
+		if err != nil {
+			slog.Warn("failed to parse", "repo url:", flagRepoUrl, "error", err)
+			return nil, err
+		}
+		pipelineState, err = fetchRemotePipelineState(context.Background(), languageRepoMetadata, "HEAD")
 	}
-	return "", nil
+
+	if err != nil {
+		return nil, err
+	}
+
+	// If the library doesn't exist, we don't use the repo at all.
+	libraryID := findLibraryIDByApiPath(pipelineState, flagAPIPath)
+	if libraryID == "" {
+		slog.Info(fmt.Sprintf("API path %s not configured in repo", flagAPIPath))
+		return nil, nil
+	}
+
+	slog.Info(fmt.Sprintf("API path %s configured in repo library %s", flagAPIPath, libraryID))
+	// Otherwise (if the library *does* exist), clone or open it as normal.
+	return cloneOrOpenLanguageRepo(workRoot)
 }

--- a/internal/command/mergereleasepr.go
+++ b/internal/command/mergereleasepr.go
@@ -61,6 +61,9 @@ var CmdMergeReleasePR = &Command{
 	maybeGetLanguageRepo: func(workRoot string) (*gitrepo.Repo, error) {
 		return nil, nil
 	},
+	maybeLoadStateAndConfig: func(languageRepo *gitrepo.Repo) (*statepb.PipelineState, *statepb.PipelineConfig, error) {
+		return nil, nil, nil
+	},
 	execute: mergeReleasePRImpl,
 }
 

--- a/internal/command/stateandconfig.go
+++ b/internal/command/stateandconfig.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/gitrepo"
+	"github.com/googleapis/librarian/internal/statepb"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const pipelineStateFile = "pipeline-state.json"
+const pipelineConfigFile = "pipeline-config.json"
+
+// Utility functions for saving and loading pipeline state and config from various places.
+
+func loadRepoStateAndConfig(languageRepo *gitrepo.Repo) (*statepb.PipelineState, *statepb.PipelineConfig, error) {
+	if languageRepo == nil {
+		return nil, nil, nil
+	}
+	state, err := loadRepoPipelineState(languageRepo)
+	if err != nil {
+		return nil, nil, err
+	}
+	config, err := loadRepoPipelineConfig(languageRepo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return state, config, nil
+}
+
+func loadRepoPipelineState(languageRepo *gitrepo.Repo) (*statepb.PipelineState, error) {
+	path := filepath.Join(languageRepo.Dir, "generator-input", pipelineStateFile)
+	return loadPipelineStateFile(path)
+}
+
+func loadPipelineStateFile(path string) (*statepb.PipelineState, error) {
+	return parsePipelineState(func() ([]byte, error) { return os.ReadFile(path) })
+}
+
+func loadRepoPipelineConfig(languageRepo *gitrepo.Repo) (*statepb.PipelineConfig, error) {
+	path := filepath.Join(languageRepo.Dir, "generator-input", "pipeline-config.json")
+	return loadPipelineConfigFile(path)
+}
+
+func loadPipelineConfigFile(path string) (*statepb.PipelineConfig, error) {
+	return parsePipelineConfig(func() ([]byte, error) { return os.ReadFile(path) })
+}
+
+func savePipelineState(ctx *CommandContext) error {
+	path := filepath.Join(ctx.languageRepo.Dir, "generator-input", pipelineStateFile)
+	// Marshal the protobuf message as JSON...
+	unformatted, err := protojson.Marshal(ctx.pipelineState)
+	if err != nil {
+		return err
+	}
+	// ... then reformat it
+	var formatted bytes.Buffer
+	err = json.Indent(&formatted, unformatted, "", "    ")
+	if err != nil {
+		return err
+	}
+	// The file mode is likely to be irrelevant, given that the permissions aren't changed
+	// if the file exists, which we expect it to anyway.
+	err = os.WriteFile(path, formatted.Bytes(), os.FileMode(0644))
+	return err
+}
+
+func fetchRemotePipelineState(ctx context.Context, repo githubrepo.GitHubRepo, ref string) (*statepb.PipelineState, error) {
+	return parsePipelineState(func() ([]byte, error) {
+		return githubrepo.GetRawContent(ctx, repo, "generator-input/"+pipelineStateFile, ref)
+	})
+}
+
+func parsePipelineState(contentLoader func() ([]byte, error)) (*statepb.PipelineState, error) {
+	bytes, err := contentLoader()
+	if err != nil {
+		return nil, err
+	}
+	state := &statepb.PipelineState{}
+	if err := protojson.Unmarshal(bytes, state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func parsePipelineConfig(contentLoader func() ([]byte, error)) (*statepb.PipelineConfig, error) {
+	bytes, err := contentLoader()
+	if err != nil {
+		return nil, err
+	}
+	config := &statepb.PipelineConfig{}
+	if err := protojson.Unmarshal(bytes, config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/internal/command/updateapis.go
+++ b/internal/command/updateapis.go
@@ -45,7 +45,8 @@ var CmdUpdateApis = &Command{
 		addFlagRepoUrl,
 		addFlagSecretsProject,
 	},
-	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
+	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
+	maybeLoadStateAndConfig: loadRepoStateAndConfig,
 	execute: func(ctx *CommandContext) error {
 		if err := validatePush(); err != nil {
 			return err

--- a/internal/command/updateimagetag.go
+++ b/internal/command/updateimagetag.go
@@ -43,7 +43,8 @@ var CmdUpdateImageTag = &Command{
 		addFlagSecretsProject,
 		addFlagTag,
 	},
-	maybeGetLanguageRepo: cloneOrOpenLanguageRepo,
+	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
+	maybeLoadStateAndConfig: loadRepoStateAndConfig,
 	execute: func(ctx *CommandContext) error {
 		if err := validatePush(); err != nil {
 			return err

--- a/internal/utils/fileutils.go
+++ b/internal/utils/fileutils.go
@@ -61,6 +61,14 @@ func CreateAndWriteBytesToFile(filePath string, content []byte) error {
 	return writeBytesToFile(*file, content)
 }
 
+func CopyFile(sourcePath, destPath string) error {
+	bytes, err := ReadAllBytesFromFile(sourcePath)
+	if err != nil {
+		return err
+	}
+	return CreateAndWriteBytesToFile(destPath, bytes)
+}
+
 func writeContentToFile(file os.File, content string) error {
 	_, err := file.WriteString(content)
 	if err != nil {


### PR DESCRIPTION
This introduces an extra bit of configurability for commands: once they've opened/cloned/ignored the language repo, RunCommand asks them to (maybe) load pipeline state and config from wherever they wish to. This is then used to work out which image to use, and configuration for container commands.

Most commands do this from the language repo they've just cloned/opened, but publish-release-artifacts does it from files under the "artifact root" passed in on the command line. (These are now copied during create-release-artifacts.) This fixes b/416449513

Additionally, the generate command now determines whether to use a local repo or a clone very early on - which means its pipeline state and config can be used accordingly.

The implementation of this required some more code to load/save the files, so that's now in a separate Go source file (stateandconfig.go).