### PR TITLE
impl(internal/command): remove validate language

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -132,11 +132,6 @@ func cloneOrOpenLanguageRepo(workRoot string) (*gitrepo.Repo, error) {
 }
 
 func RunCommand(c *Command, ctx context.Context) error {
-	if c.flags.Lookup("language") != nil {
-		if err := validateLanguage(); err != nil {
-			return err
-		}
-	}
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime)
 	if err != nil {

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -149,29 +149,9 @@ func addFlagWorkRoot(fs *flag.FlagSet) {
 	fs.StringVar(&flagWorkRoot, "work-root", "", "Working directory root. When this is not specified, a working directory will be created in /tmp.")
 }
 
-var supportedLanguages = map[string]bool{
-	"cpp":    false,
-	"dotnet": true,
-	"go":     false,
-	"java":   false,
-	"node":   false,
-	"php":    false,
-	"python": false,
-	"ruby":   false,
-	"rust":   false,
-	"all":    false,
-}
-
 func validatePush() error {
 	if flagPush && githubrepo.GetAccessToken() == "" {
 		return errors.New("no GitHub token supplied for push")
-	}
-	return nil
-}
-
-func validateLanguage() error {
-	if !supportedLanguages[flagLanguage] {
-		return fmt.Errorf("invalid -language flag specified: %q", flagLanguage)
 	}
 	return nil
 }


### PR DESCRIPTION
At the moment having this validation step is an impedence to onboarding new languages. Remove the validation, until we see a reason to add it back.