### PR TITLE
 impl(internal/command): rename CommandContext to commandState 

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -51,7 +51,7 @@ type Command struct {
 	maybeLoadStateAndConfig func(languageRepo *gitrepo.Repo) (*statepb.PipelineState, *statepb.PipelineConfig, error)
 
 	// execute runs the command's with the provided context.
-	execute func(*CommandContext) error
+	execute func(*commandState) error
 
 	// flagFunctions are functions to initialize the command's flag set.
 	flagFunctions []func(fs *flag.FlagSet)
@@ -61,8 +61,8 @@ type Command struct {
 	flags *flag.FlagSet
 }
 
-// CommandContext holds all necessary information for a command execution.
-type CommandContext struct {
+// commandState holds all necessary information for a command execution.
+type commandState struct {
 	// ctx provides context for cancellable operations.
 	ctx context.Context
 
@@ -171,7 +171,7 @@ func RunCommand(c *Command, ctx context.Context) error {
 		return err
 	}
 
-	cmdContext := &CommandContext{
+	cmdContext := &commandState{
 		ctx:             ctx,
 		startTime:       startTime,
 		workRoot:        workRoot,
@@ -183,7 +183,7 @@ func RunCommand(c *Command, ctx context.Context) error {
 	return c.execute(cmdContext)
 }
 
-func appendResultEnvironmentVariable(ctx *CommandContext, name, value string) error {
+func appendResultEnvironmentVariable(ctx *commandState, name, value string) error {
 	envFile := flagEnvFile
 	if envFile == "" {
 		envFile = filepath.Join(ctx.workRoot, "env-vars.txt")

--- a/internal/command/configure.go
+++ b/internal/command/configure.go
@@ -49,7 +49,7 @@ var CmdConfigure = &Command{
 	},
 	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
 	maybeLoadStateAndConfig: loadRepoStateAndConfig,
-	execute: func(ctx *CommandContext) error {
+	execute: func(ctx *commandState) error {
 		if err := validatePush(); err != nil {
 			return err
 		}
@@ -215,7 +215,7 @@ func shouldBeGenerated(serviceYamlPath, languageSettingsName string) (bool, erro
 //
 // This function only returns an error in the case of non-container failures, which are expected to be fatal.
 // If the function returns a non-error, the repo will be clean when the function returns (so can be used for the next step)
-func configureApi(ctx *CommandContext, outputRoot, apiRoot, apiPath string, prContent *PullRequestContent) error {
+func configureApi(ctx *commandState, outputRoot, apiRoot, apiPath string, prContent *PullRequestContent) error {
 	containerConfig := ctx.containerConfig
 	languageRepo := ctx.languageRepo
 

--- a/internal/command/createreleaseartifacts.go
+++ b/internal/command/createreleaseartifacts.go
@@ -54,7 +54,7 @@ var CmdCreateReleaseArtifacts = &Command{
 	execute:                 createReleaseArtifactsImpl,
 }
 
-func createReleaseArtifactsImpl(ctx *CommandContext) error {
+func createReleaseArtifactsImpl(ctx *commandState) error {
 	if err := validateSkipIntegrationTests(); err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func createReleaseArtifactsImpl(ctx *CommandContext) error {
 // - (Just in case) The pipeline state
 // The pipeline config and state files are copied by checking out the commit of the last
 // release, which should effectively be the tip of the release PR.
-func copyMetadataFiles(ctx *CommandContext, outputRoot string, releases []LibraryRelease) error {
+func copyMetadataFiles(ctx *commandState, outputRoot string, releases []LibraryRelease) error {
 	releasesJson, err := json.Marshal(releases)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func copyMetadataFiles(ctx *CommandContext, outputRoot string, releases []Librar
 	return nil
 }
 
-func buildTestPackageRelease(ctx *CommandContext, outputRoot string, release LibraryRelease) error {
+func buildTestPackageRelease(ctx *commandState, outputRoot string, release LibraryRelease) error {
 	containerConfig := ctx.containerConfig
 	languageRepo := ctx.languageRepo
 

--- a/internal/command/createreleasepr.go
+++ b/internal/command/createreleasepr.go
@@ -56,7 +56,7 @@ var CmdCreateReleasePR = &Command{
 	},
 	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
 	maybeLoadStateAndConfig: loadRepoStateAndConfig,
-	execute: func(ctx *CommandContext) error {
+	execute: func(ctx *commandState) error {
 		if err := validateSkipIntegrationTests(); err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ var CmdCreateReleasePR = &Command{
 //   - Library-level errors do not halt the process, but are reported in the resulting PR (if any).
 //     This can include tags being missing, release preparation failing, or the build failing.
 //   - More fundamental errors (e.g. a failure to commit, or to save pipeline state) abort the whole process immediately.
-func generateReleaseCommitForEachLibrary(ctx *CommandContext, inputDirectory string, releaseID string) (*PullRequestContent, error) {
+func generateReleaseCommitForEachLibrary(ctx *commandState, inputDirectory string, releaseID string) (*PullRequestContent, error) {
 	containerConfig := ctx.containerConfig
 	libraries := ctx.pipelineState.Libraries
 	languageRepo := ctx.languageRepo

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -49,7 +49,7 @@ var CmdGenerate = &Command{
 	// We should do so by moving the clone part to maybeGetLanguageRepo - because then we'll be set up
 	// with the right image etc.
 	maybeLoadStateAndConfig: loadRepoStateAndConfig,
-	execute: func(ctx *CommandContext) error {
+	execute: func(ctx *commandState) error {
 		if err := validateRequiredFlag("api-path", flagAPIPath); err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ var CmdGenerate = &Command{
 // and log the error.
 // If refined generation is used, the context's languageRepo field will be populated and the
 // library ID will be returned; otherwise, an empty string will be returned.
-func runGenerateCommand(ctx *CommandContext, outputDir string) (string, error) {
+func runGenerateCommand(ctx *commandState, outputDir string) (string, error) {
 	apiRoot, err := filepath.Abs(flagAPIRoot)
 	if err != nil {
 		return "", err

--- a/internal/command/publishreleaseartifacts.go
+++ b/internal/command/publishreleaseartifacts.go
@@ -59,7 +59,7 @@ var CmdPublishReleaseArtifacts = &Command{
 	execute: publishReleaseArtifactsImpl,
 }
 
-func publishReleaseArtifactsImpl(ctx *CommandContext) error {
+func publishReleaseArtifactsImpl(ctx *commandState) error {
 	if err := validateRequiredFlag("artifact-root", flagArtifactRoot); err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func publishPackages(config *container.ContainerConfig, outputRoot string, relea
 	return nil
 }
 
-func createRepoReleases(ctx *CommandContext, releases []LibraryRelease, gitHubRepo githubrepo.GitHubRepo) error {
+func createRepoReleases(ctx *commandState, releases []LibraryRelease, gitHubRepo githubrepo.GitHubRepo) error {
 	for _, release := range releases {
 		tag := formatReleaseTag(release.LibraryID, release.Version)
 		title := fmt.Sprintf("%s version %s", release.LibraryID, release.Version)

--- a/internal/command/pullrequest.go
+++ b/internal/command/pullrequest.go
@@ -57,7 +57,7 @@ func addSuccessToPullRequest(pr *PullRequestContent, text string) {
 // If content only contains errors, the pull request is not created and an error is returned (to highlight that everything failed)
 // If content contains any successes, a pull request is created and no error is returned (if the creation is successful) even if the content includes errors.
 // If the pull request would contain an excessive number of commits (as configured in pipeline-config.json)
-func createPullRequest(ctx *CommandContext, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string) (*githubrepo.PullRequestMetadata, error) {
+func createPullRequest(ctx *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string) (*githubrepo.PullRequestMetadata, error) {
 	anySuccesses := len(content.Successes) > 0
 	anyErrors := len(content.Errors) > 0
 	languageRepo := ctx.languageRepo

--- a/internal/command/stateandconfig.go
+++ b/internal/command/stateandconfig.go
@@ -65,7 +65,7 @@ func loadPipelineConfigFile(path string) (*statepb.PipelineConfig, error) {
 	return parsePipelineConfig(func() ([]byte, error) { return os.ReadFile(path) })
 }
 
-func savePipelineState(ctx *CommandContext) error {
+func savePipelineState(ctx *commandState) error {
 	path := filepath.Join(ctx.languageRepo.Dir, "generator-input", pipelineStateFile)
 	// Marshal the protobuf message as JSON...
 	unformatted, err := protojson.Marshal(ctx.pipelineState)

--- a/internal/command/updateapis.go
+++ b/internal/command/updateapis.go
@@ -47,7 +47,7 @@ var CmdUpdateApis = &Command{
 	},
 	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
 	maybeLoadStateAndConfig: loadRepoStateAndConfig,
-	execute: func(ctx *CommandContext) error {
+	execute: func(ctx *commandState) error {
 		if err := validatePush(); err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ var CmdUpdateApis = &Command{
 	},
 }
 
-func updateLibrary(ctx *CommandContext, apiRepo *gitrepo.Repo, outputRoot string, library *statepb.LibraryState, prContent *PullRequestContent) error {
+func updateLibrary(ctx *commandState, apiRepo *gitrepo.Repo, outputRoot string, library *statepb.LibraryState, prContent *PullRequestContent) error {
 	containerConfig := ctx.containerConfig
 	languageRepo := ctx.languageRepo
 

--- a/internal/command/updateimagetag.go
+++ b/internal/command/updateimagetag.go
@@ -45,7 +45,7 @@ var CmdUpdateImageTag = &Command{
 	},
 	maybeGetLanguageRepo:    cloneOrOpenLanguageRepo,
 	maybeLoadStateAndConfig: loadRepoStateAndConfig,
-	execute: func(ctx *CommandContext) error {
+	execute: func(ctx *commandState) error {
 		if err := validatePush(); err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ var CmdUpdateImageTag = &Command{
 	},
 }
 
-func regenerateLibrary(ctx *CommandContext, apiRepo *gitrepo.Repo, generatorInput string, outputRoot string, library *statepb.LibraryState) error {
+func regenerateLibrary(ctx *commandState, apiRepo *gitrepo.Repo, generatorInput string, outputRoot string, library *statepb.LibraryState) error {
 	containerConfig := ctx.containerConfig
 	languageRepo := ctx.languageRepo
 


### PR DESCRIPTION
The term context has a specific connotation in Go. See
https://go.dev/blog/context-and-structs.

CommandContext does not fit this definition, and using the variable
`ctx` in reference the variable makes it easy to confuse the two
concepts. Rename CommandContext to commandState, and unexport it, since
the struct contains only unexported fields and is not used outside the
package.

Use of the variable `ctx` to reference `commandState` exists throughout the
codebase, and will be fixed throughout upcoming PRs.