### PR TITLE
impl(internal/command): rename ctx to state

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -183,10 +183,10 @@ func RunCommand(c *Command, ctx context.Context) error {
 	return c.execute(cmdContext)
 }
 
-func appendResultEnvironmentVariable(ctx *commandState, name, value string) error {
+func appendResultEnvironmentVariable(state *commandState, name, value string) error {
 	envFile := flagEnvFile
 	if envFile == "" {
-		envFile = filepath.Join(ctx.workRoot, "env-vars.txt")
+		envFile = filepath.Join(state.workRoot, "env-vars.txt")
 	}
 
 	return utils.AppendToFile(envFile, fmt.Sprintf("%s=%s\n", name, value))

--- a/internal/command/publishreleaseartifacts.go
+++ b/internal/command/publishreleaseartifacts.go
@@ -59,7 +59,7 @@ var CmdPublishReleaseArtifacts = &Command{
 	execute: publishReleaseArtifactsImpl,
 }
 
-func publishReleaseArtifactsImpl(ctx *commandState) error {
+func publishReleaseArtifactsImpl(state *commandState) error {
 	if err := validateRequiredFlag("artifact-root", flagArtifactRoot); err != nil {
 		return err
 	}
@@ -89,10 +89,10 @@ func publishReleaseArtifactsImpl(ctx *commandState) error {
 	}
 	slog.Info(fmt.Sprintf("Publishing packages for %d libraries", len(releases)))
 
-	if err := publishPackages(ctx.containerConfig, flagArtifactRoot, releases); err != nil {
+	if err := publishPackages(state.containerConfig, flagArtifactRoot, releases); err != nil {
 		return err
 	}
-	if err := createRepoReleases(ctx, releases, gitHubRepo); err != nil {
+	if err := createRepoReleases(state, releases, gitHubRepo); err != nil {
 		return err
 	}
 	slog.Info("Release complete.")
@@ -111,12 +111,12 @@ func publishPackages(config *container.ContainerConfig, outputRoot string, relea
 	return nil
 }
 
-func createRepoReleases(ctx *commandState, releases []LibraryRelease, gitHubRepo githubrepo.GitHubRepo) error {
+func createRepoReleases(state *commandState, releases []LibraryRelease, gitHubRepo githubrepo.GitHubRepo) error {
 	for _, release := range releases {
 		tag := formatReleaseTag(release.LibraryID, release.Version)
 		title := fmt.Sprintf("%s version %s", release.LibraryID, release.Version)
 		prerelease := strings.HasPrefix(release.Version, "0.") || strings.Contains(release.Version, "-")
-		repoRelease, err := githubrepo.CreateRelease(ctx.ctx, gitHubRepo, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
+		repoRelease, err := githubrepo.CreateRelease(state.ctx, gitHubRepo, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
 		if err != nil {
 			return err
 		}

--- a/internal/command/stateandconfig.go
+++ b/internal/command/stateandconfig.go
@@ -65,10 +65,10 @@ func loadPipelineConfigFile(path string) (*statepb.PipelineConfig, error) {
 	return parsePipelineConfig(func() ([]byte, error) { return os.ReadFile(path) })
 }
 
-func savePipelineState(ctx *commandState) error {
-	path := filepath.Join(ctx.languageRepo.Dir, "generator-input", pipelineStateFile)
+func savePipelineState(state *commandState) error {
+	path := filepath.Join(state.languageRepo.Dir, "generator-input", pipelineStateFile)
 	// Marshal the protobuf message as JSON...
-	unformatted, err := protojson.Marshal(ctx.pipelineState)
+	unformatted, err := protojson.Marshal(state.pipelineState)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The term context and the variable ctx has a specific connotation in Go. See https://go.dev/blog/context-and-structs. Rename references to ctx to state.

Fixes #189