### PR TITLE
impl(all_test): use latest version of tools

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -54,11 +54,11 @@ func TestHeaders(t *testing.T) {
 }
 
 func TestStaticCheck(t *testing.T) {
-	rungo(t, "run", "honnef.co/go/tools/cmd/staticcheck@v0.5.1", "./...")
+	rungo(t, "run", "honnef.co/go/tools/cmd/staticcheck@latest", "./...")
 }
 
 func TestUnparam(t *testing.T) {
-	rungo(t, "run", "mvdan.cc/unparam@v0.0.0-20240917084806-57a3b4290ba3", "./...")
+	rungo(t, "run", "mvdan.cc/unparam@latest", "./...")
 }
 
 func TestVet(t *testing.T) {
@@ -70,7 +70,7 @@ func TestGoModTidy(t *testing.T) {
 }
 
 func TestGovulncheck(t *testing.T) {
-	rungo(t, "run", "golang.org/x/vuln/cmd/govulncheck@v1.1.3", "./...")
+	rungo(t, "run", "golang.org/x/vuln/cmd/govulncheck@latest", "./...")
 }
 
 func rungo(t *testing.T, args ...string) {


### PR DESCRIPTION
While pinning the version is technically more precise, we need to balance that with regular tool upgrades. For now, it's simpler to run on the latest version. We can consider pinning once the tooling stabilizes or if reproducibility becomes a bigger concern.

Fixes https://github.com/googleapis/librarian/issues/195