### PR TITLE
impl(internal/cli): add Command.SetFlags

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -17,7 +17,6 @@ package librarian
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -246,26 +245,6 @@ var librarianCommands = []*cli.Command{
 	CmdMergeReleasePR,
 	CmdCreateReleaseArtifacts,
 	CmdPublishReleaseArtifacts,
-}
-
-func init() {
-	for _, c := range librarianCommands {
-		c.Flags = flag.NewFlagSet(c.Name, flag.ContinueOnError)
-		c.Flags.Usage = constructUsage(c.Flags, c.Name)
-		for _, fn := range c.FlagFunctions {
-			fn(c.Flags)
-		}
-	}
-}
-
-func constructUsage(fs *flag.FlagSet, name string) func() {
-	output := fmt.Sprintf("Usage:\n\n  librarian %s [arguments]\n", name)
-	output += "\nFlags:\n\n"
-	return func() {
-		fmt.Fprint(fs.Output(), output)
-		fs.PrintDefaults()
-		fmt.Fprintf(fs.Output(), "\n\n")
-	}
 }
 
 func formatReleaseTag(libraryID, version string) string {

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -37,7 +37,10 @@ var CmdConfigure = &cli.Command{
 	Name:  "configure",
 	Short: "Set up a new API for a language.",
 	Run:   runConfigure,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdConfigure.SetFlags([]func(fs *flag.FlagSet){
 		addFlagImage,
 		addFlagWorkRoot,
 		addFlagAPIPath,
@@ -49,7 +52,7 @@ var CmdConfigure = &cli.Command{
 		addFlagRepoRoot,
 		addFlagRepoUrl,
 		addFlagSecretsProject,
-	},
+	})
 }
 
 func runConfigure(ctx context.Context) error {

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -42,7 +42,10 @@ var CmdCreateReleaseArtifacts = &cli.Command{
 	Name:  "create-release-artifacts",
 	Short: "Create release artifacts from a merged release PR.",
 	Run:   runCreateReleaseArtifacts,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdCreateReleaseArtifacts.SetFlags([]func(fs *flag.FlagSet){
 		addFlagImage,
 		addFlagWorkRoot,
 		addFlagLanguage,
@@ -51,7 +54,7 @@ var CmdCreateReleaseArtifacts = &cli.Command{
 		addFlagReleaseID,
 		addFlagSecretsProject,
 		addFlagSkipIntegrationTests,
-	},
+	})
 }
 
 func runCreateReleaseArtifacts(ctx context.Context) error {

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -42,7 +42,10 @@ var CmdCreateReleasePR = &cli.Command{
 	Name:  "create-release-pr",
 	Short: "Generate a release PR.",
 	Run:   runCreateReleasePR,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdCreateReleasePR.SetFlags([]func(fs *flag.FlagSet){
 		addFlagImage,
 		addFlagSecretsProject,
 		addFlagWorkRoot,
@@ -56,7 +59,7 @@ var CmdCreateReleasePR = &cli.Command{
 		addFlagSkipIntegrationTests,
 		addFlagEnvFile,
 		addFlagRepoUrl,
-	},
+	})
 }
 
 func runCreateReleasePR(ctx context.Context) error {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -34,7 +34,10 @@ var CmdGenerate = &cli.Command{
 	Name:  "generate",
 	Short: "Generate client library code for an API.",
 	Run:   runGenerate,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdGenerate.SetFlags([]func(fs *flag.FlagSet){
 		addFlagImage,
 		addFlagWorkRoot,
 		addFlagAPIPath,
@@ -44,7 +47,7 @@ var CmdGenerate = &cli.Command{
 		addFlagRepoRoot,
 		addFlagRepoUrl,
 		addFlagSecretsProject,
-	},
+	})
 }
 
 func runGenerate(ctx context.Context) error {

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -51,7 +51,10 @@ var CmdMergeReleasePR = &cli.Command{
 	Name:  "merge-release-pr",
 	Short: "Merge a validated release PR.",
 	Run:   runMergeReleasePR,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdMergeReleasePR.SetFlags([]func(fs *flag.FlagSet){
 		addFlagImage,
 		addFlagSecretsProject,
 		addFlagWorkRoot,
@@ -59,7 +62,7 @@ var CmdMergeReleasePR = &cli.Command{
 		addFlagReleaseID,
 		addFlagReleasePRUrl,
 		addFlagSyncUrlPrefix,
-	},
+	})
 }
 
 func runMergeReleasePR(ctx context.Context) error {

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -35,14 +35,17 @@ var CmdPublishReleaseArtifacts = &cli.Command{
 	Name:  "publish-release-artifacts",
 	Short: "Publish (previously-created) release artifacts to package managers.",
 	Run:   runPublishReleaseArtifacts,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdPublishReleaseArtifacts.SetFlags([]func(fs *flag.FlagSet){
 		addFlagArtifactRoot,
 		addFlagImage,
 		addFlagWorkRoot,
 		addFlagLanguage,
 		addFlagSecretsProject,
 		addFlagTagRepoUrl,
-	},
+	})
 }
 
 func runPublishReleaseArtifacts(ctx context.Context) error {

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -34,7 +34,10 @@ var CmdUpdateApis = &cli.Command{
 	Name:  "update-apis",
 	Short: "Regenerate APIs in a language repo with new specifications.",
 	Run:   runUpdateAPIs,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdUpdateApis.SetFlags([]func(fs *flag.FlagSet){
 		addFlagImage,
 		addFlagWorkRoot,
 		addFlagAPIRoot,
@@ -47,7 +50,7 @@ var CmdUpdateApis = &cli.Command{
 		addFlagRepoRoot,
 		addFlagRepoUrl,
 		addFlagSecretsProject,
-	},
+	})
 }
 
 func runUpdateAPIs(ctx context.Context) error {

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -33,7 +33,10 @@ var CmdUpdateImageTag = &cli.Command{
 	Name:  "update-image-tag",
 	Short: "Update a language repo's image tag and regenerate APIs.",
 	Run:   runUpdateImageTag,
-	FlagFunctions: []func(fs *flag.FlagSet){
+}
+
+func init() {
+	CmdUpdateImageTag.SetFlags([]func(fs *flag.FlagSet){
 		addFlagWorkRoot,
 		addFlagAPIRoot,
 		addFlagBranch,
@@ -45,7 +48,7 @@ var CmdUpdateImageTag = &cli.Command{
 		addFlagRepoUrl,
 		addFlagSecretsProject,
 		addFlagTag,
-	},
+	})
 }
 
 func runUpdateImageTag(ctx context.Context) error {


### PR DESCRIPTION
Instead of having Flags and FlagFunctions as exported fields, add Command.SetFlags to handle this fields. This makes it clear that there is only one place where they should set (at init), and simplifies the Commands struct.