### PR TITLE
refactor: rename createContainerForLanguage to createCommandStateForLanguage

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -99,7 +99,13 @@ func cloneOrOpenLanguageRepo(workRoot string) (*gitrepo.Repo, error) {
 	return languageRepo, nil
 }
 
-func createContainerForLanguage(ctx context.Context) (*commandState, error) {
+// createCommandStateForLanguage performs common (but not universal)
+// steps for initializing a language repo, obtaining the pipeline state/config
+// from it, deriving the container image to use, and creating an appropriate
+// ContainerState based on all of the above. This should be used by all commands
+// which always have a language repo. Commands which only conditionally use
+// language repos should construct the command state themselves.
+func createCommandStateForLanguage(ctx context.Context) (*commandState, error) {
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime)
 	if err != nil {

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -56,7 +56,7 @@ func init() {
 }
 
 func runConfigure(ctx context.Context) error {
-	state, err := createContainerForLanguage(ctx)
+	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func runCreateReleaseArtifacts(ctx context.Context) error {
-	state, err := createContainerForLanguage(ctx)
+	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func runCreateReleasePR(ctx context.Context) error {
-	state, err := createContainerForLanguage(ctx)
+	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func runUpdateAPIs(ctx context.Context) error {
-	state, err := createContainerForLanguage(ctx)
+	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 func runUpdateImageTag(ctx context.Context) error {
-	state, err := createContainerForLanguage(ctx)
+	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This also provides some documentation to make it clearer what it does, and when it should or shouldn't be used.

Fixes #227.