### PR TITLE
feat: Unconditionally run unit tests when building a library

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -139,6 +139,7 @@ func BuildLibrary(config *ContainerConfig, repoRoot, libraryId string) error {
 	}
 	commandArgs := []string{
 		"--repo-root=/repo",
+		"--test=true",
 	}
 	if libraryId != "" {
 		commandArgs = append(commandArgs, fmt.Sprintf("--library-id=%s", libraryId))


### PR DESCRIPTION
We may eventually want to only do this in some scenarios, but for now it's better to always run the tests than to never do so.

See b/416021383.