### PR TITLE
impl(internal/cli): add basic tests for package

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -48,16 +48,12 @@ func (c *Command) Parse(args []string) error {
 // Lookup finds a command by its name, and returns an error if the command is
 // not found.
 func Lookup(name string, commands []*Command) (*Command, error) {
-	var cmd *Command
 	for _, sub := range commands {
 		if sub.Name == name {
-			cmd = sub
+			return sub, nil
 		}
 	}
-	if cmd == nil {
-		return nil, fmt.Errorf("invalid command: %q", name)
-	}
-	return cmd, nil
+	return nil, fmt.Errorf("invalid command: %q", name)
 }
 
 // SetFlags registers a list of functions that configure flags for the command.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -68,16 +68,16 @@ func TestLookup(t *testing.T) {
 			cmd, err := Lookup(test.name, commands)
 			if test.wantErr {
 				if err == nil {
-					t.Fatalf("Lookup(%q): expected error, got nil", test.name)
+					t.Fatal(err)
 				}
 				return
 			}
 
 			if err != nil {
-				t.Fatalf("Lookup(%q): unexpected error: %v", test.name, err)
+				t.Fatal(err)
 			}
 			if cmd.Name != test.name {
-				t.Errorf("Lookup(%q): got %q, want %q", test.name, cmd.Name, test.name)
+				t.Errorf("got = %q, want = %q", cmd.Name, test.name)
 			}
 		})
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"testing"
+)
+
+func TestParseAndSetFlags(t *testing.T) {
+	var (
+		strFlag string
+		intFlag int
+	)
+
+	cmd := &Command{
+		Name:  "test",
+		Short: "test command is used for testing",
+	}
+	cmd.SetFlags([]func(fs *flag.FlagSet){
+		func(fs *flag.FlagSet) {
+			fs.StringVar(&strFlag, "name", "default", "name flag")
+			fs.IntVar(&intFlag, "count", 0, "count flag")
+		},
+	})
+
+	args := []string{"-name=foo", "-count=5"}
+	if err := cmd.Parse(args); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	if strFlag != "foo" {
+		t.Errorf("expected name=foo, got %q", strFlag)
+	}
+	if intFlag != 5 {
+		t.Errorf("expected count=5, got %d", intFlag)
+	}
+}
+
+func TestLookup(t *testing.T) {
+	test1 := "foo"
+	commands := []*Command{
+		{Name: test1},
+	}
+
+	cmd, err := Lookup(test1, commands)
+	if err != nil {
+		t.Fatalf("Lookup failed: %v", err)
+	}
+	if cmd.Name != test1 {
+		t.Errorf("expected command 'second', got %q", cmd.Name)
+	}
+}
+
+func TestLookup_Error(t *testing.T) {
+	test1 := "foo"
+	commands := []*Command{
+		{Name: test1},
+	}
+	test2 := "bar"
+	if _, err := Lookup(test2, commands); err == nil {
+		t.Fatalf("expected error for command %q", test2)
+	}
+}
+
+func TestRun(t *testing.T) {
+	executed := false
+	cmd := &Command{
+		Name: "run",
+		Run: func(ctx context.Context) error {
+			executed = true
+			return nil
+		},
+	}
+
+	if err := cmd.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !executed {
+		t.Errorf("cmd.Run was not executed")
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -51,28 +51,35 @@ func TestParseAndSetFlags(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	test1 := "foo"
 	commands := []*Command{
-		{Name: test1},
+		{Name: "foo"},
+		{Name: "bar"},
 	}
 
-	cmd, err := Lookup(test1, commands)
-	if err != nil {
-		t.Fatalf("Lookup failed: %v", err)
-	}
-	if cmd.Name != test1 {
-		t.Errorf("expected command 'second', got %q", cmd.Name)
-	}
-}
+	for _, test := range []struct {
+		name    string
+		wantErr bool
+	}{
+		{"foo", false},
+		{"bar", false},
+		{"baz", true}, // not found case
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, err := Lookup(test.name, commands)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("Lookup(%q): expected error, got nil", test.name)
+				}
+				return
+			}
 
-func TestLookup_Error(t *testing.T) {
-	test1 := "foo"
-	commands := []*Command{
-		{Name: test1},
-	}
-	test2 := "bar"
-	if _, err := Lookup(test2, commands); err == nil {
-		t.Fatalf("expected error for command %q", test2)
+			if err != nil {
+				t.Fatalf("Lookup(%q): unexpected error: %v", test.name, err)
+			}
+			if cmd.Name != test.name {
+				t.Errorf("Lookup(%q): got %q, want %q", test.name, cmd.Name, test.name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
There were previously no tests for internal/cli. This change adds a basic set of unit tests to cover core functionality.

A bug in Lookup is also fixed.