### PR TITLE
impl(cmd/librarian): add support for version

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -39,6 +39,9 @@ type Command struct {
 // Parse parses the provided command-line arguments using the command's flag
 // set.
 func (c *Command) Parse(args []string) error {
+	if c.flags == nil {
+		return nil
+	}
 	return c.flags.Parse(args)
 }
 

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -48,11 +48,13 @@ func version(info *debug.BuildInfo) string {
 		return "not available"
 	}
 
+	// Construct the pseudo-version string per
+	// https://go.dev/ref/mod#pseudo-versions.
 	buf := strings.Builder{}
 	buf.WriteString("0.0.0")
 	if revision != "" {
 		buf.WriteString("-")
-		buf.WriteString(revision[:12])
+		buf.WriteString(revision)
 	}
 	if at != "" {
 		// commit time is of the form 2023-01-25T19:57:54Z

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -55,7 +55,9 @@ func version(info *debug.BuildInfo) string {
 	buf.WriteString("0.0.0")
 	if revision != "" {
 		buf.WriteString("-")
-		buf.WriteString(revision)
+		// Per https://go.dev/ref/mod#pseudo-versions, only use the first 12
+		// letters of the commit hash.
+		buf.WriteString(revision[:12])
 	}
 	if at != "" {
 		// commit time is of the form 2023-01-25T19:57:54Z

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+// Version prints the version information for the binary.
+func Version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	return version(info)
+}
+
+func version(info *debug.BuildInfo) string {
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+
+	var revision, at string
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			revision = s.Value
+		}
+		if s.Key == "vcs.time" {
+			at = s.Value
+		}
+	}
+
+	if revision == "" && at == "" {
+		return "not available"
+	}
+
+	buf := strings.Builder{}
+	buf.WriteString("0.0.0")
+	if revision != "" {
+		buf.WriteString("-")
+		buf.WriteString(revision[:12])
+	}
+	if at != "" {
+		// commit time is of the form 2023-01-25T19:57:54Z
+		p, err := time.Parse(time.RFC3339, at)
+		if err == nil {
+			buf.WriteString("-")
+			buf.WriteString(p.Format("20060102150405"))
+		}
+	}
+	return buf.String()
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -20,7 +20,8 @@ import (
 	"time"
 )
 
-// Version prints the version information for the binary.
+// Version return the version information for the binary, which is constructed
+// following https://go.dev/ref/mod#versions.
 func Version() string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		want      string
+		buildinfo *debug.BuildInfo
+	}{
+		{
+			name: "tagged version",
+			want: "1.2.3",
+			buildinfo: &debug.BuildInfo{
+				Main: debug.Module{
+					Version: "1.2.3",
+				},
+			},
+		},
+		{
+			name: "pseudoversion",
+			want: "0.0.0-123456789000-20230125195754",
+			buildinfo: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "1234567890001234"},
+					{Key: "vcs.time", Value: "2023-01-25T19:57:54Z"},
+				},
+			},
+		},
+		{
+			name:      "local development",
+			want:      "not available",
+			buildinfo: &debug.BuildInfo{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := version(test.buildinfo); got != test.want {
+				t.Errorf("got %s; want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -251,6 +251,7 @@ var librarianCommands = []*cli.Command{
 	CmdMergeReleasePR,
 	CmdCreateReleaseArtifacts,
 	CmdPublishReleaseArtifacts,
+	CmdVersion,
 }
 
 func formatReleaseTag(libraryID, version string) string {

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -24,10 +24,8 @@ import (
 var CmdVersion = &cli.Command{
 	Name:  "version",
 	Short: "Print version information.",
-	Run:   runVersion,
-}
-
-func runVersion(ctx context.Context) error {
-	fmt.Println(cli.Version())
-	return nil
+	Run: func(ctx context.Context) error {
+		fmt.Println(cli.Version())
+		return nil
+	},
 }

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/cli"
+)
+
+var CmdVersion = &cli.Command{
+	Name:  "version",
+	Short: "Print version information.",
+	Run:   runVersion,
+}
+
+func runVersion(ctx context.Context) error {
+	fmt.Println(cli.Version())
+	return nil
+}


### PR DESCRIPTION
A librarian subcommand is added which prints the binary version.

Fixes https://github.com/googleapis/librarian/issues/238