### PR TITLE
feat(internal/cli): add Command.Usage and Command.Long fields

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -29,6 +29,8 @@ func TestParseAndSetFlags(t *testing.T) {
 	cmd := &Command{
 		Name:  "test",
 		Short: "test command is used for testing",
+		Long:  "This is the long documentation for command test.",
+		Usage: "foobar test [arguments]",
 	}
 	cmd.SetFlags([]func(fs *flag.FlagSet){
 		func(fs *flag.FlagSet) {

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -36,6 +36,8 @@ import (
 var CmdConfigure = &cli.Command{
 	Name:  "configure",
 	Short: "Set up a new API for a language.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runConfigure,
 }
 

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -41,6 +41,8 @@ type LibraryRelease struct {
 var CmdCreateReleaseArtifacts = &cli.Command{
 	Name:  "create-release-artifacts",
 	Short: "Create release artifacts from a merged release PR.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runCreateReleaseArtifacts,
 }
 

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -41,6 +41,8 @@ const baselineCommitEnvVarName = "_BASELINE_COMMIT"
 var CmdCreateReleasePR = &cli.Command{
 	Name:  "create-release-pr",
 	Short: "Generate a release PR.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runCreateReleasePR,
 }
 

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -34,6 +34,8 @@ import (
 var CmdGenerate = &cli.Command{
 	Name:  "generate",
 	Short: "Generate client library code for an API.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runGenerate,
 }
 

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -50,6 +50,8 @@ const MergeBlockedLabel = "merge-blocked-see-comments"
 var CmdMergeReleasePR = &cli.Command{
 	Name:  "merge-release-pr",
 	Short: "Merge a validated release PR.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runMergeReleasePR,
 }
 

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -34,6 +34,8 @@ import (
 var CmdPublishReleaseArtifacts = &cli.Command{
 	Name:  "publish-release-artifacts",
 	Short: "Publish (previously-created) release artifacts to package managers.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runPublishReleaseArtifacts,
 }
 

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -33,6 +33,8 @@ import (
 var CmdUpdateApis = &cli.Command{
 	Name:  "update-apis",
 	Short: "Regenerate APIs in a language repo with new specifications.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runUpdateAPIs,
 }
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -32,6 +32,8 @@ import (
 var CmdUpdateImageTag = &cli.Command{
 	Name:  "update-image-tag",
 	Short: "Update a language repo's image tag and regenerate APIs.",
+	Usage: "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
+	Long:  "TODO(https://github.com/googleapis/librarian/issues/237): add documentation",
 	Run:   runUpdateImageTag,
 }
 

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -24,6 +24,8 @@ import (
 var CmdVersion = &cli.Command{
 	Name:  "version",
 	Short: "Print version information.",
+	Usage: "librarian version",
+	Long:  "Print version information for the librarian binary.",
 	Run: func(ctx context.Context) error {
 		fmt.Println(cli.Version())
 		return nil


### PR DESCRIPTION
The librarian commands were previously undocumented. Added Usage and Long fields to the Command struct to serve as placeholders for usage text.  For now, these fields are populated with a TODO as a placeholders.

When constructing the usage information, the code will now panic if Short, Long, or Usage are empty, so that we ensure new commands are documented moving forward.

For https://github.com/googleapis/librarian/issues/237