### PR TITLE
tests: check all files for licenses unless we know they're unnecessary

### DIFF
--- a/cloudbuild-exitgate.yaml
+++ b/cloudbuild-exitgate.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian', '.']

--- a/generate-proto.sh
+++ b/generate-proto.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Regenerates the code in internal/statepb from the protos in the proto/
 # directory. (See proto/README.md for why we have those protos.)
 # Requirements: protoc and the protoc-gen-go plugin are in the path.


### PR DESCRIPTION
The allow-list (noHeaderRequiredFiles) may well grow quite a bit over time, but this way we'll be prompted whenever there's a file which isn't covered by an existing pattern.

Fixes #8.