### PR TITLE
chore: stop syncing labels with label-sync

### DIFF
--- a/.github/label-sync.yml
+++ b/.github/label-sync.yml
@@ -1,0 +1,1 @@
+ignored: true


### PR DESCRIPTION
Once this is merged, I'll remove the labels we don't want.

Part of #188