### PR TITLE
feat(DIREGAPIC/WIP): Add initial scripts for DIREGAPIC pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work.sum
 
 # env file
 .env
+*~

--- a/Dockerfile.DIREGAPIC
+++ b/Dockerfile.DIREGAPIC
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG CONVERTER_IMAGE_AND_TAG
+ARG LIBRARIAN_STD_IMAGE_AND_TAG
+
+FROM ${CONVERTER_IMAGE_AND_TAG} AS converter
+
+FROM ${LIBRARIAN_STD_IMAGE_AND_TAG}
+WORKDIR /app
+COPY diregapic_pipeline.sh .
+COPY --from=converter /app/disco-to-proto3-converter.jar .
+ADD https://raw.githubusercontent.com/googleapis/discovery-artifact-manager/master/scripts/normalize_discovery.py /app/normalize_discovery.py
+RUN apt-get install -y default-jre python3
+
+# TODO: Set non-root user, since output files produced by the script
+#       below are written with "root" ownership in the host filesystem
+
+ENTRYPOINT ["/app/diregapic_pipeline.sh"]

--- a/build-librarian-diregapic.sh
+++ b/build-librarian-diregapic.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+export CONVERTER_IMAGE_AND_TAG="${1:-discovery-converter:build}"
+export LIBRARIAN_STD_IMAGE_AND_TAG="${2:-librarian:build}"
+export LIBRARIAN_DIREGAPIC_IMAGE_AND_TAG="${3:-librarian-diregapic:build}"
+
+
+echo "CONVERTER_IMAGE_AND_TAG: ${CONVERTER_IMAGE_AND_TAG}"
+echo "LIBRARIAN_STD_IMAGE_AND_TAG: ${LIBRARIAN_STD_IMAGE_AND_TAG}"
+echo "LIBRARIAN_DIREGAPIC_IMAGE_AND_TAG: ${LIBRARIAN_DIREGAPIC_IMAGE_AND_TAG}"
+
+echo "\n\n*** Dockerizing converter"
+docker build -t ${CONVERTER_IMAGE_AND_TAG} "https://github.com/googleapis/disco-to-proto3-converter.git#main"
+
+echo "\n\n*** Dockerizing standard Librarian"
+docker build -t ${LIBRARIAN_STD_IMAGE_AND_TAG} .
+
+echo "\n\n*** Dockerizing DIREGAPIC Librarian"
+docker build \
+  --build-arg CONVERTER_IMAGE_AND_TAG=${CONVERTER_IMAGE_AND_TAG} \
+  --build-arg LIBRARIAN_STD_IMAGE_AND_TAG=${LIBRARIAN_STD_IMAGE_AND_TAG} \
+  -t ${LIBRARIAN_DIREGAPIC_IMAGE_AND_TAG} \
+  -f Dockerfile.DIREGAPIC \
+  .
+
+

--- a/diregapic_pipeline.sh
+++ b/diregapic_pipeline.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This is the "inner" script that coordinates the various steps in the DIREGAPIC pipeline. Assumes:
+# - the Discovery file to start from is in the directory /app/discoveries/
+# - the disco-to-proto3-converter configuration file is in /app/diregapic/
+# The output of the converter is placed in /app/output
+#
+# USAGE:
+#   diregapic_pipeline.sh API_NAME
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+  echo "ERROR: This script should be executed directly, not sourced."
+  return -1
+fi
+
+cd /app
+
+### Validate inputs
+API_NAME="$1"
+[[ -n "${API_NAME}" ]] || { echo "error: This script requires an API name" ; exit -2 ; }
+shift
+
+[ $(ls -1 discoveries/*.json 2>/dev/null | wc -l) -eq 1 ] || {
+  echo "Error: Expected exactly one Discovery .json file in /app/discoveries/. Got:" >&2
+  ls -la discoveries/*json >&2
+  exit -2
+}
+DISCOVERY_FILE=$(realpath discoveries/*.json )
+
+[ $(ls -1 diregapic/*.json 2>/dev/null | wc -l) -eq 1 ] || {
+  echo "Error: Expected exactly one converter configuration file in /app/diregapic/. Got:" >&2
+  ls -la diregapic/*json >&2
+  exit -2
+}
+CONFIGURATION_FILE=$(realpath diregapic/*.json )
+
+OUTPUT_PROTO_FILE="$(realpath output/${API_NAME}.proto)"
+OUTPUT_CONFIGURATION_FILE="$(realpath output/converter_config.json)"
+
+### Create synthetic protos
+
+# Ensure Discovery file is normalized so it's easier to track changes and errors.
+python3 normalize_discovery.py
+
+java -jar disco-to-proto3-converter.jar \
+  --discovery_doc_path=${DISCOVERY_FILE} \
+  --input_config_path=${CONFIGURATION_FILE} \
+  --output_file_path=${OUTPUT_PROTO_FILE} \
+  --output_config_path=${OUTPUT_CONFIGURATION_FILE} \
+  --enums_as_strings=True
+
+# TODO: Pass the synthetic proto to the rest of the librarian pipeline. Maybe
+# something like this:
+#   librarian "$@"
+# (but including the synthetic proto) so that additional Librarian args can be
+# passed to this script and they will passed to the librarian executable.

--- a/run_diregapic
+++ b/run_diregapic
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This is the "outer" script called by users or automations to invoke the DIREGAPIC pipeline via Librarian.
+#
+# USAGE:
+#   run-diregapic DISCOVERY_FILE CONFIG_FILE OUTPUT_DIR [LIBRARIAN_IMAGE_AND_TAG]
+#
+# Example:
+#   If ${CONVERTER_REPO} is the local path to a clone of
+#   https://github.com/googleapis/disco-to-proto3-converter, then the sample run
+#   shown in that README can be executed here by the following:
+#     ./run_diregapic \
+#         ${CONVERTER_REPO}/src/test/resources/google/cloud/compute/v1/compute.v1.json \
+#         ${CONVERTER_REPO}/src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
+#         ${CONVERTER_REPO}/google/cloud/compute/v1/
+
+# TODO: Configure this outer script and the inner script together so that they
+# call the rest of Librarian. One possible invocation might be:
+#   run-diregapic DISCOVERY_FILE CONFIG_FILE OUTPUT_DIR [LIBRARIAN_ARGS...]
+# so that after getting the synthetic proto, it and the standard LIBRARIAN_ARGS
+# are passed to the Librarian executable.
+  
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+  echo "Please execute this script directly; don't source it"
+  return -1
+fi
+
+which jq >& /dev/null|| {
+  echo "This function relies on jq"
+  echo "  On Debian, install it via: sudo apt install jq"
+  return -1
+}
+
+
+### Validate inputs.
+
+DISCOVERY_FILE="$1"
+shift
+[[ -f "${DISCOVERY_FILE}" ]] || { echo "error: Discovery file not found: ${DISCOVERY_FILE}" ; exit -2 ; }
+API_NAME=$(jq '.name' "${DISCOVERY_FILE}")
+[[ -n "${API_NAME}" ]] || { echo "error: API name not found in Discovery file: ${DISCOVERY_FILE}" ; exit -2 ; }
+echo "DISCOVERY_FILE: ${DISCOVERY_FILE}"
+
+CONVERTER_CONFIG="$1"
+shift
+[[ -f "${CONVERTER_CONFIG}" ]] || { echo "error: Converter configuration file not found: ${CONVERTER_CONFIG}" ; exit -2 ; }
+echo "CONVERTER_CONFIG: ${CONVERTER_CONFIG}"
+
+OUTPUT_DIR="$1"
+shift
+[[ -d "${OUTPUT_DIR}" ]] || { echo "error: Output directory  not found: ${OUTPUT_DIR}" ; exit -2 ; }
+echo "OUTPUT_DIR: ${OUTPUT_DIR}"
+
+LIBRARIAN_DIREGAPIC_IMAGE_AND_TAG="${1:-librarian-diregapic:build}"
+[[ -n "${LIBRARIAN_DIREGAPIC_IMAGE_AND_TAG}" ]] || { echo "error: Docker image specifier must be non-empty" ; exit -2 ; }
+
+
+### Set up directories to mount.
+
+DISCOVERIES_DIR=$(mktemp -d)
+cp "${DISCOVERY_FILE}" "${DISCOVERIES_DIR}"
+
+DIREGAPIC_DIR=$(mktemp -d)
+cp "${CONVERTER_CONFIG}" "${DIREGAPIC_DIR}"
+
+docker run \
+  -v ${DISCOVERIES_DIR}:/app/discoveries \
+  -v ${DIREGAPIC_DIR}:/app/diregapic \
+  -v ${OUTPUT_DIR}:/app/output \
+  ${LIBRARIAN_DIREGAPIC_IMAGE_AND_TAG} \
+  ${API_NAME}


### PR DESCRIPTION
Notes as of `[2025-06-12 10:00 PDT]`

Usage:
- Build the `librarian-diregapic` image with `. ./build-librarian-diregapic.sh`
- Run `librarian-diregapic` with `run-diregapic DISCOVERY_FILE CONFIG_FILE OUTPUT_DIR`

Still to do:
- pass the synthetic proto to the `librarian` tool