### PR TITLE
impl(internal/librarian): consolidate command name and short

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -27,8 +27,7 @@ func TestParseAndSetFlags(t *testing.T) {
 	)
 
 	cmd := &Command{
-		Name:  "test",
-		Short: "test command is used for testing",
+		Short: "test is used for testing",
 		Long:  "This is the long documentation for command test.",
 		Usage: "foobar test [arguments]",
 	}
@@ -54,8 +53,8 @@ func TestParseAndSetFlags(t *testing.T) {
 
 func TestLookup(t *testing.T) {
 	commands := []*Command{
-		{Name: "foo"},
-		{Name: "bar"},
+		{Short: "foo runs the foo command"},
+		{Short: "bar runs the bar command"},
 	}
 
 	for _, test := range []struct {
@@ -78,8 +77,8 @@ func TestLookup(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmd.Name != test.name {
-				t.Errorf("got = %q, want = %q", cmd.Name, test.name)
+			if cmd.Name() != test.name {
+				t.Errorf("got = %q, want = %q", cmd.Name(), test.name)
 			}
 		})
 	}
@@ -88,7 +87,7 @@ func TestLookup(t *testing.T) {
 func TestRun(t *testing.T) {
 	executed := false
 	cmd := &Command{
-		Name: "run",
+		Short: "run runs the command",
 		Run: func(ctx context.Context) error {
 			executed = true
 			return nil

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -33,8 +33,7 @@ import (
 )
 
 var CmdConfigure = &cli.Command{
-	Name:  "configure",
-	Short: "Configures libraries for new APIs in a language.",
+	Short: "configure configures libraries for new APIs in a language",
 	Usage: `Specify the language, and optional flags to use non-default repositories, e.g. for testing.
 A single API path may be specified if desired; otherwise all API paths will be checked.
 A pull request will only be created if -push is specified, in which case the LIBRARIAN_GITHUB_TOKEN

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -37,8 +37,7 @@ type LibraryRelease struct {
 }
 
 var CmdCreateReleaseArtifacts = &cli.Command{
-	Name:  "create-release-artifacts",
-	Short: "Creates release artifacts from a merged release PR.",
+	Short: "create-release-artifacts creates release artifacts from a merged release PR",
 	Usage: `Specify the language and release ID, and optional flags to use non-default repositories, e.g. for testing.
 The release ID is specified in the the release PR and in each commit within it, in a line starting "Librarian-Release-ID: ".
 `,

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -37,8 +37,7 @@ const prNumberEnvVarName = "_PR_NUMBER"
 const baselineCommitEnvVarName = "_BASELINE_COMMIT"
 
 var CmdCreateReleasePR = &cli.Command{
-	Name:  "create-release-pr",
-	Short: "Creates a release PR.",
+	Short: "create-release-pr creates a release PR",
 	Usage: `Specify the language, and optional flags to use non-default repositories, e.g. for testing.
 A single library may be specified if desired (with an optional version override);
 otherwise all configured libraries will be checked to see if they should be released.

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -32,8 +32,7 @@ import (
 )
 
 var CmdGenerate = &cli.Command{
-	Name:  "generate",
-	Short: "Generates client library code for a single API.",
+	Short: "generate generates client library code for a single API",
 	Usage: `Specify the language, the API repository root and the path within it for the API to generate.
 Optional flags can be specified to use a non-default language repository, and to indicate whether or not
 to build the generated library.`,

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/cli"
 )
@@ -46,7 +47,9 @@ Usage:
 The commands are:
 `
 	for _, c := range librarianCommands {
-		output += fmt.Sprintf("\n  %-25s  %s", c.Name, c.Short)
+		parts := strings.Fields(c.Short)
+		short := strings.Join(parts[1:], " ")
+		output += fmt.Sprintf("\n  %-25s  %s", c.Name(), short)
 	}
 
 	fs.Usage = func() {

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -48,8 +48,7 @@ const ConventionalCommitsAppId = 37172
 const MergeBlockedLabel = "merge-blocked-see-comments"
 
 var CmdMergeReleasePR = &cli.Command{
-	Name:  "merge-release-pr",
-	Short: "Merges a validated release PR.",
+	Short: "merge-release-pr merges a validated release PR",
 	Usage: `Specify a GitHub access token as an environment variable, the URL for a release PR, and the release ID.
 An optional additional URL prefix can be specified in order to wait for a mirror to have synchronized before the
 command completes.`,

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -31,8 +31,7 @@ import (
 )
 
 var CmdPublishReleaseArtifacts = &cli.Command{
-	Name:  "publish-release-artifacts",
-	Short: "Publishes (previously-created) release artifacts to package managers and documentation sites.",
+	Short: "publish-release-artifacts publishes (previously-created) release artifacts to package managers and documentation sites",
 	Usage: `Specify the language, the root output directory created by create-release-artifacts, and
 the GitHub repository in which to create tags/releases.`,
 	Long: `The command first loads the metadata created by create-release-artifacts. This

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -30,8 +30,7 @@ import (
 )
 
 var CmdUpdateApis = &cli.Command{
-	Name:  "update-apis",
-	Short: "Regenerates APIs in a language repo with new specifications.",
+	Short: "update-apis regenerates APIs in a language repo with new specifications",
 	Usage: `Specify the language, and optional flags to use non-default repositories, e.g. for testing.
 A pull request will only be created if -push is specified, in which case the LIBRARIAN_GITHUB_TOKEN
 environment variable must be populated with an access token which has write access to the

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -29,8 +29,7 @@ import (
 )
 
 var CmdUpdateImageTag = &cli.Command{
-	Name:  "update-image-tag",
-	Short: "Updates a language repo's image tag and regenerates APIs.",
+	Short: "update-image-tag updates a language repo's image tag and regenerates APIs",
 	Usage: `Specify the language, the new tag, and optional flags to use non-default repositories, e.g. for testing.
 A pull request will only be created if -push is specified, in which case the LIBRARIAN_GITHUB_TOKEN
 environment variable must be populated with an access token which has write access to the

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -22,8 +22,7 @@ import (
 )
 
 var CmdVersion = &cli.Command{
-	Name:  "version",
-	Short: "Prints version information.",
+	Short: "version prints the version information",
 	Usage: "librarian version",
 	Long:  "Prints version information for the librarian binary.",
 	Run: func(ctx context.Context) error {


### PR DESCRIPTION
Rather than splitting into two fields, use a single string with the format:

  [name] [short]

Examples:
  - configure setups new APIs for client library
  - version prints the version information

This makes it easier to read and parse in code and setups a predictable sentence structure.

Fixes https://github.com/googleapis/librarian/issues/244