### PR TITLE
chore(internal/librarian): tweaks to usage and flag validation

### DIFF
--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -38,7 +38,7 @@ type LibraryRelease struct {
 
 var CmdCreateReleaseArtifacts = &cli.Command{
 	Short: "create-release-artifacts creates release artifacts from a merged release PR",
-	Usage: "librarian create-release-artifacts -language=<language> [flags]",
+	Usage: "librarian create-release-artifacts -language=<language> -release-id=<id> [flags]",
 	Long: `Specify the language and release ID, and optional flags to use non-default repositories, e.g. for testing.
 The release ID is specified in the the release PR and in each commit within it, in a line starting "Librarian-Release-ID: ".
 
@@ -97,7 +97,6 @@ func createReleaseArtifactsImpl(state *commandState) error {
 	if err := validateRequiredFlag("release-id", flagReleaseID); err != nil {
 		return err
 	}
-
 	outputRoot := filepath.Join(state.workRoot, "output")
 	if err := os.Mkdir(outputRoot, 0755); err != nil {
 		return err

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -56,7 +56,7 @@ var (
 )
 
 func addFlagAPIPath(fs *flag.FlagSet) {
-	fs.StringVar(&flagAPIPath, "api-path", "", "(Required) path api-root to the API to be generated (e.g., google/cloud/functions/v2)")
+	fs.StringVar(&flagAPIPath, "api-path", "", "path api-root to the API to be configured/generated (e.g., google/cloud/functions/v2)")
 }
 
 func addFlagAPIRoot(fs *flag.FlagSet) {
@@ -95,7 +95,7 @@ func addFlagImage(fs *flag.FlagSet) {
 }
 
 func addFlagLanguage(fs *flag.FlagSet) {
-	fs.StringVar(&flagLanguage, "language", "", "(Required) language to generate code for")
+	fs.StringVar(&flagLanguage, "language", "", "(Required) language to configure/generate/release code for")
 }
 
 func addFlagLibraryID(fs *flag.FlagSet) {

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -56,7 +56,7 @@ var (
 )
 
 func addFlagAPIPath(fs *flag.FlagSet) {
-	fs.StringVar(&flagAPIPath, "api-path", "", "path api-root to the API to be configured/generated (e.g., google/cloud/functions/v2)")
+	fs.StringVar(&flagAPIPath, "api-path", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
 }
 
 func addFlagAPIRoot(fs *flag.FlagSet) {
@@ -95,7 +95,7 @@ func addFlagImage(fs *flag.FlagSet) {
 }
 
 func addFlagLanguage(fs *flag.FlagSet) {
-	fs.StringVar(&flagLanguage, "language", "", "(Required) language to configure/generate/release code for")
+	fs.StringVar(&flagLanguage, "language", "", "(Required) language for which to configure/generate/release code")
 }
 
 func addFlagLibraryID(fs *flag.FlagSet) {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -33,7 +33,7 @@ import (
 
 var CmdGenerate = &cli.Command{
 	Short: "generate generates client library code for a single API",
-	Usage: "librarian generate -api-path=<api-path> -language=<language> [flags]",
+	Usage: "librarian generate -api-root=<api-root> -api-path=<api-path> -language=<language> [flags]",
 	Long: `Specify the language, the API repository root and the path within it for the API to generate.
 Optional flags can be specified to use a non-default language repository, and to indicate whether or not
 to build the generated library.

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -49,8 +49,9 @@ const MergeBlockedLabel = "merge-blocked-see-comments"
 
 var CmdMergeReleasePR = &cli.Command{
 	Short: "merge-release-pr merges a validated release PR",
-	Usage: "librarian merge-release-pr [flags]",
-	Long: `Specify a GitHub access token as an environment variable, the URL for a release PR, and the release ID.
+	Usage: "librarian merge-release-pr -release-id=<id> -release-pr-url=<url> -baseline-commit=<commit> [flags]",
+	Long: `Specify a GitHub access token as an environment variable, the URL for a release PR, the baseline
+commit of the repo when the release PR was being created, and the release ID.
 An optional additional URL prefix can be specified in order to wait for a mirror to have synchronized before the
 command completes.
 
@@ -130,6 +131,16 @@ func mergeReleasePR(ctx context.Context, workRoot string) error {
 	if os.Getenv(githubrepo.GitHubTokenEnvironmentVariable) == "" {
 		return errors.New("no GitHub access token specified")
 	}
+	if err := validateRequiredFlag("release-id", flagReleaseID); err != nil {
+		return err
+	}
+	if err := validateRequiredFlag("release-pr-url", flagReleasePRUrl); err != nil {
+		return err
+	}
+	if err := validateRequiredFlag("baseline-commit", flagBaselineCommit); err != nil {
+		return err
+	}
+
 	// We'll assume the PR URL is in the format https://github.com/{owner}/{name}/pulls/{pull-number}
 	prRepo, err := githubrepo.ParseUrl(flagReleasePRUrl)
 	if err != nil {

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -32,7 +32,7 @@ import (
 
 var CmdPublishReleaseArtifacts = &cli.Command{
 	Short: "publish-release-artifacts publishes (previously-created) release artifacts to package managers and documentation sites",
-	Usage: "librarian publish-release-artifacts -language=<language> [flags]",
+	Usage: "librarian publish-release-artifacts -language=<language> -artifact-root=<artifact-root> -tag-repo-url=<repo-url> [flags]",
 	Long: `Specify the language, the root output directory created by create-release-artifacts, and
 the GitHub repository in which to create tags/releases.
 
@@ -71,6 +71,9 @@ func init() {
 }
 
 func runPublishReleaseArtifacts(ctx context.Context) error {
+	if err := validateRequiredFlag("artifact-root", flagArtifactRoot); err != nil {
+		return err
+	}
 	// Load the state and config from the artifact directory. These will have been created by create-release-artifacts.
 	ps, err := loadPipelineStateFile(filepath.Join(flagArtifactRoot, pipelineStateFile))
 	if err != nil {
@@ -97,10 +100,6 @@ func runPublishReleaseArtifacts(ctx context.Context) error {
 }
 
 func publishReleaseArtifacts(ctx context.Context, containerConfig *container.ContainerConfig) error {
-	if err := validateRequiredFlag("artifact-root", flagArtifactRoot); err != nil {
-		return err
-	}
-
 	if err := validateRequiredFlag("tag-repo-url", flagTagRepoUrl); err != nil {
 		return err
 	}

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -30,7 +30,7 @@ import (
 
 var CmdUpdateImageTag = &cli.Command{
 	Short: "update-image-tag updates a language repo's image tag and regenerates APIs",
-	Usage: "librarian update-image-tag -language=<language> [flags]",
+	Usage: "librarian update-image-tag -language=<language> -tag=<new tag> [flags]",
 	Long: `Specify the language, the new tag, and optional flags to use non-default repositories, e.g. for testing.
 A pull request will only be created if -push is specified, in which case the LIBRARIAN_GITHUB_TOKEN
 environment variable must be populated with an access token which has write access to the


### PR DESCRIPTION
The usage now genuinely specifies the required flags for each command. Some of these were only implicitly being checked (in that if they weren't specified, the command would fail in a non-obvious way).

Fixes #387
Fixes #390
Fixes #391
Fixes #392
Fixes #393