### PR TITLE
feat(all): check that exported symbols have doc comments

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -141,7 +141,7 @@ func TestExportedSymbolsHaveDocs(t *testing.T) {
 		// Visit every top-level declaration in the file.
 		for _, decl := range node.Decls {
 			gen, ok := decl.(*ast.GenDecl)
-			if ok && (gen.Tok == token.TYPE || gen.Tok == token.CONST || gen.Tok == token.VAR) {
+			if ok && (gen.Tok == token.TYPE || gen.Tok == token.VAR) {
 				for _, spec := range gen.Specs {
 					switch s := spec.(type) {
 					case *ast.TypeSpec:


### PR DESCRIPTION
Add a test to ensure that exported funcs, types, consts, and vars must have comments.

This test is skipped until https://github.com/googleapis/librarian/issues/521 is addressed.

For https://github.com/googleapis/librarian/issues/522