### PR TITLE
feat(internal/cli,librarian): use cli framework for Librarian

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,9 +36,17 @@ type Command struct {
 	// Run executes the command.
 	Run func(ctx context.Context) error
 
+	// Commands are the sub commands.
+	Commands []*Command
+
 	// flags is the command's flag set for parsing arguments and generating
 	// usage messages. This is populated for each command in init().
 	flags *flag.FlagSet
+}
+
+// Help prints the help text.
+func (c *Command) Help() {
+	c.flags.Usage()
 }
 
 // Parse parses the provided command-line arguments using the command's flag
@@ -62,8 +70,8 @@ func (c *Command) Name() string {
 
 // Lookup finds a command by its name, and returns an error if the command is
 // not found.
-func Lookup(name string, commands []*Command) (*Command, error) {
-	for _, sub := range commands {
+func (c *Command) Lookup(name string) (*Command, error) {
+	for _, sub := range c.Commands {
 		if sub.Name() == name {
 			return sub, nil
 		}
@@ -73,7 +81,7 @@ func Lookup(name string, commands []*Command) (*Command, error) {
 
 // SetFlags registers a list of functions that configure flags for the command.
 func (c *Command) SetFlags(flagFunctions []func(fs *flag.FlagSet)) {
-	initFlags(c)
+	c.InitFlags()
 	for _, fn := range flagFunctions {
 		fn(c.flags)
 	}
@@ -86,6 +94,14 @@ func (c *Command) usage(w io.Writer) {
 
 	fmt.Fprintf(w, "%s\n\n", c.Long)
 	fmt.Fprintf(w, "Usage:\n  %s", c.Usage)
+	if len(c.Commands) > 0 {
+		fmt.Fprint(w, "\n\nCommands:\n")
+		for _, c := range c.Commands {
+			parts := strings.Fields(c.Short)
+			short := strings.Join(parts[1:], " ")
+			fmt.Fprintf(w, "\n  %-25s  %s", c.Name(), short)
+		}
+	}
 	if hasFlags(c.flags) {
 		fmt.Fprint(w, "\n\nFlags:\n")
 	}
@@ -94,7 +110,7 @@ func (c *Command) usage(w io.Writer) {
 	fmt.Fprintf(w, "\n\n")
 }
 
-func initFlags(c *Command) *Command {
+func (c *Command) InitFlags() *Command {
 	c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	c.flags.Usage = func() {
 		c.usage(c.flags.Output())

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -70,7 +70,9 @@ func TestLookup(t *testing.T) {
 		{"baz", true}, // not found case
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			cmd, err := Lookup(test.name, commands)
+			cmd := &Command{}
+			cmd.Commands = commands
+			sub, err := cmd.Lookup(test.name)
 			if test.wantErr {
 				if err == nil {
 					t.Fatal(err)
@@ -81,8 +83,8 @@ func TestLookup(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmd.Name() != test.name {
-				t.Errorf("got = %q, want = %q", cmd.Name(), test.name)
+			if sub.Name() != test.name {
+				t.Errorf("got = %q, want = %q", sub.Name(), test.name)
 			}
 		})
 	}
@@ -145,7 +147,7 @@ Usage:
 				Usage: "test [flags]",
 				Long:  "Test prints test information.",
 			}
-			initFlags(c)
+			c.InitFlags()
 			c.SetFlags(test.flags)
 
 			var buf bytes.Buffer

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/docker"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
@@ -249,18 +248,6 @@ func commitAll(repo *gitrepo.Repository, msg string) error {
 func logPartialError(id string, err error, action string) string {
 	slog.Warn(fmt.Sprintf("Error while %s %s: %s", action, id, err))
 	return fmt.Sprintf("Error while %s %s", action, id)
-}
-
-var librarianCommands = []*cli.Command{
-	CmdConfigure,
-	CmdGenerate,
-	CmdUpdateApis,
-	CmdCreateReleasePR,
-	CmdUpdateImageTag,
-	CmdMergeReleasePR,
-	CmdCreateReleaseArtifacts,
-	CmdPublishReleaseArtifacts,
-	CmdVersion,
 }
 
 func formatReleaseTag(libraryID, version string) string {

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestCommandUsage(t *testing.T) {
-	for _, c := range librarianCommands {
+	for _, c := range CmdLibrarian.Commands {
 		t.Run(c.Name(), func(t *testing.T) {
 			parts := strings.Fields(c.Usage)
 			// The first word should always be "librarian".

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -16,17 +16,44 @@ package librarian
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/googleapis/librarian/internal/cli"
 )
 
+var CmdLibrarian = &cli.Command{
+	Short: "librarian manages client libraries for Google APIs",
+	Usage: "librarian <command> [arguments]",
+	Long:  "Librarian manages client libraries for Google APIs.",
+}
+
+func init() {
+	CmdLibrarian.Commands = append(CmdLibrarian.Commands,
+		CmdConfigure,
+		CmdGenerate,
+		CmdUpdateApis,
+		CmdCreateReleasePR,
+		CmdUpdateImageTag,
+		CmdMergeReleasePR,
+		CmdCreateReleaseArtifacts,
+		CmdPublishReleaseArtifacts,
+		CmdVersion,
+	)
+}
+
 func Run(ctx context.Context, arg ...string) error {
-	cmd, err := parseArgs(arg)
+	CmdLibrarian.InitFlags()
+	if err := CmdLibrarian.Parse(arg); err != nil {
+		return err
+	}
+	if len(arg) == 0 {
+		CmdLibrarian.Help()
+		return fmt.Errorf("command not specified")
+	}
+	cmd, err := CmdLibrarian.Lookup(arg[0])
 	if err != nil {
+		CmdLibrarian.Help()
 		return err
 	}
 	if err := cmd.Parse(arg[1:]); err != nil {
@@ -34,36 +61,4 @@ func Run(ctx context.Context, arg ...string) error {
 	}
 	slog.Info("librarian", "arguments", arg)
 	return cmd.Run(ctx)
-}
-
-func parseArgs(args []string) (*cli.Command, error) {
-	fs := flag.NewFlagSet("librarian", flag.ContinueOnError)
-	output := `Librarian manages client libraries for Google APIs.
-
-Usage:
-
-  librarian <command> [arguments]
-
-The commands are:
-`
-	for _, c := range librarianCommands {
-		parts := strings.Fields(c.Short)
-		short := strings.Join(parts[1:], " ")
-		output += fmt.Sprintf("\n  %-25s  %s", c.Name(), short)
-	}
-
-	fs.Usage = func() {
-		fmt.Fprint(fs.Output(), output)
-		fs.PrintDefaults()
-		fmt.Fprintf(fs.Output(), "\n\n")
-	}
-
-	if err := fs.Parse(args); err != nil {
-		return nil, err
-	}
-	if len(fs.Args()) == 0 {
-		fs.Usage()
-		return nil, fmt.Errorf("command not specified")
-	}
-	return cli.Lookup(fs.Args()[0], librarianCommands)
 }


### PR DESCRIPTION
The CLI framework now supports subcommands and is used to construct the top-level Librarian command. This aligns its construction with other commands and makes it possible for other subcommands to be supported in the future.

Fixes https://github.com/googleapis/librarian/issues/469