### PR TITLE
feat(internal/cli,librarian): use cli framework for Librarian

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -56,9 +56,11 @@ func TestParseAndSetFlags(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	commands := []*Command{
-		{Short: "foo runs the foo command"},
-		{Short: "bar runs the bar command"},
+	testCmd := &Command{
+		Commands: []*Command{
+			{Short: "foo runs the foo command"},
+			{Short: "bar runs the bar command"},
+		},
 	}
 
 	for _, test := range []struct {
@@ -70,7 +72,7 @@ func TestLookup(t *testing.T) {
 		{"baz", true}, // not found case
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			cmd, err := Lookup(test.name, commands)
+			cmd, err := testCmd.Lookup(test.name)
 			if test.wantErr {
 				if err == nil {
 					t.Fatal(err)


### PR DESCRIPTION
The CLI framework now supports subcommands and is used to construct the top-level Librarian command. This aligns its construction with other commands and makes it possible for other subcommands to be supported in the future.

Fixes https://github.com/googleapis/librarian/issues/469

---

This commit is based off of
https://github.com/googleapis/librarian/pull/478. It is ready for review, and will be rebased once
https://github.com/googleapis/librarian/pull/478 is merged. This section of the commit message will then be removed.