### PR TITLE
feat(internal/cli,librarian): pass config to cli.Run

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
 )
 
 // Command represents a single command that can be executed by the application.
@@ -34,7 +36,7 @@ type Command struct {
 	Long string
 
 	// Run executes the command.
-	Run func(ctx context.Context) error
+	Run func(ctx context.Context, cfg *config.Config) error
 
 	// flags is the command's flag set for parsing arguments and generating
 	// usage messages. This is populated for each command in init().

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestParseAndSetFlags(t *testing.T) {
@@ -92,13 +93,14 @@ func TestRun(t *testing.T) {
 	executed := false
 	cmd := &Command{
 		Short: "run runs the command",
-		Run: func(ctx context.Context) error {
+		Run: func(ctx context.Context, cfg *config.Config) error {
 			executed = true
 			return nil
 		},
 	}
 
-	if err := cmd.Run(context.Background()); err != nil {
+	cfg := &config.Config{}
+	if err := cmd.Run(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
 	if !executed {

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/statepb"
 	"gopkg.in/yaml.v3"
 )
@@ -98,7 +99,7 @@ func init() {
 	})
 }
 
-func runConfigure(ctx context.Context) error {
+func runConfigure(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
@@ -82,7 +83,7 @@ func init() {
 	})
 }
 
-func runCreateReleaseArtifacts(ctx context.Context) error {
+func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/githubrepo"
 
 	"github.com/Masterminds/semver/v3"
@@ -121,7 +122,7 @@ func init() {
 	})
 }
 
-func runCreateReleasePR(ctx context.Context) error {
+func runCreateReleasePR(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -70,15 +70,13 @@ There is no "clean" operation or copying of the generated code in raw generation
 other source code to be preserved/cleaned. Instead, the "build-raw" command is provided with the same
 output directory that was specified for the "generate-raw" command.
 `,
-	Run: func(ctx context.Context) error {
+	Run: func(ctx context.Context, cfg *config.Config) error {
 		if err := validateRequiredFlag("api-path", flagAPIPath); err != nil {
 			return err
 		}
 		if err := validateRequiredFlag("api-root", flagAPIRoot); err != nil {
 			return err
 		}
-		cfg := config.New()
-		applyFlags(cfg)
 		return runGenerate(ctx, cfg)
 	},
 }

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func Run(ctx context.Context, arg ...string) error {
@@ -33,7 +34,10 @@ func Run(ctx context.Context, arg ...string) error {
 		return err
 	}
 	slog.Info("librarian", "arguments", arg)
-	return cmd.Run(ctx)
+
+	cfg := config.New()
+	applyFlags(cfg)
+	return cmd.Run(ctx, cfg)
 }
 
 func parseArgs(args []string) (*cli.Command, error) {

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/go-github/v69/github"
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/githubrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 )
@@ -108,7 +109,7 @@ func init() {
 	})
 }
 
-func runMergeReleasePR(ctx context.Context) error {
+func runMergeReleasePR(ctx context.Context, cfg *config.Config) error {
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime)
 	if err != nil {

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/docker"
 	"github.com/googleapis/librarian/internal/githubrepo"
 )
@@ -70,7 +71,7 @@ func init() {
 	})
 }
 
-func runPublishReleaseArtifacts(ctx context.Context) error {
+func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 	if err := validateRequiredFlag("artifact-root", flagArtifactRoot); err != nil {
 		return err
 	}

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 )
@@ -100,7 +101,7 @@ func init() {
 	})
 }
 
-func runUpdateAPIs(ctx context.Context) error {
+func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 )
@@ -87,7 +88,7 @@ func init() {
 	})
 }
 
-func runUpdateImageTag(ctx context.Context) error {
+func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx)
 	if err != nil {
 		return err

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -19,13 +19,14 @@ import (
 	"fmt"
 
 	"github.com/googleapis/librarian/internal/cli"
+	"github.com/googleapis/librarian/internal/config"
 )
 
 var CmdVersion = &cli.Command{
 	Short: "version prints the version information",
 	Usage: "librarian version",
 	Long:  "Version prints version information for the librarian binary.",
-	Run: func(ctx context.Context) error {
+	Run: func(ctx context.Context, cfg *config.Config) error {
 		fmt.Println(cli.Version())
 		return nil
 	},


### PR DESCRIPTION
Change Command.Run to take a *config.Config:

    Run(ctx context.Context, cfg *config.Config) error

This lets us construct the config once in librarian.Run and pass it through, instead of rebuilding it in each command.

Fixes https://github.com/googleapis/librarian/issues/575