### PR TITLE
fix(all_test.go): make the linter ignore generated protobuf code

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -127,7 +127,7 @@ func TestExportedSymbolsHaveDocs(t *testing.T) {
 	t.Skip()
 
 	err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".pb.go") {
 			return nil
 		}
 


### PR DESCRIPTION
Fixes #587