### PR TITLE
docker: add Docker.run method

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -57,6 +57,8 @@ type Docker struct {
 
 	// The provider for environment variables, if any.
 	env *EnvironmentProvider
+
+	run func(args ...string) error
 }
 
 func New(ctx context.Context, workRoot, image, secretsProject string, pipelineConfig *statepb.PipelineConfig) (*Docker, error) {
@@ -67,6 +69,9 @@ func New(ctx context.Context, workRoot, image, secretsProject string, pipelineCo
 	return &Docker{
 		Image: image,
 		env:   envProvider,
+		run: func(args ...string) error {
+			return runCommand("docker", args...)
+		},
 	}, nil
 }
 
@@ -281,7 +286,7 @@ func (c *Docker) runDocker(command Command, mounts []string, commandArgs []strin
 	args = append(args, c.Image)
 	args = append(args, string(command))
 	args = append(args, commandArgs...)
-	return runCommand("docker", args...)
+	return c.run(args...)
 }
 
 func maybeRelocateMounts(mounts []string) []string {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDockerRun(t *testing.T) {
+	d := &Docker{
+		Image: "test-image",
+		run: func(args ...string) error {
+			fmt.Println(args)
+			return nil
+		},
+	}
+
+	for _, test := range []struct {
+		name string
+		run  func() error
+		want []string
+	}{
+		{
+			name: "generate-raw",
+			run: func() error {
+				return d.GenerateRaw("apiRoot", "output", "apiPath")
+			},
+			want: []string{
+				"run", "--rm",
+				"--user=501:20",
+				"-v", "apiRoot:/apis",
+				"-v", "output:/output",
+				"--network=none",
+				"test-image",
+				"generate-raw",
+				"--api-root=/apis",
+				"--output=/output",
+				"--api-path=apiPath",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.run(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a Docker.run method to encapsulate Docker command execution. This isolates command construction, making it easier to test.