### PR TITLE
feat(internal/docker): add Docker.run and test command construction

### DIFF
--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -1,0 +1,223 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDockerRun(t *testing.T) {
+	const (
+		testAPIPath         = "testAPIPath"
+		testAPIRoot         = "testAPIRoot"
+		testGeneratorInput  = "testGeneratorInput"
+		testGeneratorOutput = "testGeneratorOutput"
+		testImage           = "testImage"
+		testInputsDirectory = "testInputsDirectory"
+		testLanguageRepo    = "testLanguageRepo"
+		testLibraryID       = "testLibraryID"
+		testLibraryVersion  = "testLibraryVersion"
+		testOutput          = "testOutput"
+		testOutputDir       = "testOutputDir"
+		testReleaseVersion  = "testReleaseVersion"
+		testRepoRoot        = "testRepoRoot"
+	)
+
+	d := &Docker{
+		Image: testImage,
+	}
+
+	for _, test := range []struct {
+		name       Command
+		runCommand func() error
+		want       []string
+	}{
+		{
+			name: CommandGenerateRaw,
+			runCommand: func() error {
+				return d.GenerateRaw(testAPIRoot, testOutput, testAPIPath)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
+				"-v", fmt.Sprintf("%s:/output", testOutput),
+				"--network=none",
+				testImage,
+				string(CommandGenerateRaw),
+				"--api-root=/apis",
+				"--output=/output",
+				fmt.Sprintf("--api-path=%s", testAPIPath),
+			},
+		},
+		{
+			name: CommandGenerateLibrary,
+			runCommand: func() error {
+				return d.GenerateLibrary(testAPIRoot, testOutput, testGeneratorInput, testLibraryID)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
+				"-v", fmt.Sprintf("%s:/output", testOutput),
+				"-v", fmt.Sprintf("%s:/generator-input", testGeneratorInput),
+				"--network=none",
+				testImage,
+				string(CommandGenerateLibrary),
+				"--api-root=/apis",
+				"--output=/output",
+				"--generator-input=/generator-input",
+				fmt.Sprintf("--library-id=%s", testLibraryID),
+			},
+		},
+		{
+			name: CommandClean,
+			runCommand: func() error {
+				return d.Clean(testRepoRoot, testLibraryID)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/repo", testRepoRoot),
+				"--network=none",
+				testImage,
+				string(CommandClean),
+				"--repo-root=/repo",
+				fmt.Sprintf("--library-id=%s", testLibraryID),
+			},
+		},
+		{
+			name: CommandBuildRaw,
+			runCommand: func() error {
+				return d.BuildRaw(testGeneratorOutput, testAPIPath)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/generator-output", testGeneratorOutput),
+				testImage,
+				string(CommandBuildRaw),
+				"--generator-output=/generator-output",
+				fmt.Sprintf("--api-path=%s", testAPIPath),
+			},
+		},
+		{
+			name: CommandBuildLibrary,
+			runCommand: func() error {
+				return d.BuildLibrary(testRepoRoot, testLibraryID)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/repo", testRepoRoot),
+				testImage,
+				string(CommandBuildLibrary),
+				"--repo-root=/repo",
+				"--test=true",
+				fmt.Sprintf("--library-id=%s", testLibraryID),
+			},
+		},
+		{
+			name: CommandConfigure,
+			runCommand: func() error {
+				return d.Configure(testAPIRoot, testAPIPath, testGeneratorInput)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
+				"-v", fmt.Sprintf("%s:/generator-input", testGeneratorInput),
+				"--network=none",
+				testImage,
+				string(CommandConfigure),
+				"--api-root=/apis",
+				"--generator-input=/generator-input",
+				fmt.Sprintf("--api-path=%s", testAPIPath),
+			},
+		},
+		{
+			name: CommandPrepareLibraryRelease,
+			runCommand: func() error {
+				return d.PrepareLibraryRelease(testLanguageRepo, testInputsDirectory, testLibraryID, testReleaseVersion)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/repo", testLanguageRepo),
+				"-v", fmt.Sprintf("%s:/inputs", testInputsDirectory),
+				"--network=none",
+				testImage,
+				string(CommandPrepareLibraryRelease),
+				"--repo-root=/repo",
+				fmt.Sprintf("--library-id=%s", testLibraryID),
+				fmt.Sprintf("--release-notes=/inputs/%s-%s-release-notes.txt", testLibraryID, testReleaseVersion),
+				fmt.Sprintf("--version=%s", testReleaseVersion),
+			},
+		},
+		{
+			name: CommandIntegrationTestLibrary,
+			runCommand: func() error {
+				return d.IntegrationTestLibrary(testLanguageRepo, testLibraryID)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/repo", testLanguageRepo),
+				testImage,
+				string(CommandIntegrationTestLibrary),
+				"--repo-root=/repo",
+				fmt.Sprintf("--library-id=%s", testLibraryID),
+			},
+		},
+		{
+			name: CommandPackageLibrary,
+			runCommand: func() error {
+				return d.PackageLibrary(testLanguageRepo, testLibraryID, testOutputDir)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/repo", testLanguageRepo),
+				"-v", fmt.Sprintf("%s:/output", testOutputDir),
+				testImage,
+				string(CommandPackageLibrary),
+				"--repo-root=/repo",
+				"--output=/output",
+				fmt.Sprintf("--library-id=%s", testLibraryID),
+			},
+		},
+		{
+			name: CommandPublishLibrary,
+			runCommand: func() error {
+				return d.PublishLibrary(testOutputDir, testLibraryID, testLibraryVersion)
+			},
+			want: []string{
+				"run", "--rm",
+				"-v", fmt.Sprintf("%s:/output", testOutputDir),
+				testImage,
+				string(CommandPublishLibrary),
+				"--package-output=/output",
+				fmt.Sprintf("--library-id=%s", testLibraryID),
+				fmt.Sprintf("--version=%s", testLibraryVersion),
+			},
+		},
+	} {
+		t.Run(string(test.name), func(t *testing.T) {
+			d.run = func(args ...string) error {
+				if diff := cmp.Diff(test.want, args); diff != "" {
+					t.Errorf("mismatch(-want +got):\n%s", diff)
+				}
+				return nil
+			}
+			if err := test.runCommand(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A Docker.run method is added to encapsulate Docker command execution. This isolates command construction, making it easier to test.

A test is also added for Docker command construction across all supported operations, using a mock run method that compares the expected and actual docker command.

The test surfaced a bug in PublishLibrary, where the --version flag was incorrectly set to the library ID instead of the library version. This has been fixed.

Fixes https://github.com/googleapis/librarian/issues/592