### PR TITLE
docs(contributing): add guidance for opening pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,37 @@ Use the format:
 This helps provide context for future readers and keeps the TODO relevant and
 actionable as the project evolves.
 
+## Opening a pull request
+
+A pull request can be opened from a branch within the repository or from a
+fork. External contributors are only able to open pull requests from forks,
+but team members with write access can choose to open a pull request from a
+repository branch.
+
+### Pull request from a fork
+
+If you open a pull request from a personal fork, you should allow repository
+maintainers to make edits to your fork by turning on
+"Allow edits from maintainers".
+
+### Pull request from a branch
+
+If you are a team member with write access, you can create a branch within the
+repository with your changes and open a pull request from it. After the pull
+request is merged, the branch will be automatically deleted.
+
+You should not have any long-lived branches within the repository without an
+open pull request. Such non-protected branches that don't have an associated
+open pull request, will be periodically cleaned up.
+
+### Pull requests with multiple commits
+
+When opening a pull request, it can be helpful to structure the commits for review. If
+your pull request has multiple commits, note in the description whether reviewers should
+review them individually or just focus on the final result. (For example, if
+earlier commits are exploratory and only the end state matters, make that clear
+to avoid wasting reviewer time.)
+
 ## Sending a pull request
 
 All code changes must go through a pull request. First-time contributors should
@@ -217,14 +248,6 @@ back with that request without review.
 
 After creating a pull request, request a specific reviewer if relevant, or leave it for
 the default group.
-
-### Opening a pull request with multiple commits
-
-When opening a pull request, it can be helpful to structure the commits for review. If
-your pull request has multiple commits, note in the description whether reviewers should
-review them individually or just focus on the final result. (For example, if
-earlier commits are exploratory and only the end state matters, make that clear
-to avoid wasting reviewer time.)
 
 ### Merging a pull request
 


### PR DESCRIPTION
Document both options of using a branch or a fork to open pull requests.

Fixes: #343.