### PR TITLE
fix: remove direct reference of global flag from updateImageTag

### DIFF
--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -162,7 +162,7 @@ func updateImageTag(state *commandState, cfg *config.Config) error {
 	}
 
 	// Commit any changes
-	commitMsg := fmt.Sprintf("chore: update generation image tag to %s", flagTag)
+	commitMsg := fmt.Sprintf("chore: update generation image tag to %s", cfg.Tag)
 	if err := commitAll(languageRepo, commitMsg); err != nil {
 		return err
 	}


### PR DESCRIPTION
For #498, remaining work to close it is in #560 and #609.

Get tag from config instead of global flag.