### PR TITLE
fix(internal/cli,librarian): remove cli.Command.SetFlags

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -44,23 +44,15 @@ type Command struct {
 	// Commands are the sub commands.
 	Commands []*Command
 
-	// flags is the command's flag set for parsing arguments and generating
+	// Flags is the command's flag set for parsing arguments and generating
 	// usage messages. This is populated for each command in init().
-	flags *flag.FlagSet
-}
-
-// Help prints the help text.
-func (c *Command) Help() {
-	c.flags.Usage()
+	Flags *flag.FlagSet
 }
 
 // Parse parses the provided command-line arguments using the command's flag
 // set.
 func (c *Command) Parse(args []string) error {
-	if c.flags == nil {
-		return nil
-	}
-	return c.flags.Parse(args)
+	return c.Flags.Parse(args)
 }
 
 // Name is the command name. Command.Short is always expected to begin with
@@ -84,14 +76,6 @@ func (c *Command) Lookup(name string) (*Command, error) {
 	return nil, fmt.Errorf("invalid command: %q", name)
 }
 
-// SetFlags registers a list of functions that configure flags for the command.
-func (c *Command) SetFlags(flagFunctions []func(fs *flag.FlagSet)) {
-	c.InitFlags()
-	for _, fn := range flagFunctions {
-		fn(c.flags)
-	}
-}
-
 func (c *Command) usage(w io.Writer) {
 	if c.Short == "" || c.Usage == "" || c.Long == "" {
 		panic(fmt.Sprintf("command %q is missing documentation", c.Name()))
@@ -107,18 +91,18 @@ func (c *Command) usage(w io.Writer) {
 			fmt.Fprintf(w, "\n  %-25s  %s", c.Name(), short)
 		}
 	}
-	if hasFlags(c.flags) {
+	if hasFlags(c.Flags) {
 		fmt.Fprint(w, "\n\nFlags:\n")
 	}
-	c.flags.SetOutput(w)
-	c.flags.PrintDefaults()
+	c.Flags.SetOutput(w)
+	c.Flags.PrintDefaults()
 	fmt.Fprintf(w, "\n\n")
 }
 
 func (c *Command) InitFlags() *Command {
-	c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
-	c.flags.Usage = func() {
-		c.usage(c.flags.Output())
+	c.Flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	c.Flags.Usage = func() {
+		c.usage(c.Flags.Output())
 	}
 	return c
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -36,12 +36,9 @@ func TestParseAndSetFlags(t *testing.T) {
 		Long:  "This is the long documentation for command test.",
 		Usage: "foobar test [arguments]",
 	}
-	cmd.SetFlags([]func(fs *flag.FlagSet){
-		func(fs *flag.FlagSet) {
-			fs.StringVar(&strFlag, "name", "default", "name flag")
-			fs.IntVar(&intFlag, "count", 0, "count flag")
-		},
-	})
+	cmd.InitFlags()
+	cmd.Flags.StringVar(&strFlag, "name", "default", "name flag")
+	cmd.Flags.IntVar(&intFlag, "count", 0, "count flag")
 
 	args := []string{"-name=foo", "-count=5"}
 	if err := cmd.Parse(args); err != nil {
@@ -150,7 +147,9 @@ Usage:
 				Long:  "Test prints test information.",
 			}
 			c.InitFlags()
-			c.SetFlags(test.flags)
+			for _, fn := range test.flags {
+				fn(c.Flags)
+			}
 
 			var buf bytes.Buffer
 			c.usage(&buf)

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -17,7 +17,6 @@ package librarian
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -84,19 +83,18 @@ commits will still be present in the language repo.
 }
 
 func init() {
-	cmdConfigure.SetFlags([]func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagAPIPath,
-		addFlagAPIRoot,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagLanguage,
-		addFlagPush,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-		addFlagSecretsProject,
-	})
+	cmdConfigure.InitFlags()
+	addFlagImage(cmdConfigure.Flags)
+	addFlagWorkRoot(cmdConfigure.Flags)
+	addFlagAPIPath(cmdConfigure.Flags)
+	addFlagAPIRoot(cmdConfigure.Flags)
+	addFlagGitUserEmail(cmdConfigure.Flags)
+	addFlagGitUserName(cmdConfigure.Flags)
+	addFlagLanguage(cmdConfigure.Flags)
+	addFlagPush(cmdConfigure.Flags)
+	addFlagRepoRoot(cmdConfigure.Flags)
+	addFlagRepoUrl(cmdConfigure.Flags)
+	addFlagSecretsProject(cmdConfigure.Flags)
 }
 
 func runConfigure(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -17,7 +17,6 @@ package librarian
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -80,16 +79,15 @@ if retried.
 }
 
 func init() {
-	cmdCreateReleaseArtifacts.SetFlags([]func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagLanguage,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-		addFlagReleaseID,
-		addFlagSecretsProject,
-		addFlagSkipIntegrationTests,
-	})
+	cmdCreateReleaseArtifacts.InitFlags()
+	addFlagImage(cmdCreateReleaseArtifacts.Flags)
+	addFlagWorkRoot(cmdCreateReleaseArtifacts.Flags)
+	addFlagLanguage(cmdCreateReleaseArtifacts.Flags)
+	addFlagRepoRoot(cmdCreateReleaseArtifacts.Flags)
+	addFlagRepoUrl(cmdCreateReleaseArtifacts.Flags)
+	addFlagReleaseID(cmdCreateReleaseArtifacts.Flags)
+	addFlagSecretsProject(cmdCreateReleaseArtifacts.Flags)
+	addFlagSkipIntegrationTests(cmdCreateReleaseArtifacts.Flags)
 }
 
 func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -16,7 +16,6 @@ package librarian
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -105,21 +104,20 @@ commits will still be present in the language repo.
 }
 
 func init() {
-	cmdCreateReleasePR.SetFlags([]func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagSecretsProject,
-		addFlagWorkRoot,
-		addFlagLanguage,
-		addFlagLibraryID,
-		addFlagLibraryVersion,
-		addFlagPush,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagRepoRoot,
-		addFlagSkipIntegrationTests,
-		addFlagEnvFile,
-		addFlagRepoUrl,
-	})
+	cmdCreateReleasePR.InitFlags()
+	addFlagImage(cmdCreateReleasePR.Flags)
+	addFlagSecretsProject(cmdCreateReleasePR.Flags)
+	addFlagWorkRoot(cmdCreateReleasePR.Flags)
+	addFlagLanguage(cmdCreateReleasePR.Flags)
+	addFlagLibraryID(cmdCreateReleasePR.Flags)
+	addFlagLibraryVersion(cmdCreateReleasePR.Flags)
+	addFlagPush(cmdCreateReleasePR.Flags)
+	addFlagGitUserEmail(cmdCreateReleasePR.Flags)
+	addFlagGitUserName(cmdCreateReleasePR.Flags)
+	addFlagRepoRoot(cmdCreateReleasePR.Flags)
+	addFlagSkipIntegrationTests(cmdCreateReleasePR.Flags)
+	addFlagEnvFile(cmdCreateReleasePR.Flags)
+	addFlagRepoUrl(cmdCreateReleasePR.Flags)
 }
 
 func runCreateReleasePR(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -17,7 +17,6 @@ package librarian
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -82,17 +81,16 @@ output directory that was specified for the "generate-raw" command.
 }
 
 func init() {
-	cmdGenerate.SetFlags([]func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagAPIPath,
-		addFlagAPIRoot,
-		addFlagLanguage,
-		addFlagBuild,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-		addFlagSecretsProject,
-	})
+	cmdGenerate.InitFlags()
+	addFlagImage(cmdGenerate.Flags)
+	addFlagWorkRoot(cmdGenerate.Flags)
+	addFlagAPIPath(cmdGenerate.Flags)
+	addFlagAPIRoot(cmdGenerate.Flags)
+	addFlagLanguage(cmdGenerate.Flags)
+	addFlagBuild(cmdGenerate.Flags)
+	addFlagRepoRoot(cmdGenerate.Flags)
+	addFlagRepoUrl(cmdGenerate.Flags)
+	addFlagSecretsProject(cmdGenerate.Flags)
 }
 
 func runGenerate(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -34,6 +34,7 @@ var CmdLibrarian = &cli.Command{
 }
 
 func init() {
+	CmdLibrarian.InitFlags()
 	CmdLibrarian.Commands = append(CmdLibrarian.Commands,
 		cmdConfigure,
 		cmdGenerate,
@@ -50,20 +51,20 @@ func init() {
 // Run executes the Librarian CLI with the given command line
 // arguments.
 func Run(ctx context.Context, arg ...string) error {
-	CmdLibrarian.InitFlags()
 	if err := CmdLibrarian.Parse(arg); err != nil {
 		return err
 	}
 	if len(arg) == 0 {
-		CmdLibrarian.Help()
+		CmdLibrarian.Flags.Usage()
 		return fmt.Errorf("command not specified")
 	}
 	cmd, err := CmdLibrarian.Lookup(arg[0])
 	if err != nil {
-		CmdLibrarian.Help()
+		CmdLibrarian.Flags.Usage()
 		return err
 	}
 	if err := cmd.Parse(arg[1:]); err != nil {
+		CmdLibrarian.Flags.Usage()
 		return err
 	}
 	slog.Info("librarian", "arguments", arg)

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -17,7 +17,6 @@ package librarian
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -98,15 +97,14 @@ is added.
 }
 
 func init() {
-	cmdMergeReleasePR.SetFlags([]func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagSecretsProject,
-		addFlagWorkRoot,
-		addFlagBaselineCommit,
-		addFlagReleaseID,
-		addFlagReleasePRUrl,
-		addFlagSyncUrlPrefix,
-	})
+	cmdMergeReleasePR.InitFlags()
+	addFlagImage(cmdMergeReleasePR.Flags)
+	addFlagSecretsProject(cmdMergeReleasePR.Flags)
+	addFlagWorkRoot(cmdMergeReleasePR.Flags)
+	addFlagBaselineCommit(cmdMergeReleasePR.Flags)
+	addFlagReleaseID(cmdMergeReleasePR.Flags)
+	addFlagReleasePRUrl(cmdMergeReleasePR.Flags)
+	addFlagSyncUrlPrefix(cmdMergeReleasePR.Flags)
 }
 
 func runMergeReleasePR(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -62,14 +61,13 @@ create a tag which already exists.)
 }
 
 func init() {
-	cmdPublishReleaseArtifacts.SetFlags([]func(fs *flag.FlagSet){
-		addFlagArtifactRoot,
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagLanguage,
-		addFlagSecretsProject,
-		addFlagTagRepoUrl,
-	})
+	cmdPublishReleaseArtifacts.InitFlags()
+	addFlagArtifactRoot(cmdPublishReleaseArtifacts.Flags)
+	addFlagImage(cmdPublishReleaseArtifacts.Flags)
+	addFlagWorkRoot(cmdPublishReleaseArtifacts.Flags)
+	addFlagLanguage(cmdPublishReleaseArtifacts.Flags)
+	addFlagSecretsProject(cmdPublishReleaseArtifacts.Flags)
+	addFlagTagRepoUrl(cmdPublishReleaseArtifacts.Flags)
 }
 
 func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -16,7 +16,6 @@ package librarian
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -84,20 +83,19 @@ commits will still be present in the language repo.
 }
 
 func init() {
-	cmdUpdateApis.SetFlags([]func(fs *flag.FlagSet){
-		addFlagImage,
-		addFlagWorkRoot,
-		addFlagAPIRoot,
-		addFlagBranch,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagLanguage,
-		addFlagLibraryID,
-		addFlagPush,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-		addFlagSecretsProject,
-	})
+	cmdUpdateApis.InitFlags()
+	addFlagImage(cmdUpdateApis.Flags)
+	addFlagWorkRoot(cmdUpdateApis.Flags)
+	addFlagAPIRoot(cmdUpdateApis.Flags)
+	addFlagBranch(cmdUpdateApis.Flags)
+	addFlagGitUserEmail(cmdUpdateApis.Flags)
+	addFlagGitUserName(cmdUpdateApis.Flags)
+	addFlagLanguage(cmdUpdateApis.Flags)
+	addFlagLibraryID(cmdUpdateApis.Flags)
+	addFlagPush(cmdUpdateApis.Flags)
+	addFlagRepoRoot(cmdUpdateApis.Flags)
+	addFlagRepoUrl(cmdUpdateApis.Flags)
+	addFlagSecretsProject(cmdUpdateApis.Flags)
 }
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -17,7 +17,6 @@ package librarian
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -73,19 +72,18 @@ in the language repo.
 }
 
 func init() {
-	cmdUpdateImageTag.SetFlags([]func(fs *flag.FlagSet){
-		addFlagWorkRoot,
-		addFlagAPIRoot,
-		addFlagBranch,
-		addFlagGitUserEmail,
-		addFlagGitUserName,
-		addFlagLanguage,
-		addFlagPush,
-		addFlagRepoRoot,
-		addFlagRepoUrl,
-		addFlagSecretsProject,
-		addFlagTag,
-	})
+	cmdUpdateImageTag.InitFlags()
+	addFlagWorkRoot(cmdUpdateImageTag.Flags)
+	addFlagAPIRoot(cmdUpdateImageTag.Flags)
+	addFlagBranch(cmdUpdateImageTag.Flags)
+	addFlagGitUserEmail(cmdUpdateImageTag.Flags)
+	addFlagGitUserName(cmdUpdateImageTag.Flags)
+	addFlagLanguage(cmdUpdateImageTag.Flags)
+	addFlagPush(cmdUpdateImageTag.Flags)
+	addFlagRepoRoot(cmdUpdateImageTag.Flags)
+	addFlagRepoUrl(cmdUpdateImageTag.Flags)
+	addFlagSecretsProject(cmdUpdateImageTag.Flags)
+	addFlagTag(cmdUpdateImageTag.Flags)
 }
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -31,3 +31,7 @@ var cmdVersion = &cli.Command{
 		return nil
 	},
 }
+
+func init() {
+	cmdVersion.InitFlags()
+}


### PR DESCRIPTION
Command.Flags is now exported, which allows Command.SetFlags to be removed.

This simplifies flag setup by allowing direct access without needing SetFlags or other helper methods. Flags can now be added inline or via helper functions like:

  cmd.Flags.Bool("v", ...)
  addVerboseFlag(&cmd.Flags)

Fixes https://github.com/googleapis/librarian/issues/236