### PR TITLE
fix(internal/librarian): remove ctx from commandState

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -34,9 +34,6 @@ const releaseIDEnvVarName = "_RELEASE_ID"
 
 // commandState holds all necessary information for a command execution.
 type commandState struct {
-	// ctx provides context for cancellable operations.
-	ctx context.Context
-
 	// startTime records when the command began execution. This is used as a
 	// consistent timestamp for commands when necessary.
 	startTime time.Time
@@ -136,7 +133,6 @@ func createCommandStateForLanguage(ctx context.Context) (*commandState, error) {
 	}
 
 	state := &commandState{
-		ctx:             ctx,
 		startTime:       startTime,
 		workRoot:        workRoot,
 		languageRepo:    repo,

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -104,10 +104,10 @@ func runConfigure(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	return executeConfigure(state, cfg)
+	return executeConfigure(ctx, state, cfg)
 }
 
-func executeConfigure(state *commandState, cfg *config.Config) error {
+func executeConfigure(ctx context.Context, state *commandState, cfg *config.Config) error {
 
 	outputRoot := filepath.Join(state.workRoot, "output")
 	if err := os.Mkdir(outputRoot, 0755); err != nil {
@@ -144,7 +144,7 @@ func executeConfigure(state *commandState, cfg *config.Config) error {
 		}
 	}
 
-	_, err = createPullRequest(state, &prContent, "feat: API configuration", "", "config", cfg.GitHubToken, cfg.Push)
+	_, err = createPullRequest(ctx, state, &prContent, "feat: API configuration", "", "config", cfg.GitHubToken, cfg.Push)
 	return err
 }
 

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -127,10 +127,10 @@ func runCreateReleasePR(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	return createReleasePR(state, cfg)
+	return createReleasePR(ctx, state, cfg)
 }
 
-func createReleasePR(state *commandState, cfg *config.Config) error {
+func createReleasePR(ctx context.Context, state *commandState, cfg *config.Config) error {
 	if err := validateSkipIntegrationTests(); err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func createReleasePR(state *commandState, cfg *config.Config) error {
 		return err
 	}
 
-	prMetadata, err := createPullRequest(state, prContent, "chore: Library release", fmt.Sprintf("Librarian-Release-ID: %s", releaseID), "release", cfg.GitHubToken, cfg.Push)
+	prMetadata, err := createPullRequest(ctx, state, prContent, "chore: Library release", fmt.Sprintf("Librarian-Release-ID: %s", releaseID), "release", cfg.GitHubToken, cfg.Push)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func createReleasePR(state *commandState, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	err = ghClient.AddLabelToPullRequest(state.ctx, prMetadata, DoNotMergeLabel)
+	err = ghClient.AddLabelToPullRequest(ctx, prMetadata, DoNotMergeLabel)
 	if err != nil {
 		slog.Warn(fmt.Sprintf("Received error trying to add label to PR: '%s'", err))
 		return err

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -133,7 +133,6 @@ func runGenerate(ctx context.Context, cfg *config.Config) error {
 	}
 
 	state := &commandState{
-		ctx:             ctx,
 		startTime:       startTime,
 		workRoot:        workRoot,
 		languageRepo:    repo,

--- a/internal/librarian/pullrequest.go
+++ b/internal/librarian/pullrequest.go
@@ -15,6 +15,7 @@
 package librarian
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -57,7 +58,7 @@ func addSuccessToPullRequest(pr *PullRequestContent, text string) {
 // If content only contains errors, the pull request is not created and an error is returned (to highlight that everything failed)
 // If content contains any successes, a pull request is created and no error is returned (if the creation is successful) even if the content includes errors.
 // If the pull request would contain an excessive number of commits (as configured in pipeline-config.json)
-func createPullRequest(state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*githubrepo.PullRequestMetadata, error) {
+func createPullRequest(ctx context.Context, state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*githubrepo.PullRequestMetadata, error) {
 	ghClient, err := githubrepo.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
@@ -116,7 +117,7 @@ func createPullRequest(state *commandState, content *PullRequestContent, titlePr
 		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
 		return nil, err
 	}
-	return ghClient.CreatePullRequest(state.ctx, gitHubRepo, branch, title, description)
+	return ghClient.CreatePullRequest(ctx, gitHubRepo, branch, title, description)
 }
 
 // Formats the given list as a single Markdown string, with a title preceding the list,

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -105,10 +105,10 @@ func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	return updateAPIs(state, cfg)
+	return updateAPIs(ctx, state, cfg)
 }
 
-func updateAPIs(state *commandState, cfg *config.Config) error {
+func updateAPIs(ctx context.Context, state *commandState, cfg *config.Config) error {
 	var apiRepo *gitrepo.Repository
 	cleanWorkingTreePostGeneration := true
 	if cfg.APIRoot == "" {
@@ -164,7 +164,7 @@ func updateAPIs(state *commandState, cfg *config.Config) error {
 	if cleanWorkingTreePostGeneration {
 		apiRepo.CleanWorkingTree()
 	}
-	_, err := createPullRequest(state, prContent, "feat: API regeneration", "", "regen", cfg.GitHubToken, cfg.Push)
+	_, err := createPullRequest(ctx, state, prContent, "feat: API regeneration", "", "regen", cfg.GitHubToken, cfg.Push)
 	return err
 }
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -93,10 +93,10 @@ func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	return updateImageTag(state, cfg)
+	return updateImageTag(ctx, state, cfg)
 }
 
-func updateImageTag(state *commandState, cfg *config.Config) error {
+func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config) error {
 	if err := validateRequiredFlag("tag", cfg.Tag); err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func updateImageTag(state *commandState, cfg *config.Config) error {
 	// can massage it into a similar state.
 	prContent := new(PullRequestContent)
 	addSuccessToPullRequest(prContent, "Regenerated all libraries with new image tag.")
-	_, err := createPullRequest(state, prContent, "chore: update generation image tag", "", "update-image-tag", cfg.GitHubToken, cfg.Push)
+	_, err := createPullRequest(ctx, state, prContent, "chore: update generation image tag", "", "update-image-tag", cfg.GitHubToken, cfg.Push)
 	return err
 }
 


### PR DESCRIPTION
Remove `context.Context` from the `commandState` struct and instead passes it explicitly to functions that require it, following the guidance from https://go.dev/blog/context-and-structs.

This refactor improves clarity and avoids storing context across method boundaries.

Fixes #516