### PR TITLE
feat(all_test.go): unskip the linter

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -122,10 +122,6 @@ func rungo(t *testing.T, args ...string) {
 }
 
 func TestExportedSymbolsHaveDocs(t *testing.T) {
-	// TODO(https://github.com/googleapis/librarian/issues/522): turn on once
-	// all existing symbols have docs.
-	t.Skip()
-
 	err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
 			strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".pb.go") {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -115,6 +115,9 @@ func (c *Command) usage(w io.Writer) {
 	fmt.Fprintf(w, "\n\n")
 }
 
+// InitFlags creates a new set of flags for the command and initializes
+// them such that any parsing failures result in the command usage being
+// displayed.
 func (c *Command) InitFlags() *Command {
 	c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	c.flags.Usage = func() {


### PR DESCRIPTION
This requires adding a doc comment for one recently-exported method, but other than that, the test was already effectively passing.

Fixes #521