### PR TITLE
fix(internal/cli): rename Usage to UsageLine

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,8 +32,8 @@ type Command struct {
 	// Short is a concise one-line description of the command.
 	Short string
 
-	// Usage is the one line usage.
-	Usage string
+	// UsageLine is the one line usage.
+	UsageLine string
 
 	// Long is the full description of the command.
 	Long string
@@ -77,12 +77,12 @@ func (c *Command) Lookup(name string) (*Command, error) {
 }
 
 func (c *Command) usage(w io.Writer) {
-	if c.Short == "" || c.Usage == "" || c.Long == "" {
+	if c.Short == "" || c.UsageLine == "" || c.Long == "" {
 		panic(fmt.Sprintf("command %q is missing documentation", c.Name()))
 	}
 
 	fmt.Fprintf(w, "%s\n\n", c.Long)
-	fmt.Fprintf(w, "Usage:\n  %s", c.Usage)
+	fmt.Fprintf(w, "Usage:\n  %s", c.UsageLine)
 	if len(c.Commands) > 0 {
 		fmt.Fprint(w, "\n\nCommands:\n")
 		for _, c := range c.Commands {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -32,9 +32,9 @@ func TestParseAndSetFlags(t *testing.T) {
 	)
 
 	cmd := &Command{
-		Short: "test is used for testing",
-		Long:  "This is the long documentation for command test.",
-		Usage: "foobar test [arguments]",
+		Short:     "test is used for testing",
+		Long:      "This is the long documentation for command test.",
+		UsageLine: "foobar test [arguments]",
 	}
 	cmd.InitFlags()
 	cmd.Flags.StringVar(&strFlag, "name", "default", "name flag")
@@ -142,9 +142,9 @@ Usage:
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			c := &Command{
-				Short: "test prints test information",
-				Usage: "test [flags]",
-				Long:  "Test prints test information.",
+				Short:     "test prints test information",
+				UsageLine: "test [flags]",
+				Long:      "Test prints test information.",
 			}
 			c.InitFlags()
 			for _, fn := range test.flags {

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -30,14 +30,14 @@ import (
 func TestCommandUsage(t *testing.T) {
 	for _, c := range CmdLibrarian.Commands {
 		t.Run(c.Name(), func(t *testing.T) {
-			parts := strings.Fields(c.Usage)
+			parts := strings.Fields(c.UsageLine)
 			// The first word should always be "librarian".
 			if parts[0] != "librarian" {
-				t.Errorf("invalid usage text: %q (the first word should be `librarian`)", c.Usage)
+				t.Errorf("invalid usage text: %q (the first word should be `librarian`)", c.UsageLine)
 			}
 			// The second word should always be the command name.
 			if parts[1] != c.Name() {
-				t.Errorf("invalid usage text: %q (second word should be command name %q)", c.Usage, c.Name())
+				t.Errorf("invalid usage text: %q (second word should be command name %q)", c.UsageLine, c.Name())
 			}
 		})
 	}

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -32,8 +32,8 @@ import (
 )
 
 var cmdConfigure = &cli.Command{
-	Short: "configure configures libraries for new APIs in a language",
-	Usage: "librarian configure -language=<language> [flags]",
+	Short:     "configure configures libraries for new APIs in a language",
+	UsageLine: "librarian configure -language=<language> [flags]",
 	Long: `
 Specify the language, and optional flags to use non-default repositories, e.g. for testing.
 A single API path may be specified if desired; otherwise all API paths will be checked.

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -46,8 +46,8 @@ type LibraryRelease struct {
 }
 
 var cmdCreateReleaseArtifacts = &cli.Command{
-	Short: "create-release-artifacts creates release artifacts from a merged release PR",
-	Usage: "librarian create-release-artifacts -language=<language> -release-id=<id> [flags]",
+	Short:     "create-release-artifacts creates release artifacts from a merged release PR",
+	UsageLine: "librarian create-release-artifacts -language=<language> -release-id=<id> [flags]",
 	Long: `Specify the language and release ID, and optional flags to use non-default repositories, e.g. for testing.
 The release ID is specified in the the release PR and in each commit within it, in a line starting "Librarian-Release-ID: ".
 

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -36,8 +36,8 @@ const prNumberEnvVarName = "_PR_NUMBER"
 const baselineCommitEnvVarName = "_BASELINE_COMMIT"
 
 var cmdCreateReleasePR = &cli.Command{
-	Short: "create-release-pr creates a release PR",
-	Usage: "librarian create-release-pr -language=<language> [flags]",
+	Short:     "create-release-pr creates a release PR",
+	UsageLine: "librarian create-release-pr -language=<language> [flags]",
 	Long: `Specify the language, and optional flags to use non-default repositories, e.g. for testing.
 A single library may be specified if desired (with an optional version override);
 otherwise all configured libraries will be checked to see if they should be released.

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -32,8 +32,8 @@ import (
 )
 
 var cmdGenerate = &cli.Command{
-	Short: "generate generates client library code for a single API",
-	Usage: "librarian generate -api-root=<api-root> -api-path=<api-path> -language=<language> [flags]",
+	Short:     "generate generates client library code for a single API",
+	UsageLine: "librarian generate -api-root=<api-root> -api-path=<api-path> -language=<language> [flags]",
 	Long: `Specify the language, the API repository root and the path within it for the API to generate.
 Optional flags can be specified to use a non-default language repository, and to indicate whether or not
 to build the generated library.

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -28,9 +28,9 @@ import (
 
 // CmdLibrarian is the top-level command for the Librarian CLI.
 var CmdLibrarian = &cli.Command{
-	Short: "librarian manages client libraries for Google APIs",
-	Usage: "librarian <command> [arguments]",
-	Long:  "Librarian manages client libraries for Google APIs.",
+	Short:     "librarian manages client libraries for Google APIs",
+	UsageLine: "librarian <command> [arguments]",
+	Long:      "Librarian manages client libraries for Google APIs.",
 }
 
 func init() {

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -48,8 +48,8 @@ const ConventionalCommitsAppId = 37172
 const MergeBlockedLabel = "merge-blocked-see-comments"
 
 var cmdMergeReleasePR = &cli.Command{
-	Short: "merge-release-pr merges a validated release PR",
-	Usage: "librarian merge-release-pr -release-id=<id> -release-pr-url=<url> -baseline-commit=<commit> [flags]",
+	Short:     "merge-release-pr merges a validated release PR",
+	UsageLine: "librarian merge-release-pr -release-id=<id> -release-pr-url=<url> -baseline-commit=<commit> [flags]",
 	Long: `Specify a GitHub access token as an environment variable, the URL for a release PR, the baseline
 commit of the repo when the release PR was being created, and the release ID.
 An optional additional URL prefix can be specified in order to wait for a mirror to have synchronized before the

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -32,8 +32,8 @@ import (
 )
 
 var cmdPublishReleaseArtifacts = &cli.Command{
-	Short: "publish-release-artifacts publishes (previously-created) release artifacts to package managers and documentation sites",
-	Usage: "librarian publish-release-artifacts -language=<language> -artifact-root=<artifact-root> -tag-repo-url=<repo-url> [flags]",
+	Short:     "publish-release-artifacts publishes (previously-created) release artifacts to package managers and documentation sites",
+	UsageLine: "librarian publish-release-artifacts -language=<language> -artifact-root=<artifact-root> -tag-repo-url=<repo-url> [flags]",
 	Long: `Specify the language, the root output directory created by create-release-artifacts, and
 the GitHub repository in which to create tags/releases.
 

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -29,8 +29,8 @@ import (
 )
 
 var cmdUpdateApis = &cli.Command{
-	Short: "update-apis regenerates APIs in a language repo with new specifications",
-	Usage: "librarian update-apis -language=<language> [flags]",
+	Short:     "update-apis regenerates APIs in a language repo with new specifications",
+	UsageLine: "librarian update-apis -language=<language> [flags]",
 	Long: `Specify the language, and optional flags to use non-default repositories, e.g. for testing.
 A pull request will only be created if -push is specified, in which case the LIBRARIAN_GITHUB_TOKEN
 environment variable must be populated with an access token which has write access to the

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -29,8 +29,8 @@ import (
 )
 
 var cmdUpdateImageTag = &cli.Command{
-	Short: "update-image-tag updates a language repo's image tag and regenerates APIs",
-	Usage: "librarian update-image-tag -language=<language> -tag=<new tag> [flags]",
+	Short:     "update-image-tag updates a language repo's image tag and regenerates APIs",
+	UsageLine: "librarian update-image-tag -language=<language> -tag=<new tag> [flags]",
 	Long: `Specify the language, the new tag, and optional flags to use non-default repositories, e.g. for testing.
 A pull request will only be created if -push is specified, in which case the LIBRARIAN_GITHUB_TOKEN
 environment variable must be populated with an access token which has write access to the

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -23,9 +23,9 @@ import (
 )
 
 var cmdVersion = &cli.Command{
-	Short: "version prints the version information",
-	Usage: "librarian version",
-	Long:  "Version prints version information for the librarian binary.",
+	Short:     "version prints the version information",
+	UsageLine: "librarian version",
+	Long:      "Version prints version information for the librarian binary.",
 	Run: func(ctx context.Context, cfg *config.Config) error {
 		fmt.Println(cli.Version())
 		return nil


### PR DESCRIPTION
Usage is often used to refer to `flag.Flags.Usage()`, and we use it when referring to `Command.Flags.Usage()`.

Rename to `UsageLine`, which align with the terminology used by `cmd/go`:
https://pkg.go.dev/cmd/go/internal/base#Command.UsageLine.

Fixes https://github.com/googleapis/librarian/issues/613