### PR TITLE
fix(internal/github): rename githubrepo to github

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package githubrepo provides operations on GitHub repos, abstracting away go-github
-// (at least somewhat) to only the operations Librarian needs.
-package githubrepo
+// Package github provides operations on GitHub repos, abstracting away
+// go-github (at least somewhat) to only the operations Librarian needs.
+package github
 
 import (
 	"context"

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/googleapis/librarian/internal/statepb"
@@ -185,7 +185,7 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 	// Final steps if we've actually created a release PR.
 	// - We always add the do-not-merge label so that Librarian can merge later.
 	// - Add a result environment variable with the PR number, for the next stage of the process.
-	ghClient, err := githubrepo.NewClient(cfg.GitHubToken)
+	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Environment variables are specified here as they're used for the same sort of purpose as flags...
-// ... but see also githubrepo.go
+// ... but see also github.go
 const defaultRepositoryEnvironmentVariable string = "LIBRARIAN_REPOSITORY"
 
 var (

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -26,7 +26,7 @@ import (
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/docker"
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 )
@@ -224,7 +224,7 @@ func detectIfLibraryConfigured(apiPath, repoURL, repoRoot, gitHubToken string) (
 			return false, err
 		}
 	} else {
-		languageRepoMetadata, err := githubrepo.ParseUrl(repoURL)
+		languageRepoMetadata, err := github.ParseUrl(repoURL)
 		if err != nil {
 			slog.Warn("failed to parse", "repo url:", repoURL, "error", err)
 			return false, err

--- a/internal/librarian/pullrequest.go
+++ b/internal/librarian/pullrequest.go
@@ -21,7 +21,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
@@ -58,8 +58,8 @@ func addSuccessToPullRequest(pr *PullRequestContent, text string) {
 // If content only contains errors, the pull request is not created and an error is returned (to highlight that everything failed)
 // If content contains any successes, a pull request is created and no error is returned (if the creation is successful) even if the content includes errors.
 // If the pull request would contain an excessive number of commits (as configured in pipeline-config.json)
-func createPullRequest(ctx context.Context, state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*githubrepo.PullRequestMetadata, error) {
-	ghClient, err := githubrepo.NewClient(gitHubToken)
+func createPullRequest(ctx context.Context, state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*github.PullRequestMetadata, error) {
+	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func createPullRequest(ctx context.Context, state *commandState, content *PullRe
 		return nil, nil
 	}
 
-	gitHubRepo, err := getGitHubRepoFromRemote(languageRepo)
+	github, err := getgithubFromRemote(languageRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func createPullRequest(ctx context.Context, state *commandState, content *PullRe
 		slog.Info(fmt.Sprintf("Received error pushing branch: '%s'", err))
 		return nil, err
 	}
-	return ghClient.CreatePullRequest(ctx, gitHubRepo, branch, title, description)
+	return ghClient.CreatePullRequest(ctx, github, branch, title, description)
 }
 
 // Formats the given list as a single Markdown string, with a title preceding the list,
@@ -142,7 +142,7 @@ func formatListAsMarkdown(title string, list []string) string {
 // There must only be a single remote with a GitHub URL (as the first URL), in order to provide an
 // unambiguous result.
 // Remotes without any URLs, or where the first URL does not start with https://github.com/ are ignored.
-func getGitHubRepoFromRemote(repo *gitrepo.Repository) (*githubrepo.Repository, error) {
+func getgithubFromRemote(repo *gitrepo.Repository) (*github.Repository, error) {
 	remotes, err := repo.Remotes()
 	if err != nil {
 		return nil, err
@@ -165,5 +165,5 @@ func getGitHubRepoFromRemote(repo *gitrepo.Repository) (*githubrepo.Repository, 
 		joinedRemoteNames := strings.Join(gitHubRemoteNames, ", ")
 		return nil, fmt.Errorf("can only determine the GitHub repo with a single matching remote; GitHub remotes in repo: %s", joinedRemoteNames)
 	}
-	return githubrepo.ParseUrl(gitHubUrl)
+	return github.ParseUrl(gitHubUrl)
 }

--- a/internal/librarian/stateandconfig.go
+++ b/internal/librarian/stateandconfig.go
@@ -18,11 +18,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/googleapis/librarian/internal/config"
 	"os"
 	"path/filepath"
 
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/config"
+
+	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -85,8 +86,8 @@ func savePipelineState(state *commandState) error {
 	return err
 }
 
-func fetchRemotePipelineState(ctx context.Context, repo *githubrepo.Repository, ref string, gitHubToken string) (*statepb.PipelineState, error) {
-	ghClient, err := githubrepo.NewClient(gitHubToken)
+func fetchRemotePipelineState(ctx context.Context, repo *github.Repository, ref string, gitHubToken string) (*statepb.PipelineState, error) {
+	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Rename the githubrepo package to github, since this package provides operations on the GitHub API. This also avoids confusion with the gitrepo package, which provides git operations on repositories.