### PR TITLE
chore(internal/config): move `LIBRARIAN_REPOSITORY` to config package

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,6 +209,9 @@ type Config struct {
 	// LibraryID is specified with the -library-id flag.
 	LibraryID string
 
+	// LibrarianRepository specifies the repository where Librarian-related assets
+	// are stored.
+	//
 	// LibrarianRepository is fetched from the LIBRARIAN_REPOSITORY environment
 	// variable.
 	LibrarianRepository string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,6 +209,10 @@ type Config struct {
 	// LibraryID is specified with the -library-id flag.
 	LibraryID string
 
+	// LibrarianRepository is fetched from the LIBRARIAN_REPOSITORY environment
+	// variable.
+	LibrarianRepository string
+
 	// LibraryVersion is the version string used when creating a release for a specific library,
 	// overriding whatever new version would otherwise be suggested. It is only used in the
 	// create-release-pr command, where it is optional and can only be specified when LibraryID
@@ -355,10 +359,11 @@ func New() *Config {
 	return &Config{
 		// TODO(https://github.com/googleapis/librarian/issues/507): replace
 		// os.Getenv calls in other functions with these values.
-		DockerHostRootDir:  os.Getenv("KOKORO_HOST_ROOT_DIR"),
-		DockerMountRootDir: os.Getenv("KOKORO_ROOT_DIR"),
-		GitHubToken:        os.Getenv("LIBRARIAN_GITHUB_TOKEN"),
-		SyncAuthToken:      os.Getenv("LIBRARIAN_SYNC_AUTH_TOKEN"),
+		DockerHostRootDir:   os.Getenv("KOKORO_HOST_ROOT_DIR"),
+		DockerMountRootDir:  os.Getenv("KOKORO_ROOT_DIR"),
+		GitHubToken:         os.Getenv("LIBRARIAN_GITHUB_TOKEN"),
+		LibrarianRepository: os.Getenv("LIBRARIAN_REPOSITORY"),
+		SyncAuthToken:       os.Getenv("LIBRARIAN_SYNC_AUTH_TOKEN"),
 	}
 }
 

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -102,7 +102,7 @@ func init() {
 
 func runConfigure(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		os.Getenv(defaultRepositoryEnvironmentVariable), cfg.SecretsProject, cfg.CI)
+		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -95,7 +95,7 @@ func init() {
 
 func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		os.Getenv(defaultRepositoryEnvironmentVariable), cfg.SecretsProject, cfg.CI)
+		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -125,7 +125,7 @@ func init() {
 
 func runCreateReleasePR(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		os.Getenv(defaultRepositoryEnvironmentVariable), cfg.SecretsProject, cfg.CI)
+		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -23,10 +23,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-// Environment variables are specified here as they're used for the same sort of purpose as flags...
-// ... but see also githubrepo.go
-const defaultRepositoryEnvironmentVariable string = "LIBRARIAN_REPOSITORY"
-
 func addFlagAPIPath(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.APIPath, "api-path", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
 }

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -127,7 +127,7 @@ func runGenerate(ctx context.Context, cfg *config.Config) error {
 		}
 	}
 
-	image := deriveImage(cfg.Language, cfg.Image, os.Getenv(defaultRepositoryEnvironmentVariable), ps)
+	image := deriveImage(cfg.Language, cfg.Image, cfg.LibrarianRepository, ps)
 	containerConfig, err := docker.New(ctx, workRoot, image, cfg.SecretsProject, config)
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func executeGenerate(state *commandState, apiPath, apiRoot string, build bool) e
 
 // Checks if the library exists in the remote pipeline state, if so use GenerateLibrary command
 // otherwise use GenerateRaw command.
-// In case of non fatal error when looking up library, we will fallback to GenerateRaw command
+// In case of non-fatal error when looking up library, we will fall back to GenerateRaw command
 // and log the error.
 // If refined generation is used, the context's languageRepo field will be populated and the
 // library ID will be returned; otherwise, an empty string will be returned.

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -88,7 +87,7 @@ func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	image := deriveImage(cfg.Language, cfg.Image, os.Getenv(defaultRepositoryEnvironmentVariable), ps)
+	image := deriveImage(cfg.Language, cfg.Image, cfg.LibrarianRepository, ps)
 
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime, cfg.WorkRoot)

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -103,7 +103,7 @@ func init() {
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		os.Getenv(defaultRepositoryEnvironmentVariable), cfg.SecretsProject, cfg.CI)
+		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -91,7 +91,7 @@ func init() {
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		os.Getenv(defaultRepositoryEnvironmentVariable), cfg.SecretsProject, cfg.CI)
+		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 	}
 	// Derive the new image to use, and save it in the context.
 	ps.ImageTag = cfg.Tag
-	state.containerConfig.Image = deriveImage(cfg.Language, cfg.Image, os.Getenv(defaultRepositoryEnvironmentVariable), ps)
+	state.containerConfig.Image = deriveImage(cfg.Language, cfg.Image, cfg.LibrarianRepository, ps)
 	savePipelineState(state)
 
 	// Take a defensive copy of the generator input directory from the language repo.


### PR DESCRIPTION
Move the `LIBRARIAN_REPOSITORY` environment variable to the `config` package.

Fixes: #509 