### PR TITLE
refactor(internal/gitrepo): move defaultUserName and defaultUserEmail to config

### DIFF
--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -31,12 +31,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
-// Default values for username and email.
-const (
-	defaultUserName  = "Google Cloud SDK"
-	defaultUserEmail = "noreply-cloudsdk@google.com"
-)
-
 // Repository represents a git repository.
 type Repository struct {
 	Dir  string
@@ -157,12 +151,6 @@ func (r *Repository) Commit(msg string, userName, userEmail string) error {
 	}
 	if status.IsClean() {
 		return fmt.Errorf("no modifications to commit")
-	}
-	if userName == "" {
-		userName = defaultUserName
-	}
-	if userEmail == "" {
-		userEmail = defaultUserEmail
 	}
 	hash, err := worktree.Commit(msg, &git.CommitOptions{
 		Author: &object.Signature{

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -56,11 +56,11 @@ func addFlagEnvFile(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagGitUserEmail(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.GitUserEmail, "git-user-email", "", "Email address to use in Git commits")
+	fs.StringVar(&cfg.GitUserEmail, "git-user-email", "noreply-cloudsdk@google.com", "Email address to use in Git commits")
 }
 
 func addFlagGitUserName(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.GitUserName, "git-user-name", "", "Display name to use in Git commits")
+	fs.StringVar(&cfg.GitUserName, "git-user-name", "Google Cloud SDK", "Display name to use in Git commits")
 }
 
 func addFlagImage(fs *flag.FlagSet, cfg *config.Config) {


### PR DESCRIPTION
Refactors how default values for the Git user name and email are handled. The responsibility for setting defaults is moved from downstream code into the initial flag parsing logic.

The default values are now set in the flag definitions within the `config` package. This ensures that `Config.GitUserName` and `Config.GitUserEmail` are always populated, making the `config` struct the single source of truth.

Fixes #624 