### PR TITLE
refactor(internal/librarian): refactor cloneOrOpenLanguageRepo

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -59,7 +59,6 @@ type commandState struct {
 }
 
 func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (*gitrepo.Repository, error) {
-	var languageRepo *gitrepo.Repository
 	if repoRoot != "" && repoURL != "" {
 		return nil, errors.New("do not specify both repo-root and repo-url")
 	}
@@ -77,6 +76,9 @@ func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (
 		})
 	}
 	if repoRoot == "" {
+		if language == "" {
+			return nil, errors.New("language must be specified when repo-root and repo-url are not")
+		}
 		languageRepoURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-%s", language)
 		repoPath := filepath.Join(workRoot, fmt.Sprintf("google-cloud-%s", language))
 		return gitrepo.NewRepository(&gitrepo.RepositoryOptions{
@@ -90,6 +92,7 @@ func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (
 	if err != nil {
 		return nil, err
 	}
+	var languageRepo *gitrepo.Repository
 	languageRepo, err = gitrepo.NewRepository(&gitrepo.RepositoryOptions{
 		Dir: absRepoRoot,
 		CI:  ci,

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -76,17 +76,7 @@ func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (
 		})
 	}
 	if repoRoot == "" {
-		if language == "" {
-			return nil, errors.New("language must be specified when repo-root and repo-url are not")
-		}
-		languageRepoURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-%s", language)
-		repoPath := filepath.Join(workRoot, fmt.Sprintf("google-cloud-%s", language))
-		return gitrepo.NewRepository(&gitrepo.RepositoryOptions{
-			Dir:        repoPath,
-			MaybeClone: true,
-			RemoteURL:  languageRepoURL,
-			CI:         ci,
-		})
+		return nil, errors.New("one of repo-root or repo-url must be specified")
 	}
 	absRepoRoot, err := filepath.Abs(repoRoot)
 	if err != nil {

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -65,8 +66,7 @@ func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (
 	if repoURL != "" {
 		// Take the last part of the URL as the directory name. It feels very
 		// unlikely that will clash with anything else (e.g. "output")
-		bits := strings.Split(repoURL, "/")
-		repoName := bits[len(bits)-1]
+		repoName := path.Base(strings.TrimSuffix(repoURL, "/"))
 		repoPath := filepath.Join(workRoot, repoName)
 		return gitrepo.NewRepository(&gitrepo.RepositoryOptions{
 			Dir:        repoPath,

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -92,8 +92,7 @@ func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (
 	if err != nil {
 		return nil, err
 	}
-	var languageRepo *gitrepo.Repository
-	languageRepo, err = gitrepo.NewRepository(&gitrepo.RepositoryOptions{
+	languageRepo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{
 		Dir: absRepoRoot,
 		CI:  ci,
 	})

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -59,7 +59,7 @@ type commandState struct {
 	containerConfig *docker.Docker
 }
 
-func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (*gitrepo.Repository, error) {
+func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, ci string) (*gitrepo.Repository, error) {
 	if repoRoot != "" && repoURL != "" {
 		return nil, errors.New("do not specify both repo-root and repo-url")
 	}
@@ -111,7 +111,7 @@ func createCommandStateForLanguage(ctx context.Context, workRootOverride, repoRo
 	if err != nil {
 		return nil, err
 	}
-	repo, err := cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci)
+	repo, err := cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, ci)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -263,6 +263,10 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 			},
 		},
 		{
+			name:    "no repoRoot or repoURL, no language",
+			wantErr: true,
+		},
+		{
 			name:     "with dirty repoRoot",
 			repoRoot: dirtyRepoPath,
 			wantErr:  true,

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -242,27 +242,6 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 			},
 		},
 		{
-			name:     "no repoRoot or repoURL, default to open language monorepo",
-			language: "go",
-			// Setup for this specific test case: create the expected default repo.
-			// This avoids actual network cloning.
-			setup: func(t *testing.T, wr string) func() {
-				repoPath := filepath.Join(wr, "google-cloud-go")
-				newTestGitRepoWithCommit(t, repoPath)
-				return func() {
-					if err := os.RemoveAll(repoPath); err != nil {
-						t.Errorf("os.RemoveAll(%q) = %v; want nil", repoPath, err)
-					}
-				}
-			},
-			check: func(t *testing.T, repo *gitrepo.Repository) {
-				wantDir := filepath.Join(workRoot, "google-cloud-go")
-				if repo.Dir != wantDir {
-					t.Errorf("repo.Dir got %q, want %q", repo.Dir, wantDir)
-				}
-			},
-		},
-		{
 			name:    "with repoURL with trailing slash",
 			repoURL: "https://github.com/googleapis/google-cloud-go/",
 			setup: func(t *testing.T, workRoot string) func() {
@@ -283,7 +262,7 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 			},
 		},
 		{
-			name:    "no repoRoot or repoURL, no language",
+			name:    "no repoRoot or repoURL",
 			wantErr: true,
 		},
 		{

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -263,6 +263,26 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 			},
 		},
 		{
+			name:    "with repoURL with trailing slash",
+			repoURL: "https://github.com/googleapis/google-cloud-go/",
+			setup: func(t *testing.T, workRoot string) func() {
+				// The expected directory name is `google-cloud-go`.
+				repoPath := filepath.Join(workRoot, "google-cloud-go")
+				newTestGitRepoWithCommit(t, repoPath)
+				return func() {
+					if err := os.RemoveAll(repoPath); err != nil {
+						t.Errorf("os.RemoveAll(%q) = %v; want nil", repoPath, err)
+					}
+				}
+			},
+			check: func(t *testing.T, repo *gitrepo.Repository) {
+				wantDir := filepath.Join(workRoot, "google-cloud-go")
+				if repo.Dir != wantDir {
+					t.Errorf("repo.Dir got %q, want %q", repo.Dir, wantDir)
+				}
+			},
+		},
+		{
 			name:    "no repoRoot or repoURL, no language",
 			wantErr: true,
 		},

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -219,7 +219,6 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 		name     string
 		repoRoot string
 		repoURL  string
-		language string
 		ci       string
 		wantErr  bool
 		check    func(t *testing.T, repo *gitrepo.Repository)
@@ -287,7 +286,7 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 				}
 			}()
 
-			repo, err := cloneOrOpenLanguageRepo(workRoot, test.repoRoot, test.repoURL, test.language, test.ci)
+			repo, err := cloneOrOpenLanguageRepo(workRoot, test.repoRoot, test.repoURL, test.ci)
 			if test.wantErr {
 				if err == nil {
 					t.Error("cloneOrOpenLanguageRepo() expected an error but got nil")

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -116,7 +116,7 @@ func runGenerate(ctx context.Context, cfg *config.Config) error {
 	// We only clone/open the language repo and use the state within it
 	// if the requested API is configured as a library.
 	if libraryConfigured {
-		repo, err = cloneOrOpenLanguageRepo(workRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.CI)
+		repo, err = cloneOrOpenLanguageRepo(workRoot, cfg.RepoRoot, cfg.RepoURL, cfg.CI)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Refactor cloneOrOpenLanguageRepo to remove fallback to guessing and use path.Base on repoName.

Fixes #517
Fixes #518
Fixes #519
Fixes #520