### PR TITLE
feat(internal/docker): pass config to public functions in docker.go

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -360,8 +360,6 @@ type Config struct {
 // New returns a new Config populated with environment variables.
 func New() *Config {
 	return &Config{
-		// TODO(https://github.com/googleapis/librarian/issues/507): replace
-		// os.Getenv calls in other functions with these values.
 		DockerHostRootDir:   os.Getenv("KOKORO_HOST_ROOT_DIR"),
 		DockerMountRootDir:  os.Getenv("KOKORO_ROOT_DIR"),
 		GitHubToken:         os.Getenv("LIBRARIAN_GITHUB_TOKEN"),

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -131,7 +131,7 @@ func (c *Docker) GenerateRaw(apiRoot, output, apiPath string) error {
 // output specifies the empty output directory into which the command should
 // generate code, and libraryID specifies the ID of the library to generate,
 // as configured in the Librarian state file for the repository.
-func (c *Docker) GenerateLibrary(apiRoot, output, generatorInput, libraryID string) error {
+func (c *Docker) GenerateLibrary(cfg *config.Config, apiRoot, output, generatorInput, libraryID string) error {
 	if apiRoot == "" {
 		return fmt.Errorf("apiRoot cannot be empty")
 	}
@@ -155,6 +155,9 @@ func (c *Docker) GenerateLibrary(apiRoot, output, generatorInput, libraryID stri
 		fmt.Sprintf("%s:/output", output),
 		fmt.Sprintf("%s:/%s", generatorInput, config.GeneratorInputDir),
 	}
+
+	mounts = maybeRelocateMounts(cfg, mounts)
+
 	return c.runDocker(CommandGenerateLibrary, mounts, commandArgs)
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -241,7 +241,7 @@ func (c *Docker) Configure(apiRoot, apiPath, generatorInput string) error {
 // ID libraryID within repoRoot, with version releaseVersion. Release notes
 // are expected to be present within inputsDirectory, in a file named
 // `{libraryID}-{releaseVersion}-release-notes.txt`.
-func (c *Docker) PrepareLibraryRelease(repoRoot, inputsDirectory, libraryID, releaseVersion string) error {
+func (c *Docker) PrepareLibraryRelease(cfg *config.Config, repoRoot, inputsDirectory, libraryID, releaseVersion string) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -252,6 +252,8 @@ func (c *Docker) PrepareLibraryRelease(repoRoot, inputsDirectory, libraryID, rel
 		fmt.Sprintf("%s:/repo", repoRoot),
 		fmt.Sprintf("%s:/inputs", inputsDirectory),
 	}
+
+	mounts = maybeRelocateMounts(cfg, mounts)
 
 	return c.runDocker(CommandPrepareLibraryRelease, mounts, commandArgs)
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -160,7 +160,7 @@ func (c *Docker) GenerateLibrary(apiRoot, output, generatorInput, libraryID stri
 
 // Clean deletes files within repoRoot which are generated for library
 // libraryID, as configured in the Librarian state file for the repository.
-func (c *Docker) Clean(repoRoot, libraryID string) error {
+func (c *Docker) Clean(cfg *config.Config, repoRoot, libraryID string) error {
 	if repoRoot == "" {
 		return fmt.Errorf("repoRoot cannot be empty")
 	}
@@ -171,6 +171,8 @@ func (c *Docker) Clean(repoRoot, libraryID string) error {
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
 	}
+	mounts = maybeRelocateMounts(cfg, mounts)
+
 	return c.runDocker(CommandClean, mounts, commandArgs)
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -124,9 +124,7 @@ func (c *Docker) GenerateRaw(cfg *config.Config, apiRoot, output, apiPath string
 		fmt.Sprintf("%s:/output", output),
 	}
 
-	mounts = maybeRelocateMounts(cfg, mounts)
-
-	return c.runDocker(CommandGenerateRaw, mounts, commandArgs)
+	return c.runDocker(cfg, CommandGenerateRaw, mounts, commandArgs)
 }
 
 // GenerateLibrary performs generation for an API which is configured as part of a library.
@@ -159,9 +157,7 @@ func (c *Docker) GenerateLibrary(cfg *config.Config, apiRoot, output, generatorI
 		fmt.Sprintf("%s:/%s", generatorInput, config.GeneratorInputDir),
 	}
 
-	mounts = maybeRelocateMounts(cfg, mounts)
-
-	return c.runDocker(CommandGenerateLibrary, mounts, commandArgs)
+	return c.runDocker(cfg, CommandGenerateLibrary, mounts, commandArgs)
 }
 
 // Clean deletes files within repoRoot which are generated for library
@@ -177,9 +173,8 @@ func (c *Docker) Clean(cfg *config.Config, repoRoot, libraryID string) error {
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
 	}
-	mounts = maybeRelocateMounts(cfg, mounts)
 
-	return c.runDocker(CommandClean, mounts, commandArgs)
+	return c.runDocker(cfg, CommandClean, mounts, commandArgs)
 }
 
 // BuildRaw builds the result of GenerateRaw, which previously generated
@@ -198,9 +193,8 @@ func (c *Docker) BuildRaw(cfg *config.Config, generatorOutput, apiPath string) e
 		"--generator-output=/generator-output",
 		fmt.Sprintf("--api-path=%s", apiPath),
 	}
-	mounts = maybeRelocateMounts(cfg, mounts)
 
-	return c.runDocker(CommandBuildRaw, mounts, commandArgs)
+	return c.runDocker(cfg, CommandBuildRaw, mounts, commandArgs)
 }
 
 // BuildLibrary builds the library with an ID of libraryID, as configured in
@@ -218,8 +212,7 @@ func (c *Docker) BuildLibrary(cfg *config.Config, repoRoot, libraryID string) er
 		fmt.Sprintf("--library-id=%s", libraryID),
 	}
 
-	mounts = maybeRelocateMounts(cfg, mounts)
-	return c.runDocker(CommandBuildLibrary, mounts, commandArgs)
+	return c.runDocker(cfg, CommandBuildLibrary, mounts, commandArgs)
 }
 
 // Configure configures an API within a repository, either adding it to an
@@ -246,9 +239,8 @@ func (c *Docker) Configure(cfg *config.Config, apiRoot, apiPath, generatorInput 
 		fmt.Sprintf("%s:/apis", apiRoot),
 		fmt.Sprintf("%s:/%s", generatorInput, config.GeneratorInputDir),
 	}
-	mounts = maybeRelocateMounts(cfg, mounts)
 
-	return c.runDocker(CommandConfigure, mounts, commandArgs)
+	return c.runDocker(cfg, CommandConfigure, mounts, commandArgs)
 }
 
 // PrepareLibraryRelease prepares the repository languageRepo for the release of a library with
@@ -267,9 +259,7 @@ func (c *Docker) PrepareLibraryRelease(cfg *config.Config, repoRoot, inputsDirec
 		fmt.Sprintf("%s:/inputs", inputsDirectory),
 	}
 
-	mounts = maybeRelocateMounts(cfg, mounts)
-
-	return c.runDocker(CommandPrepareLibraryRelease, mounts, commandArgs)
+	return c.runDocker(cfg, CommandPrepareLibraryRelease, mounts, commandArgs)
 }
 
 // IntegrationTestLibrary runs the integration tests for a library with ID libraryID within repoRoot.
@@ -282,9 +272,7 @@ func (c *Docker) IntegrationTestLibrary(cfg *config.Config, repoRoot, libraryID 
 		fmt.Sprintf("%s:/repo", repoRoot),
 	}
 
-	mounts = maybeRelocateMounts(cfg, mounts)
-
-	return c.runDocker(CommandIntegrationTestLibrary, mounts, commandArgs)
+	return c.runDocker(cfg, CommandIntegrationTestLibrary, mounts, commandArgs)
 }
 
 // PackageLibrary packages release artifacts for a library with ID libraryID within repoRoot,
@@ -300,9 +288,7 @@ func (c *Docker) PackageLibrary(cfg *config.Config, repoRoot, libraryID, outputD
 		fmt.Sprintf("%s:/output", outputDir),
 	}
 
-	mounts = maybeRelocateMounts(cfg, mounts)
-
-	return c.runDocker(CommandPackageLibrary, mounts, commandArgs)
+	return c.runDocker(cfg, CommandPackageLibrary, mounts, commandArgs)
 }
 
 // PublishLibrary publishes release artifacts for a library with ID libraryID and version releaseVersion
@@ -318,12 +304,10 @@ func (c *Docker) PublishLibrary(cfg *config.Config, outputDir, libraryID, releas
 		fmt.Sprintf("%s:/output", outputDir),
 	}
 
-	mounts = maybeRelocateMounts(cfg, mounts)
-
-	return c.runDocker(CommandPublishLibrary, mounts, commandArgs)
+	return c.runDocker(cfg, CommandPublishLibrary, mounts, commandArgs)
 }
 
-func (c *Docker) runDocker(command Command, mounts []string, commandArgs []string) (err error) {
+func (c *Docker) runDocker(cfg *config.Config, command Command, mounts []string, commandArgs []string) (err error) {
 	if c.Image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
@@ -332,6 +316,8 @@ func (c *Docker) runDocker(command Command, mounts []string, commandArgs []strin
 		"run",
 		"--rm", // Automatically delete the container after completion
 	}
+
+	mounts = maybeRelocateMounts(cfg, mounts)
 
 	for _, mount := range mounts {
 		args = append(args, "-v", mount)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -195,7 +195,7 @@ func (c *Docker) BuildRaw(generatorOutput, apiPath string) error {
 
 // BuildLibrary builds the library with an ID of libraryID, as configured in
 // the Librarian state file for the repository with a root of repoRoot.
-func (c *Docker) BuildLibrary(repoRoot, libraryID string) error {
+func (c *Docker) BuildLibrary(cfg *config.Config, repoRoot, libraryID string) error {
 	if repoRoot == "" {
 		return fmt.Errorf("repoRoot cannot be empty")
 	}
@@ -207,6 +207,8 @@ func (c *Docker) BuildLibrary(repoRoot, libraryID string) error {
 		"--test=true",
 		fmt.Sprintf("--library-id=%s", libraryID),
 	}
+
+	mounts = maybeRelocateMounts(cfg, mounts)
 	return c.runDocker(CommandBuildLibrary, mounts, commandArgs)
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -257,7 +257,7 @@ func (c *Docker) PrepareLibraryRelease(repoRoot, inputsDirectory, libraryID, rel
 }
 
 // IntegrationTestLibrary runs the integration tests for a library with ID libraryID within repoRoot.
-func (c *Docker) IntegrationTestLibrary(repoRoot, libraryID string) error {
+func (c *Docker) IntegrationTestLibrary(cfg *config.Config, repoRoot, libraryID string) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -265,6 +265,8 @@ func (c *Docker) IntegrationTestLibrary(repoRoot, libraryID string) error {
 	mounts := []string{
 		fmt.Sprintf("%s:/repo", repoRoot),
 	}
+
+	mounts = maybeRelocateMounts(cfg, mounts)
 
 	return c.runDocker(CommandIntegrationTestLibrary, mounts, commandArgs)
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -312,12 +312,12 @@ func (c *Docker) runDocker(cfg *config.Config, command Command, mounts []string,
 		return fmt.Errorf("image cannot be empty")
 	}
 
+	mounts = maybeRelocateMounts(cfg, mounts)
+
 	args := []string{
 		"run",
 		"--rm", // Automatically delete the container after completion
 	}
-
-	mounts = maybeRelocateMounts(cfg, mounts)
 
 	for _, mount := range mounts {
 		args = append(args, "-v", mount)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -176,7 +176,7 @@ func (c *Docker) Clean(repoRoot, libraryID string) error {
 
 // BuildRaw builds the result of GenerateRaw, which previously generated
 // code for apiPath in generatorOutput.
-func (c *Docker) BuildRaw(generatorOutput, apiPath string) error {
+func (c *Docker) BuildRaw(cfg *config.Config, generatorOutput, apiPath string) error {
 	if generatorOutput == "" {
 		return fmt.Errorf("generatorOutput cannot be empty")
 	}
@@ -190,6 +190,8 @@ func (c *Docker) BuildRaw(generatorOutput, apiPath string) error {
 		"--generator-output=/generator-output",
 		fmt.Sprintf("--api-path=%s", apiPath),
 	}
+	mounts = maybeRelocateMounts(cfg, mounts)
+
 	return c.runDocker(CommandBuildRaw, mounts, commandArgs)
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -215,7 +215,7 @@ func (c *Docker) BuildLibrary(repoRoot, libraryID string) error {
 // apiPath directory within apiRoot, and the container is provided with the
 // generatorInput directory to record the results of configuration. The
 // library code is not generated.
-func (c *Docker) Configure(apiRoot, apiPath, generatorInput string) error {
+func (c *Docker) Configure(cfg *config.Config, apiRoot, apiPath, generatorInput string) error {
 	if apiRoot == "" {
 		return fmt.Errorf("apiRoot cannot be empty")
 	}
@@ -234,6 +234,8 @@ func (c *Docker) Configure(apiRoot, apiPath, generatorInput string) error {
 		fmt.Sprintf("%s:/apis", apiRoot),
 		fmt.Sprintf("%s:/%s", generatorInput, config.GeneratorInputDir),
 	}
+	mounts = maybeRelocateMounts(cfg, mounts)
+
 	return c.runDocker(CommandConfigure, mounts, commandArgs)
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -104,7 +104,7 @@ func New(ctx context.Context, workRoot, image, secretsProject string, pipelineCo
 // the subdirectory apiPath of the API specification repo apiRoot, and whatever
 // is in the language-specific Docker container. The code is generated
 // in the output directory, which is initially empty.
-func (c *Docker) GenerateRaw(apiRoot, output, apiPath string) error {
+func (c *Docker) GenerateRaw(cfg *config.Config, apiRoot, output, apiPath string) error {
 	if apiRoot == "" {
 		return fmt.Errorf("apiRoot cannot be empty")
 	}
@@ -123,6 +123,9 @@ func (c *Docker) GenerateRaw(apiRoot, output, apiPath string) error {
 		fmt.Sprintf("%s:/apis", apiRoot),
 		fmt.Sprintf("%s:/output", output),
 	}
+
+	mounts = maybeRelocateMounts(cfg, mounts)
+
 	return c.runDocker(CommandGenerateRaw, mounts, commandArgs)
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -271,7 +271,7 @@ func (c *Docker) IntegrationTestLibrary(repoRoot, libraryID string) error {
 
 // PackageLibrary packages release artifacts for a library with ID libraryID within repoRoot,
 // creating the artifacts within outputDir.
-func (c *Docker) PackageLibrary(repoRoot, libraryID, outputDir string) error {
+func (c *Docker) PackageLibrary(cfg *config.Config, repoRoot, libraryID, outputDir string) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		"--output=/output",
@@ -281,6 +281,8 @@ func (c *Docker) PackageLibrary(repoRoot, libraryID, outputDir string) error {
 		fmt.Sprintf("%s:/repo", repoRoot),
 		fmt.Sprintf("%s:/output", outputDir),
 	}
+
+	mounts = maybeRelocateMounts(cfg, mounts)
 
 	return c.runDocker(CommandPackageLibrary, mounts, commandArgs)
 }

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -16,6 +16,7 @@ package docker
 
 import (
 	"fmt"
+	"github.com/googleapis/librarian/internal/config"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -41,6 +42,8 @@ func TestDockerRun(t *testing.T) {
 	d := &Docker{
 		Image: testImage,
 	}
+
+	cfg := &config.Config{}
 
 	for _, test := range []struct {
 		name       Command
@@ -195,7 +198,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandPublishLibrary,
 			runCommand: func() error {
-				return d.PublishLibrary(testOutputDir, testLibraryID, testLibraryVersion)
+				return d.PublishLibrary(cfg, testOutputDir, testLibraryID, testLibraryVersion)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -70,7 +70,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandGenerateLibrary,
 			runCommand: func() error {
-				return d.GenerateLibrary(testAPIRoot, testOutput, testGeneratorInput, testLibraryID)
+				return d.GenerateLibrary(cfg, testAPIRoot, testOutput, testGeneratorInput, testLibraryID)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -168,7 +168,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandIntegrationTestLibrary,
 			runCommand: func() error {
-				return d.IntegrationTestLibrary(testLanguageRepo, testLibraryID)
+				return d.IntegrationTestLibrary(cfg, testLanguageRepo, testLibraryID)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -104,7 +104,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandBuildRaw,
 			runCommand: func() error {
-				return d.BuildRaw(testGeneratorOutput, testAPIPath)
+				return d.BuildRaw(cfg, testGeneratorOutput, testAPIPath)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -118,7 +118,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandBuildLibrary,
 			runCommand: func() error {
-				return d.BuildLibrary(testRepoRoot, testLibraryID)
+				return d.BuildLibrary(cfg, testRepoRoot, testLibraryID)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -89,7 +89,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandClean,
 			runCommand: func() error {
-				return d.Clean(testRepoRoot, testLibraryID)
+				return d.Clean(cfg, testRepoRoot, testLibraryID)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -133,7 +133,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandConfigure,
 			runCommand: func() error {
-				return d.Configure(testAPIRoot, testAPIPath, testGeneratorInput)
+				return d.Configure(cfg, testAPIRoot, testAPIPath, testGeneratorInput)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -150,7 +150,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandPrepareLibraryRelease,
 			runCommand: func() error {
-				return d.PrepareLibraryRelease(testLanguageRepo, testInputsDirectory, testLibraryID, testReleaseVersion)
+				return d.PrepareLibraryRelease(cfg, testLanguageRepo, testInputsDirectory, testLibraryID, testReleaseVersion)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -53,7 +53,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandGenerateRaw,
 			runCommand: func() error {
-				return d.GenerateRaw(testAPIRoot, testOutput, testAPIPath)
+				return d.GenerateRaw(cfg, testAPIRoot, testOutput, testAPIPath)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -182,7 +182,7 @@ func TestDockerRun(t *testing.T) {
 		{
 			name: CommandPackageLibrary,
 			runCommand: func() error {
-				return d.PackageLibrary(testLanguageRepo, testLibraryID, testOutputDir)
+				return d.PackageLibrary(cfg, testLanguageRepo, testLibraryID, testOutputDir)
 			},
 			want: []string{
 				"run", "--rm",

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -140,7 +140,7 @@ func executeConfigure(ctx context.Context, state *commandState, cfg *config.Conf
 
 	prContent := PullRequestContent{}
 	for _, apiPath := range apiPaths {
-		err = configureApi(state, outputRoot, apiRoot, apiPath, cfg.GitUserName, cfg.GitUserEmail, &prContent)
+		err = configureApi(state, cfg, outputRoot, apiRoot, apiPath, &prContent)
 		if err != nil {
 			return err
 		}
@@ -271,14 +271,14 @@ func shouldBeGenerated(serviceYamlPath, languageSettingsName string) (bool, erro
 //
 // This function only returns an error in the case of non-container failures, which are expected to be fatal.
 // If the function returns a non-error, the repo will be clean when the function returns (so can be used for the next step)
-func configureApi(state *commandState, outputRoot, apiRoot, apiPath, gitUserName, gitUserEmail string, prContent *PullRequestContent) error {
+func configureApi(state *commandState, cfg *config.Config, outputRoot, apiRoot, apiPath string, prContent *PullRequestContent) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 
 	slog.Info(fmt.Sprintf("Configuring %s", apiPath))
 
 	generatorInput := filepath.Join(languageRepo.Dir, config.GeneratorInputDir)
-	if err := cc.Configure(apiRoot, apiPath, generatorInput); err != nil {
+	if err := cc.Configure(cfg, apiRoot, apiPath, generatorInput); err != nil {
 		addErrorToPullRequest(prContent, apiPath, err, "configuring")
 		if err := languageRepo.CleanWorkingTree(); err != nil {
 			return err
@@ -303,7 +303,7 @@ func configureApi(state *commandState, outputRoot, apiRoot, apiPath, gitUserName
 		// If it's newly-ignored, just commit the state change. This is still a "success" case.
 		if slices.Contains(ps.IgnoredApiPaths, apiPath) {
 			msg := fmt.Sprintf("feat: Added ignore entry for API %s", apiPath)
-			if err := commitAll(languageRepo, msg, gitUserName, gitUserEmail); err != nil {
+			if err := commitAll(languageRepo, msg, cfg.GitUserName, cfg.GitUserEmail); err != nil {
 				return err
 			}
 			addSuccessToPullRequest(prContent, fmt.Sprintf("Ignored API %s", apiPath))
@@ -317,7 +317,7 @@ func configureApi(state *commandState, outputRoot, apiRoot, apiPath, gitUserName
 	}
 
 	msg := fmt.Sprintf("feat: Configured library %s for API %s", libraryID, apiPath)
-	if err := commitAll(languageRepo, msg, gitUserName, gitUserEmail); err != nil {
+	if err := commitAll(languageRepo, msg, cfg.GitUserName, cfg.GitUserEmail); err != nil {
 		return err
 	}
 

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -346,7 +346,7 @@ func configureApi(state *commandState, cfg *config.Config, outputRoot, apiRoot, 
 	if err := os.CopyFS(languageRepo.Dir, os.DirFS(outputDir)); err != nil {
 		return err
 	}
-	if err := cc.BuildLibrary(languageRepo.Dir, libraryID); err != nil {
+	if err := cc.BuildLibrary(cfg, languageRepo.Dir, libraryID); err != nil {
 		prContent.Errors = append(prContent.Errors, logPartialError(libraryID, err, "building"))
 		if err := languageRepo.CleanAndRevertHeadCommit(); err != nil {
 			return err

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -328,7 +328,7 @@ func configureApi(state *commandState, cfg *config.Config, outputRoot, apiRoot, 
 		return err
 	}
 
-	if err := cc.GenerateLibrary(apiRoot, outputDir, generatorInput, libraryID); err != nil {
+	if err := cc.GenerateLibrary(cfg, apiRoot, outputDir, generatorInput, libraryID); err != nil {
 		prContent.Errors = append(prContent.Errors, logPartialError(libraryID, err, "generating"))
 		if err := languageRepo.CleanAndRevertHeadCommit(); err != nil {
 			return err

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -335,7 +335,7 @@ func configureApi(state *commandState, cfg *config.Config, outputRoot, apiRoot, 
 		}
 		return nil
 	}
-	if err := cc.Clean(languageRepo.Dir, libraryID); err != nil {
+	if err := cc.Clean(cfg, languageRepo.Dir, libraryID); err != nil {
 		prContent.Errors = append(prContent.Errors, logPartialError(libraryID, err, "cleaning"))
 		if err := languageRepo.CleanAndRevertHeadCommit(); err != nil {
 			return err

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -121,7 +121,7 @@ func createReleaseArtifactsImpl(state *commandState, cfg *config.Config) error {
 	}
 
 	for _, release := range releases {
-		if err := buildTestPackageRelease(state, outputRoot, release, cfg); err != nil {
+		if err := buildTestPackageRelease(state, cfg, outputRoot, release); err != nil {
 			return err
 		}
 	}
@@ -176,14 +176,14 @@ func copyFile(sourcePath, destPath string) error {
 	return createAndWriteBytesToFile(destPath, bytes)
 }
 
-func buildTestPackageRelease(state *commandState, outputRoot string, release LibraryRelease, cfg *config.Config) error {
+func buildTestPackageRelease(state *commandState, cfg *config.Config, outputRoot string, release LibraryRelease) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 
 	if err := languageRepo.Checkout(release.CommitHash); err != nil {
 		return err
 	}
-	if err := cc.BuildLibrary(languageRepo.Dir, release.LibraryID); err != nil {
+	if err := cc.BuildLibrary(cfg, languageRepo.Dir, release.LibraryID); err != nil {
 		return err
 	}
 	if cfg.SkipIntegrationTests != "" {

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -188,7 +188,7 @@ func buildTestPackageRelease(state *commandState, outputRoot string, release Lib
 	}
 	if cfg.SkipIntegrationTests != "" {
 		slog.Info(fmt.Sprintf("Skipping integration tests: %s", cfg.SkipIntegrationTests))
-	} else if err := cc.IntegrationTestLibrary(languageRepo.Dir, release.LibraryID); err != nil {
+	} else if err := cc.IntegrationTestLibrary(cfg, languageRepo.Dir, release.LibraryID); err != nil {
 		return err
 	}
 	outputDir := filepath.Join(outputRoot, release.LibraryID)

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -166,8 +166,7 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 		return err
 	}
 
-	prContent, err := generateReleaseCommitForEachLibrary(state, inputDirectory, releaseID, cfg.LibraryID, cfg.LibraryVersion,
-		cfg.SkipIntegrationTests, cfg.GitUserName, cfg.GitUserEmail)
+	prContent, err := generateReleaseCommitForEachLibrary(state, cfg, inputDirectory, releaseID)
 	if err != nil {
 		return err
 	}
@@ -208,8 +207,7 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 //   - Library-level errors do not halt the process, but are reported in the resulting PR (if any).
 //     This can include tags being missing, release preparation failing, or the build failing.
 //   - More fundamental errors (e.g. a failure to commit, or to save pipeline state) abort the whole process immediately.
-func generateReleaseCommitForEachLibrary(state *commandState, inputDirectory, releaseID, libraryID,
-	libraryVersion, skipIntegrationTests, gitUserName, gitUserEmail string) (*PullRequestContent, error) {
+func generateReleaseCommitForEachLibrary(state *commandState, cfg *config.Config, inputDirectory, releaseID string) (*PullRequestContent, error) {
 	cc := state.containerConfig
 	libraries := state.pipelineState.Libraries
 	languageRepo := state.languageRepo
@@ -218,7 +216,7 @@ func generateReleaseCommitForEachLibrary(state *commandState, inputDirectory, re
 
 	for _, library := range libraries {
 		// If we've specified a single library to release, skip all the others.
-		if libraryID != "" && library.Id != libraryID {
+		if cfg.LibraryID != "" && library.Id != cfg.LibraryID {
 			continue
 		}
 		if library.ReleaseAutomationLevel == statepb.AutomationLevel_AUTOMATION_LEVEL_BLOCKED {
@@ -245,11 +243,11 @@ func generateReleaseCommitForEachLibrary(state *commandState, inputDirectory, re
 
 		// If nothing release-worthy has happened, just continue to the next library.
 		// (But if we've been asked to release a specific library, we force-release it anyway.)
-		if libraryID == "" && (len(commitMessages) == 0 || !isReleaseWorthy(commitMessages, library.Id)) {
+		if cfg.LibraryID == "" && (len(commitMessages) == 0 || !isReleaseWorthy(commitMessages, library.Id)) {
 			continue
 		}
 
-		releaseVersion, err := calculateNextVersion(library, libraryVersion)
+		releaseVersion, err := calculateNextVersion(library, cfg.LibraryVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -286,9 +284,9 @@ func generateReleaseCommitForEachLibrary(state *commandState, inputDirectory, re
 			}
 			continue
 		}
-		if skipIntegrationTests != "" {
-			slog.Info(fmt.Sprintf("Skipping integration tests: %s", skipIntegrationTests))
-		} else if err := cc.IntegrationTestLibrary(languageRepo.Dir, library.Id); err != nil {
+		if cfg.SkipIntegrationTests != "" {
+			slog.Info(fmt.Sprintf("Skipping integration tests: %s", cfg.SkipIntegrationTests))
+		} else if err := cc.IntegrationTestLibrary(cfg, languageRepo.Dir, library.Id); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "integration testing library")
 			if err := languageRepo.CleanWorkingTree(); err != nil {
 				return nil, err
@@ -302,7 +300,7 @@ func generateReleaseCommitForEachLibrary(state *commandState, inputDirectory, re
 		metadata := fmt.Sprintf("Librarian-Release-Library: %s\nLibrarian-Release-Version: %s\nLibrarian-Release-ID: %s", library.Id, releaseVersion, releaseID)
 		// Note that releaseDescription will already end with two line breaks, so we don't need any more before the metadata.
 		err = commitAll(languageRepo, fmt.Sprintf("%s\n\n%s%s", releaseDescription, releaseNotes, metadata),
-			gitUserName, gitUserEmail)
+			cfg.GitUserName, cfg.GitUserEmail)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -268,7 +268,7 @@ func generateReleaseCommitForEachLibrary(state *commandState, cfg *config.Config
 			return nil, err
 		}
 
-		if err := cc.PrepareLibraryRelease(languageRepo.Dir, inputDirectory, library.Id, releaseVersion); err != nil {
+		if err := cc.PrepareLibraryRelease(cfg, languageRepo.Dir, inputDirectory, library.Id, releaseVersion); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "preparing library release")
 			// Clean up any changes before starting the next iteration.
 			if err := languageRepo.CleanWorkingTree(); err != nil {

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -276,7 +276,7 @@ func generateReleaseCommitForEachLibrary(state *commandState, cfg *config.Config
 			}
 			continue
 		}
-		if err := cc.BuildLibrary(languageRepo.Dir, library.Id); err != nil {
+		if err := cc.BuildLibrary(cfg, languageRepo.Dir, library.Id); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "building/testing library")
 			// Clean up any changes before starting the next iteration.
 			if err := languageRepo.CleanWorkingTree(); err != nil {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -158,7 +158,7 @@ func executeGenerate(state *commandState, cfg *config.Config) error {
 	if cfg.Build {
 		if libraryID != "" {
 			slog.Info("Build requested in the context of refined generation; cleaning and copying code to the local language repo before building.")
-			if err := state.containerConfig.Clean(state.languageRepo.Dir, libraryID); err != nil {
+			if err := state.containerConfig.Clean(cfg, state.languageRepo.Dir, libraryID); err != nil {
 				return err
 			}
 			if err := os.CopyFS(state.languageRepo.Dir, os.DirFS(outputDir)); err != nil {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -151,7 +151,7 @@ func executeGenerate(state *commandState, cfg *config.Config) error {
 	}
 	slog.Info(fmt.Sprintf("Code will be generated in %s", outputDir))
 
-	libraryID, err := runGenerateCommand(state, cfg.APIRoot, cfg.APIPath, outputDir)
+	libraryID, err := runGenerateCommand(state, cfg, outputDir)
 	if err != nil {
 		return err
 	}
@@ -180,8 +180,8 @@ func executeGenerate(state *commandState, cfg *config.Config) error {
 // and log the error.
 // If refined generation is used, the context's languageRepo field will be populated and the
 // library ID will be returned; otherwise, an empty string will be returned.
-func runGenerateCommand(state *commandState, apiRoot, apiPath, outputDir string) (string, error) {
-	apiRoot, err := filepath.Abs(apiRoot)
+func runGenerateCommand(state *commandState, cfg *config.Config, outputDir string) (string, error) {
+	apiRoot, err := filepath.Abs(cfg.APIRoot)
 	if err != nil {
 		return "", err
 	}
@@ -189,16 +189,16 @@ func runGenerateCommand(state *commandState, apiRoot, apiPath, outputDir string)
 	// If we've got a language repo, it's because we've already found a library for the
 	// specified API, configured in the repo.
 	if state.languageRepo != nil {
-		libraryID := findLibraryIDByApiPath(state.pipelineState, apiPath)
+		libraryID := findLibraryIDByApiPath(state.pipelineState, cfg.APIPath)
 		if libraryID == "" {
 			return "", errors.New("bug in Librarian: Library not found during generation, despite being found in earlier steps")
 		}
 		generatorInput := filepath.Join(state.languageRepo.Dir, config.GeneratorInputDir)
 		slog.Info(fmt.Sprintf("Performing refined generation for library %s", libraryID))
-		return libraryID, state.containerConfig.GenerateLibrary(apiRoot, outputDir, generatorInput, libraryID)
+		return libraryID, state.containerConfig.GenerateLibrary(cfg, apiRoot, outputDir, generatorInput, libraryID)
 	} else {
-		slog.Info(fmt.Sprintf("No matching library found (or no repo specified); performing raw generation for %s", apiPath))
-		return "", state.containerConfig.GenerateRaw(apiRoot, outputDir, apiPath)
+		slog.Info(fmt.Sprintf("No matching library found (or no repo specified); performing raw generation for %s", cfg.APIPath))
+		return "", state.containerConfig.GenerateRaw(apiRoot, outputDir, cfg.APIPath)
 	}
 }
 

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -198,7 +198,7 @@ func runGenerateCommand(state *commandState, cfg *config.Config, outputDir strin
 		return libraryID, state.containerConfig.GenerateLibrary(cfg, apiRoot, outputDir, generatorInput, libraryID)
 	} else {
 		slog.Info(fmt.Sprintf("No matching library found (or no repo specified); performing raw generation for %s", cfg.APIPath))
-		return "", state.containerConfig.GenerateRaw(apiRoot, outputDir, cfg.APIPath)
+		return "", state.containerConfig.GenerateRaw(cfg, apiRoot, outputDir, cfg.APIPath)
 	}
 }
 

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -167,7 +167,7 @@ func executeGenerate(state *commandState, cfg *config.Config) error {
 			if err := state.containerConfig.BuildLibrary(cfg, state.languageRepo.Dir, libraryID); err != nil {
 				return err
 			}
-		} else if err := state.containerConfig.BuildRaw(outputDir, cfg.APIPath); err != nil {
+		} else if err := state.containerConfig.BuildRaw(cfg, outputDir, cfg.APIPath); err != nil {
 			return err
 		}
 	}

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -225,7 +225,7 @@ func updateLibrary(state *commandState, cfg *config.Config, apiRepo *gitrepo.Rep
 		addErrorToPullRequest(prContent, library.Id, err, "generating")
 		return nil
 	}
-	if err := cc.Clean(languageRepo.Dir, library.Id); err != nil {
+	if err := cc.Clean(cfg, languageRepo.Dir, library.Id); err != nil {
 		addErrorToPullRequest(prContent, library.Id, err, "cleaning")
 		// Clean up any changes before starting the next iteration.
 		if err := languageRepo.CleanWorkingTree(); err != nil {

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -221,7 +221,7 @@ func updateLibrary(state *commandState, cfg *config.Config, apiRepo *gitrepo.Rep
 		return err
 	}
 
-	if err := cc.GenerateLibrary(apiRepo.Dir, outputDir, generatorInput, library.Id); err != nil {
+	if err := cc.GenerateLibrary(cfg, apiRepo.Dir, outputDir, generatorInput, library.Id); err != nil {
 		addErrorToPullRequest(prContent, library.Id, err, "generating")
 		return nil
 	}

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -157,7 +157,7 @@ func updateAPIs(ctx context.Context, state *commandState, cfg *config.Config) er
 	prContent := new(PullRequestContent)
 	// Perform "generate, clean, commit, build" on each library.
 	for _, library := range state.pipelineState.Libraries {
-		err := updateLibrary(state, apiRepo, outputDir, library, prContent, cfg.LibraryID, cfg.GitUserName, cfg.GitUserEmail)
+		err := updateLibrary(state, cfg, apiRepo, outputDir, library, prContent)
 		if err != nil {
 			return err
 		}
@@ -173,12 +173,12 @@ func updateAPIs(ctx context.Context, state *commandState, cfg *config.Config) er
 	return err
 }
 
-func updateLibrary(state *commandState, apiRepo *gitrepo.Repository, outputRoot string, library *statepb.LibraryState,
-	prContent *PullRequestContent, libraryID, gitUserName, gitUserEmail string) error {
+func updateLibrary(state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, outputRoot string, library *statepb.LibraryState,
+	prContent *PullRequestContent) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 
-	if libraryID != "" && libraryID != library.Id {
+	if cfg.LibraryID != "" && cfg.LibraryID != library.Id {
 		// If LibraryID has been passed in, we only act on that library.
 		return nil
 	}
@@ -256,14 +256,14 @@ func updateLibrary(state *commandState, apiRepo *gitrepo.Repository, outputRoot 
 		msg = createCommitMessage(library.Id, commits)
 	}
 	if err := commitAll(languageRepo, msg,
-		gitUserName, gitUserEmail); err != nil {
+		cfg.GitUserName, cfg.GitUserEmail); err != nil {
 		return err
 	}
 
 	// Once we've committed, we can build - but then check that nothing has changed afterwards.
 	// We consider a "something changed" error as fatal, whereas a build error just needs to
 	// undo the commit, report the failure and continue
-	buildErr := cc.BuildLibrary(languageRepo.Dir, library.Id)
+	buildErr := cc.BuildLibrary(cfg, languageRepo.Dir, library.Id)
 	clean, err := languageRepo.IsClean()
 	if err != nil {
 		return err

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -209,7 +209,7 @@ func regenerateLibrary(state *commandState, cfg *config.Config, apiRepo *gitrepo
 		return err
 	}
 
-	if err := cc.GenerateLibrary(apiRepo.Dir, outputDir, generatorInput, library.Id); err != nil {
+	if err := cc.GenerateLibrary(cfg, apiRepo.Dir, outputDir, generatorInput, library.Id); err != nil {
 		return err
 	}
 	if err := cc.Clean(cfg, languageRepo.Dir, library.Id); err != nil {

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -175,7 +175,7 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 
 	// Build everything at the end. (This is more efficient than building each library with a separate container invocation.)
 	slog.Info("Building all libraries.")
-	if err := state.containerConfig.BuildLibrary(languageRepo.Dir, ""); err != nil {
+	if err := state.containerConfig.BuildLibrary(cfg, languageRepo.Dir, ""); err != nil {
 		return err
 	}
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -160,7 +160,7 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 
 	// Perform "generate, clean" on each library.
 	for _, library := range ps.Libraries {
-		err := regenerateLibrary(state, apiRepo, generatorInput, outputDir, library)
+		err := regenerateLibrary(state, cfg, apiRepo, generatorInput, outputDir, library)
 		if err != nil {
 			return err
 		}
@@ -187,7 +187,7 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 	return err
 }
 
-func regenerateLibrary(state *commandState, apiRepo *gitrepo.Repository, generatorInput string, outputRoot string, library *statepb.LibraryState) error {
+func regenerateLibrary(state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, generatorInput string, outputRoot string, library *statepb.LibraryState) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 
@@ -212,7 +212,7 @@ func regenerateLibrary(state *commandState, apiRepo *gitrepo.Repository, generat
 	if err := cc.GenerateLibrary(apiRepo.Dir, outputDir, generatorInput, library.Id); err != nil {
 		return err
 	}
-	if err := cc.Clean(languageRepo.Dir, library.Id); err != nil {
+	if err := cc.Clean(cfg, languageRepo.Dir, library.Id); err != nil {
 		return err
 	}
 	if err := os.CopyFS(languageRepo.Dir, os.DirFS(outputDir)); err != nil {


### PR DESCRIPTION
These two env variables, `KOKORO_HOST_ROOT_DIR` and `KOKORO_ROOT_DIR`, are used in `docker` package. Therefore, these two variables can't be converted to flags because all functions in `flags.go` are package private.

These variables are already part of `config` package, but there will be breaking changes in `docker` package. For example, we need to pass `*config.Config` to all public functions in `docker/docker.go`.

Fixes #507 