### PR TITLE
fix(all): set up golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Defines the configuration version.
+# The only possible value is "2".
+version: "2"
+
+linters:
+  # See https://golangci-lint.run/usage/linters for details.
+  default: none
+  enable:
+    - fatcontext
+    - govet
+    - ineffassign
+    - staticcheck
+    - unparam
+    - unused

--- a/all_test.go
+++ b/all_test.go
@@ -89,16 +89,8 @@ func TestHeaders(t *testing.T) {
 	})
 }
 
-func TestStaticCheck(t *testing.T) {
-	rungo(t, "run", "honnef.co/go/tools/cmd/staticcheck@latest", "./...")
-}
-
-func TestUnparam(t *testing.T) {
-	rungo(t, "run", "mvdan.cc/unparam@latest", "./...")
-}
-
-func TestVet(t *testing.T) {
-	rungo(t, "vet", "-all", "./...")
+func TestGolangCILint(t *testing.T) {
+	rungo(t, "run", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest", "run")
 }
 
 func TestGoModTidy(t *testing.T) {


### PR DESCRIPTION
Configure golangci-lint to run as part of `go test ./...`.

Remove TestStaticcheck, TestVet, and TestUnparam, as these are now covered by golangci-lint. Disable linters that cause test failures, which will be adjusted as a follow-up.

For https://github.com/googleapis/librarian/issues/638