### PR TITLE
fix(internal/librarian): merge-release-pr should accept -env-file #589

### DIFF
--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -102,6 +102,7 @@ func init() {
 	addFlagReleaseID(fs, cfg)
 	addFlagReleasePRUrl(fs, cfg)
 	addFlagSyncUrlPrefix(fs, cfg)
+	addFlagEnvFile(fs, cfg)
 }
 
 func runMergeReleasePR(ctx context.Context, cfg *config.Config) error {


### PR DESCRIPTION
The merge-release-pr command creates an env-vars.txt file, but doesn't allow its location to be specified, so it's always created in the work root. It should accept the `-env-file` flag.

Fixes #589 
