### PR TITLE
fix(internal/github): rename githubrepo to github

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package githubrepo provides operations on GitHub repos, abstracting away go-github
+// Package github provides operations on GitHub repos, abstracting away go-github
 // (at least somewhat) to only the operations Librarian needs.
-package githubrepo
+package github
 
 import (
 	"context"
@@ -24,6 +24,18 @@ import (
 
 	"github.com/google/go-github/v69/github"
 )
+
+// PullRequest is a type alia for the go-github type.
+type PullRequest = github.PullRequest
+
+// RepositoryCommit is a type alias for the go-github type.
+type RepositoryCommit = github.RepositoryCommit
+
+// PullRequestReview is a type alias for the go-github type.
+type PullRequestReview = github.PullRequestReview
+
+// MergeMethodRebase is a constant alias for the go-github constant.
+const MergeMethodRebase = github.MergeMethodRebase
 
 // Client represents this package's abstraction of a GitHub client, including
 // an access token.

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-github/v69/github"
 )
 
-// PullRequest is a type alia for the go-github type.
+// PullRequest is a type alias for the go-github type.
 type PullRequest = github.PullRequest
 
 // RepositoryCommit is a type alias for the go-github type.

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/googleapis/librarian/internal/statepb"
@@ -188,7 +188,7 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 	// Final steps if we've actually created a release PR.
 	// - We always add the do-not-merge label so that Librarian can merge later.
 	// - Add a result environment variable with the PR number, for the next stage of the process.
-	ghClient, err := githubrepo.NewClient(cfg.GitHubToken)
+	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -26,7 +26,7 @@ import (
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/docker"
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 )
@@ -227,7 +227,7 @@ func detectIfLibraryConfigured(apiPath, repoURL, repoRoot, gitHubToken string) (
 			return false, err
 		}
 	} else {
-		languageRepoMetadata, err := githubrepo.ParseUrl(repoURL)
+		languageRepoMetadata, err := github.ParseUrl(repoURL)
 		if err != nil {
 			slog.Warn("failed to parse", "repo url:", repoURL, "error", err)
 			return false, err

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -25,10 +25,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v69/github"
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/statepb"
 )
 
@@ -139,7 +138,7 @@ func mergeReleasePR(ctx context.Context, workRoot string, cfg *config.Config) er
 	}
 
 	// We'll assume the PR URL is in the format https://github.com/{owner}/{name}/pulls/{pull-number}
-	prRepo, err := githubrepo.ParseUrl(cfg.ReleasePRURL)
+	prRepo, err := github.ParseUrl(cfg.ReleasePRURL)
 	if err != nil {
 		return err
 	}
@@ -149,7 +148,7 @@ func mergeReleasePR(ctx context.Context, workRoot string, cfg *config.Config) er
 		return err
 	}
 
-	prMetadata := &githubrepo.PullRequestMetadata{Repo: prRepo, Number: prNumber}
+	prMetadata := &github.PullRequestMetadata{Repo: prRepo, Number: prNumber}
 
 	if err := waitForPullRequestReadiness(ctx, prMetadata, cfg); err != nil {
 		return err
@@ -173,7 +172,7 @@ func mergeReleasePR(ctx context.Context, workRoot string, cfg *config.Config) er
 // TODO(https://github.com/googleapis/librarian/issues/544): make timing configurable?
 const sleepDelay = time.Duration(60) * time.Second
 
-func waitForPullRequestReadiness(ctx context.Context, prMetadata *githubrepo.PullRequestMetadata, cfg *config.Config) error {
+func waitForPullRequestReadiness(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) error {
 	// TODO(https://github.com/googleapis/librarian/issues/543): time out here, or let Kokoro do so?
 
 	for {
@@ -201,9 +200,9 @@ func waitForPullRequestReadiness(ctx context.Context, prMetadata *githubrepo.Pul
 // - No commit in the PR must start its release notes with "FIXME"
 // - There must be no commits in the head of the repo which affect libraries released by the PR
 // - There must be at least one approving reviews from a member/owner of the repo, and no reviews from members/owners requesting changes
-func waitForPullRequestReadinessSingleIteration(ctx context.Context, prMetadata *githubrepo.PullRequestMetadata, cfg *config.Config) (bool, error) {
+func waitForPullRequestReadinessSingleIteration(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) (bool, error) {
 	slog.Info("Checking pull request for readiness")
-	ghClient, err := githubrepo.NewClient(cfg.GitHubToken)
+	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return false, err
 	}
@@ -304,8 +303,8 @@ func waitForPullRequestReadinessSingleIteration(ctx context.Context, prMetadata 
 	return true, nil
 }
 
-func mergePullRequest(ctx context.Context, prMetadata *githubrepo.PullRequestMetadata, cfg *config.Config) (string, error) {
-	ghClient, err := githubrepo.NewClient(cfg.GitHubToken)
+func mergePullRequest(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) (string, error) {
+	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return "", err
 	}
@@ -376,8 +375,8 @@ func waitForSync(mergeCommit string, cfg *config.Config) error {
 //
 // Returns true if all the commits are fine, or false if a problem was detected, in which
 // case it will have been reported on the PR, and the merge-blocking label applied.
-func checkPullRequestCommits(ctx context.Context, prMetadata *githubrepo.PullRequestMetadata, pr *github.PullRequest, cfg *config.Config) (bool, error) {
-	baseRepo := githubrepo.CreateGitHubRepoFromRepository(pr.Base.Repo)
+func checkPullRequestCommits(ctx context.Context, prMetadata *github.PullRequestMetadata, pr *github.PullRequest, cfg *config.Config) (bool, error) {
+	baseRepo := github.CreateGitHubRepoFromRepository(pr.Base.Repo)
 	baseHeadState, err := fetchRemotePipelineState(ctx, baseRepo, *pr.Base.Ref, cfg.GitHubToken)
 	if err != nil {
 		return false, err
@@ -390,7 +389,7 @@ func checkPullRequestCommits(ctx context.Context, prMetadata *githubrepo.PullReq
 	// Fetch the commits which are in the PR, compared with the base (the target of the merge).
 	// In most cases pr.Base.SHA will be the same as cfg.BaselineCommit, but the PR may have been rebased -
 	// and we always only want the commits in the PR, not any that it's been rebased on top of.
-	ghClient, err := githubrepo.NewClient(cfg.GitHubToken)
+	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return false, err
 	}
@@ -455,8 +454,8 @@ func checkPullRequestCommits(ctx context.Context, prMetadata *githubrepo.PullReq
 }
 
 // Checks that the pull request has at least one approved review, and no "changes requested" reviews.
-func checkPullRequestApproval(ctx context.Context, prMetadata *githubrepo.PullRequestMetadata, cfg *config.Config) (bool, error) {
-	ghClient, err := githubrepo.NewClient(cfg.GitHubToken)
+func checkPullRequestApproval(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) (bool, error) {
+	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return false, err
 	}
@@ -501,10 +500,10 @@ func checkPullRequestApproval(ctx context.Context, prMetadata *githubrepo.PullRe
 	return approved, nil
 }
 
-func reportBlockingReason(ctx context.Context, prMetadata *githubrepo.PullRequestMetadata, description string, cfg *config.Config) error {
+func reportBlockingReason(ctx context.Context, prMetadata *github.PullRequestMetadata, description string, cfg *config.Config) error {
 	slog.Warn(fmt.Sprintf("Adding '%s' label to PR and a comment with a description of '%s'", MergeBlockedLabel, description))
 	comment := fmt.Sprintf("%s\n\nAfter resolving the issue, please remove the '%s' label.", description, MergeBlockedLabel)
-	ghClient, err := githubrepo.NewClient(cfg.GitHubToken)
+	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -27,7 +27,7 @@ import (
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/docker"
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 )
 
 var cmdPublishReleaseArtifacts = &cli.Command{
@@ -122,7 +122,7 @@ func publishReleaseArtifacts(ctx context.Context, containerConfig *docker.Docker
 
 	// Load the pipeline config from the commit of the first release, using the tag repo, then
 	// update our context to use it for the container config.
-	gitHubRepo, err := githubrepo.ParseUrl(tagRepoURL)
+	gitHubRepo, err := github.ParseUrl(tagRepoURL)
 	if err != nil {
 		return err
 	}
@@ -150,8 +150,8 @@ func publishPackages(config *docker.Docker, outputRoot string, releases []Librar
 	return nil
 }
 
-func createRepoReleases(ctx context.Context, releases []LibraryRelease, gitHubRepo *githubrepo.Repository, gitHubToken string) error {
-	ghClient, err := githubrepo.NewClient(gitHubToken)
+func createRepoReleases(ctx context.Context, releases []LibraryRelease, gitHubRepo *github.Repository, gitHubToken string) error {
+	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/pullrequest.go
+++ b/internal/librarian/pullrequest.go
@@ -21,7 +21,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
@@ -58,8 +58,8 @@ func addSuccessToPullRequest(pr *PullRequestContent, text string) {
 // If content only contains errors, the pull request is not created and an error is returned (to highlight that everything failed)
 // If content contains any successes, a pull request is created and no error is returned (if the creation is successful) even if the content includes errors.
 // If the pull request would contain an excessive number of commits (as configured in pipeline-config.json)
-func createPullRequest(ctx context.Context, state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*githubrepo.PullRequestMetadata, error) {
-	ghClient, err := githubrepo.NewClient(gitHubToken)
+func createPullRequest(ctx context.Context, state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*github.PullRequestMetadata, error) {
+	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func formatListAsMarkdown(title string, list []string) string {
 // There must only be a single remote with a GitHub URL (as the first URL), in order to provide an
 // unambiguous result.
 // Remotes without any URLs, or where the first URL does not start with https://github.com/ are ignored.
-func getGitHubRepoFromRemote(repo *gitrepo.Repository) (*githubrepo.Repository, error) {
+func getGitHubRepoFromRemote(repo *gitrepo.Repository) (*github.Repository, error) {
 	remotes, err := repo.Remotes()
 	if err != nil {
 		return nil, err
@@ -165,5 +165,5 @@ func getGitHubRepoFromRemote(repo *gitrepo.Repository) (*githubrepo.Repository, 
 		joinedRemoteNames := strings.Join(gitHubRemoteNames, ", ")
 		return nil, fmt.Errorf("can only determine the GitHub repo with a single matching remote; GitHub remotes in repo: %s", joinedRemoteNames)
 	}
-	return githubrepo.ParseUrl(gitHubUrl)
+	return github.ParseUrl(gitHubUrl)
 }

--- a/internal/librarian/stateandconfig.go
+++ b/internal/librarian/stateandconfig.go
@@ -18,11 +18,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/googleapis/librarian/internal/config"
 	"os"
 	"path/filepath"
 
-	"github.com/googleapis/librarian/internal/githubrepo"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/github"
+
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"github.com/googleapis/librarian/internal/statepb"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -85,8 +86,8 @@ func savePipelineState(state *commandState) error {
 	return err
 }
 
-func fetchRemotePipelineState(ctx context.Context, repo *githubrepo.Repository, ref string, gitHubToken string) (*statepb.PipelineState, error) {
-	ghClient, err := githubrepo.NewClient(gitHubToken)
+func fetchRemotePipelineState(ctx context.Context, repo *github.Repository, ref string, gitHubToken string) (*statepb.PipelineState, error) {
+	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add type and constant alias in githubrepo package to remove all uses of github.com/google/go-github/v69/github types and constants.

Rename the githubrepo package to github, since this package provides operations on the GitHub API. This also avoids confusion with the gitrepo package, which provides git operations on repositories.

Fixes #626