### PR TITLE
refactor(internal): move user lookup to config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,13 +166,13 @@ type Config struct {
 	// GitUserName is specified with the -git-user-name flag.
 	GitUserName string
 
-	// GID is the group ID of the current user. It is used to run Docker
+	// UserGID is the group ID of the current user. It is used to run Docker
 	// containers with the same user, so that created files have the correct
 	// ownership.
 	//
 	// This is populated automatically after flag parsing. No user setup is
 	// expected.
-	GID string
+	UserGID string
 
 	// Image is the language-specific container image to use for language-specific
 	// operations. It is primarily used for testing Librarian and/or new images.
@@ -358,13 +358,13 @@ type Config struct {
 	// TagRepoURL is specified with the -tag-repo-url flag.
 	TagRepoURL string
 
-	// UID is the user ID of the current user. It is used to run Docker
+	// UserUID is the user ID of the current user. It is used to run Docker
 	// containers with the same user, so that created files have the correct
 	// ownership.
 	//
 	// This is populated automatically after flag parsing. No user setup is
 	// expected.
-	UID string
+	UserUID string
 
 	// WorkRoot is the root directory used for temporary working files, including
 	// any repositories that are cloned. By default, this is created in /tmp with
@@ -394,8 +394,8 @@ func (c *Config) SetupUser() error {
 	if err != nil {
 		return fmt.Errorf("failed to get current user: %w", err)
 	}
-	c.UID = currentUser.Uid
-	c.GID = currentUser.Gid
+	c.UserUID = currentUser.Uid
+	c.UserGID = currentUser.Gid
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,9 @@ type Config struct {
 	// GID is the group ID of the current user. It is used to run Docker
 	// containers with the same user, so that created files have the correct
 	// ownership.
+	//
+	// This is populated automatically after flag parsing. No user setup is
+	// expected.
 	GID string
 
 	// Image is the language-specific container image to use for language-specific
@@ -358,6 +361,9 @@ type Config struct {
 	// UID is the user ID of the current user. It is used to run Docker
 	// containers with the same user, so that created files have the correct
 	// ownership.
+	//
+	// This is populated automatically after flag parsing. No user setup is
+	// expected.
 	UID string
 
 	// WorkRoot is the root directory used for temporary working files, including
@@ -380,10 +386,10 @@ func New() *Config {
 	}
 }
 
-// Init performs late initialization of the configuration, such as determining
-// the current user. This is in a separate method as it can fail, and is
-// called after flag parsing.
-func (c *Config) Init() error {
+// SetupUser performs late initialization of user-specific configuration,
+// determining the current user. This is in a separate method as it
+// can fail, and is called after flag parsing.
+func (c *Config) SetupUser() error {
 	currentUser, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("failed to get current user: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -386,16 +386,19 @@ func New() *Config {
 	}
 }
 
+// currentUser is a variable so it can be replaced during testing.
+var currentUser = user.Current
+
 // SetupUser performs late initialization of user-specific configuration,
 // determining the current user. This is in a separate method as it
 // can fail, and is called after flag parsing.
 func (c *Config) SetupUser() error {
-	currentUser, err := user.Current()
+	user, err := currentUser()
 	if err != nil {
 		return fmt.Errorf("failed to get current user: %w", err)
 	}
-	c.UserUID = currentUser.Uid
-	c.UserGID = currentUser.Gid
+	c.UserUID = user.Uid
+	c.UserGID = user.Gid
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"os/user"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNew(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		envVars map[string]string
+		want    Config
+	}{
+		{
+			name: "All environment variables set",
+			envVars: map[string]string{
+				"KOKORO_HOST_ROOT_DIR":      "/host/root",
+				"KOKORO_ROOT_DIR":           "/mount/root",
+				"LIBRARIAN_GITHUB_TOKEN":    "gh_token",
+				"LIBRARIAN_REPOSITORY":      "lib_repo",
+				"LIBRARIAN_SYNC_AUTH_TOKEN": "sync_token",
+			},
+			want: Config{
+				DockerHostRootDir:   "/host/root",
+				DockerMountRootDir:  "/mount/root",
+				GitHubToken:         "gh_token",
+				LibrarianRepository: "lib_repo",
+				SyncAuthToken:       "sync_token",
+			},
+		},
+		{
+			name:    "No environment variables set",
+			envVars: map[string]string{},
+			want: Config{
+				DockerHostRootDir:   "",
+				DockerMountRootDir:  "",
+				GitHubToken:         "",
+				LibrarianRepository: "",
+				SyncAuthToken:       "",
+			},
+		},
+		{
+			name: "Some environment variables set",
+			envVars: map[string]string{
+				"KOKORO_HOST_ROOT_DIR":   "/host/root",
+				"LIBRARIAN_GITHUB_TOKEN": "gh_token",
+			},
+			want: Config{
+				DockerHostRootDir:   "/host/root",
+				DockerMountRootDir:  "",
+				GitHubToken:         "gh_token",
+				LibrarianRepository: "",
+				SyncAuthToken:       "",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+
+			got := New()
+
+			if diff := cmp.Diff(&test.want, got); diff != "" {
+				t.Errorf("New() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetupUser(t *testing.T) {
+	originalCurrentUser := currentUser
+	t.Cleanup(func() {
+		currentUser = originalCurrentUser
+	})
+
+	for _, test := range []struct {
+		name     string
+		mockUser *user.User
+		mockErr  error
+		wantUID  string
+		wantGID  string
+		wantErr  bool
+	}{
+		{
+			name: "Success",
+			mockUser: &user.User{
+				Uid: "1001",
+				Gid: "1002",
+			},
+			mockErr: nil,
+			wantUID: "1001",
+			wantGID: "1002",
+			wantErr: false,
+		},
+		{
+			name:     "Error getting user",
+			mockUser: nil,
+			mockErr:  errors.New("user lookup failed"),
+			wantUID:  "",
+			wantGID:  "",
+			wantErr:  true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			currentUser = func() (*user.User, error) {
+				return test.mockUser, test.mockErr
+			}
+
+			cfg := &Config{}
+			err := cfg.SetupUser()
+
+			if (err != nil) != test.wantErr {
+				t.Errorf("SetupUser() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+
+			if cfg.UserUID != test.wantUID {
+				t.Errorf("SetupUser() got UID = %q, want %q", cfg.UserUID, test.wantUID)
+			}
+			if cfg.UserGID != test.wantGID {
+				t.Errorf("SetupUser() got GID = %q, want %q", cfg.UserGID, test.wantGID)
+			}
+		})
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		cfg       Config
+		wantValid bool
+		wantErr   bool
+	}{
+		{
+			name: "Valid config - Push false",
+			cfg: Config{
+				Push:        false,
+				GitHubToken: "",
+			},
+			wantValid: true,
+			wantErr:   false,
+		},
+		{
+			name: "Valid config - Push true, token present",
+			cfg: Config{
+				Push:        true,
+				GitHubToken: "some_token",
+			},
+			wantValid: true,
+			wantErr:   false,
+		},
+		{
+			name: "Invalid config - Push true, token missing",
+			cfg: Config{
+				Push:        true,
+				GitHubToken: "",
+			},
+			wantValid: false,
+			wantErr:   true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotValid, err := test.cfg.IsValid()
+
+			if gotValid != test.wantValid {
+				t.Errorf("IsValid() got valid = %t, want %t", gotValid, test.wantValid)
+			}
+
+			if (err != nil) != test.wantErr {
+				t.Errorf("IsValid() got error = %v, want error = %t", err, test.wantErr)
+			}
+			if test.wantErr && err != nil && err.Error() != "no GitHub token supplied for push" {
+				t.Errorf("IsValid() got unexpected error message: %q", err.Error())
+			}
+		})
+	}
+}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -91,16 +91,16 @@ type Docker struct {
 // providing the container with required environment variables.
 func New(workRoot, image, secretsProject, uid, gid string, pipelineConfig *statepb.PipelineConfig) (*Docker, error) {
 	envProvider := newEnvironmentProvider(workRoot, secretsProject, pipelineConfig)
-	d := &Docker{
+	docker := &Docker{
 		Image: image,
 		env:   envProvider,
 		uid:   uid,
 		gid:   gid,
 	}
-	d.run = func(args ...string) error {
-		return d.runCommand("docker", args...)
+	docker.run = func(args ...string) error {
+		return docker.runCommand("docker", args...)
 	}
-	return d, nil
+	return docker, nil
 }
 
 // GenerateRaw performs generation for an API not configured in a library.
@@ -319,14 +319,14 @@ func maybeRelocateMounts(cfg *config.Config, mounts []string) []string {
 	return relocatedMounts
 }
 
-func (d *Docker) runCommand(c string, args ...string) error {
+func (c *Docker) runCommand(cmdName string, args ...string) error {
 	// Run as the current user in the container - primarily so that any files
 	// we create end up being owned by the current user (and easily deletable).
-	if d.uid != "" && d.gid != "" {
-		args = append(args, "--user", fmt.Sprintf("%s:%s", d.uid, d.gid))
+	if c.uid != "" && c.gid != "" {
+		args = append(args, "--user", fmt.Sprintf("%s:%s", c.uid, c.gid))
 	}
 
-	cmd := exec.Command(c, args...)
+	cmd := exec.Command(cmdName, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	slog.Info(fmt.Sprintf("=== Docker start %s", strings.Repeat("=", 63)))

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -112,7 +112,7 @@ func cloneOrOpenLanguageRepo(workRoot, repoRoot, repoURL, language, ci string) (
 // ContainerState based on all of the above. This should be used by all commands
 // which always have a language repo. Commands which only conditionally use
 // language repos should construct the command state themselves.
-func createCommandStateForLanguage(ctx context.Context, workRootOverride, repoRoot, repoURL, language, imageOverride, defaultRepository, secretsProject, ci string) (*commandState, error) {
+func createCommandStateForLanguage(ctx context.Context, workRootOverride, repoRoot, repoURL, language, imageOverride, defaultRepository, secretsProject, ci, uid, gid string) (*commandState, error) {
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime, workRootOverride)
 	if err != nil {
@@ -129,7 +129,7 @@ func createCommandStateForLanguage(ctx context.Context, workRootOverride, repoRo
 	}
 
 	image := deriveImage(language, imageOverride, defaultRepository, ps)
-	containerConfig, err := docker.New(ctx, workRoot, image, secretsProject, config)
+	containerConfig, err := docker.New(ctx, workRoot, image, secretsProject, uid, gid, config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -101,8 +101,8 @@ func init() {
 }
 
 func runConfigure(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
+	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -102,7 +102,7 @@ func init() {
 
 func runConfigure(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
-		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -95,7 +95,7 @@ func init() {
 
 func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
-		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -94,8 +94,8 @@ func init() {
 }
 
 func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
+	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -125,7 +125,7 @@ func init() {
 
 func runCreateReleasePR(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
-		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -124,8 +124,8 @@ func init() {
 }
 
 func runCreateReleasePR(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
+	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -128,7 +128,7 @@ func runGenerate(ctx context.Context, cfg *config.Config) error {
 	}
 
 	image := deriveImage(cfg.Language, cfg.Image, cfg.LibrarianRepository, ps)
-	containerConfig, err := docker.New(workRoot, image, cfg.SecretsProject, cfg.UID, cfg.GID, config)
+	containerConfig, err := docker.New(workRoot, image, cfg.SecretsProject, cfg.UserUID, cfg.UserGID, config)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -128,7 +128,7 @@ func runGenerate(ctx context.Context, cfg *config.Config) error {
 	}
 
 	image := deriveImage(cfg.Language, cfg.Image, cfg.LibrarianRepository, ps)
-	containerConfig, err := docker.New(ctx, workRoot, image, cfg.SecretsProject, config)
+	containerConfig, err := docker.New(ctx, workRoot, image, cfg.SecretsProject, cfg.UID, cfg.GID, config)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -67,5 +67,8 @@ func Run(ctx context.Context, arg ...string) error {
 		return err
 	}
 	slog.Info("librarian", "arguments", arg)
+	if err := cmd.Config.Init(); err != nil {
+		return fmt.Errorf("failed to initialize config: %w", err)
+	}
 	return cmd.Run(ctx, cmd.Config)
 }

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -67,8 +67,8 @@ func Run(ctx context.Context, arg ...string) error {
 		return err
 	}
 	slog.Info("librarian", "arguments", arg)
-	if err := cmd.Config.Init(); err != nil {
-		return fmt.Errorf("failed to initialize config: %w", err)
+	if err := cmd.Config.SetupUser(); err != nil {
+		return fmt.Errorf("failed to setup user config: %w", err)
 	}
 	return cmd.Run(ctx, cmd.Config)
 }

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -95,7 +95,7 @@ func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	containerConfig, err := docker.New(workRoot, image, cfg.SecretsProject, cfg.UID, cfg.GID, pipelineConfig)
+	containerConfig, err := docker.New(workRoot, image, cfg.SecretsProject, cfg.UserUID, cfg.UserGID, pipelineConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -95,7 +95,7 @@ func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	containerConfig, err := docker.New(ctx, workRoot, image, cfg.SecretsProject, pipelineConfig)
+	containerConfig, err := docker.New(ctx, workRoot, image, cfg.SecretsProject, cfg.UID, cfg.GID, pipelineConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -103,7 +103,7 @@ func init() {
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
-		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -102,8 +102,8 @@ func init() {
 }
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
+	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -91,7 +91,7 @@ func init() {
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
 	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
-		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -90,8 +90,8 @@ func init() {
 }
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
-		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
+	state, err := createCommandStateForLanguage(ctx, cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language,
+		cfg.Image, cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI, cfg.UID, cfg.GID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Moves the call to user.Current into the config package, keep Docker-related logic focused.

Fixes #590