### PR TITLE
fix(internal/librarian): don't display both usage twice

### DIFF
--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -63,7 +63,9 @@ func Run(ctx context.Context, arg ...string) error {
 		return err
 	}
 	if err := cmd.Parse(arg[1:]); err != nil {
-		CmdLibrarian.Flags.Usage()
+		// We expect that if cmd.Parse fails, it will already
+		// have printed out a command-specific usage error,
+		// so we don't need to display the general usage.
 		return err
 	}
 	slog.Info("librarian", "arguments", arg)


### PR DESCRIPTION
If Command.Parse fails having found a specific command, we can expect that command to have displayed a suitable command-specific-usage message; we don't need to display the generic usage as well.

This affects both the case of "help explicitly requested with -h" as well as "a flag that's not registed for this command was supplied".

Fixes #666