### PR TITLE
refactor(internal/librarian): merge -repo-root and -repo-url into a single -repo flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -268,31 +268,24 @@ type Config struct {
 	// ReleasePRURL is specified with the -release-pr-url flag.
 	ReleasePRURL string
 
-	// RepoRoot is the local root directory of the language repository, which can
-	// be specified relative to the current working directory. The repository must
+	// Repo specifies the language repository to use, as either a local root directory
+	// or a URL to clone from. If a local directory is specified, it can
+	// be relative to the current working directory. The repository must
 	// be in a clean state (i.e. git status should report no changes) to avoid mixing
 	// Librarian-created changes with other changes.
 	//
-	// RepoRoot is used by all commands which operate on a language repository:
+	// Repo is used by all commands which operate on a language repository:
 	// configure, create-release-artifacts, create-release-pr, generate, update-apis,
 	// update-image-tag.
 	//
-	// RepoRoot is always optional, and always mutually exclusive with RepoURL, as both
-	// are used to explicitly indicate a language repository to use.
+	// When a local directory is specified for the generate command, the repo is checked to
+	// determine whether the specified API path is configured as a library. See the generate
+	// command documentation for more details.
+	// For all commands other than generate, omitting Repo is equivalent to
+	// specifying Repo as https://github.com/googleapis/google-cloud-{Language}.
 	//
-	// When specified for the generate command, the repo is checked to determine whether the
-	// specified API path is configured as a library. See the generate command documentation
-	// for more details. For all other commands, omitting both RepoRoot and RepoUrl is equivalent
-	// to specifying a RepoUrl of https://github.com/googleapis/google-cloud-{Language}.
-	//
-	// RepoRoot is specified with the -repo-root flag.
-	RepoRoot string
-
-	// RepoURL is the URL to clone the language repository from. It is a mutually exclusive
-	// alternative to RepoRoot; see the RepoRoot documentation for more details.
-	//
-	// RepoURL is specified with the -repo-url flag.
-	RepoURL string
+	// Repo is specified with the -repo flag.
+	Repo string
 
 	// SyncAuthToken provides an auth token used when polling a synchronization
 	// URL at the end of the merge-release-pr command, if SyncURLPrefix has been

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -75,28 +75,27 @@ func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.Repository, er
 			RemoteURL:  repo,
 			CI:         ci,
 		})
-	} else {
-		// repo is a directory
-		absRepoRoot, err := filepath.Abs(repo)
-		if err != nil {
-			return nil, err
-		}
-		languageRepo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{
-			Dir: absRepoRoot,
-			CI:  ci,
-		})
-		if err != nil {
-			return nil, err
-		}
-		clean, err := languageRepo.IsClean()
-		if err != nil {
-			return nil, err
-		}
-		if !clean {
-			return nil, errors.New("language repo must be clean")
-		}
-		return languageRepo, nil
 	}
+	// repo is a directory
+	absRepoRoot, err := filepath.Abs(repo)
+	if err != nil {
+		return nil, err
+	}
+	languageRepo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{
+		Dir: absRepoRoot,
+		CI:  ci,
+	})
+	if err != nil {
+		return nil, err
+	}
+	clean, err := languageRepo.IsClean()
+	if err != nil {
+		return nil, err
+	}
+	if !clean {
+		return nil, errors.New("language repo must be clean")
+	}
+	return languageRepo, nil
 }
 
 // createCommandStateForLanguage performs common (but not universal)

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -216,23 +216,16 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 	notARepoPath := t.TempDir()
 
 	for _, test := range []struct {
-		name     string
-		repoRoot string
-		repoURL  string
-		ci       string
-		wantErr  bool
-		check    func(t *testing.T, repo *gitrepo.Repository)
-		setup    func(t *testing.T, workRoot string) func()
+		name    string
+		repo    string
+		ci      string
+		wantErr bool
+		check   func(t *testing.T, repo *gitrepo.Repository)
+		setup   func(t *testing.T, workRoot string) func()
 	}{
 		{
-			name:     "repoRoot and repoURL both set",
-			repoRoot: "a",
-			repoURL:  "b",
-			wantErr:  true,
-		},
-		{
-			name:     "with clean repoRoot",
-			repoRoot: cleanRepoPath,
+			name: "with clean repoRoot",
+			repo: cleanRepoPath,
 			check: func(t *testing.T, repo *gitrepo.Repository) {
 				absWantDir, _ := filepath.Abs(cleanRepoPath)
 				if repo.Dir != absWantDir {
@@ -241,8 +234,8 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 			},
 		},
 		{
-			name:    "with repoURL with trailing slash",
-			repoURL: "https://github.com/googleapis/google-cloud-go/",
+			name: "with repoURL with trailing slash",
+			repo: "https://github.com/googleapis/google-cloud-go/",
 			setup: func(t *testing.T, workRoot string) func() {
 				// The expected directory name is `google-cloud-go`.
 				repoPath := filepath.Join(workRoot, "google-cloud-go")
@@ -265,14 +258,14 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:     "with dirty repoRoot",
-			repoRoot: dirtyRepoPath,
-			wantErr:  true,
+			name:    "with dirty repoRoot",
+			repo:    dirtyRepoPath,
+			wantErr: true,
 		},
 		{
-			name:     "with repoRoot that is not a repo",
-			repoRoot: notARepoPath,
-			wantErr:  true,
+			name:    "with repoRoot that is not a repo",
+			repo:    notARepoPath,
+			wantErr: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -286,7 +279,7 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 				}
 			}()
 
-			repo, err := cloneOrOpenLanguageRepo(workRoot, test.repoRoot, test.repoURL, test.ci)
+			repo, err := cloneOrOpenLanguageRepo(workRoot, test.repo, test.ci)
 			if test.wantErr {
 				if err == nil {
 					t.Error("cloneOrOpenLanguageRepo() expected an error but got nil")

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -95,13 +95,12 @@ func init() {
 	addFlagGitUserName(fs, cfg)
 	addFlagLanguage(fs, cfg)
 	addFlagPush(fs, cfg)
-	addFlagRepoRoot(fs, cfg)
-	addFlagRepoUrl(fs, cfg)
+	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
 }
 
 func runConfigure(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
+	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Language, cfg.Image,
 		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -86,15 +86,14 @@ func init() {
 	addFlagImage(fs, cfg)
 	addFlagWorkRoot(fs, cfg)
 	addFlagLanguage(fs, cfg)
-	addFlagRepoRoot(fs, cfg)
-	addFlagRepoUrl(fs, cfg)
+	addFlagRepo(fs, cfg)
 	addFlagReleaseID(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
 	addFlagSkipIntegrationTests(fs, cfg)
 }
 
 func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
+	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Language, cfg.Image,
 		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -117,14 +117,13 @@ func init() {
 	addFlagPush(fs, cfg)
 	addFlagGitUserEmail(fs, cfg)
 	addFlagGitUserName(fs, cfg)
-	addFlagRepoRoot(fs, cfg)
 	addFlagSkipIntegrationTests(fs, cfg)
 	addFlagEnvFile(fs, cfg)
-	addFlagRepoUrl(fs, cfg)
+	addFlagRepo(fs, cfg)
 }
 
 func runCreateReleasePR(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
+	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Language, cfg.Image,
 		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -87,12 +87,8 @@ func addFlagReleasePRUrl(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.ReleasePRURL, "release-pr-url", "", "The URL of a release PR")
 }
 
-func addFlagRepoRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.RepoRoot, "repo-root", "", "Repository root. When this (and repo-url) are not specified, the language repo will be cloned.")
-}
-
-func addFlagRepoUrl(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.RepoURL, "repo-url", "", "Repository URL to clone. If this and repo-root are not specified, the default language repo will be cloned.")
+func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {
+	fs.StringVar(&cfg.Repo, "repo", "", "Repository root or URL to clone. If this is not specified, the default language repo will be cloned.")
 }
 
 func addFlagSecretsProject(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -91,13 +91,12 @@ func init() {
 	addFlagAPIRoot(fs, cfg)
 	addFlagLanguage(fs, cfg)
 	addFlagBuild(fs, cfg)
-	addFlagRepoRoot(fs, cfg)
-	addFlagRepoUrl(fs, cfg)
+	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
 }
 
 func runGenerate(ctx context.Context, cfg *config.Config) error {
-	libraryConfigured, err := detectIfLibraryConfigured(ctx, cfg.APIPath, cfg.RepoURL, cfg.RepoRoot, cfg.GitHubToken)
+	libraryConfigured, err := detectIfLibraryConfigured(ctx, cfg.APIPath, cfg.Repo, cfg.GitHubToken)
 	if err != nil {
 		return err
 	}
@@ -116,7 +115,7 @@ func runGenerate(ctx context.Context, cfg *config.Config) error {
 	// We only clone/open the language repo and use the state within it
 	// if the requested API is configured as a library.
 	if libraryConfigured {
-		repo, err = cloneOrOpenLanguageRepo(workRoot, cfg.RepoRoot, cfg.RepoURL, cfg.CI)
+		repo, err = cloneOrOpenLanguageRepo(workRoot, cfg.Repo, cfg.CI)
 		if err != nil {
 			return err
 		}
@@ -207,13 +206,10 @@ func runGenerateCommand(ctx context.Context, state *commandState, cfg *config.Co
 // pipeline state if repoRoot has been specified, or the remote pipeline state (just
 // by fetching the single file) if flatRepoUrl has been specified. If neither the repo
 // root not the repo url has been specified, we always perform raw generation.
-func detectIfLibraryConfigured(ctx context.Context, apiPath, repoURL, repoRoot, gitHubToken string) (bool, error) {
-	if repoURL == "" && repoRoot == "" {
-		slog.Warn("repo url and root are not specified, cannot check if library exists")
+func detectIfLibraryConfigured(ctx context.Context, apiPath, repo, gitHubToken string) (bool, error) {
+	if repo == "" {
+		slog.Warn("repo is not specified, cannot check if library exists")
 		return false, nil
-	}
-	if repoRoot != "" && repoURL != "" {
-		return false, errors.New("do not specify both repo-root and repo-url")
 	}
 
 	// Attempt to load the pipeline state either locally or from the repo URL
@@ -221,15 +217,17 @@ func detectIfLibraryConfigured(ctx context.Context, apiPath, repoURL, repoRoot, 
 		pipelineState *statepb.PipelineState
 		err           error
 	)
-	if repoRoot != "" {
-		pipelineState, err = loadPipelineStateFile(filepath.Join(repoRoot, config.GeneratorInputDir, pipelineStateFile))
+	if !isUrl(repo) {
+		// repo is a directory
+		pipelineState, err = loadPipelineStateFile(filepath.Join(repo, config.GeneratorInputDir, pipelineStateFile))
 		if err != nil {
 			return false, err
 		}
 	} else {
-		languageRepoMetadata, err := github.ParseUrl(repoURL)
+		// repo is a URL
+		languageRepoMetadata, err := github.ParseUrl(repo)
 		if err != nil {
-			slog.Warn("failed to parse", "repo url:", repoURL, "error", err)
+			slog.Warn("failed to parse", "repo url:", repo, "error", err)
 			return false, err
 		}
 		pipelineState, err = fetchRemotePipelineState(ctx, languageRepoMetadata, "HEAD", gitHubToken)

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -96,13 +96,12 @@ func init() {
 	addFlagLanguage(fs, cfg)
 	addFlagLibraryID(fs, cfg)
 	addFlagPush(fs, cfg)
-	addFlagRepoRoot(fs, cfg)
-	addFlagRepoUrl(fs, cfg)
+	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
 }
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
+	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Language, cfg.Image,
 		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -83,14 +83,13 @@ func init() {
 	addFlagGitUserName(fs, cfg)
 	addFlagLanguage(fs, cfg)
 	addFlagPush(fs, cfg)
-	addFlagRepoRoot(fs, cfg)
-	addFlagRepoUrl(fs, cfg)
+	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
 	addFlagTag(fs, cfg)
 }
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.RepoRoot, cfg.RepoURL, cfg.Language, cfg.Image,
+	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Language, cfg.Image,
 		cfg.LibrarianRepository, cfg.SecretsProject, cfg.CI)
 	if err != nil {
 		return err

--- a/internal/librarian/url.go
+++ b/internal/librarian/url.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"net/url"
+)
+
+func isUrl(s string) bool {
+	u, err := url.ParseRequestURI(s)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+
+	return true
+}

--- a/internal/librarian/url_test.go
+++ b/internal/librarian/url_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import "testing"
+
+func TestIsUrl(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "Valid HTTPS URL",
+			input: "https://github.com/googleapis/librarian-go",
+			want:  true,
+		},
+		{
+			name:  "Valid HTTP URL",
+			input: "http://example.com/path?query=value",
+			want:  true,
+		},
+		{
+			name:  "Valid FTP URL",
+			input: "ftp://user:password@host/path",
+			want:  true,
+		},
+		{
+			name:  "URL without scheme",
+			input: "google.com",
+			want:  false,
+		},
+		{
+			name:  "URL with scheme only",
+			input: "https://",
+			want:  false,
+		},
+		{
+			name:  "Absolute Unix file path",
+			input: "/home/user/file",
+			want:  false,
+		},
+		{
+			name:  "Relative file path",
+			input: "home/user/file",
+			want:  false,
+		},
+		{
+			name:  "Empty string",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "Plain string",
+			input: "just-a-string",
+			want:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isUrl(tc.input)
+			if got != tc.want {
+				t.Errorf("isUrl(%q) = %v; want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/url_test.go
+++ b/internal/librarian/url_test.go
@@ -14,10 +14,14 @@
 
 package librarian
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestIsUrl(t *testing.T) {
-	testCases := []struct {
+	for _, test := range []struct {
 		name  string
 		input string
 		want  bool
@@ -67,13 +71,11 @@ func TestIsUrl(t *testing.T) {
 			input: "just-a-string",
 			want:  false,
 		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := isUrl(tc.input)
-			if got != tc.want {
-				t.Errorf("isUrl(%q) = %v; want %v", tc.input, got, tc.want)
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := isUrl(test.input)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("isUrl() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Simplify the CLI by merging the redundant -repo-root and -repo-url flags into a single -repo flag.

Previously, users had to choose between two different flags to specify the repository context.

The new -repo flag accepts either a local filesystem path or a remote Git URL. The CLI will now automatically detect the input type and handle it accordingly.

Fixes #611 