### PR TITLE
docs(build): add AR Exit Gate explanation in  cloudbuild-exitgate.yaml

### DIFF
--- a/cloudbuild-exitgate.yaml
+++ b/cloudbuild-exitgate.yaml
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This Cloud Build configuration is used by a Louhi flow for the Artifact
+# Registry (AR) Exit Gate process.
+#
+# This build step creates the librarian container image and publishes it to the
+# 'images-dev' repository, which serves as the entry point for the AR Exit Gate.
+# After passing the gate's security checks, the image is promoted and
+# published to the 'images-prod' repository.
+
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian', '.']


### PR DESCRIPTION
This adds a comment in the `cloudbuild-exitgate.yaml` explaining how the librarian docker image is published using Cloud Build and AR Exit Gate.

Fixes: #209