### PR TITLE
chore(internal/librarian): remove configure command

### DIFF
--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -35,7 +35,6 @@ var CmdLibrarian = &cli.Command{
 func init() {
 	CmdLibrarian.Init()
 	CmdLibrarian.Commands = append(CmdLibrarian.Commands,
-		cmdConfigure,
 		cmdGenerate,
 		cmdUpdateApis,
 		cmdCreateReleasePR,


### PR DESCRIPTION
Remove configure command, because it is no longer needed.

Keep the unused backend code, because most of it will be used in the new generate command.

Fix: #673