### PR TITLE
chore(internal/librarian): remove update-apis command

### DIFF
--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -37,7 +37,6 @@ func init() {
 	CmdLibrarian.Commands = append(CmdLibrarian.Commands,
 		cmdConfigure,
 		cmdGenerate,
-		cmdUpdateApis,
 		cmdCreateReleasePR,
 		cmdUpdateImageTag,
 		cmdMergeReleasePR,


### PR DESCRIPTION
Remove update-apis command, because it is no longer needed.

Keep the unused backend code, because most of it will be used in the new generate command.

Fix: #674 