### PR TITLE
fix(internal/config,internal/librarian): rename APIRoot to Source

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,15 +43,15 @@ type Config struct {
 	// API Path is specified with the -api flag.
 	APIPath string
 
-	// APIRoot is the path to the root of the googleapis repository.
+	// Source is the path to the root of the googleapis repository.
 	// When this is not specified, the googleapis repository is cloned
 	// automatically.
 	//
-	// APIRoot is used by generate, update-apis, update-image-tag and configure
+	// Source is used by generate, update-apis, update-image-tag and configure
 	// commands.
 	//
-	// APIRoot is specified with the -source flag.
-	APIRoot string
+	// Source is specified with the -source flag.
+	Source string
 
 	// ArtifactRoot is the path to previously-created release artifacts to be published.
 	// It is only used by the publish-release-artifacts command, and is expected

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -90,7 +90,7 @@ func init() {
 	addFlagImage(fs, cfg)
 	addFlagWorkRoot(fs, cfg)
 	addFlagAPIPath(fs, cfg)
-	addFlagAPIRoot(fs, cfg)
+	addFlagSource(fs, cfg)
 	addFlagGitUserEmail(fs, cfg)
 	addFlagGitUserName(fs, cfg)
 	addFlagLanguage(fs, cfg)
@@ -117,7 +117,7 @@ func executeConfigure(ctx context.Context, state *commandState, cfg *config.Conf
 	slog.Info("Code will be generated", "dir", outputRoot)
 
 	var apiRoot string
-	if cfg.APIRoot == "" {
+	if cfg.Source == "" {
 		repo, err := cloneGoogleapis(state.workRoot, cfg.CI)
 		if err != nil {
 			return err
@@ -126,7 +126,7 @@ func executeConfigure(ctx context.Context, state *commandState, cfg *config.Conf
 	} else {
 		// We assume it's okay not to take a defensive copy of apiRoot in the configure command,
 		// as "vanilla" configuration/generation shouldn't need to edit any protos. (That's just an escape hatch.)
-		absRoot, err := filepath.Abs(cfg.APIRoot)
+		absRoot, err := filepath.Abs(cfg.Source)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -27,8 +27,8 @@ func addFlagAPIPath(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.APIPath, "api", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
 }
 
-func addFlagAPIRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.APIRoot, "source", "", "location of googleapis repository. If undefined, googleapis will be cloned to the output")
+func addFlagSource(fs *flag.FlagSet, cfg *config.Config) {
+	fs.StringVar(&cfg.Source, "source", "", "location of googleapis repository. If undefined, googleapis will be cloned to the output")
 }
 
 func addFlagArtifactRoot(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -72,7 +72,7 @@ output directory that was specified for the "generate-raw" command.
 		if err := validateRequiredFlag("api", cfg.APIPath); err != nil {
 			return err
 		}
-		if err := validateRequiredFlag("source", cfg.APIRoot); err != nil {
+		if err := validateRequiredFlag("source", cfg.Source); err != nil {
 			return err
 		}
 		return runGenerate(ctx, cfg)
@@ -84,14 +84,14 @@ func init() {
 	fs := cmdGenerate.Flags
 	cfg := cmdGenerate.Config
 
-	addFlagImage(fs, cfg)
-	addFlagWorkRoot(fs, cfg)
 	addFlagAPIPath(fs, cfg)
-	addFlagAPIRoot(fs, cfg)
-	addFlagLanguage(fs, cfg)
 	addFlagBuild(fs, cfg)
+	addFlagImage(fs, cfg)
+	addFlagLanguage(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
+	addFlagSource(fs, cfg)
+	addFlagWorkRoot(fs, cfg)
 }
 
 func runGenerate(ctx context.Context, cfg *config.Config) error {
@@ -179,7 +179,7 @@ func executeGenerate(ctx context.Context, state *commandState, cfg *config.Confi
 // If refined generation is used, the context's languageRepo field will be populated and the
 // library ID will be returned; otherwise, an empty string will be returned.
 func runGenerateCommand(ctx context.Context, state *commandState, cfg *config.Config, outputDir string) (string, error) {
-	apiRoot, err := filepath.Abs(cfg.APIRoot)
+	apiRoot, err := filepath.Abs(cfg.Source)
 	if err != nil {
 		return "", err
 	}

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -87,17 +87,17 @@ func init() {
 	fs := cmdUpdateApis.Flags
 	cfg := cmdUpdateApis.Config
 
-	addFlagImage(fs, cfg)
-	addFlagWorkRoot(fs, cfg)
-	addFlagAPIRoot(fs, cfg)
 	addFlagBranch(fs, cfg)
 	addFlagGitUserEmail(fs, cfg)
 	addFlagGitUserName(fs, cfg)
+	addFlagImage(fs, cfg)
 	addFlagLanguage(fs, cfg)
 	addFlagLibraryID(fs, cfg)
 	addFlagPush(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
+	addFlagSource(fs, cfg)
+	addFlagWorkRoot(fs, cfg)
 }
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
@@ -112,14 +112,14 @@ func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
 func updateAPIs(ctx context.Context, state *commandState, cfg *config.Config) error {
 	var apiRepo *gitrepo.Repository
 	cleanWorkingTreePostGeneration := true
-	if cfg.APIRoot == "" {
+	if cfg.Source == "" {
 		var err error
 		apiRepo, err = cloneGoogleapis(state.workRoot, cfg.CI)
 		if err != nil {
 			return err
 		}
 	} else {
-		apiRoot, err := filepath.Abs(cfg.APIRoot)
+		apiRoot, err := filepath.Abs(cfg.Source)
 		slog.Info("Using apiRoot", "api_root", apiRoot)
 		if err != nil {
 			slog.Info("Error retrieving apiRoot", "err", err)

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -76,8 +76,6 @@ func init() {
 	fs := cmdUpdateImageTag.Flags
 	cfg := cmdUpdateImageTag.Config
 
-	addFlagWorkRoot(fs, cfg)
-	addFlagAPIRoot(fs, cfg)
 	addFlagBranch(fs, cfg)
 	addFlagGitUserEmail(fs, cfg)
 	addFlagGitUserName(fs, cfg)
@@ -85,7 +83,9 @@ func init() {
 	addFlagPush(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
+	addFlagSource(fs, cfg)
 	addFlagTag(fs, cfg)
+	addFlagWorkRoot(fs, cfg)
 }
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
@@ -103,14 +103,14 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 	}
 
 	var apiRepo *gitrepo.Repository
-	if cfg.APIRoot == "" {
+	if cfg.Source == "" {
 		var err error
 		apiRepo, err = cloneGoogleapis(state.workRoot, cfg.CI)
 		if err != nil {
 			return err
 		}
 	} else {
-		apiRoot, err := filepath.Abs(cfg.APIRoot)
+		apiRoot, err := filepath.Abs(cfg.Source)
 		slog.Info("Using apiRoot", "api_root", apiRoot)
 		if err != nil {
 			slog.Info("Error retrieving apiRoot", "err", err)


### PR DESCRIPTION
Rename config.APIRoot to config.Source and flagAddAPIRoot to flagAddSource to match the flag name.

Fixes https://github.com/googleapis/librarian/issues/677