### PR TITLE
fix(internal/config): rename APIPath to API

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,16 +32,16 @@ const (
 // variables. When adding members to this struct, please keep them in
 // alphabetical order.
 type Config struct {
-	// APIPath is the path to the API to be configured or generated,
+	// API is the path to the API to be configured or generated,
 	// relative to the root of the googleapis repository. It is a directory
 	// name as far as (and including) the version (v1, v2, v1alpha etc). It
 	// is expected to contain a service config YAML file.
 	// Example: "google/cloud/functions/v2"
 	//
-	// APIPath is used by generate and configure commands.
+	// API is used by generate and configure commands.
 	//
 	// API Path is specified with the -api flag.
-	APIPath string
+	API string
 
 	// APIRoot is the path to the root of the googleapis repository.
 	// When this is not specified, the googleapis repository is cloned

--- a/internal/librarian/configure.go
+++ b/internal/librarian/configure.go
@@ -132,7 +132,7 @@ func executeConfigure(ctx context.Context, state *commandState, cfg *config.Conf
 		}
 		apiRoot = absRoot
 	}
-	apiPaths, err := findApisToConfigure(apiRoot, state.pipelineState, cfg.Language, cfg.APIPath)
+	apiPaths, err := findApisToConfigure(apiRoot, state.pipelineState, cfg.Language, cfg.API)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -24,7 +24,7 @@ import (
 )
 
 func addFlagAPIPath(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.APIPath, "api", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
+	fs.StringVar(&cfg.API, "api", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
 }
 
 func addFlagAPIRoot(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -69,7 +69,7 @@ other source code to be preserved/cleaned. Instead, the "build-raw" command is p
 output directory that was specified for the "generate-raw" command.
 `,
 	Run: func(ctx context.Context, cfg *config.Config) error {
-		if err := validateRequiredFlag("api", cfg.APIPath); err != nil {
+		if err := validateRequiredFlag("api", cfg.API); err != nil {
 			return err
 		}
 		if err := validateRequiredFlag("source", cfg.APIRoot); err != nil {
@@ -95,7 +95,7 @@ func init() {
 }
 
 func runGenerate(ctx context.Context, cfg *config.Config) error {
-	libraryConfigured, err := detectIfLibraryConfigured(ctx, cfg.APIPath, cfg.Repo, cfg.GitHubToken)
+	libraryConfigured, err := detectIfLibraryConfigured(ctx, cfg.API, cfg.Repo, cfg.GitHubToken)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func executeGenerate(ctx context.Context, state *commandState, cfg *config.Confi
 			if err := state.containerConfig.BuildLibrary(ctx, cfg, state.languageRepo.Dir, libraryID); err != nil {
 				return err
 			}
-		} else if err := state.containerConfig.BuildRaw(ctx, cfg, outputDir, cfg.APIPath); err != nil {
+		} else if err := state.containerConfig.BuildRaw(ctx, cfg, outputDir, cfg.API); err != nil {
 			return err
 		}
 	}
@@ -187,7 +187,7 @@ func runGenerateCommand(ctx context.Context, state *commandState, cfg *config.Co
 	// If we've got a language repo, it's because we've already found a library for the
 	// specified API, configured in the repo.
 	if state.languageRepo != nil {
-		libraryID := findLibraryIDByApiPath(state.pipelineState, cfg.APIPath)
+		libraryID := findLibraryIDByApiPath(state.pipelineState, cfg.API)
 		if libraryID == "" {
 			return "", errors.New("bug in Librarian: Library not found during generation, despite being found in earlier steps")
 		}
@@ -195,8 +195,8 @@ func runGenerateCommand(ctx context.Context, state *commandState, cfg *config.Co
 		slog.Info("Performing refined generation for library", "id", libraryID)
 		return libraryID, state.containerConfig.GenerateLibrary(ctx, cfg, apiRoot, outputDir, generatorInput, libraryID)
 	} else {
-		slog.Info("No matching library found (or no repo specified); performing raw generation", "path", cfg.APIPath)
-		return "", state.containerConfig.GenerateRaw(ctx, cfg, apiRoot, outputDir, cfg.APIPath)
+		slog.Info("No matching library found (or no repo specified); performing raw generation", "path", cfg.API)
+		return "", state.containerConfig.GenerateRaw(ctx, cfg, apiRoot, outputDir, cfg.API)
 	}
 }
 


### PR DESCRIPTION
Rename APIPath to API to match the new flag name.

For https://github.com/googleapis/librarian/pull/686