### PR TITLE
refactor(internal): combine git-user-name and git-user-email flags

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,25 +146,17 @@ type Config struct {
 	// LIBRARIAN_GITHUB_TOKEN environment variable.
 	GitHubToken string
 
-	// GitUserEmail is the email address used in Git commits. It is used in
-	// all commands that create commits in a language repository:
+	// PushConfig specifies the email address and display name used in Git commits,
+	// in the format "name:email".
+	//
+	// PushConfig is used in all commands that create commits in a language repository:
 	// create-release-pr, configure, update-apis and update-image-tag.
 	//
-	// GitUserEmail is optional, with a default value of noreply-cloudsdk@google.com
-	// being used for commits if it's unspecified.
+	// PushConfig is optional. If unspecified, commits will use a default name of
+	// "Google Cloud SDK" and a default email of noreply-cloudsdk@google.com.
 	//
-	// GitUserEmail is specified with the -git-user-email flag.
-	GitUserEmail string
-
-	// GitUserName is the display name used in Git commits. It is used in
-	// all commands that create commits in a language repository:
-	// create-release-pr, configure, update-apis and update-image-tag.
-	//
-	// GitUserName is optional, with a default value of "Google Cloud SDK"
-	// being used for commits if it's unspecified.
-	//
-	// GitUserName is specified with the -git-user-name flag.
-	GitUserName string
+	// PushConfig is specified with the -push-config flag.
+	PushConfig string
 
 	// UserGID is the group ID of the current user. It is used to run Docker
 	// containers with the same user, so that created files have the correct

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"strings"
 )
 
 const (
@@ -147,7 +148,7 @@ type Config struct {
 	GitHubToken string
 
 	// PushConfig specifies the email address and display name used in Git commits,
-	// in the format "name:email".
+	// in the format "email,name".
 	//
 	// PushConfig is used in all commands that create commits in a language repository:
 	// create-release-pr, configure, update-apis and update-image-tag.
@@ -368,6 +369,12 @@ func (c *Config) SetupUser() error {
 func (c *Config) IsValid() (bool, error) {
 	if c.Push && c.GitHubToken == "" {
 		return false, errors.New("no GitHub token supplied for push")
+	}
+	if c.Push {
+		parts := strings.Split(c.PushConfig, ",")
+		if len(parts) != 2 {
+			return false, errors.New("unable to parse push config")
+		}
 	}
 	return true, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,11 +370,9 @@ func (c *Config) IsValid() (bool, error) {
 	if c.Push && c.GitHubToken == "" {
 		return false, errors.New("no GitHub token supplied for push")
 	}
-	if c.Push {
-		parts := strings.Split(c.PushConfig, ",")
-		if len(parts) != 2 {
-			return false, errors.New("unable to parse push config")
-		}
+	parts := strings.Split(c.PushConfig, ",")
+	if len(parts) != 2 {
+		return false, errors.New("unable to parse push config")
 	}
 	return true, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -146,10 +146,11 @@ func TestIsValid(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "Valid config - Push false",
+			name: "Valid config - Push false, push config valid",
 			cfg: Config{
 				Push:        false,
 				GitHubToken: "",
+				PushConfig:  "def@ghi.com,abc",
 			},
 			wantValid: true,
 			wantErr:   false,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -155,19 +155,31 @@ func TestIsValid(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name: "Valid config - Push true, token present",
+			name: "Valid config - Push true, token present, push config valid",
 			cfg: Config{
 				Push:        true,
 				GitHubToken: "some_token",
+				PushConfig:  "def@ghi.com,abc",
 			},
 			wantValid: true,
 			wantErr:   false,
 		},
 		{
-			name: "Invalid config - Push true, token missing",
+			name: "Invalid config - Push true, token missing, push config valid",
 			cfg: Config{
 				Push:        true,
 				GitHubToken: "",
+				PushConfig:  "def@ghi.com,abc",
+			},
+			wantValid: false,
+			wantErr:   true,
+		},
+		{
+			name: "Invalid config - Push true, token present, push config invalid",
+			cfg: Config{
+				Push:        true,
+				GitHubToken: "some_token",
+				PushConfig:  "abc:def@ghi.com",
 			},
 			wantValid: false,
 			wantErr:   true,
@@ -183,7 +195,7 @@ func TestIsValid(t *testing.T) {
 			if (err != nil) != test.wantErr {
 				t.Errorf("IsValid() got error = %v, want error = %t", err, test.wantErr)
 			}
-			if test.wantErr && err != nil && err.Error() != "no GitHub token supplied for push" {
+			if test.wantErr && err != nil && err.Error() != "no GitHub token supplied for push" && err.Error() != "unable to parse push config" {
 				t.Errorf("IsValid() got unexpected error message: %q", err.Error())
 			}
 		})

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -104,7 +104,7 @@ func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.Repository, er
 // ContainerState based on all of the above. This should be used by all commands
 // which always have a language repo. Commands which only conditionally use
 // language repos should construct the command state themselves.
-func createCommandStateForLanguage(workRootOverride, repo, imageOverride, secretsProject, ci, uid, gid string) (*commandState, error) {
+func createCommandStateForLanguage(workRootOverride, repo, imageOverride, project, ci, uid, gid string) (*commandState, error) {
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime, workRootOverride)
 	if err != nil {
@@ -124,7 +124,7 @@ func createCommandStateForLanguage(workRootOverride, repo, imageOverride, secret
 	if err != nil {
 		return nil, err
 	}
-	containerConfig, err := docker.New(workRoot, image, secretsProject, uid, gid, config)
+	containerConfig, err := docker.New(workRoot, image, project, uid, gid, config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -215,7 +215,14 @@ func createWorkRoot(t time.Time, workRootOverride string) (string, error) {
 }
 
 // No commit is made if there are no file modifications.
-func commitAll(repo *gitrepo.Repository, msg, userName, userEmail string) error {
+func commitAll(repo *gitrepo.Repository, msg, pushConfig string) error {
+	parts := strings.Split(pushConfig, ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("unable to parse pushConfig: %s", pushConfig)
+	}
+	userName := parts[0]
+	userEmail := parts[1]
+
 	status, err := repo.AddAll()
 	if err != nil {
 		return err

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -346,7 +346,7 @@ func TestCommitAll(t *testing.T) {
 
 			test.setup(t, repoDir)
 
-			if err := commitAll(repo, "test commit", "tester", "tester@example.com"); err != nil {
+			if err := commitAll(repo, "test commit", "tester:tester@example.com"); err != nil {
 				t.Errorf("commitAll() error = %v, wantErr nil", err)
 			}
 

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -346,7 +346,7 @@ func TestCommitAll(t *testing.T) {
 
 			test.setup(t, repoDir)
 
-			if err := commitAll(repo, "test commit", "tester:tester@example.com"); err != nil {
+			if err := commitAll(repo, "test commit", "tester@example.com,tester"); err != nil {
 				t.Errorf("commitAll() error = %v, wantErr nil", err)
 			}
 
@@ -358,6 +358,59 @@ func TestCommitAll(t *testing.T) {
 			hasCommitted := initialHead != finalHead
 			if hasCommitted != test.wantCommit {
 				t.Errorf("commitAll() commit status = %v, want %v", hasCommitted, test.wantCommit)
+			}
+		})
+	}
+}
+
+func TestParsePushConfig(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		pushConfig string
+		wantEmail  string
+		wantName   string
+		wantErr    bool
+	}{
+		{
+			name:       "valid input",
+			pushConfig: "tester@example.com,tester",
+			wantEmail:  "tester@example.com",
+			wantName:   "tester",
+		},
+		{
+			name:       "invalid input, too few parts",
+			pushConfig: "tester@example.com",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid input, too many parts",
+			pushConfig: "tester@example.com,tester,extra",
+			wantErr:    true,
+		},
+		{
+			name:       "empty input",
+			pushConfig: "",
+			wantErr:    true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotEmail, gotName, err := parsePushConfig(test.pushConfig)
+
+			if test.wantErr {
+				if err == nil {
+					t.Error("parsePushConfig() expected an error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parsePushConfig() got unexpected error: %v", err)
+				return
+			}
+			if gotEmail != test.wantEmail {
+				t.Errorf("parsePushConfig() email = %q, want %q", gotEmail, test.wantEmail)
+			}
+			if gotName != test.wantName {
+				t.Errorf("parsePushConfig() name = %q, want %q", gotName, test.wantName)
 			}
 		})
 	}

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -114,8 +114,7 @@ func init() {
 	addFlagLibraryID(fs, cfg)
 	addFlagLibraryVersion(fs, cfg)
 	addFlagPush(fs, cfg)
-	addFlagGitUserEmail(fs, cfg)
-	addFlagGitUserName(fs, cfg)
+	addFlagPushConfig(fs, cfg)
 	addFlagSkipIntegrationTests(fs, cfg)
 	addFlagEnvFile(fs, cfg)
 	addFlagRepo(fs, cfg)
@@ -297,7 +296,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		metadata := fmt.Sprintf("Librarian-Release-Library: %s\nLibrarian-Release-Version: %s\nLibrarian-Release-ID: %s", library.Id, releaseVersion, releaseID)
 		// Note that releaseDescription will already end with two line breaks, so we don't need any more before the metadata.
 		err = commitAll(languageRepo, fmt.Sprintf("%s\n\n%s%s", releaseDescription, releaseNotes, metadata),
-			cfg.GitUserName, cfg.GitUserEmail)
+			cfg.PushConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -51,12 +51,8 @@ func addFlagEnvFile(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.EnvFile, "env-file", "", "full path to the file where the environment variables are stored. Defaults to env-vars.txt within the output")
 }
 
-func addFlagGitUserEmail(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.GitUserEmail, "git-user-email", "noreply-cloudsdk@google.com", "Email address to use in Git commits")
-}
-
-func addFlagGitUserName(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.GitUserName, "git-user-name", "Google Cloud SDK", "Display name to use in Git commits")
+func addFlagPushConfig(fs *flag.FlagSet, cfg *config.Config) {
+	fs.StringVar(&cfg.PushConfig, "push-config", "Google Cloud SDK:noreply-cloudsdk@google.com", "Display name and email address to use in Git commits")
 }
 
 func addFlagImage(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -52,7 +52,8 @@ func addFlagEnvFile(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagPushConfig(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.PushConfig, "push-config", "Google Cloud SDK:noreply-cloudsdk@google.com", "Display name and email address to use in Git commits")
+	// TODO(https://github.com/googleapis/librarian/issues/724):remove the default for push-config
+	fs.StringVar(&cfg.PushConfig, "push-config", "noreply-cloudsdk@google.com,Google Cloud SDK", "The user and email for Git commits, in the format \"user:email\"")
 }
 
 func addFlagImage(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -88,8 +88,7 @@ func init() {
 	cfg := cmdUpdateApis.Config
 
 	addFlagBranch(fs, cfg)
-	addFlagGitUserEmail(fs, cfg)
-	addFlagGitUserName(fs, cfg)
+	addFlagPushConfig(fs, cfg)
 	addFlagImage(fs, cfg)
 	addFlagLibraryID(fs, cfg)
 	addFlagPush(fs, cfg)
@@ -253,7 +252,7 @@ func updateLibrary(ctx context.Context, state *commandState, cfg *config.Config,
 		msg = createCommitMessage(library.Id, commits)
 	}
 	if err := commitAll(languageRepo, msg,
-		cfg.GitUserName, cfg.GitUserEmail); err != nil {
+		cfg.PushConfig); err != nil {
 		return err
 	}
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -77,8 +77,7 @@ func init() {
 	cfg := cmdUpdateImageTag.Config
 
 	addFlagBranch(fs, cfg)
-	addFlagGitUserEmail(fs, cfg)
-	addFlagGitUserName(fs, cfg)
+	addFlagPushConfig(fs, cfg)
 	addFlagPush(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagSecretsProject(fs, cfg)
@@ -170,7 +169,7 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 	// Commit any changes
 	commitMsg := fmt.Sprintf("chore: update generation image tag to %s", cfg.Tag)
 	if err := commitAll(languageRepo, commitMsg,
-		cfg.GitUserName, cfg.GitUserEmail); err != nil {
+		cfg.PushConfig); err != nil {
 		return err
 	}
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -78,7 +78,6 @@ func init() {
 
 	addFlagBranch(fs, cfg)
 	addFlagPushConfig(fs, cfg)
-	addFlagPush(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagProject(fs, cfg)
 	addFlagPush(fs, cfg)


### PR DESCRIPTION
Combine git-user-name and git-user-email flags into push-config flag.

Fixes #678 