### PR TITLE
fix(internal/librarian): remove flag push

### DIFF
--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -116,7 +116,6 @@ func init() {
 	addFlagLibraryVersion(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagProject(fs, cfg)
-	addFlagPush(fs, cfg)
 	addFlagSkipIntegrationTests(fs, cfg)
 	addFlagWorkRoot(fs, cfg)
 }

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -71,10 +71,6 @@ func addFlagLibraryVersion(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.LibraryVersion, "library-version", "", "The version to release (only valid with library-id, only when creating a release PR)")
 }
 
-func addFlagPush(fs *flag.FlagSet, cfg *config.Config) {
-	fs.BoolVar(&cfg.Push, "push", false, "push to GitHub if true")
-}
-
 func addFlagReleaseID(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.ReleaseID, "release-id", "", "The ID of a release PR")
 }

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -94,7 +94,6 @@ func init() {
 	addFlagLibraryID(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagProject(fs, cfg)
-	addFlagPush(fs, cfg)
 	addFlagSource(fs, cfg)
 	addFlagWorkRoot(fs, cfg)
 }

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -81,7 +81,6 @@ func init() {
 	addFlagGitUserName(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagProject(fs, cfg)
-	addFlagPush(fs, cfg)
 	addFlagSource(fs, cfg)
 	addFlagTag(fs, cfg)
 	addFlagWorkRoot(fs, cfg)


### PR DESCRIPTION
Remove the flag push according to go/librarian:cli-reimagined.

The config is not touched and will get false by default. Underlying logic will change in future, leaving out of scope for this fix.

Fixes #679