### PR TITLE
chore(golangci-lint): add gofmt, goimports and golines and fix issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,6 +39,3 @@ formatters:
     - gofmt
     - goimports
     - golines
-  settings:
-    golines:
-      max-len: 120 # Align with lll's max-len

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,3 +32,13 @@ linters:
     - unused
     - usetesting
     
+formatters:
+  # See https://golangci-lint.run/usage/formatters for details.
+  default: none
+  enable:
+    - gofmt
+    - goimports
+    - golines
+  settings:
+    golines:
+      max-len: 120 # Align with lll's max-len

--- a/all_test.go
+++ b/all_test.go
@@ -44,7 +44,14 @@ var hashHeader = regexp.MustCompile(`^# Copyright 20\d\d Google LLC
 #
 # Licensed under the Apache License, Version 2\.0 \(the "License"\);`)
 
-var noHeaderRequiredFiles = []string{".github/CODEOWNERS", "go.sum", "go.mod", ".gitignore", "LICENSE", "renovate.json"}
+var noHeaderRequiredFiles = []string{
+	".github/CODEOWNERS",
+	"go.sum",
+	"go.mod",
+	".gitignore",
+	"LICENSE",
+	"renovate.json",
+}
 
 func TestHeaders(t *testing.T) {
 	sfs := os.DirFS(".")

--- a/all_test.go
+++ b/all_test.go
@@ -44,7 +44,15 @@ var hashHeader = regexp.MustCompile(`^# Copyright 20\d\d Google LLC
 #
 # Licensed under the Apache License, Version 2\.0 \(the "License"\);`)
 
-var noHeaderRequiredFiles = []string{".github/CODEOWNERS", "go.sum", "go.mod", ".gitignore", "LICENSE", "renovate.json", "coverage.out"}
+var noHeaderRequiredFiles = []string{
+	".github/CODEOWNERS",
+	"go.sum",
+	"go.mod",
+	".gitignore",
+	"LICENSE",
+	"renovate.json",
+	"coverage.out",
+}
 
 func TestHeaders(t *testing.T) {
 	sfs := os.DirFS(".")

--- a/all_test.go
+++ b/all_test.go
@@ -44,14 +44,7 @@ var hashHeader = regexp.MustCompile(`^# Copyright 20\d\d Google LLC
 #
 # Licensed under the Apache License, Version 2\.0 \(the "License"\);`)
 
-var noHeaderRequiredFiles = []string{
-	".github/CODEOWNERS",
-	"go.sum",
-	"go.mod",
-	".gitignore",
-	"LICENSE",
-	"renovate.json",
-}
+var noHeaderRequiredFiles = []string{".github/CODEOWNERS", "go.sum", "go.mod", ".gitignore", "LICENSE", "renovate.json"}
 
 func TestHeaders(t *testing.T) {
 	sfs := os.DirFS(".")

--- a/doc/howwewritego.md
+++ b/doc/howwewritego.md
@@ -127,6 +127,14 @@ handling:
 - [Generics Tutorial](https://go.dev/doc/tutorial/generics)
 - [Error Handling with Generics](https://go.dev/blog/error-syntax)
 
+## Linters and Formatter
+
+This repository has linters and formatters configured in .golangci.yaml.
+To install golangci-lint locally, see https://golangci-lint.run/welcome/install/#binaries
+
+To run linter: `golangci-lint run`
+
+To run formatter: `golangci-lint run --fix`
 
 ## Need Help? Just Ask!
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -196,7 +196,8 @@ func TestIsValid(t *testing.T) {
 			if (err != nil) != test.wantErr {
 				t.Errorf("IsValid() got error = %v, want error = %t", err, test.wantErr)
 			}
-			if test.wantErr && err != nil && err.Error() != "no GitHub token supplied for push" && err.Error() != "unable to parse push config" {
+			if test.wantErr && err != nil && err.Error() != "no GitHub token supplied for push" &&
+				err.Error() != "unable to parse push config" {
 				t.Errorf("IsValid() got unexpected error message: %q", err.Error())
 			}
 		})

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -89,10 +89,7 @@ type Docker struct {
 // New constructs a Docker instance which will invoke the specified
 // Docker image as required to implement language-specific commands,
 // providing the container with required environment variables.
-func New(
-	workRoot, image, secretsProject, uid, gid string,
-	pipelineConfig *statepb.PipelineConfig,
-) (*Docker, error) {
+func New(workRoot, image, secretsProject, uid, gid string, pipelineConfig *statepb.PipelineConfig) (*Docker, error) {
 	envProvider := newEnvironmentProvider(workRoot, secretsProject, pipelineConfig)
 	docker := &Docker{
 		Image: image,
@@ -112,11 +109,7 @@ func New(
 // the subdirectory apiPath of the API specification repo apiRoot, and whatever
 // is in the language-specific Docker container. The code is generated
 // in the output directory, which is initially empty.
-func (c *Docker) GenerateRaw(
-	ctx context.Context,
-	cfg *config.Config,
-	apiRoot, output, apiPath string,
-) error {
+func (c *Docker) GenerateRaw(ctx context.Context, cfg *config.Config, apiRoot, output, apiPath string) error {
 	commandArgs := []string{
 		"--source=/apis",
 		"--output=/output",
@@ -135,11 +128,7 @@ func (c *Docker) GenerateRaw(
 // output specifies the empty output directory into which the command should
 // generate code, and libraryID specifies the ID of the library to generate,
 // as configured in the Librarian state file for the repository.
-func (c *Docker) GenerateLibrary(
-	ctx context.Context,
-	cfg *config.Config,
-	apiRoot, output, generatorInput, libraryID string,
-) error {
+func (c *Docker) GenerateLibrary(ctx context.Context, cfg *config.Config, apiRoot, output, generatorInput, libraryID string) error {
 	commandArgs := []string{
 		"--source=/apis",
 		"--output=/output",
@@ -171,11 +160,7 @@ func (c *Docker) Clean(ctx context.Context, cfg *config.Config, repoRoot, librar
 
 // BuildRaw builds the result of GenerateRaw, which previously generated
 // code for apiPath in generatorOutput.
-func (c *Docker) BuildRaw(
-	ctx context.Context,
-	cfg *config.Config,
-	generatorOutput, apiPath string,
-) error {
+func (c *Docker) BuildRaw(ctx context.Context, cfg *config.Config, generatorOutput, apiPath string) error {
 	mounts := []string{
 		fmt.Sprintf("%s:/generator-output", generatorOutput),
 	}
@@ -189,11 +174,7 @@ func (c *Docker) BuildRaw(
 
 // BuildLibrary builds the library with an ID of libraryID, as configured in
 // the Librarian state file for the repository with a root of repoRoot.
-func (c *Docker) BuildLibrary(
-	ctx context.Context,
-	cfg *config.Config,
-	repoRoot, libraryID string,
-) error {
+func (c *Docker) BuildLibrary(ctx context.Context, cfg *config.Config, repoRoot, libraryID string) error {
 	mounts := []string{
 		fmt.Sprintf("%s:/repo", repoRoot),
 	}
@@ -211,11 +192,7 @@ func (c *Docker) BuildLibrary(
 // apiPath directory within apiRoot, and the container is provided with the
 // generatorInput directory to record the results of configuration. The
 // library code is not generated.
-func (c *Docker) Configure(
-	ctx context.Context,
-	cfg *config.Config,
-	apiRoot, apiPath, generatorInput string,
-) error {
+func (c *Docker) Configure(ctx context.Context, cfg *config.Config, apiRoot, apiPath, generatorInput string) error {
 	commandArgs := []string{
 		"--source=/apis",
 		fmt.Sprintf("--%s=/%s", config.GeneratorInputDir, config.GeneratorInputDir),
@@ -233,11 +210,7 @@ func (c *Docker) Configure(
 // ID libraryID within repoRoot, with version releaseVersion. Release notes
 // are expected to be present within inputsDirectory, in a file named
 // `{libraryID}-{releaseVersion}-release-notes.txt`.
-func (c *Docker) PrepareLibraryRelease(
-	ctx context.Context,
-	cfg *config.Config,
-	repoRoot, inputsDirectory, libraryID, releaseVersion string,
-) error {
+func (c *Docker) PrepareLibraryRelease(ctx context.Context, cfg *config.Config, repoRoot, inputsDirectory, libraryID, releaseVersion string) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -253,11 +226,7 @@ func (c *Docker) PrepareLibraryRelease(
 }
 
 // IntegrationTestLibrary runs the integration tests for a library with ID libraryID within repoRoot.
-func (c *Docker) IntegrationTestLibrary(
-	ctx context.Context,
-	cfg *config.Config,
-	repoRoot, libraryID string,
-) error {
+func (c *Docker) IntegrationTestLibrary(ctx context.Context, cfg *config.Config, repoRoot, libraryID string) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -271,11 +240,7 @@ func (c *Docker) IntegrationTestLibrary(
 
 // PackageLibrary packages release artifacts for a library with ID libraryID within repoRoot,
 // creating the artifacts within output.
-func (c *Docker) PackageLibrary(
-	ctx context.Context,
-	cfg *config.Config,
-	repoRoot, libraryID, output string,
-) error {
+func (c *Docker) PackageLibrary(ctx context.Context, cfg *config.Config, repoRoot, libraryID, output string) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		"--output=/output",
@@ -292,11 +257,7 @@ func (c *Docker) PackageLibrary(
 // PublishLibrary publishes release artifacts for a library with ID libraryID and version releaseVersion
 // to package managers, documentation sites etc. The artifacts will previously have been
 // created by PackageLibrary.
-func (c *Docker) PublishLibrary(
-	ctx context.Context,
-	cfg *config.Config,
-	output, libraryID, releaseVersion string,
-) error {
+func (c *Docker) PublishLibrary(ctx context.Context, cfg *config.Config, output, libraryID, releaseVersion string) error {
 	commandArgs := []string{
 		"--package-output=/output",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -309,13 +270,7 @@ func (c *Docker) PublishLibrary(
 	return c.runDocker(ctx, cfg, CommandPublishLibrary, mounts, commandArgs)
 }
 
-func (c *Docker) runDocker(
-	ctx context.Context,
-	cfg *config.Config,
-	command Command,
-	mounts []string,
-	commandArgs []string,
-) (err error) {
+func (c *Docker) runDocker(ctx context.Context, cfg *config.Config, command Command, mounts []string, commandArgs []string) (err error) {
 	mounts = maybeRelocateMounts(cfg, mounts)
 
 	args := []string{

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -89,7 +89,10 @@ type Docker struct {
 // New constructs a Docker instance which will invoke the specified
 // Docker image as required to implement language-specific commands,
 // providing the container with required environment variables.
-func New(workRoot, image, secretsProject, uid, gid string, pipelineConfig *statepb.PipelineConfig) (*Docker, error) {
+func New(
+	workRoot, image, secretsProject, uid, gid string,
+	pipelineConfig *statepb.PipelineConfig,
+) (*Docker, error) {
 	envProvider := newEnvironmentProvider(workRoot, secretsProject, pipelineConfig)
 	docker := &Docker{
 		Image: image,
@@ -109,7 +112,11 @@ func New(workRoot, image, secretsProject, uid, gid string, pipelineConfig *state
 // the subdirectory apiPath of the API specification repo apiRoot, and whatever
 // is in the language-specific Docker container. The code is generated
 // in the output directory, which is initially empty.
-func (c *Docker) GenerateRaw(ctx context.Context, cfg *config.Config, apiRoot, output, apiPath string) error {
+func (c *Docker) GenerateRaw(
+	ctx context.Context,
+	cfg *config.Config,
+	apiRoot, output, apiPath string,
+) error {
 	commandArgs := []string{
 		"--source=/apis",
 		"--output=/output",
@@ -128,7 +135,11 @@ func (c *Docker) GenerateRaw(ctx context.Context, cfg *config.Config, apiRoot, o
 // output specifies the empty output directory into which the command should
 // generate code, and libraryID specifies the ID of the library to generate,
 // as configured in the Librarian state file for the repository.
-func (c *Docker) GenerateLibrary(ctx context.Context, cfg *config.Config, apiRoot, output, generatorInput, libraryID string) error {
+func (c *Docker) GenerateLibrary(
+	ctx context.Context,
+	cfg *config.Config,
+	apiRoot, output, generatorInput, libraryID string,
+) error {
 	commandArgs := []string{
 		"--source=/apis",
 		"--output=/output",
@@ -160,7 +171,11 @@ func (c *Docker) Clean(ctx context.Context, cfg *config.Config, repoRoot, librar
 
 // BuildRaw builds the result of GenerateRaw, which previously generated
 // code for apiPath in generatorOutput.
-func (c *Docker) BuildRaw(ctx context.Context, cfg *config.Config, generatorOutput, apiPath string) error {
+func (c *Docker) BuildRaw(
+	ctx context.Context,
+	cfg *config.Config,
+	generatorOutput, apiPath string,
+) error {
 	mounts := []string{
 		fmt.Sprintf("%s:/generator-output", generatorOutput),
 	}
@@ -174,7 +189,11 @@ func (c *Docker) BuildRaw(ctx context.Context, cfg *config.Config, generatorOutp
 
 // BuildLibrary builds the library with an ID of libraryID, as configured in
 // the Librarian state file for the repository with a root of repoRoot.
-func (c *Docker) BuildLibrary(ctx context.Context, cfg *config.Config, repoRoot, libraryID string) error {
+func (c *Docker) BuildLibrary(
+	ctx context.Context,
+	cfg *config.Config,
+	repoRoot, libraryID string,
+) error {
 	mounts := []string{
 		fmt.Sprintf("%s:/repo", repoRoot),
 	}
@@ -192,7 +211,11 @@ func (c *Docker) BuildLibrary(ctx context.Context, cfg *config.Config, repoRoot,
 // apiPath directory within apiRoot, and the container is provided with the
 // generatorInput directory to record the results of configuration. The
 // library code is not generated.
-func (c *Docker) Configure(ctx context.Context, cfg *config.Config, apiRoot, apiPath, generatorInput string) error {
+func (c *Docker) Configure(
+	ctx context.Context,
+	cfg *config.Config,
+	apiRoot, apiPath, generatorInput string,
+) error {
 	commandArgs := []string{
 		"--source=/apis",
 		fmt.Sprintf("--%s=/%s", config.GeneratorInputDir, config.GeneratorInputDir),
@@ -210,7 +233,11 @@ func (c *Docker) Configure(ctx context.Context, cfg *config.Config, apiRoot, api
 // ID libraryID within repoRoot, with version releaseVersion. Release notes
 // are expected to be present within inputsDirectory, in a file named
 // `{libraryID}-{releaseVersion}-release-notes.txt`.
-func (c *Docker) PrepareLibraryRelease(ctx context.Context, cfg *config.Config, repoRoot, inputsDirectory, libraryID, releaseVersion string) error {
+func (c *Docker) PrepareLibraryRelease(
+	ctx context.Context,
+	cfg *config.Config,
+	repoRoot, inputsDirectory, libraryID, releaseVersion string,
+) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -226,7 +253,11 @@ func (c *Docker) PrepareLibraryRelease(ctx context.Context, cfg *config.Config, 
 }
 
 // IntegrationTestLibrary runs the integration tests for a library with ID libraryID within repoRoot.
-func (c *Docker) IntegrationTestLibrary(ctx context.Context, cfg *config.Config, repoRoot, libraryID string) error {
+func (c *Docker) IntegrationTestLibrary(
+	ctx context.Context,
+	cfg *config.Config,
+	repoRoot, libraryID string,
+) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -240,7 +271,11 @@ func (c *Docker) IntegrationTestLibrary(ctx context.Context, cfg *config.Config,
 
 // PackageLibrary packages release artifacts for a library with ID libraryID within repoRoot,
 // creating the artifacts within output.
-func (c *Docker) PackageLibrary(ctx context.Context, cfg *config.Config, repoRoot, libraryID, output string) error {
+func (c *Docker) PackageLibrary(
+	ctx context.Context,
+	cfg *config.Config,
+	repoRoot, libraryID, output string,
+) error {
 	commandArgs := []string{
 		"--repo-root=/repo",
 		"--output=/output",
@@ -257,7 +292,11 @@ func (c *Docker) PackageLibrary(ctx context.Context, cfg *config.Config, repoRoo
 // PublishLibrary publishes release artifacts for a library with ID libraryID and version releaseVersion
 // to package managers, documentation sites etc. The artifacts will previously have been
 // created by PackageLibrary.
-func (c *Docker) PublishLibrary(ctx context.Context, cfg *config.Config, output, libraryID, releaseVersion string) error {
+func (c *Docker) PublishLibrary(
+	ctx context.Context,
+	cfg *config.Config,
+	output, libraryID, releaseVersion string,
+) error {
 	commandArgs := []string{
 		"--package-output=/output",
 		fmt.Sprintf("--library-id=%s", libraryID),
@@ -270,7 +309,13 @@ func (c *Docker) PublishLibrary(ctx context.Context, cfg *config.Config, output,
 	return c.runDocker(ctx, cfg, CommandPublishLibrary, mounts, commandArgs)
 }
 
-func (c *Docker) runDocker(ctx context.Context, cfg *config.Config, command Command, mounts []string, commandArgs []string) (err error) {
+func (c *Docker) runDocker(
+	ctx context.Context,
+	cfg *config.Config,
+	command Command,
+	mounts []string,
+	commandArgs []string,
+) (err error) {
 	mounts = maybeRelocateMounts(cfg, mounts)
 
 	args := []string{

--- a/internal/docker/environment.go
+++ b/internal/docker/environment.go
@@ -43,7 +43,10 @@ type EnvironmentProvider struct {
 	pipelineConfig *statepb.PipelineConfig
 }
 
-func newEnvironmentProvider(workRoot, secretsProject string, pipelineConfig *statepb.PipelineConfig) *EnvironmentProvider {
+func newEnvironmentProvider(
+	workRoot, secretsProject string,
+	pipelineConfig *statepb.PipelineConfig,
+) *EnvironmentProvider {
 	if pipelineConfig == nil {
 		return nil
 	}
@@ -78,7 +81,10 @@ func createAndWriteToFile(filePath string, content string) (err error) {
 	return err
 }
 
-func (e *EnvironmentProvider) constructEnvironmentFileContent(ctx context.Context, commandName string) (string, error) {
+func (e *EnvironmentProvider) constructEnvironmentFileContent(
+	ctx context.Context,
+	commandName string,
+) (string, error) {
 	commandConfig := e.pipelineConfig.Commands[commandName]
 	if commandConfig == nil {
 		return "# No environment variables", nil
@@ -118,7 +124,11 @@ func (e *EnvironmentProvider) constructEnvironmentFileContent(ctx context.Contex
 	return builder.String(), nil
 }
 
-func getSecretManagerValue(ctx context.Context, dockerEnv *EnvironmentProvider, variable *statepb.CommandEnvironmentVariable) (string, bool, error) {
+func getSecretManagerValue(
+	ctx context.Context,
+	dockerEnv *EnvironmentProvider,
+	variable *statepb.CommandEnvironmentVariable,
+) (string, bool, error) {
 	if variable.SecretName == "" {
 		return "", false, nil
 	}

--- a/internal/docker/environment.go
+++ b/internal/docker/environment.go
@@ -43,10 +43,7 @@ type EnvironmentProvider struct {
 	pipelineConfig *statepb.PipelineConfig
 }
 
-func newEnvironmentProvider(
-	workRoot, secretsProject string,
-	pipelineConfig *statepb.PipelineConfig,
-) *EnvironmentProvider {
+func newEnvironmentProvider(workRoot, secretsProject string, pipelineConfig *statepb.PipelineConfig) *EnvironmentProvider {
 	if pipelineConfig == nil {
 		return nil
 	}
@@ -81,10 +78,7 @@ func createAndWriteToFile(filePath string, content string) (err error) {
 	return err
 }
 
-func (e *EnvironmentProvider) constructEnvironmentFileContent(
-	ctx context.Context,
-	commandName string,
-) (string, error) {
+func (e *EnvironmentProvider) constructEnvironmentFileContent(ctx context.Context, commandName string) (string, error) {
 	commandConfig := e.pipelineConfig.Commands[commandName]
 	if commandConfig == nil {
 		return "# No environment variables", nil
@@ -124,11 +118,7 @@ func (e *EnvironmentProvider) constructEnvironmentFileContent(
 	return builder.String(), nil
 }
 
-func getSecretManagerValue(
-	ctx context.Context,
-	dockerEnv *EnvironmentProvider,
-	variable *statepb.CommandEnvironmentVariable,
-) (string, bool, error) {
+func getSecretManagerValue(ctx context.Context, dockerEnv *EnvironmentProvider, variable *statepb.CommandEnvironmentVariable) (string, bool, error) {
 	if variable.SecretName == "" {
 		return "", false, nil
 	}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -77,7 +77,11 @@ type PullRequestMetadata struct {
 // CreatePullRequest creates a pull request in the remote repo.
 // At the moment this requires a single remote to be configured,
 // which must have a GitHub HTTPS URL. We assume a base branch of "main".
-func (c *Client) CreatePullRequest(ctx context.Context, repo *Repository, remoteBranch, title, body string) (*PullRequestMetadata, error) {
+func (c *Client) CreatePullRequest(
+	ctx context.Context,
+	repo *Repository,
+	remoteBranch, title, body string,
+) (*PullRequestMetadata, error) {
 	if body == "" {
 		body = "Regenerated all changed APIs. See individual commits for details."
 	}
@@ -100,7 +104,12 @@ func (c *Client) CreatePullRequest(ctx context.Context, repo *Repository, remote
 
 // CreateRelease creates a release on GitHub for the specified commit,
 // including the named tag, with the given title and description.
-func (c *Client) CreateRelease(ctx context.Context, repo *Repository, tag, commit, title, description string, prerelease bool) (*github.RepositoryRelease, error) {
+func (c *Client) CreateRelease(
+	ctx context.Context,
+	repo *Repository,
+	tag, commit, title, description string,
+	prerelease bool,
+) (*github.RepositoryRelease, error) {
 	release := &github.RepositoryRelease{
 		TagName:         &tag,
 		TargetCommitish: &commit,
@@ -118,10 +127,20 @@ func (c *Client) CreateRelease(ctx context.Context, repo *Repository, tag, commi
 
 // AddLabelToPullRequest adds a label to the pull request identified by
 // prMetadata.
-func (c *Client) AddLabelToPullRequest(ctx context.Context, prMetadata *PullRequestMetadata, label string) error {
+func (c *Client) AddLabelToPullRequest(
+	ctx context.Context,
+	prMetadata *PullRequestMetadata,
+	label string,
+) error {
 	labels := []string{label}
 
-	_, _, err := c.Issues.AddLabelsToIssue(ctx, prMetadata.Repo.Owner, prMetadata.Repo.Name, prMetadata.Number, labels)
+	_, _, err := c.Issues.AddLabelsToIssue(
+		ctx,
+		prMetadata.Repo.Owner,
+		prMetadata.Repo.Name,
+		prMetadata.Number,
+		labels,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to add label: %w", err)
 	}
@@ -130,7 +149,12 @@ func (c *Client) AddLabelToPullRequest(ctx context.Context, prMetadata *PullRequ
 
 // RemoveLabelFromPullRequest removes a label from the pull request identified
 // by prMetadata.
-func (c *Client) RemoveLabelFromPullRequest(ctx context.Context, repo *Repository, prNumber int, label string) error {
+func (c *Client) RemoveLabelFromPullRequest(
+	ctx context.Context,
+	repo *Repository,
+	prNumber int,
+	label string,
+) error {
 	_, err := c.Issues.RemoveLabelForIssue(ctx, repo.Owner, repo.Name, prNumber, label)
 	if err != nil {
 		return fmt.Errorf("failed to remove label: %w", err)
@@ -140,7 +164,12 @@ func (c *Client) RemoveLabelFromPullRequest(ctx context.Context, repo *Repositor
 
 // AddCommentToPullRequest adds a comment to the pull request identified by
 // repo and prNumber.
-func (c *Client) AddCommentToPullRequest(ctx context.Context, repo *Repository, prNumber int, comment string) error {
+func (c *Client) AddCommentToPullRequest(
+	ctx context.Context,
+	repo *Repository,
+	prNumber int,
+	comment string,
+) error {
 	issueComment := &github.IssueComment{
 		Body: &comment,
 	}
@@ -153,7 +182,12 @@ func (c *Client) AddCommentToPullRequest(ctx context.Context, repo *Repository, 
 
 // MergePullRequest merges the pull request identified by repo and prNumber,
 // using the merge method (e.g. rebase or squash) specified as method.
-func (c *Client) MergePullRequest(ctx context.Context, repo *Repository, prNumber int, method github.MergeMethod) (*github.PullRequestMergeResult, error) {
+func (c *Client) MergePullRequest(
+	ctx context.Context,
+	repo *Repository,
+	prNumber int,
+	method github.MergeMethod,
+) (*github.PullRequestMergeResult, error) {
 	options := &github.PullRequestOptions{
 		MergeMethod: string(method),
 	}
@@ -166,7 +200,11 @@ func (c *Client) MergePullRequest(ctx context.Context, repo *Repository, prNumbe
 
 // GetPullRequest fetches information about the pull request identified by repo
 // and prNumber from GitHub.
-func (c *Client) GetPullRequest(ctx context.Context, repo *Repository, prNumber int) (*github.PullRequest, error) {
+func (c *Client) GetPullRequest(
+	ctx context.Context,
+	repo *Repository,
+	prNumber int,
+) (*github.PullRequest, error) {
 	pr, _, err := c.PullRequests.Get(ctx, repo.Owner, repo.Name, prNumber)
 	return pr, err
 }
@@ -175,10 +213,19 @@ func (c *Client) GetPullRequest(ctx context.Context, repo *Repository, prNumber 
 // for the given pull request.
 //
 // See https://docs.github.com/en/rest/checks/runs.
-func (c *Client) GetPullRequestCheckRuns(ctx context.Context, pullRequest *github.PullRequest) ([]*github.CheckRun, error) {
+func (c *Client) GetPullRequestCheckRuns(
+	ctx context.Context,
+	pullRequest *github.PullRequest,
+) ([]*github.CheckRun, error) {
 	prHead := pullRequest.Head
 	options := &github.ListCheckRunsOptions{}
-	checkRuns, _, err := c.Checks.ListCheckRunsForRef(ctx, *prHead.User.Login, *prHead.Repo.Name, *prHead.Ref, options)
+	checkRuns, _, err := c.Checks.ListCheckRunsForRef(
+		ctx,
+		*prHead.User.Login,
+		*prHead.Repo.Name,
+		*prHead.Ref,
+		options,
+	)
 	if checkRuns == nil {
 		return nil, err
 	}
@@ -187,10 +234,19 @@ func (c *Client) GetPullRequestCheckRuns(ctx context.Context, pullRequest *githu
 
 // GetPullRequestReviews fetches all reviews for the pull request identified
 // by prMetadata.
-func (c *Client) GetPullRequestReviews(ctx context.Context, prMetadata *PullRequestMetadata) ([]*github.PullRequestReview, error) {
+func (c *Client) GetPullRequestReviews(
+	ctx context.Context,
+	prMetadata *PullRequestMetadata,
+) ([]*github.PullRequestReview, error) {
 	// TODO(https://github.com/googleapis/librarian/issues/540): implement pagination or use go-github-paginate
 	listOptions := &github.ListOptions{PerPage: 100}
-	reviews, _, err := c.PullRequests.ListReviews(ctx, prMetadata.Repo.Owner, prMetadata.Repo.Name, prMetadata.Number, listOptions)
+	reviews, _, err := c.PullRequests.ListReviews(
+		ctx,
+		prMetadata.Repo.Owner,
+		prMetadata.Repo.Name,
+		prMetadata.Number,
+		listOptions,
+	)
 	return reviews, err
 }
 
@@ -216,7 +272,11 @@ func CreateGitHubRepoFromRepository(repo *github.Repository) *Repository {
 
 // GetRawContent fetches the raw content of a file within a repository repo,
 // identifying the file by path, at a specific commit/tag/branch of ref.
-func (c *Client) GetRawContent(ctx context.Context, repo *Repository, path, ref string) (_ []byte, err error) {
+func (c *Client) GetRawContent(
+	ctx context.Context,
+	repo *Repository,
+	path, ref string,
+) (_ []byte, err error) {
 	options := &github.RepositoryContentGetOptions{
 		Ref: ref,
 	}
@@ -235,15 +295,30 @@ func (c *Client) GetRawContent(ctx context.Context, repo *Repository, path, ref 
 
 // GetDiffCommits returns the commits in a repository repo between source
 // and target references (commit hashes, branches etc).
-func (c *Client) GetDiffCommits(ctx context.Context, repo *Repository, source, target string) ([]*github.RepositoryCommit, error) {
+func (c *Client) GetDiffCommits(
+	ctx context.Context,
+	repo *Repository,
+	source, target string,
+) ([]*github.RepositoryCommit, error) {
 	// TODO(https://github.com/googleapis/librarian/issues/540): implement pagination or use go-github-paginate
 	listOptions := &github.ListOptions{PerPage: 100}
-	commitsComparison, _, err := c.Repositories.CompareCommits(ctx, repo.Owner, repo.Name, source, target, listOptions)
+	commitsComparison, _, err := c.Repositories.CompareCommits(
+		ctx,
+		repo.Owner,
+		repo.Name,
+		source,
+		target,
+		listOptions,
+	)
 	return commitsComparison.Commits, err
 }
 
 // GetCommit returns the commit in a repository repo with the a commit hash of sha.
-func (c *Client) GetCommit(ctx context.Context, repo *Repository, sha string) (*github.RepositoryCommit, error) {
+func (c *Client) GetCommit(
+	ctx context.Context,
+	repo *Repository,
+	sha string,
+) (*github.RepositoryCommit, error) {
 	// TODO(https://github.com/googleapis/librarian/issues/540): implement pagination or use go-github-paginate
 	listOptions := &github.ListOptions{PerPage: 100}
 	commit, _, err := c.Repositories.GetCommit(ctx, repo.Owner, repo.Name, sha, listOptions)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -77,11 +77,7 @@ type PullRequestMetadata struct {
 // CreatePullRequest creates a pull request in the remote repo.
 // At the moment this requires a single remote to be configured,
 // which must have a GitHub HTTPS URL. We assume a base branch of "main".
-func (c *Client) CreatePullRequest(
-	ctx context.Context,
-	repo *Repository,
-	remoteBranch, title, body string,
-) (*PullRequestMetadata, error) {
+func (c *Client) CreatePullRequest(ctx context.Context, repo *Repository, remoteBranch, title, body string) (*PullRequestMetadata, error) {
 	if body == "" {
 		body = "Regenerated all changed APIs. See individual commits for details."
 	}
@@ -104,12 +100,7 @@ func (c *Client) CreatePullRequest(
 
 // CreateRelease creates a release on GitHub for the specified commit,
 // including the named tag, with the given title and description.
-func (c *Client) CreateRelease(
-	ctx context.Context,
-	repo *Repository,
-	tag, commit, title, description string,
-	prerelease bool,
-) (*github.RepositoryRelease, error) {
+func (c *Client) CreateRelease(ctx context.Context, repo *Repository, tag, commit, title, description string, prerelease bool) (*github.RepositoryRelease, error) {
 	release := &github.RepositoryRelease{
 		TagName:         &tag,
 		TargetCommitish: &commit,
@@ -127,20 +118,10 @@ func (c *Client) CreateRelease(
 
 // AddLabelToPullRequest adds a label to the pull request identified by
 // prMetadata.
-func (c *Client) AddLabelToPullRequest(
-	ctx context.Context,
-	prMetadata *PullRequestMetadata,
-	label string,
-) error {
+func (c *Client) AddLabelToPullRequest(ctx context.Context, prMetadata *PullRequestMetadata, label string) error {
 	labels := []string{label}
 
-	_, _, err := c.Issues.AddLabelsToIssue(
-		ctx,
-		prMetadata.Repo.Owner,
-		prMetadata.Repo.Name,
-		prMetadata.Number,
-		labels,
-	)
+	_, _, err := c.Issues.AddLabelsToIssue(ctx, prMetadata.Repo.Owner, prMetadata.Repo.Name, prMetadata.Number, labels)
 	if err != nil {
 		return fmt.Errorf("failed to add label: %w", err)
 	}
@@ -149,12 +130,7 @@ func (c *Client) AddLabelToPullRequest(
 
 // RemoveLabelFromPullRequest removes a label from the pull request identified
 // by prMetadata.
-func (c *Client) RemoveLabelFromPullRequest(
-	ctx context.Context,
-	repo *Repository,
-	prNumber int,
-	label string,
-) error {
+func (c *Client) RemoveLabelFromPullRequest(ctx context.Context, repo *Repository, prNumber int, label string) error {
 	_, err := c.Issues.RemoveLabelForIssue(ctx, repo.Owner, repo.Name, prNumber, label)
 	if err != nil {
 		return fmt.Errorf("failed to remove label: %w", err)
@@ -164,12 +140,7 @@ func (c *Client) RemoveLabelFromPullRequest(
 
 // AddCommentToPullRequest adds a comment to the pull request identified by
 // repo and prNumber.
-func (c *Client) AddCommentToPullRequest(
-	ctx context.Context,
-	repo *Repository,
-	prNumber int,
-	comment string,
-) error {
+func (c *Client) AddCommentToPullRequest(ctx context.Context, repo *Repository, prNumber int, comment string) error {
 	issueComment := &github.IssueComment{
 		Body: &comment,
 	}
@@ -182,12 +153,7 @@ func (c *Client) AddCommentToPullRequest(
 
 // MergePullRequest merges the pull request identified by repo and prNumber,
 // using the merge method (e.g. rebase or squash) specified as method.
-func (c *Client) MergePullRequest(
-	ctx context.Context,
-	repo *Repository,
-	prNumber int,
-	method github.MergeMethod,
-) (*github.PullRequestMergeResult, error) {
+func (c *Client) MergePullRequest(ctx context.Context, repo *Repository, prNumber int, method github.MergeMethod) (*github.PullRequestMergeResult, error) {
 	options := &github.PullRequestOptions{
 		MergeMethod: string(method),
 	}
@@ -200,11 +166,7 @@ func (c *Client) MergePullRequest(
 
 // GetPullRequest fetches information about the pull request identified by repo
 // and prNumber from GitHub.
-func (c *Client) GetPullRequest(
-	ctx context.Context,
-	repo *Repository,
-	prNumber int,
-) (*github.PullRequest, error) {
+func (c *Client) GetPullRequest(ctx context.Context, repo *Repository, prNumber int) (*github.PullRequest, error) {
 	pr, _, err := c.PullRequests.Get(ctx, repo.Owner, repo.Name, prNumber)
 	return pr, err
 }
@@ -213,19 +175,10 @@ func (c *Client) GetPullRequest(
 // for the given pull request.
 //
 // See https://docs.github.com/en/rest/checks/runs.
-func (c *Client) GetPullRequestCheckRuns(
-	ctx context.Context,
-	pullRequest *github.PullRequest,
-) ([]*github.CheckRun, error) {
+func (c *Client) GetPullRequestCheckRuns(ctx context.Context, pullRequest *github.PullRequest) ([]*github.CheckRun, error) {
 	prHead := pullRequest.Head
 	options := &github.ListCheckRunsOptions{}
-	checkRuns, _, err := c.Checks.ListCheckRunsForRef(
-		ctx,
-		*prHead.User.Login,
-		*prHead.Repo.Name,
-		*prHead.Ref,
-		options,
-	)
+	checkRuns, _, err := c.Checks.ListCheckRunsForRef(ctx, *prHead.User.Login, *prHead.Repo.Name, *prHead.Ref, options)
 	if checkRuns == nil {
 		return nil, err
 	}
@@ -234,19 +187,10 @@ func (c *Client) GetPullRequestCheckRuns(
 
 // GetPullRequestReviews fetches all reviews for the pull request identified
 // by prMetadata.
-func (c *Client) GetPullRequestReviews(
-	ctx context.Context,
-	prMetadata *PullRequestMetadata,
-) ([]*github.PullRequestReview, error) {
+func (c *Client) GetPullRequestReviews(ctx context.Context, prMetadata *PullRequestMetadata) ([]*github.PullRequestReview, error) {
 	// TODO(https://github.com/googleapis/librarian/issues/540): implement pagination or use go-github-paginate
 	listOptions := &github.ListOptions{PerPage: 100}
-	reviews, _, err := c.PullRequests.ListReviews(
-		ctx,
-		prMetadata.Repo.Owner,
-		prMetadata.Repo.Name,
-		prMetadata.Number,
-		listOptions,
-	)
+	reviews, _, err := c.PullRequests.ListReviews(ctx, prMetadata.Repo.Owner, prMetadata.Repo.Name, prMetadata.Number, listOptions)
 	return reviews, err
 }
 
@@ -272,11 +216,7 @@ func CreateGitHubRepoFromRepository(repo *github.Repository) *Repository {
 
 // GetRawContent fetches the raw content of a file within a repository repo,
 // identifying the file by path, at a specific commit/tag/branch of ref.
-func (c *Client) GetRawContent(
-	ctx context.Context,
-	repo *Repository,
-	path, ref string,
-) (_ []byte, err error) {
+func (c *Client) GetRawContent(ctx context.Context, repo *Repository, path, ref string) (_ []byte, err error) {
 	options := &github.RepositoryContentGetOptions{
 		Ref: ref,
 	}
@@ -295,30 +235,15 @@ func (c *Client) GetRawContent(
 
 // GetDiffCommits returns the commits in a repository repo between source
 // and target references (commit hashes, branches etc).
-func (c *Client) GetDiffCommits(
-	ctx context.Context,
-	repo *Repository,
-	source, target string,
-) ([]*github.RepositoryCommit, error) {
+func (c *Client) GetDiffCommits(ctx context.Context, repo *Repository, source, target string) ([]*github.RepositoryCommit, error) {
 	// TODO(https://github.com/googleapis/librarian/issues/540): implement pagination or use go-github-paginate
 	listOptions := &github.ListOptions{PerPage: 100}
-	commitsComparison, _, err := c.Repositories.CompareCommits(
-		ctx,
-		repo.Owner,
-		repo.Name,
-		source,
-		target,
-		listOptions,
-	)
+	commitsComparison, _, err := c.Repositories.CompareCommits(ctx, repo.Owner, repo.Name, source, target, listOptions)
 	return commitsComparison.Commits, err
 }
 
 // GetCommit returns the commit in a repository repo with the a commit hash of sha.
-func (c *Client) GetCommit(
-	ctx context.Context,
-	repo *Repository,
-	sha string,
-) (*github.RepositoryCommit, error) {
+func (c *Client) GetCommit(ctx context.Context, repo *Repository, sha string) (*github.RepositoryCommit, error) {
 	// TODO(https://github.com/googleapis/librarian/issues/540): implement pagination or use go-github-paginate
 	listOptions := &github.ListOptions{PerPage: 100}
 	commit, _, err := c.Repositories.GetCommit(ctx, repo.Owner, repo.Name, sha, listOptions)

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -250,10 +250,7 @@ func (r *Repository) PrintStatus() error {
 //
 // If sinceCommit is not provided, all commits are searched; otherwise, if no
 // commit matching sinceCommit is found, an error is returned.
-func (r *Repository) GetCommitsForPathsSinceCommit(
-	paths []string,
-	sinceCommit string,
-) ([]*Commit, error) {
+func (r *Repository) GetCommitsForPathsSinceCommit(paths []string, sinceCommit string) ([]*Commit, error) {
 	if len(paths) == 0 {
 		return nil, errors.New("no paths to check for commits")
 	}
@@ -397,10 +394,7 @@ func (r *Repository) GetCommitsForReleaseID(releaseID string) ([]*Commit, error)
 		}
 
 		if candidateCommit.NumParents() != 1 {
-			return nil, fmt.Errorf(
-				"aborted finding release PR commits; commit %s has multiple parents",
-				candidateCommit.Hash.String(),
-			)
+			return nil, fmt.Errorf("aborted finding release PR commits; commit %s has multiple parents", candidateCommit.Hash.String())
 		}
 		candidateCommit, err = candidateCommit.Parent(0)
 		if err != nil {

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -250,7 +250,10 @@ func (r *Repository) PrintStatus() error {
 //
 // If sinceCommit is not provided, all commits are searched; otherwise, if no
 // commit matching sinceCommit is found, an error is returned.
-func (r *Repository) GetCommitsForPathsSinceCommit(paths []string, sinceCommit string) ([]*Commit, error) {
+func (r *Repository) GetCommitsForPathsSinceCommit(
+	paths []string,
+	sinceCommit string,
+) ([]*Commit, error) {
 	if len(paths) == 0 {
 		return nil, errors.New("no paths to check for commits")
 	}
@@ -394,7 +397,10 @@ func (r *Repository) GetCommitsForReleaseID(releaseID string) ([]*Commit, error)
 		}
 
 		if candidateCommit.NumParents() != 1 {
-			return nil, fmt.Errorf("aborted finding release PR commits; commit %s has multiple parents", candidateCommit.Hash.String())
+			return nil, fmt.Errorf(
+				"aborted finding release PR commits; commit %s has multiple parents",
+				candidateCommit.Hash.String(),
+			)
 		}
 		candidateCommit, err = candidateCommit.Parent(0)
 		if err != nil {

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -15,13 +15,14 @@
 package gitrepo
 
 import (
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 func TestGetCommitsForPathsSinceCommit(t *testing.T) {

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -104,7 +104,9 @@ func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.Repository, er
 // ContainerState based on all of the above. This should be used by all commands
 // which always have a language repo. Commands which only conditionally use
 // language repos should construct the command state themselves.
-func createCommandStateForLanguage(workRootOverride, repo, imageOverride, project, ci, uid, gid string) (*commandState, error) {
+func createCommandStateForLanguage(
+	workRootOverride, repo, imageOverride, project, ci, uid, gid string,
+) (*commandState, error) {
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime, workRootOverride)
 	if err != nil {
@@ -159,7 +161,9 @@ func deriveImage(imageOverride string, state *statepb.PipelineState) (string, er
 	// TODO(https://github.com/googleapis/librarian/issues/326):
 	// use image from state.yaml when switch to this config file. see go/librarian:cli-reimagined
 	if state.ImageTag == "" {
-		return "", errors.New("pipeline state does not have image specified and no override was provided")
+		return "", errors.New(
+			"pipeline state does not have image specified and no override was provided",
+		)
 	}
 	return state.ImageTag, nil
 }
@@ -202,7 +206,11 @@ func createWorkRoot(t time.Time, workRootOverride string) (string, error) {
 	switch {
 	case os.IsNotExist(err):
 		if err := os.Mkdir(path, 0755); err != nil {
-			return "", fmt.Errorf("unable to create temporary working directory '%s': %w", path, err)
+			return "", fmt.Errorf(
+				"unable to create temporary working directory '%s': %w",
+				path,
+				err,
+			)
 		}
 	case err == nil:
 		return "", fmt.Errorf("temporary working directory already exists: %s", path)

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -104,7 +104,9 @@ func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.Repository, er
 // ContainerState based on all of the above. This should be used by all commands
 // which always have a language repo. Commands which only conditionally use
 // language repos should construct the command state themselves.
-func createCommandStateForLanguage(workRootOverride, repo, imageOverride, project, ci, uid, gid string) (*commandState, error) {
+func createCommandStateForLanguage(
+	workRootOverride, repo, imageOverride, project, ci, uid, gid string,
+) (*commandState, error) {
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime, workRootOverride)
 	if err != nil {
@@ -159,7 +161,9 @@ func deriveImage(imageOverride string, state *statepb.PipelineState) (string, er
 	// TODO(https://github.com/googleapis/librarian/issues/326):
 	// use image from state.yaml when switch to this config file. see go/librarian:cli-reimagined
 	if state.ImageTag == "" {
-		return "", errors.New("pipeline state does not have image specified and no override was provided")
+		return "", errors.New(
+			"pipeline state does not have image specified and no override was provided",
+		)
 	}
 	return state.ImageTag, nil
 }
@@ -202,7 +206,11 @@ func createWorkRoot(t time.Time, workRootOverride string) (string, error) {
 	switch {
 	case os.IsNotExist(err):
 		if err := os.Mkdir(path, 0755); err != nil {
-			return "", fmt.Errorf("unable to create temporary working directory '%s': %w", path, err)
+			return "", fmt.Errorf(
+				"unable to create temporary working directory '%s': %w",
+				path,
+				err,
+			)
 		}
 	case err == nil:
 		return "", fmt.Errorf("temporary working directory already exists: %s", path)
@@ -236,7 +244,10 @@ func commitAll(repo *gitrepo.Repository, msg, pushConfig string) error {
 func parsePushConfig(pushConfig string) (string, string, error) {
 	parts := strings.Split(pushConfig, ",")
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid pushConfig format: expected 'email,user', got %q", pushConfig)
+		return "", "", fmt.Errorf(
+			"invalid pushConfig format: expected 'email,user', got %q",
+			pushConfig,
+		)
 	}
 	userEmail := parts[0]
 	userName := parts[1]

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -104,9 +104,7 @@ func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.Repository, er
 // ContainerState based on all of the above. This should be used by all commands
 // which always have a language repo. Commands which only conditionally use
 // language repos should construct the command state themselves.
-func createCommandStateForLanguage(
-	workRootOverride, repo, imageOverride, project, ci, uid, gid string,
-) (*commandState, error) {
+func createCommandStateForLanguage(workRootOverride, repo, imageOverride, project, ci, uid, gid string) (*commandState, error) {
 	startTime := time.Now()
 	workRoot, err := createWorkRoot(startTime, workRootOverride)
 	if err != nil {
@@ -161,9 +159,7 @@ func deriveImage(imageOverride string, state *statepb.PipelineState) (string, er
 	// TODO(https://github.com/googleapis/librarian/issues/326):
 	// use image from state.yaml when switch to this config file. see go/librarian:cli-reimagined
 	if state.ImageTag == "" {
-		return "", errors.New(
-			"pipeline state does not have image specified and no override was provided",
-		)
+		return "", errors.New("pipeline state does not have image specified and no override was provided")
 	}
 	return state.ImageTag, nil
 }
@@ -206,11 +202,7 @@ func createWorkRoot(t time.Time, workRootOverride string) (string, error) {
 	switch {
 	case os.IsNotExist(err):
 		if err := os.Mkdir(path, 0755); err != nil {
-			return "", fmt.Errorf(
-				"unable to create temporary working directory '%s': %w",
-				path,
-				err,
-			)
+			return "", fmt.Errorf("unable to create temporary working directory '%s': %w", path, err)
 		}
 	case err == nil:
 		return "", fmt.Errorf("temporary working directory already exists: %s", path)

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -33,11 +33,18 @@ func TestCommandUsage(t *testing.T) {
 			parts := strings.Fields(c.UsageLine)
 			// The first word should always be "librarian".
 			if parts[0] != "librarian" {
-				t.Errorf("invalid usage text: %q (the first word should be `librarian`)", c.UsageLine)
+				t.Errorf(
+					"invalid usage text: %q (the first word should be `librarian`)",
+					c.UsageLine,
+				)
 			}
 			// The second word should always be the command name.
 			if parts[1] != c.Name() {
-				t.Errorf("invalid usage text: %q (second word should be command name %q)", c.UsageLine, c.Name())
+				t.Errorf(
+					"invalid usage text: %q (second word should be command name %q)",
+					c.UsageLine,
+					c.Name(),
+				)
 			}
 		})
 	}

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -33,18 +33,11 @@ func TestCommandUsage(t *testing.T) {
 			parts := strings.Fields(c.UsageLine)
 			// The first word should always be "librarian".
 			if parts[0] != "librarian" {
-				t.Errorf(
-					"invalid usage text: %q (the first word should be `librarian`)",
-					c.UsageLine,
-				)
+				t.Errorf("invalid usage text: %q (the first word should be `librarian`)", c.UsageLine)
 			}
 			// The second word should always be the command name.
 			if parts[1] != c.Name() {
-				t.Errorf(
-					"invalid usage text: %q (second word should be command name %q)",
-					c.UsageLine,
-					c.Name(),
-				)
+				t.Errorf("invalid usage text: %q (second word should be command name %q)", c.UsageLine, c.Name())
 			}
 		})
 	}

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -100,11 +100,7 @@ func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 	return createReleaseArtifactsImpl(ctx, state, cfg)
 }
 
-func createReleaseArtifactsImpl(
-	ctx context.Context,
-	state *commandState,
-	cfg *config.Config,
-) error {
+func createReleaseArtifactsImpl(ctx context.Context, state *commandState, cfg *config.Config) error {
 	if err := validateSkipIntegrationTests(cfg.SkipIntegrationTests); err != nil {
 		return err
 	}
@@ -162,11 +158,7 @@ func copyMetadataFiles(state *commandState, outputRoot string, releases []Librar
 		return err
 	}
 
-	sourceConfigFile := filepath.Join(
-		languageRepo.Dir,
-		config.GeneratorInputDir,
-		pipelineConfigFile,
-	)
+	sourceConfigFile := filepath.Join(languageRepo.Dir, config.GeneratorInputDir, pipelineConfigFile)
 	destConfigFile := filepath.Join(outputRoot, pipelineConfigFile)
 	if err := copyFile(sourceConfigFile, destConfigFile); err != nil {
 		return err
@@ -182,13 +174,7 @@ func copyFile(sourcePath, destPath string) error {
 	return createAndWriteBytesToFile(destPath, bytes)
 }
 
-func buildTestPackageRelease(
-	ctx context.Context,
-	state *commandState,
-	cfg *config.Config,
-	outputRoot string,
-	release LibraryRelease,
-) error {
+func buildTestPackageRelease(ctx context.Context, state *commandState, cfg *config.Config, outputRoot string, release LibraryRelease) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -100,7 +100,11 @@ func runCreateReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 	return createReleaseArtifactsImpl(ctx, state, cfg)
 }
 
-func createReleaseArtifactsImpl(ctx context.Context, state *commandState, cfg *config.Config) error {
+func createReleaseArtifactsImpl(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+) error {
 	if err := validateSkipIntegrationTests(cfg.SkipIntegrationTests); err != nil {
 		return err
 	}
@@ -158,7 +162,11 @@ func copyMetadataFiles(state *commandState, outputRoot string, releases []Librar
 		return err
 	}
 
-	sourceConfigFile := filepath.Join(languageRepo.Dir, config.GeneratorInputDir, pipelineConfigFile)
+	sourceConfigFile := filepath.Join(
+		languageRepo.Dir,
+		config.GeneratorInputDir,
+		pipelineConfigFile,
+	)
 	destConfigFile := filepath.Join(outputRoot, pipelineConfigFile)
 	if err := copyFile(sourceConfigFile, destConfigFile); err != nil {
 		return err
@@ -174,7 +182,13 @@ func copyFile(sourcePath, destPath string) error {
 	return createAndWriteBytesToFile(destPath, bytes)
 }
 
-func buildTestPackageRelease(ctx context.Context, state *commandState, cfg *config.Config, outputRoot string, release LibraryRelease) error {
+func buildTestPackageRelease(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	outputRoot string,
+	release LibraryRelease,
+) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -164,12 +164,27 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 		return err
 	}
 
-	prContent, err := generateReleaseCommitForEachLibrary(ctx, state, cfg, inputDirectory, releaseID)
+	prContent, err := generateReleaseCommitForEachLibrary(
+		ctx,
+		state,
+		cfg,
+		inputDirectory,
+		releaseID,
+	)
 	if err != nil {
 		return err
 	}
 
-	prMetadata, err := createPullRequest(ctx, state, prContent, "chore: Library release", fmt.Sprintf("Librarian-Release-ID: %s", releaseID), "release", cfg.GitHubToken, cfg.Push)
+	prMetadata, err := createPullRequest(
+		ctx,
+		state,
+		prContent,
+		"chore: Library release",
+		fmt.Sprintf("Librarian-Release-ID: %s", releaseID),
+		"release",
+		cfg.GitHubToken,
+		cfg.Push,
+	)
 	if err != nil {
 		return err
 	}
@@ -205,7 +220,12 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 //   - Library-level errors do not halt the process, but are reported in the resulting PR (if any).
 //     This can include tags being missing, release preparation failing, or the build failing.
 //   - More fundamental errors (e.g. a failure to commit, or to save pipeline state) abort the whole process immediately.
-func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandState, cfg *config.Config, inputDirectory, releaseID string) (*PullRequestContent, error) {
+func generateReleaseCommitForEachLibrary(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	inputDirectory, releaseID string,
+) (*PullRequestContent, error) {
 	cc := state.containerConfig
 	libraries := state.pipelineState.Libraries
 	languageRepo := state.languageRepo
@@ -228,7 +248,9 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		} else {
 			previousReleaseTag = formatReleaseTag(library.Id, library.CurrentVersion)
 		}
-		allSourcePaths := append(state.pipelineState.CommonLibrarySourcePaths, library.SourcePaths...)
+		allSourcePaths := append(
+			state.pipelineState.CommonLibrarySourcePaths,
+			library.SourcePaths...)
 		commits, err := languageRepo.GetCommitsForPathsSinceTag(allSourcePaths, previousReleaseTag)
 		if err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "retrieving commits since last release")
@@ -241,7 +263,8 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 
 		// If nothing release-worthy has happened, just continue to the next library.
 		// (But if we've been asked to release a specific library, we force-release it anyway.)
-		if cfg.LibraryID == "" && (len(commitMessages) == 0 || !isReleaseWorthy(commitMessages, library.Id)) {
+		if cfg.LibraryID == "" &&
+			(len(commitMessages) == 0 || !isReleaseWorthy(commitMessages, library.Id)) {
 			continue
 		}
 
@@ -292,13 +315,26 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 			continue
 		}
 
-		releaseDescription := fmt.Sprintf("chore: Release library %s version %s", library.Id, releaseVersion)
+		releaseDescription := fmt.Sprintf(
+			"chore: Release library %s version %s",
+			library.Id,
+			releaseVersion,
+		)
 		addSuccessToPullRequest(pr, releaseDescription)
 		// Metadata for easy extraction later.
-		metadata := fmt.Sprintf("Librarian-Release-Library: %s\nLibrarian-Release-Version: %s\nLibrarian-Release-ID: %s", library.Id, releaseVersion, releaseID)
+		metadata := fmt.Sprintf(
+			"Librarian-Release-Library: %s\nLibrarian-Release-Version: %s\nLibrarian-Release-ID: %s",
+			library.Id,
+			releaseVersion,
+			releaseID,
+		)
 		// Note that releaseDescription will already end with two line breaks, so we don't need any more before the metadata.
-		err = commitAll(languageRepo, fmt.Sprintf("%s\n\n%s%s", releaseDescription, releaseNotes, metadata),
-			cfg.GitUserName, cfg.GitUserEmail)
+		err = commitAll(
+			languageRepo,
+			fmt.Sprintf("%s\n\n%s%s", releaseDescription, releaseNotes, metadata),
+			cfg.GitUserName,
+			cfg.GitUserEmail,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -345,13 +381,18 @@ func formatReleaseNotes(commitMessages []*CommitMessage) string {
 	maybeAppendReleaseNotesSection(&builder, "Documentation improvements", docs)
 
 	if builder.Len() == 0 {
-		builder.WriteString("FIXME: Forced release with no commit messages; please write release notes.\n\n")
+		builder.WriteString(
+			"FIXME: Forced release with no commit messages; please write release notes.\n\n",
+		)
 	}
 	return builder.String()
 }
 
 func createReleaseNotesFile(inputDirectory, libraryId, releaseVersion, releaseNotes string) error {
-	path := filepath.Join(inputDirectory, fmt.Sprintf("%s-%s-release-notes.txt", libraryId, releaseVersion))
+	path := filepath.Join(
+		inputDirectory,
+		fmt.Sprintf("%s-%s-release-notes.txt", libraryId, releaseVersion),
+	)
 	return createAndWriteToFile(path, releaseNotes)
 }
 

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -162,12 +162,27 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 		return err
 	}
 
-	prContent, err := generateReleaseCommitForEachLibrary(ctx, state, cfg, inputDirectory, releaseID)
+	prContent, err := generateReleaseCommitForEachLibrary(
+		ctx,
+		state,
+		cfg,
+		inputDirectory,
+		releaseID,
+	)
 	if err != nil {
 		return err
 	}
 
-	prMetadata, err := createPullRequest(ctx, state, prContent, "chore: Library release", fmt.Sprintf("Librarian-Release-ID: %s", releaseID), "release", cfg.GitHubToken, cfg.Push)
+	prMetadata, err := createPullRequest(
+		ctx,
+		state,
+		prContent,
+		"chore: Library release",
+		fmt.Sprintf("Librarian-Release-ID: %s", releaseID),
+		"release",
+		cfg.GitHubToken,
+		cfg.Push,
+	)
 	if err != nil {
 		return err
 	}
@@ -203,7 +218,12 @@ func createReleasePR(ctx context.Context, state *commandState, cfg *config.Confi
 //   - Library-level errors do not halt the process, but are reported in the resulting PR (if any).
 //     This can include tags being missing, release preparation failing, or the build failing.
 //   - More fundamental errors (e.g. a failure to commit, or to save pipeline state) abort the whole process immediately.
-func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandState, cfg *config.Config, inputDirectory, releaseID string) (*PullRequestContent, error) {
+func generateReleaseCommitForEachLibrary(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	inputDirectory, releaseID string,
+) (*PullRequestContent, error) {
 	cc := state.containerConfig
 	libraries := state.pipelineState.Libraries
 	languageRepo := state.languageRepo
@@ -226,7 +246,9 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		} else {
 			previousReleaseTag = formatReleaseTag(library.Id, library.CurrentVersion)
 		}
-		allSourcePaths := append(state.pipelineState.CommonLibrarySourcePaths, library.SourcePaths...)
+		allSourcePaths := append(
+			state.pipelineState.CommonLibrarySourcePaths,
+			library.SourcePaths...)
 		commits, err := languageRepo.GetCommitsForPathsSinceTag(allSourcePaths, previousReleaseTag)
 		if err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "retrieving commits since last release")
@@ -239,7 +261,8 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 
 		// If nothing release-worthy has happened, just continue to the next library.
 		// (But if we've been asked to release a specific library, we force-release it anyway.)
-		if cfg.LibraryID == "" && (len(commitMessages) == 0 || !isReleaseWorthy(commitMessages, library.Id)) {
+		if cfg.LibraryID == "" &&
+			(len(commitMessages) == 0 || !isReleaseWorthy(commitMessages, library.Id)) {
 			continue
 		}
 
@@ -290,13 +313,25 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 			continue
 		}
 
-		releaseDescription := fmt.Sprintf("chore: Release library %s version %s", library.Id, releaseVersion)
+		releaseDescription := fmt.Sprintf(
+			"chore: Release library %s version %s",
+			library.Id,
+			releaseVersion,
+		)
 		addSuccessToPullRequest(pr, releaseDescription)
 		// Metadata for easy extraction later.
-		metadata := fmt.Sprintf("Librarian-Release-Library: %s\nLibrarian-Release-Version: %s\nLibrarian-Release-ID: %s", library.Id, releaseVersion, releaseID)
+		metadata := fmt.Sprintf(
+			"Librarian-Release-Library: %s\nLibrarian-Release-Version: %s\nLibrarian-Release-ID: %s",
+			library.Id,
+			releaseVersion,
+			releaseID,
+		)
 		// Note that releaseDescription will already end with two line breaks, so we don't need any more before the metadata.
-		err = commitAll(languageRepo, fmt.Sprintf("%s\n\n%s%s", releaseDescription, releaseNotes, metadata),
-			cfg.PushConfig)
+		err = commitAll(
+			languageRepo,
+			fmt.Sprintf("%s\n\n%s%s", releaseDescription, releaseNotes, metadata),
+			cfg.PushConfig,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -343,13 +378,18 @@ func formatReleaseNotes(commitMessages []*CommitMessage) string {
 	maybeAppendReleaseNotesSection(&builder, "Documentation improvements", docs)
 
 	if builder.Len() == 0 {
-		builder.WriteString("FIXME: Forced release with no commit messages; please write release notes.\n\n")
+		builder.WriteString(
+			"FIXME: Forced release with no commit messages; please write release notes.\n\n",
+		)
 	}
 	return builder.String()
 }
 
 func createReleaseNotesFile(inputDirectory, libraryId, releaseVersion, releaseNotes string) error {
-	path := filepath.Join(inputDirectory, fmt.Sprintf("%s-%s-release-notes.txt", libraryId, releaseVersion))
+	path := filepath.Join(
+		inputDirectory,
+		fmt.Sprintf("%s-%s-release-notes.txt", libraryId, releaseVersion),
+	)
 	return createAndWriteToFile(path, releaseNotes)
 }
 

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -24,19 +24,39 @@ import (
 )
 
 func addFlagAPIPath(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.API, "api", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
+	fs.StringVar(
+		&cfg.API,
+		"api",
+		"",
+		"path to the API to be configured/generated (e.g., google/cloud/functions/v2)",
+	)
 }
 
 func addFlagSource(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.Source, "source", "", "location of googleapis repository. If undefined, googleapis will be cloned to the output")
+	fs.StringVar(
+		&cfg.Source,
+		"source",
+		"",
+		"location of googleapis repository. If undefined, googleapis will be cloned to the output",
+	)
 }
 
 func addFlagArtifactRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.ArtifactRoot, "artifact-root", "", "Path to root of release artifacts to publish (as created by create-release-artifacts)")
+	fs.StringVar(
+		&cfg.ArtifactRoot,
+		"artifact-root",
+		"",
+		"Path to root of release artifacts to publish (as created by create-release-artifacts)",
+	)
 }
 
 func addFlagBaselineCommit(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.BaselineCommit, "baseline-commit", "", "the commit hash that was at HEAD for the language repo when create-release-pr was run")
+	fs.StringVar(
+		&cfg.BaselineCommit,
+		"baseline-commit",
+		"",
+		"the commit hash that was at HEAD for the language repo when create-release-pr was run",
+	)
 }
 
 func addFlagBranch(fs *flag.FlagSet, cfg *config.Config) {
@@ -48,19 +68,39 @@ func addFlagBuild(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagEnvFile(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.EnvFile, "env-file", "", "full path to the file where the environment variables are stored. Defaults to env-vars.txt within the output")
+	fs.StringVar(
+		&cfg.EnvFile,
+		"env-file",
+		"",
+		"full path to the file where the environment variables are stored. Defaults to env-vars.txt within the output",
+	)
 }
 
 func addFlagGitUserEmail(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.GitUserEmail, "git-user-email", "noreply-cloudsdk@google.com", "Email address to use in Git commits")
+	fs.StringVar(
+		&cfg.GitUserEmail,
+		"git-user-email",
+		"noreply-cloudsdk@google.com",
+		"Email address to use in Git commits",
+	)
 }
 
 func addFlagGitUserName(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.GitUserName, "git-user-name", "Google Cloud SDK", "Display name to use in Git commits")
+	fs.StringVar(
+		&cfg.GitUserName,
+		"git-user-name",
+		"Google Cloud SDK",
+		"Display name to use in Git commits",
+	)
 }
 
 func addFlagImage(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.Image, "image", "", "Container image to run for subcommands. Defaults to the image in the pipeline state.")
+	fs.StringVar(
+		&cfg.Image,
+		"image",
+		"",
+		"Container image to run for subcommands. Defaults to the image in the pipeline state.",
+	)
 }
 
 func addFlagLibraryID(fs *flag.FlagSet, cfg *config.Config) {
@@ -68,7 +108,12 @@ func addFlagLibraryID(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagLibraryVersion(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.LibraryVersion, "library-version", "", "The version to release (only valid with library-id, only when creating a release PR)")
+	fs.StringVar(
+		&cfg.LibraryVersion,
+		"library-version",
+		"",
+		"The version to release (only valid with library-id, only when creating a release PR)",
+	)
 }
 
 func addFlagPush(fs *flag.FlagSet, cfg *config.Config) {
@@ -84,7 +129,12 @@ func addFlagReleasePRUrl(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.Repo, "repo", "", "Repository root or URL to clone. If this is not specified, the default language repo will be cloned.")
+	fs.StringVar(
+		&cfg.Repo,
+		"repo",
+		"",
+		"Repository root or URL to clone. If this is not specified, the default language repo will be cloned.",
+	)
 }
 
 func addFlagProject(fs *flag.FlagSet, cfg *config.Config) {
@@ -92,11 +142,21 @@ func addFlagProject(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagSkipIntegrationTests(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.SkipIntegrationTests, "skip-integration-tests", "", "set to a value of b/{explanatory-bug} to skip integration tests")
+	fs.StringVar(
+		&cfg.SkipIntegrationTests,
+		"skip-integration-tests",
+		"",
+		"set to a value of b/{explanatory-bug} to skip integration tests",
+	)
 }
 
 func addFlagSyncUrlPrefix(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.SyncURLPrefix, "sync-url-prefix", "", "the prefix of the URL to check for commit synchronization; the commit hash will be appended to this")
+	fs.StringVar(
+		&cfg.SyncURLPrefix,
+		"sync-url-prefix",
+		"",
+		"the prefix of the URL to check for commit synchronization; the commit hash will be appended to this",
+	)
 }
 
 func addFlagTag(fs *flag.FlagSet, cfg *config.Config) {
@@ -104,16 +164,28 @@ func addFlagTag(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagTagRepoUrl(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.TagRepoURL, "tag-repo-url", "", "Repository URL to tag and create releases in. Requires when push is true.")
+	fs.StringVar(
+		&cfg.TagRepoURL,
+		"tag-repo-url",
+		"",
+		"Repository URL to tag and create releases in. Requires when push is true.",
+	)
 }
 
 func addFlagWorkRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.WorkRoot, "output", "", "Working directory root. When this is not specified, a working directory will be created in /tmp.")
+	fs.StringVar(
+		&cfg.WorkRoot,
+		"output",
+		"",
+		"Working directory root. When this is not specified, a working directory will be created in /tmp.",
+	)
 }
 
 func validateSkipIntegrationTests(skipIntegrationTests string) error {
 	if skipIntegrationTests != "" && !strings.HasPrefix(skipIntegrationTests, "b/") {
-		return errors.New("skipping integration tests requires a bug to be specified, e.g. -skip-integration-tests=b/12345")
+		return errors.New(
+			"skipping integration tests requires a bug to be specified, e.g. -skip-integration-tests=b/12345",
+		)
 	}
 	return nil
 }

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -24,19 +24,39 @@ import (
 )
 
 func addFlagAPI(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.API, "api", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
+	fs.StringVar(
+		&cfg.API,
+		"api",
+		"",
+		"path to the API to be configured/generated (e.g., google/cloud/functions/v2)",
+	)
 }
 
 func addFlagSource(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.Source, "source", "", "location of googleapis repository. If undefined, googleapis will be cloned to the output")
+	fs.StringVar(
+		&cfg.Source,
+		"source",
+		"",
+		"location of googleapis repository. If undefined, googleapis will be cloned to the output",
+	)
 }
 
 func addFlagArtifactRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.ArtifactRoot, "artifact-root", "", "Path to root of release artifacts to publish (as created by create-release-artifacts)")
+	fs.StringVar(
+		&cfg.ArtifactRoot,
+		"artifact-root",
+		"",
+		"Path to root of release artifacts to publish (as created by create-release-artifacts)",
+	)
 }
 
 func addFlagBaselineCommit(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.BaselineCommit, "baseline-commit", "", "the commit hash that was at HEAD for the language repo when create-release-pr was run")
+	fs.StringVar(
+		&cfg.BaselineCommit,
+		"baseline-commit",
+		"",
+		"the commit hash that was at HEAD for the language repo when create-release-pr was run",
+	)
 }
 
 func addFlagBranch(fs *flag.FlagSet, cfg *config.Config) {
@@ -48,16 +68,31 @@ func addFlagBuild(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagEnvFile(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.EnvFile, "env-file", "", "full path to the file where the environment variables are stored. Defaults to env-vars.txt within the output")
+	fs.StringVar(
+		&cfg.EnvFile,
+		"env-file",
+		"",
+		"full path to the file where the environment variables are stored. Defaults to env-vars.txt within the output",
+	)
 }
 
 func addFlagPushConfig(fs *flag.FlagSet, cfg *config.Config) {
 	// TODO(https://github.com/googleapis/librarian/issues/724):remove the default for push-config
-	fs.StringVar(&cfg.PushConfig, "push-config", "noreply-cloudsdk@google.com,Google Cloud SDK", "The user and email for Git commits, in the format \"user:email\"")
+	fs.StringVar(
+		&cfg.PushConfig,
+		"push-config",
+		"noreply-cloudsdk@google.com,Google Cloud SDK",
+		"The user and email for Git commits, in the format \"user:email\"",
+	)
 }
 
 func addFlagImage(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.Image, "image", "", "Container image to run for subcommands. Defaults to the image in the pipeline state.")
+	fs.StringVar(
+		&cfg.Image,
+		"image",
+		"",
+		"Container image to run for subcommands. Defaults to the image in the pipeline state.",
+	)
 }
 
 func addFlagLibraryID(fs *flag.FlagSet, cfg *config.Config) {
@@ -65,7 +100,12 @@ func addFlagLibraryID(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagLibraryVersion(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.LibraryVersion, "library-version", "", "The version to release (only valid with library-id, only when creating a release PR)")
+	fs.StringVar(
+		&cfg.LibraryVersion,
+		"library-version",
+		"",
+		"The version to release (only valid with library-id, only when creating a release PR)",
+	)
 }
 
 func addFlagReleaseID(fs *flag.FlagSet, cfg *config.Config) {
@@ -77,7 +117,12 @@ func addFlagReleasePRUrl(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.Repo, "repo", "", "Repository root or URL to clone. If this is not specified, the default language repo will be cloned.")
+	fs.StringVar(
+		&cfg.Repo,
+		"repo",
+		"",
+		"Repository root or URL to clone. If this is not specified, the default language repo will be cloned.",
+	)
 }
 
 func addFlagProject(fs *flag.FlagSet, cfg *config.Config) {
@@ -85,11 +130,21 @@ func addFlagProject(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagSkipIntegrationTests(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.SkipIntegrationTests, "skip-integration-tests", "", "set to a value of b/{explanatory-bug} to skip integration tests")
+	fs.StringVar(
+		&cfg.SkipIntegrationTests,
+		"skip-integration-tests",
+		"",
+		"set to a value of b/{explanatory-bug} to skip integration tests",
+	)
 }
 
 func addFlagSyncUrlPrefix(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.SyncURLPrefix, "sync-url-prefix", "", "the prefix of the URL to check for commit synchronization; the commit hash will be appended to this")
+	fs.StringVar(
+		&cfg.SyncURLPrefix,
+		"sync-url-prefix",
+		"",
+		"the prefix of the URL to check for commit synchronization; the commit hash will be appended to this",
+	)
 }
 
 func addFlagTag(fs *flag.FlagSet, cfg *config.Config) {
@@ -97,16 +152,28 @@ func addFlagTag(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagTagRepoUrl(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.TagRepoURL, "tag-repo-url", "", "Repository URL to tag and create releases in. Requires when push is true.")
+	fs.StringVar(
+		&cfg.TagRepoURL,
+		"tag-repo-url",
+		"",
+		"Repository URL to tag and create releases in. Requires when push is true.",
+	)
 }
 
 func addFlagWorkRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.WorkRoot, "output", "", "Working directory root. When this is not specified, a working directory will be created in /tmp.")
+	fs.StringVar(
+		&cfg.WorkRoot,
+		"output",
+		"",
+		"Working directory root. When this is not specified, a working directory will be created in /tmp.",
+	)
 }
 
 func validateSkipIntegrationTests(skipIntegrationTests string) error {
 	if skipIntegrationTests != "" && !strings.HasPrefix(skipIntegrationTests, "b/") {
-		return errors.New("skipping integration tests requires a bug to be specified, e.g. -skip-integration-tests=b/12345")
+		return errors.New(
+			"skipping integration tests requires a bug to be specified, e.g. -skip-integration-tests=b/12345",
+		)
 	}
 	return nil
 }

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -24,39 +24,19 @@ import (
 )
 
 func addFlagAPIPath(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.API,
-		"api",
-		"",
-		"path to the API to be configured/generated (e.g., google/cloud/functions/v2)",
-	)
+	fs.StringVar(&cfg.API, "api", "", "path to the API to be configured/generated (e.g., google/cloud/functions/v2)")
 }
 
 func addFlagSource(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.Source,
-		"source",
-		"",
-		"location of googleapis repository. If undefined, googleapis will be cloned to the output",
-	)
+	fs.StringVar(&cfg.Source, "source", "", "location of googleapis repository. If undefined, googleapis will be cloned to the output")
 }
 
 func addFlagArtifactRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.ArtifactRoot,
-		"artifact-root",
-		"",
-		"Path to root of release artifacts to publish (as created by create-release-artifacts)",
-	)
+	fs.StringVar(&cfg.ArtifactRoot, "artifact-root", "", "Path to root of release artifacts to publish (as created by create-release-artifacts)")
 }
 
 func addFlagBaselineCommit(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.BaselineCommit,
-		"baseline-commit",
-		"",
-		"the commit hash that was at HEAD for the language repo when create-release-pr was run",
-	)
+	fs.StringVar(&cfg.BaselineCommit, "baseline-commit", "", "the commit hash that was at HEAD for the language repo when create-release-pr was run")
 }
 
 func addFlagBranch(fs *flag.FlagSet, cfg *config.Config) {
@@ -68,39 +48,19 @@ func addFlagBuild(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagEnvFile(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.EnvFile,
-		"env-file",
-		"",
-		"full path to the file where the environment variables are stored. Defaults to env-vars.txt within the output",
-	)
+	fs.StringVar(&cfg.EnvFile, "env-file", "", "full path to the file where the environment variables are stored. Defaults to env-vars.txt within the output")
 }
 
 func addFlagGitUserEmail(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.GitUserEmail,
-		"git-user-email",
-		"noreply-cloudsdk@google.com",
-		"Email address to use in Git commits",
-	)
+	fs.StringVar(&cfg.GitUserEmail, "git-user-email", "noreply-cloudsdk@google.com", "Email address to use in Git commits")
 }
 
 func addFlagGitUserName(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.GitUserName,
-		"git-user-name",
-		"Google Cloud SDK",
-		"Display name to use in Git commits",
-	)
+	fs.StringVar(&cfg.GitUserName, "git-user-name", "Google Cloud SDK", "Display name to use in Git commits")
 }
 
 func addFlagImage(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.Image,
-		"image",
-		"",
-		"Container image to run for subcommands. Defaults to the image in the pipeline state.",
-	)
+	fs.StringVar(&cfg.Image, "image", "", "Container image to run for subcommands. Defaults to the image in the pipeline state.")
 }
 
 func addFlagLibraryID(fs *flag.FlagSet, cfg *config.Config) {
@@ -108,12 +68,7 @@ func addFlagLibraryID(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagLibraryVersion(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.LibraryVersion,
-		"library-version",
-		"",
-		"The version to release (only valid with library-id, only when creating a release PR)",
-	)
+	fs.StringVar(&cfg.LibraryVersion, "library-version", "", "The version to release (only valid with library-id, only when creating a release PR)")
 }
 
 func addFlagPush(fs *flag.FlagSet, cfg *config.Config) {
@@ -129,12 +84,7 @@ func addFlagReleasePRUrl(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.Repo,
-		"repo",
-		"",
-		"Repository root or URL to clone. If this is not specified, the default language repo will be cloned.",
-	)
+	fs.StringVar(&cfg.Repo, "repo", "", "Repository root or URL to clone. If this is not specified, the default language repo will be cloned.")
 }
 
 func addFlagProject(fs *flag.FlagSet, cfg *config.Config) {
@@ -142,21 +92,11 @@ func addFlagProject(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagSkipIntegrationTests(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.SkipIntegrationTests,
-		"skip-integration-tests",
-		"",
-		"set to a value of b/{explanatory-bug} to skip integration tests",
-	)
+	fs.StringVar(&cfg.SkipIntegrationTests, "skip-integration-tests", "", "set to a value of b/{explanatory-bug} to skip integration tests")
 }
 
 func addFlagSyncUrlPrefix(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.SyncURLPrefix,
-		"sync-url-prefix",
-		"",
-		"the prefix of the URL to check for commit synchronization; the commit hash will be appended to this",
-	)
+	fs.StringVar(&cfg.SyncURLPrefix, "sync-url-prefix", "", "the prefix of the URL to check for commit synchronization; the commit hash will be appended to this")
 }
 
 func addFlagTag(fs *flag.FlagSet, cfg *config.Config) {
@@ -164,28 +104,16 @@ func addFlagTag(fs *flag.FlagSet, cfg *config.Config) {
 }
 
 func addFlagTagRepoUrl(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.TagRepoURL,
-		"tag-repo-url",
-		"",
-		"Repository URL to tag and create releases in. Requires when push is true.",
-	)
+	fs.StringVar(&cfg.TagRepoURL, "tag-repo-url", "", "Repository URL to tag and create releases in. Requires when push is true.")
 }
 
 func addFlagWorkRoot(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(
-		&cfg.WorkRoot,
-		"output",
-		"",
-		"Working directory root. When this is not specified, a working directory will be created in /tmp.",
-	)
+	fs.StringVar(&cfg.WorkRoot, "output", "", "Working directory root. When this is not specified, a working directory will be created in /tmp.")
 }
 
 func validateSkipIntegrationTests(skipIntegrationTests string) error {
 	if skipIntegrationTests != "" && !strings.HasPrefix(skipIntegrationTests, "b/") {
-		return errors.New(
-			"skipping integration tests requires a bug to be specified, e.g. -skip-integration-tests=b/12345",
-		)
+		return errors.New("skipping integration tests requires a bug to be specified, e.g. -skip-integration-tests=b/12345")
 	}
 	return nil
 }

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -128,7 +128,14 @@ func runGenerate(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	containerConfig, err := docker.New(workRoot, image, cfg.Project, cfg.UserUID, cfg.UserGID, config)
+	containerConfig, err := docker.New(
+		workRoot,
+		image,
+		cfg.Project,
+		cfg.UserUID,
+		cfg.UserGID,
+		config,
+	)
 	if err != nil {
 		return err
 	}
@@ -157,7 +164,9 @@ func executeGenerate(ctx context.Context, state *commandState, cfg *config.Confi
 	}
 	if cfg.Build {
 		if libraryID != "" {
-			slog.Info("Build requested in the context of refined generation; cleaning and copying code to the local language repo before building.")
+			slog.Info(
+				"Build requested in the context of refined generation; cleaning and copying code to the local language repo before building.",
+			)
 			if err := state.containerConfig.Clean(ctx, cfg, state.languageRepo.Dir, libraryID); err != nil {
 				return err
 			}
@@ -180,7 +189,12 @@ func executeGenerate(ctx context.Context, state *commandState, cfg *config.Confi
 // and log the error.
 // If refined generation is used, the context's languageRepo field will be populated and the
 // library ID will be returned; otherwise, an empty string will be returned.
-func runGenerateCommand(ctx context.Context, state *commandState, cfg *config.Config, outputDir string) (string, error) {
+func runGenerateCommand(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	outputDir string,
+) (string, error) {
 	apiRoot, err := filepath.Abs(cfg.Source)
 	if err != nil {
 		return "", err
@@ -191,11 +205,20 @@ func runGenerateCommand(ctx context.Context, state *commandState, cfg *config.Co
 	if state.languageRepo != nil {
 		libraryID := findLibraryIDByApiPath(state.pipelineState, cfg.API)
 		if libraryID == "" {
-			return "", errors.New("bug in Librarian: Library not found during generation, despite being found in earlier steps")
+			return "", errors.New(
+				"bug in Librarian: Library not found during generation, despite being found in earlier steps",
+			)
 		}
 		generatorInput := filepath.Join(state.languageRepo.Dir, config.GeneratorInputDir)
 		slog.Info("Performing refined generation for library", "id", libraryID)
-		return libraryID, state.containerConfig.GenerateLibrary(ctx, cfg, apiRoot, outputDir, generatorInput, libraryID)
+		return libraryID, state.containerConfig.GenerateLibrary(
+			ctx,
+			cfg,
+			apiRoot,
+			outputDir,
+			generatorInput,
+			libraryID,
+		)
 	} else {
 		slog.Info("No matching library found (or no repo specified); performing raw generation", "path", cfg.API)
 		return "", state.containerConfig.GenerateRaw(ctx, cfg, apiRoot, outputDir, cfg.API)
@@ -207,7 +230,10 @@ func runGenerateCommand(ctx context.Context, state *commandState, cfg *config.Co
 // pipeline state if repoRoot has been specified, or the remote pipeline state (just
 // by fetching the single file) if flatRepoUrl has been specified. If neither the repo
 // root not the repo url has been specified, we always perform raw generation.
-func detectIfLibraryConfigured(ctx context.Context, apiPath, repo, gitHubToken string) (bool, error) {
+func detectIfLibraryConfigured(
+	ctx context.Context,
+	apiPath, repo, gitHubToken string,
+) (bool, error) {
 	if repo == "" {
 		slog.Warn("repo is not specified, cannot check if library exists")
 		return false, nil
@@ -220,7 +246,9 @@ func detectIfLibraryConfigured(ctx context.Context, apiPath, repo, gitHubToken s
 	)
 	if !isUrl(repo) {
 		// repo is a directory
-		pipelineState, err = loadPipelineStateFile(filepath.Join(repo, config.GeneratorInputDir, pipelineStateFile))
+		pipelineState, err = loadPipelineStateFile(
+			filepath.Join(repo, config.GeneratorInputDir, pipelineStateFile),
+		)
 		if err != nil {
 			return false, err
 		}

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -179,11 +179,7 @@ func mergeReleasePR(ctx context.Context, workRoot string, cfg *config.Config) er
 // TODO(https://github.com/googleapis/librarian/issues/544): make timing configurable?
 const sleepDelay = time.Duration(60) * time.Second
 
-func waitForPullRequestReadiness(
-	ctx context.Context,
-	prMetadata *github.PullRequestMetadata,
-	cfg *config.Config,
-) error {
+func waitForPullRequestReadiness(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) error {
 	// TODO(https://github.com/googleapis/librarian/issues/543): time out here, or let Kokoro do so?
 
 	for {
@@ -216,11 +212,7 @@ func waitForPullRequestReadiness(
 //     released by the PR
 //   - There must be at least one approving reviews from a member/owner of the
 //     repo, and no reviews from members/owners requesting changes
-func waitForPullRequestReadinessSingleIteration(
-	ctx context.Context,
-	prMetadata *github.PullRequestMetadata,
-	cfg *config.Config,
-) (bool, error) {
+func waitForPullRequestReadinessSingleIteration(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) (bool, error) {
 	slog.Info("Checking pull request for readiness")
 	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
@@ -256,11 +248,7 @@ func waitForPullRequestReadinessSingleIteration(
 	gotDoNotMergeLabel := false
 	for _, label := range pr.Labels {
 		if label.GetName() == MergeBlockedLabel {
-			slog.Info(
-				"PR still has merge-blocked label; skipping other checks",
-				"label",
-				MergeBlockedLabel,
-			)
+			slog.Info("PR still has merge-blocked label; skipping other checks", "label", MergeBlockedLabel)
 			return false, nil
 		}
 		if label.GetName() == DoNotMergeLabel {
@@ -270,23 +258,13 @@ func waitForPullRequestReadinessSingleIteration(
 
 	// We expect to remove the do-not-merge label ourselves (and we'll fail otherwise).
 	if !gotDoNotMergeLabel {
-		return false, reportBlockingReason(
-			ctx,
-			prMetadata,
-			fmt.Sprintf("Label '%s' has been removed already", DoNotMergeLabel),
-			cfg,
-		)
+		return false, reportBlockingReason(ctx, prMetadata, fmt.Sprintf("Label '%s' has been removed already", DoNotMergeLabel), cfg)
 	}
 
 	// If the PR isn't mergeable, that requires user action.
 	if !pr.GetMergeable() {
 		// This will log the reason.
-		return false, reportBlockingReason(
-			ctx,
-			prMetadata,
-			"PR is not mergeable (e.g. there are conflicting commit)",
-			cfg,
-		)
+		return false, reportBlockingReason(ctx, prMetadata, "PR is not mergeable (e.g. there are conflicting commit)", cfg)
 	}
 
 	// Check that all the statuses have passed.
@@ -297,8 +275,7 @@ func waitForPullRequestReadinessSingleIteration(
 	for _, checkRun := range checkRuns {
 		// Skip the do-not-merge check and conventional commits checks
 		// (Once b/416489721 has been fixed, we can remove the conventional commits check)
-		if checkRun.GetApp().GetID() == DoNotMergeAppId ||
-			checkRun.GetApp().GetID() == ConventionalCommitsAppId {
+		if checkRun.GetApp().GetID() == DoNotMergeAppId || checkRun.GetApp().GetID() == ConventionalCommitsAppId {
 			continue
 		}
 
@@ -310,12 +287,7 @@ func waitForPullRequestReadinessSingleIteration(
 			return false, nil
 		}
 		if checkRun.GetConclusion() != "success" {
-			return false, reportBlockingReason(
-				ctx,
-				prMetadata,
-				fmt.Sprintf("Check '%s' failed", *checkRun.Name),
-				cfg,
-			)
+			return false, reportBlockingReason(ctx, prMetadata, fmt.Sprintf("Check '%s' failed", *checkRun.Name), cfg)
 		}
 	}
 
@@ -343,11 +315,7 @@ func waitForPullRequestReadinessSingleIteration(
 	return true, nil
 }
 
-func mergePullRequest(
-	ctx context.Context,
-	prMetadata *github.PullRequestMetadata,
-	cfg *config.Config,
-) (string, error) {
+func mergePullRequest(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) (string, error) {
 	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return "", err
@@ -356,12 +324,7 @@ func mergePullRequest(
 	if err := ghClient.RemoveLabelFromPullRequest(ctx, prMetadata.Repo, prMetadata.Number, "do-not-merge"); err != nil {
 		return "", err
 	}
-	mergeResult, err := ghClient.MergePullRequest(
-		ctx,
-		prMetadata.Repo,
-		prMetadata.Number,
-		github.MergeMethodRebase,
-	)
+	mergeResult, err := ghClient.MergePullRequest(ctx, prMetadata.Repo, prMetadata.Number, github.MergeMethodRebase)
 	if err != nil {
 		return "", err
 	}
@@ -424,23 +387,13 @@ func waitForSync(mergeCommit string, cfg *config.Config) error {
 //
 // Returns true if all the commits are fine, or false if a problem was detected, in which
 // case it will have been reported on the PR, and the merge-blocking label applied.
-func checkPullRequestCommits(
-	ctx context.Context,
-	prMetadata *github.PullRequestMetadata,
-	pr *github.PullRequest,
-	cfg *config.Config,
-) (bool, error) {
+func checkPullRequestCommits(ctx context.Context, prMetadata *github.PullRequestMetadata, pr *github.PullRequest, cfg *config.Config) (bool, error) {
 	baseRepo := github.CreateGitHubRepoFromRepository(pr.Base.Repo)
 	baseHeadState, err := fetchRemotePipelineState(ctx, baseRepo, *pr.Base.Ref, cfg.GitHubToken)
 	if err != nil {
 		return false, err
 	}
-	baselineState, err := fetchRemotePipelineState(
-		ctx,
-		baseRepo,
-		cfg.BaselineCommit,
-		cfg.GitHubToken,
-	)
+	baselineState, err := fetchRemotePipelineState(ctx, baseRepo, cfg.BaselineCommit, cfg.GitHubToken)
 	if err != nil {
 		return false, err
 	}
@@ -471,12 +424,7 @@ func checkPullRequestCommits(
 
 	for _, release := range releases {
 		if strings.HasPrefix(release.ReleaseNotes, "FIXME") {
-			return false, reportBlockingReason(
-				ctx,
-				prMetadata,
-				fmt.Sprintf("Release notes for '%s' need fixing", release.LibraryID),
-				cfg,
-			)
+			return false, reportBlockingReason(ctx, prMetadata, fmt.Sprintf("Release notes for '%s' need fixing", release.LibraryID), cfg)
 		}
 	}
 
@@ -497,13 +445,7 @@ func checkPullRequestCommits(
 
 	suspectReleases := []SuspectRelease{}
 
-	slog.Info(
-		"Checking commits against libraries for intervening changes",
-		"commits",
-		len(fullBaseCommits),
-		"libraries",
-		len(releases),
-	)
+	slog.Info("Checking commits against libraries for intervening changes", "commits", len(fullBaseCommits), "libraries", len(releases))
 	for _, release := range releases {
 		suspectRelease := checkRelease(release, baseHeadState, baselineState, fullBaseCommits)
 		if suspectRelease != nil {
@@ -516,23 +458,15 @@ func checkPullRequestCommits(
 	}
 
 	var builder strings.Builder
-	builder.WriteString(
-		"At least one library being released may have changed since release PR creation:\n\n",
-	)
+	builder.WriteString("At least one library being released may have changed since release PR creation:\n\n")
 	for _, suspectRelease := range suspectReleases {
-		builder.WriteString(
-			fmt.Sprintf("%s: %s\n", suspectRelease.LibraryID, suspectRelease.Reason),
-		)
+		builder.WriteString(fmt.Sprintf("%s: %s\n", suspectRelease.LibraryID, suspectRelease.Reason))
 	}
 	return false, reportBlockingReason(ctx, prMetadata, builder.String(), cfg)
 }
 
 // Checks that the pull request has at least one approved review, and no "changes requested" reviews.
-func checkPullRequestApproval(
-	ctx context.Context,
-	prMetadata *github.PullRequestMetadata,
-	cfg *config.Config,
-) (bool, error) {
+func checkPullRequestApproval(ctx context.Context, prMetadata *github.PullRequestMetadata, cfg *config.Config) (bool, error) {
 	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return false, err
@@ -548,8 +482,7 @@ func checkPullRequestApproval(
 	for _, review := range reviews {
 		association := review.GetAuthorAssociation()
 		// TODO(https://github.com/googleapis/librarian/issues/545): check the required approvals
-		if association != "MEMBER" && association != "OWNER" && association != "COLLABORATOR" &&
-			association != "CONTRIBUTOR" {
+		if association != "MEMBER" && association != "OWNER" && association != "COLLABORATOR" && association != "CONTRIBUTOR" {
 			slog.Info("Ignoring review with author association", "association", association)
 			continue
 		}
@@ -561,21 +494,14 @@ func checkPullRequestApproval(
 
 		userID := review.GetUser().GetID()
 		// Need to ensure review is the latest for the user
-		if current, exists := latestReviews[userID]; !exists ||
-			review.GetSubmittedAt().After(current.GetSubmittedAt().Time) {
+		if current, exists := latestReviews[userID]; !exists || review.GetSubmittedAt().After(current.GetSubmittedAt().Time) {
 			latestReviews[userID] = review
 		}
 	}
 
 	approved := false
 	for _, review := range latestReviews {
-		slog.Info(
-			"Review state",
-			"submitted_at",
-			review.GetSubmittedAt().Format(time.RFC3339),
-			"state",
-			review.GetState(),
-		)
+		slog.Info("Review state", "submitted_at", review.GetSubmittedAt().Format(time.RFC3339), "state", review.GetState())
 		if review.GetState() == "APPROVED" {
 			approved = true
 		} else if review.GetState() == "CHANGES_REQUESTED" {
@@ -586,24 +512,9 @@ func checkPullRequestApproval(
 	return approved, nil
 }
 
-func reportBlockingReason(
-	ctx context.Context,
-	prMetadata *github.PullRequestMetadata,
-	description string,
-	cfg *config.Config,
-) error {
-	slog.Warn(
-		"Adding label to PR and commenting with description",
-		"label",
-		MergeBlockedLabel,
-		"description",
-		description,
-	)
-	comment := fmt.Sprintf(
-		"%s\n\nAfter resolving the issue, please remove the '%s' label.",
-		description,
-		MergeBlockedLabel,
-	)
+func reportBlockingReason(ctx context.Context, prMetadata *github.PullRequestMetadata, description string, cfg *config.Config) error {
+	slog.Warn("Adding label to PR and commenting with description", "label", MergeBlockedLabel, "description", description)
+	comment := fmt.Sprintf("%s\n\nAfter resolving the issue, please remove the '%s' label.", description, MergeBlockedLabel)
 	ghClient, err := github.NewClient(cfg.GitHubToken)
 	if err != nil {
 		return err
@@ -617,31 +528,18 @@ func reportBlockingReason(
 	return nil
 }
 
-func checkRelease(
-	release LibraryRelease,
-	baseHeadState, baselineState *statepb.PipelineState,
-	baseCommits []*github.RepositoryCommit,
-) *SuspectRelease {
+func checkRelease(release LibraryRelease, baseHeadState, baselineState *statepb.PipelineState, baseCommits []*github.RepositoryCommit) *SuspectRelease {
 	baseHeadLibrary := findLibraryByID(baseHeadState, release.LibraryID)
 	if baseHeadLibrary == nil {
-		return &SuspectRelease{
-			LibraryID: release.LibraryID,
-			Reason:    "Library does not exist in head pipeline state",
-		}
+		return &SuspectRelease{LibraryID: release.LibraryID, Reason: "Library does not exist in head pipeline state"}
 	}
 	baselineLibrary := findLibraryByID(baselineState, release.LibraryID)
 	if baselineLibrary == nil {
-		return &SuspectRelease{
-			LibraryID: release.LibraryID,
-			Reason:    "Library does not exist in baseline commit pipeline state",
-		}
+		return &SuspectRelease{LibraryID: release.LibraryID, Reason: "Library does not exist in baseline commit pipeline state"}
 	}
 	// TODO(https://github.com/googleapis/librarian/issues/546): find a better way of comparing these.
 	if baseHeadLibrary.String() != baselineLibrary.String() {
-		return &SuspectRelease{
-			LibraryID: release.LibraryID,
-			Reason:    "Pipeline state has changed between baseline and head",
-		}
+		return &SuspectRelease{LibraryID: release.LibraryID, Reason: "Pipeline state has changed between baseline and head"}
 	}
 	sourcePaths := append(baseHeadState.CommonLibrarySourcePaths, baseHeadLibrary.SourcePaths...)
 	changeCommits := []string{}
@@ -651,10 +549,7 @@ func checkRelease(
 		}
 	}
 	if len(changeCommits) > 0 {
-		reason := fmt.Sprintf(
-			"Library source changed in intervening commits: %s",
-			strings.Join(changeCommits, ", "),
-		)
+		reason := fmt.Sprintf("Library source changed in intervening commits: %s", strings.Join(changeCommits, ", "))
 		return &SuspectRelease{LibraryID: release.LibraryID, Reason: reason}
 	}
 	return nil
@@ -664,8 +559,7 @@ func checkIfCommitAffectsAnySourcePath(commit *github.RepositoryCommit, sourcePa
 	for _, commitFile := range commit.Files {
 		changedPath := *commitFile.Filename
 		for _, sourcePath := range sourcePaths {
-			if changedPath == sourcePath ||
-				(strings.HasPrefix(changedPath, sourcePath) && strings.HasPrefix(changedPath, sourcePath+"/")) {
+			if changedPath == sourcePath || (strings.HasPrefix(changedPath, sourcePath) && strings.HasPrefix(changedPath, sourcePath+"/")) {
 				return true
 			}
 		}
@@ -673,10 +567,7 @@ func checkIfCommitAffectsAnySourcePath(commit *github.RepositoryCommit, sourcePa
 	return false
 }
 
-func parseRemoteCommitsForReleases(
-	commits []*github.RepositoryCommit,
-	releaseID string,
-) ([]LibraryRelease, error) {
+func parseRemoteCommitsForReleases(commits []*github.RepositoryCommit, releaseID string) ([]LibraryRelease, error) {
 	releases := []LibraryRelease{}
 	for _, commit := range commits {
 		release, err := parseCommitMessageForRelease(*commit.Commit.Message, *commit.SHA)
@@ -684,11 +575,7 @@ func parseRemoteCommitsForReleases(
 			return nil, err
 		}
 		if release.ReleaseID != releaseID {
-			return nil, fmt.Errorf(
-				"while finding releases for release ID %s, found commit with release ID %s",
-				releaseID,
-				release.ReleaseID,
-			)
+			return nil, fmt.Errorf("while finding releases for release ID %s, found commit with release ID %s", releaseID, release.ReleaseID)
 		}
 		releases = append(releases, *release)
 	}

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -81,9 +81,7 @@ func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	pipelineConfig, err := loadPipelineConfigFile(
-		filepath.Join(cfg.ArtifactRoot, pipelineConfigFile),
-	)
+	pipelineConfig, err := loadPipelineConfigFile(filepath.Join(cfg.ArtifactRoot, pipelineConfigFile))
 	if err != nil {
 		return err
 	}
@@ -99,25 +97,14 @@ func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	containerConfig, err := docker.New(
-		workRoot,
-		image,
-		cfg.Project,
-		cfg.UserUID,
-		cfg.UserGID,
-		pipelineConfig,
-	)
+	containerConfig, err := docker.New(workRoot, image, cfg.Project, cfg.UserUID, cfg.UserGID, pipelineConfig)
 	if err != nil {
 		return err
 	}
 	return publishReleaseArtifacts(ctx, containerConfig, cfg)
 }
 
-func publishReleaseArtifacts(
-	ctx context.Context,
-	containerConfig *docker.Docker,
-	cfg *config.Config,
-) error {
+func publishReleaseArtifacts(ctx context.Context, containerConfig *docker.Docker, cfg *config.Config) error {
 	if err := validateRequiredFlag("tag-repo-url", cfg.TagRepoURL); err != nil {
 		return err
 	}
@@ -154,12 +141,7 @@ func publishReleaseArtifacts(
 	return nil
 }
 
-func publishPackages(
-	ctx context.Context,
-	config *docker.Docker,
-	cfg *config.Config,
-	releases []LibraryRelease,
-) error {
+func publishPackages(ctx context.Context, config *docker.Docker, cfg *config.Config, releases []LibraryRelease) error {
 	for _, release := range releases {
 		outputDir := filepath.Join(cfg.ArtifactRoot, release.LibraryID)
 		if err := config.PublishLibrary(ctx, cfg, outputDir, release.LibraryID, release.Version); err != nil {
@@ -170,12 +152,7 @@ func publishPackages(
 	return nil
 }
 
-func createRepoReleases(
-	ctx context.Context,
-	releases []LibraryRelease,
-	gitHubRepo *github.Repository,
-	gitHubToken string,
-) error {
+func createRepoReleases(ctx context.Context, releases []LibraryRelease, gitHubRepo *github.Repository, gitHubToken string) error {
 	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return err
@@ -183,17 +160,8 @@ func createRepoReleases(
 	for _, release := range releases {
 		tag := formatReleaseTag(release.LibraryID, release.Version)
 		title := fmt.Sprintf("%s version %s", release.LibraryID, release.Version)
-		prerelease := strings.HasPrefix(release.Version, "0.") ||
-			strings.Contains(release.Version, "-")
-		repoRelease, err := ghClient.CreateRelease(
-			ctx,
-			gitHubRepo,
-			tag,
-			release.CommitHash,
-			title,
-			release.ReleaseNotes,
-			prerelease,
-		)
+		prerelease := strings.HasPrefix(release.Version, "0.") || strings.Contains(release.Version, "-")
+		repoRelease, err := ghClient.CreateRelease(ctx, gitHubRepo, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -81,7 +81,9 @@ func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	pipelineConfig, err := loadPipelineConfigFile(filepath.Join(cfg.ArtifactRoot, pipelineConfigFile))
+	pipelineConfig, err := loadPipelineConfigFile(
+		filepath.Join(cfg.ArtifactRoot, pipelineConfigFile),
+	)
 	if err != nil {
 		return err
 	}
@@ -97,14 +99,25 @@ func runPublishReleaseArtifacts(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	containerConfig, err := docker.New(workRoot, image, cfg.Project, cfg.UserUID, cfg.UserGID, pipelineConfig)
+	containerConfig, err := docker.New(
+		workRoot,
+		image,
+		cfg.Project,
+		cfg.UserUID,
+		cfg.UserGID,
+		pipelineConfig,
+	)
 	if err != nil {
 		return err
 	}
 	return publishReleaseArtifacts(ctx, containerConfig, cfg)
 }
 
-func publishReleaseArtifacts(ctx context.Context, containerConfig *docker.Docker, cfg *config.Config) error {
+func publishReleaseArtifacts(
+	ctx context.Context,
+	containerConfig *docker.Docker,
+	cfg *config.Config,
+) error {
 	if err := validateRequiredFlag("tag-repo-url", cfg.TagRepoURL); err != nil {
 		return err
 	}
@@ -141,7 +154,12 @@ func publishReleaseArtifacts(ctx context.Context, containerConfig *docker.Docker
 	return nil
 }
 
-func publishPackages(ctx context.Context, config *docker.Docker, cfg *config.Config, releases []LibraryRelease) error {
+func publishPackages(
+	ctx context.Context,
+	config *docker.Docker,
+	cfg *config.Config,
+	releases []LibraryRelease,
+) error {
 	for _, release := range releases {
 		outputDir := filepath.Join(cfg.ArtifactRoot, release.LibraryID)
 		if err := config.PublishLibrary(ctx, cfg, outputDir, release.LibraryID, release.Version); err != nil {
@@ -152,7 +170,12 @@ func publishPackages(ctx context.Context, config *docker.Docker, cfg *config.Con
 	return nil
 }
 
-func createRepoReleases(ctx context.Context, releases []LibraryRelease, gitHubRepo *github.Repository, gitHubToken string) error {
+func createRepoReleases(
+	ctx context.Context,
+	releases []LibraryRelease,
+	gitHubRepo *github.Repository,
+	gitHubToken string,
+) error {
 	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return err
@@ -160,8 +183,17 @@ func createRepoReleases(ctx context.Context, releases []LibraryRelease, gitHubRe
 	for _, release := range releases {
 		tag := formatReleaseTag(release.LibraryID, release.Version)
 		title := fmt.Sprintf("%s version %s", release.LibraryID, release.Version)
-		prerelease := strings.HasPrefix(release.Version, "0.") || strings.Contains(release.Version, "-")
-		repoRelease, err := ghClient.CreateRelease(ctx, gitHubRepo, tag, release.CommitHash, title, release.ReleaseNotes, prerelease)
+		prerelease := strings.HasPrefix(release.Version, "0.") ||
+			strings.Contains(release.Version, "-")
+		repoRelease, err := ghClient.CreateRelease(
+			ctx,
+			gitHubRepo,
+			tag,
+			release.CommitHash,
+			title,
+			release.ReleaseNotes,
+			prerelease,
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/pullrequest.go
+++ b/internal/librarian/pullrequest.go
@@ -67,14 +67,7 @@ func addSuccessToPullRequest(pr *PullRequestContent, text string) {
 //
 // If the pull request would contain an excessive number of commits (as
 // configured in pipeline-config.json).
-func createPullRequest(
-	ctx context.Context,
-	state *commandState,
-	content *PullRequestContent,
-	titlePrefix, descriptionSuffix, branchType string,
-	gitHubToken string,
-	push bool,
-) (*github.PullRequestMetadata, error) {
+func createPullRequest(ctx context.Context, state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*github.PullRequestMetadata, error) {
 	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
@@ -90,11 +83,7 @@ func createPullRequest(
 			// We've got too many commits. Roll some back locally, and we'll add them to the description.
 			excessSuccesses = content.Successes[maxCommits:]
 			content.Successes = content.Successes[:maxCommits]
-			slog.Info(
-				"Excess commits created; winding back language repo",
-				"excess_commits",
-				len(excessSuccesses),
-			)
+			slog.Info("Excess commits created; winding back language repo", "excess_commits", len(excessSuccesses))
 			if err := languageRepo.CleanAndRevertCommits(len(excessSuccesses)); err != nil {
 				return nil, err
 			}
@@ -117,20 +106,12 @@ func createPullRequest(
 	errorsText := formatListAsMarkdown("Errors", content.Errors)
 	excessText := formatListAsMarkdown("Excess changes not included", excessSuccesses)
 
-	description = strings.TrimSpace(
-		successesText + errorsText + excessText + "\n" + descriptionSuffix,
-	)
+	description = strings.TrimSpace(successesText + errorsText + excessText + "\n" + descriptionSuffix)
 
 	title := fmt.Sprintf("%s: %s", titlePrefix, formatTimestamp(state.startTime))
 
 	if !push {
-		slog.Info(
-			"Push not specified; would have created PR",
-			"title",
-			title,
-			"description",
-			description,
-		)
+		slog.Info("Push not specified; would have created PR", "title", title, "description", description)
 		return nil, nil
 	}
 
@@ -191,10 +172,7 @@ func getGitHubRepoFromRemote(repo *gitrepo.Repository) (*github.Repository, erro
 
 	if len(gitHubRemoteNames) > 1 {
 		joinedRemoteNames := strings.Join(gitHubRemoteNames, ", ")
-		return nil, fmt.Errorf(
-			"can only determine the GitHub repo with a single matching remote; GitHub remotes in repo: %s",
-			joinedRemoteNames,
-		)
+		return nil, fmt.Errorf("can only determine the GitHub repo with a single matching remote; GitHub remotes in repo: %s", joinedRemoteNames)
 	}
 	return github.ParseUrl(gitHubUrl)
 }

--- a/internal/librarian/pullrequest.go
+++ b/internal/librarian/pullrequest.go
@@ -67,7 +67,14 @@ func addSuccessToPullRequest(pr *PullRequestContent, text string) {
 //
 // If the pull request would contain an excessive number of commits (as
 // configured in pipeline-config.json).
-func createPullRequest(ctx context.Context, state *commandState, content *PullRequestContent, titlePrefix, descriptionSuffix, branchType string, gitHubToken string, push bool) (*github.PullRequestMetadata, error) {
+func createPullRequest(
+	ctx context.Context,
+	state *commandState,
+	content *PullRequestContent,
+	titlePrefix, descriptionSuffix, branchType string,
+	gitHubToken string,
+	push bool,
+) (*github.PullRequestMetadata, error) {
 	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
@@ -83,7 +90,11 @@ func createPullRequest(ctx context.Context, state *commandState, content *PullRe
 			// We've got too many commits. Roll some back locally, and we'll add them to the description.
 			excessSuccesses = content.Successes[maxCommits:]
 			content.Successes = content.Successes[:maxCommits]
-			slog.Info("Excess commits created; winding back language repo", "excess_commits", len(excessSuccesses))
+			slog.Info(
+				"Excess commits created; winding back language repo",
+				"excess_commits",
+				len(excessSuccesses),
+			)
 			if err := languageRepo.CleanAndRevertCommits(len(excessSuccesses)); err != nil {
 				return nil, err
 			}
@@ -106,12 +117,20 @@ func createPullRequest(ctx context.Context, state *commandState, content *PullRe
 	errorsText := formatListAsMarkdown("Errors", content.Errors)
 	excessText := formatListAsMarkdown("Excess changes not included", excessSuccesses)
 
-	description = strings.TrimSpace(successesText + errorsText + excessText + "\n" + descriptionSuffix)
+	description = strings.TrimSpace(
+		successesText + errorsText + excessText + "\n" + descriptionSuffix,
+	)
 
 	title := fmt.Sprintf("%s: %s", titlePrefix, formatTimestamp(state.startTime))
 
 	if !push {
-		slog.Info("Push not specified; would have created PR", "title", title, "description", description)
+		slog.Info(
+			"Push not specified; would have created PR",
+			"title",
+			title,
+			"description",
+			description,
+		)
 		return nil, nil
 	}
 
@@ -172,7 +191,10 @@ func getGitHubRepoFromRemote(repo *gitrepo.Repository) (*github.Repository, erro
 
 	if len(gitHubRemoteNames) > 1 {
 		joinedRemoteNames := strings.Join(gitHubRemoteNames, ", ")
-		return nil, fmt.Errorf("can only determine the GitHub repo with a single matching remote; GitHub remotes in repo: %s", joinedRemoteNames)
+		return nil, fmt.Errorf(
+			"can only determine the GitHub repo with a single matching remote; GitHub remotes in repo: %s",
+			joinedRemoteNames,
+		)
 	}
 	return github.ParseUrl(gitHubUrl)
 }

--- a/internal/librarian/stateandconfig.go
+++ b/internal/librarian/stateandconfig.go
@@ -34,9 +34,7 @@ const pipelineConfigFile = "pipeline-config.json"
 
 // Utility functions for saving and loading pipeline state and config from various places.
 
-func loadRepoStateAndConfig(
-	languageRepo *gitrepo.Repository,
-) (*statepb.PipelineState, *statepb.PipelineConfig, error) {
+func loadRepoStateAndConfig(languageRepo *gitrepo.Repository) (*statepb.PipelineState, *statepb.PipelineConfig, error) {
 	if languageRepo == nil {
 		return nil, nil, nil
 	}
@@ -88,23 +86,13 @@ func savePipelineState(state *commandState) error {
 	return err
 }
 
-func fetchRemotePipelineState(
-	ctx context.Context,
-	repo *github.Repository,
-	ref string,
-	gitHubToken string,
-) (*statepb.PipelineState, error) {
+func fetchRemotePipelineState(ctx context.Context, repo *github.Repository, ref string, gitHubToken string) (*statepb.PipelineState, error) {
 	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
 	}
 	return parsePipelineState(func() ([]byte, error) {
-		return ghClient.GetRawContent(
-			ctx,
-			repo,
-			config.GeneratorInputDir+"/"+pipelineStateFile,
-			ref,
-		)
+		return ghClient.GetRawContent(ctx, repo, config.GeneratorInputDir+"/"+pipelineStateFile, ref)
 	})
 }
 

--- a/internal/librarian/stateandconfig.go
+++ b/internal/librarian/stateandconfig.go
@@ -34,7 +34,9 @@ const pipelineConfigFile = "pipeline-config.json"
 
 // Utility functions for saving and loading pipeline state and config from various places.
 
-func loadRepoStateAndConfig(languageRepo *gitrepo.Repository) (*statepb.PipelineState, *statepb.PipelineConfig, error) {
+func loadRepoStateAndConfig(
+	languageRepo *gitrepo.Repository,
+) (*statepb.PipelineState, *statepb.PipelineConfig, error) {
 	if languageRepo == nil {
 		return nil, nil, nil
 	}
@@ -86,13 +88,23 @@ func savePipelineState(state *commandState) error {
 	return err
 }
 
-func fetchRemotePipelineState(ctx context.Context, repo *github.Repository, ref string, gitHubToken string) (*statepb.PipelineState, error) {
+func fetchRemotePipelineState(
+	ctx context.Context,
+	repo *github.Repository,
+	ref string,
+	gitHubToken string,
+) (*statepb.PipelineState, error) {
 	ghClient, err := github.NewClient(gitHubToken)
 	if err != nil {
 		return nil, err
 	}
 	return parsePipelineState(func() ([]byte, error) {
-		return ghClient.GetRawContent(ctx, repo, config.GeneratorInputDir+"/"+pipelineStateFile, ref)
+		return ghClient.GetRawContent(
+			ctx,
+			repo,
+			config.GeneratorInputDir+"/"+pipelineStateFile,
+			ref,
+		)
 	})
 }
 

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -100,15 +100,7 @@ func init() {
 }
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(
-		cfg.WorkRoot,
-		cfg.Repo,
-		cfg.Image,
-		cfg.Project,
-		cfg.CI,
-		cfg.UserUID,
-		cfg.UserGID,
-	)
+	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Image, cfg.Project, cfg.CI, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return err
 	}
@@ -174,28 +166,12 @@ func updateAPIs(ctx context.Context, state *commandState, cfg *config.Config) er
 			return err
 		}
 	}
-	_, err := createPullRequest(
-		ctx,
-		state,
-		prContent,
-		"feat: API regeneration",
-		"",
-		"regen",
-		cfg.GitHubToken,
-		cfg.Push,
-	)
+	_, err := createPullRequest(ctx, state, prContent, "feat: API regeneration", "", "regen", cfg.GitHubToken, cfg.Push)
 	return err
 }
 
-func updateLibrary(
-	ctx context.Context,
-	state *commandState,
-	cfg *config.Config,
-	apiRepo *gitrepo.Repository,
-	outputRoot string,
-	library *statepb.LibraryState,
-	prContent *PullRequestContent,
-) error {
+func updateLibrary(ctx context.Context, state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, outputRoot string, library *statepb.LibraryState,
+	prContent *PullRequestContent) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 
@@ -215,10 +191,7 @@ func updateLibrary(
 	}
 
 	initialGeneration := library.LastGeneratedCommit == ""
-	commits, err := apiRepo.GetCommitsForPathsSinceCommit(
-		library.ApiPaths,
-		library.LastGeneratedCommit,
-	)
+	commits, err := apiRepo.GetCommitsForPathsSinceCommit(library.ApiPaths, library.LastGeneratedCommit)
 	if err != nil {
 		return err
 	}
@@ -313,13 +286,7 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 	var builder strings.Builder
 
 	// Start the commit with a line on its own saying what's being regenerated.
-	builder.WriteString(
-		fmt.Sprintf(
-			"regen: Regenerate %s at API commit %s",
-			libraryID,
-			commits[0].Hash.String()[0:7],
-		),
-	)
+	builder.WriteString(fmt.Sprintf("regen: Regenerate %s at API commit %s", libraryID, commits[0].Hash.String()[0:7]))
 	builder.WriteString("\n")
 	builder.WriteString("\n")
 
@@ -330,13 +297,7 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 	for i := len(commits) - 1; i >= 0; i-- {
 		commit := commits[i]
 		messageLines := strings.Split(commit.Message, "\n")
-		sourceLinkLines = append(
-			sourceLinkLines,
-			fmt.Sprintf(
-				"Source-Link: https://github.com/googleapis/googleapis/commit/%s",
-				commit.Hash.String(),
-			),
-		)
+		sourceLinkLines = append(sourceLinkLines, fmt.Sprintf("Source-Link: https://github.com/googleapis/googleapis/commit/%s", commit.Hash.String()))
 		for _, line := range messageLines {
 			if strings.HasPrefix(line, PiperPrefix) {
 				piperRevIdLines = append(piperRevIdLines, line)

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -98,7 +98,15 @@ func init() {
 }
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Image, cfg.Project, cfg.CI, cfg.UserUID, cfg.UserGID)
+	state, err := createCommandStateForLanguage(
+		cfg.WorkRoot,
+		cfg.Repo,
+		cfg.Image,
+		cfg.Project,
+		cfg.CI,
+		cfg.UserUID,
+		cfg.UserGID,
+	)
 	if err != nil {
 		return err
 	}
@@ -164,12 +172,28 @@ func updateAPIs(ctx context.Context, state *commandState, cfg *config.Config) er
 			return err
 		}
 	}
-	_, err := createPullRequest(ctx, state, prContent, "feat: API regeneration", "", "regen", cfg.GitHubToken, cfg.Push)
+	_, err := createPullRequest(
+		ctx,
+		state,
+		prContent,
+		"feat: API regeneration",
+		"",
+		"regen",
+		cfg.GitHubToken,
+		cfg.Push,
+	)
 	return err
 }
 
-func updateLibrary(ctx context.Context, state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, outputRoot string, library *statepb.LibraryState,
-	prContent *PullRequestContent) error {
+func updateLibrary(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	apiRepo *gitrepo.Repository,
+	outputRoot string,
+	library *statepb.LibraryState,
+	prContent *PullRequestContent,
+) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 
@@ -189,7 +213,10 @@ func updateLibrary(ctx context.Context, state *commandState, cfg *config.Config,
 	}
 
 	initialGeneration := library.LastGeneratedCommit == ""
-	commits, err := apiRepo.GetCommitsForPathsSinceCommit(library.ApiPaths, library.LastGeneratedCommit)
+	commits, err := apiRepo.GetCommitsForPathsSinceCommit(
+		library.ApiPaths,
+		library.LastGeneratedCommit,
+	)
 	if err != nil {
 		return err
 	}
@@ -284,7 +311,13 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 	var builder strings.Builder
 
 	// Start the commit with a line on its own saying what's being regenerated.
-	builder.WriteString(fmt.Sprintf("regen: Regenerate %s at API commit %s", libraryID, commits[0].Hash.String()[0:7]))
+	builder.WriteString(
+		fmt.Sprintf(
+			"regen: Regenerate %s at API commit %s",
+			libraryID,
+			commits[0].Hash.String()[0:7],
+		),
+	)
 	builder.WriteString("\n")
 	builder.WriteString("\n")
 
@@ -295,7 +328,13 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 	for i := len(commits) - 1; i >= 0; i-- {
 		commit := commits[i]
 		messageLines := strings.Split(commit.Message, "\n")
-		sourceLinkLines = append(sourceLinkLines, fmt.Sprintf("Source-Link: https://github.com/googleapis/googleapis/commit/%s", commit.Hash.String()))
+		sourceLinkLines = append(
+			sourceLinkLines,
+			fmt.Sprintf(
+				"Source-Link: https://github.com/googleapis/googleapis/commit/%s",
+				commit.Hash.String(),
+			),
+		)
 		for _, line := range messageLines {
 			if strings.HasPrefix(line, PiperPrefix) {
 				piperRevIdLines = append(piperRevIdLines, line)

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -100,7 +100,15 @@ func init() {
 }
 
 func runUpdateAPIs(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Image, cfg.Project, cfg.CI, cfg.UserUID, cfg.UserGID)
+	state, err := createCommandStateForLanguage(
+		cfg.WorkRoot,
+		cfg.Repo,
+		cfg.Image,
+		cfg.Project,
+		cfg.CI,
+		cfg.UserUID,
+		cfg.UserGID,
+	)
 	if err != nil {
 		return err
 	}
@@ -166,12 +174,28 @@ func updateAPIs(ctx context.Context, state *commandState, cfg *config.Config) er
 			return err
 		}
 	}
-	_, err := createPullRequest(ctx, state, prContent, "feat: API regeneration", "", "regen", cfg.GitHubToken, cfg.Push)
+	_, err := createPullRequest(
+		ctx,
+		state,
+		prContent,
+		"feat: API regeneration",
+		"",
+		"regen",
+		cfg.GitHubToken,
+		cfg.Push,
+	)
 	return err
 }
 
-func updateLibrary(ctx context.Context, state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, outputRoot string, library *statepb.LibraryState,
-	prContent *PullRequestContent) error {
+func updateLibrary(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	apiRepo *gitrepo.Repository,
+	outputRoot string,
+	library *statepb.LibraryState,
+	prContent *PullRequestContent,
+) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 
@@ -191,7 +215,10 @@ func updateLibrary(ctx context.Context, state *commandState, cfg *config.Config,
 	}
 
 	initialGeneration := library.LastGeneratedCommit == ""
-	commits, err := apiRepo.GetCommitsForPathsSinceCommit(library.ApiPaths, library.LastGeneratedCommit)
+	commits, err := apiRepo.GetCommitsForPathsSinceCommit(
+		library.ApiPaths,
+		library.LastGeneratedCommit,
+	)
 	if err != nil {
 		return err
 	}
@@ -286,7 +313,13 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 	var builder strings.Builder
 
 	// Start the commit with a line on its own saying what's being regenerated.
-	builder.WriteString(fmt.Sprintf("regen: Regenerate %s at API commit %s", libraryID, commits[0].Hash.String()[0:7]))
+	builder.WriteString(
+		fmt.Sprintf(
+			"regen: Regenerate %s at API commit %s",
+			libraryID,
+			commits[0].Hash.String()[0:7],
+		),
+	)
 	builder.WriteString("\n")
 	builder.WriteString("\n")
 
@@ -297,7 +330,13 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 	for i := len(commits) - 1; i >= 0; i-- {
 		commit := commits[i]
 		messageLines := strings.Split(commit.Message, "\n")
-		sourceLinkLines = append(sourceLinkLines, fmt.Sprintf("Source-Link: https://github.com/googleapis/googleapis/commit/%s", commit.Hash.String()))
+		sourceLinkLines = append(
+			sourceLinkLines,
+			fmt.Sprintf(
+				"Source-Link: https://github.com/googleapis/googleapis/commit/%s",
+				commit.Hash.String(),
+			),
+		)
 		for _, line := range messageLines {
 			if strings.HasPrefix(line, PiperPrefix) {
 				piperRevIdLines = append(piperRevIdLines, line)

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -88,7 +88,15 @@ func init() {
 }
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Image, cfg.Project, cfg.CI, cfg.UserUID, cfg.UserGID)
+	state, err := createCommandStateForLanguage(
+		cfg.WorkRoot,
+		cfg.Repo,
+		cfg.Image,
+		cfg.Project,
+		cfg.CI,
+		cfg.UserUID,
+		cfg.UserGID,
+	)
 	if err != nil {
 		return err
 	}
@@ -184,11 +192,28 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 	// can massage it into a similar state.
 	prContent := new(PullRequestContent)
 	addSuccessToPullRequest(prContent, "Regenerated all libraries with new image tag.")
-	_, err = createPullRequest(ctx, state, prContent, "chore: update generation image tag", "", "update-image-tag", cfg.GitHubToken, cfg.Push)
+	_, err = createPullRequest(
+		ctx,
+		state,
+		prContent,
+		"chore: update generation image tag",
+		"",
+		"update-image-tag",
+		cfg.GitHubToken,
+		cfg.Push,
+	)
 	return err
 }
 
-func regenerateLibrary(ctx context.Context, state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, generatorInput string, outputRoot string, library *statepb.LibraryState) error {
+func regenerateLibrary(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	apiRepo *gitrepo.Repository,
+	generatorInput string,
+	outputRoot string,
+	library *statepb.LibraryState,
+) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -86,7 +86,15 @@ func init() {
 }
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Image, cfg.Project, cfg.CI, cfg.UserUID, cfg.UserGID)
+	state, err := createCommandStateForLanguage(
+		cfg.WorkRoot,
+		cfg.Repo,
+		cfg.Image,
+		cfg.Project,
+		cfg.CI,
+		cfg.UserUID,
+		cfg.UserGID,
+	)
 	if err != nil {
 		return err
 	}
@@ -182,11 +190,28 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 	// can massage it into a similar state.
 	prContent := new(PullRequestContent)
 	addSuccessToPullRequest(prContent, "Regenerated all libraries with new image tag.")
-	_, err = createPullRequest(ctx, state, prContent, "chore: update generation image tag", "", "update-image-tag", cfg.GitHubToken, cfg.Push)
+	_, err = createPullRequest(
+		ctx,
+		state,
+		prContent,
+		"chore: update generation image tag",
+		"",
+		"update-image-tag",
+		cfg.GitHubToken,
+		cfg.Push,
+	)
 	return err
 }
 
-func regenerateLibrary(ctx context.Context, state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, generatorInput string, outputRoot string, library *statepb.LibraryState) error {
+func regenerateLibrary(
+	ctx context.Context,
+	state *commandState,
+	cfg *config.Config,
+	apiRepo *gitrepo.Repository,
+	generatorInput string,
+	outputRoot string,
+	library *statepb.LibraryState,
+) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -88,15 +88,7 @@ func init() {
 }
 
 func runUpdateImageTag(ctx context.Context, cfg *config.Config) error {
-	state, err := createCommandStateForLanguage(
-		cfg.WorkRoot,
-		cfg.Repo,
-		cfg.Image,
-		cfg.Project,
-		cfg.CI,
-		cfg.UserUID,
-		cfg.UserGID,
-	)
+	state, err := createCommandStateForLanguage(cfg.WorkRoot, cfg.Repo, cfg.Image, cfg.Project, cfg.CI, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return err
 	}
@@ -192,28 +184,11 @@ func updateImageTag(ctx context.Context, state *commandState, cfg *config.Config
 	// can massage it into a similar state.
 	prContent := new(PullRequestContent)
 	addSuccessToPullRequest(prContent, "Regenerated all libraries with new image tag.")
-	_, err = createPullRequest(
-		ctx,
-		state,
-		prContent,
-		"chore: update generation image tag",
-		"",
-		"update-image-tag",
-		cfg.GitHubToken,
-		cfg.Push,
-	)
+	_, err = createPullRequest(ctx, state, prContent, "chore: update generation image tag", "", "update-image-tag", cfg.GitHubToken, cfg.Push)
 	return err
 }
 
-func regenerateLibrary(
-	ctx context.Context,
-	state *commandState,
-	cfg *config.Config,
-	apiRepo *gitrepo.Repository,
-	generatorInput string,
-	outputRoot string,
-	library *statepb.LibraryState,
-) error {
+func regenerateLibrary(ctx context.Context, state *commandState, cfg *config.Config, apiRepo *gitrepo.Repository, generatorInput string, outputRoot string, library *statepb.LibraryState) error {
 	cc := state.containerConfig
 	languageRepo := state.languageRepo
 

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -28,12 +28,21 @@ import (
 // service. Provide a secretManager.Client to reuse an existing client
 // or a fake implementation for testing.
 type SecretsClient interface {
-	AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	AccessSecretVersion(
+		ctx context.Context,
+		req *secretmanagerpb.AccessSecretVersionRequest,
+		opts ...gax.CallOption,
+	) (*secretmanagerpb.AccessSecretVersionResponse, error)
 }
 
 // Get fetches the latest version of a secret as a string. This method assumes
 // the secret payload is a UTF-8 string.
-func Get(ctx context.Context, project string, secretName string, secretsClient SecretsClient) (_ string, err error) {
+func Get(
+	ctx context.Context,
+	project string,
+	secretName string,
+	secretsClient SecretsClient,
+) (_ string, err error) {
 	if secretsClient == nil {
 		secretsClient, err := secretmanager.NewClient(ctx)
 		if err != nil {

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -28,21 +28,12 @@ import (
 // service. Provide a secretManager.Client to reuse an existing client
 // or a fake implementation for testing.
 type SecretsClient interface {
-	AccessSecretVersion(
-		ctx context.Context,
-		req *secretmanagerpb.AccessSecretVersionRequest,
-		opts ...gax.CallOption,
-	) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
 }
 
 // Get fetches the latest version of a secret as a string. This method assumes
 // the secret payload is a UTF-8 string.
-func Get(
-	ctx context.Context,
-	project string,
-	secretName string,
-	secretsClient SecretsClient,
-) (_ string, err error) {
+func Get(ctx context.Context, project string, secretName string, secretsClient SecretsClient) (_ string, err error) {
 	if secretsClient == nil {
 		secretsClient, err := secretmanager.NewClient(ctx)
 		if err != nil {

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -27,7 +27,11 @@ type mockClient struct {
 	result string
 }
 
-func (c *mockClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+func (c *mockClient) AccessSecretVersion(
+	ctx context.Context,
+	req *secretmanagerpb.AccessSecretVersionRequest,
+	opts ...gax.CallOption,
+) (*secretmanagerpb.AccessSecretVersionResponse, error) {
 	resp := &secretmanagerpb.AccessSecretVersionResponse{
 		Payload: &secretmanagerpb.SecretPayload{
 			Data: []byte(c.result),

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -27,11 +27,7 @@ type mockClient struct {
 	result string
 }
 
-func (c *mockClient) AccessSecretVersion(
-	ctx context.Context,
-	req *secretmanagerpb.AccessSecretVersionRequest,
-	opts ...gax.CallOption,
-) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+func (c *mockClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
 	resp := &secretmanagerpb.AccessSecretVersionResponse{
 		Payload: &secretmanagerpb.SecretPayload{
 			Data: []byte(c.result),


### PR DESCRIPTION
Added formatters and fixed issues, also added documentation on usage.

Note golines formatter and lll linter together can leads to conflicts, even if aligning settings. Preferring golines as it can be used with `golangci-lint run --fix` for shorten long lines automatically.
Will close #713 to avoid conflict.

Fixes #730
