### PR TITLE
refactor(internal/librarian): decompose commandState

### DIFF
--- a/internal/librarian/stateandconfig.go
+++ b/internal/librarian/stateandconfig.go
@@ -67,10 +67,10 @@ func loadPipelineConfigFile(path string) (*statepb.PipelineConfig, error) {
 	return parsePipelineConfig(func() ([]byte, error) { return os.ReadFile(path) })
 }
 
-func savePipelineState(state *commandState) error {
-	path := filepath.Join(state.languageRepo.Dir, config.GeneratorInputDir, pipelineStateFile)
+func savePipelineState(languageRepo *gitrepo.Repository, pipelineState *statepb.PipelineState) error {
+	path := filepath.Join(languageRepo.Dir, config.GeneratorInputDir, pipelineStateFile)
 	// Marshal the protobuf message as JSON...
-	unformatted, err := protojson.Marshal(state.pipelineState)
+	unformatted, err := protojson.Marshal(pipelineState)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This refactoring removes the commandState struct in favor of passing explicit arguments to functions.

The reason is, passing the entire struct to functions made it unclear which specific fields were actually being used, hiding the true dependencies of the function. Mocking a large commandState struct for tests was cumbersome, especially when only one or two fields were needed. 

Fixes #516 