### PR TITLE
refactor(internal/docker): rm commands not used for generate CLI cmd and rm network access limitations

### DIFF
--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -83,64 +83,20 @@ func TestDockerRun(t *testing.T) {
 		want       []string
 	}{
 		{
-			name: "GenerateRaw",
+			name: "Generate",
 			docker: &Docker{
 				Image: testImage,
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.GenerateRaw(ctx, cfg, testAPIRoot, testOutput, testAPIPath)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
-				"-v", fmt.Sprintf("%s:/output", testOutput),
-				"--network=none",
-				testImage,
-				string(CommandGenerateRaw),
-				"--source=/apis",
-				"--output=/output",
-				fmt.Sprintf("--api=%s", testAPIPath),
-			},
-		},
-		{
-			name: "GenerateRaw with user",
-			docker: &Docker{
-				Image: testImage,
-				uid:   testUID,
-				gid:   testGID,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.GenerateRaw(ctx, cfg, testAPIRoot, testOutput, testAPIPath)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
-				"-v", fmt.Sprintf("%s:/output", testOutput),
-				"--user", fmt.Sprintf("%s:%s", testUID, testGID),
-				"--network=none",
-				testImage,
-				string(CommandGenerateRaw),
-				"--source=/apis",
-				"--output=/output",
-				fmt.Sprintf("--api=%s", testAPIPath),
-			},
-		},
-		{
-			name: "GenerateLibrary",
-			docker: &Docker{
-				Image: testImage,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.GenerateLibrary(ctx, cfg, testAPIRoot, testOutput, testGeneratorInput, testLibraryID)
+				return d.Generate(ctx, cfg, testAPIRoot, testOutput, testGeneratorInput, testLibraryID)
 			},
 			want: []string{
 				"run", "--rm",
 				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
 				"-v", fmt.Sprintf("%s:/output", testOutput),
 				"-v", fmt.Sprintf("%s:/generator-input", testGeneratorInput),
-				"--network=none",
 				testImage,
-				string(CommandGenerateLibrary),
+				string(CommandGenerate),
 				"--source=/apis",
 				"--output=/output",
 				"--generator-input=/generator-input",
@@ -148,21 +104,20 @@ func TestDockerRun(t *testing.T) {
 			},
 		},
 		{
-			name: "GenerateLibrary runs in docker",
+			name: "Generate runs in docker",
 			docker: &Docker{
 				Image: testImage,
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.GenerateLibrary(ctx, cfgInDocker, testAPIRoot, "hostDir", testGeneratorInput, testLibraryID)
+				return d.Generate(ctx, cfgInDocker, testAPIRoot, "hostDir", testGeneratorInput, testLibraryID)
 			},
 			want: []string{
 				"run", "--rm",
 				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
 				"-v", "localDir:/output",
 				"-v", fmt.Sprintf("%s:/generator-input", testGeneratorInput),
-				"--network=none",
 				testImage,
-				string(CommandGenerateLibrary),
+				string(CommandGenerate),
 				"--source=/apis",
 				"--output=/output",
 				"--generator-input=/generator-input",
@@ -170,53 +125,18 @@ func TestDockerRun(t *testing.T) {
 			},
 		},
 		{
-			name: "Clean",
+			name: "Build",
 			docker: &Docker{
 				Image: testImage,
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.Clean(ctx, cfg, testRepoRoot, testLibraryID)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/repo", testRepoRoot),
-				"--network=none",
-				testImage,
-				string(CommandClean),
-				"--repo-root=/repo",
-				fmt.Sprintf("--library-id=%s", testLibraryID),
-			},
-		},
-		{
-			name: "BuildRaw",
-			docker: &Docker{
-				Image: testImage,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.BuildRaw(ctx, cfg, testGeneratorOutput, testAPIPath)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/generator-output", testGeneratorOutput),
-				testImage,
-				string(CommandBuildRaw),
-				"--generator-output=/generator-output",
-				fmt.Sprintf("--api=%s", testAPIPath),
-			},
-		},
-		{
-			name: "BuildLibrary",
-			docker: &Docker{
-				Image: testImage,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.BuildLibrary(ctx, cfg, testRepoRoot, testLibraryID)
+				return d.Build(ctx, cfg, testRepoRoot, testLibraryID)
 			},
 			want: []string{
 				"run", "--rm",
 				"-v", fmt.Sprintf("%s:/repo", testRepoRoot),
 				testImage,
-				string(CommandBuildLibrary),
+				string(CommandBuild),
 				"--repo-root=/repo",
 				"--test=true",
 				fmt.Sprintf("--library-id=%s", testLibraryID),
@@ -234,87 +154,11 @@ func TestDockerRun(t *testing.T) {
 				"run", "--rm",
 				"-v", fmt.Sprintf("%s:/apis", testAPIRoot),
 				"-v", fmt.Sprintf("%s:/generator-input", testGeneratorInput),
-				"--network=none",
 				testImage,
 				string(CommandConfigure),
 				"--source=/apis",
 				"--generator-input=/generator-input",
 				fmt.Sprintf("--api=%s", testAPIPath),
-			},
-		},
-		{
-			name: "PrepareLibraryRelease",
-			docker: &Docker{
-				Image: testImage,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.PrepareLibraryRelease(ctx, cfg, testLanguageRepo, testInputsDirectory, testLibraryID, testReleaseVersion)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/repo", testLanguageRepo),
-				"-v", fmt.Sprintf("%s:/inputs", testInputsDirectory),
-				"--network=none",
-				testImage,
-				string(CommandPrepareLibraryRelease),
-				"--repo-root=/repo",
-				fmt.Sprintf("--library-id=%s", testLibraryID),
-				fmt.Sprintf("--release-notes=/inputs/%s-%s-release-notes.txt", testLibraryID, testReleaseVersion),
-				fmt.Sprintf("--version=%s", testReleaseVersion),
-			},
-		},
-		{
-			name: "IntegrationTestLibrary",
-			docker: &Docker{
-				Image: testImage,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.IntegrationTestLibrary(ctx, cfg, testLanguageRepo, testLibraryID)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/repo", testLanguageRepo),
-				testImage,
-				string(CommandIntegrationTestLibrary),
-				"--repo-root=/repo",
-				fmt.Sprintf("--library-id=%s", testLibraryID),
-			},
-		},
-		{
-			name: "PackageLibrary",
-			docker: &Docker{
-				Image: testImage,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.PackageLibrary(ctx, cfg, testLanguageRepo, testLibraryID, testOutput)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/repo", testLanguageRepo),
-				"-v", fmt.Sprintf("%s:/output", testOutput),
-				testImage,
-				string(CommandPackageLibrary),
-				"--repo-root=/repo",
-				"--output=/output",
-				fmt.Sprintf("--library-id=%s", testLibraryID),
-			},
-		},
-		{
-			name: "PublishLibrary",
-			docker: &Docker{
-				Image: testImage,
-			},
-			runCommand: func(ctx context.Context, d *Docker) error {
-				return d.PublishLibrary(ctx, cfg, testOutput, testLibraryID, testLibraryVersion)
-			},
-			want: []string{
-				"run", "--rm",
-				"-v", fmt.Sprintf("%s:/output", testOutput),
-				testImage,
-				string(CommandPublishLibrary),
-				"--package-output=/output",
-				fmt.Sprintf("--library-id=%s", testLibraryID),
-				fmt.Sprintf("--version=%s", testLibraryVersion),
 			},
 		},
 	} {

--- a/internal/librarian/createreleaseartifacts.go
+++ b/internal/librarian/createreleaseartifacts.go
@@ -179,19 +179,14 @@ func buildTestPackageRelease(ctx context.Context, cfg *config.Config, outputRoot
 	if err := languageRepo.Checkout(release.CommitHash); err != nil {
 		return err
 	}
-	if err := containerConfig.BuildLibrary(ctx, cfg, languageRepo.Dir, release.LibraryID); err != nil {
+	if err := containerConfig.Build(ctx, cfg, languageRepo.Dir, release.LibraryID); err != nil {
 		return err
 	}
 	if cfg.SkipIntegrationTests != "" {
 		slog.Info("Skipping integration tests", "bug", cfg.SkipIntegrationTests)
-	} else if err := containerConfig.IntegrationTestLibrary(ctx, cfg, languageRepo.Dir, release.LibraryID); err != nil {
-		return err
 	}
 	outputDir := filepath.Join(outputRoot, release.LibraryID)
 	if err := os.Mkdir(outputDir, 0755); err != nil {
-		return err
-	}
-	if err := containerConfig.PackageLibrary(ctx, cfg, languageRepo.Dir, release.LibraryID, outputDir); err != nil {
 		return err
 	}
 	return nil

--- a/internal/librarian/publishreleaseartifacts.go
+++ b/internal/librarian/publishreleaseartifacts.go
@@ -142,13 +142,6 @@ func publishReleaseArtifacts(ctx context.Context, containerConfig *docker.Docker
 }
 
 func publishPackages(ctx context.Context, config *docker.Docker, cfg *config.Config, releases []LibraryRelease) error {
-	for _, release := range releases {
-		outputDir := filepath.Join(cfg.ArtifactRoot, release.LibraryID)
-		if err := config.PublishLibrary(ctx, cfg, outputDir, release.LibraryID, release.Version); err != nil {
-			return err
-		}
-	}
-	slog.Info("All packages published.")
 	return nil
 }
 

--- a/internal/librarian/updateimagetag.go
+++ b/internal/librarian/updateimagetag.go
@@ -172,7 +172,7 @@ func updateImageTag(ctx context.Context, cfg *config.Config, startTime time.Time
 
 	// Build everything at the end. (This is more efficient than building each library with a separate container invocation.)
 	slog.Info("Building all libraries.")
-	if err := containerConfig.BuildLibrary(ctx, cfg, languageRepo.Dir, ""); err != nil {
+	if err := containerConfig.Build(ctx, cfg, languageRepo.Dir, ""); err != nil {
 		return err
 	}
 
@@ -203,10 +203,7 @@ func regenerateLibrary(ctx context.Context, cfg *config.Config, apiRepo *gitrepo
 		return err
 	}
 
-	if err := containerConfig.GenerateLibrary(ctx, cfg, apiRepo.Dir, outputDir, generatorInput, library.ID); err != nil {
-		return err
-	}
-	if err := containerConfig.Clean(ctx, cfg, languageRepo.Dir, library.ID); err != nil {
+	if err := containerConfig.Generate(ctx, cfg, apiRepo.Dir, outputDir, generatorInput, library.ID); err != nil {
 		return err
 	}
 	if err := os.CopyFS(languageRepo.Dir, os.DirFS(outputDir)); err != nil {


### PR DESCRIPTION
Also removed network access limitations and renamed command to their documented names in go/librarian:cli-reimagined

Fixes: #806