### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # is the same as .gitignore.
 
 # The owners for all files in the repo.
-* @googleapis/cloud-sdk-generator
+* @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
Codeowners currently invalid as the group did not have write access to the repo. This change will more the power to review/approve PRs.