### PR TITLE
fix(internal/librarian): load state.yaml from librarian dir

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -265,7 +265,7 @@ func (r *generateRunner) detectIfLibraryConfigured(ctx context.Context) (bool, e
 		}
 	} else {
 		// repo is a directory
-		pipelineState, err = loadLibrarianStateFile(filepath.Join(repo, config.GeneratorInputDir, pipelineStateFile), source)
+		pipelineState, err = loadLibrarianStateFile(filepath.Join(repo, config.LibrarianDir, pipelineStateFile), source)
 		if err != nil {
 			return false, err
 		}

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -16,11 +16,12 @@ package librarian
 
 import (
 	"context"
-	"github.com/googleapis/librarian/internal/docker"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/googleapis/librarian/internal/docker"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
@@ -103,11 +104,11 @@ func TestDetectIfLibraryConfigured(t *testing.T) {
 			if test.repo != "" {
 				repo = newTestGitRepo(t)
 				if test.state != nil {
-					generatorInputDir := filepath.Join(repo.Dir, config.GeneratorInputDir)
-					if err := os.MkdirAll(generatorInputDir, 0755); err != nil {
-						t.Fatalf("os.MkdirAll(%q, 0755) = %v", generatorInputDir, err)
+					librarianDir := filepath.Join(repo.Dir, config.LibrarianDir)
+					if err := os.MkdirAll(librarianDir, 0755); err != nil {
+						t.Fatalf("os.MkdirAll(%q, 0755) = %v", librarianDir, err)
 					}
-					stateFile := filepath.Join(generatorInputDir, pipelineStateFile)
+					stateFile := filepath.Join(librarianDir, pipelineStateFile)
 					b, err := yaml.Marshal(test.state)
 					if err != nil {
 						t.Fatalf("yaml.Marshal = %v", err)

--- a/internal/librarian/stateandconfig.go
+++ b/internal/librarian/stateandconfig.go
@@ -76,7 +76,7 @@ func loadPipelineConfigFile(path string) (*config.PipelineConfig, error) {
 func fetchRemoteLibrarianState(ctx context.Context, client GitHubClient, ref, source string) (*config.LibrarianState, error) {
 	return parseLibrarianState(func(file string) ([]byte, error) {
 		return client.GetRawContent(ctx, file, ref)
-	}, filepath.Join(config.GeneratorInputDir, pipelineStateFile), source)
+	}, filepath.Join(config.LibrarianDir, pipelineStateFile), source)
 }
 
 func parsePipelineConfig(contentLoader func() ([]byte, error)) (*config.PipelineConfig, error) {


### PR DESCRIPTION
State file is now expected in `.librarian/state.yaml`

Fixes #916