### PR TITLE
fix(internal/librarian): generate library id in configure command

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -439,11 +439,6 @@ func (r *generateRunner) runConfigureCommand(ctx context.Context) error {
 		return errors.New("a language repository must be specified to run configure")
 	}
 
-	if r.cfg.API == "" {
-		slog.Error("No API path specified; cannot run configure.", "api", r.cfg.API)
-		return errors.New("API path must be specified to run configure")
-	}
-
 	libraryID := strings.ReplaceAll(r.cfg.API, "/", "-")
 
 	configureRequest := &docker.ConfigureRequest{

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -327,30 +327,6 @@ func TestRunConfigureCommand(t *testing.T) {
 			container: &mockContainerClient{},
 			wantErr:   true,
 		},
-		{
-			name: "library not found in state",
-			api:  "other/api",
-			repo: newTestGitRepo(t),
-			state: &config.LibrarianState{
-				Libraries: []*config.LibraryState{
-					{
-						ID:   "some-library",
-						APIs: []*config.API{{Path: "some/api"}},
-					},
-				},
-			},
-			container: &mockContainerClient{},
-			wantErr:   true,
-		},
-		{
-			name:               "error on invalid source path",
-			source:             "invalid path",
-			repo:               newTestGitRepo(t),
-			state:              &config.LibrarianState{},
-			container:          &mockContainerClient{},
-			wantConfigureCalls: 0,
-			wantErr:            true,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Generate library id by api path.

Configure should create the library id if it is not in the state yaml file.

Fix #931 