### PR TITLE
fix: update generate required flag checks

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -108,10 +108,7 @@ type generateRunner struct {
 }
 
 func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
-	if err := validateRequiredFlag("api", cfg.API); err != nil {
-		return nil, err
-	}
-	if err := validateRequiredFlag("source", cfg.Source); err != nil {
+	if err := validateRequiredFlag("repo", cfg.Repo); err != nil {
 		return nil, err
 	}
 	workRoot, err := createWorkRoot(time.Now(), cfg.WorkRoot)
@@ -427,6 +424,9 @@ func compileRegexps(patterns []string) ([]*regexp.Regexp, error) {
 // from the runner's state, gathers all paths and settings, and then delegates
 // the execution to the container client.
 func (r *generateRunner) runConfigureCommand(ctx context.Context) error {
+	if r.cfg.API == "" {
+		return errors.New("API flag not specified for new library configuration")
+	}
 	apiRoot, err := filepath.Abs(r.cfg.Source)
 	if err != nil {
 		return err

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -328,6 +328,13 @@ func TestRunConfigureCommand(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name:      "missing api",
+			repo:      newTestGitRepo(t),
+			state:     &config.LibrarianState{},
+			container: &mockContainerClient{},
+			wantErr:   true,
+		},
+		{
 			name: "library not found in state",
 			api:  "other/api",
 			repo: newTestGitRepo(t),
@@ -387,12 +394,7 @@ func TestNewGenerateRunner(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "missing api flag",
-			cfg:     &config.Config{Source: "some/source"},
-			wantErr: true,
-		},
-		{
-			name:    "missing source flag",
+			name:    "missing repo flag",
 			cfg:     &config.Config{API: "some/api"},
 			wantErr: true,
 		},


### PR DESCRIPTION
Fix required flag check in generate.go

- remove required flag check for `api` and `source` flag in newGenerateRunner
- add a check in `runConfigureCommand` for `api` as it is required for generating a library for the first time
- swap test cases accordingly

Fixes #928