### PR TITLE
fix: Remove project flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,19 +100,6 @@ type Config struct {
 	// variable.
 	LibrarianRepository string
 
-	// Project is the Google Cloud project containing Secret Manager secrets to
-	// provide to the language-specific container commands via environment variables.
-	//
-	// Project is used by all commands which perform language-specific operations.
-	// (This covers all commands other than merge-release-pr.)
-	// If no value is set, any language-specific operations which include an
-	// environment variable based on a secret will act as if the secret name
-	// wasn't set (so will just use a host environment variable or default value,
-	// if any).
-	//
-	// Project is specified with the -project flag.
-	Project string
-
 	// Push determines whether to push changes to GitHub. It is used in
 	// all commands that create commits in a language repository:
 	// configure and update-apis.

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -119,8 +119,8 @@ type ConfigureRequest struct {
 // New constructs a Docker instance which will invoke the specified
 // Docker image as required to implement language-specific commands,
 // providing the container with required environment variables.
-func New(workRoot, image, secretsProject, uid, gid string, pipelineConfig *config.PipelineConfig) (*Docker, error) {
-	envProvider := newEnvironmentProvider(workRoot, secretsProject, pipelineConfig)
+func New(workRoot, image, uid, gid string, pipelineConfig *config.PipelineConfig) (*Docker, error) {
+	envProvider := newEnvironmentProvider(workRoot, pipelineConfig)
 	docker := &Docker{
 		Image: image,
 		env:   envProvider,

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -30,14 +30,13 @@ import (
 
 func TestNew(t *testing.T) {
 	const (
-		testWorkRoot       = "testWorkRoot"
-		testImage          = "testImage"
-		testSecretsProject = "testSecretsProject"
-		testUID            = "1000"
-		testGID            = "1001"
+		testWorkRoot = "testWorkRoot"
+		testImage    = "testImage"
+		testUID      = "1000"
+		testGID      = "1001"
 	)
 	pipelineConfig := &config.PipelineConfig{}
-	d, err := New(testWorkRoot, testImage, testSecretsProject, testUID, testGID, pipelineConfig)
+	d, err := New(testWorkRoot, testImage, testUID, testGID, pipelineConfig)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/internal/docker/environment.go
+++ b/internal/docker/environment.go
@@ -34,8 +34,6 @@ import (
 type EnvironmentProvider struct {
 	// The file used to store the environment variables for the duration of a docker run.
 	tmpFile string
-	// The project in which to look up secrets
-	secretsProject string
 	// A cache of secrets we've already fetched.
 	secretCache map[string]string
 	// The pipeline configuration, specifying which environment variables to obtain
@@ -43,14 +41,13 @@ type EnvironmentProvider struct {
 	pipelineConfig *config.PipelineConfig
 }
 
-func newEnvironmentProvider(workRoot, secretsProject string, pipelineConfig *config.PipelineConfig) *EnvironmentProvider {
+func newEnvironmentProvider(workRoot string, pipelineConfig *config.PipelineConfig) *EnvironmentProvider {
 	if pipelineConfig == nil {
 		return nil
 	}
 	tmpFile := filepath.Join(workRoot, "docker-env.txt")
 	return &EnvironmentProvider{
 		tmpFile:        tmpFile,
-		secretsProject: secretsProject,
 		secretCache:    make(map[string]string),
 		pipelineConfig: pipelineConfig,
 	}
@@ -131,7 +128,7 @@ func (e *EnvironmentProvider) getSecretManagerValue(ctx context.Context, variabl
 		return "", false, err
 	}
 	defer client.Close()
-	value, err = client.Get(ctx, e.secretsProject, variable.SecretName)
+	value, err = client.Get(ctx, variable.SecretName)
 	if err != nil {
 		// If the error is that the secret wasn't found, continue to the next source.
 		// Any other error causes a real error to be returned.

--- a/internal/docker/environment_test.go
+++ b/internal/docker/environment_test.go
@@ -26,20 +26,16 @@ import (
 
 func TestNewEnvironmentProvider(t *testing.T) {
 	const (
-		testWorkRoot       = "testWorkRoot"
-		testSecretsProject = "testSecretsProject"
+		testWorkRoot = "testWorkRoot"
 	)
 	pipelineConfig := &config.PipelineConfig{}
-	ep := newEnvironmentProvider(testWorkRoot, testSecretsProject, pipelineConfig)
+	ep := newEnvironmentProvider(testWorkRoot, pipelineConfig)
 	if ep == nil {
 		t.Fatal("newEnvironmentProvider() returned nil")
 	}
 	wantTmpFile := filepath.Join(testWorkRoot, "docker-env.txt")
 	if ep.tmpFile != wantTmpFile {
 		t.Errorf("ep.tmpFile = %q, want %q", ep.tmpFile, wantTmpFile)
-	}
-	if ep.secretsProject != testSecretsProject {
-		t.Errorf("ep.secretsProject = %q, want %q", ep.secretsProject, testSecretsProject)
 	}
 	if ep.pipelineConfig != pipelineConfig {
 		t.Error("ep.pipelineConfig is not the same as the one passed in")
@@ -53,7 +49,7 @@ func TestWriteEnvironmentFile(t *testing.T) {
 	ctx := context.Background()
 	testContent := "foo=bar\n"
 	tmpDir := t.TempDir()
-	e := newEnvironmentProvider(tmpDir, "", &config.PipelineConfig{
+	e := newEnvironmentProvider(tmpDir, &config.PipelineConfig{
 		Commands: map[string]*config.CommandConfig{
 			"test-command": {
 				EnvironmentVariables: []*config.CommandEnvironmentVariable{
@@ -96,7 +92,7 @@ func TestConstructEnvironmentFileContent(t *testing.T) {
 		},
 	}
 
-	e := newEnvironmentProvider("", "", pipelineConfig)
+	e := newEnvironmentProvider("", pipelineConfig)
 	e.secretCache[testSecretName] = testSecretValue
 	t.Setenv(testHostVar, testHostValue)
 

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -42,10 +42,6 @@ func addFlagImage(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.Image, "image", "", "Container image to run for subcommands. Defaults to the image in the pipeline state.")
 }
 
-func addFlagProject(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.Project, "project", "", "Project containing Secret Manager secrets.")
-}
-
 func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.Repo, "repo", "",
 		"Code repository where the generated code will reside. "+

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -91,7 +91,6 @@ func init() {
 	addFlagHostMount(fs, cfg)
 	addFlagPushConfig(fs, cfg)
 	addFlagImage(fs, cfg)
-	addFlagProject(fs, cfg)
 	addFlagRepo(fs, cfg)
 	addFlagSource(fs, cfg)
 	addFlagWorkRoot(fs, cfg)
@@ -141,7 +140,7 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 			return nil, fmt.Errorf("failed to create GitHub client: %w", err)
 		}
 	}
-	container, err := docker.New(workRoot, image, cfg.Project, cfg.UserUID, cfg.UserGID, pipelineConfig)
+	container, err := docker.New(workRoot, image, cfg.UserUID, cfg.UserGID, pipelineConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -54,9 +54,9 @@ func newClient(client secretsClient) *Client {
 
 // Get fetches the latest version of a secret as a string. This method assumes
 // the secret payload is a UTF-8 string.
-func (c *Client) Get(ctx context.Context, project string, secretName string) (string, error) {
+func (c *Client) Get(ctx context.Context, secretName string) (string, error) {
 	request := &secretmanagerpb.AccessSecretVersionRequest{
-		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", project, secretName),
+		Name: fmt.Sprintf("projects/googleapis/secrets/%s/versions/latest", secretName),
 	}
 	secret, err := c.client.AccessSecretVersion(ctx, request)
 	if err != nil {

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -43,13 +43,12 @@ func (c *mockClient) Close() error {
 func TestFetchSecrets(t *testing.T) {
 	for _, test := range []struct {
 		name       string
-		project    string
 		secretName string
 		mockResult string
 		want       string
 	}{
-		{"Basic", "some-project-id", "some-secret-name", "some-secret-value", "some-secret-value"},
-		{"Empty response", "some-project-id", "some-secret-name", "", ""},
+		{"Basic", "some-secret-name", "some-secret-value", "some-secret-value"},
+		{"Empty response", "some-secret-name", "", ""},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			mock := &mockClient{
@@ -57,7 +56,7 @@ func TestFetchSecrets(t *testing.T) {
 			}
 			client := newClient(mock)
 			defer client.Close()
-			got, err := client.Get(t.Context(), test.project, test.secretName)
+			got, err := client.Get(t.Context(), test.secretName)
 			if err != nil {
 				t.Errorf("unexpected error fetching secret: %s", err)
 			}


### PR DESCRIPTION
Remove project flag as go/librarian:cli-reimagined does not specify this flag

fix: #934