### PR TITLE
chore(internal): fix Url to URL casing

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -85,11 +85,11 @@ type PullRequestMetadata struct {
 
 // ParseURL parses a GitHub URL (anything to do with a repository) to determine
 // the GitHub repo details (owner and name).
-func ParseURL(remoteUrl string) (*Repository, error) {
-	if !strings.HasPrefix(remoteUrl, "https://github.com/") {
-		return nil, fmt.Errorf("remote '%s' is not a GitHub remote", remoteUrl)
+func ParseURL(remoteURL string) (*Repository, error) {
+	if !strings.HasPrefix(remoteURL, "https://github.com/") {
+		return nil, fmt.Errorf("remote '%s' is not a GitHub remote", remoteURL)
 	}
-	remotePath := remoteUrl[len("https://github.com/"):]
+	remotePath := remoteURL[len("https://github.com/"):]
 	pathParts := strings.Split(remotePath, "/")
 	organization := pathParts[0]
 	repoName := pathParts[1]

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -241,56 +241,56 @@ func TestFetchGitHubRepoFromRemote(t *testing.T) {
 	}
 }
 
-func TestParseUrl(t *testing.T) {
+func TestParseURL(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
 		name          string
-		remoteUrl     string
+		remoteURL     string
 		wantRepo      *Repository
 		wantErr       bool
 		wantErrSubstr string
 	}{
 		{
 			name:      "Valid HTTPS URL",
-			remoteUrl: "https://github.com/owner/repo.git",
+			remoteURL: "https://github.com/owner/repo.git",
 			wantRepo:  &Repository{Owner: "owner", Name: "repo"},
 			wantErr:   false,
 		},
 		{
 			name:      "Valid HTTPS URL without .git",
-			remoteUrl: "https://github.com/owner/repo",
+			remoteURL: "https://github.com/owner/repo",
 			wantRepo:  &Repository{Owner: "owner", Name: "repo"},
 			wantErr:   false,
 		},
 		{
 			name:          "Invalid URL scheme",
-			remoteUrl:     "http://github.com/owner/repo.git",
+			remoteURL:     "http://github.com/owner/repo.git",
 			wantErr:       true,
 			wantErrSubstr: "not a GitHub remote",
 		},
 		{
 			name:      "URL with extra path components",
-			remoteUrl: "https://github.com/owner/repo/pulls",
+			remoteURL: "https://github.com/owner/repo/pulls",
 			wantRepo:  &Repository{Owner: "owner", Name: "repo"},
 			wantErr:   false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			repo, err := ParseURL(test.remoteUrl)
+			repo, err := ParseURL(test.remoteURL)
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("ParseUrl() err = nil, want error containing %q", test.wantErrSubstr)
+					t.Errorf("ParseURL() err = nil, want error containing %q", test.wantErrSubstr)
 				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
-					t.Errorf("ParseUrl() err = %v, want error containing %q", err, test.wantErrSubstr)
+					t.Errorf("ParseURL() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else {
 				if err != nil {
-					t.Errorf("ParseUrl() err = %v, want nil", err)
+					t.Errorf("ParseURL() err = %v, want nil", err)
 				}
 				if diff := cmp.Diff(test.wantRepo, repo); diff != "" {
-					t.Errorf("ParseUrl() repo mismatch (-want +got): %s", diff)
+					t.Errorf("ParseURL() repo mismatch (-want +got): %s", diff)
 				}
 			}
 		})

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -35,7 +35,7 @@ func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.Repository, er
 		return nil, errors.New("repo must be specified")
 	}
 
-	if isUrl(repo) {
+	if isURL(repo) {
 		// repo is a URL
 		// Take the last part of the URL as the directory name. It feels very
 		// unlikely that will clash with anything else (e.g. "output")

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -120,7 +120,7 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 	image := deriveImage(cfg.Image, state)
 
 	var ghClient GitHubClient
-	if isUrl(cfg.Repo) {
+	if isURL(cfg.Repo) {
 		// repo is a URL
 		languageRepo, err := github.ParseURL(cfg.Repo)
 		if err != nil {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -310,7 +310,7 @@ func TestNewGenerateRunner(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			// We need to create a fake state and config file for the test to pass.
-			if test.cfg.Repo != "" && !isUrl(test.cfg.Repo) {
+			if test.cfg.Repo != "" && !isURL(test.cfg.Repo) {
 				stateFile := filepath.Join(test.cfg.Repo, config.LibrarianDir, pipelineStateFile)
 
 				if err := os.MkdirAll(filepath.Dir(stateFile), 0755); err != nil {
@@ -353,7 +353,7 @@ func TestNewGenerateRunner(t *testing.T) {
 func newTestGitRepo(t *testing.T) *gitrepo.Repository {
 	t.Helper()
 	dir := t.TempDir()
-	remoteUrl := "https://github.com/googleapis/librarian.git"
+	remoteURL := "https://github.com/googleapis/librarian.git"
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")
@@ -362,7 +362,7 @@ func newTestGitRepo(t *testing.T) *gitrepo.Repository {
 	}
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "initial commit")
-	runGit(t, dir, "remote", "add", "origin", remoteUrl)
+	runGit(t, dir, "remote", "add", "origin", remoteURL)
 	repo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{Dir: dir})
 	if err != nil {
 		t.Fatalf("gitrepo.Open(%q) = %v", dir, err)

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -88,7 +88,7 @@ type ContainerClient interface {
 	Configure(ctx context.Context, request *docker.ConfigureRequest) error
 }
 
-func isUrl(s string) bool {
+func isURL(s string) bool {
 	u, err := url.ParseRequestURI(s)
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return false

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -29,7 +29,7 @@ func TestRun(t *testing.T) {
 	}
 }
 
-func TestIsUrl(t *testing.T) {
+func TestIsURL(t *testing.T) {
 	for _, test := range []struct {
 		name  string
 		input string
@@ -82,9 +82,9 @@ func TestIsUrl(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := isUrl(test.input)
+			got := isURL(test.input)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("isUrl() mismatch (-want +got):\n%s", diff)
+				t.Errorf("isURL() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Just a little clean up, renaming all instances of CamelCase `Url` to upper case `URL`

Fixes #689