### PR TITLE
fix(internal/github): derive github url from remote origin

### DIFF
--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -164,7 +164,7 @@ func TestFetchGitHubRepoFromRemote(t *testing.T) {
 		wantErrSubstr string
 	}{
 		{
-			name: "Single GitHub remote",
+			name: "origin is a GitHub remote",
 			remotes: map[string][]string{
 				"origin": {"https://github.com/owner/repo.git"},
 			},
@@ -174,43 +174,44 @@ func TestFetchGitHubRepoFromRemote(t *testing.T) {
 			name:          "No remotes",
 			remotes:       map[string][]string{},
 			wantErr:       true,
-			wantErrSubstr: "no GitHub remotes found",
+			wantErrSubstr: "could not find an 'origin' remote",
 		},
 		{
-			name: "No GitHub remotes",
+			name: "origin is not a GitHub remote",
 			remotes: map[string][]string{
 				"origin": {"https://gitlab.com/owner/repo.git"},
 			},
 			wantErr:       true,
-			wantErrSubstr: "no GitHub remotes found",
+			wantErrSubstr: "could not find an 'origin' remote",
 		},
 		{
-			name: "Multiple remotes, one is GitHub",
+			name: "upstream is GitHub, but no origin",
 			remotes: map[string][]string{
 				"gitlab":   {"https://gitlab.com/owner/repo.git"},
 				"upstream": {"https://github.com/gh-owner/gh-repo.git"},
 			},
-			wantRepo: &Repository{Owner: "gh-owner", Name: "gh-repo"},
+			wantErr:       true,
+			wantErrSubstr: "could not find an 'origin' remote",
 		},
 		{
-			name: "Multiple GitHub remotes",
+			name: "origin and upstream are GitHub remotes, should use origin",
 			remotes: map[string][]string{
 				"origin":   {"https://github.com/owner/repo.git"},
 				"upstream": {"https://github.com/owner2/repo2.git"},
 			},
-			wantErr:       true,
-			wantErrSubstr: "can only determine the GitHub repo with a single matching remote",
+			wantRepo: &Repository{Owner: "owner", Name: "repo"},
 		},
 		{
-			name: "Remote with multiple URLs, first is not GitHub",
+			name: "origin is not GitHub, but upstream is",
 			remotes: map[string][]string{
-				"origin": {"https://gitlab.com/owner/repo.git", "https://github.com/owner/repo.git"},
+				"origin":   {"https://gitlab.com/owner/repo.git"},
+				"upstream": {"https://github.com/gh-owner/gh-repo.git"},
 			},
 			wantErr:       true,
-			wantErrSubstr: "no GitHub remotes found",
+			wantErrSubstr: "could not find an 'origin' remote",
 		},
 		{
-			name: "Remote with multiple URLs, first is GitHub",
+			name: "origin has multiple URLs, first is GitHub",
 			remotes: map[string][]string{
 				"origin": {"https://github.com/owner/repo.git", "https://gitlab.com/owner/repo.git"},
 			},

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -488,8 +488,8 @@ func TestCommitAndPush(t *testing.T) {
 			setupMockClient: func(t *testing.T) *github.Client {
 				return nil
 			},
-			expectedErr:    errors.New("no GitHub remotes found"),
-			expectedErrMsg: "no GitHub remotes found",
+			expectedErr:    errors.New("could not find an 'origin' remote"),
+			expectedErrMsg: "could not find an 'origin' remote",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Derive Github url only from the remote named origin. The other remotes will be ignored.

Fix #919 

