### PR TITLE
chore: remove pull_request_review trigger from multi_approvers.yaml

### DIFF
--- a/.github/workflows/multi_approvers.yaml
+++ b/.github/workflows/multi_approvers.yaml
@@ -24,10 +24,6 @@ on:
       - 'ready_for_review'
       - 'review_requested'
       - 'review_request_removed'
-  pull_request_review:
-    types:
-      - 'submitted'
-      - 'dismissed'
 
 permissions:
   actions: 'write'


### PR DESCRIPTION
When a PR is initiated from a fork, GitHub actions that are triggered based on `pull_request_review` do not receive the needed secrets. So, multi-approvers can't work. Additionally, for non-fork PRs, multi-approvers will already be green anyway because all users with permission to create branches are Googlers. So, the `pull_request_review` trigger is useless.