### PR TITLE
fix(internal/github): add github remote https limitation in error message

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -156,5 +156,5 @@ func FetchGitHubRepoFromRemote(repo *gitrepo.Repository) (*Repository, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("could not find an 'origin' remote pointing to a GitHub URL")
+	return nil, fmt.Errorf("could not find an 'origin' remote pointing to a GitHub https URL")
 }


### PR DESCRIPTION
Add https scheme in error message, because we limit git to use https urls.

Fixes #993