### PR TITLE
fix(internal/librarian): populate service config in `configure` command

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -462,6 +462,15 @@ func (r *generateRunner) runConfigureCommand(ctx context.Context) (string, error
 		APIs: []*config.API{{Path: r.cfg.API}},
 	})
 
+	if err := populateServiceConfigIfEmpty(
+		r.state,
+		func(file string) ([]byte, error) {
+			return os.ReadFile(file)
+		},
+		r.cfg.APISource); err != nil {
+		return "", err
+	}
+
 	configureRequest := &docker.ConfigureRequest{
 		Cfg:       r.cfg,
 		State:     r.state,

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -237,14 +237,24 @@ func TestRunConfigureCommand(t *testing.T) {
 			if sourcePath == "" {
 				sourcePath = t.TempDir()
 			}
+			cfg := &config.Config{
+				API:       test.api,
+				APISource: sourcePath,
+			}
 			r := &generateRunner{
-				cfg: &config.Config{
-					API:       test.api,
-					APISource: sourcePath,
-				},
+				cfg:             cfg,
 				repo:            test.repo,
 				state:           test.state,
 				containerClient: test.container,
+			}
+
+			if err := os.MkdirAll(filepath.Join(cfg.APISource, test.api), 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			data := []byte("type: google.api.Service")
+			if err := os.WriteFile(filepath.Join(cfg.APISource, test.api, "example_service_v2.yaml"), data, 0755); err != nil {
+				t.Fatal(err)
 			}
 
 			_, err := r.runConfigureCommand(context.Background())
@@ -746,19 +756,31 @@ func TestGenerateScenarios(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+
+			cfg := &config.Config{
+				API:        test.api,
+				Library:    test.library,
+				PushConfig: test.pushConfig,
+				APISource:  t.TempDir(),
+				Build:      test.build,
+			}
+
 			r := &generateRunner{
-				cfg: &config.Config{
-					API:        test.api,
-					Library:    test.library,
-					PushConfig: test.pushConfig,
-					APISource:  t.TempDir(),
-					Build:      test.build,
-				},
+				cfg:             cfg,
 				repo:            test.repo,
 				state:           test.state,
 				containerClient: test.container,
 				ghClient:        test.ghClient,
 				workRoot:        t.TempDir(),
+			}
+
+			if err := os.MkdirAll(filepath.Join(cfg.APISource, test.api), 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			data := []byte("type: google.api.Service")
+			if err := os.WriteFile(filepath.Join(cfg.APISource, test.api, "example_service_v2.yaml"), data, 0755); err != nil {
+				t.Fatal(err)
 			}
 
 			err := r.run(context.Background())


### PR DESCRIPTION
Fixes #1499 