### PR TITLE
fix(internal/librarian): make repo flag optional and derive from cwd when applicable

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -30,6 +30,22 @@ import (
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
+func deriveRepoPath(repoFlag string) (string, error) {
+	if repoFlag != "" {
+		return repoFlag, nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+	stateFile := filepath.Join(wd, config.LibrarianDir, pipelineStateFile)
+	if _, err := os.Stat(stateFile); err != nil {
+		return "", fmt.Errorf("repo flag not specified and no state file found in current working directory: %w", err)
+	}
+	slog.Info("repo not specified, using current working directory as repo root", "path", wd)
+	return wd, nil
+}
+
 func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.LocalRepository, error) {
 	if repo == "" {
 		return nil, errors.New("repo must be specified")

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -52,26 +52,16 @@ func addFlagPushConfig(fs *flag.FlagSet, cfg *config.Config) {
 
 func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.Repo, "repo", "",
-		"Code repository where the generated code will reside. "+
-			"Can be a remote in the format of a remote URL such as "+
-			"https://github.com/{owner}/{repo} or a local file path like "+
-			"/path/to/repo`. Both absolute and relative paths are supported.")
+		`Code repository where the generated code will reside.
+			Can be a remote in the format of a remote URL such as 
+			https://github.com/{owner}/{repo} or a local file path like 
+			/path/to/repo. Both absolute and relative paths are supported.
+			If not specified, will try to detect if the current working 
+			directory is configured as a language repository.`)
 }
 
 func addFlagWorkRoot(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.WorkRoot, "output", "", "Working directory root. When this is not specified, a working directory will be created in /tmp.")
-}
-
-// validateRequiredFlag validates that the flag with the given name has been provided.
-// TODO(https://github.com/googleapis/librarian/issues/488): add support for required string flags
-// We should rework how we add flags so that these can be validated before we even
-// start executing the command. (At least for simple cases where a flag is required;
-// note that this isn't always going to be the same for all commands for one flag.)
-func validateRequiredFlag(name, value string) error {
-	if value == "" {
-		return fmt.Errorf("required flag -%s not specified", name)
-	}
-	return nil
 }
 
 // validatePushConfigAndGithubTokenCoexist validates that the github token should exist if pushConfig flag is set.

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -29,6 +28,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
@@ -101,10 +102,28 @@ type generateRunner struct {
 	image           string
 }
 
+func deriveRepoPath(repoFlag string) (string, error) {
+	if repoFlag != "" {
+		return repoFlag, nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+	stateFile := filepath.Join(wd, config.LibrarianDir, pipelineStateFile)
+	if _, err := os.Stat(stateFile); err != nil {
+		return "", fmt.Errorf("repo flag not specified and no state file found in current working directory: %w", err)
+	}
+	slog.Info("repo not specified, using current working directory as repo root", "path", wd)
+	return wd, nil
+}
+
 func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
-	if err := validateRequiredFlag("repo", cfg.Repo); err != nil {
+	repoPath, err := deriveRepoPath(cfg.Repo)
+	if err != nil {
 		return nil, err
 	}
+	cfg.Repo = repoPath
 	if err := validatePushConfigAndGithubTokenCoexist(cfg.PushConfig, cfg.GitHubToken); err != nil {
 		return nil, err
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -102,22 +102,6 @@ type generateRunner struct {
 	image           string
 }
 
-func deriveRepoPath(repoFlag string) (string, error) {
-	if repoFlag != "" {
-		return repoFlag, nil
-	}
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("getting working directory: %w", err)
-	}
-	stateFile := filepath.Join(wd, config.LibrarianDir, pipelineStateFile)
-	if _, err := os.Stat(stateFile); err != nil {
-		return "", fmt.Errorf("repo flag not specified and no state file found in current working directory: %w", err)
-	}
-	slog.Info("repo not specified, using current working directory as repo root", "path", wd)
-	return wd, nil
-}
-
 func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 	repoPath, err := deriveRepoPath(cfg.Repo)
 	if err != nil {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -32,6 +32,62 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestDeriveRepoPath(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		repoPath     string
+		setup        func(t *testing.T, dir string)
+		wantErr      bool
+		wantRepoPath string
+	}{
+		{
+			name:         "repo path provided",
+			repoPath:     "/some/path",
+			wantRepoPath: "/some/path",
+		},
+		{
+			name: "empty repo path, state file exists",
+			setup: func(t *testing.T, dir string) {
+				stateDir := filepath.Join(dir, config.LibrarianDir)
+				if err := os.MkdirAll(stateDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				stateFile := filepath.Join(stateDir, pipelineStateFile)
+				if err := os.WriteFile(stateFile, []byte("test"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:    "empty repo path, no state file",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, tmpDir)
+			}
+			t.Chdir(tmpDir)
+
+			gotRepoPath, err := deriveRepoPath(test.repoPath)
+			if (err != nil) != test.wantErr {
+				t.Errorf("deriveRepoPath() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+
+			wantPath := test.wantRepoPath
+			if wantPath == "" && !test.wantErr {
+				wantPath = tmpDir
+			}
+
+			if diff := cmp.Diff(wantPath, gotRepoPath); diff != "" {
+				t.Errorf("deriveRepoPath() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestRunGenerateCommand(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -32,62 +32,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestDeriveRepoPath(t *testing.T) {
-	for _, test := range []struct {
-		name         string
-		repoPath     string
-		setup        func(t *testing.T, dir string)
-		wantErr      bool
-		wantRepoPath string
-	}{
-		{
-			name:         "repo path provided",
-			repoPath:     "/some/path",
-			wantRepoPath: "/some/path",
-		},
-		{
-			name: "empty repo path, state file exists",
-			setup: func(t *testing.T, dir string) {
-				stateDir := filepath.Join(dir, config.LibrarianDir)
-				if err := os.MkdirAll(stateDir, 0755); err != nil {
-					t.Fatal(err)
-				}
-				stateFile := filepath.Join(stateDir, pipelineStateFile)
-				if err := os.WriteFile(stateFile, []byte("test"), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
-		{
-			name:    "empty repo path, no state file",
-			wantErr: true,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			if test.setup != nil {
-				test.setup(t, tmpDir)
-			}
-			t.Chdir(tmpDir)
-
-			gotRepoPath, err := deriveRepoPath(test.repoPath)
-			if (err != nil) != test.wantErr {
-				t.Errorf("deriveRepoPath() error = %v, wantErr %v", err, test.wantErr)
-				return
-			}
-
-			wantPath := test.wantRepoPath
-			if wantPath == "" && !test.wantErr {
-				wantPath = tmpDir
-			}
-
-			if diff := cmp.Diff(wantPath, gotRepoPath); diff != "" {
-				t.Errorf("deriveRepoPath() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestRunGenerateCommand(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {


### PR DESCRIPTION
Make repo flag optional, removing required flag validation. Add logic to derive from current working directory when there is librarian state file detected, otherwise, return error.

Fixes: #1516