### PR TITLE
test: enforce goimports formatting

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -27,8 +27,6 @@ jobs:
         run: go version
       - name: Run tests
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
-      - name: Check Go formatting
-        run: go fmt ./...
       - name: Check YAML formatting
         run: |
           go install github.com/google/yamlfmt/cmd/yamlfmt@v0.17.2

--- a/all_test.go
+++ b/all_test.go
@@ -107,20 +107,6 @@ func TestGolangCILint(t *testing.T) {
 	rungo(t, "run", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest", "run")
 }
 
-func TestGoFmt(t *testing.T) {
-	cmd := exec.Command("gofmt", "-l", ".")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("gofmt failed to run: %v\nOutput:\n%s", err, out.String())
-	}
-	if out.Len() > 0 {
-		t.Errorf("gofmt found unformatted files:\n%s", out.String())
-	}
-}
-
 func TestGoImports(t *testing.T) {
 	cmd := exec.Command("go", "run", "golang.org/x/tools/cmd/goimports@latest", "-d", ".")
 	var out bytes.Buffer

--- a/all_test.go
+++ b/all_test.go
@@ -121,7 +121,22 @@ func TestGoFmt(t *testing.T) {
 	}
 }
 
+func TestGoImports(t *testing.T) {
+	cmd := exec.Command("go", "run", "golang.org/x/tools/cmd/goimports@latest", "-d", ".")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("goimports failed to run: %v\nOutput:\n%s", err, out.String())
+	}
+	if out.Len() > 0 {
+		t.Errorf("goimports found unformatted files:\n%s", out.String())
+	}
+}
+
 func TestGoModTidy(t *testing.T) {
+
 	rungo(t, "mod", "tidy", "-diff")
 }
 

--- a/all_test.go
+++ b/all_test.go
@@ -136,7 +136,6 @@ func TestGoImports(t *testing.T) {
 }
 
 func TestGoModTidy(t *testing.T) {
-
 	rungo(t, "mod", "tidy", "-diff")
 }
 

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -18,11 +18,12 @@ package gitrepo
 import (
 	"errors"
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 // Repository defines the interface for git repository operations.

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -16,6 +16,7 @@ package librarian
 
 import (
 	"flag"
+
 	"github.com/googleapis/librarian/internal/config"
 )
 

--- a/internal/librarian/mocks_test.go
+++ b/internal/librarian/mocks_test.go
@@ -16,6 +16,7 @@ package librarian
 
 import (
 	"context"
+
 	"github.com/go-git/go-git/v5"
 	"github.com/googleapis/librarian/internal/docker"
 	"github.com/googleapis/librarian/internal/github"

--- a/internal/librarian/state.go
+++ b/internal/librarian/state.go
@@ -17,13 +17,14 @@ package librarian
 import (
 	"errors"
 	"fmt"
-	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/gitrepo"
-	"gopkg.in/yaml.v3"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/gitrepo"
+	"gopkg.in/yaml.v3"
 )
 
 const (


### PR DESCRIPTION
Add TestGoImports to ensure all Go files are formatted according to `goimports`.

The new test runs `goimports -d` and fails the build if there is a diff. This ensures all committed code is correctly formatted.

As part of this change, existing files have been formatted with `goimports -w`.

Fixes https://github.com/googleapis/librarian/issues/1529