### PR TITLE
fix(internal/config/gcloudyaml): fix TestGcloudConfig

### DIFF
--- a/internal/sidekick/internal/config/gcloudyaml/gcloud_test.go
+++ b/internal/sidekick/internal/config/gcloudyaml/gcloud_test.go
@@ -16,6 +16,7 @@ package gcloudyaml
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -51,7 +52,7 @@ func TestGcloudConfig(t *testing.T) {
 			continue
 		}
 	}
-	want := strings.Join(lines[index:], "\n")
+	want := fmt.Sprintf("service_name: %s\n%s", config.ServiceName, strings.Join(lines[index:], "\n"))
 	if diff := cmp.Diff(want, got.String()); diff != "" {
 		t.Errorf("mismatch(-want, +got)\n%s", diff)
 	}


### PR DESCRIPTION
TestGcloudConfig is skipped in https://github.com/googleapis/librarian/pull/1533. The test failure is now fixed.

Fixes https://github.com/googleapis/librarian/issues/1544