### PR TITLE
fix(internal/sidekick): hardcode dart as excluded path

### DIFF
--- a/internal/sidekick/refreshall.go
+++ b/internal/sidekick/refreshall.go
@@ -111,9 +111,12 @@ func findAllDirectories() ([]string, error) {
 			return nil
 		}
 		dir := filepath.Dir(path)
+
+		// TODO(https://github.com/googleapis/librarian/issues/1563): do not
+		// harcode
 		ignored := []string{
 			"target/package/", // The output from `cargo package`
-			"generator/",      // Testing
+			"dart/",           // Testing
 		}
 		for _, candidate := range ignored {
 			if strings.Contains(dir, candidate) {


### PR DESCRIPTION
Sidekick currently hardcodes paths that are excluded when running on the google-cloud-rust repo. Change this from generator/ to dart/ since the code moved.

This logic will be refactored in a follow-up PR.

For https://github.com/googleapis/librarian/issues/1563