### PR TITLE
fix(golangci-lint): fix errors in internal/sidekick

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,8 +29,3 @@ linters:
     - unparam
     - unused
     - usetesting
-  # TODO(https://github.com/googleapis/librarian/issues/1510): fix tests and
-  # remove
-  exclusions:
-    paths:
-      - internal/sidekick

--- a/internal/sidekick/downloads_cache_test.go
+++ b/internal/sidekick/downloads_cache_test.go
@@ -30,11 +30,7 @@ import (
 )
 
 func TestExistingDirectory(t *testing.T) {
-	tmp, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	rootConfig := config.Config{
 		Source: map[string]string{
 			"googleapis-root": tmp,
@@ -62,11 +58,7 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestWithDownload(t *testing.T) {
-	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	simulatedSha := "2d08f07eab9bbe8300cd20b871d0811bbb693fab"
 	simulatedSubdir := fmt.Sprintf("googleapis-%s", simulatedSha)
@@ -109,11 +101,7 @@ func TestWithDownload(t *testing.T) {
 }
 
 func TestTargetExists(t *testing.T) {
-	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	sha256 := "eb853d49313f20a096607fea87dfc10bd6a1b917ad17ad5db8a205b457a940e1"
 	rootConfig := &config.Config{
@@ -144,16 +132,9 @@ func TestTargetExists(t *testing.T) {
 }
 
 func TestDownloadGoogleapisRootTgzExists(t *testing.T) {
-	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
-	tarball, err := makeTestContents(t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tarball := makeTestContents(t)
 
 	// In this test we will create the download file with the right contents.
 	target := path.Join(testDir, "existing-file")
@@ -167,16 +148,9 @@ func TestDownloadGoogleapisRootTgzExists(t *testing.T) {
 }
 
 func TestDownloadGoogleapisRootNeedsDownload(t *testing.T) {
-	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
-	tarball, err := makeTestContents(t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tarball := makeTestContents(t)
 
 	// In this test we expect that a download is needed.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -206,7 +180,7 @@ type contents struct {
 	Contents []byte
 }
 
-func makeTestContents(t *testing.T) (*contents, error) {
+func makeTestContents(t *testing.T) *contents {
 	t.Helper()
 
 	hasher := sha256.New()
@@ -220,7 +194,7 @@ func makeTestContents(t *testing.T) (*contents, error) {
 	return &contents{
 		Sha256:   fmt.Sprintf("%x", hasher.Sum(nil)),
 		Contents: data,
-	}, nil
+	}
 }
 
 func makeTestTarball(t *testing.T, tempDir, subdir string) (*contents, error) {

--- a/internal/sidekick/internal/api/dependencies_test.go
+++ b/internal/sidekick/internal/api/dependencies_test.go
@@ -583,7 +583,7 @@ func TestFindDependenciesService(t *testing.T) {
 	}
 }
 
-// Simplify the test expectations
+// Simplify the test expectations.
 func flatten(m map[string]bool) []string {
 	var arr []string
 	for k, v := range m {

--- a/internal/sidekick/internal/api/documentation.go
+++ b/internal/sidekick/internal/api/documentation.go
@@ -113,7 +113,7 @@ func patchMethodDocs(svc *Service, name string, override *config.DocumentationOv
 }
 
 func patchElementDocs(documentation *string, override *config.DocumentationOverride) error {
-	new := strings.Replace(*documentation, override.Match, override.Replace, -1)
+	new := strings.ReplaceAll(*documentation, override.Match, override.Replace)
 	if *documentation == new {
 		slog.Error("comment override mismatch", "id", override.ID, "want", override.Match, "text", *documentation)
 		return fmt.Errorf("comment override for %s did not match", override.ID)

--- a/internal/sidekick/internal/api/model.go
+++ b/internal/sidekick/internal/api/model.go
@@ -24,7 +24,7 @@ type Typez int
 
 const (
 	// These are the different field types as defined in
-	// descriptorpb.FieldDescriptorProto_Type
+	// descriptorpb.FieldDescriptorProto_Type.
 
 	UNDEFINED_TYPE Typez = iota // 0
 	DOUBLE_TYPE                 // 1
@@ -287,7 +287,7 @@ type Method struct {
 //	[(a, va3), (b, vb2), (c, vc1)],
 //
 // ]
-// ```
+// ```.
 func (m *Method) RoutingCombos() []*RoutingInfoCombo {
 	combos := []*RoutingInfoCombo{
 		{},
@@ -365,7 +365,7 @@ type PathBinding struct {
 	Codec any
 }
 
-// OperationInfo contains normalized long running operation info
+// OperationInfo contains normalized long running operation info.
 type OperationInfo struct {
 	// The metadata type. If there is no metadata, this is set to
 	// `.google.protobuf.Empty`.
@@ -451,11 +451,11 @@ type RoutingPathSpec struct {
 
 const (
 	// SingleSegmentWildcard is a special routing path segment which indicates
-	// "match anything that does not include a `/`"
+	// "match anything that does not include a `/`".
 	SingleSegmentWildcard = "*"
 
 	// MultiSegmentWildcard is a special routing path segment which indicates
-	// "match anything including `/`"
+	// "match anything including `/`".
 	MultiSegmentWildcard = "**"
 )
 

--- a/internal/sidekick/internal/dart/annotate_test.go
+++ b/internal/sidekick/internal/dart/annotate_test.go
@@ -26,7 +26,7 @@ func TestAnnotateModel(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "test"
 	annotate := newAnnotateModel(model)
-	_, err := annotate.annotateModel(map[string]string{})
+	err := annotate.annotateModel(map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestAnnotateModel(t *testing.T) {
 func TestAnnotateModel_Options(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	annotate := newAnnotateModel(model)
-	_, err := annotate.annotateModel(map[string]string{
+	err := annotate.annotateModel(map[string]string{
 		"version":   "1.0.0",
 		"part-file": "src/test.p.dart",
 	})
@@ -80,7 +80,7 @@ func TestAnnotateMethod(t *testing.T) {
 	)
 	api.Validate(model)
 	annotate := newAnnotateModel(model)
-	_, err := annotate.annotateModel(map[string]string{})
+	err := annotate.annotateModel(map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/internal/dart/dart.go
+++ b/internal/sidekick/internal/dart/dart.go
@@ -184,7 +184,7 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 // both regular references as well as implit references.
 //
 // - `[Code][google.rpc.Code]`
-// - `[google.rpc.Code][]`
+// - `[google.rpc.Code][]`.
 var commentRefsRegex = regexp.MustCompile(`\[([\w\d\._]+)\]\[([\d\w\._]*)\]`)
 
 func formatDocComments(documentation string, _ *api.APIState) []string {

--- a/internal/sidekick/internal/dart/generate.go
+++ b/internal/sidekick/internal/dart/generate.go
@@ -29,13 +29,12 @@ var dartTemplates embed.FS
 // Generate generates Dart code from the model.
 func Generate(model *api.API, outdir string, config *config.Config) error {
 	annotate := newAnnotateModel(model)
-	_, err := annotate.annotateModel(config.Codec)
-	if err != nil {
+	if err := annotate.annotateModel(config.Codec); err != nil {
 		return err
 	}
 
 	provider := templatesProvider()
-	err = language.GenerateFromModel(outdir, model, provider, generatedFiles(model))
+	err := language.GenerateFromModel(outdir, model, provider, generatedFiles(model))
 	if err == nil {
 		// Check if we're configured to skip formatting.
 		skipFormat := config.Codec["skip-format"]
@@ -43,7 +42,6 @@ func Generate(model *api.API, outdir string, config *config.Config) error {
 			err = formatDirectory(outdir)
 		}
 	}
-
 	return err
 }
 

--- a/internal/sidekick/internal/golang/golang.go
+++ b/internal/sidekick/internal/golang/golang.go
@@ -37,8 +37,7 @@ type goImport struct {
 
 // Generate generates Go code from the model.
 func Generate(model *api.API, outdir string, cfg *config.Config) error {
-	_, err := annotateModel(model, cfg.Codec)
-	if err != nil {
+	if err := annotateModel(model, cfg.Codec); err != nil {
 		return err
 	}
 	provider := templatesProvider()

--- a/internal/sidekick/internal/golang/gotemplate.go
+++ b/internal/sidekick/internal/golang/gotemplate.go
@@ -103,7 +103,7 @@ type enumValueAnnotation struct {
 // Fields and methods defined in this struct directly correspond to Mustache
 // tags. For example, the Mustache tag {{#Services}} uses the
 // [Template.Services] field.
-func annotateModel(model *api.API, options map[string]string) (*modelAnnotations, error) {
+func annotateModel(model *api.API, options map[string]string) error {
 	var (
 		sourceSpecificationPackageName string
 		packageNameOverride            string
@@ -123,11 +123,11 @@ func annotateModel(model *api.API, options map[string]string) (*modelAnnotations
 		case strings.HasPrefix(key, "import-mapping"):
 			keys := strings.Split(key, ":")
 			if len(keys) != 2 {
-				return nil, fmt.Errorf("key should be in the format import-mapping:proto.path, got=%q", key)
+				return fmt.Errorf("key should be in the format import-mapping:proto.path, got=%q", key)
 			}
 			defs := strings.Split(definition, ";")
 			if len(defs) != 2 {
-				return nil, fmt.Errorf("%s should be in the format path;name, got=%q", definition, keys[1])
+				return fmt.Errorf("%s should be in the format path;name, got=%q", definition, keys[1])
 			}
 			importMap[keys[1]] = &goImport{
 				path: defs[0],
@@ -165,7 +165,7 @@ func annotateModel(model *api.API, options map[string]string) (*modelAnnotations
 	}
 
 	model.Codec = ann
-	return ann, nil
+	return nil
 }
 
 func annotateService(s *api.Service, state *api.APIState) {

--- a/internal/sidekick/internal/golang/gotemplate_test.go
+++ b/internal/sidekick/internal/golang/gotemplate_test.go
@@ -47,7 +47,7 @@ func TestGoEnumAnnotations(t *testing.T) {
 
 	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	_, err := annotateModel(model, map[string]string{})
+	err := annotateModel(model, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/internal/parser/pagination.go
+++ b/internal/sidekick/internal/parser/pagination.go
@@ -60,7 +60,7 @@ func updateMethodPagination(a *api.API) {
 				break
 			}
 		}
-		if !(hasPageSize && hasPageToken != nil) {
+		if !hasPageSize || hasPageToken == nil {
 			continue
 		}
 
@@ -84,7 +84,7 @@ func updateMethodPagination(a *api.API) {
 				break
 			}
 		}
-		if !(hasNextPageToken && hasRepeatedItem) {
+		if !hasNextPageToken || !hasRepeatedItem {
 			continue
 		}
 		m.Pagination = hasPageToken

--- a/internal/sidekick/internal/parser/service_config.go
+++ b/internal/sidekick/internal/parser/service_config.go
@@ -53,7 +53,7 @@ func readServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 //
 // The service config files are specified as relative to the `googleapis-root`
 // path (or `extra-protos-root` when set). This finds the right path given a
-// configuration
+// configuration.
 func findServiceConfigPath(serviceConfigFile string, options map[string]string) string {
 	for _, opt := range config.SourceRoots(options) {
 		dir, ok := options[opt]

--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -63,7 +63,7 @@ func (m *modelAnnotations) IsWktCrate() bool {
 	return m.PackageName == "google-cloud-wkt"
 }
 
-// HasServices returns true if there are any services in the model
+// HasServices returns true if there are any services in the model.
 func (m *modelAnnotations) HasServices() bool {
 	return len(m.Services) > 0
 }
@@ -283,14 +283,14 @@ type bindingSubstitution struct {
 // This array is supplied as an argument to `gaxi::path_parameter::try_match()`,
 // and `gaxi::path_parameter::PathMismatchBuilder`.
 //
-// e.g.: `&[Segment::Literal("projects/"), Segment::SingleWildcard]`
+// e.g.: `&[Segment::Literal("projects/"), Segment::SingleWildcard]`.
 func (s *bindingSubstitution) TemplateAsArray() string {
 	return "&[" + strings.Join(annotateSegments(s.Template), ", ") + "]"
 }
 
 // TemplateAsString returns the expected template, which can be used as a static string.
 //
-// e.g.: "projects/*"
+// e.g.: "projects/*".
 func (s *bindingSubstitution) TemplateAsString() string {
 	return strings.Join(s.Template, "/")
 }
@@ -584,7 +584,7 @@ func (c *codec) addFeatureAnnotations(model *api.API, ann *modelAnnotations) {
 	}
 }
 
-// packageToModuleName maps "google.foo.v1" to "google::foo::v1"
+// packageToModuleName maps "google.foo.v1" to "google::foo::v1".
 func packageToModuleName(p string) string {
 	components := strings.Split(p, ".")
 	for i, c := range components {
@@ -772,8 +772,8 @@ func annotateSegments(segments []string) []string {
 		literalBuffer = ""
 	}
 	for index, segment := range segments {
-		switch {
-		case segment == api.MultiSegmentWildcard:
+		switch segment {
+		case api.MultiSegmentWildcard:
 			flushBuffer()
 			if len(segments) == 1 {
 				ann = append(ann, "Segment::MultiWildcard")
@@ -782,7 +782,7 @@ func annotateSegments(segments []string) []string {
 			} else {
 				ann = append(ann, "Segment::TrailingMultiWildcard")
 			}
-		case segment == api.SingleSegmentWildcard:
+		case api.SingleSegmentWildcard:
 			if index != 0 {
 				literalBuffer += "/"
 			}

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -489,7 +489,8 @@ func mapType(f *api.Field, state *api.APIState, modulePath, sourceSpecificationP
 // baseFieldType returns the field type, ignoring any repeated or optional
 // attributes.
 func baseFieldType(f *api.Field, state *api.APIState, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) string {
-	if f.Typez == api.MESSAGE_TYPE {
+	switch f.Typez {
+	case api.MESSAGE_TYPE:
 		m, ok := state.MessageByID[f.TypezID]
 		if !ok {
 			slog.Error("unable to lookup type", "id", f.TypezID, "field", f.ID)
@@ -501,18 +502,19 @@ func baseFieldType(f *api.Field, state *api.APIState, modulePath, sourceSpecific
 			return "std::collections::HashMap<" + key + "," + val + ">"
 		}
 		return fullyQualifiedMessageName(m, modulePath, sourceSpecificationPackageName, packageMapping)
-	} else if f.Typez == api.ENUM_TYPE {
+	case api.ENUM_TYPE:
 		e, ok := state.EnumByID[f.TypezID]
 		if !ok {
 			slog.Error("unable to lookup type", "id", f.TypezID, "field", f.ID)
 			return ""
 		}
 		return fullyQualifiedEnumName(e, modulePath, sourceSpecificationPackageName, packageMapping)
-	} else if f.Typez == api.GROUP_TYPE {
+	case api.GROUP_TYPE:
 		slog.Error("TODO(#39) - better handling of `oneof` fields")
 		return ""
+	default:
+		return scalarFieldType(f)
 	}
-	return scalarFieldType(f)
 }
 
 func addQueryParameter(f *api.Field) string {

--- a/internal/sidekick/sidekick_dart_test.go
+++ b/internal/sidekick/sidekick_dart_test.go
@@ -23,11 +23,7 @@ import (
 func TestDartFromProtobuf(t *testing.T) {
 	requireProtoc(t)
 
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	svcConfig := path.Join(testdataDir, "googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml")
 	specificationSource := path.Join(testdataDir, "googleapis/google/cloud/secretmanager/v1")

--- a/internal/sidekick/sidekick_rust_prost_convert_test.go
+++ b/internal/sidekick/sidekick_rust_prost_convert_test.go
@@ -15,18 +15,13 @@
 package sidekick
 
 import (
-	"os"
 	"path"
 	"testing"
 )
 
 func TestRustProstConvert(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	type TestConfig struct {
 		Source        string

--- a/internal/sidekick/sidekick_rust_prost_test.go
+++ b/internal/sidekick/sidekick_rust_prost_test.go
@@ -22,11 +22,7 @@ import (
 
 func TestRustProstFromProtobuf(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	svcConfig := path.Join(testdataDir, "googleapis/google/type/type.yaml")
 	specificationSource := path.Join(testdataDir, "googleapis/google/type")
 	googleapisRoot := path.Join(testdataDir, "googleapis")

--- a/internal/sidekick/sidekick_sample_test.go
+++ b/internal/sidekick/sidekick_sample_test.go
@@ -22,11 +22,7 @@ import (
 
 func TestSampleFromProtobuf(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	svcConfig := path.Join(testdataDir, "googleapis/google/type/type.yaml")
 	specificationSource := path.Join(testdataDir, "googleapis/google/type")
 	googleapisRoot := path.Join(testdataDir, "googleapis")

--- a/internal/sidekick/sidekick_test.go
+++ b/internal/sidekick/sidekick_test.go
@@ -40,11 +40,7 @@ var (
 )
 
 func TestRustFromOpenAPI(t *testing.T) {
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	cmdLine := &CommandLine{
 		Command:             []string{},
 		ProjectRoot:         projectRoot,
@@ -81,11 +77,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 
 func TestRustFromProtobuf(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	type TestConfig struct {
 		Source        string
@@ -145,7 +137,7 @@ func TestRustFromProtobuf(t *testing.T) {
 			Codec: map[string]string{
 				"not-for-publication":   "true",
 				"copyright-year":        "2024",
-				"package-name-override": strings.Replace(config.Name, "/", "-", -1) + "-golden-protobuf",
+				"package-name-override": strings.ReplaceAll(config.Name, "/", "-") + "-golden-protobuf",
 				"package:wkt":           "package=google-cloud-wkt,source=google.protobuf",
 				"package:gax":           "package=gcp-sdk-gax,feature=unstable-sdk-client",
 			},
@@ -173,11 +165,7 @@ func TestRustFromProtobuf(t *testing.T) {
 
 func TestRustModuleFromProtobuf(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	type TestConfig struct {
 		Source        string
@@ -241,11 +229,7 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 
 func TestRustBootstrapWkt(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	type TestConfig struct {
 		Source        string
@@ -308,11 +292,7 @@ func TestRustBootstrapWkt(t *testing.T) {
 
 func TestRustOverrideTitleAndDescription(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	titleOverride := "Replace or Provide Custom Title"
 	descriptionOverride := "Replace or Provide Custom Description\nIncluding multiple lines."
 	cmdLine := &CommandLine{
@@ -360,11 +340,7 @@ func TestRustOverrideTitleAndDescription(t *testing.T) {
 
 func TestGoFromProtobuf(t *testing.T) {
 	requireProtoc(t)
-	outDir, err := os.MkdirTemp(t.TempDir(), "golden")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	type TestConfig struct {
 		Source       string

--- a/internal/sidekick/update_test.go
+++ b/internal/sidekick/update_test.go
@@ -32,14 +32,7 @@ func TestUpdateRootConfig(t *testing.T) {
 	// temporary directory to avoid changing the actual configuration, and any
 	// conflicts with other tests running at the same time.
 	tempDir := t.TempDir()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(cwd)
-	if err := os.Chdir(tempDir); err != nil {
-		t.Fatal(err)
-	}
+	t.Chdir(tempDir)
 
 	const (
 		getLatestShaPath      = "/repos/googleapis/googleapis/commits/master"


### PR DESCRIPTION
Fix these errors detected by TestGolangCILint:

```
--- FAIL: TestGolangCILint (1.53s)
    all_test.go:156: /Users/julieqiu/bin/homebrew/Cellar/go/1.24.4/libexec/bin/go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run: exit status 1
        internal/sidekick/internal/api/model.go:27:2: Comment should end in a period (godot)
                // descriptorpb.FieldDescriptorProto_Type
                ^
        internal/sidekick/internal/api/model.go:290:1: Comment should end in a period (godot)
        // ```
        ^
        internal/sidekick/internal/api/model.go:368:1: Comment should end in a period (godot)
        // OperationInfo contains normalized long running operation info
        ^
        internal/sidekick/internal/api/documentation.go:116:9: QF1004: could use strings.ReplaceAll instead (staticcheck)
                new := strings.Replace(*documentation, override.Match, override.Replace, -1)
                       ^
        internal/sidekick/internal/dart/annotate.go:593:3: QF1002: could use tagged switch on field.Typez (staticcheck)
                        switch {
                        ^
        internal/sidekick/internal/dart/annotate.go:613:3: QF1002: could use tagged switch on valueField.Typez (staticcheck)
                        switch {
                        ^
        internal/sidekick/internal/dart/annotate.go:669:3: QF1002: could use tagged switch on field.Typez (staticcheck)
                        switch {
                        ^
        internal/sidekick/internal/dart/annotate.go:681:3: QF1002: could use tagged switch on valueField.Typez (staticcheck)
                        switch {
                        ^
        internal/sidekick/internal/dart/annotate.go:730:3: QF1002: could use tagged switch on field.Typez (staticcheck)
                        switch {
                        ^
        internal/sidekick/internal/parser/pagination.go:63:6: QF1001: could apply De Morgan's law (staticcheck)
                        if !(hasPageSize && hasPageToken != nil) {
                           ^
        internal/sidekick/internal/parser/pagination.go:87:6: QF1001: could apply De Morgan's law (staticcheck)
                        if !(hasNextPageToken && hasRepeatedItem) {
                           ^
        internal/sidekick/internal/rust/annotate.go:775:3: QF1002: could use tagged switch on segment (staticcheck)
                        switch {
                        ^
        internal/sidekick/internal/rust/codec.go:492:2: QF1003: could use tagged switch on f.Typez (staticcheck)
                if f.Typez == api.MESSAGE_TYPE {
                ^
        internal/sidekick/sidekick_test.go:148:30: QF1004: could use strings.ReplaceAll instead (staticcheck)
                                        "package-name-override": strings.Replace(config.Name, "/", "-", -1) + "-golden-protobuf",
                                                                 ^
        internal/sidekick/downloads_cache_test.go:209:49: makeTestContents - result 1 (error) is always nil (unparam)
        func makeTestContents(t *testing.T) (*contents, error) {
                                                        ^
        internal/sidekick/internal/dart/annotate.go:202:74: (*annotateModel).annotateModel - result 0 (*github.com/googleapis/librarian/internal/sidekick/internal/dart.modelAnnotations) is never used (unparam)
        func (annotate *annotateModel) annotateModel(options map[string]string) (*modelAnnotations, error) {
                                                                                 ^
        internal/sidekick/internal/golang/gotemplate.go:106:64: annotateModel - result 0 (*github.com/googleapis/librarian/internal/sidekick/internal/golang.modelAnnotations) is never used (unparam)
        func annotateModel(model *api.API, options map[string]string) (*modelAnnotations, error) {
                                                                       ^
        internal/sidekick/downloads_cache_test.go:33:14: os.MkdirTemp() could be replaced by t.TempDir() in TestExistingDirectory (usetesting)
                tmp, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
                            ^
        internal/sidekick/downloads_cache_test.go:65:18: os.MkdirTemp() could be replaced by t.TempDir() in TestWithDownload (usetesting)
                testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
                                ^
        internal/sidekick/downloads_cache_test.go:112:18: os.MkdirTemp() could be replaced by t.TempDir() in TestTargetExists (usetesting)
                testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
                                ^
        internal/sidekick/downloads_cache_test.go:147:18: os.MkdirTemp() could be replaced by t.TempDir() in TestDownloadGoogleapisRootTgzExists (usetesting)
                testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
                                ^
        internal/sidekick/downloads_cache_test.go:170:18: os.MkdirTemp() could be replaced by t.TempDir() in TestDownloadGoogleapisRootNeedsDownload (usetesting)
                testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
                                ^
        internal/sidekick/sidekick_dart_test.go:26:17: os.MkdirTemp() could be replaced by t.TempDir() in TestDartFromProtobuf (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_rust_prost_convert_test.go:25:17: os.MkdirTemp() could be replaced by t.TempDir() in TestRustProstConvert (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_rust_prost_test.go:25:17: os.MkdirTemp() could be replaced by t.TempDir() in TestRustProstFromProtobuf (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_sample_test.go:25:17: os.MkdirTemp() could be replaced by t.TempDir() in TestSampleFromProtobuf (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_test.go:43:17: os.MkdirTemp() could be replaced by t.TempDir() in TestRustFromOpenAPI (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_test.go:84:17: os.MkdirTemp() could be replaced by t.TempDir() in TestRustFromProtobuf (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_test.go:176:17: os.MkdirTemp() could be replaced by t.TempDir() in TestRustModuleFromProtobuf (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_test.go:244:17: os.MkdirTemp() could be replaced by t.TempDir() in TestRustBootstrapWkt (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_test.go:311:17: os.MkdirTemp() could be replaced by t.TempDir() in TestRustOverrideTitleAndDescription (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/sidekick_test.go:363:17: os.MkdirTemp() could be replaced by t.TempDir() in TestGoFromProtobuf (usetesting)
                outDir, err := os.MkdirTemp(t.TempDir(), "golden")
                               ^
        internal/sidekick/update_test.go:39:8: os.Chdir() could be replaced by t.Chdir() in TestUpdateRootConfig (usetesting)
                defer os.Chdir(cwd)
                      ^
        internal/sidekick/update_test.go:40:12: os.Chdir() could be replaced by t.Chdir() in TestUpdateRootConfig (usetesting)
                if err := os.Chdir(tempDir); err != nil {
                          ^
```

Fixes https://github.com/googleapis/librarian/issues/1541