### PR TITLE
feat: clone googleapis if apisource is unspecified

### DIFF
--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -114,6 +114,7 @@ func TestRunConfigure(t *testing.T) {
 		localRepoDir        = "testdata/e2e/configure/repo"
 		initialRepoStateDir = "testdata/e2e/configure/repo_init"
 		repo                = "repo"
+		APISourceRepo       = "apisource"
 	)
 	for _, test := range []struct {
 		name         string
@@ -143,8 +144,12 @@ func TestRunConfigure(t *testing.T) {
 			t.Parallel()
 			workRoot := filepath.Join(os.TempDir(), fmt.Sprintf("rand-%d", rand.Intn(1000)))
 			repo := filepath.Join(workRoot, repo)
+			APISourceRepo := filepath.Join(workRoot, APISourceRepo)
 			if err := prepareTest(t, repo, workRoot, initialRepoStateDir); err != nil {
 				t.Fatalf("prepare test error = %v", err)
+			}
+			if err := prepareTest(t, APISourceRepo, workRoot, test.apiSource); err != nil {
+				t.Fatalf("APISouceRepo prepare test error = %v", err)
 			}
 
 			cmd := exec.Command(
@@ -155,7 +160,7 @@ func TestRunConfigure(t *testing.T) {
 				fmt.Sprintf("--api=%s", test.api),
 				fmt.Sprintf("--output=%s", workRoot),
 				fmt.Sprintf("--repo=%s", repo),
-				fmt.Sprintf("--api-source=%s", test.apiSource),
+				fmt.Sprintf("--api-source=%s", APISourceRepo),
 				fmt.Sprintf("--library=%s", test.library),
 			)
 			cmd.Stderr = os.Stderr

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -34,6 +34,7 @@ func TestRunGenerate(t *testing.T) {
 	const (
 		repo                = "repo"
 		initialRepoStateDir = "testdata/e2e/generate/repo_init"
+		APISourceRepo       = "apisource"
 		localAPISource      = "testdata/e2e/generate/api_root"
 	)
 	t.Parallel()
@@ -55,8 +56,12 @@ func TestRunGenerate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			workRoot := filepath.Join(t.TempDir())
 			repo := filepath.Join(workRoot, repo)
+			APISourceRepo := filepath.Join(workRoot, APISourceRepo)
 			if err := prepareTest(t, repo, workRoot, initialRepoStateDir); err != nil {
-				t.Fatalf("prepare test error = %v", err)
+				t.Fatalf("languageRepo prepare test error = %v", err)
+			}
+			if err := prepareTest(t, APISourceRepo, workRoot, localAPISource); err != nil {
+				t.Fatalf("APISouceRepo prepare test error = %v", err)
 			}
 
 			cmd := exec.Command(
@@ -67,7 +72,7 @@ func TestRunGenerate(t *testing.T) {
 				fmt.Sprintf("--api=%s", test.api),
 				fmt.Sprintf("--output=%s", workRoot),
 				fmt.Sprintf("--repo=%s", repo),
-				fmt.Sprintf("--api-source=%s", localAPISource),
+				fmt.Sprintf("--api-source=%s", APISourceRepo),
 			)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -46,7 +46,7 @@ func deriveRepoPath(repoFlag string) (string, error) {
 	return wd, nil
 }
 
-func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.LocalRepository, error) {
+func cloneOrOpenRepo(workRoot, repo, ci string) (*gitrepo.LocalRepository, error) {
 	if repo == "" {
 		return nil, errors.New("repo must be specified")
 	}
@@ -69,21 +69,21 @@ func cloneOrOpenLanguageRepo(workRoot, repo, ci string) (*gitrepo.LocalRepositor
 	if err != nil {
 		return nil, err
 	}
-	languageRepo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{
+	githubRepo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{
 		Dir: absRepoRoot,
 		CI:  ci,
 	})
 	if err != nil {
 		return nil, err
 	}
-	clean, err := languageRepo.IsClean()
+	clean, err := githubRepo.IsClean()
 	if err != nil {
 		return nil, err
 	}
 	if !clean {
-		return nil, errors.New("language repo must be clean")
+		return nil, fmt.Errorf("%s repo must be clean", repo)
 	}
-	return languageRepo, nil
+	return githubRepo, nil
 }
 
 func deriveImage(imageOverride string, state *config.LibrarianState) string {

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -383,7 +383,7 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 				}
 			}()
 
-			repo, err := cloneOrOpenLanguageRepo(workRoot, test.repo, test.ci)
+			repo, err := cloneOrOpenRepo(workRoot, test.repo, test.ci)
 			if test.wantErr {
 				if err == nil {
 					t.Error("cloneOrOpenLanguageRepo() expected an error but got nil")

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -112,14 +112,13 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cfg.APISource == "" {
-		if _, err := cloneOrOpenRepo(workRoot, "https://github.com/googleapis/googleapis", cfg.CI); err != nil {
-			return nil, err
-		}
-	} else {
-		if _, err := cloneOrOpenRepo(workRoot, cfg.APISource, cfg.CI); err != nil {
-			return nil, err
-		}
+
+	apiSource := cfg.APISource
+	if apiSource == "" {
+		apiSource = "https://github.com/googleapis/googleapis"
+	}
+	if _, err := cloneOrOpenRepo(workRoot, cfg.APISource, cfg.CI); err != nil {
+		return nil, err
 	}
 
 	languageRepo, err := cloneOrOpenRepo(workRoot, cfg.Repo, cfg.CI)

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -117,7 +117,7 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 	if apiSource == "" {
 		apiSource = "https://github.com/googleapis/googleapis"
 	}
-	if _, err := cloneOrOpenRepo(workRoot, cfg.APISource, cfg.CI); err != nil {
+	if _, err := cloneOrOpenRepo(workRoot, apiSource, cfg.CI); err != nil {
 		return nil, err
 	}
 

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -112,11 +112,21 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 	if err != nil {
 		return nil, err
 	}
-	repo, err := cloneOrOpenLanguageRepo(workRoot, cfg.Repo, cfg.CI)
+	if cfg.APISource == "" {
+		if _, err := cloneOrOpenRepo(workRoot, "https://github.com/googleapis/googleapis", cfg.CI); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := cloneOrOpenRepo(workRoot, cfg.APISource, cfg.CI); err != nil {
+			return nil, err
+		}
+	}
+
+	languageRepo, err := cloneOrOpenRepo(workRoot, cfg.Repo, cfg.CI)
 	if err != nil {
 		return nil, err
 	}
-	state, err := loadRepoState(repo, cfg.APISource)
+	state, err := loadRepoState(languageRepo, cfg.APISource)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +151,7 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 	return &generateRunner{
 		cfg:             cfg,
 		workRoot:        workRoot,
-		repo:            repo,
+		repo:            languageRepo,
 		state:           state,
 		image:           image,
 		ghClient:        ghClient,

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -324,11 +324,22 @@ func TestNewGenerateRunner(t *testing.T) {
 			name: "valid config",
 			cfg: &config.Config{
 				API:       "some/api",
-				APISource: t.TempDir(),
+				APISource: newTestGitRepo(t).GetDir(),
 				Repo:      newTestGitRepo(t).GetDir(),
 				WorkRoot:  t.TempDir(),
 				Image:     "gcr.io/test/test-image",
 			},
+		},
+		{
+			name: "invalid api source",
+			cfg: &config.Config{
+				API:       "some/api",
+				APISource: t.TempDir(), // Not a git repo
+				Repo:      newTestGitRepo(t).GetDir(),
+				WorkRoot:  t.TempDir(),
+				Image:     "gcr.io/test/test-image",
+			},
+			wantErr: true,
 		},
 		{
 			name: "missing image",
@@ -345,7 +356,7 @@ func TestNewGenerateRunner(t *testing.T) {
 			name: "valid config with github token",
 			cfg: &config.Config{
 				API:         "some/api",
-				APISource:   t.TempDir(),
+				APISource:   newTestGitRepo(t).GetDir(),
 				Repo:        newTestGitRepo(t).GetDir(),
 				WorkRoot:    t.TempDir(),
 				Image:       "gcr.io/test/test-image",

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -353,16 +353,6 @@ func TestNewGenerateRunner(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "valid config with empty api source",
-			cfg: &config.Config{
-				API:       "some/api",
-				APISource: "",
-				Repo:      newTestGitRepo(t).GetDir(),
-				WorkRoot:  t.TempDir(),
-				Image:     "gcr.io/test/test-image",
-			},
-		},
-		{
 			name: "valid config with github token",
 			cfg: &config.Config{
 				API:         "some/api",


### PR DESCRIPTION
Set api-source value to https://github.com/googleapis/googleapis when the flag is unspecified.
Also clone googleapis repo. 

fix: https://github.com/googleapis/librarian/issues/1512