### PR TITLE
fix(internal/librarian): use source repo if `api-source` flag is not specified

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -255,7 +255,7 @@ func (r *generateRunner) runGenerateCommand(ctx context.Context, libraryID, outp
 	if findLibraryByID(r.state, libraryID) == nil {
 		return "", fmt.Errorf("library %q not configured yet, generation stopped", libraryID)
 	}
-	apiRoot, err := filepath.Abs(r.cfg.APISource)
+	apiRoot, err := filepath.Abs(r.sourceRepo.GetDir())
 	if err != nil {
 		return "", err
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -111,11 +111,10 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 		return nil, err
 	}
 
-	apiSource := cfg.APISource
-	if apiSource == "" {
-		apiSource = "https://github.com/googleapis/googleapis"
+	if cfg.APISource == "" {
+		cfg.APISource = "https://github.com/googleapis/googleapis"
 	}
-	sourceRepo, err := cloneOrOpenRepo(workRoot, apiSource, cfg.CI)
+	sourceRepo, err := cloneOrOpenRepo(workRoot, cfg.APISource, cfg.CI)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -388,7 +388,6 @@ func TestNewGenerateRunner(t *testing.T) {
 		{
 			name: "missing image",
 			cfg: &config.Config{
-
 				API:       "some/api",
 				APISource: t.TempDir(),
 				Repo:      "https://github.com/googleapis/librarian.git",
@@ -405,6 +404,16 @@ func TestNewGenerateRunner(t *testing.T) {
 				WorkRoot:    t.TempDir(),
 				Image:       "gcr.io/test/test-image",
 				GitHubToken: "gh-token",
+			},
+		},
+		{
+			name: "empty API source",
+			cfg: &config.Config{
+				API:       "some/api",
+				APISource: "", // This will trigger the clone of googleapis
+				Repo:      newTestGitRepo(t).GetDir(),
+				WorkRoot:  t.TempDir(),
+				Image:     "gcr.io/test/test-image",
 			},
 		},
 		{
@@ -457,7 +466,7 @@ func TestNewGenerateRunner(t *testing.T) {
 
 			if test.cfg.APISource == "" && test.cfg.WorkRoot != "" {
 				if test.name == "clone googleapis fails" {
-					// The function will try to clone googleapis into the workroot.
+					// The function will try to clone googleapis into the current work directory.
 					// To make it fail, create a non-empty, non-git directory.
 					googleapisDir := filepath.Join(test.cfg.WorkRoot, "googleapis")
 					if err := os.MkdirAll(googleapisDir, 0755); err != nil {
@@ -467,7 +476,7 @@ func TestNewGenerateRunner(t *testing.T) {
 						t.Fatalf("os.WriteFile() = %v", err)
 					}
 				} else {
-					// The function will try to clone googleapis into the workroot.
+					// The function will try to clone googleapis into the current work directory.
 					// To prevent a real clone, we can pre-create a fake googleapis repo.
 					googleapisDir := filepath.Join(test.cfg.WorkRoot, "googleapis")
 					if err := os.MkdirAll(googleapisDir, 0755); err != nil {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -71,6 +71,7 @@ func TestRunGenerateCommand(t *testing.T) {
 					APISource: t.TempDir(),
 				},
 				repo:            test.repo,
+				sourceRepo:      newTestGitRepo(t),
 				ghClient:        test.ghClient,
 				state:           test.state,
 				containerClient: test.container,


### PR DESCRIPTION
Fixes #1631 