### PR TITLE
impl(generator/rust): empty body fields

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -186,7 +186,7 @@ type methodAnnotation struct {
 	BuilderName         string
 	DocLines            []string
 	PathInfo            *api.PathInfo
-	BodyAccessor        string
+	Body                string
 	ServiceNameToPascal string
 	ServiceNameToCamel  string
 	ServiceNameToSnake  string
@@ -694,7 +694,7 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 	annotation := &methodAnnotation{
 		Name:                strcase.ToSnake(m.Name),
 		BuilderName:         toPascal(m.Name),
-		BodyAccessor:        bodyAccessor(m),
+		Body:                bodyAccessor(m),
 		DocLines:            c.formatDocComments(m.Documentation, m.ID, state, s.Scopes()),
 		PathInfo:            m.PathInfo,
 		ServiceNameToPascal: toPascal(serviceName),

--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -179,10 +179,10 @@ func TestServiceAnnotations(t *testing.T) {
 	}
 
 	wantMethod := &methodAnnotation{
-		Name:         "get_resource",
-		BuilderName:  "GetResource",
-		BodyAccessor: ".",
-		PathInfo:     method.PathInfo,
+		Name:        "get_resource",
+		BuilderName: "GetResource",
+		Body:        "None::<gaxi::http::NoBody>",
+		PathInfo:    method.PathInfo,
 		SystemParameters: []systemParameter{
 			{Name: "$alt", Value: "json;enum-encoding=int"},
 		},
@@ -196,10 +196,10 @@ func TestServiceAnnotations(t *testing.T) {
 	}
 
 	wantMethod = &methodAnnotation{
-		Name:         "delete_resource",
-		BuilderName:  "DeleteResource",
-		BodyAccessor: ".",
-		PathInfo:     emptyMethod.PathInfo,
+		Name:        "delete_resource",
+		BuilderName: "DeleteResource",
+		Body:        "None::<gaxi::http::NoBody>",
+		PathInfo:    emptyMethod.PathInfo,
 		SystemParameters: []systemParameter{
 			{Name: "$alt", Value: "json;enum-encoding=int"},
 		},
@@ -348,7 +348,7 @@ func TestServiceAnnotationsNameOverrides(t *testing.T) {
 		t.Errorf("mismatch in service annotations (-want, +got)\n:%s", diff)
 	}
 
-	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "BuilderName", "BodyAccessor", "PathInfo", "SystemParameters", "ReturnType")
+	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "BuilderName", "Body", "PathInfo", "SystemParameters", "ReturnType")
 	wantMethod := &methodAnnotation{
 		ServiceNameToPascal: "Renamed",
 		ServiceNameToCamel:  "renamed",

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -691,11 +691,14 @@ func fullyQualifiedEnumValueName(v *api.EnumValue, modulePath, sourceSpecificati
 }
 
 func bodyAccessor(m *api.Method) string {
-	if m.PathInfo.BodyFieldPath == "*" {
-		// no accessor needed, use the whole request
-		return ""
+	if m.PathInfo.BodyFieldPath == "" {
+		return "None::<gaxi::http::NoBody>"
 	}
-	return "." + toSnake(m.PathInfo.BodyFieldPath)
+	if m.PathInfo.BodyFieldPath == "*" {
+		// use the whole request
+		return "Some(req)"
+	}
+	return "req." + toSnake(m.PathInfo.BodyFieldPath)
 }
 
 func httpPathFmt(t *api.PathTemplate) string {

--- a/internal/sidekick/internal/rust/codec_test.go
+++ b/internal/sidekick/internal/rust/codec_test.go
@@ -1857,3 +1857,26 @@ func TestPathFmt(t *testing.T) {
 	}
 
 }
+
+func TestBodyAccessor(t *testing.T) {
+	for _, test := range []struct {
+		bodyFieldPath string
+		want          string
+	}{
+		{"*", "Some(req)"},
+		{"field", "req.field"},
+		{"", "None::<gaxi::http::NoBody>"},
+	} {
+		method := &api.Method{
+			Name: "DoFoo",
+			ID:   ".test.Service.DoFoo",
+			PathInfo: &api.PathInfo{
+				BodyFieldPath: test.bodyFieldPath,
+			},
+		}
+		got := bodyAccessor(method)
+		if test.want != got {
+			t.Errorf("incorrect body, for BodyFieldPath=%s\nwant=%s\n got=%s", test.bodyFieldPath, test.want, got)
+		}
+	}
+}

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -142,14 +142,10 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 .query(&[("{{Name}}", "{{Value}}")])
                 {{/Codec.SystemParameters}}
                 .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
+        let body = gaxi::http::handle_empty({{{Codec.Body}}}, &method);
         self.inner.execute(
             builder,
-            {{#PathInfo.Codec.HasBody}}
-            Some(req{{Codec.BodyAccessor}}),
-            {{/PathInfo.Codec.HasBody}}
-            {{^PathInfo.Codec.HasBody}}
-            gaxi::http::NoBody::new(&method),
-            {{/PathInfo.Codec.HasBody}}
+            body,
             options,
         ).await
         {{#ReturnsEmpty}}


### PR DESCRIPTION
Part of the work for https://github.com/googleapis/google-cloud-rust/issues/2823

```rs
pub fn handle_empty<T: Default>(body: Option<T>, method: &Method) -> Option<T> {
    body.or_else(|| {
        if method == Method::PUT || method == Method::POST {
            Some(T::default())
        } else {
            None
        }
    })
}
```