### PR TITLE
ci: github token check Cloud Build yaml file

### DIFF
--- a/infra/test/token-access-test.yaml
+++ b/infra/test/token-access-test.yaml
@@ -38,7 +38,7 @@ steps:
       cat infra/prod/repositories.yaml | grep '^\s*-\s*name:' |awk '{print $NF}' |tr -d '"' | while read -r repo_name; do
         echo "Validating credentials for repository: $repo_name"
         GITHUB_TOKEN=$(gcloud secrets versions access latest --secret="${repo_name}-github-token")
-        curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/googleapis/${repo_name}/collaborators/${ROBOT_ACCOUNT}/permission"
+        curl --fail -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/googleapis/${repo_name}/collaborators/${ROBOT_ACCOUNT}/permission"
         if [[ $? -ne 0 ]]; then
           echo "Failed to validate credentials for repository: $repo_name"
           exit 1


### PR DESCRIPTION
In https://github.com/googleapis/librarian/issues/1646 we're creating a periodic check to validate the tokens stored in the secret manager.

This pull request creates the trigger's Cloud Build YAML file. This iterates the repository in the `repositories.yaml` file and checks the permissions using the token stored in the secret manager. This relies on the convention of having "-github-token" for each repository.