### PR TITLE
impl(rust): custom polling policies for gRPC

### DIFF
--- a/internal/sidekick/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -161,6 +161,21 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     }
 
     {{/Codec.Methods}}
+    {{#Codec.HasLROs}}
+    fn get_polling_error_policy(
+        &self,
+        options: &gax::options::RequestOptions,
+    ) -> std::sync::Arc<dyn gax::polling_error_policy::PollingErrorPolicy> {
+        self.inner.get_polling_error_policy(options)
+    }
+
+    fn get_polling_backoff_policy(
+        &self,
+        options: &gax::options::RequestOptions,
+    ) -> std::sync::Arc<dyn gax::polling_backoff_policy::PollingBackoffPolicy> {
+        self.inner.get_polling_backoff_policy(options)
+    }
+    {{/Codec.HasLROs}}
 }
 
 {{/Codec.Services}}


### PR DESCRIPTION
Part of the work for https://github.com/googleapis/google-cloud-rust/issues/2863

Override the default polling policy in the gRPC transport stub, actually taking into account the provided `RequestOptions` and gRPC client options.