### PR TITLE
refactor(internal/librarian): remove contentLoader

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -16,7 +16,6 @@ package librarian
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -274,9 +273,6 @@ func (r *generateRunner) runGenerateCommand(ctx context.Context, libraryID, outp
 
 	// Read the library state from the response.
 	if _, err := readLibraryState(
-		func(data []byte, libraryState *config.LibraryState) error {
-			return json.Unmarshal(data, libraryState)
-		},
 		filepath.Join(generateRequest.RepoDir, config.LibrarianDir, config.GenerateResponse)); err != nil {
 		return "", err
 	}
@@ -334,10 +330,8 @@ func (r *generateRunner) runBuildCommand(ctx context.Context, libraryID string) 
 
 	// Read the library state from the response.
 	_, err := readLibraryState(
-		func(data []byte, libraryState *config.LibraryState) error {
-			return json.Unmarshal(data, libraryState)
-		},
-		filepath.Join(buildRequest.RepoDir, config.LibrarianDir, config.BuildResponse))
+		filepath.Join(buildRequest.RepoDir, config.LibrarianDir, config.BuildResponse),
+	)
 
 	return err
 }
@@ -529,9 +523,6 @@ func (r *generateRunner) runConfigureCommand(ctx context.Context) (string, error
 
 	if err := populateServiceConfigIfEmpty(
 		r.state,
-		func(file string) ([]byte, error) {
-			return os.ReadFile(file)
-		},
 		r.cfg.APISource); err != nil {
 		return "", err
 	}
@@ -550,10 +541,8 @@ func (r *generateRunner) runConfigureCommand(ctx context.Context) (string, error
 
 	// Read the new library state from the response.
 	libraryState, err := readLibraryState(
-		func(data []byte, libraryState *config.LibraryState) error {
-			return json.Unmarshal(data, libraryState)
-		},
-		filepath.Join(r.repo.GetDir(), config.LibrarianDir, config.ConfigureResponse))
+		filepath.Join(r.repo.GetDir(), config.LibrarianDir, config.ConfigureResponse),
+	)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The release code will also need to use some of this functionality and to make the code easier to call/read I refactored out the idea of a content loader that I believe was added to help coverage. I am fine taking a couple points of a coverage hit to make the code, in my opinion, more readable.

Updates: #1009