### PR TITLE
ci: troubleshooting token validation error

### DIFF
--- a/infra/test/token-access-test.yaml
+++ b/infra/test/token-access-test.yaml
@@ -23,6 +23,8 @@ steps:
     script: |
       #!/usr/bin/env bash
 
+      # "-o pipefail" stops execution of the piped command fails, especially
+      # the body of the while loop in this case.
       set -eo pipefail
       echo "Your project ID is $PROJECT_ID"
       echo "gcloud config get-value core/account:"


### PR DESCRIPTION
This verbose logging will clarify the root cause of this 403 error:
"curl: (22) The requested URL returned error: 403"

Also, the entire script returned success because the "exit 1" was called within the piped while loop. For it to work, we need `-o pipefail`.
