### PR TITLE
ci: fixing missing 'workspace/librarian' error

### DIFF
--- a/infra/test/token-access-test.yaml
+++ b/infra/test/token-access-test.yaml
@@ -26,7 +26,8 @@ steps:
       # "-o pipefail" stops execution of the piped command fails, especially
       # the body of the while loop in this case.
       set -eo pipefail
-      echo "Your project ID is $PROJECT_ID"
+      echo "gcloud config get-value project:"
+      gcloud config get-value project
       echo "gcloud config get-value core/account:"
       gcloud config get-value core/account
       echo "pwd is $(pwd)"

--- a/infra/test/token-access-test.yaml
+++ b/infra/test/token-access-test.yaml
@@ -38,7 +38,7 @@ steps:
         echo "xtrace is ON. Exiting to avoid credentials showing up in logs."
         exit 1
       fi
-      cat infra/prod/repositories.yaml | grep '^\s*-\s*name:' |awk '{print $NF}' |tr -d '"' | while read -r repo_name; do
+      sed -n 's/.* - name: \"\(.*\)".*/\1/p' infra/prod/repositories.yaml | while read -r repo_name; do
         echo "Validating credentials for repository: ${repo_name}"
         GITHUB_TOKEN=$(gcloud secrets versions access latest --secret="${repo_name}-github-token")
         if [[ -z "${GITHUB_TOKEN}" ]]; then

--- a/infra/test/token-access-test.yaml
+++ b/infra/test/token-access-test.yaml
@@ -33,7 +33,6 @@ steps:
       echo "ls -la ."
       ls -la .
       echo "Finding YAML files:"
-      find /workspace/librarian -name '*.yaml'
       ROBOT_ACCOUNT=cloud-sdk-librarian-robot
       if [[ $- == *x* ]]; then
         echo "xtrace is ON. Exiting to avoid credentials showing up in logs."

--- a/infra/test/token-access-test.yaml
+++ b/infra/test/token-access-test.yaml
@@ -32,7 +32,6 @@ steps:
       echo "pwd is $(pwd)"
       echo "ls -la ."
       ls -la .
-      echo "Finding YAML files:"
       ROBOT_ACCOUNT=cloud-sdk-librarian-robot
       if [[ $- == *x* ]]; then
         echo "xtrace is ON. Exiting to avoid credentials showing up in logs."


### PR DESCRIPTION
The librarian repository is checked out as /workspace. There's no
/workspace/librarian folder.
