### PR TITLE
test: restore len check for goimports

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -165,6 +165,9 @@ func TestGoImports(t *testing.T) {
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("goimports failed to run: %v\nOutput:\n%s", err, out.String())
 	}
+	if out.Len() > 0 {
+		t.Errorf("goimports found unformatted files:\n%s", out.String())
+	}
 }
 
 func TestGoModTidy(t *testing.T) {


### PR DESCRIPTION
I must have forgot to revert removing this in #1662. Currently this check is not being enforced.

Found reviewing: #1686