### PR TITLE
fix(librarian/internal): fix invalidPathChars regex

### DIFF
--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -201,7 +201,7 @@ func (a *API) Validate() error {
 
 // invalidPathChars contains characters that are invalid in path components,
 // plus path separators and the null byte.
-const invalidPathChars = `<>:"|?*\/\\x00`
+const invalidPathChars = "<>:\"|?*/\\\x00"
 
 func isValidDirPath(pathString string) bool {
 	if pathString == "" {

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -323,12 +323,14 @@ func TestIsValidDirPath(t *testing.T) {
 	}{
 		{"valid", "a/b/c", true},
 		{"valid with dots", "a/./b/../c", true},
+		{"valid path area120", "google/area120/tables/v1alpha1", true},
 		{"empty", "", false},
 		{"absolute", "/a/b", false},
 		{"up traversal", "../a", false},
 		{"double dot", "..", false},
 		{"single dot", ".", false},
 		{"invalid chars", "a/b<c", false},
+		{"invalid null byte", "a/b\x00c", false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := isValidDirPath(test.path); got != test.want {


### PR DESCRIPTION
Failure observed in #1713 because flaw in regex `invalidPathChars`, the null byte (\x00) to be treated as a literal string of \, x, 0, 0, which incorrectly flagged any path containing the number 0 as invalid (e.g., area120). This fix changes the constant to an interpreted string. 

Test cases added.


Fixes #1713