### PR TITLE
build: allow specifying organization for generate command

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -21,7 +21,7 @@ steps:
     args:
       - 'clone'
       - '--depth=1'
-      - https://github.com/googleapis/$_REPOSITORY
+      - https://github.com/$_ORGANIZATION/$_REPOSITORY
   - name: gcr.io/cloud-builders/git
     id: clone-googleapis
     waitFor: ['-']


### PR DESCRIPTION
This will aid in testing. The default is set to `googleapis` on the Cloud Build trigger