### PR TITLE
build: conditionally add -push flag for generate command

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -41,6 +41,7 @@ steps:
       - $_LIBRARY_ID
       - '-api-source'
       - '/workspace/googleapis'
+      - '-push=$_PUSH'
     secretEnv: ['LIBRARIAN_GITHUB_TOKEN']
 tags: ['generate-$_REPOSITORY']
 availableSecrets:


### PR DESCRIPTION
Read the `$_PUSH` substitution for conditionally using the `-push` flag

cl/795511901 for updating the trigger (defaults `$_PUSH` to `true`)