### PR TITLE
ci: Cloud Build jobs to propagate _PUSH substitution variable

### DIFF
--- a/infra/prod/generate-worker.yaml
+++ b/infra/prod/generate-worker.yaml
@@ -23,6 +23,7 @@ steps:
       - './cmd/automation'
       - '--project=$PROJECT_ID'
       - '--command=generate'
+      - '--push=$_PUSH'
 tags: ['generate-dispatcher']
 availableSecrets:
 options:

--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -41,6 +41,7 @@ steps:
       - $_LIBRARY_ID
       - '-api-source'
       - '/workspace/googleapis'
+      - '-push=$_PUSH'
     secretEnv: ['LIBRARIAN_GITHUB_TOKEN']
 tags: ['generate-$_REPOSITORY']
 availableSecrets:

--- a/internal/automation/cli.go
+++ b/internal/automation/cli.go
@@ -29,7 +29,7 @@ func Run(args []string) error {
 		return err
 	}
 
-	err = RunCommand(ctx, options.Command, options.ProjectId)
+	err = RunCommand(ctx, options.Command, options.ProjectId, options.Push)
 	if err != nil {
 		slog.Error("Error running command", slog.Any("err", err))
 		return err
@@ -40,12 +40,14 @@ func Run(args []string) error {
 type runOptions struct {
 	Command   string
 	ProjectId string
+	Push      bool
 }
 
 func parseFlags(args []string) (*runOptions, error) {
 	flagSet := flag.NewFlagSet("dispatcher", flag.ContinueOnError)
 	projectId := flagSet.String("project", "cloud-sdk-librarian-prod", "GCP project ID")
 	command := flagSet.String("command", "generate", "The librarian command to run")
+	push := flagSet.Bool("push", true, "The _PUSH flag (true/false) to Librarian CLI's -push option")
 	err := flagSet.Parse(args)
 	if err != nil {
 		return nil, err
@@ -53,5 +55,6 @@ func parseFlags(args []string) (*runOptions, error) {
 	return &runOptions{
 		ProjectId: *projectId,
 		Command:   *command,
+		Push:      *push,
 	}, nil
 }

--- a/internal/automation/cli_test.go
+++ b/internal/automation/cli_test.go
@@ -34,6 +34,7 @@ func TestParseArgs(t *testing.T) {
 			want: &runOptions{
 				Command:   "generate",
 				ProjectId: "cloud-sdk-librarian-prod",
+				Push:      true,
 			},
 		},
 		{
@@ -43,6 +44,7 @@ func TestParseArgs(t *testing.T) {
 			want: &runOptions{
 				Command:   "generate",
 				ProjectId: "some-project-id",
+				Push:      true,
 			},
 		},
 		{
@@ -52,6 +54,17 @@ func TestParseArgs(t *testing.T) {
 			want: &runOptions{
 				Command:   "stage-release",
 				ProjectId: "cloud-sdk-librarian-prod",
+				Push:      true,
+			},
+		},
+		{
+			name:    "sets command",
+			args:    []string{"--command=stage-release", "--push=false"},
+			wantErr: false,
+			want: &runOptions{
+				Command:   "stage-release",
+				ProjectId: "cloud-sdk-librarian-prod",
+				Push:      false,
 			},
 		},
 	} {

--- a/internal/automation/trigger_test.go
+++ b/internal/automation/trigger_test.go
@@ -26,6 +26,7 @@ func TestRunCommandWithClient(t *testing.T) {
 	for _, test := range []struct {
 		name          string
 		command       string
+		push          bool
 		want          string
 		runError      error
 		wantErr       bool
@@ -34,6 +35,7 @@ func TestRunCommandWithClient(t *testing.T) {
 		{
 			name:    "runs generate trigger",
 			command: "generate",
+			push:    true,
 			wantErr: false,
 			buildTriggers: []*cloudbuildpb.BuildTrigger{
 				{
@@ -49,6 +51,7 @@ func TestRunCommandWithClient(t *testing.T) {
 		{
 			name:    "runs prepare-release trigger",
 			command: "stage-release",
+			push:    true,
 			wantErr: false,
 			buildTriggers: []*cloudbuildpb.BuildTrigger{
 				{
@@ -64,6 +67,7 @@ func TestRunCommandWithClient(t *testing.T) {
 		{
 			name:    "invalid command",
 			command: "invalid-command",
+			push:    true,
 			wantErr: true,
 			buildTriggers: []*cloudbuildpb.BuildTrigger{
 				{
@@ -79,6 +83,7 @@ func TestRunCommandWithClient(t *testing.T) {
 		{
 			name:     "error triggering",
 			command:  "generate",
+			push:     true,
 			runError: fmt.Errorf("some-error"),
 			wantErr:  true,
 			buildTriggers: []*cloudbuildpb.BuildTrigger{
@@ -99,7 +104,7 @@ func TestRunCommandWithClient(t *testing.T) {
 				runError:      test.runError,
 				buildTriggers: test.buildTriggers,
 			}
-			err := runCommandWithClient(ctx, client, test.command, "some-project")
+			err := runCommandWithClient(ctx, client, test.command, "some-project", test.push)
 			if test.wantErr && err == nil {
 				t.Errorf("expected error, but did not return one")
 			} else if !test.wantErr && err != nil {


### PR DESCRIPTION
The Cloud Build generate-worker job to pass the _PUSH substitution variable to the next Cloud Build jobs. They invoke Librarian CLI with either '-push=true' or '-push=false' parameter. This controls whether the job creates a pull request or not.

This change should come with the Terraform change cl/795539979.

