### PR TITLE
feat: add ability to create branch and push to remote repository

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -119,8 +119,10 @@ func (c *Client) GetRawContent(ctx context.Context, path, ref string) ([]byte, e
 // which must have a GitHub HTTPS URL. We assume a base branch of "main".
 func (c *Client) CreatePullRequest(ctx context.Context, repo *Repository, remoteBranch, title, body string) (*PullRequestMetadata, error) {
 	if body == "" {
+		slog.Warn("Provided PR body is empty, setting default.")
 		body = "Regenerated all changed APIs. See individual commits for details."
 	}
+	slog.Info("Creating PR", slog.String("branch", remoteBranch), slog.String("title", title), slog.String("body", body))
 	newPR := &github.NewPullRequest{
 		Title:               &title,
 		Head:                &remoteBranch,

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -122,7 +122,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, repo *Repository, remote
 		slog.Warn("Provided PR body is empty, setting default.")
 		body = "Regenerated all changed APIs. See individual commits for details."
 	}
-	slog.Info("Creating PR", slog.String("branch", remoteBranch), slog.String("title", title), slog.String("body", body))
+	slog.Info("Creating PR", "branch", remoteBranch, "title", title, "body", body)
 	newPR := &github.NewPullRequest{
 		Title:               &title,
 		Head:                &remoteBranch,

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -23,8 +23,10 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	httpAuth "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 // Repository defines the interface for git repository operations.
@@ -37,12 +39,27 @@ type Repository interface {
 	HeadHash() (string, error)
 	ChangedFilesInCommit(commitHash string) ([]string, error)
 	GetCommitsForPathsSinceTag(paths []string, tagName string) ([]*Commit, error)
+	CreateBranchAndCheckout(name string) error
+	Push(branchName string) error
 }
 
 // LocalRepository represents a git repository.
 type LocalRepository struct {
 	Dir  string
 	repo *git.Repository
+	user *GitUser
+}
+
+// GitUser represents a git user for commits.
+type GitUser struct {
+	// Username is the username used for Basic Authentication.
+	Username string
+	// Password is the password used for Basic Authentication.
+	Password string
+	// DisplayName is the user.name specified for a commit.
+	DisplayName string
+	// Email is the user.email specified for a commit.
+	Email string
 }
 
 // Commit represents a git commit.
@@ -63,6 +80,8 @@ type RepositoryOptions struct {
 	// CI is the type of Continuous Integration (CI) environment in which
 	// the tool is executing.
 	CI string
+	// GitUser is the metadata used for git commits and pushes.
+	User *GitUser
 }
 
 // NewRepository provides access to a git repository based on the provided options.
@@ -72,6 +91,15 @@ type RepositoryOptions struct {
 // otherwise it clones from opts.RemoteURL.
 // If opts.Clone is CloneOptionAlways, it always clones from opts.RemoteURL.
 func NewRepository(opts *RepositoryOptions) (*LocalRepository, error) {
+	repo, err := newRepositoryWithoutUser(opts)
+	if err != nil {
+		return repo, err
+	}
+	repo.user = opts.User
+	return repo, nil
+}
+
+func newRepositoryWithoutUser(opts *RepositoryOptions) (*LocalRepository, error) {
 	if opts.Dir == "" {
 		return nil, errors.New("gitrepo: dir is required")
 	}
@@ -100,6 +128,7 @@ func open(dir string) (*LocalRepository, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &LocalRepository{
 		Dir:  dir,
 		repo: repo,
@@ -362,4 +391,43 @@ func (r *LocalRepository) ChangedFilesInCommit(commitHash string) ([]string, err
 		}
 	}
 	return files, nil
+}
+
+// CreateBranchAndCheckout creates a new git branch and checks out the
+// branch in the local git repository.
+func (r *LocalRepository) CreateBranchAndCheckout(name string) error {
+	slog.Info("Creating branch and checking out", "name", name)
+	worktree, err := r.repo.Worktree()
+	if err != nil {
+		return err
+	}
+	return worktree.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(name),
+		Create: true,
+		Keep:   true,
+	})
+}
+
+// Push pushes the local branch to the origin remote.
+func (r *LocalRepository) Push(branchName string) error {
+	// https://stackoverflow.com/a/75727620
+	refSpec := config.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/heads/%s", branchName, branchName))
+	slog.Info("Pushing changes", slog.Any("refspec", refSpec))
+	var auth *httpAuth.BasicAuth
+	if r.user != nil {
+		slog.Info("Authenticating with basic auth", slog.String("user", r.user.Username))
+		auth = &httpAuth.BasicAuth{
+			Username: r.user.Username,
+			Password: r.user.Password,
+		}
+	}
+	if err := r.repo.Push(&git.PushOptions{
+		RemoteName: "origin",
+		RefSpecs:   []config.RefSpec{refSpec},
+		Auth:       auth,
+	}); err != nil {
+		return err
+	}
+	slog.Info("Successfully pushed branch to remote 'origin", "branch", branchName)
+	return nil
 }

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -976,10 +976,6 @@ func TestGetCommitsForPathsSinceTag(t *testing.T) {
 }
 
 func TestCreateBranchAndCheckout(t *testing.T) {
-	t.Parallel()
-
-	// repo, _ := setupRepoForGetCommitsTest(t)
-
 	for _, test := range []struct {
 		name          string
 		branchName    string
@@ -990,8 +986,13 @@ func TestCreateBranchAndCheckout(t *testing.T) {
 			name:       "works",
 			branchName: "test-branch",
 		},
+		{
+			name:          "invalid branch name",
+			branchName:    "invalid branch name",
+			wantErr:       true,
+			wantErrPhrase: "invalid",
+		},
 	} {
-
 		t.Run(test.name, func(t *testing.T) {
 			repo, _ := setupRepoForGetCommitsTest(t)
 			err := repo.CreateBranchAndCheckout(test.branchName)
@@ -1007,16 +1008,8 @@ func TestCreateBranchAndCheckout(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			config, _ := repo.repo.Config()
-			t.Logf("%#v", config)
-			branches, _ := repo.repo.Branches()
-			t.Logf("%#v", branches)
-			t.Logf("%#v", repo.repo)
-			existing, err := repo.repo.Branch(test.branchName)
-			if err != nil {
-				t.Errorf("%s should create branch", test.branchName)
-			}
-			if diff := cmp.Diff(test.branchName, existing.Name); diff != "" {
+			head, _ := repo.repo.Head()
+			if diff := cmp.Diff(test.branchName, head.Name().Short()); diff != "" {
 				t.Errorf("CreateBranchAndCheckout() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -975,6 +975,54 @@ func TestGetCommitsForPathsSinceTag(t *testing.T) {
 	}
 }
 
+func TestCreateBranchAndCheckout(t *testing.T) {
+	t.Parallel()
+
+	// repo, _ := setupRepoForGetCommitsTest(t)
+
+	for _, test := range []struct {
+		name          string
+		branchName    string
+		wantErr       bool
+		wantErrPhrase string
+	}{
+		{
+			name:       "works",
+			branchName: "test-branch",
+		},
+	} {
+
+		t.Run(test.name, func(t *testing.T) {
+			repo, _ := setupRepoForGetCommitsTest(t)
+			err := repo.CreateBranchAndCheckout(test.branchName)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("%s should return error", test.name)
+				}
+				if !strings.Contains(err.Error(), test.wantErrPhrase) {
+					t.Errorf("CreateBranchAndCheckout() returned error %q, want to contain %q", err.Error(), test.wantErrPhrase)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			config, _ := repo.repo.Config()
+			t.Logf("%#v", config)
+			branches, _ := repo.repo.Branches()
+			t.Logf("%#v", branches)
+			t.Logf("%#v", repo.repo)
+			existing, err := repo.repo.Branch(test.branchName)
+			if err != nil {
+				t.Errorf("%s should create branch", test.branchName)
+			}
+			if diff := cmp.Diff(test.branchName, existing.Name); diff != "" {
+				t.Errorf("CreateBranchAndCheckout() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 // initTestRepo creates a new git repository in a temporary directory.
 func initTestRepo(t *testing.T) (*git.Repository, string) {
 	t.Helper()

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -254,7 +254,7 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 				}
 			}()
 
-			repo, err := cloneOrOpenRepo(workRoot, test.repo, test.ci, nil)
+			repo, err := cloneOrOpenRepo(workRoot, test.repo, test.ci, "")
 			if test.wantErr {
 				if err == nil {
 					t.Error("cloneOrOpenLanguageRepo() expected an error but got nil")

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -135,6 +135,7 @@ func (r *generateRunner) run(ctx context.Context) error {
 		if err := r.generateSingleLibrary(ctx, libraryID, outputDir); err != nil {
 			return err
 		}
+		prBody += fmt.Sprintf("feat: generated %s\n", libraryID)
 	} else {
 		for _, library := range r.state.Libraries {
 			if err := r.generateSingleLibrary(ctx, library.ID, outputDir); err != nil {

--- a/internal/librarian/mocks_test.go
+++ b/internal/librarian/mocks_test.go
@@ -202,6 +202,8 @@ type MockRepository struct {
 	GetCommitsForPathsSinceTagError error
 	ChangedFilesInCommitValue       []string
 	ChangedFilesInCommitError       error
+	CreateBranchAndCheckoutError    error
+	PushError                       error
 }
 
 func (m *MockRepository) IsClean() (bool, error) {
@@ -246,4 +248,18 @@ func (m *MockRepository) ChangedFilesInCommit(hash string) ([]string, error) {
 		return nil, m.ChangedFilesInCommitError
 	}
 	return m.ChangedFilesInCommitValue, nil
+}
+
+func (m *MockRepository) CreateBranchAndCheckout(name string) error {
+	if m.CreateBranchAndCheckoutError != nil {
+		return m.CreateBranchAndCheckoutError
+	}
+	return nil
+}
+
+func (m *MockRepository) Push(name string) error {
+	if m.PushError != nil {
+		return m.PushError
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes #1762

Introduces a new `GitUser` struct which represents all potential configuration data needed for git operations (username/password for auth, name/email for commit messages). This is stored on the LocalRepository when it is loaded or cloned. Currently, we only allow CLI-based configuration for the password (GitHub token) -- other values are hard-coded, but we could easily pipe through arguments from the command line if needed.