### PR TITLE
fix: add secret in publish-release-worker

### DIFF
--- a/infra/prod/publish-release-worker.yaml
+++ b/infra/prod/publish-release-worker.yaml
@@ -25,5 +25,8 @@ steps:
       - '--command=publish-release'
 tags: ['publish-release-dispatcher']
 availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/$_GITHUB_TOKEN_SECRET_NAME/versions/latest
+      env: 'LIBRARIAN_GITHUB_TOKEN'
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Add secret in publish-release-worker job.

This is to fix this [error](https://pantheon.corp.google.com/cloud-build/builds;region=global/2b272e37-9895-4d51-8203-60aed2040255?invt=Ab6K1g&orgonly=true&project=cloud-sdk-librarian-prod&supportedpurview=organizationId)

```

2025/08/21 19:29:44 GET https://api.github.com/repos/googleapis/google-cloud-python/pulls?per_page=100&state=closed: 401 Bad credentials []
--
  | 2025/08/21 19:29:44 ERROR Error running command err="GET https://api.github.com/repos/googleapis/google-cloud-python/pulls?per_page=100&state=closed: 401 Bad credentials []"
  | 2025/08/21 19:29:44 ERROR Error finding merged pull requests for publish-release err="GET https://api.github.com/repos/googleapis/google-cloud-python/pulls?per_page=100&state=closed: 401 Bad credentials []" repository=google-cloud-python


```