### PR TITLE
fix: specify output directory so librarian builds have access to files created

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -49,6 +49,7 @@ steps:
   - name: 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-prod/librarian@sha256:fd5a83ab38e775ccf7f8431f97050c12c1cad2490d5ca8f80a456e9f87fc88e1'
     id: generate
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
+    dir: tmp
     args:
       - 'generate'
       - '-repo'
@@ -57,6 +58,8 @@ steps:
       - $_LIBRARY_ID
       - '-api-source'
       - '/workspace/googleapis'
+      - '-output'
+      - /workspace/tmp
       - '-push=$_PUSH'
     secretEnv: ['LIBRARIAN_GITHUB_TOKEN']
 tags: ['generate-$_REPOSITORY']

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -35,6 +35,7 @@ steps:
   - name: 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-prod/librarian@sha256:fd5a83ab38e775ccf7f8431f97050c12c1cad2490d5ca8f80a456e9f87fc88e1'
     id: stage-release
     waitFor: ['clone-language-repo', 'clone-googleapis']
+    dir: tmp
     args:
       - 'release init'
       - '-repo'
@@ -43,6 +44,9 @@ steps:
       - $_LIBRARY_ID
       - '-api-source'
       - '/workspace/googleapis'
+      - '-output'
+      - /workspace/tmp
+      - '-push=$_PUSH'
     secretEnv: ['LIBRARIAN_GITHUB_TOKEN']
 tags: ['stage-release-$_REPOSITORY']
 availableSecrets:


### PR DESCRIPTION
This is to fix the issue that we weren't able to see the contents of the output directory when created directly by librarian.

This also adds the push command to the stage-release build