### PR TITLE
ci: push option to stage-release-dispatcher

### DIFF
--- a/infra/prod/stage-release-worker.yaml
+++ b/infra/prod/stage-release-worker.yaml
@@ -23,6 +23,7 @@ steps:
       - './cmd/automation'
       - '--project=$PROJECT_ID'
       - '--command=stage-release'
+      - '--push=$_PUSH'
 tags: ['stage-release-dispatcher']
 availableSecrets:
 options:


### PR DESCRIPTION
Let's propagate the _PUSH substitution variable when we run stage-release job. The corresponding change in Terraform is at cl/798304040.