### PR TITLE
chore: migrate librarian to publish to new cloud-sdk-librarian-prod GCP project

### DIFF
--- a/cloudbuild-exitgate-deprecated.yaml
+++ b/cloudbuild-exitgate-deprecated.yaml
@@ -20,6 +20,6 @@
 # published to the 'images-prod' repository.
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian', '.']
+    args: ['build', '-t', 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian', '.']
 images:
-  - 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian'
+  - 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian'


### PR DESCRIPTION
This additionally deprecates old AR exit gate cloud build file