### PR TITLE
chore: update automation to use latest librarian image from correct GCP project

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -46,7 +46,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-prod/librarian@sha256:fd5a83ab38e775ccf7f8431f97050c12c1cad2490d5ca8f80a456e9f87fc88e1'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian'
     id: generate
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
     dir: tmp

--- a/infra/prod/publish-release.yaml
+++ b/infra/prod/publish-release.yaml
@@ -26,7 +26,7 @@ steps:
       - '--single-branch'
       - '--branch=$_BRANCH'
       - https://github.com/googleapis/$_REPOSITORY
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-prod/librarian@sha256:fd5a83ab38e775ccf7f8431f97050c12c1cad2490d5ca8f80a456e9f87fc88e1'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian'
     id: publish-release
     waitFor: ['clone-language-repo']
     args:

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -32,7 +32,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-prod/librarian@sha256:fd5a83ab38e775ccf7f8431f97050c12c1cad2490d5ca8f80a456e9f87fc88e1'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian'
     id: stage-release
     waitFor: ['clone-language-repo', 'clone-googleapis']
     dir: tmp


### PR DESCRIPTION
This will allow us to get daily builds, while we are integrating to see if anything breaks