### PR TITLE
fix: release init command invocation

### DIFF
--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -37,7 +37,8 @@ steps:
     waitFor: ['clone-language-repo', 'clone-googleapis']
     dir: tmp
     args:
-      - 'release init'
+      - 'release'
+      - 'init'
       - '-repo'
       - '/workspace/$_REPOSITORY'
       - '-library'


### PR DESCRIPTION
I believe this wasn't treating "init" as a separate command, so made it its own argument