### PR TITLE
fix(sidekick): track the source service for mixins

### DIFF
--- a/internal/sidekick/internal/api/model.go
+++ b/internal/sidekick/internal/api/model.go
@@ -242,6 +242,12 @@ type Method struct {
 	// Service is the service this method belongs to, mustache templates use this field to
 	// navigate the data structure.
 	Service *Service
+	// `SourceService` is the original service this method belongs to. For most
+	// methods `SourceService` and `Service` are the same. For mixins, the
+	// source service is the mixin, such as longrunning.Operations.
+	SourceService *Service
+	// `SourceServiceID` is the original service ID for this method.
+	SourceServiceID string
 	// Codec contains language specific annotations.
 	Codec any
 }

--- a/internal/sidekick/internal/api/skip_test.go
+++ b/internal/sidekick/internal/api/skip_test.go
@@ -362,7 +362,7 @@ func TestIncludeMethods(t *testing.T) {
 			ID:   ".test.Service1.Method2",
 		},
 	}
-	if diff := cmp.Diff(wantMethods, s1.Methods, cmpopts.IgnoreFields(Method{}, "Model", "Service", "InputType", "OutputType", "InputTypeID", "OutputTypeID")); diff != "" {
+	if diff := cmp.Diff(wantMethods, s1.Methods, cmpopts.IgnoreFields(Method{}, "Model", "Service", "SourceService", "InputType", "OutputType", "InputTypeID", "OutputTypeID")); diff != "" {
 		t.Errorf("mismatch in methods (-want, +got)\n:%s", diff)
 	}
 }

--- a/internal/sidekick/internal/api/xref.go
+++ b/internal/sidekick/internal/api/xref.go
@@ -55,6 +55,14 @@ func CrossReference(model *API) error {
 		for _, m := range s.Methods {
 			m.Model = model
 			m.Service = s
+			source, ok := model.State.ServiceByID[m.SourceServiceID]
+			if ok {
+				m.SourceService = source
+			} else {
+				// Default to the regular service. OpenAPI does not define the
+				// services for mixins.
+				m.SourceService = s
+			}
 		}
 	}
 	return nil

--- a/internal/sidekick/internal/parser/protobuf.go
+++ b/internal/sidekick/internal/parser/protobuf.go
@@ -262,7 +262,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 			service := processService(state, s, sFQN, f.GetPackage())
 			for _, m := range s.Method {
 				mFQN := sFQN + "." + m.GetName()
-				if method := processMethod(state, m, mFQN, f.GetPackage()); method != nil {
+				if method := processMethod(state, m, mFQN, f.GetPackage(), sFQN); method != nil {
 					service.Methods = append(service.Methods, method)
 				}
 			}
@@ -322,7 +322,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 						// define the mixin method in the code.
 						continue
 					}
-					if method := processMethod(state, m, mFQN, service.Package); method != nil {
+					if method := processMethod(state, m, mFQN, service.Package, sFQN); method != nil {
 						applyServiceConfigMethodOverrides(method, originalFQN, serviceConfig, result, mixin)
 						service.Methods = append(service.Methods, method)
 					}
@@ -443,7 +443,7 @@ func processService(state *api.APIState, s *descriptorpb.ServiceDescriptorProto,
 	return service
 }
 
-func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, mFQN, packagez string) *api.Method {
+func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, mFQN, packagez, serviceID string) *api.Method {
 	pathInfo, err := parsePathInfo(m, state)
 	if err != nil {
 		slog.Error("unsupported http method", "method", m, "error", err)
@@ -467,6 +467,7 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		OperationInfo:       parseOperationInfo(packagez, m),
 		Routing:             routing,
 		ReturnsEmpty:        outputTypeID == ".google.protobuf.Empty",
+		SourceServiceID:     serviceID,
 	}
 	state.MethodByID[mFQN] = method
 	return method

--- a/internal/sidekick/internal/parser/protobuf_mixin_test.go
+++ b/internal/sidekick/internal/parser/protobuf_mixin_test.go
@@ -66,11 +66,12 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 	}
 
 	checkMethod(t, service, "GetLocation", &api.Method{
-		Documentation: "Provides the [Locations][google.cloud.location.Locations] service functionality in this service.",
-		Name:          "GetLocation",
-		ID:            ".test.TestService.GetLocation",
-		InputTypeID:   ".google.cloud.location.GetLocationRequest",
-		OutputTypeID:  ".google.cloud.location.Location",
+		Documentation:   "Provides the [Locations][google.cloud.location.Locations] service functionality in this service.",
+		Name:            "GetLocation",
+		ID:              ".test.TestService.GetLocation",
+		SourceServiceID: ".google.cloud.location.Locations",
+		InputTypeID:     ".google.cloud.location.GetLocationRequest",
+		OutputTypeID:    ".google.cloud.location.Location",
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{
@@ -133,11 +134,12 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 		t.Fatal("Cannot find .test.TestService.GetIamPolicy")
 	}
 	checkMethod(t, service, "GetIamPolicy", &api.Method{
-		Documentation: "Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.",
-		Name:          "GetIamPolicy",
-		ID:            ".test.TestService.GetIamPolicy",
-		InputTypeID:   ".google.iam.v1.GetIamPolicyRequest",
-		OutputTypeID:  ".google.iam.v1.Policy",
+		Documentation:   "Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.",
+		Name:            "GetIamPolicy",
+		ID:              ".test.TestService.GetIamPolicy",
+		SourceServiceID: ".google.iam.v1.IAMPolicy",
+		InputTypeID:     ".google.iam.v1.GetIamPolicyRequest",
+		OutputTypeID:    ".google.iam.v1.Policy",
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{
@@ -206,11 +208,12 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 	}
 
 	checkMethod(t, service, "GetOperation", &api.Method{
-		Documentation: "Custom docs.",
-		Name:          "GetOperation",
-		ID:            ".test.TestService.GetOperation",
-		InputTypeID:   ".google.longrunning.GetOperationRequest",
-		OutputTypeID:  ".google.longrunning.Operation",
+		Documentation:   "Custom docs.",
+		Name:            "GetOperation",
+		ID:              ".test.TestService.GetOperation",
+		SourceServiceID: ".google.longrunning.Operations",
+		InputTypeID:     ".google.longrunning.GetOperationRequest",
+		OutputTypeID:    ".google.longrunning.Operation",
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{
@@ -289,12 +292,13 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 	}
 
 	checkMethod(t, service, "CancelOperation", &api.Method{
-		Documentation: "Custom docs.",
-		Name:          "CancelOperation",
-		ID:            ".test.TestService.CancelOperation",
-		InputTypeID:   ".google.longrunning.CancelOperationRequest",
-		OutputTypeID:  ".google.protobuf.Empty",
-		ReturnsEmpty:  true,
+		Documentation:   "Custom docs.",
+		Name:            "CancelOperation",
+		ID:              ".test.TestService.CancelOperation",
+		SourceServiceID: ".google.longrunning.Operations",
+		InputTypeID:     ".google.longrunning.CancelOperationRequest",
+		OutputTypeID:    ".google.protobuf.Empty",
+		ReturnsEmpty:    true,
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{
@@ -371,11 +375,12 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 	}
 
 	checkMethod(t, service, "GetOperation", &api.Method{
-		Documentation: "Source file docs.",
-		Name:          "GetOperation",
-		ID:            ".test.LroService.GetOperation",
-		InputTypeID:   ".google.longrunning.GetOperationRequest",
-		OutputTypeID:  ".google.longrunning.Operation",
+		Documentation:   "Source file docs.",
+		Name:            "GetOperation",
+		ID:              ".test.LroService.GetOperation",
+		SourceServiceID: ".test.LroService",
+		InputTypeID:     ".google.longrunning.GetOperationRequest",
+		OutputTypeID:    ".google.longrunning.Operation",
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{

--- a/internal/sidekick/internal/parser/protobuf_test.go
+++ b/internal/sidekick/internal/parser/protobuf_test.go
@@ -446,11 +446,12 @@ func TestProtobuf_Comments(t *testing.T) {
 		DefaultHost:   "test.googleapis.com",
 		Methods: []*api.Method{
 			{
-				Name:          "Create",
-				ID:            ".test.Service.Create",
-				Documentation: "Some RPC.\n\nIt does not do much.",
-				InputTypeID:   ".test.Request",
-				OutputTypeID:  ".test.Response",
+				Name:            "Create",
+				ID:              ".test.Service.Create",
+				SourceServiceID: ".test.Service",
+				Documentation:   "Some RPC.\n\nIt does not do much.",
+				InputTypeID:     ".test.Request",
+				OutputTypeID:    ".test.Response",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -838,11 +839,12 @@ func TestProtobuf_Service(t *testing.T) {
 		DefaultHost:   "test.googleapis.com",
 		Methods: []*api.Method{
 			{
-				Name:          "GetFoo",
-				ID:            ".test.TestService.GetFoo",
-				Documentation: "Gets a Foo resource.",
-				InputTypeID:   ".test.GetFooRequest",
-				OutputTypeID:  ".test.Foo",
+				Name:            "GetFoo",
+				ID:              ".test.TestService.GetFoo",
+				SourceServiceID: ".test.TestService",
+				Documentation:   "Gets a Foo resource.",
+				InputTypeID:     ".test.GetFooRequest",
+				OutputTypeID:    ".test.Foo",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -861,11 +863,12 @@ func TestProtobuf_Service(t *testing.T) {
 				},
 			},
 			{
-				Name:          "CreateFoo",
-				ID:            ".test.TestService.CreateFoo",
-				Documentation: "Creates a new Foo resource.",
-				InputTypeID:   ".test.CreateFooRequest",
-				OutputTypeID:  ".test.Foo",
+				Name:            "CreateFoo",
+				ID:              ".test.TestService.CreateFoo",
+				SourceServiceID: ".test.TestService",
+				Documentation:   "Creates a new Foo resource.",
+				InputTypeID:     ".test.CreateFooRequest",
+				OutputTypeID:    ".test.Foo",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -883,11 +886,12 @@ func TestProtobuf_Service(t *testing.T) {
 				},
 			},
 			{
-				Name:          "DeleteFoo",
-				ID:            ".test.TestService.DeleteFoo",
-				Documentation: "Deletes a Foo resource.",
-				InputTypeID:   ".test.DeleteFooRequest",
-				OutputTypeID:  ".google.protobuf.Empty",
+				Name:            "DeleteFoo",
+				ID:              ".test.TestService.DeleteFoo",
+				SourceServiceID: ".test.TestService",
+				Documentation:   "Deletes a Foo resource.",
+				InputTypeID:     ".test.DeleteFooRequest",
+				OutputTypeID:    ".google.protobuf.Empty",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -908,6 +912,7 @@ func TestProtobuf_Service(t *testing.T) {
 			{
 				Name:                "UploadFoos",
 				ID:                  ".test.TestService.UploadFoos",
+				SourceServiceID:     ".test.TestService",
 				Documentation:       "A client-side streaming RPC.",
 				InputTypeID:         ".test.CreateFooRequest",
 				OutputTypeID:        ".test.Foo",
@@ -915,11 +920,12 @@ func TestProtobuf_Service(t *testing.T) {
 				ClientSideStreaming: true,
 			},
 			{
-				Name:          "DownloadFoos",
-				ID:            ".test.TestService.DownloadFoos",
-				Documentation: "A server-side streaming RPC.",
-				InputTypeID:   ".test.GetFooRequest",
-				OutputTypeID:  ".test.Foo",
+				Name:            "DownloadFoos",
+				ID:              ".test.TestService.DownloadFoos",
+				SourceServiceID: ".test.TestService",
+				Documentation:   "A server-side streaming RPC.",
+				InputTypeID:     ".test.GetFooRequest",
+				OutputTypeID:    ".test.Foo",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -942,6 +948,7 @@ func TestProtobuf_Service(t *testing.T) {
 			{
 				Name:                "ChatLike",
 				ID:                  ".test.TestService.ChatLike",
+				SourceServiceID:     ".test.TestService",
 				Documentation:       "A bidi streaming RPC.",
 				InputTypeID:         ".test.Foo",
 				OutputTypeID:        ".test.Foo",
@@ -968,11 +975,12 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 		DefaultHost:   "test.googleapis.com",
 		Methods: []*api.Method{
 			{
-				Name:          "CreateFoo",
-				ID:            ".test.TestService.CreateFoo",
-				Documentation: "Creates a new `Foo` resource. `Foo`s are containers for `Bar`s.\n\nShows how a `body: \"${field}\"` option works.",
-				InputTypeID:   ".test.CreateFooRequest",
-				OutputTypeID:  ".test.Foo",
+				Name:            "CreateFoo",
+				ID:              ".test.TestService.CreateFoo",
+				SourceServiceID: ".test.TestService",
+				Documentation:   "Creates a new `Foo` resource. `Foo`s are containers for `Bar`s.\n\nShows how a `body: \"${field}\"` option works.",
+				InputTypeID:     ".test.CreateFooRequest",
+				OutputTypeID:    ".test.Foo",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -990,11 +998,12 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 				},
 			},
 			{
-				Name:          "AddBar",
-				ID:            ".test.TestService.AddBar",
-				Documentation: "Add a Bar resource.\n\nShows how a `body: \"*\"` option works.",
-				InputTypeID:   ".test.AddBarRequest",
-				OutputTypeID:  ".test.Bar",
+				Name:            "AddBar",
+				ID:              ".test.TestService.AddBar",
+				SourceServiceID: ".test.TestService",
+				Documentation:   "Add a Bar resource.\n\nShows how a `body: \"*\"` option works.",
+				InputTypeID:     ".test.AddBarRequest",
+				OutputTypeID:    ".test.Bar",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1081,10 +1090,11 @@ func TestProtobuf_Pagination(t *testing.T) {
 		Package:     "test",
 		Methods: []*api.Method{
 			{
-				Name:         "ListFoo",
-				ID:           ".test.TestService.ListFoo",
-				InputTypeID:  ".test.ListFooRequest",
-				OutputTypeID: ".test.ListFooResponse",
+				Name:            "ListFoo",
+				ID:              ".test.TestService.ListFoo",
+				SourceServiceID: ".test.TestService",
+				InputTypeID:     ".test.ListFooRequest",
+				OutputTypeID:    ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1108,10 +1118,11 @@ func TestProtobuf_Pagination(t *testing.T) {
 				},
 			},
 			{
-				Name:         "ListFooWithMaxResultsInt32",
-				ID:           ".test.TestService.ListFooWithMaxResultsInt32",
-				InputTypeID:  ".test.ListFooMaxResultsInt32Request",
-				OutputTypeID: ".test.ListFooResponse",
+				Name:            "ListFooWithMaxResultsInt32",
+				ID:              ".test.TestService.ListFooWithMaxResultsInt32",
+				SourceServiceID: ".test.TestService",
+				InputTypeID:     ".test.ListFooMaxResultsInt32Request",
+				OutputTypeID:    ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1135,10 +1146,11 @@ func TestProtobuf_Pagination(t *testing.T) {
 				},
 			},
 			{
-				Name:         "ListFooWithMaxResultsUInt32",
-				ID:           ".test.TestService.ListFooWithMaxResultsUInt32",
-				InputTypeID:  ".test.ListFooMaxResultsUInt32Request",
-				OutputTypeID: ".test.ListFooResponse",
+				Name:            "ListFooWithMaxResultsUInt32",
+				ID:              ".test.TestService.ListFooWithMaxResultsUInt32",
+				SourceServiceID: ".test.TestService",
+				InputTypeID:     ".test.ListFooMaxResultsUInt32Request",
+				OutputTypeID:    ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1162,10 +1174,11 @@ func TestProtobuf_Pagination(t *testing.T) {
 				},
 			},
 			{
-				Name:         "ListFooMissingNextPageToken",
-				ID:           ".test.TestService.ListFooMissingNextPageToken",
-				InputTypeID:  ".test.ListFooRequest",
-				OutputTypeID: ".test.ListFooMissingNextPageTokenResponse",
+				Name:            "ListFooMissingNextPageToken",
+				ID:              ".test.TestService.ListFooMissingNextPageToken",
+				SourceServiceID: ".test.TestService",
+				InputTypeID:     ".test.ListFooRequest",
+				OutputTypeID:    ".test.ListFooMissingNextPageTokenResponse",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1182,10 +1195,11 @@ func TestProtobuf_Pagination(t *testing.T) {
 				},
 			},
 			{
-				Name:         "ListFooMissingPageSize",
-				ID:           ".test.TestService.ListFooMissingPageSize",
-				InputTypeID:  ".test.ListFooMissingPageSizeRequest",
-				OutputTypeID: ".test.ListFooResponse",
+				Name:            "ListFooMissingPageSize",
+				ID:              ".test.TestService.ListFooMissingPageSize",
+				SourceServiceID: ".test.TestService",
+				InputTypeID:     ".test.ListFooMissingPageSizeRequest",
+				OutputTypeID:    ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1202,10 +1216,11 @@ func TestProtobuf_Pagination(t *testing.T) {
 				},
 			},
 			{
-				Name:         "ListFooMissingPageToken",
-				ID:           ".test.TestService.ListFooMissingPageToken",
-				InputTypeID:  ".test.ListFooMissingPageTokenRequest",
-				OutputTypeID: ".test.ListFooResponse",
+				Name:            "ListFooMissingPageToken",
+				ID:              ".test.TestService.ListFooMissingPageToken",
+				SourceServiceID: ".test.TestService",
+				InputTypeID:     ".test.ListFooMissingPageTokenRequest",
+				OutputTypeID:    ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1222,10 +1237,11 @@ func TestProtobuf_Pagination(t *testing.T) {
 				},
 			},
 			{
-				Name:         "ListFooMissingRepeatedItemToken",
-				ID:           ".test.TestService.ListFooMissingRepeatedItemToken",
-				InputTypeID:  ".test.ListFooRequest",
-				OutputTypeID: ".test.ListFooMissingRepeatedItemResponse",
+				Name:            "ListFooMissingRepeatedItemToken",
+				ID:              ".test.TestService.ListFooMissingRepeatedItemToken",
+				SourceServiceID: ".test.TestService",
+				InputTypeID:     ".test.ListFooRequest",
+				OutputTypeID:    ".test.ListFooMissingRepeatedItemResponse",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1342,11 +1358,12 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 		Package:       "test",
 		Methods: []*api.Method{
 			{
-				Documentation: "Creates a new Foo resource.",
-				Name:          "CreateFoo",
-				ID:            ".test.LroService.CreateFoo",
-				InputTypeID:   ".test.CreateFooRequest",
-				OutputTypeID:  ".google.longrunning.Operation",
+				Documentation:   "Creates a new Foo resource.",
+				Name:            "CreateFoo",
+				ID:              ".test.LroService.CreateFoo",
+				SourceServiceID: ".test.LroService",
+				InputTypeID:     ".test.CreateFooRequest",
+				OutputTypeID:    ".google.longrunning.Operation",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1368,11 +1385,12 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 				},
 			},
 			{
-				Documentation: "Creates a new Foo resource.",
-				Name:          "CreateFooWithProgress",
-				ID:            ".test.LroService.CreateFooWithProgress",
-				InputTypeID:   ".test.CreateFooRequest",
-				OutputTypeID:  ".google.longrunning.Operation",
+				Documentation:   "Creates a new Foo resource.",
+				Name:            "CreateFooWithProgress",
+				ID:              ".test.LroService.CreateFooWithProgress",
+				SourceServiceID: ".test.LroService",
+				InputTypeID:     ".test.CreateFooRequest",
+				OutputTypeID:    ".google.longrunning.Operation",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1394,11 +1412,12 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 				},
 			},
 			{
-				Documentation: "Custom docs.",
-				Name:          "GetOperation",
-				ID:            ".test.LroService.GetOperation",
-				InputTypeID:   ".google.longrunning.GetOperationRequest",
-				OutputTypeID:  ".google.longrunning.Operation",
+				Documentation:   "Custom docs.",
+				Name:            "GetOperation",
+				ID:              ".test.LroService.GetOperation",
+				SourceServiceID: ".google.longrunning.Operations",
+				InputTypeID:     ".google.longrunning.GetOperationRequest",
+				OutputTypeID:    ".google.longrunning.Operation",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
@@ -1609,12 +1628,13 @@ func TestProtobuf_Deprecated(t *testing.T) {
 		Deprecated: false,
 		Methods: []*api.Method{
 			{
-				Name:         "RpcA",
-				ID:           ".test.ServiceB.RpcA",
-				Deprecated:   true,
-				InputTypeID:  ".test.Request",
-				OutputTypeID: ".test.Response",
-				PathInfo:     &api.PathInfo{},
+				Name:            "RpcA",
+				ID:              ".test.ServiceB.RpcA",
+				Deprecated:      true,
+				InputTypeID:     ".test.Request",
+				OutputTypeID:    ".test.Response",
+				PathInfo:        &api.PathInfo{},
+				SourceServiceID: ".test.ServiceB",
 			},
 		},
 	})

--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -174,7 +174,7 @@ func TestServiceAnnotations(t *testing.T) {
 	// Codec.
 	serviceAnn := service.Codec.(*serviceAnnotations)
 	wantMethodList := []*api.Method{method, emptyMethod}
-	if diff := cmp.Diff(wantMethodList, serviceAnn.Methods, cmpopts.IgnoreFields(api.Method{}, "Model", "Service")); diff != "" {
+	if diff := cmp.Diff(wantMethodList, serviceAnn.Methods, cmpopts.IgnoreFields(api.Method{}, "Model", "Service", "SourceService")); diff != "" {
 		t.Errorf("mismatch in method list (-want, +got)\n:%s", diff)
 	}
 

--- a/internal/sidekick/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -107,11 +107,11 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
         let extensions = {
             let mut e = tonic::Extensions::new();
-            e.insert(tonic::GrpcMethod::new("{{Service.Package}}.{{Service.Name}}", "{{Name}}"));
+            e.insert(tonic::GrpcMethod::new("{{SourceService.Package}}.{{SourceService.Name}}", "{{Name}}"));
             e
         };
         let path = http::uri::PathAndQuery::from_static(
-            "/{{Service.Package}}.{{Service.Name}}/{{Name}}"
+            "/{{SourceService.Package}}.{{Service.Name}}/{{Name}}"
         );
         {{!
         AIP-4222 says:


### PR DESCRIPTION
We need this to generate the right gRPC calls in Rust.

Related to https://github.com/googleapis/google-cloud-rust/issues/3125
