### PR TITLE
fix(internal/librarian): don't clean dir for release init copies

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -208,6 +208,56 @@ func cleanAndCopyLibrary(state *config.LibrarianState, repoDir, libraryID, outpu
 	return copyLibrary(repoDir, outputDir, library)
 }
 
+func copyLibraryFiles(state *config.LibrarianState, dest, libraryID, src string) error {
+	library := findLibraryByID(state, libraryID)
+	if library == nil {
+		return fmt.Errorf("library %q not found", libraryID)
+	}
+	slog.Info("Copying library files", "id", library.ID, "destination", dest, "source", src)
+	for _, srcRoot := range library.SourceRoots {
+		dstPath := filepath.Join(dest, srcRoot)
+		srcPath := filepath.Join(src, srcRoot)
+		files, err := getDirectoryFilesnames(srcPath)
+		if err != nil {
+			return err
+		}
+		for _, file := range files {
+			slog.Info("Copying file", "file", file)
+			srcFile := filepath.Join(srcPath, file)
+			dstFile := filepath.Join(dstPath, file)
+			if err := copyFile(dstFile, srcFile); err != nil {
+				return fmt.Errorf("failed to copy file %q for library %s: %w", srcFile, library.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func getDirectoryFilesnames(dir string) ([]string, error) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	var fileNames []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			relativePath, err := filepath.Rel(dir, path)
+			if err != nil {
+				return err
+			}
+			fileNames = append(fileNames, relativePath)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return fileNames, nil
+}
+
 // copyLibrary copies library file from src to dst.
 func copyLibrary(dst, src string, library *config.LibraryState) error {
 	slog.Info("Copying library", "id", library.ID, "destination", dst, "source", src)

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -234,8 +234,12 @@ func copyLibraryFiles(state *config.LibrarianState, dest, libraryID, src string)
 }
 
 func getDirectoryFilesnames(dir string) ([]string, error) {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return nil, nil
+	if _, err := os.Stat(dir); err != nil {
+		// Skip dirs that don't exist
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	var fileNames []string

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -771,8 +771,8 @@ func TestCopyLibraryFiles(t *testing.T) {
 			wantErrMsg: "not found",
 		},
 		{
-			name:      "source root not found",
 			repoDir:   filepath.Join(t.TempDir(), "dst"),
+			name:      "one source root empty",
 			outputDir: filepath.Join(t.TempDir(), "src"),
 			libraryID: "example-library",
 			state: &config.LibrarianState{
@@ -795,7 +795,6 @@ func TestCopyLibraryFiles(t *testing.T) {
 			},
 			skipFiles: []string{
 				"skipped/path/example.txt",
-				"another/path/example.txt",
 			},
 		},
 	} {

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -700,6 +700,142 @@ func TestCommitAndPush(t *testing.T) {
 	}
 }
 
+func TestCopyLibraryFiles(t *testing.T) {
+	t.Parallel()
+	setup := func(src string, files []string) {
+		for _, relPath := range files {
+			fullPath := filepath.Join(src, relPath)
+			if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+				t.Error(err)
+			}
+
+			if _, err := os.Create(fullPath); err != nil {
+				t.Error(err)
+			}
+		}
+	}
+	for _, test := range []struct {
+		name          string
+		repoDir       string
+		outputDir     string
+		libraryID     string
+		state         *config.LibrarianState
+		filesToCreate []string
+		wantFiles     []string
+		skipFiles     []string
+		wantErr       bool
+		wantErrMsg    string
+	}{
+		{
+			name:      "copy library files",
+			repoDir:   filepath.Join(t.TempDir(), "dst"),
+			outputDir: filepath.Join(t.TempDir(), "src"),
+			libraryID: "example-library",
+			state: &config.LibrarianState{
+				Libraries: []*config.LibraryState{
+					{
+						ID: "example-library",
+						SourceRoots: []string{
+							"a/path",
+							"another/path",
+						},
+					},
+				},
+			},
+			filesToCreate: []string{
+				"a/path/example.txt",
+				"another/path/example.txt",
+				"skipped/path/example.txt",
+			},
+			wantFiles: []string{
+				"a/path/example.txt",
+				"another/path/example.txt",
+			},
+			skipFiles: []string{
+				"skipped/path/example.txt",
+			},
+		},
+		{
+			name:      "library not found",
+			repoDir:   filepath.Join(t.TempDir(), "dst"),
+			outputDir: filepath.Join(t.TempDir(), "src"),
+			libraryID: "non-existent-library",
+			state: &config.LibrarianState{
+				Libraries: []*config.LibraryState{
+					{
+						ID: "example-library",
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "not found",
+		},
+		{
+			name:      "source root not found",
+			repoDir:   filepath.Join(t.TempDir(), "dst"),
+			outputDir: filepath.Join(t.TempDir(), "src"),
+			libraryID: "example-library",
+			state: &config.LibrarianState{
+				Libraries: []*config.LibraryState{
+					{
+						ID: "example-library",
+						SourceRoots: []string{
+							"a/path",
+							"another/path",
+						},
+					},
+				},
+			},
+			filesToCreate: []string{
+				"a/path/example.txt",
+				"skipped/path/example.txt",
+			},
+			wantFiles: []string{
+				"a/path/example.txt",
+			},
+			skipFiles: []string{
+				"skipped/path/example.txt",
+				"another/path/example.txt",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if !test.wantErr {
+				setup(test.outputDir, test.filesToCreate)
+			}
+			err := copyLibraryFiles(test.state, test.repoDir, test.libraryID, test.outputDir)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("copyLibraryFiles() shoud fail")
+				}
+
+				if !strings.Contains(err.Error(), test.wantErrMsg) {
+					t.Errorf("want error message: %s, got: %s", test.wantErrMsg, err.Error())
+				}
+
+				return
+			}
+			if err != nil {
+				t.Errorf("failed to run copyLibraryFiles(): %s", err.Error())
+			}
+
+			for _, file := range test.wantFiles {
+				fullPath := filepath.Join(test.repoDir, file)
+				if _, err := os.Stat(fullPath); err != nil {
+					t.Errorf("file %s is not copied to %s", file, test.repoDir)
+				}
+			}
+
+			for _, file := range test.skipFiles {
+				fullPath := filepath.Join(test.repoDir, file)
+				if _, err := os.Stat(fullPath); !os.IsNotExist(err) {
+					t.Errorf("file %s should not be copied to %s", file, test.repoDir)
+				}
+			}
+		})
+	}
+}
+
 func TestCopyFile(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -147,7 +147,7 @@ func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error
 		return fmt.Errorf("failed to copy librarian dir from %s to %s: %w", src, dst, err)
 	}
 
-	if err := cleanAndCopyGlobalAllowlist(r.librarianConfig, dst, src); err != nil {
+	if err := copyGlobalAllowlist(r.librarianConfig, dst, src, true); err != nil {
 		return fmt.Errorf("failed to copy global allowlist  from %s to %s: %w", src, dst, err)
 	}
 
@@ -171,7 +171,7 @@ func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error
 				continue
 			}
 			// Only copy one library to repository.
-			if err := cleanAndCopyLibrary(r.state, r.repo.GetDir(), r.cfg.Library, outputDir); err != nil {
+			if err := copyLibraryFiles(r.state, r.repo.GetDir(), r.cfg.Library, outputDir); err != nil {
 				return err
 			}
 
@@ -179,12 +179,12 @@ func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error
 		}
 
 		// Copy all libraries to repository.
-		if err := cleanAndCopyLibrary(r.state, r.repo.GetDir(), library.ID, outputDir); err != nil {
+		if err := copyLibraryFiles(r.state, r.repo.GetDir(), library.ID, outputDir); err != nil {
 			return err
 		}
 	}
 
-	return cleanAndCopyGlobalAllowlist(r.librarianConfig, r.repo.GetDir(), outputDir)
+	return copyGlobalAllowlist(r.librarianConfig, r.repo.GetDir(), outputDir, false)
 }
 
 // updateLibrary updates the library which is the index-th library in the given
@@ -251,29 +251,26 @@ func getChangeType(commit *conventionalcommits.ConventionalCommit) string {
 	return changeType
 }
 
-// cleanAndCopyGlobalAllowlist cleans the files listed in global allowlist in
-// src, excluding read-only files and copies global files from src.
-func cleanAndCopyGlobalAllowlist(cfg *config.LibrarianConfig, dst, src string) error {
+// copyGlobalAllowlist copies files in the global file allowlist excluding
+//
+//	read-only files and copies global files from src.
+func copyGlobalAllowlist(cfg *config.LibrarianConfig, dst, src string, copyReadOnly bool) error {
 	if cfg == nil {
 		slog.Info("librarian config is not setup, skip copying global allowlist")
 		return nil
 	}
+	slog.Info("Copying global allowlist files", "destination", dst, "source", src)
 	for _, globalFile := range cfg.GlobalFilesAllowlist {
-		if globalFile.Permissions == config.PermissionReadOnly {
+		if globalFile.Permissions == config.PermissionReadOnly && !copyReadOnly {
+			slog.Debug("skipping read-only file", "path", globalFile.Path)
 			continue
 		}
-
-		dstPath := filepath.Join(dst, globalFile.Path)
-		if err := os.Remove(dstPath); err != nil {
-			return fmt.Errorf("failed to remove global file %s: %w", dstPath, err)
-		}
-
 		srcPath := filepath.Join(src, globalFile.Path)
+		dstPath := filepath.Join(dst, globalFile.Path)
 		if err := copyFile(dstPath, srcPath); err != nil {
 			return fmt.Errorf("failed to copy global file %s from %s: %w", dstPath, srcPath, err)
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
We should intentionally copy over only the files that are in the output directory of the release init container. We don't mandate today that all libraries files must be copied over, so we should selectively overwrite files when required.

Fixes: #1806