### PR TITLE
fix(librarian): don't clone apisource for `release init`

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -57,7 +57,7 @@ func newCommandRunner(cfg *config.Config) (*commandRunner, error) {
 
 	var sourceRepo gitrepo.Repository
 	var sourceRepoDir string
-	if cfg.CommandName != tagAndReleaseCmdName {
+	if cfg.CommandName == generateCmdName {
 		sourceRepo, err = cloneOrOpenRepo(cfg.WorkRoot, cfg.APISource, cfg.CI, cfg.GitHubToken)
 		if err != nil {
 			return nil, err

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -32,6 +32,10 @@ import (
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
+const (
+	generateCmdName = "generate"
+)
+
 var cmdGenerate = &cli.Command{
 	Short:     "generate generates client library code for a single API",
 	UsageLine: "librarian generate -source=<api-root> -api=<api-path> [flags]",

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -397,31 +397,34 @@ func TestNewGenerateRunner(t *testing.T) {
 		{
 			name: "valid config",
 			cfg: &config.Config{
-				API:       "some/api",
-				APISource: newTestGitRepo(t).GetDir(),
-				Repo:      newTestGitRepo(t).GetDir(),
-				WorkRoot:  t.TempDir(),
-				Image:     "gcr.io/test/test-image",
+				API:         "some/api",
+				APISource:   newTestGitRepo(t).GetDir(),
+				Repo:        newTestGitRepo(t).GetDir(),
+				WorkRoot:    t.TempDir(),
+				Image:       "gcr.io/test/test-image",
+				CommandName: generateCmdName,
 			},
 		},
 		{
 			name: "invalid api source",
 			cfg: &config.Config{
-				API:       "some/api",
-				APISource: t.TempDir(), // Not a git repo
-				Repo:      newTestGitRepo(t).GetDir(),
-				WorkRoot:  t.TempDir(),
-				Image:     "gcr.io/test/test-image",
+				API:         "some/api",
+				APISource:   t.TempDir(), // Not a git repo
+				Repo:        newTestGitRepo(t).GetDir(),
+				WorkRoot:    t.TempDir(),
+				Image:       "gcr.io/test/test-image",
+				CommandName: generateCmdName,
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing image",
 			cfg: &config.Config{
-				API:       "some/api",
-				APISource: t.TempDir(),
-				Repo:      "https://github.com/googleapis/librarian.git",
-				WorkRoot:  t.TempDir(),
+				API:         "some/api",
+				APISource:   t.TempDir(),
+				Repo:        "https://github.com/googleapis/librarian.git",
+				WorkRoot:    t.TempDir(),
+				CommandName: generateCmdName,
 			},
 			wantErr: true,
 		},
@@ -434,37 +437,41 @@ func TestNewGenerateRunner(t *testing.T) {
 				WorkRoot:    t.TempDir(),
 				Image:       "gcr.io/test/test-image",
 				GitHubToken: "gh-token",
+				CommandName: generateCmdName,
 			},
 		},
 		{
 			name: "empty API source",
 			cfg: &config.Config{
-				API:       "some/api",
-				APISource: "", // This will trigger the clone of googleapis
-				Repo:      newTestGitRepo(t).GetDir(),
-				WorkRoot:  t.TempDir(),
-				Image:     "gcr.io/test/test-image",
+				API:         "some/api",
+				APISource:   "", // This will trigger the clone of googleapis
+				Repo:        newTestGitRepo(t).GetDir(),
+				WorkRoot:    t.TempDir(),
+				Image:       "gcr.io/test/test-image",
+				CommandName: generateCmdName,
 			},
 		},
 		{
 			name: "clone googleapis fails",
 			cfg: &config.Config{
-				API:       "some/api",
-				APISource: "", // This will trigger the clone of googleapis
-				Repo:      newTestGitRepo(t).GetDir(),
-				WorkRoot:  t.TempDir(),
-				Image:     "gcr.io/test/test-image",
+				API:         "some/api",
+				APISource:   "", // This will trigger the clone of googleapis
+				Repo:        newTestGitRepo(t).GetDir(),
+				WorkRoot:    t.TempDir(),
+				Image:       "gcr.io/test/test-image",
+				CommandName: generateCmdName,
 			},
 			wantErr: true,
 		},
 		{
 			name: "valid config with local repo",
 			cfg: &config.Config{
-				API:       "some/api",
-				APISource: newTestGitRepo(t).GetDir(),
-				Repo:      newTestGitRepo(t).GetDir(),
-				WorkRoot:  t.TempDir(),
-				Image:     "gcr.io/test/test-image",
+				API:         "some/api",
+				APISource:   newTestGitRepo(t).GetDir(),
+				Repo:        newTestGitRepo(t).GetDir(),
+				WorkRoot:    t.TempDir(),
+				Image:       "gcr.io/test/test-image",
+				CommandName: generateCmdName,
 			},
 		},
 	} {


### PR DESCRIPTION
Fixes: #1808