### PR TITLE
fix: add MergeCommitSHA check, _PR substitution, PR limit in publish-release automation command

### DIFF
--- a/internal/automation/trigger.go
+++ b/internal/automation/trigger.go
@@ -112,6 +112,8 @@ func runCommandWithClient(ctx context.Context, client CloudBuildClient, ghClient
 			if len(prs) == 0 {
 				slog.Info("No pull requests with label 'release:pending' found. Skipping 'publish-release' trigger.", slog.String("repository", repository.Name))
 				continue
+			} else {
+				substitutions["_PR"] = fmt.Sprintf("%v", prs[0].GetHTMLURL())
 			}
 		} else if command == "generate" {
 			// only pass _BUILD to generate trigger

--- a/internal/automation/trigger_test.go
+++ b/internal/automation/trigger_test.go
@@ -126,7 +126,7 @@ func TestRunCommandWithClient(t *testing.T) {
 					Id:   "publish-release-trigger-id",
 				},
 			},
-			ghPRs: []*github.PullRequest{{}},
+			ghPRs: []*github.PullRequest{{HTMLURL: github.Ptr("https://github.com/googleapis/librarian/pull/1")}},
 		},
 		{
 			name:    "skips publish-release with no PRs",

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -261,7 +261,6 @@ func (c *Client) FindMergedPullRequestsWithPendingReleaseLabel(ctx context.Conte
 	opt := &github.PullRequestListOptions{
 		State: "closed",
 		ListOptions: github.ListOptions{
-			Page:    5,
 			PerPage: 100,
 		},
 	}
@@ -275,7 +274,7 @@ func (c *Client) FindMergedPullRequestsWithPendingReleaseLabel(ctx context.Conte
 				allPRs = append(allPRs, pr)
 			}
 		}
-		if resp.NextPage == 0 {
+		if resp.NextPage == 0 || len(allPRs) >= 10 {
 			break
 		}
 		opt.Page = resp.NextPage

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -270,7 +270,7 @@ func (c *Client) FindMergedPullRequestsWithPendingReleaseLabel(ctx context.Conte
 			return nil, err
 		}
 		for _, pr := range prs {
-			if pr.GetMerged() && hasLabel(pr, "release:pending") {
+			if (pr.GetMerged() || pr.GetMergeCommitSHA() != "") && hasLabel(pr, "release:pending") {
 				allPRs = append(allPRs, pr)
 			}
 		}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -261,6 +261,7 @@ func (c *Client) FindMergedPullRequestsWithPendingReleaseLabel(ctx context.Conte
 	opt := &github.PullRequestListOptions{
 		State: "closed",
 		ListOptions: github.ListOptions{
+			Page:    5,
 			PerPage: 100,
 		},
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -952,7 +952,7 @@ func TestFindMergedPullRequestsWithPendingReleaseLabel(t *testing.T) {
 				}
 				pr1 := github.PullRequest{Number: github.Ptr(1), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
 				pr2 := github.PullRequest{Number: github.Ptr(2), Labels: []*github.Label{{Name: github.Ptr("other-label")}}}
-				pr3 := github.PullRequest{Number: github.Ptr(4), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
+				pr3 := github.PullRequest{Number: github.Ptr(4), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
 				prs := []*github.PullRequest{&pr1, &pr2, &pr3}
 				b, err := json.Marshal(prs)
 				if err != nil {
@@ -961,7 +961,7 @@ func TestFindMergedPullRequestsWithPendingReleaseLabel(t *testing.T) {
 				fmt.Fprint(w, string(b))
 			},
 			wantPRs: []*PullRequest{
-				{Number: github.Ptr(4), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
+				{Number: github.Ptr(4), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
 			},
 		},
 		{

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -950,10 +950,11 @@ func TestFindMergedPullRequestsWithPendingReleaseLabel(t *testing.T) {
 				if r.URL.Query().Get("state") != "closed" {
 					t.Errorf("unexpected state: got %q", r.URL.Query().Get("state"))
 				}
+				pr0 := github.PullRequest{Number: github.Ptr(0), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/0"), MergeCommitSHA: github.Ptr("sha456"), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
 				pr1 := github.PullRequest{Number: github.Ptr(1), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
 				pr2 := github.PullRequest{Number: github.Ptr(2), Labels: []*github.Label{{Name: github.Ptr("other-label")}}}
-				pr3 := github.PullRequest{Number: github.Ptr(4), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
-				prs := []*github.PullRequest{&pr1, &pr2, &pr3}
+				pr3 := github.PullRequest{Number: github.Ptr(3), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/3"), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
+				prs := []*github.PullRequest{&pr0, &pr1, &pr2, &pr3}
 				b, err := json.Marshal(prs)
 				if err != nil {
 					t.Fatalf("json.Marshal() failed: %v", err)
@@ -961,7 +962,8 @@ func TestFindMergedPullRequestsWithPendingReleaseLabel(t *testing.T) {
 				fmt.Fprint(w, string(b))
 			},
 			wantPRs: []*PullRequest{
-				{Number: github.Ptr(4), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
+				{Number: github.Ptr(0), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/0"), MergeCommitSHA: github.Ptr("sha456"), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
+				{Number: github.Ptr(3), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/3"), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
 			},
 		},
 		{


### PR DESCRIPTION
add MergeCommitSHA check, _PR substitution, PR limit in publish-release automation command

https://github.com/googleapis/librarian/issues/1786
https://github.com/googleapis/librarian/issues/1810