### PR TITLE
impl(rust): template for an http client

### DIFF
--- a/internal/sidekick/internal/rust/templates/http-client/builder.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/builder.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../crate/src/builder.rs}}

--- a/internal/sidekick/internal/rust/templates/http-client/client.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/client.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../crate/src/client.rs}}

--- a/internal/sidekick/internal/rust/templates/http-client/enum.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/enum.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../common/enum}}

--- a/internal/sidekick/internal/rust/templates/http-client/message.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/message.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../common/message}}

--- a/internal/sidekick/internal/rust/templates/http-client/mod.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/mod.rs.mustache
@@ -1,0 +1,50 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+// Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+//{{{.}}}
+{{/Codec.BoilerPlate}}
+
+{{!
+    The generated code uses deprecated items in:
+    - setters for deprecated fields.
+    - fields that reference deprecated messages and enums.
+    - clients and stubs use deprecated RPCs.
+    - clients and stubs use deprecated services and deprecated request messages.
+}}
+{{#HasDeprecatedEntities}}
+#![allow(deprecated)]
+{{/HasDeprecatedEntities}}
+
+/// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
+pub mod model;
+
+{{! We use explicit links because it is easier to generate the code with them. }}
+#[allow(rustdoc::redundant_explicit_links)]
+pub mod stub;
+
+/// Request builders.
+pub mod builder;
+
+/// The client(s) for this client library.
+pub mod client;
+
+#[doc(hidden)]
+pub(crate) mod tracing;
+
+#[doc(hidden)]
+pub(crate) mod transport;

--- a/internal/sidekick/internal/rust/templates/http-client/model.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/model.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../mod/mod.rs}}

--- a/internal/sidekick/internal/rust/templates/http-client/oneof.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/oneof.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../common/oneof}}

--- a/internal/sidekick/internal/rust/templates/http-client/stub.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/stub.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../crate/src/stub.rs}}

--- a/internal/sidekick/internal/rust/templates/http-client/stub/dynamic.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/stub/dynamic.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../../crate/src/stub/dynamic.rs}}

--- a/internal/sidekick/internal/rust/templates/http-client/tracing.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/tracing.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../crate/src/tracing.rs}}

--- a/internal/sidekick/internal/rust/templates/http-client/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/transport.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../crate/src/transport.rs}}


### PR DESCRIPTION
Add a Rust template for http client library code, without the crate structure.

cc: @whuffman36