### PR TITLE
fix: remove invalid api-source flag from release init command

### DIFF
--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -43,8 +43,6 @@ steps:
       - '/workspace/$_REPOSITORY'
       - '-library'
       - $_LIBRARY_ID
-      - '-api-source'
-      - '/workspace/googleapis'
       - '-output'
       - /workspace/tmp
       - '-push=$_PUSH'

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -24,14 +24,6 @@ steps:
       - 'clone'
       - '--depth=1'
       - $_FULL_REPOSITORY
-  - name: gcr.io/cloud-builders/git
-    id: clone-googleapis
-    waitFor: ['-']
-    args:
-      - 'clone'
-      - '--single-branch'
-      - '--branch=master'
-      - https://github.com/googleapis/googleapis
   - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian'
     id: stage-release
     waitFor: ['clone-language-repo', 'clone-googleapis']

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -26,7 +26,7 @@ steps:
       - $_FULL_REPOSITORY
   - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian'
     id: stage-release
-    waitFor: ['clone-language-repo', 'clone-googleapis']
+    waitFor: ['clone-language-repo']
     dir: tmp
     args:
       - 'release'


### PR DESCRIPTION
Remove unnecessary step to fetch googleapis.  We don't need it for release