### PR TITLE
feat(librarian): allow libraries to have no APIs

### DIFF
--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -162,9 +162,6 @@ func (l *LibraryState) Validate() error {
 			return fmt.Errorf("last_generated_commit must be 40 characters")
 		}
 	}
-	if len(l.APIs) == 0 {
-		return fmt.Errorf("apis cannot be empty")
-	}
 	for i, a := range l.APIs {
 		if err := a.Validate(); err != nil {
 			return fmt.Errorf("invalid api at index %d: %w", i, err)

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -112,6 +112,14 @@ func TestLibrary_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "valid library with no APIs",
+			library: &LibraryState{
+				ID:          "a/b",
+				SourceRoots: []string{"src/a", "src/b"},
+			},
+			wantErr: false,
+		},
+		{
 			name:       "missing id",
 			library:    &LibraryState{},
 			wantErr:    true,
@@ -145,15 +153,6 @@ func TestLibrary_Validate(t *testing.T) {
 			},
 			wantErr:    true,
 			wantErrMsg: "source_roots cannot be empty",
-		},
-		{
-			name: "missing apis",
-			library: &LibraryState{
-				ID:          "a/b",
-				SourceRoots: []string{"src/a", "src/b"},
-			},
-			wantErr:    true,
-			wantErrMsg: "apis cannot be empty",
 		},
 		{
 			name: "valid version without v prefix",

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -175,6 +175,17 @@ func (r *generateRunner) generateSingleLibrary(ctx context.Context, libraryID, o
 		libraryID = configuredLibraryID
 	}
 
+	// At this point, we should have a library in the state.
+	libraryState := findLibraryByID(r.state, libraryID)
+	if libraryState == nil {
+		return fmt.Errorf("library %q not configured yet, generation stopped", libraryID)
+	}
+
+	if len(libraryState.APIs) == 0 {
+		slog.Info("library has no APIs; skipping generation", "library", libraryID)
+		return nil
+	}
+
 	// For each library, create a separate output directory. This avoids
 	// libraries interfering with each other, and makes it easier to see what
 	// was generated for each library when debugging.
@@ -221,9 +232,6 @@ func (r *generateRunner) updateLastGeneratedCommitState(libraryID string) error 
 // If successful, it returns the ID of the generated library; otherwise, it
 // returns an empty string and an error.
 func (r *generateRunner) runGenerateCommand(ctx context.Context, libraryID, outputDir string) (string, error) {
-	if findLibraryByID(r.state, libraryID) == nil {
-		return "", fmt.Errorf("library %q not configured yet, generation stopped", libraryID)
-	}
 	apiRoot, err := filepath.Abs(r.sourceRepo.GetDir())
 	if err != nil {
 		return "", err

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -928,6 +928,24 @@ func TestGenerateScenarios(t *testing.T) {
 			build:     true,
 			wantErr:   true,
 		},
+		{
+			name: "generate skips libraries with no APIs",
+			repo: newTestGitRepo(t),
+			state: &config.LibrarianState{
+				Image: "gcr.io/test/image:v1.2.3",
+				Libraries: []*config.LibraryState{
+					{
+						ID: "some-library",
+					},
+				},
+			},
+			container:          &mockContainerClient{},
+			ghClient:           &mockGitHubClient{},
+			build:              true,
+			wantGenerateCalls:  0,
+			wantBuildCalls:     0,
+			wantConfigureCalls: 0,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/librarian/mocks_test.go
+++ b/internal/librarian/mocks_test.go
@@ -150,6 +150,7 @@ func (m *mockContainerClient) Configure(ctx context.Context, request *docker.Con
 
 	var libraryBuilder strings.Builder
 	libraryBuilder.WriteString(fmt.Sprintf("{\"id\":\"%s\"", request.State.Libraries[0].ID))
+	libraryBuilder.WriteString(fmt.Sprintf(",\"apis\":[{\"path\":\"%s\"}]", request.State.Libraries[0].APIs[0].Path))
 	if !m.noInitVersion {
 		libraryBuilder.WriteString(",\"version\": \"0.1.0\"")
 	}


### PR DESCRIPTION
This is required for handwritten libraries to be representable in Librarian state.

For the moment, such libraries are skipped in generate calls.

Fixes #1852.