### PR TITLE
feat(librarian): allow APIs to have no service config

### DIFF
--- a/internal/librarian/state.go
+++ b/internal/librarian/state.go
@@ -146,7 +146,8 @@ func findServiceConfigIn(path string) (string, error) {
 		}
 	}
 
-	return "", errors.New("could not find service config in " + path)
+	// No service config present: assume it's proto-only.
+	return "", nil
 }
 
 func saveLibrarianState(repoDir string, state *config.LibrarianState) error {

--- a/internal/librarian/state_test.go
+++ b/internal/librarian/state_test.go
@@ -121,22 +121,16 @@ func TestFindServiceConfigIn(t *testing.T) {
 			want: "service_config.yaml",
 		},
 		{
-			name:    "non existed source path",
-			path:    filepath.Join("..", "..", "testdata", "non-existed-path"),
+			name:    "non-existent source path",
+			path:    filepath.Join("..", "..", "testdata", "non-existent-path"),
 			want:    "",
 			wantErr: true,
 		},
 		{
-			name:    "non service config in a source path",
+			name:    "no service config in a source path",
 			path:    filepath.Join("..", "..", "testdata", "no_service_config"),
 			want:    "",
-			wantErr: true,
-		},
-		{
-			name:    "simulated load error",
-			path:    filepath.Join("..", "..", "testdata", "no_service_config"),
-			want:    "",
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "invalid yaml",


### PR DESCRIPTION
This allows libraries from "just protos" to be represented.

Fixes #1712.