### PR TITLE
refactor(sidekick): move test helpers

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,7 @@ coverage:
         threshold: 0% # Allow 0% drop from the target; any drop below target will fail
         if_ci_failed: error # Set the CI status to 'error' if coverage conditions are not met
 ignore:
-  # test packages do not need code coverate
+  # test packages do not need code coverage
   - internal/sidekick/internal/api/apitest
   - internal/sidekick/internal/sample
   # Running tests for this would require installing the Rust toolchain.

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,5 +19,8 @@ coverage:
         threshold: 0% # Allow 0% drop from the target; any drop below target will fail
         if_ci_failed: error # Set the CI status to 'error' if coverage conditions are not met
 ignore:
+  # test packages do not need code coverate
+  - internal/sidekick/internal/api/apitest
   - internal/sidekick/internal/sample
+  # Running tests for this would require installing the Rust toolchain.
   - internal/sidekick/internal/rust_prost

--- a/internal/sidekick/internal/api/apitest/apitest.go
+++ b/internal/sidekick/internal/api/apitest/apitest.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitest
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+)
+
+// CheckMessage compares two `Message` instances ignoring the order of fields, and oneofs and ignoring child messages.
+func CheckMessage(t *testing.T, got *api.Message, want *api.Message) {
+	t.Helper()
+	// Checking Parent, Messages, Fields, and OneOfs requires special handling.
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Message{}, "Fields", "OneOfs", "Parent", "Messages")); diff != "" {
+		t.Errorf("message attributes mismatch (-want +got):\n%s", diff)
+	}
+	less := func(a, b *api.Field) bool { return a.Name < b.Name }
+	if diff := cmp.Diff(want.Fields, got.Fields, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("field mismatch (-want, +got):\n%s", diff)
+	}
+	// Ignore parent because types are cyclic
+	if diff := cmp.Diff(want.OneOfs, got.OneOfs, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("oneofs mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+// CheckEnum compares two `Enum` instances ignoring the enum value order.
+func CheckEnum(t *testing.T, got api.Enum, want api.Enum) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Enum{}, "Values", "UniqueNumberValues", "Parent")); diff != "" {
+		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
+	}
+	less := func(a, b *api.EnumValue) bool { return a.Name < b.Name }
+	if diff := cmp.Diff(want.Values, got.Values, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
+		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+// CheckService compares two `Service` instances ignoring method order.
+func CheckService(t *testing.T, got *api.Service, want *api.Service) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Service{}, "Methods")); diff != "" {
+		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
+	}
+	less := func(a, b *api.Method) bool { return a.Name < b.Name }
+	if diff := cmp.Diff(want.Methods, got.Methods, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+// CheckMethod finds a `Method` in a `Service` and compares the values.
+func CheckMethod(t *testing.T, service *api.Service, name string, want *api.Method) {
+	t.Helper()
+	findMethod := func(name string) (*api.Method, bool) {
+		for _, method := range service.Methods {
+			if method.Name == name {
+				return method, true
+			}
+		}
+		return nil, false
+	}
+	got, ok := findMethod(name)
+	if !ok {
+		t.Errorf("missing method %s", name)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatched data for method %s (-want, +got):\n%s", name, diff)
+	}
+}

--- a/internal/sidekick/internal/parser/openapi_test.go
+++ b/internal/sidekick/internal/parser/openapi_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+	"github.com/googleapis/librarian/internal/sidekick/internal/api/apitest"
 	"github.com/googleapis/librarian/internal/sidekick/internal/sample"
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
@@ -73,7 +74,7 @@ func TestOpenAPI_AllOf(t *testing.T) {
 		t.Errorf("missing message in MessageByID index")
 		return
 	}
-	checkMessage(t, message, want)
+	apitest.CheckMessage(t, message, want)
 }
 
 func TestOpenAPI_BasicTypes(t *testing.T) {
@@ -123,7 +124,7 @@ func TestOpenAPI_BasicTypes(t *testing.T) {
 		t.Errorf("missing message in MessageByID index")
 		return
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Fake",
 		ID:            "..Fake",
 		Documentation: "A test message.",
@@ -255,7 +256,7 @@ func TestOpenAPI_ArrayTypes(t *testing.T) {
 		t.Errorf("missing message in MessageByID index")
 		return
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Fake",
 		ID:            "..Fake",
 		Documentation: "A test message.",
@@ -365,7 +366,7 @@ func TestOpenAPI_SimpleObject(t *testing.T) {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
 
-	checkMessage(t, test.Messages[0], &api.Message{
+	apitest.CheckMessage(t, test.Messages[0], &api.Message{
 		Name:          "Fake",
 		ID:            "..Fake",
 		Documentation: "A test message.",
@@ -412,7 +413,7 @@ func TestOpenAPI_Any(t *testing.T) {
 		t.Errorf("Error in makeAPI() %q", err)
 	}
 
-	checkMessage(t, test.Messages[0], &api.Message{
+	apitest.CheckMessage(t, test.Messages[0], &api.Message{
 		Name:          "Fake",
 		ID:            "..Fake",
 		Documentation: "A test message.",
@@ -445,7 +446,7 @@ func TestOpenAPI_MapString(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkMessage(t, test.Messages[0], &api.Message{
+	apitest.CheckMessage(t, test.Messages[0], &api.Message{
 		Name:          "Fake",
 		ID:            "..Fake",
 		Documentation: "A test message.",
@@ -497,7 +498,7 @@ func TestOpenAPI_MapInteger(t *testing.T) {
 		t.Errorf("Error in makeAPI() %q", err)
 	}
 
-	checkMessage(t, test.Messages[0], &api.Message{
+	apitest.CheckMessage(t, test.Messages[0], &api.Message{
 		Name:          "Fake",
 		ID:            "..Fake",
 		Documentation: "A test message.",
@@ -541,7 +542,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		t.Errorf("missing message (Location) in MessageByID index")
 		return
 	}
-	checkMessage(t, location, &api.Message{
+	apitest.CheckMessage(t, location, &api.Message{
 		Documentation: "A resource that represents a Google Cloud location.",
 		Name:          "Location",
 		ID:            "..Location",
@@ -595,7 +596,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		t.Errorf("missing message (ListLocationsResponse) in MessageByID index")
 		return
 	}
-	checkMessage(t, listLocationsResponse, &api.Message{
+	apitest.CheckMessage(t, listLocationsResponse, &api.Message{
 		Documentation: "The response message for Locations.ListLocations.",
 		Name:          "ListLocationsResponse",
 		ID:            "..ListLocationsResponse",
@@ -644,7 +645,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		t.Errorf("missing message (ListLocationsRequest) in MessageByID index")
 		return
 	}
-	checkMessage(t, listLocationsRequest, &api.Message{
+	apitest.CheckMessage(t, listLocationsRequest, &api.Message{
 		Name:          "ListLocationsRequest",
 		ID:            "..ListLocationsRequest",
 		Documentation: "The request message for ListLocations.",
@@ -698,7 +699,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		t.Errorf("missing message (SecretPayload) in MessageByID index")
 		return
 	}
-	checkMessage(t, got, sp)
+	apitest.CheckMessage(t, got, sp)
 
 	service, ok := test.State.ServiceByID["..Service"]
 	if !ok {
@@ -714,7 +715,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
 	}
 
-	checkMethod(t, service, "ListLocations", &api.Method{
+	apitest.CheckMethod(t, service, "ListLocations", &api.Method{
 		Name:          "ListLocations",
 		ID:            "..Service.ListLocations",
 		Documentation: "Lists information about the supported locations for this service.",
@@ -749,10 +750,10 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 	})
 
 	cs := sample.MethodCreate()
-	checkMethod(t, service, cs.Name, cs)
+	apitest.CheckMethod(t, service, cs.Name, cs)
 
 	asv := sample.MethodAddSecretVersion()
-	checkMethod(t, service, asv.Name, asv)
+	apitest.CheckMethod(t, service, asv.Name, asv)
 }
 
 func TestOpenAPI_MakeApiWithServiceConfig(t *testing.T) {
@@ -819,7 +820,7 @@ func TestOpenAPI_SyntheticMessageWithExistingRequest(t *testing.T) {
 		t.Errorf("missing message (%s) in MessageByID index", id)
 		return
 	}
-	checkMessage(t, setIamPolicyRequest, &api.Message{
+	apitest.CheckMessage(t, setIamPolicyRequest, &api.Message{
 		Name:          "SetIamPolicyRequest",
 		ID:            "..SetIamPolicyRequest",
 		Documentation: "Request message for `SetIamPolicy` method.",
@@ -890,7 +891,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 		t.Errorf("missing service (Service) in ServiceByID index")
 		return
 	}
-	checkService(t, service, &api.Service{
+	apitest.CheckService(t, service, &api.Service{
 		Name: "Service",
 		ID:   "..Service",
 		Methods: []*api.Method{
@@ -929,7 +930,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 		t.Errorf("missing message (ListFoosResponse) in MessageByID index")
 		return
 	}
-	checkMessage(t, resp, &api.Message{
+	apitest.CheckMessage(t, resp, &api.Message{
 		Name: "ListFoosResponse",
 		ID:   "..ListFoosResponse",
 		Fields: []*api.Field{
@@ -1032,7 +1033,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 		Optional:      true,
 		AutoPopulated: true,
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "CreateFooRequest",
 		ID:            ".test.CreateFooRequest",
 		Package:       "test",
@@ -1120,7 +1121,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		t.Errorf("cannot find service %s in model", "..Service.ListFoos")
 		return
 	}
-	checkMethod(t, service, "RpcA", &api.Method{
+	apitest.CheckMethod(t, service, "RpcA", &api.Method{
 		Name:         "RpcA",
 		ID:           "..Service.RpcA",
 		InputTypeID:  "..RpcARequest",
@@ -1141,7 +1142,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		},
 	})
 
-	checkMethod(t, service, "RpcB", &api.Method{
+	apitest.CheckMethod(t, service, "RpcB", &api.Method{
 		Name:         "RpcB",
 		ID:           "..Service.RpcB",
 		Deprecated:   true,
@@ -1168,7 +1169,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		t.Errorf("cannot find message %s", "..Response")
 		return
 	}
-	checkMessage(t, response, &api.Message{
+	apitest.CheckMessage(t, response, &api.Message{
 		Name: "Response",
 		ID:   "..Response",
 		Fields: []*api.Field{
@@ -1195,7 +1196,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		t.Errorf("cannot find message %s", "..DeprecatedMessage")
 		return
 	}
-	checkMessage(t, deprecatedMessage, &api.Message{
+	apitest.CheckMessage(t, deprecatedMessage, &api.Message{
 		Name:       "DeprecatedMessage",
 		ID:         "..DeprecatedMessage",
 		Deprecated: true,

--- a/internal/sidekick/internal/parser/parser_test.go
+++ b/internal/sidekick/internal/parser/parser_test.go
@@ -19,9 +19,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/googleapis/librarian/internal/sidekick/internal/api"
 	"github.com/googleapis/librarian/internal/sidekick/internal/config"
 )
 
@@ -127,62 +124,5 @@ func TestCreateModelNone(t *testing.T) {
 	}
 	if model != nil {
 		t.Errorf("expected `nil` model with source format == none")
-	}
-}
-
-func checkMessage(t *testing.T, got *api.Message, want *api.Message) {
-	t.Helper()
-	// Checking Parent, Messages, Fields, and OneOfs requires special handling.
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Message{}, "Fields", "OneOfs", "Parent", "Messages")); diff != "" {
-		t.Errorf("message attributes mismatch (-want +got):\n%s", diff)
-	}
-	less := func(a, b *api.Field) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(want.Fields, got.Fields, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("field mismatch (-want, +got):\n%s", diff)
-	}
-	// Ignore parent because types are cyclic
-	if diff := cmp.Diff(want.OneOfs, got.OneOfs, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("oneofs mismatch (-want, +got):\n%s", diff)
-	}
-}
-
-func checkEnum(t *testing.T, got api.Enum, want api.Enum) {
-	t.Helper()
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Enum{}, "Values", "UniqueNumberValues", "Parent")); diff != "" {
-		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
-	}
-	less := func(a, b *api.EnumValue) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(want.Values, got.Values, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("method mismatch (-want, +got):\n%s", diff)
-	}
-}
-
-func checkService(t *testing.T, got *api.Service, want *api.Service) {
-	t.Helper()
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Service{}, "Methods")); diff != "" {
-		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
-	}
-	less := func(a, b *api.Method) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(want.Methods, got.Methods, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("method mismatch (-want, +got):\n%s", diff)
-	}
-}
-
-func checkMethod(t *testing.T, service *api.Service, name string, want *api.Method) {
-	t.Helper()
-	findMethod := func(name string) (*api.Method, bool) {
-		for _, method := range service.Methods {
-			if method.Name == name {
-				return method, true
-			}
-		}
-		return nil, false
-	}
-	got, ok := findMethod(name)
-	if !ok {
-		t.Errorf("missing method %s", name)
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched data for method %s (-want, +got):\n%s", name, diff)
 	}
 }

--- a/internal/sidekick/internal/parser/protobuf_mixin_test.go
+++ b/internal/sidekick/internal/parser/protobuf_mixin_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+	"github.com/googleapis/librarian/internal/sidekick/internal/api/apitest"
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/types/known/apipb"
@@ -65,7 +66,7 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 		t.Fatal("Cannot find .test.TestService.GetLocation")
 	}
 
-	checkMethod(t, service, "GetLocation", &api.Method{
+	apitest.CheckMethod(t, service, "GetLocation", &api.Method{
 		Documentation:   "Provides the [Locations][google.cloud.location.Locations] service functionality in this service.",
 		Name:            "GetLocation",
 		ID:              ".test.TestService.GetLocation",
@@ -133,7 +134,7 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 	if _, ok := test.State.MethodByID[".test.TestService.GetIamPolicy"]; !ok {
 		t.Fatal("Cannot find .test.TestService.GetIamPolicy")
 	}
-	checkMethod(t, service, "GetIamPolicy", &api.Method{
+	apitest.CheckMethod(t, service, "GetIamPolicy", &api.Method{
 		Documentation:   "Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.",
 		Name:            "GetIamPolicy",
 		ID:              ".test.TestService.GetIamPolicy",
@@ -207,7 +208,7 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 		t.Fatal("Cannot find .test.TestService.GetOperation")
 	}
 
-	checkMethod(t, service, "GetOperation", &api.Method{
+	apitest.CheckMethod(t, service, "GetOperation", &api.Method{
 		Documentation:   "Custom docs.",
 		Name:            "GetOperation",
 		ID:              ".test.TestService.GetOperation",
@@ -291,7 +292,7 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 		t.Fatal("Cannot find .test.TestService.GetOperation")
 	}
 
-	checkMethod(t, service, "CancelOperation", &api.Method{
+	apitest.CheckMethod(t, service, "CancelOperation", &api.Method{
 		Documentation:   "Custom docs.",
 		Name:            "CancelOperation",
 		ID:              ".test.TestService.CancelOperation",
@@ -318,7 +319,7 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 	if !ok {
 		t.Fatal("Cannot find .google.protobuf.Empty")
 	}
-	checkMessage(t, got, &api.Message{
+	apitest.CheckMessage(t, got, &api.Message{
 		Name:    "Empty",
 		ID:      ".google.protobuf.Empty",
 		Package: "google.protobuf",
@@ -374,7 +375,7 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 		t.Fatal("Cannot find .test.LroService.GetOperation")
 	}
 
-	checkMethod(t, service, "GetOperation", &api.Method{
+	apitest.CheckMethod(t, service, "GetOperation", &api.Method{
 		Documentation:   "Source file docs.",
 		Name:            "GetOperation",
 		ID:              ".test.LroService.GetOperation",

--- a/internal/sidekick/internal/parser/protobuf_test.go
+++ b/internal/sidekick/internal/parser/protobuf_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+	"github.com/googleapis/librarian/internal/sidekick/internal/api/apitest"
 	"github.com/googleapis/librarian/internal/sidekick/internal/sample"
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
@@ -69,7 +70,7 @@ func TestProtobuf_Scalar(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Fake",
 		Package:       "test",
 		ID:            ".test.Fake",
@@ -191,7 +192,7 @@ func TestProtobuf_ScalarArray(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Fake",
 		Package:       "test",
 		ID:            ".test.Fake",
@@ -240,7 +241,7 @@ func TestProtobuf_ScalarOptional(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API", "Fake")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Fake",
 		Package:       "test",
 		ID:            ".test.Fake",
@@ -294,7 +295,7 @@ func TestProtobuf_SkipExternalMessages(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.LocalMessage")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "LocalMessage",
 		Package:       "test",
 		ID:            ".test.LocalMessage",
@@ -340,7 +341,7 @@ func TestProtobuf_SkipExternaEnums(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find enum %s in API State", ".test.LocalEnum")
 	}
-	checkEnum(t, *enum, api.Enum{
+	apitest.CheckEnum(t, *enum, api.Enum{
 		Name:          "LocalEnum",
 		ID:            ".test.LocalEnum",
 		Package:       "test",
@@ -375,7 +376,7 @@ func TestProtobuf_Comments(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Request")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Request",
 		Package:       "test",
 		ID:            ".test.Request",
@@ -395,7 +396,7 @@ func TestProtobuf_Comments(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Response.nested")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Nested",
 		Package:       "test",
 		ID:            ".test.Response.Nested",
@@ -415,7 +416,7 @@ func TestProtobuf_Comments(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find enum %s in API State", ".test.Response.Status")
 	}
-	checkEnum(t, *e, api.Enum{
+	apitest.CheckEnum(t, *e, api.Enum{
 		Name:          "Status",
 		ID:            ".test.Response.Status",
 		Package:       "test",
@@ -438,7 +439,7 @@ func TestProtobuf_Comments(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.Service")
 	}
-	checkService(t, service, &api.Service{
+	apitest.CheckService(t, service, &api.Service{
 		Name:          "Service",
 		ID:            ".test.Service",
 		Package:       "test",
@@ -531,7 +532,7 @@ func TestProtobuf_OneOfs(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Request")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Fake",
 		Package:       "test",
 		ID:            ".test.Fake",
@@ -603,7 +604,7 @@ func TestProtobuf_ObjectFields(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:    "Fake",
 		Package: "test",
 		ID:      ".test.Fake",
@@ -637,7 +638,7 @@ func TestProtobuf_WellKnownTypeFields(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:    "Fake",
 		Package: "test",
 		ID:      ".test.Fake",
@@ -701,7 +702,7 @@ func TestProtobuf_JsonName(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Request")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "Request",
 		Package:       "test",
 		ID:            ".test.Request",
@@ -736,7 +737,7 @@ func TestProtobuf_MapFields(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:    "Fake",
 		Package: "test",
 		ID:      ".test.Fake",
@@ -768,7 +769,7 @@ func TestProtobuf_MapFields(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake.SingularMapEntry")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:    "SingularMapEntry",
 		Package: "test",
 		ID:      ".test.Fake.SingularMapEntry",
@@ -797,7 +798,7 @@ func TestProtobuf_MapFields(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake.EnumValueEntry")
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:    "EnumValueEntry",
 		Package: "test",
 		ID:      ".test.Fake.EnumValueEntry",
@@ -831,7 +832,7 @@ func TestProtobuf_Service(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
 	}
-	checkService(t, service, &api.Service{
+	apitest.CheckService(t, service, &api.Service{
 		Name:          "TestService",
 		Package:       "test",
 		ID:            ".test.TestService",
@@ -967,7 +968,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
 	}
-	checkService(t, service, &api.Service{
+	apitest.CheckService(t, service, &api.Service{
 		Name:          "TestService",
 		Package:       "test",
 		ID:            ".test.TestService",
@@ -1033,7 +1034,7 @@ func TestProtobuf_Enum(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find enum %s in API State", ".test.Code")
 	}
-	checkEnum(t, *e, api.Enum{
+	apitest.CheckEnum(t, *e, api.Enum{
 		Name:          "Code",
 		ID:            ".test.Code",
 		Package:       "test",
@@ -1083,7 +1084,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
 	}
-	checkService(t, service, &api.Service{
+	apitest.CheckService(t, service, &api.Service{
 		Name:        "TestService",
 		ID:          ".test.TestService",
 		DefaultHost: "test.googleapis.com",
@@ -1265,7 +1266,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 		t.Errorf("missing message (ListFooResponse) in MessageByID index")
 		return
 	}
-	checkMessage(t, resp, &api.Message{
+	apitest.CheckMessage(t, resp, &api.Message{
 		Name:    "ListFooResponse",
 		ID:      ".test.ListFooResponse",
 		Package: "test",
@@ -1350,7 +1351,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.LroService")
 	}
-	checkService(t, service, &api.Service{
+	apitest.CheckService(t, service, &api.Service{
 		Documentation: "A service to unit test the protobuf translator.",
 		DefaultHost:   "test.googleapis.com",
 		Name:          "LroService",
@@ -1508,7 +1509,7 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 		AutoPopulated: true,
 		Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_OPTIONAL, api.FIELD_BEHAVIOR_INPUT_ONLY},
 	}
-	checkMessage(t, message, &api.Message{
+	apitest.CheckMessage(t, message, &api.Message{
 		Name:          "CreateFooRequest",
 		Package:       "test",
 		ID:            ".test.CreateFooRequest",
@@ -1610,7 +1611,7 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.ServiceA")
 	}
-	checkService(t, s, &api.Service{
+	apitest.CheckService(t, s, &api.Service{
 		Name:       "ServiceA",
 		ID:         ".test.ServiceA",
 		Package:    "test",
@@ -1621,7 +1622,7 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.ServiceB")
 	}
-	checkService(t, s, &api.Service{
+	apitest.CheckService(t, s, &api.Service{
 		Name:       "ServiceB",
 		ID:         ".test.ServiceB",
 		Package:    "test",
@@ -1643,7 +1644,7 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.Request")
 	}
-	checkMessage(t, m, &api.Message{
+	apitest.CheckMessage(t, m, &api.Message{
 		Name:       "Request",
 		ID:         ".test.Request",
 		Package:    "test",
@@ -1669,7 +1670,7 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.Response")
 	}
-	checkMessage(t, m, &api.Message{
+	apitest.CheckMessage(t, m, &api.Message{
 		Name:       "Response",
 		ID:         ".test.Response",
 		Package:    "test",
@@ -1680,7 +1681,7 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.EnumA")
 	}
-	checkEnum(t, *e, api.Enum{
+	apitest.CheckEnum(t, *e, api.Enum{
 		Name:       "EnumA",
 		ID:         ".test.EnumA",
 		Package:    "test",
@@ -1697,7 +1698,7 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.EnumB")
 	}
-	checkEnum(t, *e, api.Enum{
+	apitest.CheckEnum(t, *e, api.Enum{
 		Name:    "EnumB",
 		ID:      ".test.EnumB",
 		Package: "test",


### PR DESCRIPTION
To implement discovery doc parsing I am going to need a new package
that `parser` will depend on and also needs the `Check*()` helpers.

Part of the work for #1850