### PR TITLE
refactor(sidekick): service config overrides

### DIFF
--- a/internal/sidekick/internal/parser/openapi.go
+++ b/internal/sidekick/internal/parser/openapi.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
 	"github.com/googleapis/librarian/internal/sidekick/internal/parser/httprule"
+	"github.com/googleapis/librarian/internal/sidekick/internal/parser/svcconfig"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
@@ -91,14 +92,9 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 	// one. In tests, the service config is typically `nil`.
 	serviceName := "Service"
 	packageName := ""
-	if serviceConfig != nil {
-		for _, api := range serviceConfig.Apis {
-			packageName, serviceName = splitApiName(api.Name)
-			// Keep searching after well-known mixin services.
-			if !wellKnownMixin(api.Name) {
-				break
-			}
-		}
+	names := svcconfig.ExtractPackageName(serviceConfig)
+	if names != nil {
+		serviceName, packageName = names.ServiceName, names.PackageName
 		result.PackageName = packageName
 	}
 

--- a/internal/sidekick/internal/parser/parser.go
+++ b/internal/sidekick/internal/parser/parser.go
@@ -16,7 +16,6 @@ package parser
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
 	"github.com/googleapis/librarian/internal/sidekick/internal/config"
@@ -65,18 +64,4 @@ func CreateModel(config *config.Config) (*api.API, error) {
 		model.Description = description
 	}
 	return model, nil
-}
-
-func splitApiName(name string) (string, string) {
-	li := strings.LastIndex(name, ".")
-	if li == -1 {
-		return "", name
-	}
-	return name[:li], name[li+1:]
-}
-
-func wellKnownMixin(apiName string) bool {
-	return strings.HasPrefix(apiName, "google.cloud.location.Location") ||
-		strings.HasPrefix(apiName, "google.longrunning.Operations") ||
-		strings.HasPrefix(apiName, "google.iam.v1.IAMPolicy")
 }

--- a/internal/sidekick/internal/parser/protobuf.go
+++ b/internal/sidekick/internal/parser/protobuf.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
 	"github.com/googleapis/librarian/internal/sidekick/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/internal/parser/svcconfig"
 	"github.com/googleapis/librarian/internal/sidekick/internal/protobuf"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/proto"
@@ -202,15 +203,10 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		}
 		withLongrunning := requiresLongrunningMixin(req)
 		enabledMixinMethods, mixinFileDesc = loadMixins(serviceConfig, withLongrunning)
-		packageName := ""
-		for _, api := range serviceConfig.Apis {
-			packageName, _ = splitApiName(api.Name)
-			// Keep searching after well-known mixin services.
-			if !wellKnownMixin(api.Name) {
-				break
-			}
+		names := svcconfig.ExtractPackageName(serviceConfig)
+		if names != nil {
+			result.PackageName = names.PackageName
 		}
-		result.PackageName = packageName
 	}
 
 	// First we need to add all the message and enums types to the

--- a/internal/sidekick/internal/parser/svcconfig/svcconfig.go
+++ b/internal/sidekick/internal/parser/svcconfig/svcconfig.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// serviceconfig contains helper functions to parse service config files.
+package svcconfig
+
+import (
+	"strings"
+
+	"google.golang.org/genproto/googleapis/api/serviceconfig"
+)
+
+// ServiceNames contains the package and (unqualified) name of a service.
+type ServiceNames struct {
+	PackageName string
+	ServiceName string
+}
+
+// ExtractServiceNames determines the package name and service implied by a
+// service config file.
+func ExtractPackageName(serviceConfig *serviceconfig.Service) *ServiceNames {
+	if serviceConfig == nil {
+		return nil
+	}
+	for _, api := range serviceConfig.Apis {
+		if wellKnownMixin(api.Name) {
+			continue
+		}
+		names := splitQualifiedServiceName(api.Name)
+		return &names
+	}
+	return nil
+}
+
+// SplitQualifiedServiceName splits a service name into the package name and the
+// unqualified service name.
+func splitQualifiedServiceName(name string) ServiceNames {
+	li := strings.LastIndex(name, ".")
+	if li == -1 {
+		return ServiceNames{PackageName: "", ServiceName: name}
+	}
+	return ServiceNames{PackageName: name[:li], ServiceName: name[li+1:]}
+}
+
+// WellKnownmixin returns true if the qualified service name is one of the
+// well-known mixins.
+func wellKnownMixin(qualifiedServiceName string) bool {
+	return strings.HasPrefix(qualifiedServiceName, "google.cloud.location.Location") ||
+		strings.HasPrefix(qualifiedServiceName, "google.longrunning.Operations") ||
+		strings.HasPrefix(qualifiedServiceName, "google.iam.v1.IAMPolicy")
+}

--- a/internal/sidekick/internal/parser/svcconfig/svcconfig_test.go
+++ b/internal/sidekick/internal/parser/svcconfig/svcconfig_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package svcconfig
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/internal/sample"
+	"google.golang.org/genproto/googleapis/api/serviceconfig"
+)
+
+func TestExtractPackageName(t *testing.T) {
+	for _, test := range []struct {
+		Input *serviceconfig.Service
+		Want  *ServiceNames
+	}{
+		{nil, nil},
+		{&serviceconfig.Service{}, nil},
+		{sample.ServiceConfig(), &ServiceNames{"google.cloud.secretmanager.v1", "SecretManagerService"}},
+	} {
+		got := ExtractPackageName(test.Input)
+		if diff := cmp.Diff(got, test.Want); diff != "" {
+			t.Errorf("mismatched API attributes (-want, +got):\n%s", diff)
+		}
+	}
+}
+
+func TestSplit(t *testing.T) {
+	for _, test := range []struct {
+		Input       string
+		WantPackage string
+		WantName    string
+	}{
+		{"google.cloud.location.Location", "google.cloud.location", "Location"},
+		{"Service", "", "Service"},
+	} {
+		got := splitQualifiedServiceName(test.Input)
+		if got.PackageName != test.WantPackage {
+			t.Errorf("mismatched package, want=%q, got=%q", test.WantPackage, got.PackageName)
+		}
+		if got.ServiceName != test.WantName {
+			t.Errorf("mismatched name, want=%q, got=%q", test.WantName, got.ServiceName)
+		}
+	}
+}
+
+func TestMixin(t *testing.T) {
+	for _, test := range []struct {
+		Input string
+		Want  bool
+	}{
+		{"google.cloud.location.Location", true},
+		{"google.longrunning.Operations", true},
+		{"google.iam.v1.IAMPolicy", true},
+		{"google.storage.v2.Storage", false},
+	} {
+		got := wellKnownMixin(test.Input)
+		if got != test.Want {
+			t.Errorf("mismatched WellKnownMixin, want=%v, got=%v", test.Want, got)
+		}
+	}
+}


### PR DESCRIPTION
Eliminate duplicate code to apply the service config overrides. I am
going to add the discovery docparser and want to avoid copying this code
one more time. This third parser will live in a separate package (for
reasons), so we need to move the helpers for service config overrides
to avoid a dependency cycle.

Part of the work for #1850
