### PR TITLE
chore(librarian): log when a service config isn't found

### DIFF
--- a/internal/librarian/state.go
+++ b/internal/librarian/state.go
@@ -146,7 +146,7 @@ func findServiceConfigIn(path string) (string, error) {
 		}
 	}
 
-	// No service config present: assume it's proto-only.
+	slog.Info("No service config found; assuming proto-only package", "path", path)
 	return "", nil
 }
 


### PR DESCRIPTION
(As requested on #1854.)