### PR TITLE
impl(sidekick): populate services skeleton

### DIFF
--- a/internal/sidekick/internal/parser/discovery/discovery.go
+++ b/internal/sidekick/internal/parser/discovery/discovery.go
@@ -82,6 +82,10 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte) (*api.API, er
 		result.State.MessageByID[id] = message
 	}
 
+	for _, resource := range doc.Resources {
+		addServiceRecursive(result, resource)
+	}
+
 	return result, nil
 }
 

--- a/internal/sidekick/internal/parser/discovery/services.go
+++ b/internal/sidekick/internal/parser/discovery/services.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+)
+
+func addServiceRecursive(model *api.API, resource *resource) {
+	if len(resource.Methods) != 0 {
+		addService(model, resource)
+	}
+	for _, child := range resource.Resources {
+		addServiceRecursive(model, child)
+	}
+}
+
+func addService(model *api.API, resource *resource) {
+	id := fmt.Sprintf(".%s.%s", model.PackageName, resource.Name)
+	var service *api.Service
+	if _, ok := model.State.ServiceByID[id]; !ok {
+		service = &api.Service{
+			ID:            id,
+			Name:          resource.Name,
+			Package:       model.PackageName,
+			Documentation: fmt.Sprintf("Service for the `%s` resource.", resource.Name),
+		}
+		model.Services = append(model.Services, service)
+		model.State.ServiceByID[id] = service
+	}
+	// TODO(#1850) - add the methods, if the service already exists then merge
+	//     the methods.
+}

--- a/internal/sidekick/internal/parser/discovery/services_test.go
+++ b/internal/sidekick/internal/parser/discovery/services_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+	"github.com/googleapis/librarian/internal/sidekick/internal/api/apitest"
+)
+
+func TestService(t *testing.T) {
+	model, err := PublicCaDisco(t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := model.State.ServiceByID["..projects"]; ok {
+		t.Errorf("expected no service for `projects` resource as it has no methods")
+	}
+
+	id := "..externalAccountKeys"
+	got, ok := model.State.ServiceByID[id]
+	if !ok {
+		t.Fatalf("expected service %s in the API model", id)
+	}
+	want := &api.Service{
+		Name:          "externalAccountKeys",
+		ID:            id,
+		Package:       "",
+		Documentation: "Service for the `externalAccountKeys` resource.",
+	}
+	apitest.CheckService(t, got, want)
+}


### PR DESCRIPTION
This change starts parsing the services. Only resources with methods
get a `api.Service` entry.

Part of the work for #1850 