### PR TITLE
impl(sidekick): create skeleton for methods

### DIFF
--- a/internal/sidekick/internal/parser/discovery/discovery.go
+++ b/internal/sidekick/internal/parser/discovery/discovery.go
@@ -83,7 +83,9 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte) (*api.API, er
 	}
 
 	for _, resource := range doc.Resources {
-		addServiceRecursive(result, resource)
+		if err := addServiceRecursive(result, resource); err != nil {
+			return nil, err
+		}
 	}
 
 	return result, nil

--- a/internal/sidekick/internal/parser/discovery/discovery_test.go
+++ b/internal/sidekick/internal/parser/discovery/discovery_test.go
@@ -191,6 +191,20 @@ func TestMessageErrors(t *testing.T) {
 	}
 }
 
+func TestServiceErrors(t *testing.T) {
+	for _, test := range []struct {
+		Name     string
+		Contents string
+	}{
+		{"bad method", `{"resources": {"withBadMethod": {"methods": {"uploadNotSupported": { "mediaUpload": {} }}}}}`},
+	} {
+		contents := []byte(test.Contents)
+		if got, err := NewAPI(nil, contents); err == nil {
+			t.Fatalf("expected error for %s input, got=%v", test.Name, got)
+		}
+	}
+}
+
 func PublicCaDisco(t *testing.T, sc *serviceconfig.Service) (*api.API, error) {
 	t.Helper()
 	contents, err := os.ReadFile("../../../testdata/disco/publicca.v1.json")

--- a/internal/sidekick/internal/parser/discovery/methods.go
+++ b/internal/sidekick/internal/parser/discovery/methods.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+)
+
+func makeServiceMethods(model *api.API, serviceID string, resource *resource) ([]*api.Method, error) {
+	var methods []*api.Method
+	for _, input := range resource.Methods {
+		method, err := makeMethod(model, serviceID, input)
+		if err != nil {
+			return nil, err
+		}
+		methods = append(methods, method)
+	}
+
+	return methods, nil
+}
+
+func makeMethod(model *api.API, serviceID string, input *method) (*api.Method, error) {
+	id := fmt.Sprintf("%s.%s", serviceID, input.Name)
+	if input.MediaUpload != nil {
+		return nil, fmt.Errorf("media upload methods are not supported, id=%s", id)
+	}
+	inputID, err := getMethodType(model, id, "request type", input.Request)
+	if err != nil {
+		return nil, err
+	}
+	outputID, err := getMethodType(model, id, "response type", input.Response)
+	if err != nil {
+		return nil, err
+	}
+	method := &api.Method{
+		ID:            id,
+		Name:          input.Name,
+		Documentation: input.Description,
+		// TODO(#1850) - handle deprecated methods
+		// Deprecated: ...,
+		InputTypeID:  inputID,
+		OutputTypeID: outputID,
+	}
+	return method, nil
+}
+
+func getMethodType(model *api.API, methodID, name string, typez *schema) (string, error) {
+	if typez == nil {
+		return ".google.protobuf.Empty", nil
+	}
+	if typez.Ref == "" {
+		return "", fmt.Errorf("expected a ref-like schema for %s in method %s", name, methodID)
+	}
+	return fmt.Sprintf(".%s.%s", model.PackageName, typez.Ref), nil
+}

--- a/internal/sidekick/internal/parser/discovery/methods_test.go
+++ b/internal/sidekick/internal/parser/discovery/methods_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import "testing"
+
+func TestMakeServiceMethodsError(t *testing.T) {
+	model, err := PublicCaDisco(t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := &resource{
+		Name: "testResource",
+		Methods: []*method{
+			{
+				Name:        "upload",
+				MediaUpload: &mediaUpload{},
+			},
+		},
+	}
+	if methods, err := makeServiceMethods(model, "..testResource", input); err == nil {
+		t.Errorf("expected error on method with media upload, got=%v", methods)
+	}
+}
+
+func TestMakeMethodError(t *testing.T) {
+	model, err := PublicCaDisco(t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		Name  string
+		Input method
+	}{
+		{"mediaUploadMustBeNil", method{MediaUpload: &mediaUpload{}}},
+		{"requestMustHaveRef", method{Request: &schema{}}},
+		{"responseMustHaveRef", method{Response: &schema{}}},
+	} {
+		if method, err := makeMethod(model, "..Test", &test.Input); err == nil {
+			t.Errorf("expected error on method[%s], got=%v", test.Name, method)
+		}
+	}
+
+}

--- a/internal/sidekick/internal/parser/discovery/services_test.go
+++ b/internal/sidekick/internal/parser/discovery/services_test.go
@@ -40,6 +40,49 @@ func TestService(t *testing.T) {
 		ID:            id,
 		Package:       "",
 		Documentation: "Service for the `externalAccountKeys` resource.",
+		Methods: []*api.Method{
+			{
+				ID:            "..externalAccountKeys.create",
+				Name:          "create",
+				Documentation: "Creates a new ExternalAccountKey bound to the project.",
+				InputTypeID:   "..ExternalAccountKey",
+				OutputTypeID:  "..ExternalAccountKey",
+			},
+		},
 	}
 	apitest.CheckService(t, got, want)
+}
+
+func TestServiceTopLevelMethodErrors(t *testing.T) {
+	model, err := PublicCaDisco(t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := resource{
+		Methods: []*method{
+			{MediaUpload: &mediaUpload{}},
+		},
+	}
+	if err := addServiceRecursive(model, &input); err == nil {
+		t.Errorf("expected error in addServiceRecursive invalid top-level method, got=%v", model.Services)
+	}
+}
+
+func TestServiceChildMethodErrors(t *testing.T) {
+	model, err := PublicCaDisco(t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := resource{
+		Resources: []*resource{
+			{
+				Methods: []*method{
+					{MediaUpload: &mediaUpload{}},
+				},
+			},
+		},
+	}
+	if err := addServiceRecursive(model, &input); err == nil {
+		t.Errorf("expected error in addServiceRecursive invalid child method, got=%v", model.Services)
+	}
 }


### PR DESCRIPTION
Add methods (with many details missing) to the services created from a
discovery doc.

Part of the work for #1850