### PR TITLE
chore: refactor `commitAndPush` func

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -382,28 +382,12 @@ func commitAndPush(ctx context.Context, info *commitInfo) error {
 	}
 
 	title := fmt.Sprintf("Librarian %s pull request: %s", info.prType, datetimeNow)
-	prBody, err := createPRBody(info)
-	if err != nil {
-		return err
-	}
-
 	slog.Info("Creating pull request", slog.String("branch", branch), slog.String("title", title))
-	if _, err = info.ghClient.CreatePullRequest(ctx, gitHubRepo, branch, cfg.Branch, title, prBody); err != nil {
+	if _, err = info.ghClient.CreatePullRequest(ctx, gitHubRepo, branch, cfg.Branch, title, commitMessage); err != nil {
 		return fmt.Errorf("failed to create pull request: %w", err)
 	}
 
 	return nil
-}
-
-func createPRBody(info *commitInfo) (string, error) {
-	switch info.prType {
-	case generate:
-		return formatGenerationPRBody(info.repo, info.state)
-	case release:
-		return formatReleaseNotes(info.repo, info.state)
-	default:
-		return "", fmt.Errorf("unrecognized pull request type: %s", info.prType)
-	}
 }
 
 func copyFile(dst, src string) (err error) {

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -38,6 +38,21 @@ import (
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
+const (
+	generate = "generate"
+	release  = "release"
+)
+
+type commitInfo struct {
+	cfg               *config.Config
+	state             *config.LibrarianState
+	repo              gitrepo.Repository
+	ghClient          GitHubClient
+	additionalMessage string
+	commitMessage     string
+	prType            string
+}
+
 type commandRunner struct {
 	cfg             *config.Config
 	repo            gitrepo.Repository

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -335,12 +335,14 @@ func coerceLibraryChanges(commits []*conventionalcommits.ConventionalCommit) []*
 // changes.
 // It uses the GitHub client to create a PR with the specified branch, title, and
 // description to the repository.
-func commitAndPush(ctx context.Context, cfg *config.Config, repo gitrepo.Repository, ghClient GitHubClient, commitMessage string) error {
+func commitAndPush(ctx context.Context, info *commitInfo) error {
+	cfg := info.cfg
 	if !cfg.Push && !cfg.Commit {
 		slog.Info("Push flag and Commit flag are not specified, skipping committing")
 		return nil
 	}
 
+	repo := info.repo
 	status, err := repo.AddAll()
 	if err != nil {
 		return err
@@ -358,6 +360,7 @@ func commitAndPush(ctx context.Context, cfg *config.Config, repo gitrepo.Reposit
 	}
 
 	// TODO: get correct language for message (https://github.com/googleapis/librarian/issues/885)
+	commitMessage := info.commitMessage
 	slog.Info("Committing", "message", commitMessage)
 	if err := repo.Commit(commitMessage); err != nil {
 		return err
@@ -378,14 +381,29 @@ func commitAndPush(ctx context.Context, cfg *config.Config, repo gitrepo.Reposit
 		return err
 	}
 
-	// Create a new branch, set title and message for the PR.
-	titlePrefix := "Librarian pull request"
-	title := fmt.Sprintf("%s: %s", titlePrefix, datetimeNow)
+	title := fmt.Sprintf("Librarian %s pull request: %s", info.prType, datetimeNow)
+	prBody, err := createPRBody(info)
+	if err != nil {
+		return err
+	}
+
 	slog.Info("Creating pull request", slog.String("branch", branch), slog.String("title", title))
-	if _, err = ghClient.CreatePullRequest(ctx, gitHubRepo, branch, cfg.Branch, title, commitMessage); err != nil {
+	if _, err = info.ghClient.CreatePullRequest(ctx, gitHubRepo, branch, cfg.Branch, title, prBody); err != nil {
 		return fmt.Errorf("failed to create pull request: %w", err)
 	}
+
 	return nil
+}
+
+func createPRBody(info *commitInfo) (string, error) {
+	switch info.prType {
+	case generate:
+		return formatGenerationPRBody(info.repo, info.state)
+	case release:
+		return formatReleaseNotes(info.repo, info.state)
+	default:
+		return "", fmt.Errorf("unrecognized pull request type: %s", info.prType)
+	}
 }
 
 func copyFile(dst, src string) (err error) {

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -1313,8 +1313,15 @@ func TestCommitAndPush(t *testing.T) {
 				Push:   test.push,
 				Commit: test.commit,
 			}
-
-			err := commitAndPush(context.Background(), localConfig, repo, client, "")
+			commitInfo := &commitInfo{
+				cfg:           localConfig,
+				state:         nil,
+				repo:          repo,
+				ghClient:      client,
+				commitMessage: "",
+				prType:        generate,
+			}
+			err := commitAndPush(context.Background(), commitInfo)
 
 			if test.wantErr {
 				if err == nil {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -141,7 +141,6 @@ func (r *generateRunner) run(ctx context.Context) error {
 		failedGenerations := 0
 		for _, library := range r.state.Libraries {
 			if err := r.generateSingleLibrary(ctx, library.ID, outputDir); err != nil {
-				// TODO(https://github.com/googleapis/librarian/issues/983): record failure and report in PR body when applicable
 				slog.Error("failed to generate library", "id", library.ID, "err", err)
 				additionalMsg += fmt.Sprintf("%s failed to generate\n", library.ID)
 				failedGenerations++

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -127,7 +127,7 @@ func (r *generateRunner) run(ctx context.Context) error {
 	}
 	slog.Info("Code will be generated", "dir", outputDir)
 
-	prBody := ""
+	additionalMsg := ""
 	if r.cfg.API != "" || r.cfg.Library != "" {
 		libraryID := r.cfg.Library
 		if libraryID == "" {
@@ -136,14 +136,14 @@ func (r *generateRunner) run(ctx context.Context) error {
 		if err := r.generateSingleLibrary(ctx, libraryID, outputDir); err != nil {
 			return err
 		}
-		prBody += fmt.Sprintf("feat: generated %s\n", libraryID)
+		additionalMsg += fmt.Sprintf("feat: generated %s\n", libraryID)
 	} else {
 		failedGenerations := 0
 		for _, library := range r.state.Libraries {
 			if err := r.generateSingleLibrary(ctx, library.ID, outputDir); err != nil {
 				// TODO(https://github.com/googleapis/librarian/issues/983): record failure and report in PR body when applicable
 				slog.Error("failed to generate library", "id", library.ID, "err", err)
-				prBody += fmt.Sprintf("%s failed to generate\n", library.ID)
+				additionalMsg += fmt.Sprintf("%s failed to generate\n", library.ID)
 				failedGenerations++
 			}
 		}
@@ -155,7 +155,17 @@ func (r *generateRunner) run(ctx context.Context) error {
 	if err := saveLibrarianState(r.repo.GetDir(), r.state); err != nil {
 		return err
 	}
-	if err := commitAndPush(ctx, r.cfg, r.repo, r.ghClient, prBody); err != nil {
+
+	commitInfo := &commitInfo{
+		cfg:               r.cfg,
+		state:             r.state,
+		repo:              r.repo,
+		ghClient:          r.ghClient,
+		additionalMessage: additionalMsg,
+		commitMessage:     "",
+		prType:            generate,
+	}
+	if err := commitAndPush(ctx, commitInfo); err != nil {
 		return err
 	}
 	return nil

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -105,9 +105,15 @@ func (r *initRunner) run(ctx context.Context) error {
 		return err
 	}
 
-	// TODO: https://github.com/googleapis/librarian/issues/1697
-	// Add commit message after this issue is resolved.
-	if err := commitAndPush(ctx, r.cfg, r.repo, r.ghClient, ""); err != nil {
+	commitInfo := &commitInfo{
+		cfg:           r.cfg,
+		state:         r.state,
+		repo:          r.repo,
+		ghClient:      r.ghClient,
+		commitMessage: "",
+		prType:        release,
+	}
+	if err := commitAndPush(ctx, commitInfo); err != nil {
 		return fmt.Errorf("failed to commit and push: %w", err)
 	}
 


### PR DESCRIPTION
Refactor `commitAndPush` function so that it can be used to create generate and release pull requests.

Updates #1703
Updates #1899