### PR TITLE
fix(generate): Correct help text for push flag

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -58,9 +58,9 @@ new files into place, according to the configuration in '.librarian/state.yaml'.
 If the '--build' flag is specified, the 'build' command is also executed.
 
 **Output:**
-After generation, if a push configuration is provided (e.g., via the "-push-config" flag), the changes
-are committed to a new branch, and a pull request is created. Otherwise, the changes are left in the
-local working tree for inspection.`,
+After generation, if the "-push" flag is provided, the changes are committed to a new branch, and
+a pull request is created. Otherwise, the changes are left in the local working tree for
+inspection.`,
 	Run: func(ctx context.Context, cfg *config.Config) error {
 		runner, err := newGenerateRunner(cfg)
 		if err != nil {


### PR DESCRIPTION
Updates help text to refer to the correct '-push' flag instead of the non-existent '-push-config'.

Fixes #1726