### PR TITLE
chore: branches attribute in repositories.yaml

### DIFF
--- a/internal/automation/prod/repositories.yaml
+++ b/internal/automation/prod/repositories.yaml
@@ -1,6 +1,7 @@
 repositories:
   - name: "google-cloud-python"
     full-name: https://github.com/googleapis/google-cloud-python
+    branches: ["main"]
     github-token-secret-name: "google-cloud-python-github-token"
     supported-commands:
       - generate
@@ -8,6 +9,7 @@ repositories:
       - publish-release
   - name: "google-cloud-go"
     full-name: https://github.com/googleapis/google-cloud-go
+    branches: ["main"]
     github-token-secret-name: "google-cloud-go-github-token"
     supported-commands:
       - generate
@@ -15,6 +17,7 @@ repositories:
       - publish-release
   - name: "librarian"
     full-name: https://github.com/googleapis/librarian
+    branches: ["main"]
     github-token-secret-name: "librarian-github-token"
     supported-commands:
       - stage-release


### PR DESCRIPTION
An idea to leverage the branch option added to the CLI (https://github.com/googleapis/librarian/pull/1893; `-branch=$_BRANCH`). The current design is to have `branches` field:

```
  - name: "google-cloud-python"
    full-name: https://github.com/googleapis/google-cloud-python
    branches: ["main"]
    github-token-secret-name: "google-cloud-python-github-token"
    supported-commands:
      - generate
      - stage-release
      - publish-release
```

### Risk: Duplicate "publish-release"

The publish-release does not take the branch into account as of https://github.com/googleapis/librarian/pull/1893. This means every 5 minutes, the two jobs are looking for recently merged pull request for the same repository.


### Alternative

Alternatively, we could duplicate the entries by branches, but it looked redundant:

```
  - name: "google-cloud-python"
    full-name: https://github.com/googleapis/google-cloud-python
    branch: "main"
    github-token-secret-name: "google-cloud-python-github-token"
    supported-commands:
      - generate
      - stage-release
      - publish-release
  - name: "google-cloud-python"
    full-name: https://github.com/googleapis/google-cloud-python
    # We maintain this 2.1.x branch for critical bug fixes and vulnerabilities until the end of 2026.
    branches: 2.1.x
    github-token-secret-name: "google-cloud-python-github-token"
    supported-commands:
      - generate
      - stage-release
```

The second entry for google-cloud-python is for the 2.1.x branch and does not need "publish-release" because the "publish-release" for the main branch takes care of the releases for the 2.1.x branch as well.
