### PR TITLE
ci: use '-branch' option in Cloud Builds

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -54,6 +54,7 @@ steps:
       - 'generate'
       - '-repo'
       - '/workspace/$_REPOSITORY'
+      - '-branch=$_BRANCH'
       - '-library'
       - $_LIBRARY_ID
       - '-api-source'

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -48,6 +48,7 @@ steps:
       - 'init'
       - '-repo'
       - '/workspace/$_REPOSITORY'
+      - '-branch=$_BRANCH'
       - '-library'
       - $_LIBRARY_ID
       - '-output'


### PR DESCRIPTION
The branch option helps us to test the Librarian's generate and
stage-release behavior without touching the main branch of the SDK
repository.

The flag has been added in https://github.com/googleapis/librarian/pull/1893.
Let's use the flag in the Cloud Builds YAML files.
By default, "main" is passed to the variable (cl/802643045).

I have to wait for the librarian container image update so that the CLI interprets the `-push` option.