### PR TITLE
chore: revert "refactor(librarian): Inject client factories and add test for generate default"

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -62,7 +62,7 @@ After generation, if the "-push" flag is provided, the changes are committed to 
 a pull request is created. Otherwise, the changes are left in the local working tree for
 inspection.`,
 	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newGenerateRunner(cfg, nil, nil)
+		runner, err := newGenerateRunner(cfg)
 		if err != nil {
 			return err
 		}
@@ -98,8 +98,8 @@ type generateRunner struct {
 	image           string
 }
 
-func newGenerateRunner(cfg *config.Config, ghClientFactory GitHubClientFactory, containerClientFactory ContainerClientFactory) (*generateRunner, error) {
-	runner, err := newCommandRunner(cfg, ghClientFactory, containerClientFactory)
+func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
+	runner, err := newCommandRunner(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -505,7 +505,7 @@ func TestNewGenerateRunner(t *testing.T) {
 				}
 			}
 
-			r, err := newGenerateRunner(test.cfg, nil, nil)
+			r, err := newGenerateRunner(test.cfg)
 			if (err != nil) != test.wantErr {
 				t.Errorf("newGenerateRunner() error = %v, wantErr %v", err, test.wantErr)
 			}

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"gopkg.in/yaml.v3"
 
@@ -80,44 +79,6 @@ func TestParentCommands(t *testing.T) {
 				t.Fatalf("Run(ctx, %q) got error %v, want nil", test.command, err)
 			}
 		})
-	}
-}
-
-func TestGenerate_DefaultBehavior(t *testing.T) {
-	ctx := context.Background()
-
-	// 1. Setup a mock repository with a state file
-	repo := newTestGitRepoWithState(t, true)
-	repoDir := repo.GetDir()
-
-	t.Chdir(repoDir)
-
-	// 2. Override dependency creation to use mocks
-	mockContainer := &mockContainerClient{
-		wantLibraryGen: true,
-	}
-	mockGH := &mockGitHubClient{}
-
-	// 3. Call librarian.Run
-	cfg := config.New("generate")
-	cfg.WorkRoot = repoDir
-	cfg.Repo = repoDir
-	runner, err := newGenerateRunner(cfg, func(token string, repo *github.Repository) (GitHubClient, error) {
-		return mockGH, nil
-	}, func(workRoot, image, userUID, userGID string) (ContainerClient, error) {
-		return mockContainer, nil
-	})
-	if err != nil {
-		t.Fatalf("newGenerateRunner() failed: %v", err)
-	}
-	if err := runner.run(ctx); err != nil {
-		t.Fatalf("runner.run() failed: %v", err)
-	}
-
-	// 4. Assertions
-	expectedGenerateCalls := 1
-	if mockContainer.generateCalls != expectedGenerateCalls {
-		t.Errorf("Run(ctx, \"generate\"): got %d generate calls, want %d", mockContainer.generateCalls, expectedGenerateCalls)
 	}
 }
 

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -78,7 +78,7 @@ type initRunner struct {
 }
 
 func newInitRunner(cfg *config.Config) (*initRunner, error) {
-	runner, err := newCommandRunner(cfg, nil, nil)
+	runner, err := newCommandRunner(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create init runner: %w", err)
 	}

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -74,7 +74,7 @@ type tagAndReleaseRunner struct {
 }
 
 func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
-	runner, err := newCommandRunner(cfg, nil, nil)
+	runner, err := newCommandRunner(cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The time to run all unit tests increases from 1 mins to 5 mins.
Example logs:
[Before](https://github.com/googleapis/librarian/actions/runs/17449743710/job/49552035801)
[After](https://github.com/googleapis/librarian/actions/runs/17449910373/job/49552495491)

Reverts googleapis/librarian#1918