### PR TITLE
fix: do not delete any files in .librarian/generator-input directory

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -42,7 +42,7 @@ const (
 )
 
 var globalPreservePatterns = []string{
-	`^\.librarian/generator-input(/.*)?$`, // Preserve the generator-input directory and its contents.
+	fmt.Sprintf(`^%s(/.*)?$`, regexp.QuoteMeta(config.GeneratorInputDir)), // Preserve the generator-input directory and its contents.
 }
 
 // GitHubClientFactory type for creating a GitHubClient.

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -243,6 +243,7 @@ func cleanAndCopyLibrary(state *config.LibrarianState, repoDir, libraryID, outpu
 	}
 
 	removePatterns := library.RemoveRegex
+	slog.Info("Cleaning and copying library files", "removePatterns", removePatterns)
 	if len(removePatterns) == 0 {
 		slog.Info("remove_regex not provided, defaulting to source_roots")
 		removePatterns = make([]string, len(library.SourceRoots))
@@ -250,6 +251,7 @@ func cleanAndCopyLibrary(state *config.LibrarianState, repoDir, libraryID, outpu
 		// directory itself, and any file or subdirectory within it.
 		for i, root := range library.SourceRoots {
 			removePatterns[i] = fmt.Sprintf("^%s(/.*)?$", regexp.QuoteMeta(root))
+			slog.Info("Adding source root", "root", root, "pattern", removePatterns[i])
 		}
 	}
 

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -42,7 +42,7 @@ const (
 )
 
 var globalPreservePatterns = []string{
-	`^\.librarian/generator-input(/.*)?$`,
+	`^\.librarian/generator-input(/.*)?$`, // Preserve the generator-input directory and its contents.
 }
 
 // GitHubClientFactory type for creating a GitHubClient.
@@ -257,7 +257,6 @@ func cleanAndCopyLibrary(state *config.LibrarianState, repoDir, libraryID, outpu
 		}
 	}
 
-	// Make sure we never delete the generator-input directory.
 	preservePatterns := append(library.PreserveRegex,
 		globalPreservePatterns...)
 

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -388,6 +388,58 @@ func TestCleanAndCopyLibrary(t *testing.T) {
 				"a/path/stale.txt",
 			},
 		},
+		{
+			name:      "clean never deletes generator-input directory",
+			libraryID: "some-library",
+			state: &config.LibrarianState{
+				Libraries: []*config.LibraryState{
+					{
+						ID:          "some-library",
+						SourceRoots: []string{"a/path"},
+						RemoveRegex: []string{"a/path"},
+					},
+				},
+			},
+			repo: newTestGitRepo(t),
+			setup: func(t *testing.T, repoDir, outputDir string) {
+				// Create a file in the repo directory to test cleaning.
+				fileToBeDeleted := filepath.Join(repoDir, "a/path/delete.txt")
+				fileToNotBeDeleted := filepath.Join(repoDir, ".librarian/generator-input/a/path/do-not-delete.txt")
+				if err := os.MkdirAll(filepath.Dir(fileToBeDeleted), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Create(fileToBeDeleted); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Dir(fileToNotBeDeleted), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Create(fileToNotBeDeleted); err != nil {
+					t.Fatal(err)
+				}
+
+				// Create generated files in the output directory.
+				filesToCreate := []string{
+					"a/path/new_generated_file_to_copy.txt",
+				}
+				for _, relPath := range filesToCreate {
+					fullPath := filepath.Join(outputDir, relPath)
+					if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := os.Create(fullPath); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			shouldCopy: []string{
+				".librarian/generator-input/a/path/do-not-delete.txt",
+				"a/path/new_generated_file_to_copy.txt",
+			},
+			shouldDelete: []string{
+				"a/path/delete.txt",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			repoDir := test.repo.GetDir()

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -440,6 +440,59 @@ func TestCleanAndCopyLibrary(t *testing.T) {
 				"a/path/delete.txt",
 			},
 		},
+		{
+			name:      "if same value is present in preserve regex and global preserver regex list there is no conflict",
+			libraryID: "some-library",
+			state: &config.LibrarianState{
+				Libraries: []*config.LibraryState{
+					{
+						ID:            "some-library",
+						SourceRoots:   []string{"a/path"},
+						RemoveRegex:   []string{"a/path"},
+						PreserveRegex: globalPreservePatterns,
+					},
+				},
+			},
+			repo: newTestGitRepo(t),
+			setup: func(t *testing.T, repoDir, outputDir string) {
+				// Create a file in the repo directory to test cleaning.
+				fileToBeDeleted := filepath.Join(repoDir, "a/path/delete.txt")
+				fileToNotBeDeleted := filepath.Join(repoDir, ".librarian/generator-input/a/path/do-not-delete.txt")
+				if err := os.MkdirAll(filepath.Dir(fileToBeDeleted), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Create(fileToBeDeleted); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Dir(fileToNotBeDeleted), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Create(fileToNotBeDeleted); err != nil {
+					t.Fatal(err)
+				}
+
+				// Create generated files in the output directory.
+				filesToCreate := []string{
+					"a/path/new_generated_file_to_copy.txt",
+				}
+				for _, relPath := range filesToCreate {
+					fullPath := filepath.Join(outputDir, relPath)
+					if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := os.Create(fullPath); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			shouldCopy: []string{
+				".librarian/generator-input/a/path/do-not-delete.txt",
+				"a/path/new_generated_file_to_copy.txt",
+			},
+			shouldDelete: []string{
+				"a/path/delete.txt",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			repoDir := test.repo.GetDir()


### PR DESCRIPTION
In case the remove-regex contains a directory that exists in .librarian/generator-input, the librarian CLI should not delete it when calling clean.

fixes: #1925 