### PR TITLE
test: remove redundant test exectution

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -186,10 +186,6 @@ func TestGodocLint(t *testing.T) {
 		"./...")
 }
 
-func TestCoverage(t *testing.T) {
-	rungo(t, "test", "-coverprofile=coverage.out", "./internal/...", "./cmd/...")
-}
-
 func rungo(t *testing.T, args ...string) {
 	t.Helper()
 


### PR DESCRIPTION
If someone runs `go test ./...` locally all tests were being run twice because of this nested test. Also CI already explicitly runs for coverage so this is not needed.

Fixes: #734