### PR TITLE
refactor(librarian): Move generate_e2e_test.go to internal/librarian

### DIFF
--- a/internal/librarian/generate_e2e_test.go
+++ b/internal/librarian/generate_e2e_test.go
@@ -33,8 +33,8 @@ import (
 
 func TestRunGenerate(t *testing.T) {
 	const (
-		initialRepoStateDir = "testdata/e2e/generate/repo_init"
-		localAPISource      = "testdata/e2e/generate/api_root"
+		initialRepoStateDir = "../../testdata/e2e/generate/repo_init"
+		localAPISource      = "../../testdata/e2e/generate/api_root"
 	)
 	t.Parallel()
 	for _, test := range []struct {
@@ -99,7 +99,7 @@ func TestRunGenerate(t *testing.T) {
 
 func TestCleanAndCopy(t *testing.T) {
 	const (
-		localAPISource = "testdata/e2e/generate/api_root"
+		localAPISource = "../../testdata/e2e/generate/api_root"
 		apiToGenerate  = "google/cloud/pubsub/v1"
 	)
 	// create a temp directory for writing files, so we don't have to create testdata files.
@@ -213,8 +213,8 @@ func TestCleanAndCopy(t *testing.T) {
 
 func TestRunConfigure(t *testing.T) {
 	const (
-		localRepoDir        = "testdata/e2e/configure/repo"
-		initialRepoStateDir = "testdata/e2e/configure/repo_init"
+		localRepoDir        = "../../testdata/e2e/configure/repo"
+		initialRepoStateDir = "../../testdata/e2e/configure/repo_init"
 	)
 	t.Parallel()
 	for _, test := range []struct {
@@ -229,15 +229,15 @@ func TestRunConfigure(t *testing.T) {
 			name:         "runs successfully",
 			api:          "google/cloud/new-library-path/v2",
 			library:      "new-library",
-			apiSource:    "testdata/e2e/configure/api_root",
-			updatedState: "testdata/e2e/configure/updated-state.yaml",
+			apiSource:    "../../testdata/e2e/configure/api_root",
+			updatedState: "../../testdata/e2e/configure/updated-state.yaml",
 		},
 		{
 			name:         "failed due to simulated error in configure command",
 			api:          "google/cloud/another-library/v3",
 			library:      "simulate-command-error-id",
-			apiSource:    "testdata/e2e/configure/api_root",
-			updatedState: "testdata/e2e/configure/updated-state.yaml",
+			apiSource:    "../../testdata/e2e/configure/api_root",
+			updatedState: "../../testdata/e2e/configure/updated-state.yaml",
 			wantErr:      true,
 		},
 	} {
@@ -330,13 +330,4 @@ func initRepo(t *testing.T, dir, source string) error {
 
 type genResponse struct {
 	ErrorMessage string `json:"error,omitempty"`
-}
-
-func runGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("git %v: %v", args, err)
-	}
 }

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"os/exec"
+
 	"path/filepath"
 	"strings"
 	"testing"
@@ -252,15 +252,6 @@ func newTestGitRepoWithState(t *testing.T, writeState bool) gitrepo.Repository {
 		t.Fatalf("gitrepo.Open(%q) = %v", dir, err)
 	}
 	return repo
-}
-
-func runGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("git %v: %v", args, err)
-	}
 }
 
 // setupRepoForGetCommits creates an empty gitrepo and creates some commits and

--- a/internal/librarian/test_helpers.go
+++ b/internal/librarian/test_helpers.go
@@ -1,0 +1,30 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// runGit is a helper function to run git commands in tests.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+}


### PR DESCRIPTION
Moved generate_e2e_test.go from the root directory to internal/librarian/ to co-locate it with the generate command's core logic.

This change also involved:
- Extracting the common test helper function runGit into internal/librarian/test_helpers.go to resolve name collisions.
- Updating relative paths to testdata in generate_e2e_test.go.
- Resolving unused imports and formatting issues.