### PR TITLE
fix: change merge PR check condition to use merge_at field

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -300,7 +300,7 @@ func (c *Client) FindMergedPullRequestsWithPendingReleaseLabel(ctx context.Conte
 			return nil, err
 		}
 		for _, pr := range prs {
-			if (pr.GetMerged() || pr.GetMergeCommitSHA() != "") && hasLabel(pr, "release:pending") {
+			if !pr.GetMergedAt().IsZero() && hasLabel(pr, "release:pending") {
 				allPRs = append(allPRs, pr)
 			}
 		}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	gogitConfig "github.com/go-git/go-git/v5/config"
@@ -1026,10 +1027,10 @@ func TestFindMergedPullRequestsWithPendingReleaseLabel(t *testing.T) {
 				if r.URL.Query().Get("state") != "closed" {
 					t.Errorf("unexpected state: got %q", r.URL.Query().Get("state"))
 				}
-				pr0 := github.PullRequest{Number: github.Ptr(0), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/0"), MergeCommitSHA: github.Ptr("sha456"), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
+				pr0 := github.PullRequest{Number: github.Ptr(0), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/0"), MergedAt: &github.Timestamp{Time: time.Date(2025, time.September, 5, 20, 44, 59, 0, time.UTC)}, Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
 				pr1 := github.PullRequest{Number: github.Ptr(1), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
 				pr2 := github.PullRequest{Number: github.Ptr(2), Labels: []*github.Label{{Name: github.Ptr("other-label")}}}
-				pr3 := github.PullRequest{Number: github.Ptr(3), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/3"), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
+				pr3 := github.PullRequest{Number: github.Ptr(3), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/3"), ClosedAt: &github.Timestamp{Time: time.Date(2025, time.September, 5, 20, 44, 59, 0, time.UTC)}, Labels: []*github.Label{{Name: github.Ptr("release:pending")}}}
 				prs := []*github.PullRequest{&pr0, &pr1, &pr2, &pr3}
 				b, err := json.Marshal(prs)
 				if err != nil {
@@ -1038,8 +1039,7 @@ func TestFindMergedPullRequestsWithPendingReleaseLabel(t *testing.T) {
 				fmt.Fprint(w, string(b))
 			},
 			wantPRs: []*PullRequest{
-				{Number: github.Ptr(0), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/0"), MergeCommitSHA: github.Ptr("sha456"), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
-				{Number: github.Ptr(3), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/3"), MergeCommitSHA: github.Ptr("sha123"), Merged: github.Ptr(true), Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
+				{Number: github.Ptr(0), HTMLURL: github.Ptr("https://github.com/owner/repo/pull/0"), MergedAt: &github.Timestamp{Time: time.Date(2025, time.September, 5, 20, 44, 59, 0, time.UTC)}, Labels: []*github.Label{{Name: github.Ptr("release:pending")}}},
 			},
 		},
 		{


### PR DESCRIPTION
If the PR is merged, then the `merged_at` field has value as timestamp. Otherwise it is a closed PR, and the `merged_at` field is null.

Test Example:
In my forked repo, only https://github.com/catchyzheng/google-cloud-python/pull/4 is closed PR, and its `merged_at` field is null.  Other PRs were merged and has `merged_at` values. 
The `merged_at` field can be checked here: https://api.github.com/repos/catchyzheng/google-cloud-python/pulls?per_page=100&state=closed