### PR TITLE
feat(o12y)!: include client and request info for tracing

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -301,6 +301,17 @@ func (s *bindingSubstitution) TemplateAsString() string {
 	return strings.Join(s.Template, "/")
 }
 
+// Produces a (partial) path template for this substitution.
+//
+// e.g.: "projects/{field_name}" or "{field_name}" if the template is * or **.
+func (s *bindingSubstitution) SubstitutionAsString() string {
+	name := "{" + s.FieldName + "}";
+	if (s.Template[0] == "*" || s.Template[0] == "**") {
+		return name;
+	}
+	return s.Template[0] + "/" + name;
+}
+
 type pathBindingAnnotation struct {
 	// The path format string for this binding
 	//
@@ -329,6 +340,19 @@ func (b *pathBindingAnnotation) QueryParamsCanFail() bool {
 // HasVariablePath returns true if the path has a variable.
 func (b *pathBindingAnnotation) HasVariablePath() bool {
 	return len(b.Substitutions) != 0
+}
+
+// Produces a path template suitable for instrumentation and logging.
+func (b *pathBindingAnnotation) PathTemplate() string {
+	if len(b.Substitutions) == 0 {
+		return b.PathFmt
+	}
+
+ 	template := b.PathFmt
+	for _, s := range b.Substitutions {
+		template = strings.Replace(template, "{}", s.SubstitutionAsString(), 1);
+	}
+	return template
 }
 
 type oneOfAnnotation struct {

--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -42,7 +42,7 @@ limitations under the License.
 //! This crate contains traits, types, and functions to interact with {{{Title}}}
 //! Most applications will use the structs defined in the [client] module.
 //! {{#Codec.ReleaseLevelIsGA}}
-//! 
+//!
 //! The client library types and functions are stable and not expected to change.
 //! Please note that Google Cloud services do change from time to time. The client
 //! libraries are designed to preserve backwards compatibility when the service
@@ -103,17 +103,31 @@ pub(crate) mod transport;
 {{/Codec.PerServiceFeatures}}
 const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}/";
 
+/// The default host used by the service.
+{{#Codec.PerServiceFeatures}}
+#[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
+{{/Codec.PerServiceFeatures}}
+const DEFAULT_HOST_SHORT: &str = "{{Codec.DefaultHostShort}}";
+
+{{#Codec.PerServiceFeatures}}
+#[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
+{{/Codec.PerServiceFeatures}}
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+{{#Codec.PerServiceFeatures}}
+#[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
+{{/Codec.PerServiceFeatures}}
+const NAME: &str = env!("CARGO_PKG_NAME");
+
 {{#Codec.PerServiceFeatures}}
 #[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
 {{/Codec.PerServiceFeatures}}
 pub(crate) mod info {
-    const NAME: &str = env!("CARGO_PKG_NAME");
-    const VERSION: &str = env!("CARGO_PKG_VERSION");
     lazy_static::lazy_static! {
         pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
             let ac = gaxi::api_header::XGoogApiClient{
-                name:          NAME,
-                version:       VERSION,
+                name:          crate::NAME,
+                version:       crate::VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
             ac.rest_header_value()

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -53,7 +53,7 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
-        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
+        let inner = gaxi::http::ReqwestClient::new2(config, crate::DEFAULT_HOST, crate::NAME, crate::VERSION, crate::DEFAULT_HOST_SHORT).await?;
         Ok(Self { inner })
     }
 }
@@ -80,7 +80,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             true,
         );
         {{/HasAutoPopulatedFields}}
-        let (builder, method) = None
+        let (builder, method, template) = None
         {{#PathInfo.Bindings}}
         .or_else(|| {
             {{#Codec.HasVariablePath}}
@@ -112,7 +112,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{/Codec.QueryParams}}
             let builder = Ok(builder);
             {{/Codec.QueryParamsCanFail}}
-            Some(builder.map(|b| (b, reqwest::Method::{{Verb}})))
+            Some(builder.map(|b| (b, reqwest::Method::{{Verb}}, "{{Codec.PathTemplate}}")))
         })
         {{/PathInfo.Bindings}}
         .ok_or_else(|| {
@@ -143,15 +143,16 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 {{/Codec.SystemParameters}}
                 .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let body = gaxi::http::handle_empty({{{Codec.Body}}}, &method);
-        self.inner.execute(
+        self.inner.execute2(
             builder,
             body,
             options,
+            String::from(template),
         ).await
         {{#ReturnsEmpty}}
         .map(|r: gax::response::Response<{{OutputType.Codec.QualifiedName}}>| {
             let (parts, _) = r.into_parts();
-            gax::response::Response::from_parts(parts, ()) 
+            gax::response::Response::from_parts(parts, ())
         })
         {{/ReturnsEmpty}}
     }


### PR DESCRIPTION
DO NOT SUBMIT.  This calls `new2` and `execute2` functions that do not exist.

This is a prototype of one way to bring the binding URL into the client so it can be included in network request traces.  These are assigned after the message is mapped to a URL.

Details about the client are also embedded in lib.rs for access from transport.

We could potentially pull the template directly from a proto annotation, but I actually prefer this shortened view of the data so there is still parsing work to do if we choose that path.

This should demonstrate a bit of the pain we will experience as we try to collect a bunch of information from sidekick into the client libraries for use in tracing and logging.  I *think* this won't grow a lot, but it could grow a bit.

Before submitting anything like this, we should agree on the API between generated code and Rust for instrumentation.  We can collect client details into ClientConfig (like the `default_idempotency`) and potentially collect per-request data as well.

https://github.com/googleapis/google-cloud-rust/issues/3239