### PR TITLE
fix(sidekick/rust): `GA` is spelled `stable`

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -77,7 +77,7 @@ func (m *modelAnnotations) IsGaxiCrate() bool {
 // ReleaseLevelIsGA returns true if the ReleaseLevel attribute indicates this
 // is a GA library.
 func (m *modelAnnotations) ReleaseLevelIsGA() bool {
-	return m.ReleaseLevel == "GA"
+	return m.ReleaseLevel == "GA" || m.ReleaseLevel == "stable"
 }
 
 type serviceAnnotations struct {


### PR DESCRIPTION
At least that is how you spell it in the `.repo-metadata.json` files.