### PR TITLE
fix(release): use --output path directly for container mount

### DIFF
--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -117,7 +117,7 @@ func newInitRunner(cfg *config.Config) (*initRunner, error) {
 }
 
 func (r *initRunner) run(ctx context.Context) error {
-	outputDir := filepath.Join(r.workRoot, "output")
+	outputDir := r.workRoot
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return fmt.Errorf("failed to create output dir: %s", outputDir)
 	}


### PR DESCRIPTION
The 'release init' command was incorrectly creating a nested 'output' subdirectory within the path provided by the --output flag (aliased to WorkRoot). This caused the container's /output volume to be mounted to <workroot>/output instead of <workroot>.

This commit changes the behavior to use the r.workRoot value directly as the source for the /output volume mount, aligning with user expectations for the --output flag.

Fixes #2014