### PR TITLE
fix(docker): pass library and version flags to release-init container

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -269,6 +269,13 @@ func (c *Docker) ReleaseInit(ctx context.Context, request *ReleaseInitRequest) e
 		"--repo=/repo",
 		"--output=/output",
 	}
+	if request.LibraryID != "" {
+		commandArgs = append(commandArgs, fmt.Sprintf("--library=%s", request.LibraryID))
+	}
+	if request.LibraryVersion != "" {
+		commandArgs = append(commandArgs, fmt.Sprintf("--library-version=%s", request.LibraryVersion))
+	}
+	slog.Info("Docker ReleaseInit commandArgs", "args", commandArgs)
 
 	librarianDir := filepath.Join(request.PartialRepoDir, config.LibrarianDir)
 	mounts := []string{

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -493,6 +493,7 @@ func TestDockerRun(t *testing.T) {
 				"--librarian=/librarian",
 				"--repo=/repo",
 				"--output=/output",
+				"--library=testLibraryID",
 			},
 		},
 		{
@@ -531,6 +532,8 @@ func TestDockerRun(t *testing.T) {
 				"--librarian=/librarian",
 				"--repo=/repo",
 				"--output=/output",
+				"--library=testLibraryID",
+				"--library-version=1.2.3",
 			},
 		},
 	} {


### PR DESCRIPTION
The ReleaseInit function in internal/docker/docker.go was not forwarding the LibraryID and LibraryVersion from the ReleaseInitRequest to the container's command-line arguments. This prevented the containerized process from knowing which library to operate on.

This commit adds the --library and --library-version flags to the commandArgs passed to the container in the ReleaseInit function. The associated tests in docker_test.go have been updated to expect these flags.

Fixes #2019