### PR TITLE
feat(testing): add e2e test for release init workflow

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -333,6 +333,7 @@ func TestReleaseInit(t *testing.T) {
 		}
 		runGit(t, repo, "add", newFilePath)
 		runGit(t, repo, "commit", "-m", "feat: add new feature")
+		runGit(t, repo, "log", "--oneline", "go-google-cloud-pubsub-v1-1.0.0..HEAD", "--", "google-cloud-pubsub/v1")
 
 		cmd := exec.Command(
 			"go",
@@ -343,11 +344,6 @@ func TestReleaseInit(t *testing.T) {
 			fmt.Sprintf("--repo=%s", repo),
 			fmt.Sprintf("--library=%s", libraryID),
 		)
-		t.Logf("repo: %s", repo)
-		t.Logf("initialRepoStateDir: %s", initialRepoStateDir)
-		t.Logf("updatedState: %s", updatedState)
-		t.Logf("libraryID: %s", libraryID)
-		t.Logf("cmd: %s", cmd.String())
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		err := cmd.Run()

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -325,7 +325,14 @@ func TestReleaseInit(t *testing.T) {
 		if err := initRepo(t, repo, initialRepoStateDir); err != nil {
 			t.Fatalf("prepare test error = %v", err)
 		}
-		runGit(t, repo, "tag", "go-google-cloud-pubsub-v1-v1.0.0")
+		runGit(t, repo, "tag", "go-google-cloud-pubsub-v1-1.0.0")
+		// Add a new commit to simulate a change.
+		newFilePath := filepath.Join(repo, "google-cloud-pubsub/v1", "new-file.txt")
+		if err := os.WriteFile(newFilePath, []byte("new file"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, repo, "add", newFilePath)
+		runGit(t, repo, "commit", "-m", "feat: add new feature")
 
 		cmd := exec.Command(
 			"go",
@@ -336,6 +343,11 @@ func TestReleaseInit(t *testing.T) {
 			fmt.Sprintf("--repo=%s", repo),
 			fmt.Sprintf("--library=%s", libraryID),
 		)
+		t.Logf("repo: %s", repo)
+		t.Logf("initialRepoStateDir: %s", initialRepoStateDir)
+		t.Logf("updatedState: %s", updatedState)
+		t.Logf("libraryID: %s", libraryID)
+		t.Logf("cmd: %s", cmd.String())
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		err := cmd.Run()

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -375,7 +375,7 @@ func TestReleaseInit(t *testing.T) {
 			"init",
 			fmt.Sprintf("--repo=%s", repo),
 			fmt.Sprintf("--output=%s", outputDir),
-			fmt.Sprintf("--librarian=%s", librarianDir),
+			fmt.Sprintf("--library=%s", libraryID),
 		)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -322,6 +322,11 @@ func TestReleaseInit(t *testing.T) {
 	t.Parallel()
 	t.Run("runs successfully", func(t *testing.T) {
 		repo := t.TempDir()
+		outputDir := filepath.Join(t.TempDir(), "output")
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			t.Fatal(err)
+	    	}
+
 		if err := initRepo(t, repo, initialRepoStateDir); err != nil {
 			t.Fatalf("prepare test error = %v", err)
 		}
@@ -343,6 +348,7 @@ func TestReleaseInit(t *testing.T) {
 			"init",
 			fmt.Sprintf("--repo=%s", repo),
 			fmt.Sprintf("--library=%s", libraryID),
+			fmt.Sprintf("--output=%s", outputDir),
 		)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
@@ -352,9 +358,10 @@ func TestReleaseInit(t *testing.T) {
 		}
 
 		// Verify the file content
-		gotBytes, err := os.ReadFile(filepath.Join(repo, ".librarian", "state.yaml"))
+		t.Logf("Checking for output file in: %s", filepath.Join(outputDir, ".librarian", "state.yaml"))
+		gotBytes, err := os.ReadFile(filepath.Join(outputDir, ".librarian", "state.yaml"))
 		if err != nil {
-			t.Fatalf("Failed to read configure response file: %v", err)
+			t.Fatalf("Failed to read updated state.yaml from output directory: %v", err)
 		}
 		wantBytes, readErr := os.ReadFile(updatedState)
 		if readErr != nil {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -301,7 +301,7 @@ func TestRunConfigure(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(wantState, gotState, cmpopts.IgnoreFields(config.LibraryState{}, "LastGeneratedCommit")); diff != "" {
-				t.Fatalf("Generated yaml mismatch (-want +got):\n%s", diff)
+				t.Fatalf("Generated yaml mismatch (-want +got): %s", diff)
 			}
 			for _, lib := range gotState.Libraries {
 				if lib.ID == test.library && lib.LastGeneratedCommit == "" {
@@ -311,6 +311,60 @@ func TestRunConfigure(t *testing.T) {
 
 		})
 	}
+}
+
+func TestReleaseInit(t *testing.T) {
+	const (
+		initialRepoStateDir = "testdata/e2e/release/init/repo_init"
+		updatedState        = "testdata/e2e/release/init/updated-state.yaml"
+		libraryID           = "go-google-cloud-pubsub-v1"
+	)
+	t.Parallel()
+	t.Run("runs successfully", func(t *testing.T) {
+		repo := t.TempDir()
+		if err := initRepo(t, repo, initialRepoStateDir); err != nil {
+			t.Fatalf("prepare test error = %v", err)
+		}
+		runGit(t, repo, "tag", "go-google-cloud-pubsub-v1-v1.0.0")
+
+		cmd := exec.Command(
+			"go",
+			"run",
+			"github.com/googleapis/librarian/cmd/librarian",
+			"release",
+			"init",
+			fmt.Sprintf("--repo=%s", repo),
+			fmt.Sprintf("--library=%s", libraryID),
+		)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		err := cmd.Run()
+		if err != nil {
+			t.Fatalf("Failed to run release init: %v", err)
+		}
+
+		// Verify the file content
+		gotBytes, err := os.ReadFile(filepath.Join(repo, ".librarian", "state.yaml"))
+		if err != nil {
+			t.Fatalf("Failed to read configure response file: %v", err)
+		}
+		wantBytes, readErr := os.ReadFile(updatedState)
+		if readErr != nil {
+			t.Fatalf("Failed to read expected state for comparison: %v", readErr)
+		}
+		var gotState *config.LibrarianState
+		if err := yaml.Unmarshal(gotBytes, &gotState); err != nil {
+			t.Fatalf("Failed to unmarshal configure response file: %v", err)
+		}
+		var wantState *config.LibrarianState
+		if err := yaml.Unmarshal(wantBytes, &wantState); err != nil {
+			t.Fatalf("Failed to unmarshal expected state: %v", err)
+		}
+
+		if diff := cmp.Diff(wantState, gotState); diff != "" {
+			t.Fatalf("Generated yaml mismatch (-want +got): %s", diff)
+		}
+	})
 }
 
 // initRepo initiates a git repo in the given directory, copy

--- a/internal/librarian/commit_version_analyzer.go
+++ b/internal/librarian/commit_version_analyzer.go
@@ -31,6 +31,7 @@ const defaultTagFormat = "{id}-{version}"
 // version specified in the state file.
 func GetConventionalCommitsSinceLastRelease(repo gitrepo.Repository, library *config.LibraryState) ([]*conventionalcommits.ConventionalCommit, error) {
 	tag := formatTag(library, "")
+	slog.Info("Getting commits since tag", "tag", tag)
 	commits, err := repo.GetCommitsForPathsSinceTag(library.SourceRoots, tag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commits for library %s: %w", library.ID, err)

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -211,6 +211,10 @@ func updateLibrary(repo gitrepo.Repository, library *config.LibraryState, librar
 	if err != nil {
 		return fmt.Errorf("failed to fetch conventional commits for library, %s: %w", library.ID, err)
 	}
+	slog.Info("Found commits", "count", len(commits))
+	for _, c := range commits {
+		slog.Info("commit", "message", c.Description)
+	}
 
 	library.Changes = coerceLibraryChanges(commits)
 	if len(library.Changes) == 0 {
@@ -222,6 +226,7 @@ func updateLibrary(repo gitrepo.Repository, library *config.LibraryState, librar
 	if err != nil {
 		return err
 	}
+	slog.Info("Next version", "version", nextVersion)
 
 	library.Version = nextVersion
 	library.ReleaseTriggered = true

--- a/testdata/e2e/release/init/CHANGELOG.md
+++ b/testdata/e2e/release/init/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.1.0
+
+- feat: add new feature

--- a/testdata/e2e/release/init/repo_init/.librarian/state.yaml
+++ b/testdata/e2e/release/init/repo_init/.librarian/state.yaml
@@ -1,0 +1,8 @@
+image: test-image:latest
+libraries:
+- id: go-google-cloud-pubsub-v1
+  version: v1.0.0
+  apis:
+  - path: google/cloud/pubsub/v1
+  source_roots:
+  - pubsub

--- a/testdata/e2e/release/init/repo_init/.librarian/state.yaml
+++ b/testdata/e2e/release/init/repo_init/.librarian/state.yaml
@@ -1,8 +1,8 @@
 image: test-image:latest
 libraries:
 - id: go-google-cloud-pubsub-v1
-  version: v1.0.0
+  version: 1.0.0
   apis:
   - path: google/cloud/pubsub/v1
   source_roots:
-  - pubsub
+  - google-cloud-pubsub/v1

--- a/testdata/e2e/release/init/repo_init/google-cloud-pubsub/v1/dummy.go
+++ b/testdata/e2e/release/init/repo_init/google-cloud-pubsub/v1/dummy.go
@@ -1,0 +1,1 @@
+package pubsub

--- a/testdata/e2e/release/init/updated-state.yaml
+++ b/testdata/e2e/release/init/updated-state.yaml
@@ -1,0 +1,11 @@
+image: test-image:latest
+libraries:
+- id: go-google-cloud-pubsub-v1
+  version: v1.0.0
+  apis:
+  - path: google/cloud/pubsub/v1
+  source_roots:
+  - pubsub
+  release:
+    release-level: minor
+    release-version: v1.1.0

--- a/testdata/e2e/release/init/updated-state.yaml
+++ b/testdata/e2e/release/init/updated-state.yaml
@@ -1,11 +1,11 @@
 image: test-image:latest
 libraries:
 - id: go-google-cloud-pubsub-v1
-  version: v1.0.0
+  version: 1.1.0
   apis:
   - path: google/cloud/pubsub/v1
   source_roots:
-  - pubsub
+  - google-cloud-pubsub/v1
   release:
     release-level: minor
-    release-version: v1.1.0
+    release-version: 1.1.0

--- a/testdata/e2e/release/tag-and-release/repo_init/.librarian/state.yaml
+++ b/testdata/e2e/release/tag-and-release/repo_init/.librarian/state.yaml
@@ -1,0 +1,11 @@
+image: test-image:latest
+libraries:
+- id: go-google-cloud-pubsub-v1
+  version: v1.0.0
+  apis:
+  - path: google/cloud/pubsub/v1
+  source_roots:
+  - pubsub
+  release:
+    release-level: minor
+    release-version: v1.1.0

--- a/testdata/e2e/release/tag-and-release/updated-state.yaml
+++ b/testdata/e2e/release/tag-and-release/updated-state.yaml
@@ -1,0 +1,8 @@
+image: test-image:latest
+libraries:
+- id: go-google-cloud-pubsub-v1
+  version: v1.1.0
+  apis:
+  - path: google/cloud/pubsub/v1
+  source_roots:
+  - pubsub

--- a/testdata/e2e_func.go
+++ b/testdata/e2e_func.go
@@ -88,10 +88,12 @@ func doGenerate(args []string) error {
 }
 
 func doReleaseInit(args []string) error {
+	log.Printf("doReleaseInit received args: %v", args)
 	request, err := parseReleaseInitRequest(args)
 	if err != nil {
 		return err
 	}
+	log.Printf("doReleaseInit received request: %+v", request)
 	log.Printf("doReleaseInit received outputDir: %s", request.outputDir)
 	if err := validateLibrarianDir(request.librarianDir, "release-init-request.json"); err != nil {
 		// The request file is not created for release-init, so we don't validate it.
@@ -111,13 +113,20 @@ func doReleaseInit(args []string) error {
 	}
 
 	// Update the version of the library.
+	log.Printf("Initial state: %+v", state)
 	for _, library := range state.Libraries {
+		log.Printf("Checking library: %s", request.libraryID)
 		if library.ID == request.libraryID {
+			log.Printf("Found library to update: %s", library.ID)
+			log.Printf("Original version: %s", library.Version)
 			library.Version = request.libraryVersion
+			log.Printf("Updated version: %s", library.ID)
+			log.Printf("Original SourceRoots: %v", library.SourceRoots)
 			break
 		}
 	}
 
+	log.Printf("State after update: %+v", state)
 	updatedStateBytes, err := yaml.Marshal(state)
 	if err != nil {
 		return fmt.Errorf("failed to marshal updated state: %w", err)
@@ -158,7 +167,7 @@ func parseReleaseInitRequest(args []string) (*releaseInitOption, error) {
 			option.repoDir = strs[1]
 		case "output":
 			option.outputDir = strs[1]
-		case "library-id":
+		case "library":
 			option.libraryID = strs[1]
 		case "library-version":
 			option.libraryVersion = strs[1]


### PR DESCRIPTION
This PR adds E2E test for the release init workflow.
The tests verify that the command updates the state.yaml file correctly by comparing it with golden files.