### PR TITLE
refactor(internal/librarian): remove unnecessary factory pattern

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -45,12 +45,6 @@ var globalPreservePatterns = []string{
 	fmt.Sprintf(`^%s(/.*)?$`, regexp.QuoteMeta(config.GeneratorInputDir)), // Preserve the generator-input directory and its contents.
 }
 
-// GitHubClientFactory type for creating a GitHubClient.
-type GitHubClientFactory func(token string, repo *github.Repository) (GitHubClient, error)
-
-// ContainerClientFactory type for creating a ContainerClient.
-type ContainerClientFactory func(workRoot, image, userUID, userGID string) (ContainerClient, error)
-
 type commitInfo struct {
 	cfg               *config.Config
 	state             *config.LibrarianState
@@ -78,19 +72,7 @@ type commandRunner struct {
 
 const defaultAPISourceBranch = "master"
 
-func newCommandRunner(cfg *config.Config, ghClientFactory GitHubClientFactory, containerClientFactory ContainerClientFactory) (*commandRunner, error) {
-	// If no GitHub client factory is provided, use the default one.
-	if ghClientFactory == nil {
-		ghClientFactory = func(token string, repo *github.Repository) (GitHubClient, error) {
-			return github.NewClient(token, repo)
-		}
-	}
-	// If no container client factory is provided, use the default one.
-	if containerClientFactory == nil {
-		containerClientFactory = func(workRoot, image, userUID, userGID string) (ContainerClient, error) {
-			return docker.New(workRoot, image, userUID, userGID)
-		}
-	}
+func newCommandRunner(cfg *config.Config) (*commandRunner, error) {
 
 	if cfg.APISource == "" {
 		cfg.APISource = "https://github.com/googleapis/googleapis"
@@ -134,12 +116,12 @@ func newCommandRunner(cfg *config.Config, ghClientFactory GitHubClientFactory, c
 			return nil, fmt.Errorf("failed to get GitHub repo from remote: %w", err)
 		}
 	}
-	ghClient, err := ghClientFactory(cfg.GitHubToken, gitRepo)
+	ghClient, err := github.NewClient(cfg.GitHubToken, gitRepo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
 	}
 
-	container, err := containerClientFactory(cfg.WorkRoot, image, cfg.UserUID, cfg.UserGID)
+	container, err := docker.New(cfg.WorkRoot, image, cfg.UserUID, cfg.UserGID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -87,7 +87,7 @@ in '.librarian/state.yaml'.
 Example with build and push:
   SDK_LIBRARIAN_GITHUB_TOKEN=xxx librarian generate --push --build`,
 	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newGenerateRunner(cfg, nil, nil)
+		runner, err := newGenerateRunner(cfg)
 		if err != nil {
 			return err
 		}
@@ -123,8 +123,8 @@ type generateRunner struct {
 	image           string
 }
 
-func newGenerateRunner(cfg *config.Config, ghClientFactory GitHubClientFactory, containerClientFactory ContainerClientFactory) (*generateRunner, error) {
-	runner, err := newCommandRunner(cfg, ghClientFactory, containerClientFactory)
+func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
+	runner, err := newCommandRunner(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -504,7 +504,7 @@ func TestNewGenerateRunner(t *testing.T) {
 				}
 			}
 
-			r, err := newGenerateRunner(test.cfg, nil, nil)
+			r, err := newGenerateRunner(test.cfg)
 			if (err != nil) != test.wantErr {
 				t.Errorf("newGenerateRunner() error = %v, wantErr %v", err, test.wantErr)
 			}

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/googleapis/librarian/internal/cli"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 	"gopkg.in/yaml.v3"
 
@@ -110,14 +109,13 @@ func TestGenerate_DefaultBehavior(t *testing.T) {
 	cfg.WorkRoot = repoDir
 	cfg.Repo = repoDir
 	cfg.APISource = apiSourceDir
-	runner, err := newGenerateRunner(cfg, func(token string, repo *github.Repository) (GitHubClient, error) {
-		return mockGH, nil
-	}, func(workRoot, image, userUID, userGID string) (ContainerClient, error) {
-		return mockContainer, nil
-	})
+	runner, err := newGenerateRunner(cfg)
 	if err != nil {
 		t.Fatalf("newGenerateRunner() failed: %v", err)
 	}
+
+	runner.ghClient = mockGH
+	runner.containerClient = mockContainer
 	if err := runner.run(ctx); err != nil {
 		t.Fatalf("runner.run() failed: %v", err)
 	}

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -98,7 +98,7 @@ type initRunner struct {
 }
 
 func newInitRunner(cfg *config.Config) (*initRunner, error) {
-	runner, err := newCommandRunner(cfg, nil, nil)
+	runner, err := newCommandRunner(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create init runner: %w", err)
 	}

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -95,7 +95,7 @@ type tagAndReleaseRunner struct {
 }
 
 func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
-	runner, err := newCommandRunner(cfg, nil, nil)
+	runner, err := newCommandRunner(cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, the codebase had a GitHubClientFactory and ContainerClientFactory, which were a more complicated abstraction layer than necessary and only used for testing.

This change simplifies the existing logic by removing GitHubClientFactory and ContainerClientFactory, and setting runner.ghClient and runner.containerClient directly in tests.