### PR TITLE
test: standardize error messages for cmp.Diff

### DIFF
--- a/internal/automation/cli_test.go
+++ b/internal/automation/cli_test.go
@@ -91,7 +91,7 @@ func TestParseArgs(t *testing.T) {
 				t.Errorf("did not expect error, but received one: %s", err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("parseRepositoriesConfig() mismatch (-want +got): %s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/automation/cloudbuild_test.go
+++ b/internal/automation/cloudbuild_test.go
@@ -79,7 +79,7 @@ func TestRunCloudBuildTrigger(t *testing.T) {
 			substitutions := make(map[string]string)
 			err := runCloudBuildTrigger(ctx, client, "some-project", "some-location", "some-trigger-id", substitutions)
 			if diff := cmp.Diff(test.wantErr, err != nil); diff != "" {
-				t.Errorf("runCloudBuildTrigger() error")
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -144,10 +144,10 @@ func TestFindTriggerIdByName(t *testing.T) {
 			}
 			triggerId, err := findTriggerIdByName(ctx, client, "some-project", "some-location", "some-trigger-name")
 			if diff := cmp.Diff(test.wantErr, err != nil); diff != "" {
-				t.Errorf("expected error() error")
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.want, triggerId); diff != "" {
-				t.Errorf("runCloudBuildTrigger() error")
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -209,7 +209,7 @@ func TestRunCloudBuildTriggerByName(t *testing.T) {
 			}
 			err := runCloudBuildTriggerByName(ctx, client, "some-project", "some-location", "some-trigger-name", make(map[string]string))
 			if diff := cmp.Diff(test.wantErr, err != nil); diff != "" {
-				t.Errorf("expected error() error")
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/conventionalcommits/conventional_commits_test.go
+++ b/internal/conventionalcommits/conventional_commits_test.go
@@ -415,7 +415,7 @@ END_NESTED_COMMIT`,
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("ParseCommits(%q) returned diff (-want +got):\n%s", test.message, diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -478,7 +478,7 @@ fix(sub): fix a bug that is never closed`,
 		t.Run(test.name, func(t *testing.T) {
 			got := extractCommitParts(test.message)
 			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(commitPart{})); diff != "" {
-				t.Errorf("extractCommitParts(%q) returned diff (-want +got):\n%s", test.message, diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/commit_version_analyzer_test.go
+++ b/internal/librarian/commit_version_analyzer_test.go
@@ -321,7 +321,7 @@ func TestGetHighestChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			highestChange := getHighestChange(test.commits)
 			if diff := cmp.Diff(test.expectedChange, highestChange); diff != "" {
-				t.Errorf("getHighestChange() returned diff (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -99,7 +99,7 @@ func TestParse(t *testing.T) {
 				t.Fatalf("Parse() failed: %v", err)
 			}
 			if diff := cmp.Diff(test.want, actual); diff != "" {
-				t.Errorf("Parse() returned diff (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -236,7 +236,7 @@ func TestDeriveNext(t *testing.T) {
 				t.Fatalf("DeriveNext() returned an error: %v", err)
 			}
 			if diff := cmp.Diff(test.expectedVersion, nextVersion); diff != "" {
-				t.Errorf("DeriveNext() returned diff (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -381,7 +381,7 @@ func TestCompare(t *testing.T) {
 			}
 			got := a.Compare(b)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("TestCompare() returned diff (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/internal/parser/disco_test.go
+++ b/internal/sidekick/internal/parser/disco_test.go
@@ -36,8 +36,8 @@ func TestDisco_Parse(t *testing.T) {
 	if got.Title != wantTitle {
 		t.Errorf("want = %q; got = %q", wantTitle, got.Title)
 	}
-	if diff := cmp.Diff(got.Description, wantDescription); diff != "" {
-		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(wantDescription, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if got.PackageName != wantPackageName {
 		t.Errorf("want = %q; got = %q", wantPackageName, got.PackageName)
@@ -58,8 +58,8 @@ func TestDisco_ParseNoServiceConfig(t *testing.T) {
 	if got.Title != wantTitle {
 		t.Errorf("want = %q; got = %q", wantTitle, got.Title)
 	}
-	if diff := cmp.Diff(got.Description, wantDescription); diff != "" {
-		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(wantDescription, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/internal/parser/discovery/discovery_test.go
+++ b/internal/sidekick/internal/parser/discovery/discovery_test.go
@@ -40,8 +40,8 @@ func TestInfo(t *testing.T) {
 	if got.Title != wantTitle {
 		t.Errorf("want = %q; got = %q", wantTitle, got.Title)
 	}
-	if diff := cmp.Diff(got.Description, wantDescription); diff != "" {
-		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(wantDescription, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if got.PackageName != "" {
 		t.Errorf("expected empty package name")
@@ -66,8 +66,8 @@ func TestComputeParses(t *testing.T) {
 	if got.Title != wantTitle {
 		t.Errorf("want = %q; got = %q", wantTitle, got.Title)
 	}
-	if diff := cmp.Diff(got.Description, wantDescription); diff != "" {
-		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(wantDescription, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if got.PackageName != "" {
 		t.Errorf("expected empty package name")
@@ -90,8 +90,8 @@ func TestServiceConfigOverridesInfo(t *testing.T) {
 	if got.Title != sc.Title {
 		t.Errorf("want = %q; got = %q", sc.Title, got.Title)
 	}
-	if diff := cmp.Diff(got.Description, sc.Documentation.Summary); diff != "" {
-		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(sc.Documentation.Summary, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if len(sc.Apis) != 2 {
 		t.Fatalf("expected 2 APIs in service config")

--- a/internal/sidekick/internal/parser/discovery/message_fields_test.go
+++ b/internal/sidekick/internal/parser/discovery/message_fields_test.go
@@ -66,8 +66,8 @@ func TestMakeMessageFields(t *testing.T) {
 		},
 	}
 	less := func(a, b *api.Field) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(got, want, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("message fields mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/internal/parser/openapi_test.go
+++ b/internal/sidekick/internal/parser/openapi_test.go
@@ -770,8 +770,8 @@ func TestOpenAPI_MakeApiWithServiceConfig(t *testing.T) {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
 	want := sample.API()
-	if diff := cmp.Diff(got, want, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums", "State")); diff != "" {
-		t.Errorf("mismatched API attributes (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums", "State")); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 }
@@ -793,8 +793,8 @@ func TestOpenAPI_MakeApiServiceConfigOverridesDescription(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
-	if diff := cmp.Diff(got, want, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums", "State")); diff != "" {
-		t.Errorf("mismatched API attributes (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums", "State")); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 }

--- a/internal/sidekick/internal/parser/parser_test.go
+++ b/internal/sidekick/internal/parser/parser_test.go
@@ -52,8 +52,8 @@ func TestCreateModelDisco(t *testing.T) {
 	if got.Title != wantTitle {
 		t.Errorf("want = %q; got = %q", wantTitle, got.Title)
 	}
-	if diff := cmp.Diff(got.Description, wantDescription); diff != "" {
-		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(wantDescription, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if got.PackageName != wantPackageName {
 		t.Errorf("want = %q; got = %q", wantPackageName, got.PackageName)

--- a/internal/sidekick/internal/parser/protobuf_test.go
+++ b/internal/sidekick/internal/parser/protobuf_test.go
@@ -39,8 +39,8 @@ func TestProtobuf_Info(t *testing.T) {
 	if got.Title != sc.Title {
 		t.Errorf("want = %q; got = %q", sc.Title, got.Title)
 	}
-	if diff := cmp.Diff(got.Description, sc.Documentation.Summary); diff != "" {
-		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(sc.Documentation.Summary, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -58,8 +58,8 @@ func TestProtobuf_PartialInfo(t *testing.T) {
 		Title:       "Secret Manager API",
 		Description: "",
 	}
-	if diff := cmp.Diff(got, want, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums", "State")); diff != "" {
-		t.Errorf("mismatched API attributes (-want, +got):\n%s", diff)
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums", "State")); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/internal/parser/routing_info_test.go
+++ b/internal/sidekick/internal/parser/routing_info_test.go
@@ -249,7 +249,7 @@ func TestExamples(t *testing.T) {
 				t.Fatalf("Cannot find method %s in API State", test.methodID)
 			}
 			if diff := cmp.Diff(got.Routing, test.want); diff != "" {
-				t.Errorf("routing mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -430,8 +430,8 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(got, &test.want); diff != "" {
-				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
+			if diff := cmp.Diff(&test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -489,8 +489,8 @@ func TestParseVariableSuccess(t *testing.T) {
 			if gotName != test.wantName {
 				t.Errorf("mismatched variable names, want=%s, got=%s", test.wantName, gotName)
 			}
-			if diff := cmp.Diff(gotSpec, test.wantSpec); diff != "" {
-				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
+			if diff := cmp.Diff(test.wantSpec, gotSpec); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if test.path[width:] != test.wantTrailer {
 				t.Errorf("trailer segment mismatch, want=%s, got=%s", test.wantTrailer, test.path[width:])
@@ -528,7 +528,7 @@ func TestParseRoutingPathSpecSuccess(t *testing.T) {
 		t.Run(test.path, func(t *testing.T) {
 			got, width := parseRoutingPathSpec(test.path)
 			if diff := cmp.Diff(got.Segments, test.wantSegments); diff != "" {
-				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
+				t.Errorf("mismatch (-want, +got):\n%s\n", diff)
 			}
 			if test.path[width:] != test.wantTrailer {
 				t.Errorf("trailer segment mismatch, want=%s, got=%s", test.wantTrailer, test.path[width:])

--- a/internal/sidekick/internal/parser/svcconfig/svcconfig_test.go
+++ b/internal/sidekick/internal/parser/svcconfig/svcconfig_test.go
@@ -32,8 +32,8 @@ func TestExtractPackageName(t *testing.T) {
 		{sample.ServiceConfig(), &ServiceNames{"google.cloud.secretmanager.v1", "SecretManagerService"}},
 	} {
 		got := ExtractPackageName(test.Input)
-		if diff := cmp.Diff(got, test.Want); diff != "" {
-			t.Errorf("mismatched API attributes (-want, +got):\n%s", diff)
+		if diff := cmp.Diff(test.Want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/internal/sidekick/protojson/wkt_in_any_test.go
+++ b/internal/sidekick/protojson/wkt_in_any_test.go
@@ -55,7 +55,7 @@ func TestAnyInAny(t *testing.T) {
 		Value: "123s",
 	}
 	if diff := cmp.Diff(wantInner, gotInner); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	anyz, err := anypb.New(inner)
@@ -78,7 +78,7 @@ func TestAnyInAny(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(wantOuter, gotOuter); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -105,7 +105,7 @@ func TestNullInAny(t *testing.T) {
 		Value: nil,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -132,7 +132,7 @@ func TestBoolInAny(t *testing.T) {
 		Value: true,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -159,7 +159,7 @@ func TestNumberInAny(t *testing.T) {
 		Value: 1234.5,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -186,7 +186,7 @@ func TestStringInAny(t *testing.T) {
 		Value: "1234.5",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -227,7 +227,7 @@ func TestStructValue(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -258,7 +258,7 @@ func TestListInAny(t *testing.T) {
 		Value: []any{float64(1), float64(2), float64(3), float64(4), "abc"},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -298,6 +298,6 @@ func TestStructInAny(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Refactor error messages across all test files to use the standard format: `mismatch (-want +got):\n%s`, as specified in doc/howwewritego.md on using cmp.Diff for comparisons.