### PR TITLE
test: standardize table-driven test patterns per Go style guide

### DIFF
--- a/internal/conventionalcommits/conventional_commits_test.go
+++ b/internal/conventionalcommits/conventional_commits_test.go
@@ -27,7 +27,7 @@ import (
 func TestParseCommits(t *testing.T) {
 	now := time.Now()
 	sha := plumbing.NewHash("fake-sha")
-	tests := []struct {
+	for _, test := range []struct {
 		name          string
 		message       string
 		want          []*ConventionalCommit
@@ -394,8 +394,7 @@ END_NESTED_COMMIT`,
 				},
 			},
 		},
-	}
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			commit := &gitrepo.Commit{
 				Message: test.message,

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -789,7 +789,7 @@ func TestWriteLibrarianState(t *testing.T) {
 }
 
 func TestDocker_runCommand(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		name    string
 		cmdName string
 		args    []string
@@ -807,12 +807,11 @@ func TestDocker_runCommand(t *testing.T) {
 			args:    []string{},
 			wantErr: true,
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	} {
+		t.Run(test.name, func(t *testing.T) {
 			c := &Docker{}
-			if err := c.runCommand(tt.cmdName, tt.args...); (err != nil) != tt.wantErr {
-				t.Errorf("Docker.runCommand() error = %v, wantErr %v", err, tt.wantErr)
+			if err := c.runCommand(test.cmdName, test.args...); (err != nil) != test.wantErr {
+				t.Errorf("Docker.runCommand() error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -409,7 +409,7 @@ func TestCommit(t *testing.T) {
 		return &LocalRepository{Dir: dir, repo: goGitRepo}
 	}
 
-	for _, tc := range []struct {
+	for _, test := range []struct {
 		name       string
 		setup      func(t *testing.T) *LocalRepository
 		commitMsg  string
@@ -514,18 +514,18 @@ func TestCommit(t *testing.T) {
 			wantErrMsg: "permission denied",
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			repo := tc.setup(t)
+			repo := test.setup(t)
 
-			err := repo.Commit(tc.commitMsg)
+			err := repo.Commit(test.commitMsg)
 
-			if tc.wantErr {
+			if test.wantErr {
 				if err == nil {
 					t.Fatalf("Commit() expected error, got nil")
 				}
-				if tc.wantErrMsg != "" && !strings.Contains(err.Error(), tc.wantErrMsg) {
-					t.Errorf("Commit() error = %q, want to contain %q", err.Error(), tc.wantErrMsg)
+				if test.wantErrMsg != "" && !strings.Contains(err.Error(), test.wantErrMsg) {
+					t.Errorf("Commit() error = %q, want to contain %q", err.Error(), test.wantErrMsg)
 				}
 				return
 			}
@@ -534,8 +534,8 @@ func TestCommit(t *testing.T) {
 				t.Fatalf("Commit() unexpected error = %v", err)
 			}
 
-			if tc.check != nil {
-				tc.check(t, repo, tc.commitMsg)
+			if test.check != nil {
+				test.check(t, repo, test.commitMsg)
 			}
 		})
 	}
@@ -543,7 +543,7 @@ func TestCommit(t *testing.T) {
 
 func TestRemotes(t *testing.T) {
 	t.Parallel()
-	for _, tt := range []struct {
+	for _, test := range []struct {
 		name         string
 		setupRemotes map[string][]string
 		wantErr      bool
@@ -566,11 +566,11 @@ func TestRemotes(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			gogitRepo, dir := initTestRepo(t)
 
-			for name, urls := range tt.setupRemotes {
+			for name, urls := range test.setupRemotes {
 				if _, err := gogitRepo.CreateRemote(&goGitConfig.RemoteConfig{
 					Name: name,
 					URLs: urls,
@@ -581,15 +581,15 @@ func TestRemotes(t *testing.T) {
 
 			repo := &LocalRepository{Dir: dir, repo: gogitRepo}
 			got, err := repo.Remotes()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Remotes() error = %v, wantErr %v", err, tt.wantErr)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Remotes() error = %v, wantErr %v", err, test.wantErr)
 			}
 
 			gotRemotes := make(map[string][]string)
 			for _, r := range got {
 				gotRemotes[r.Config().Name] = r.Config().URLs
 			}
-			if diff := cmp.Diff(tt.setupRemotes, gotRemotes); diff != "" {
+			if diff := cmp.Diff(test.setupRemotes, gotRemotes); diff != "" {
 				t.Errorf("Remotes() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -1257,7 +1257,7 @@ func TestSeparateFilesAndDirs(t *testing.T) {
 
 func TestCompileRegexps(t *testing.T) {
 	t.Parallel()
-	for _, tc := range []struct {
+	for _, test := range []struct {
 		name     string
 		patterns []string
 		wantErr  bool
@@ -1291,15 +1291,15 @@ func TestCompileRegexps(t *testing.T) {
 			wantErr: true,
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			regexps, err := compileRegexps(tc.patterns)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("compileRegexps() error = %v, wantErr %v", err, tc.wantErr)
+			regexps, err := compileRegexps(test.patterns)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("compileRegexps() error = %v, wantErr %v", err, test.wantErr)
 			}
-			if !tc.wantErr {
-				if len(regexps) != len(tc.patterns) {
-					t.Errorf("compileRegexps() len = %d, want %d", len(regexps), len(tc.patterns))
+			if !test.wantErr {
+				if len(regexps) != len(test.patterns) {
+					t.Errorf("compileRegexps() len = %d, want %d", len(regexps), len(test.patterns))
 				}
 			}
 		})

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -48,7 +48,7 @@ func TestRun(t *testing.T) {
 func TestParentCommands(t *testing.T) {
 	ctx := context.Background()
 
-	tests := []struct {
+	for _, test := range []struct {
 		name       string
 		command    string
 		wantErr    bool
@@ -60,9 +60,7 @@ func TestParentCommands(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: `command "release" requires a subcommand`,
 		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := Run(ctx, test.command)
 

--- a/internal/librarian/tag_and_release_test.go
+++ b/internal/librarian/tag_and_release_test.go
@@ -217,7 +217,7 @@ func Test_tagAndReleaseRunner_run(t *testing.T) {
 }
 
 func TestParsePullRequestBody(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		name string
 		body string
 		want []libraryRelease
@@ -329,12 +329,10 @@ some content
 				},
 			},
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := parsePullRequestBody(tt.body)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := parsePullRequestBody(test.body)
+			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("ParsePullRequestBody() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/sidekick/internal/language/codec_test.go
+++ b/internal/sidekick/internal/language/codec_test.go
@@ -107,7 +107,7 @@ func TestMapSlice(t *testing.T) {
 }
 
 func TestHasNestedTypes(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		input *api.Message
 		want  bool
 	}{
@@ -145,12 +145,10 @@ func TestHasNestedTypes(t *testing.T) {
 			},
 			want: false,
 		},
-	}
-
-	for _, c := range tests {
-		got := HasNestedTypes(c.input)
-		if got != c.want {
-			t.Errorf("mismatched result for HasNestedTypes on %v", c.input)
+	} {
+		got := HasNestedTypes(test.input)
+		if got != test.want {
+			t.Errorf("mismatched result for HasNestedTypes on %v", test.input)
 		}
 	}
 }

--- a/internal/sidekick/internal/parser/httprule/http_rule_parser_test.go
+++ b/internal/sidekick/internal/parser/httprule/http_rule_parser_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestParseSegments(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		path        string
 		want        *api.PathTemplate
 		explanation string
@@ -67,24 +67,22 @@ func TestParseSegments(t *testing.T) {
 		{"/foo:bar/baz", nil, "verb must be the last segment, and : isn't allowed in a LITERAL"},
 		{":foo", nil, "verb cannot be the first segment"},
 		{"/foo/{bar={baz}}", nil, "variables cannot be nested"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.path, func(t *testing.T) {
-			got, err := ParseSegments(tc.path)
-			if tc.want != nil {
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			got, err := ParseSegments(test.path)
+			if test.want != nil {
 				if err != nil {
 					t.Fatalf("expected no error, got: %v", err)
 				}
 				if got == nil {
-					t.Fatalf("expected path template for %s, got nil", tc.path)
+					t.Fatalf("expected path template for %s, got nil", test.path)
 				}
-				if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
-					t.Fatalf("failed parsing path [%s] (-want, +got):\n%s", tc.path, diff)
+				if diff := cmp.Diff(test.want, got, cmpopts.EquateEmpty()); diff != "" {
+					t.Fatalf("failed parsing path [%s] (-want, +got):\n%s", test.path, diff)
 				}
 			} else {
 				if err == nil {
-					t.Fatalf("ParseSegments(%s) succeeded, want error: %s", tc.path, tc.explanation)
+					t.Fatalf("ParseSegments(%s) succeeded, want error: %s", test.path, test.explanation)
 				}
 			}
 		})

--- a/internal/sidekick/internal/parser/routing_info_test.go
+++ b/internal/sidekick/internal/parser/routing_info_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestExamples(t *testing.T) {
 	requireProtoc(t)
-	tests := []struct {
+	for _, test := range []struct {
 		methodID string
 		want     []*api.RoutingInfo
 	}{
@@ -241,16 +241,14 @@ func TestExamples(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "routing_info.proto"))
-	for _, tc := range tests {
-		t.Run(tc.methodID, func(t *testing.T) {
-			got, ok := test.State.MethodByID[tc.methodID]
+	} {
+		api := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "routing_info.proto"))
+		t.Run(test.methodID, func(t *testing.T) {
+			got, ok := api.State.MethodByID[test.methodID]
 			if !ok {
-				t.Fatalf("Cannot find method %s in API State", tc.methodID)
+				t.Fatalf("Cannot find method %s in API State", test.methodID)
 			}
-			if diff := cmp.Diff(got.Routing, tc.want); diff != "" {
+			if diff := cmp.Diff(got.Routing, test.want); diff != "" {
 				t.Errorf("routing mismatch (-want, +got):\n%s", diff)
 			}
 		})
@@ -258,7 +256,7 @@ func TestExamples(t *testing.T) {
 }
 
 func TestParsePathTemplateSuccess(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		fieldPath string
 		path      string
 		want      api.RoutingInfo
@@ -426,15 +424,13 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 					}},
 			},
 		},
-	}
-
-	for _, tc := range tests {
-		t.Run(fmt.Sprintf("%s:%s", tc.fieldPath, tc.path), func(t *testing.T) {
-			got, err := parseRoutingPathTemplate(tc.fieldPath, tc.path)
+	} {
+		t.Run(fmt.Sprintf("%s:%s", test.fieldPath, test.path), func(t *testing.T) {
+			got, err := parseRoutingPathTemplate(test.fieldPath, test.path)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(got, &tc.want); diff != "" {
+			if diff := cmp.Diff(got, &test.want); diff != "" {
 				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
 			}
 		})
@@ -473,7 +469,7 @@ func TestParsePathTemplateFailures(t *testing.T) {
 }
 
 func TestParseVariableSuccess(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		path        string
 		wantName    string
 		wantSpec    api.RoutingPathSpec
@@ -484,22 +480,20 @@ func TestParseVariableSuccess(t *testing.T) {
 		{"routing=a/*/b/**", "routing", api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}}, ""},
 		{"routing=a/*/b/**}", "routing", api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}}, "}"},
 		{"routing=a/*/b/**}/c/*", "routing", api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}}, "}/c/*"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.path, func(t *testing.T) {
-			gotName, gotSpec, width, err := parseRoutingVariable("default", tc.path)
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			gotName, gotSpec, width, err := parseRoutingVariable("default", test.path)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if gotName != tc.wantName {
-				t.Errorf("mismatched variable names, want=%s, got=%s", tc.wantName, gotName)
+			if gotName != test.wantName {
+				t.Errorf("mismatched variable names, want=%s, got=%s", test.wantName, gotName)
 			}
-			if diff := cmp.Diff(gotSpec, tc.wantSpec); diff != "" {
+			if diff := cmp.Diff(gotSpec, test.wantSpec); diff != "" {
 				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
 			}
-			if tc.path[width:] != tc.wantTrailer {
-				t.Errorf("trailer segment mismatch, want=%s, got=%s", tc.wantTrailer, tc.path[width:])
+			if test.path[width:] != test.wantTrailer {
+				t.Errorf("trailer segment mismatch, want=%s, got=%s", test.wantTrailer, test.path[width:])
 			}
 		})
 	}
@@ -519,7 +513,7 @@ func TestParseRoutingVariableError(t *testing.T) {
 }
 
 func TestParseRoutingPathSpecSuccess(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		path         string
 		wantTrailer  string
 		wantSegments []string
@@ -530,16 +524,14 @@ func TestParseRoutingPathSpecSuccess(t *testing.T) {
 		{"a/*/b/*}/c/**", "}/c/**", []string{"a", "*", "b", "*"}},
 		{"a=b/*/c/*", "=b/*/c/*", []string{"a"}},
 		{"a/b=b/*/c/*", "=b/*/c/*", []string{"a", "b"}},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.path, func(t *testing.T) {
-			got, width := parseRoutingPathSpec(tc.path)
-			if diff := cmp.Diff(got.Segments, tc.wantSegments); diff != "" {
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			got, width := parseRoutingPathSpec(test.path)
+			if diff := cmp.Diff(got.Segments, test.wantSegments); diff != "" {
 				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
 			}
-			if tc.path[width:] != tc.wantTrailer {
-				t.Errorf("trailer segment mismatch, want=%s, got=%s", tc.wantTrailer, tc.path[width:])
+			if test.path[width:] != test.wantTrailer {
+				t.Errorf("trailer segment mismatch, want=%s, got=%s", test.wantTrailer, test.path[width:])
 			}
 		})
 	}

--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -1040,7 +1040,7 @@ func TestFieldAnnotations(t *testing.T) {
 }
 
 func TestPrimitiveFieldAnnotations(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		wantType    string
 		wantSerdeAs string
 		typez       api.Typez
@@ -1057,14 +1057,12 @@ func TestPrimitiveFieldAnnotations(t *testing.T) {
 		{"u64", "wkt::internal::U64", api.FIXED64_TYPE},
 		{"f32", "wkt::internal::F32", api.FLOAT_TYPE},
 		{"f64", "wkt::internal::F64", api.DOUBLE_TYPE},
-	}
-
-	for _, c := range tests {
+	} {
 		singular_field := &api.Field{
 			Name:     "singular_field",
 			JSONName: "singularField",
 			ID:       ".test.Message.singular_field",
-			Typez:    c.typez,
+			Typez:    test.typez,
 		}
 		message := &api.Message{
 			Name:          "TestMessage",
@@ -1087,9 +1085,9 @@ func TestPrimitiveFieldAnnotations(t *testing.T) {
 			SetterName:         "singular_field",
 			BranchName:         "SingularField",
 			FQMessageName:      "crate::model::TestMessage",
-			FieldType:          c.wantType,
-			PrimitiveFieldType: c.wantType,
-			SerdeAs:            c.wantSerdeAs,
+			FieldType:          test.wantType,
+			PrimitiveFieldType: test.wantType,
+			SerdeAs:            test.wantSerdeAs,
 			AddQueryParameter:  `let builder = builder.query(&[("singularField", &req.singular_field)]);`,
 			SkipIfIsDefault:    true,
 		}
@@ -1101,7 +1099,7 @@ func TestPrimitiveFieldAnnotations(t *testing.T) {
 }
 
 func TestWrapperFieldAnnotations(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		wantType    string
 		wantSerdeAs string
 		typezID     string
@@ -1114,15 +1112,13 @@ func TestWrapperFieldAnnotations(t *testing.T) {
 		{"wkt::FloatValue", "wkt::internal::F32", ".google.protobuf.FloatValue"},
 		{"wkt::DoubleValue", "wkt::internal::F64", ".google.protobuf.DoubleValue"},
 		{"wkt::BoolValue", "", ".google.protobuf.BoolValue"},
-	}
-
-	for _, c := range tests {
+	} {
 		singular_field := &api.Field{
 			Name:     "singular_field",
 			JSONName: "singularField",
 			ID:       ".test.Message.singular_field",
 			Typez:    api.MESSAGE_TYPE,
-			TypezID:  c.typezID,
+			TypezID:  test.typezID,
 			Optional: true,
 		}
 		message := &api.Message{
@@ -1144,9 +1140,9 @@ func TestWrapperFieldAnnotations(t *testing.T) {
 			SetterName:         "singular_field",
 			BranchName:         "SingularField",
 			FQMessageName:      "crate::model::TestMessage",
-			FieldType:          fmt.Sprintf("std::option::Option<%s>", c.wantType),
-			PrimitiveFieldType: c.wantType,
-			SerdeAs:            c.wantSerdeAs,
+			FieldType:          fmt.Sprintf("std::option::Option<%s>", test.wantType),
+			PrimitiveFieldType: test.wantType,
+			SerdeAs:            test.wantSerdeAs,
 			SkipIfIsDefault:    true,
 		}
 		if diff := cmp.Diff(wantField, singular_field.Codec, cmpopts.IgnoreFields(fieldAnnotations{}, "AddQueryParameter")); diff != "" {


### PR DESCRIPTION
Refactor all table-driven tests to follow the conventions in doc/howwewritego.md.

Use `for _, test := range []struct{...}{...}` pattern instead of named slices. Standardize range variable name to `test`.