### PR TITLE
refactor(internal/cli): move command execution logic to cli package

### DIFF
--- a/cmd/librarian/main.go
+++ b/cmd/librarian/main.go
@@ -28,7 +28,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	if err := librarian.Run(ctx, os.Args[1:]...); err != nil {
+	if err := librarian.CmdLibrarian.Run(ctx, os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -38,8 +38,8 @@ type Command struct {
 	// Long is the full description of the command.
 	Long string
 
-	// Run executes the command.
-	Run func(ctx context.Context, cfg *config.Config) error
+	// Action is the action to be executed.
+	Action func(context.Context, *Command) error
 
 	// Commands are the sub commands.
 	Commands []*Command
@@ -52,10 +52,34 @@ type Command struct {
 	Config *config.Config
 }
 
-// Parse parses the provided command-line arguments using the command's flag
-// set.
-func (c *Command) Parse(args []string) error {
-	return c.Flags.Parse(args)
+// Run executes the command with the provided arguments.
+func (c *Command) Run(ctx context.Context, args []string) error {
+	cmd, remaining, err := lookupCommand(c, args)
+	if err != nil {
+		c.Flags.Usage()
+		return err
+	}
+	if err := cmd.Flags.Parse(remaining); err != nil {
+		return err
+	}
+
+	if cmd.Action == nil {
+		cmd.Flags.Usage()
+		if len(cmd.Commands) > 0 {
+			return fmt.Errorf("command %q requires a subcommand", cmd.Name())
+		}
+		return fmt.Errorf("no action defined for command %q", cmd.Name())
+	}
+
+	if cmd.Config == nil {
+		if err := cmd.Config.SetDefaults(); err != nil {
+			return fmt.Errorf("failed to initialize config: %w", err)
+		}
+	}
+	if _, err := cmd.Config.IsValid(); err != nil {
+		return fmt.Errorf("failed to validate config: %s", err)
+	}
+	return cmd.Action(ctx, cmd)
 }
 
 // Name is the command name. Command.Short is always expected to begin with
@@ -68,9 +92,33 @@ func (c *Command) Name() string {
 	return parts[0]
 }
 
-// Lookup finds a command by its name, and returns an error if the command is
+// lookupCommand recursively looks up the command specified by the given arguments.
+// It returns the command, the remaining arguments, and an error if the command
+// is not found.
+func lookupCommand(cmd *Command, args []string) (*Command, []string, error) {
+	if len(args) == 0 {
+		return cmd, nil, nil
+	}
+	subcommand, err := cmd.lookup(args[0])
+	if err != nil {
+		cmd.Flags.Usage()
+		return nil, nil, err
+	}
+	// If the next argument matches a potential flag (first char is `-`), parse the
+	// remaining arguments as flags. Check if argument is a flag before calling
+	// `lookupCommand` again to avoid flags from being treated as subcommands.
+	if len(args) > 1 && args[1][0] == '-' {
+		return subcommand, args[1:], nil
+	}
+	if len(subcommand.Commands) > 0 {
+		return lookupCommand(subcommand, args[1:])
+	}
+	return subcommand, args[1:], nil
+}
+
+// lookup finds a command by its name, and returns an error if the command is
 // not found.
-func (c *Command) Lookup(name string) (*Command, error) {
+func (c *Command) lookup(name string) (*Command, error) {
 	for _, sub := range c.Commands {
 		if sub.Name() == name {
 			return sub, nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestParseAndSetFlags(t *testing.T) {
@@ -41,7 +40,7 @@ func TestParseAndSetFlags(t *testing.T) {
 	cmd.Flags.IntVar(&intFlag, "count", 0, "count flag")
 
 	args := []string{"-name=foo", "-count=5"}
-	if err := cmd.Parse(args); err != nil {
+	if err := cmd.Flags.Parse(args); err != nil {
 		t.Fatalf("Parse() failed: %v", err)
 	}
 
@@ -88,22 +87,24 @@ func TestLookup(t *testing.T) {
 	}
 }
 
-func TestRun(t *testing.T) {
+func TestAction(t *testing.T) {
 	executed := false
 	cmd := &Command{
-		Short: "run runs the command",
-		Run: func(ctx context.Context, cfg *config.Config) error {
+		Short: "action runs the command",
+		Action: func(ctx context.Context, cmd *Command) error {
 			executed = true
 			return nil
 		},
 	}
+	cmd.Init()
+	// Disable config validation for test
+	cmd.Config = nil
 
-	cfg := &config.Config{}
-	if err := cmd.Run(t.Context(), cfg); err != nil {
+	if err := cmd.Run(context.Background(), []string{}); err != nil {
 		t.Fatal(err)
 	}
 	if !executed {
-		t.Errorf("cmd.Run was not executed")
+		t.Errorf("cmd.Action was not executed")
 	}
 }
 

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -86,8 +86,8 @@ in '.librarian/state.yaml'.
 
 Example with build and push:
   SDK_LIBRARIAN_GITHUB_TOKEN=xxx librarian generate --push --build`,
-	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newGenerateRunner(cfg, nil, nil)
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		runner, err := newGenerateRunner(cmd.Config, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -16,8 +16,6 @@ package librarian
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
 	"net/url"
 
 	"github.com/googleapis/librarian/internal/docker"
@@ -40,68 +38,6 @@ func init() {
 		cmdRelease,
 		cmdVersion,
 	)
-}
-
-// Run executes the Librarian CLI with the given command line
-// arguments.
-func Run(ctx context.Context, arg ...string) error {
-	if err := CmdLibrarian.Parse(arg); err != nil {
-		return err
-	}
-	if len(arg) == 0 {
-		CmdLibrarian.Flags.Usage()
-		return nil
-	}
-	cmd, arg, err := lookupCommand(CmdLibrarian, arg)
-	if err != nil {
-		return err
-	}
-
-	// If a command is just a container for subcommands, it won't have a
-	// Run function. In that case, display its usage instructions.
-	if cmd.Run == nil {
-		cmd.Flags.Usage()
-		return fmt.Errorf("command %q requires a subcommand", cmd.Name())
-	}
-
-	if err := cmd.Parse(arg); err != nil {
-		// We expect that if cmd.Parse fails, it will already
-		// have printed out a command-specific usage error,
-		// so we don't need to display the general usage.
-		return err
-	}
-	slog.Info("librarian", "arguments", arg)
-	if err := cmd.Config.SetDefaults(); err != nil {
-		return fmt.Errorf("failed to initialize config: %w", err)
-	}
-	if _, err := cmd.Config.IsValid(); err != nil {
-		return fmt.Errorf("failed to validate config: %s", err)
-	}
-	return cmd.Run(ctx, cmd.Config)
-}
-
-// lookupCommand recursively looks up the command specified by the given arguments.
-// It returns the command, the remaining arguments, and an error if the command
-// is not found.
-func lookupCommand(cmd *cli.Command, args []string) (*cli.Command, []string, error) {
-	if len(args) == 0 {
-		return cmd, nil, nil
-	}
-	subcommand, err := cmd.Lookup(args[0])
-	if err != nil {
-		cmd.Flags.Usage()
-		return nil, nil, err
-	}
-	// If the next argument matches a potential flag (first char is `-`), parse the
-	// remaining arguments as flags. Check if argument is a flag before calling
-	// `lookupCommand` again to avoid flags from being treated as subcommands.
-	if len(args) > 1 && args[1][0] == '-' {
-		return subcommand, args[1:], nil
-	}
-	if len(subcommand.Commands) > 0 {
-		return lookupCommand(subcommand, args[1:])
-	}
-	return subcommand, args[1:], nil
 }
 
 // GitHubClient is an abstraction over the GitHub client.

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -450,7 +450,7 @@ func TestLookupCommand(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotCmd, gotArgs, err := lookupCommand(tc.cmd, tc.args)
+			gotCmd, gotArgs, err := cli.LookupCommand(tc.cmd, tc.args)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("lookupCommand() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -60,8 +60,8 @@ Examples:
 
   # Manually specify a version for a single library, overriding the calculation.
   librarian release init --library=secretmanager --library-version=2.0.0 --push`,
-	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newInitRunner(cfg)
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		runner, err := newInitRunner(cmd.Config)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -69,8 +69,8 @@ Examples:
 
   # Find and process all pending merged release PRs in a repository.
   librarian release tag-and-release --repo=https://github.com/googleapis/google-cloud-go`,
-	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newTagAndReleaseRunner(cfg)
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		runner, err := newTagAndReleaseRunner(cmd.Config)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -19,14 +19,13 @@ import (
 	"fmt"
 
 	"github.com/googleapis/librarian/internal/cli"
-	"github.com/googleapis/librarian/internal/config"
 )
 
 var cmdVersion = &cli.Command{
 	Short:     "version prints the version information",
 	UsageLine: "librarian version",
 	Long:      "Version prints version information for the librarian binary.",
-	Run: func(ctx context.Context, cfg *config.Config) error {
+	Action: func(ctx context.Context, cmd *cli.Command) error {
 		fmt.Println(cli.Version())
 		return nil
 	},


### PR DESCRIPTION
The CLI framework now owns command parsing and execution logic that previously lived in the librarian package. This consolidates all CLI functionality in one place.

The Command.Run field is renamed to Command.Action to better reflect its purpose.  Command.Run is now a method that executes the command.