### PR TITLE
refactor(internal/cli): move command execution logic to cli package

### DIFF
--- a/cmd/librarian/main.go
+++ b/cmd/librarian/main.go
@@ -28,7 +28,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	if err := librarian.Run(ctx, os.Args[1:]...); err != nil {
+	if err := librarian.Run(ctx, os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -38,8 +38,8 @@ type Command struct {
 	// Long is the full description of the command.
 	Long string
 
-	// Run executes the command.
-	Run func(ctx context.Context, cfg *config.Config) error
+	// Action is the action to be executed.
+	Action func(context.Context, *Command) error
 
 	// Commands are the sub commands.
 	Commands []*Command
@@ -52,10 +52,25 @@ type Command struct {
 	Config *config.Config
 }
 
-// Parse parses the provided command-line arguments using the command's flag
-// set.
-func (c *Command) Parse(args []string) error {
-	return c.Flags.Parse(args)
+// Run executes the command with the provided arguments.
+func (c *Command) Run(ctx context.Context, args []string) error {
+	cmd, remaining, err := lookupCommand(c, args)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Flags.Parse(remaining); err != nil {
+		return err
+	}
+
+	if cmd.Action == nil {
+		cmd.Flags.Usage()
+		if len(cmd.Commands) > 0 {
+			return nil
+		}
+		return fmt.Errorf("no action defined for command %q", cmd.Name())
+	}
+
+	return cmd.Action(ctx, cmd)
 }
 
 // Name is the command name. Command.Short is always expected to begin with
@@ -74,7 +89,7 @@ func (c *Command) usage(w io.Writer) {
 	}
 
 	fmt.Fprintf(w, "%s\n\n", c.Long)
-	fmt.Fprintf(w, "Usage:\n  %s", c.UsageLine)
+	fmt.Fprintf(w, "Usage:\n\n  %s", c.UsageLine)
 	if len(c.Commands) > 0 {
 		fmt.Fprint(w, "\n\nCommands:\n")
 		for _, c := range c.Commands {
@@ -111,10 +126,10 @@ func hasFlags(fs *flag.FlagSet) bool {
 	return visited
 }
 
-// LookupCommand recursively looks up the command specified by the given arguments.
+// lookupCommand recursively looks up the command specified by the given arguments.
 // It returns the command, the remaining arguments, and an error if the command
 // is not found.
-func LookupCommand(cmd *Command, args []string) (*Command, []string, error) {
+func lookupCommand(cmd *Command, args []string) (*Command, []string, error) {
 	if len(args) == 0 {
 		return cmd, nil, nil
 	}
@@ -130,7 +145,7 @@ func LookupCommand(cmd *Command, args []string) (*Command, []string, error) {
 		return subcommand, args[1:], nil
 	}
 	if len(subcommand.Commands) > 0 {
-		return LookupCommand(subcommand, args[1:])
+		return lookupCommand(subcommand, args[1:])
 	}
 	return subcommand, args[1:], nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestParseAndSetFlags(t *testing.T) {
@@ -41,7 +40,7 @@ func TestParseAndSetFlags(t *testing.T) {
 	cmd.Flags.IntVar(&intFlag, "count", 0, "count flag")
 
 	args := []string{"-name=foo", "-count=5"}
-	if err := cmd.Parse(args); err != nil {
+	if err := cmd.Flags.Parse(args); err != nil {
 		t.Fatalf("Parse() failed: %v", err)
 	}
 
@@ -88,22 +87,23 @@ func TestLookup(t *testing.T) {
 	}
 }
 
-func TestRun(t *testing.T) {
+func TestAction(t *testing.T) {
 	executed := false
 	cmd := &Command{
-		Short: "run runs the command",
-		Run: func(ctx context.Context, cfg *config.Config) error {
+		Short: "action runs the command",
+		Action: func(ctx context.Context, cmd *Command) error {
 			executed = true
 			return nil
 		},
 	}
+	cmd.Init()
+	cmd.Config.Repo = "test"
 
-	cfg := &config.Config{}
-	if err := cmd.Run(t.Context(), cfg); err != nil {
+	if err := cmd.Run(context.Background(), []string{}); err != nil {
 		t.Fatal(err)
 	}
 	if !executed {
-		t.Errorf("cmd.Run was not executed")
+		t.Errorf("cmd.Action was not executed")
 	}
 }
 
@@ -143,6 +143,7 @@ func TestUsage(t *testing.T) {
 	preamble := `Test prints test information.
 
 Usage:
+
   test [flags]
 
 `
@@ -313,7 +314,7 @@ func TestLookupCommand(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			gotCmd, gotArgs, err := LookupCommand(test.cmd, test.args)
+			gotCmd, gotArgs, err := lookupCommand(test.cmd, test.args)
 			if (err != nil) != test.wantErr {
 				t.Errorf("lookupCommand() error = %v, wantErr %v", err, test.wantErr)
 				return

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -86,8 +86,8 @@ in '.librarian/state.yaml'.
 
 Example with build and push:
   SDK_LIBRARIAN_GITHUB_TOKEN=xxx librarian generate --push --build`,
-	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newGenerateRunner(cfg)
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		runner, err := newGenerateRunner(cmd.Config)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -17,7 +17,6 @@ package librarian
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/url"
 
 	"github.com/googleapis/librarian/internal/docker"
@@ -31,53 +30,23 @@ var CmdLibrarian = &cli.Command{
 	Short:     "librarian manages client libraries for Google APIs",
 	UsageLine: "librarian <command> [arguments]",
 	Long:      "Librarian manages client libraries for Google APIs.",
-}
-
-func init() {
-	CmdLibrarian.Init()
-	CmdLibrarian.Commands = append(CmdLibrarian.Commands,
+	Commands: []*cli.Command{
 		cmdGenerate,
 		cmdRelease,
 		cmdVersion,
-	)
+	},
 }
 
-// Run executes the Librarian CLI with the given command line
-// arguments.
-func Run(ctx context.Context, arg ...string) error {
-	if err := CmdLibrarian.Parse(arg); err != nil {
-		return err
-	}
-	if len(arg) == 0 {
-		CmdLibrarian.Flags.Usage()
-		return nil
-	}
-	cmd, arg, err := cli.LookupCommand(CmdLibrarian, arg)
-	if err != nil {
-		return err
-	}
-
-	// If a command is just a container for subcommands, it won't have a
-	// Run function. In that case, display its usage instructions.
-	if cmd.Run == nil {
-		cmd.Flags.Usage()
-		return fmt.Errorf("command %q requires a subcommand", cmd.Name())
-	}
-
-	if err := cmd.Parse(arg); err != nil {
-		// We expect that if cmd.Parse fails, it will already
-		// have printed out a command-specific usage error,
-		// so we don't need to display the general usage.
-		return err
-	}
-	slog.Info("librarian", "arguments", arg)
-	if err := cmd.Config.SetDefaults(); err != nil {
+// Run Librarian with the given args.
+func Run(ctx context.Context, args []string) error {
+	CmdLibrarian.Init()
+	if err := CmdLibrarian.Config.SetDefaults(); err != nil {
 		return fmt.Errorf("failed to initialize config: %w", err)
 	}
-	if _, err := cmd.Config.IsValid(); err != nil {
+	if _, err := CmdLibrarian.Config.IsValid(); err != nil {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
-	return cmd.Run(ctx, cmd.Config)
+	return CmdLibrarian.Run(ctx, args)
 }
 
 // GitHubClient is an abstraction over the GitHub client.

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -17,12 +17,10 @@ package librarian
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -34,50 +32,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 )
-
-// TODO(https://github.com/googleapis/librarian/issues/202): add better tests
-// for librarian.Run.
-func TestRun(t *testing.T) {
-	if err := Run(t.Context(), []string{"version"}...); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func TestParentCommands(t *testing.T) {
-	ctx := context.Background()
-
-	for _, test := range []struct {
-		name       string
-		command    string
-		wantErr    bool
-		wantErrMsg string // Expected substring in the error
-	}{
-		{
-			name:       "release no subcommand",
-			command:    "release",
-			wantErr:    true,
-			wantErrMsg: `command "release" requires a subcommand`,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			err := Run(ctx, test.command)
-
-			if test.wantErr {
-				if err == nil {
-					t.Fatalf("Run(ctx, %q) got nil, want error containing %q", test.command, test.wantErrMsg)
-				}
-				if !strings.Contains(err.Error(), test.wantErrMsg) {
-					t.Errorf("Run(ctx, %q) got error %q, want error containing %q", test.command, err.Error(), test.wantErrMsg)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("Run(ctx, %q) got error %v, want nil", test.command, err)
-			}
-		})
-	}
-}
 
 func TestGenerate_DefaultBehavior(t *testing.T) {
 	ctx := context.Background()

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -62,8 +62,8 @@ Examples:
 
   # Manually specify a version for a single library, overriding the calculation.
   librarian release init --library=secretmanager --library-version=2.0.0 --push`,
-	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newInitRunner(cfg)
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		runner, err := newInitRunner(cmd.Config)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -69,8 +69,8 @@ Examples:
 
   # Find and process all pending merged release PRs in a repository.
   librarian release tag-and-release --repo=https://github.com/googleapis/google-cloud-go`,
-	Run: func(ctx context.Context, cfg *config.Config) error {
-		runner, err := newTagAndReleaseRunner(cfg)
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		runner, err := newTagAndReleaseRunner(cmd.Config)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/version.go
+++ b/internal/librarian/version.go
@@ -19,14 +19,13 @@ import (
 	"fmt"
 
 	"github.com/googleapis/librarian/internal/cli"
-	"github.com/googleapis/librarian/internal/config"
 )
 
 var cmdVersion = &cli.Command{
 	Short:     "version prints the version information",
 	UsageLine: "librarian version",
 	Long:      "Version prints version information for the librarian binary.",
-	Run: func(ctx context.Context, cfg *config.Config) error {
+	Action: func(ctx context.Context, cmd *cli.Command) error {
 		fmt.Println(cli.Version())
 		return nil
 	},


### PR DESCRIPTION
The CLI framework now owns command parsing and execution logic that previously lived in the librarian package. This consolidates all CLI functionality in one place.

The Command.Run field is renamed to Command.Action to better reflect its purpose. Command.Run is now a method that executes the command.

lookupCommand is moved from internal/librarian to internal/cli with no modifications.