### PR TITLE
chore: only run stage release jobs on even weeks

### DIFF
--- a/internal/automation/cloudbuild_test.go
+++ b/internal/automation/cloudbuild_test.go
@@ -26,6 +26,8 @@ import (
 	"golang.org/x/exp/slog"
 )
 
+var triggersRan = 0
+
 type mockCloudBuildClient struct {
 	runError      error
 	buildTriggers []*cloudbuildpb.BuildTrigger
@@ -33,6 +35,7 @@ type mockCloudBuildClient struct {
 
 func (c *mockCloudBuildClient) RunBuildTrigger(ctx context.Context, req *cloudbuildpb.RunBuildTriggerRequest, opts ...gax.CallOption) error {
 	slog.Info("running fake RunBuildTrigger")
+	triggersRan++
 	if c.runError != nil {
 		return c.runError
 	}

--- a/internal/automation/trigger.go
+++ b/internal/automation/trigger.go
@@ -38,6 +38,9 @@ var triggerNameByCommandName = map[string]string{
 
 const region = "global"
 
+// timeNow is a variable so we can patch it in tests.
+var timeNow = time.Now
+
 // GitHubClient handles communication with the GitHub API.
 type GitHubClient interface {
 	FindMergedPullRequestsWithPendingReleaseLabel(ctx context.Context, owner, repo string) ([]*github.PullRequest, error)
@@ -100,9 +103,7 @@ func runCommandWithConfig(ctx context.Context, client CloudBuildClient, ghClient
 	// Cloud Scheduler does not support cron expressions with bi-weekly frequency,
 	// so we handle that logic here.
 	if triggerName == "stage-release" {
-		today := time.Now()
-		_, weekNumber := today.ISOWeek()
-
+		_, weekNumber :=  timeNow().ISOWeek()
 		if weekNumber%2 == 1 {
 			slog.Info("odd week, skipping stage-release trigger", "weekNumber", weekNumber)
 			return nil


### PR DESCRIPTION
Google Cloud Scheduler does not allow for a cron that setups a job to run bi-weekly.  Instead we will run weekly via scheduler and in code provide a no-op if its an odd week.