### PR TITLE
test(internal/sidekick): skip test instead of failing when cargo is not installed

### DIFF
--- a/internal/sidekick/sidekick_rust_prost_test.go
+++ b/internal/sidekick/sidekick_rust_prost_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestRustProstFromProtobuf(t *testing.T) {
+	requireCargo(t)
 	requireProtoc(t)
 	outDir := t.TempDir()
 	svcConfig := path.Join(testdataDir, "googleapis/google/type/type.yaml")

--- a/internal/sidekick/sidekick_test.go
+++ b/internal/sidekick/sidekick_test.go
@@ -41,3 +41,10 @@ func requireProtoc(t *testing.T) {
 		t.Skip("skipping test because protoc is not installed")
 	}
 }
+
+func requireCargo(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("cargo"); err != nil {
+		t.Skip("skipping test because cargo is not installed")
+	}
+}


### PR DESCRIPTION
`go test ./...` should always pass on a fresh clone of github.com/librarian/googleapis.

At the moment, TestRustProstFromProtobuf fails because it requires cargo.

```
--- FAIL: TestRustProstFromProtobuf (0.09s)
    sidekick_rust_prost_test.go:48: got an error trying to run `cargo
    --version`, the instructions on
    https://www.rust-lang.org/learn/get-started may solve this problem:
    cargo --version: exec: "cargo": executable file not found in $PATH
```

Skip this test when cargo is not installed.