### PR TITLE
fix(internal/cli): add newline after Usage in help text

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -74,7 +74,7 @@ func (c *Command) usage(w io.Writer) {
 	}
 
 	fmt.Fprintf(w, "%s\n\n", c.Long)
-	fmt.Fprintf(w, "Usage:\n  %s", c.UsageLine)
+	fmt.Fprintf(w, "Usage:\n\n  %s", c.UsageLine)
 	if len(c.Commands) > 0 {
 		fmt.Fprint(w, "\n\nCommands:\n")
 		for _, c := range c.Commands {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -143,6 +143,7 @@ func TestUsage(t *testing.T) {
 	preamble := `Test prints test information.
 
 Usage:
+
   test [flags]
 
 `


### PR DESCRIPTION
Currently there is a newline after `Commands:` but not `Usage:` in the help text. Add a newline after `Usage:` for consistency.