### PR TITLE
chore: release next version as 0.2.0

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,0 +1,3 @@
+libraries:
+  - id: librarian
+    next_version: 0.2.0


### PR DESCRIPTION
Since we are using the pre-1.0 versioning strategy of non-breaking changes only bump the patch version and we want release the next version as 0.2.0, we will use the .librarian/config.yaml method for forcing the next version

See #2109