### PR TITLE
test(e2e): skip failing TestReleaseInit

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -413,6 +413,7 @@ func TestReleaseInit(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Skip("Skipping until parser is fixed. See: https://github.com/googleapis/librarian/issues/2120")
 			workRoot := t.TempDir()
 			repo := t.TempDir()
 


### PR DESCRIPTION
Skips the test pending a fix for the commit parser. 
See: https://github.com/googleapis/librarian/issues/2120