### PR TITLE
refactor(internal/librarian): set default for api-source flag

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -73,18 +73,15 @@ type commandRunner struct {
 const defaultAPISourceBranch = "master"
 
 func newCommandRunner(cfg *config.Config) (*commandRunner, error) {
-
-	if cfg.APISource == "" {
-		cfg.APISource = "https://github.com/googleapis/googleapis"
-	}
-
 	languageRepo, err := cloneOrOpenRepo(cfg.WorkRoot, cfg.Repo, cfg.Branch, cfg.CI, cfg.GitHubToken)
 	if err != nil {
 		return nil, err
 	}
 
-	var sourceRepo gitrepo.Repository
-	var sourceRepoDir string
+	var (
+		sourceRepo    gitrepo.Repository
+		sourceRepoDir string
+	)
 	if cfg.CommandName == generateCmdName {
 		sourceRepo, err = cloneOrOpenRepo(cfg.WorkRoot, cfg.APISource, defaultAPISourceBranch, cfg.CI, cfg.GitHubToken)
 		if err != nil {
@@ -140,7 +137,7 @@ func newCommandRunner(cfg *config.Config) (*commandRunner, error) {
 
 func cloneOrOpenRepo(workRoot, repo, branch, ci string, gitPassword string) (*gitrepo.LocalRepository, error) {
 	if repo == "" {
-		return nil, errors.New("repo must be specified")
+		return nil, fmt.Errorf("repo must be specified")
 	}
 
 	if isURL(repo) {

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -22,15 +22,14 @@ import (
 
 func addFlagAPI(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.API, "api", "",
-		`Relative path to the API to be configured/generated (e.g., google/cloud/functions/v2). 
+		`Relative path to the API to be configured/generated (e.g., google/cloud/functions/v2).
 Must be specified when generating a new library.`)
 }
 
 func addFlagAPISource(fs *flag.FlagSet, cfg *config.Config) {
-	fs.StringVar(&cfg.APISource, "api-source", "",
+	fs.StringVar(&cfg.APISource, "api-source", "https://github.com/googleapis/googleapis",
 		`The location of an API specification repository.
-Can be a remote URL or a local file path. If not specified, googleapis is the
-default and will be cloned.`)
+Can be a remote URL or a local file path.`)
 }
 
 func addFlagBuild(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -442,7 +442,7 @@ func TestNewGenerateRunner(t *testing.T) {
 			name: "empty API source",
 			cfg: &config.Config{
 				API:         "some/api",
-				APISource:   "", // This will trigger the clone of googleapis
+				APISource:   "https://github.com/googleapis/googleapis", // This will trigger the clone of googleapis
 				Repo:        newTestGitRepo(t).GetDir(),
 				WorkRoot:    t.TempDir(),
 				Image:       "gcr.io/test/test-image",


### PR DESCRIPTION
Rather than checking if `config.APISource` is empty inside `newCommandRunner` and then setting a default, assign the default when the `api-source` flag is parsed.