### PR TITLE
fix(internal/cli): add newline after Flags in help text

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -84,7 +84,7 @@ func (c *Command) usage(w io.Writer) {
 		}
 	}
 	if hasFlags(c.Flags) {
-		fmt.Fprint(w, "\n\nFlags:\n")
+		fmt.Fprint(w, "\n\nFlags:\n\n")
 	}
 	c.Flags.SetOutput(w)
 	c.Flags.PrintDefaults()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -167,6 +167,7 @@ Usage:
 				},
 			},
 			want: fmt.Sprintf(`%sFlags:
+
   -name string
     	name flag (default "default")
 


### PR DESCRIPTION
Currently there is a newline after `Commands:` and `Usage:` in the help text. Add a newline after `Flags:` for consistency.