### PR TITLE
refactor(sidekick): move `rustBumpVersions()`

### DIFF
--- a/internal/sidekick/internal/rust_release/bump_versions.go
+++ b/internal/sidekick/internal/rust_release/bump_versions.go
@@ -23,5 +23,4 @@ func BumpVersions(config *config.Release) error {
 		return err
 	}
 	return nil
-
 }

--- a/internal/sidekick/internal/rust_release/bump_versions.go
+++ b/internal/sidekick/internal/rust_release/bump_versions.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rustrelease
+
+import "github.com/googleapis/librarian/internal/sidekick/internal/config"
+
+// BumpVersions finds all the crates that need a version bump and performs the
+// bump, changing both the Cargo.toml and sidekick.toml files.
+func BumpVersions(config *config.Release) error {
+	if err := PreFlight(config); err != nil {
+		return err
+	}
+	return nil
+
+}

--- a/internal/sidekick/internal/rust_release/bump_versions_test.go
+++ b/internal/sidekick/internal/rust_release/bump_versions_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sidekick
+package rustrelease
 
 import (
 	"testing"
@@ -20,33 +20,26 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/internal/config"
 )
 
-func TestPreflightSuccess(t *testing.T) {
-	requireGit(t)
-	config := config.Config{
-		Release: &config.Release{
-			Preinstalled: map[string]string{
-				"git":   "git",
-				"cargo": "git",
-			},
+func TestBumpVersionsSuccess(t *testing.T) {
+	requireCommand(t, "git")
+	config := &config.Release{
+		Preinstalled: map[string]string{
+			"git":   "git",
+			"cargo": "git",
 		},
 	}
-	cmdLine := CommandLine{}
-	if err := rustBumpVersions(&config, &cmdLine); err != nil {
+	if err := BumpVersions(config); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestPreflightMissingCommand(t *testing.T) {
-	requireGit(t)
-	config := config.Config{
-		Release: &config.Release{
-			Preinstalled: map[string]string{
-				"cargo": "not-a-valid-command-bad-bad",
-			},
+func TestBumpVersionsPreflightError(t *testing.T) {
+	config := &config.Release{
+		Preinstalled: map[string]string{
+			"git": "git-not-found",
 		},
 	}
-	cmdLine := CommandLine{}
-	if err := rustBumpVersions(&config, &cmdLine); err == nil {
-		t.Errorf("expected an error in rustBumpVersions() with a bad cargo command")
+	if err := BumpVersions(config); err == nil {
+		t.Errorf("expected an error in BumpVersions() with a bad git command")
 	}
 }

--- a/internal/sidekick/rust_bump_versions.go
+++ b/internal/sidekick/rust_bump_versions.go
@@ -38,8 +38,5 @@ effect.
 
 // rustGenerate increments the version numbers as needed.
 func rustBumpVersions(rootConfig *config.Config, cmdLine *CommandLine) error {
-	if err := rustrelease.PreFlight(rootConfig.Release); err != nil {
-		return err
-	}
-	return nil
+	return rustrelease.BumpVersions(rootConfig.Release)
 }

--- a/internal/sidekick/rust_bump_versions.go
+++ b/internal/sidekick/rust_bump_versions.go
@@ -36,7 +36,7 @@ effect.
 	)
 }
 
-// rustGenerate increments the version numbers as needed.
+// rustBumpVersions increments the version numbers as needed.
 func rustBumpVersions(rootConfig *config.Config, cmdLine *CommandLine) error {
 	return rustrelease.BumpVersions(rootConfig.Release)
 }

--- a/internal/sidekick/rust_bump_versions_test.go
+++ b/internal/sidekick/rust_bump_versions_test.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sidekick
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/sidekick/internal/config"
+)
+
+func TestRustBumpVersions(t *testing.T) {
+	config := &config.Config{
+		Release: &config.Release{
+			Preinstalled: map[string]string{
+				"git": "git-not-found",
+			},
+		},
+	}
+	cmdLine := &CommandLine{}
+	if err := rustBumpVersions(config, cmdLine); err == nil {
+		t.Errorf("expected an error with invalid git command")
+	}
+}

--- a/internal/sidekick/sidekick_test.go
+++ b/internal/sidekick/sidekick_test.go
@@ -49,7 +49,3 @@ func requireProtoc(t *testing.T) {
 func requireCargo(t *testing.T) {
 	requireCommand(t, "cargo")
 }
-
-func requireGit(t *testing.T) {
-	requireCommand(t, "git")
-}


### PR DESCRIPTION
Moving the implementation of `rustBumpVersions()` will make it easier to
share test code. I will need helpers to simulate a git repository and
I would rather keep those in a single package.

Part of the work for #2127
