### PR TITLE
refactor(internal/librarian): remove cfg field from generateRunner

### DIFF
--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -80,10 +80,8 @@ func TestRunGenerateCommand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			r := &generateRunner{
-				cfg: &config.Config{
-					API:       test.api,
-					APISource: t.TempDir(),
-				},
+				api:             test.api,
+				apiSource:       t.TempDir(),
 				repo:            test.repo,
 				sourceRepo:      newTestGitRepo(t),
 				ghClient:        test.ghClient,
@@ -183,9 +181,7 @@ func TestRunBuildCommand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			r := &generateRunner{
-				cfg: &config.Config{
-					Build: test.build,
-				},
+				build:           test.build,
 				repo:            test.repo,
 				state:           test.state,
 				containerClient: test.container,
@@ -331,31 +327,28 @@ func TestRunConfigureCommand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			sourcePath := t.TempDir()
-			cfg := &config.Config{
-				API:       test.api,
-				APISource: sourcePath,
-			}
 			r := &generateRunner{
-				cfg:             cfg,
+				api:             test.api,
+				apiSource:       sourcePath,
 				repo:            test.repo,
 				state:           test.state,
 				containerClient: test.container,
 			}
 
 			// Create a service config
-			if err := os.MkdirAll(filepath.Join(cfg.APISource, test.api), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Join(r.apiSource, test.api), 0755); err != nil {
 				t.Fatal(err)
 			}
 
 			data := []byte("type: google.api.Service")
-			if err := os.WriteFile(filepath.Join(cfg.APISource, test.api, "example_service_v2.yaml"), data, 0755); err != nil {
+			if err := os.WriteFile(filepath.Join(r.apiSource, test.api, "example_service_v2.yaml"), data, 0755); err != nil {
 				t.Fatal(err)
 			}
 
 			if test.name == "configures library with non-existent api source" {
 				// This test verifies the scenario of no service config is found
 				// in api path.
-				if err := os.RemoveAll(filepath.Join(cfg.APISource)); err != nil {
+				if err := os.RemoveAll(filepath.Join(r.apiSource)); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -857,17 +850,14 @@ func TestGenerateScenarios(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := &config.Config{
-				API:       test.api,
-				Library:   test.library,
-				APISource: t.TempDir(),
-				Build:     test.build,
-			}
-
+			apiSource := t.TempDir()
 			repo := newTestGitRepoWithState(t, test.state, true)
 
 			r := &generateRunner{
-				cfg:             cfg,
+				api:             test.api,
+				library:         test.library,
+				apiSource:       apiSource,
+				build:           test.build,
 				repo:            repo,
 				sourceRepo:      newTestGitRepo(t),
 				state:           test.state,
@@ -877,11 +867,11 @@ func TestGenerateScenarios(t *testing.T) {
 			}
 
 			// Create a service config in api path.
-			if err := os.MkdirAll(filepath.Join(cfg.APISource, test.api), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Join(r.apiSource, test.api), 0755); err != nil {
 				t.Fatal(err)
 			}
 			data := []byte("type: google.api.Service")
-			if err := os.WriteFile(filepath.Join(cfg.APISource, test.api, "example_service_v2.yaml"), data, 0755); err != nil {
+			if err := os.WriteFile(filepath.Join(r.apiSource, test.api, "example_service_v2.yaml"), data, 0755); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Remove generateRunner.cfg and inline the individual fields to reduce coupling and only pass values through that are actually used.