### PR TITLE
refactor(librarian): remove cfg field from tagAndReleaseRunner

### DIFF
--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -88,10 +88,10 @@ func init() {
 }
 
 type tagAndReleaseRunner struct {
-	cfg      *config.Config
-	ghClient GitHubClient
-	repo     gitrepo.Repository
-	state    *config.LibrarianState
+	ghClient    GitHubClient
+	pullRequest string
+	repo        gitrepo.Repository
+	state       *config.LibrarianState
 }
 
 func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
@@ -103,10 +103,10 @@ func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
 		return nil, fmt.Errorf("`LIBRARIAN_GITHUB_TOKEN` must be set")
 	}
 	return &tagAndReleaseRunner{
-		cfg:      cfg,
-		repo:     runner.repo,
-		state:    runner.state,
-		ghClient: runner.ghClient,
+		ghClient:    runner.ghClient,
+		pullRequest: cfg.PullRequest,
+		repo:        runner.repo,
+		state:       runner.state,
 	}, nil
 }
 
@@ -140,11 +140,11 @@ func (r *tagAndReleaseRunner) run(ctx context.Context) error {
 
 func (r *tagAndReleaseRunner) determinePullRequestsToProcess(ctx context.Context) ([]*github.PullRequest, error) {
 	slog.Info("determining pull requests to process")
-	if r.cfg.PullRequest != "" {
-		slog.Info("processing a single pull request", "pr", r.cfg.PullRequest)
-		ss := strings.Split(r.cfg.PullRequest, "/")
+	if r.pullRequest != "" {
+		slog.Info("processing a single pull request", "pr", r.pullRequest)
+		ss := strings.Split(r.pullRequest, "/")
 		if len(ss) != pullRequestSegments {
-			return nil, fmt.Errorf("invalid pull request format: %s", r.cfg.PullRequest)
+			return nil, fmt.Errorf("invalid pull request format: %s", r.pullRequest)
 		}
 		prNum, err := strconv.Atoi(ss[pullRequestSegments-1])
 		if err != nil {

--- a/internal/librarian/tag_and_release_test.go
+++ b/internal/librarian/tag_and_release_test.go
@@ -15,7 +15,6 @@
 package librarian
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -132,10 +131,10 @@ func TestDeterminePullRequestsToProcess(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			r := &tagAndReleaseRunner{
-				cfg:      test.cfg,
-				ghClient: test.ghClient,
+				pullRequest: test.cfg.PullRequest,
+				ghClient:    test.ghClient,
 			}
-			got, err := r.determinePullRequestsToProcess(context.Background())
+			got, err := r.determinePullRequestsToProcess(t.Context())
 			if err != nil {
 				if test.wantErrMsg == "" {
 					t.Fatalf("unexpected error: %v", err)
@@ -193,10 +192,9 @@ func Test_tagAndReleaseRunner_run(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			r := &tagAndReleaseRunner{
-				cfg:      &config.Config{}, // empty config so it searches
 				ghClient: test.ghClient,
 			}
-			err := r.run(context.Background())
+			err := r.run(t.Context())
 			if err != nil {
 				if test.wantErrMsg == "" {
 					t.Fatalf("unexpected error: %v", err)
@@ -435,7 +433,7 @@ func TestProcessPullRequest(t *testing.T) {
 				ghClient: test.ghClient,
 				state:    test.state,
 			}
-			err := r.processPullRequest(context.Background(), test.pr)
+			err := r.processPullRequest(t.Context(), test.pr)
 			if err != nil {
 				if test.wantErrMsg == "" {
 					t.Fatalf("unexpected error: %v", err)
@@ -496,7 +494,7 @@ func TestReplacePendingLabel(t *testing.T) {
 			r := &tagAndReleaseRunner{
 				ghClient: test.ghClient,
 			}
-			err := r.replacePendingLabel(context.Background(), test.pr)
+			err := r.replacePendingLabel(t.Context(), test.pr)
 			if err != nil {
 				if test.wantErrMsg == "" {
 					t.Fatalf("unexpected error: %v", err)
@@ -531,7 +529,6 @@ func Test_tagAndReleaseRunner_run_processPullRequests(t *testing.T) {
 	}
 
 	r := &tagAndReleaseRunner{
-		cfg:      &config.Config{},
 		ghClient: ghClient,
 		state: &config.LibrarianState{
 			Libraries: []*config.LibraryState{
@@ -541,7 +538,7 @@ func Test_tagAndReleaseRunner_run_processPullRequests(t *testing.T) {
 			},
 		},
 	}
-	err := r.run(context.Background())
+	err := r.run(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "failed to process some pull requests") {
 		t.Fatalf("expected error 'failed to process some pull requests', got %v", err)
 	}


### PR DESCRIPTION
Remove tagAndReleaseRunner.cfg and add `pullRequest` as a field to tagAndReleaseRunner. It is the only value used from Config.