### PR TITLE
refactor(internal/librarian): remove cfg field from initRunner

### DIFF
--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -101,7 +101,6 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg:             &config.Config{},
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -205,9 +204,7 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg: &config.Config{
-					Library: "example-id",
-				},
+				library:         "example-id",
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -274,10 +271,7 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg: &config.Config{
-					Push:    false,
-					Library: "example-id",
-				},
+				library:         "example-id",
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -345,7 +339,6 @@ func TestInitRun(t *testing.T) {
 				containerClient: &mockContainerClient{
 					initErr: errors.New("simulated init error"),
 				},
-				cfg:   &config.Config{},
 				state: &config.LibrarianState{},
 				repo: &MockRepository{
 					Dir: t.TempDir(),
@@ -363,7 +356,6 @@ func TestInitRun(t *testing.T) {
 				containerClient: &mockContainerClient{
 					wantErrorMsg: true,
 				},
-				cfg:   &config.Config{},
 				state: &config.LibrarianState{},
 				repo: &MockRepository{
 					Dir: t.TempDir(),
@@ -390,9 +382,7 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg: &config.Config{
-					Library: "example-id",
-				},
+				library:         "example-id",
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -414,7 +404,6 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg:             &config.Config{},
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -436,9 +425,7 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        os.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg: &config.Config{
-					Push: true,
-				},
+				push:            true,
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -474,10 +461,7 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg: &config.Config{
-					Library: "example-id",
-					Push:    false,
-				},
+				library:         "example-id",
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -516,10 +500,7 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg: &config.Config{
-					Library: "example-id",
-					Push:    false,
-				},
+				library:         "example-id",
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -547,7 +528,6 @@ func TestInitRun(t *testing.T) {
 			runner: &initRunner{
 				workRoot:        t.TempDir(),
 				containerClient: &mockContainerClient{},
-				cfg:             &config.Config{},
 				state: &config.LibrarianState{
 					Libraries: []*config.LibraryState{
 						{
@@ -796,10 +776,8 @@ func TestUpdateLibrary(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			r := &initRunner{
-				cfg: &config.Config{
-					LibraryVersion: test.libraryVersion,
-				},
-				repo: test.repo,
+				libraryVersion: test.libraryVersion,
+				repo:           test.repo,
 			}
 			var err error
 			if test.repo != nil {
@@ -1156,7 +1134,7 @@ func TestDetermineNextVersion(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			runner := &initRunner{
-				cfg:             test.config,
+				libraryVersion:  test.config.LibraryVersion,
 				librarianConfig: test.librarianConfig,
 			}
 			got, err := runner.determineNextVersion(test.commits, test.currentVersion, test.libraryID)


### PR DESCRIPTION
Remove initRunner.cfg and inline the individual fields to reduce coupling and only pass values through that are actually used.