### PR TITLE
refactor(internal/librarian): remove cfg field from commitInfo

### DIFF
--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -1594,17 +1594,15 @@ func TestCommitAndPush(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			repo := test.setupMockRepo(t)
 			client := test.setupMockClient(t)
-			localConfig := &config.Config{
-				Push:   test.push,
-				Commit: test.commit,
-			}
+
 			commitInfo := &commitInfo{
-				cfg:           localConfig,
-				state:         test.state,
-				repo:          repo,
-				ghClient:      client,
+				commit:        test.commit,
 				commitMessage: "",
+				ghClient:      client,
 				prType:        test.prType,
+				push:          test.push,
+				repo:          repo,
+				state:         test.state,
 			}
 
 			err := commitAndPush(context.Background(), commitInfo)

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -115,6 +115,7 @@ func init() {
 type generateRunner struct {
 	api             string
 	apiSource       string
+	branch          string
 	build           bool
 	commit          bool
 	containerClient ContainerClient
@@ -209,14 +210,14 @@ func (r *generateRunner) run(ctx context.Context) error {
 	}
 
 	commitInfo := &commitInfo{
-		branch:          r.cfg.Branch,
-		commit:          r.cfg.Commit,
+		branch:          r.branch,
+		commit:          r.commit,
 		commitMessage:   "feat: generate libraries",
 		failedLibraries: failedLibraries,
 		ghClient:        r.ghClient,
 		idToCommits:     idToCommits,
 		prType:          generate,
-		push:            r.cfg.Push,
+		push:            r.push,
 		repo:            r.repo,
 		sourceRepo:      r.sourceRepo,
 		state:           r.state,

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -209,15 +209,17 @@ func (r *generateRunner) run(ctx context.Context) error {
 	}
 
 	commitInfo := &commitInfo{
-		cfg:             &config.Config{Push: r.push, Commit: r.commit},
-		state:           r.state,
-		repo:            r.repo,
-		sourceRepo:      r.sourceRepo,
+		branch:          r.cfg.Branch,
+		commit:          r.cfg.Commit,
+		commitMessage:   "feat: generate libraries",
+		failedLibraries: failedLibraries,
 		ghClient:        r.ghClient,
 		idToCommits:     idToCommits,
-		failedLibraries: failedLibraries,
-		commitMessage:   "feat: generate libraries",
 		prType:          generate,
+		push:            r.cfg.Push,
+		repo:            r.repo,
+		sourceRepo:      r.sourceRepo,
+		state:           r.state,
 	}
 
 	return commitAndPush(ctx, commitInfo)

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -141,22 +141,20 @@ func (r *initRunner) run(ctx context.Context) error {
 	}
 
 	commitInfo := &commitInfo{
-		cfg: &config.Config{
-			Library:        r.library,
-			LibraryVersion: r.libraryVersion,
-			Push:           r.push,
-			Commit:         r.commit,
-			Branch:         r.branch,
-		},
-		state:         r.state,
-		repo:          r.repo,
-		sourceRepo:    r.sourceRepo,
-		ghClient:      r.ghClient,
-		commitMessage: "chore: create a release",
-		prType:        release,
+		branch:         r.branch,
+		commit:         r.commit,
+		commitMessage:  "chore: create a release",
+		ghClient:       r.ghClient,
+		library:        r.library,
+		libraryVersion: r.libraryVersion,
+		prType:         release,
 		// Newly created PRs from the `release init` command should have a
 		// `release:pending` GitHub tab to be tracked for release.
 		pullRequestLabels: []string{"release:pending"},
+		push:              r.push,
+		repo:              r.repo,
+		sourceRepo:        r.sourceRepo,
+		state:             r.state,
 	}
 	if err := commitAndPush(ctx, commitInfo); err != nil {
 		return fmt.Errorf("failed to commit and push: %w", err)


### PR DESCRIPTION
Remove commitInfo.cfg and inline the individual fields to reduce coupling and only pass values through that are actually used.