### PR TITLE
config: extract LIBRARIAN_GITHUB_TOKEN into shared constant

### DIFF
--- a/internal/automation/trigger.go
+++ b/internal/automation/trigger.go
@@ -15,18 +15,19 @@
 package automation
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"iter"
-	"log/slog"
-	"os"
-	"strings"
+    "context"
+    "errors"
+    "fmt"
+    "iter"
+    "log/slog"
+    "os"
+    "strings"
 
-	cloudbuild "cloud.google.com/go/cloudbuild/apiv1/v2"
-	"cloud.google.com/go/cloudbuild/apiv1/v2/cloudbuildpb"
-	"github.com/googleapis/gax-go/v2"
-	"github.com/googleapis/librarian/internal/github"
+    cloudbuild "cloud.google.com/go/cloudbuild/apiv1/v2"
+    "cloud.google.com/go/cloudbuild/apiv1/v2/cloudbuildpb"
+    "github.com/googleapis/gax-go/v2"
+    "github.com/googleapis/librarian/internal/config"
+    "github.com/googleapis/librarian/internal/github"
 )
 
 var triggerNameByCommandName = map[string]string{
@@ -72,7 +73,7 @@ func RunCommand(ctx context.Context, command string, projectId string, push bool
 	wrappedClient := &wrappedCloudBuildClient{
 		client: c,
 	}
-	ghClient, err := github.NewClient(os.Getenv("LIBRARIAN_GITHUB_TOKEN"), &github.Repository{})
+    ghClient, err := github.NewClient(os.Getenv(config.EnvVarGitHubToken), &github.Repository{})
 	if err != nil {
 		return fmt.Errorf("error creating github client: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,16 +16,20 @@
 package config
 
 import (
-	"errors"
-	"fmt"
-	"log/slog"
-	"os"
-	"os/user"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
+    "errors"
+    "fmt"
+    "log/slog"
+    "os"
+    "os/user"
+    "path/filepath"
+    "regexp"
+    "strings"
+    "time"
 )
+
+// EnvVarGitHubToken is the environment variable name used to read the
+// GitHub access token for operations that push to GitHub.
+const EnvVarGitHubToken = "LIBRARIAN_GITHUB_TOKEN"
 
 const (
 	// BuildRequest is a JSON file that describes which library to build/test.
@@ -238,10 +242,10 @@ type Config struct {
 
 // New returns a new Config populated with environment variables.
 func New(cmdName string) *Config {
-	return &Config{
-		CommandName: cmdName,
-		GitHubToken: os.Getenv("LIBRARIAN_GITHUB_TOKEN"),
-	}
+    return &Config{
+        CommandName: cmdName,
+        GitHubToken: os.Getenv(EnvVarGitHubToken),
+    }
 }
 
 // setupUser performs late initialization of user-specific configuration,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	t.Setenv("LIBRARIAN_GITHUB_TOKEN", "")
+    t.Setenv(EnvVarGitHubToken, "")
 	for _, test := range []struct {
 		name    string
 		envVars map[string]string
@@ -36,10 +36,10 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			name: "All environment variables set",
-			envVars: map[string]string{
-				"LIBRARIAN_GITHUB_TOKEN":    "gh_token",
-				"LIBRARIAN_SYNC_AUTH_TOKEN": "sync_token",
-			},
+            envVars: map[string]string{
+                EnvVarGitHubToken:           "gh_token",
+                "LIBRARIAN_SYNC_AUTH_TOKEN": "sync_token",
+            },
 			want: Config{
 				GitHubToken: "gh_token",
 				CommandName: "test",
@@ -55,9 +55,9 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "Some environment variables set",
-			envVars: map[string]string{
-				"LIBRARIAN_GITHUB_TOKEN": "gh_token",
-			},
+            envVars: map[string]string{
+                EnvVarGitHubToken: "gh_token",
+            },
 			want: Config{
 				GitHubToken: "gh_token",
 				CommandName: "test",

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -15,9 +15,10 @@
 package librarian
 
 import (
-	"flag"
+    "flag"
+    "fmt"
 
-	"github.com/googleapis/librarian/internal/config"
+    "github.com/googleapis/librarian/internal/config"
 )
 
 func addFlagAPI(fs *flag.FlagSet, cfg *config.Config) {
@@ -80,10 +81,10 @@ If not specified, will search for all merged pull requests with the label
 }
 
 func addFlagPush(fs *flag.FlagSet, cfg *config.Config) {
-	fs.BoolVar(&cfg.Push, "push", false,
-		`If true, Librarian will create a commit and a pull request for the changes.
+    fs.BoolVar(&cfg.Push, "push", false,
+        fmt.Sprintf(`If true, Librarian will create a commit and a pull request for the changes.
 A GitHub token with push access must be provided via the
-LIBRARIAN_GITHUB_TOKEN environment variable.`)
+%s environment variable.`, config.EnvVarGitHubToken))
 }
 
 func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -99,9 +99,9 @@ func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cfg.GitHubToken == "" {
-		return nil, fmt.Errorf("`LIBRARIAN_GITHUB_TOKEN` must be set")
-	}
+    if cfg.GitHubToken == "" {
+        return nil, fmt.Errorf("`%s` must be set", config.EnvVarGitHubToken)
+    }
 	return &tagAndReleaseRunner{
 		cfg:      cfg,
 		repo:     runner.repo,


### PR DESCRIPTION
This refactor defines a single exported constant for the environment variable used to supply the GitHub token and replaces hardcoded references across the codebase:

- Add `config.EnvVarGitHubToken = "LIBRARIAN_GITHUB_TOKEN"`
- Use the constant in `config.New()`, `internal/automation/trigger.go`, `internal/librarian/tag_and_release.go` (error message), and `internal/librarian/flags.go` (help text via `fmt.Sprintf`).
- Update tests in `internal/config/config_test.go` to reference the constant.

Motivation: avoids duplication of the env var name and keeps it consistent if it ever changes.

No functional behavior changes.

Fixes #2089.
