### PR TITLE
doc: fix typo in example in howwewritego.md

### DIFF
--- a/doc/howwewritego.md
+++ b/doc/howwewritego.md
@@ -106,7 +106,7 @@ func TestTransform(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := Transform(test.input)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("Transform() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Match the example under `Table-driven tests` with the guidelines under `Use cmp.Diff for comparisons`.