### PR TITLE
refactor: inline fields from Cfg

### DIFF
--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -64,10 +64,6 @@ func TestDockerRun(t *testing.T) {
 	)
 
 	state := &config.LibrarianState{}
-	cfg := &config.Config{}
-	cfgInDocker := &config.Config{
-		HostMount: "hostDir:localDir",
-	}
 	repoDir := filepath.Join(os.TempDir())
 	for _, test := range []struct {
 		name       string
@@ -84,7 +80,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				generateRequest := &GenerateRequest{
-					Cfg:       cfg,
 					State:     state,
 					RepoDir:   repoDir,
 					ApiRoot:   testAPIRoot,
@@ -115,7 +110,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				generateRequest := &GenerateRequest{
-					Cfg:       cfg,
 					State:     state,
 					RepoDir:   "/non-existed-dir",
 					ApiRoot:   testAPIRoot,
@@ -135,7 +129,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				generateRequest := &GenerateRequest{
-					Cfg:       cfg,
 					State:     state,
 					RepoDir:   repoDir,
 					ApiRoot:   testAPIRoot,
@@ -156,12 +149,12 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				generateRequest := &GenerateRequest{
-					Cfg:       cfgInDocker,
 					State:     state,
 					RepoDir:   repoDir,
 					ApiRoot:   testAPIRoot,
 					Output:    "hostDir",
 					LibraryID: testLibraryID,
+					HostMount: "hostDir:localDir",
 				}
 
 				return d.Generate(ctx, generateRequest)
@@ -187,7 +180,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				buildRequest := &BuildRequest{
-					Cfg:       cfg,
 					State:     state,
 					LibraryID: testLibraryID,
 					RepoDir:   repoDir,
@@ -212,7 +204,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				buildRequest := &BuildRequest{
-					Cfg:       cfg,
 					State:     state,
 					LibraryID: testLibraryID,
 					RepoDir:   "/non-exist-dir",
@@ -230,7 +221,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				buildRequest := &BuildRequest{
-					Cfg:       cfg,
 					State:     state,
 					LibraryID: testLibraryID,
 					RepoDir:   repoDir,
@@ -249,7 +239,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				configureRequest := &ConfigureRequest{
-					Cfg:       cfg,
 					State:     state,
 					LibraryID: testLibraryID,
 					RepoDir:   repoDir,
@@ -306,7 +295,6 @@ func TestDockerRun(t *testing.T) {
 					},
 				}
 				configureRequest := &ConfigureRequest{
-					Cfg:       cfg,
 					State:     curState,
 					LibraryID: testLibraryID,
 					RepoDir:   repoDir,
@@ -341,7 +329,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				configureRequest := &ConfigureRequest{
-					Cfg:       cfg,
 					State:     state,
 					LibraryID: testLibraryID,
 					RepoDir:   "/non-exist-dir",
@@ -361,7 +348,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				configureRequest := &ConfigureRequest{
-					Cfg:       cfg,
 					State:     state,
 					LibraryID: testLibraryID,
 					RepoDir:   repoDir,
@@ -388,9 +374,6 @@ func TestDockerRun(t *testing.T) {
 				}
 
 				releaseInitRequest := &ReleaseInitRequest{
-					Cfg: &config.Config{
-						Repo: repoDir,
-					},
 					State:           state,
 					Output:          testOutput,
 					LibrarianConfig: &config.LibrarianConfig{},
@@ -425,9 +408,6 @@ func TestDockerRun(t *testing.T) {
 				}
 
 				releaseInitRequest := &ReleaseInitRequest{
-					Cfg: &config.Config{
-						Repo: repoDir,
-					},
 					State:           state,
 					PartialRepoDir:  partialRepoDir,
 					Output:          testOutput,
@@ -447,9 +427,6 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				releaseInitRequest := &ReleaseInitRequest{
-					Cfg: &config.Config{
-						Repo: os.TempDir(),
-					},
 					State:          state,
 					PartialRepoDir: "/non-exist-dir",
 					Output:         testOutput,
@@ -471,9 +448,6 @@ func TestDockerRun(t *testing.T) {
 					t.Fatal(err)
 				}
 				releaseInitRequest := &ReleaseInitRequest{
-					Cfg: &config.Config{
-						Repo: repoDir,
-					},
 					State:           state,
 					PartialRepoDir:  partialRepoDir,
 					Output:          testOutput,
@@ -508,9 +482,6 @@ func TestDockerRun(t *testing.T) {
 				}
 
 				releaseInitRequest := &ReleaseInitRequest{
-					Cfg: &config.Config{
-						Repo: os.TempDir(),
-					},
 					State:           state,
 					PartialRepoDir:  partialRepoDir,
 					Output:          testOutput,
@@ -888,9 +859,6 @@ func TestReleaseInitRequestContent(t *testing.T) {
 	}
 
 	req := &ReleaseInitRequest{
-		Cfg: &config.Config{
-			Repo: tmpDir,
-		},
 		State:           stateWithChanges,
 		PartialRepoDir:  partialRepoDir,
 		Output:          filepath.Join(tmpDir, "output"),

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -321,12 +321,12 @@ func (r *generateRunner) runGenerateCommand(ctx context.Context, libraryID, outp
 	}
 
 	generateRequest := &docker.GenerateRequest{
-		Cfg:       &config.Config{HostMount: r.hostMount},
-		State:     r.state,
 		ApiRoot:   apiRoot,
+		HostMount: r.hostMount,
 		LibraryID: libraryID,
 		Output:    outputDir,
 		RepoDir:   r.repo.GetDir(),
+		State:     r.state,
 	}
 	slog.Info("Performing generation for library", "id", libraryID, "outputDir", outputDir)
 	if err := r.containerClient.Generate(ctx, generateRequest); err != nil {
@@ -363,10 +363,10 @@ func (r *generateRunner) runBuildCommand(ctx context.Context, libraryID string) 
 	}
 
 	buildRequest := &docker.BuildRequest{
-		Cfg:       &config.Config{HostMount: r.hostMount},
-		State:     r.state,
+		HostMount: r.hostMount,
 		LibraryID: libraryID,
 		RepoDir:   r.repo.GetDir(),
+		State:     r.state,
 	}
 	slog.Info("Performing build for library", "id", libraryID)
 	if err := r.containerClient.Build(ctx, buildRequest); err != nil {
@@ -425,11 +425,11 @@ func (r *generateRunner) runConfigureCommand(ctx context.Context) (string, error
 	}
 
 	configureRequest := &docker.ConfigureRequest{
-		Cfg:       &config.Config{HostMount: r.hostMount},
-		State:     r.state,
 		ApiRoot:   apiRoot,
+		HostMount: r.hostMount,
 		LibraryID: r.library,
 		RepoDir:   r.repo.GetDir(),
+		State:     r.state,
 	}
 	slog.Info("Performing configuration for library", "id", r.library)
 	if _, err := r.containerClient.Configure(ctx, configureRequest); err != nil {

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -211,19 +211,15 @@ func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error
 	}
 
 	initRequest := &docker.ReleaseInitRequest{
-		Cfg: &config.Config{
-			Library:        r.library,
-			LibraryVersion: r.libraryVersion,
-			Push:           r.push,
-			Commit:         r.commit,
-			Branch:         r.branch,
-		},
-		State:           r.state,
+		Branch:          r.branch,
+		Commit:          r.commit,
 		LibrarianConfig: r.librarianConfig,
 		LibraryID:       r.library,
 		LibraryVersion:  r.libraryVersion,
 		Output:          outputDir,
 		PartialRepoDir:  dst,
+		Push:            r.push,
+		State:           r.state,
 	}
 
 	if err := r.containerClient.ReleaseInit(ctx, initRequest); err != nil {


### PR DESCRIPTION
Remove the Cfg field from BuildRequest, ConfigureRequest, GenerateRequest, and ReleaseInitRequest to decouple config.Config from these structs. Add fields only for the ones that are used.

Also reorder fields on these structs alphabetically.