### PR TITLE
refactor(internal/librarian): inline logic from newCommandRunner

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -92,68 +92,6 @@ type commitInfo struct {
 	failedGenerations int
 }
 
-type commandRunner struct {
-	repo            gitrepo.Repository
-	sourceRepo      gitrepo.Repository
-	state           *config.LibrarianState
-	librarianConfig *config.LibrarianConfig
-	ghClient        GitHubClient
-	containerClient ContainerClient
-	image           string
-	workRoot        string
-}
-
-func newCommandRunner(cfg *config.Config) (*commandRunner, error) {
-	languageRepo, err := cloneOrOpenRepo(cfg.WorkRoot, cfg.Repo, cfg.APISourceDepth, cfg.Branch, cfg.CI, cfg.GitHubToken)
-	if err != nil {
-		return nil, err
-	}
-
-	var (
-		sourceRepo    gitrepo.Repository
-		sourceRepoDir string
-	)
-	if cfg.CommandName == generateCmdName {
-		sourceRepo, err = cloneOrOpenRepo(cfg.WorkRoot, cfg.APISource, cfg.APISourceDepth, defaultAPISourceBranch, cfg.CI, cfg.GitHubToken)
-		if err != nil {
-			return nil, err
-		}
-		sourceRepoDir = sourceRepo.GetDir()
-	}
-	state, err := loadRepoState(languageRepo, sourceRepoDir)
-	if err != nil {
-		return nil, err
-	}
-
-	librarianConfig, err := loadLibrarianConfig(languageRepo)
-	if err != nil {
-		return nil, err
-	}
-
-	image := deriveImage(cfg.Image, state)
-
-	gitHubRepo, err := GetGitHubRepository(cfg, languageRepo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get GitHub repository: %w", err)
-	}
-
-	ghClient := github.NewClient(cfg.GitHubToken, gitHubRepo)
-	container, err := docker.New(cfg.WorkRoot, image, cfg.UserUID, cfg.UserGID)
-	if err != nil {
-		return nil, err
-	}
-	return &commandRunner{
-		workRoot:        cfg.WorkRoot,
-		repo:            languageRepo,
-		sourceRepo:      sourceRepo,
-		state:           state,
-		librarianConfig: librarianConfig,
-		image:           image,
-		ghClient:        ghClient,
-		containerClient: container,
-	}, nil
-}
-
 func cloneOrOpenRepo(workRoot, repo string, depth int, branch, ci string, gitPassword string) (*gitrepo.LocalRepository, error) {
 	if repo == "" {
 		return nil, fmt.Errorf("repo must be specified")

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/docker"
+	"github.com/googleapis/librarian/internal/github"
 	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
@@ -50,28 +51,67 @@ type generateRunner struct {
 	workRoot        string
 }
 
+const defaultAPISourceBranch = "master"
+
 func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
-	runner, err := newCommandRunner(cfg)
+	languageRepo, err := cloneOrOpenRepo(cfg.WorkRoot, cfg.Repo, cfg.APISourceDepth, cfg.Branch, cfg.CI, cfg.GitHubToken)
 	if err != nil {
 		return nil, err
 	}
+	sourceRepo, err := cloneOrOpenRepo(cfg.WorkRoot, cfg.APISource, cfg.APISourceDepth, defaultAPISourceBranch, cfg.CI, cfg.GitHubToken)
+	if err != nil {
+		return nil, err
+	}
+	sourceRepoDir := sourceRepo.GetDir()
+	state, err := loadRepoState(languageRepo, sourceRepoDir)
+	if err != nil {
+		return nil, err
+	}
+
+	image := deriveImage(cfg.Image, state)
+	container, err := docker.New(cfg.WorkRoot, image, cfg.UserUID, cfg.UserGID)
+	if err != nil {
+		return nil, err
+	}
+
+	ghClient, err := newGitHubClient(cfg.Repo, cfg.GitHubToken, languageRepo)
+	if err != nil {
+		return nil, err
+	}
+
 	return &generateRunner{
 		api:             cfg.API,
 		branch:          cfg.Branch,
 		build:           cfg.Build,
 		commit:          cfg.Commit,
-		containerClient: runner.containerClient,
-		ghClient:        runner.ghClient,
+		containerClient: container,
+		ghClient:        ghClient,
 		hostMount:       cfg.HostMount,
-		image:           runner.image,
+		image:           image,
+		librarianConfig: cfg.LibrarianConfig,
 		library:         cfg.Library,
 		push:            cfg.Push,
-		repo:            runner.repo,
-		sourceRepo:      runner.sourceRepo,
-		state:           runner.state,
-		librarianConfig: runner.librarianConfig,
-		workRoot:        runner.workRoot,
+		repo:            languageRepo,
+		sourceRepo:      sourceRepo,
+		state:           state,
+		workRoot:        cfg.WorkRoot,
 	}, nil
+}
+
+func newGitHubClient(repo, token string, languageRepo *gitrepo.LocalRepository) (_ GitHubClient, err error) {
+	var gitRepo *github.Repository
+	if isURL(repo) {
+		gitRepo, err = github.ParseRemote(repo)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse repo url: %w", err)
+		}
+	} else {
+		gitRepo, err = github.FetchGitHubRepoFromRemote(languageRepo)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get GitHub repo from remote: %w", err)
+		}
+	}
+	return github.NewClient(token, gitRepo), nil
 }
 
 // run executes the library generation process.

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -551,6 +551,30 @@ func TestNewGenerateRunner(t *testing.T) {
 				CommandName: generateCmdName,
 			},
 		},
+		{
+			name: "invalid github repo URL",
+			cfg: &config.Config{
+				API:         "some/api",
+				APISource:   newTestGitRepo(t).GetDir(),
+				Repo:        "not-a-github-url",
+				WorkRoot:    t.TempDir(),
+				Image:       "gcr.io/test/test-image",
+				CommandName: generateCmdName,
+			},
+			wantErr: true,
+		},
+		{
+			name: "github repo URL",
+			cfg: &config.Config{
+				API:         "some/api",
+				APISource:   newTestGitRepo(t).GetDir(),
+				Repo:        "https://github.com/googleapis/librarian",
+				WorkRoot:    t.TempDir(),
+				Image:       "gcr.io/test/test-image",
+				CommandName: generateCmdName,
+			},
+			wantErr: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -46,24 +46,44 @@ type initRunner struct {
 }
 
 func newInitRunner(cfg *config.Config) (*initRunner, error) {
-	runner, err := newCommandRunner(cfg)
+	languageRepo, err := cloneOrOpenRepo(cfg.WorkRoot, cfg.Repo, cfg.APISourceDepth, cfg.Branch, cfg.CI, cfg.GitHubToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create init runner: %w", err)
+		return nil, err
 	}
+	state, err := loadRepoState(languageRepo, "")
+	if err != nil {
+		return nil, err
+	}
+	librarianConfig, err := loadLibrarianConfig(languageRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	image := deriveImage(cfg.Image, state)
+	container, err := docker.New(cfg.WorkRoot, image, cfg.UserUID, cfg.UserGID)
+	if err != nil {
+		return nil, err
+	}
+
+	ghClient, err := newGitHubClient(cfg.Repo, cfg.GitHubToken, languageRepo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
+	}
+
 	return &initRunner{
 		branch:          cfg.Branch,
 		commit:          cfg.Commit,
-		containerClient: runner.containerClient,
-		ghClient:        runner.ghClient,
-		image:           runner.image,
-		librarianConfig: runner.librarianConfig,
+		containerClient: container,
+		ghClient:        ghClient,
+		image:           deriveImage(cfg.Image, state),
+		librarianConfig: librarianConfig,
 		library:         cfg.Library,
 		libraryVersion:  cfg.LibraryVersion,
+		partialRepo:     filepath.Join(cfg.WorkRoot, "release-init"),
 		push:            cfg.Push,
-		repo:            runner.repo,
-		sourceRepo:      runner.sourceRepo,
-		state:           runner.state,
-		workRoot:        runner.workRoot,
+		repo:            languageRepo,
+		state:           state,
+		workRoot:        cfg.WorkRoot,
 	}, nil
 }
 

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -54,7 +54,7 @@ func TestNewInitRunner(t *testing.T) {
 				APISource: newTestGitRepo(t).GetDir(),
 			},
 			wantErr:    true,
-			wantErrMsg: "failed to create init runner",
+			wantErrMsg: "repo must be specified",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -70,6 +70,8 @@ func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
 	return &tagAndReleaseRunner{
 		ghClient:    ghClient,
 		pullRequest: cfg.PullRequest,
+		repo:        languageRepo,
+		state:       state,
 	}, nil
 }
 


### PR DESCRIPTION
newCommandRunner currently builds a shared base runner that is then consumed by initRunner, tagAndReleaseRunner, and generateRunner.

In practice, each of these runners use a different subset of that base. Inline the construction logic into each runner so that each runner declares exactly what it needs.

For https://github.com/googleapis/librarian/issues/2176