### PR TITLE
fix(sidekick): skip bumps for new crates

### DIFF
--- a/internal/sidekick/internal/rust_release/update_manifest.go
+++ b/internal/sidekick/internal/rust_release/update_manifest.go
@@ -38,9 +38,12 @@ type cargo struct {
 }
 
 func updateManifest(config *config.Release, lastTag, manifest string) ([]string, error) {
-	updated, err := manifestVersionUpdated(config, lastTag, manifest)
+	needsBump, err := manifestVersionNeedsBump(config, lastTag, manifest)
 	if err != nil {
 		return nil, err
+	}
+	if !needsBump {
+		return nil, nil
 	}
 	contents, err := os.ReadFile(manifest)
 	if err != nil {
@@ -56,9 +59,6 @@ func updateManifest(config *config.Release, lastTag, manifest string) ([]string,
 	}
 	if !info.Package.Publish {
 		return nil, nil
-	}
-	if updated {
-		return []string{info.Package.Name}, nil
 	}
 	newVersion, err := bumpPackageVersion(info.Package.Version)
 	if err != nil {
@@ -95,7 +95,7 @@ func bumpPackageVersion(version string) (string, error) {
 	return strings.Join(components, "."), nil
 }
 
-func manifestVersionUpdated(config *config.Release, lastTag, manifest string) (bool, error) {
+func manifestVersionNeedsBump(config *config.Release, lastTag, manifest string) (bool, error) {
 	delta := fmt.Sprintf("%s..HEAD", lastTag)
 	cmd := exec.Command(gitExe(config), "diff", delta, "--", manifest)
 	cmd.Dir = "."
@@ -103,10 +103,12 @@ func manifestVersionUpdated(config *config.Release, lastTag, manifest string) (b
 	if err != nil {
 		return false, err
 	}
+	if len(contents) == 0 {
+		return true, nil
+	}
 	lines := strings.Split(string(contents), "\n")
 	has := func(prefix string) bool {
 		return slices.ContainsFunc(lines, func(line string) bool { return strings.HasPrefix(line, prefix) })
 	}
-	updated := has("+version") && has("-version")
-	return updated, nil
+	return !has("+version "), nil
 }


### PR DESCRIPTION
Renamed `manifestVersionUpdated` to better capture what it does, fix the
code to skip new files, and fixed all the tests.

Part of the work for #2127
