### PR TITLE
impl(sidekick): cosmetic fixes in the output

### DIFF
--- a/internal/sidekick/internal/rust_release/update_manifest.go
+++ b/internal/sidekick/internal/rust_release/update_manifest.go
@@ -69,7 +69,9 @@ func updateManifest(config *config.Release, lastTag, manifest string) ([]string,
 	if idx == -1 {
 		return nil, fmt.Errorf("expected a line starting with `version ` in %v", lines)
 	}
-	lines[idx] = fmt.Sprintf(`version = "%s"`, newVersion)
+	// The number of spaces may seem weird. They match the number of spaces in
+	// the mustache template.
+	lines[idx] = fmt.Sprintf(`version                = "%s"`, newVersion)
 	if err := os.WriteFile(manifest, []byte(strings.Join(lines, "\n")), 0644); err != nil {
 		return nil, err
 	}

--- a/internal/sidekick/internal/rust_release/update_manifest_test.go
+++ b/internal/sidekick/internal/rust_release/update_manifest_test.go
@@ -50,7 +50,7 @@ func TestUpdateManifestSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	idx := bytes.Index(contents, []byte("version = \"1.1.0\"\n"))
+	idx := bytes.Index(contents, []byte("version                = \"1.1.0\"\n"))
 	if idx == -1 {
 		t.Errorf("expected version = 1.1.0 in new file, got=%s", contents)
 	}
@@ -70,7 +70,7 @@ func TestUpdateManifestSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	idx = bytes.Index(contents, []byte("version = \"1.1.0\"\n"))
+	idx = bytes.Index(contents, []byte("version                = \"1.1.0\"\n"))
 	if idx == -1 {
 		t.Errorf("expected version = 1.1.0 in new file, got=%s", contents)
 	}

--- a/internal/sidekick/internal/rust_release/update_sidekick_config.go
+++ b/internal/sidekick/internal/rust_release/update_sidekick_config.go
@@ -46,7 +46,7 @@ func updateSidekickConfig(manifest, newVersion string) error {
 	result = append(result, lines[:iCodec+1]...)
 	tail := lines[iCodec+1:]
 	iVersion := slices.IndexFunc(tail, func(a string) bool { return strings.HasPrefix(a, "version = ") })
-	verLine := fmt.Sprintf(`version = "%s"`, newVersion)
+	verLine := fmt.Sprintf(`version        = '%s'`, newVersion)
 	if iVersion == -1 {
 		result = append(result, verLine)
 		result = append(result, tail...)

--- a/internal/sidekick/internal/rust_release/update_sidekick_config_test.go
+++ b/internal/sidekick/internal/rust_release/update_sidekick_config_test.go
@@ -30,13 +30,13 @@ func TestUpdateSidekickConfigSuccess(t *testing.T) {
 [codec]
 a = 123
 version = "1.2.3"
-c = 345
+copyright-year = '2038'
 `
 	const want = `# With version line
 [codec]
 a = 123
-version = "2.3.4"
-c = 345
+version        = '2.3.4'
+copyright-year = '2038'
 `
 	if err := os.WriteFile(sidekick, []byte(contents), 0644); err != nil {
 		t.Fatal(err)
@@ -59,13 +59,13 @@ func TestUpdateSidekickConfigSuccessNoVersion(t *testing.T) {
 	sidekick := path.Join(tmpDir, ".sidekick.toml")
 	const contents = `# With version line
 [codec]
-a = 123
+copyright-year = '2038'
 c = 345
 `
 	const want = `# With version line
 [codec]
-version = "2.3.4"
-a = 123
+version        = '2.3.4'
+copyright-year = '2038'
 c = 345
 `
 	if err := os.WriteFile(sidekick, []byte(contents), 0644); err != nil {
@@ -94,7 +94,7 @@ func TestUpdateSidekickConfigSuccessEmptyCodec(t *testing.T) {
 	const want = `# With version line
 
 [codec]
-version = "2.3.4"
+version        = '2.3.4'
 `
 	if err := os.WriteFile(sidekick, []byte(contents), 0644); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Make the produced deltas easier to grok in the context of the Rust
repository.

Part of the work for #2127 
