### PR TITLE
chore: turn of patch report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,7 @@ coverage:
         target: 80% # The target coverage percentage for the project
         threshold: 0% # Allow 0% drop from the target; any drop below target will fail
         if_ci_failed: error # Set the CI status to 'error' if coverage conditions are not met
+    patch: off
 ignore:
   # test packages do not need code coverage
   - internal/sidekick/internal/api/apitest


### PR DESCRIPTION
We don't require this check and it super valuable. We will stil maintain our current coverage goals.