### PR TITLE
build: build go binary for automation command

### DIFF
--- a/infra/dispatcher/Dockerfile
+++ b/infra/dispatcher/Dockerfile
@@ -20,7 +20,7 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build ./cmd/librarian
+RUN CGO_ENABLED=0 GOOS=linux go build ./cmd/automation
 
 FROM golang:1.25.0
 

--- a/infra/dispatcher/Dockerfile
+++ b/infra/dispatcher/Dockerfile
@@ -11,11 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+FROM golang:1.25.0 AS build
+
+WORKDIR /src
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build ./cmd/librarian
+
 FROM golang:1.25.0
 
 WORKDIR /app
 
-ADD . /app
-RUN go build ./...
-
-ENTRYPOINT [ "go" ]
+COPY --from=build /src/automation .
+ENTRYPOINT [ "/app/automation" ]

--- a/infra/prod/generate-worker.yaml
+++ b/infra/prod/generate-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian generate` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:00aa886a70e110e9e8cfb888a232a1c508031e58cfeee60870ef7a11ca3d5656
     id: generate-dispatcher
     entrypoint: go
     args:

--- a/infra/prod/publish-release-worker.yaml
+++ b/infra/prod/publish-release-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian release tag-and-release` command with a provided repository,
 # secret name, and optional PR
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:00aa886a70e110e9e8cfb888a232a1c508031e58cfeee60870ef7a11ca3d5656
     id: publish-release-dispatcher
     entrypoint: go
     args:

--- a/infra/prod/stage-release-worker.yaml
+++ b/infra/prod/stage-release-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian release init` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:00aa886a70e110e9e8cfb888a232a1c508031e58cfeee60870ef7a11ca3d5656
     id: stage-release-dispatcher
     entrypoint: go
     args:


### PR DESCRIPTION
Also pins the dispatcher image to the current version. We will need to update the command args when the new image is built.

Locally, the image size goes from 2.2Gb -> 900Mb

Towards #2142