### PR TITLE
feat: Make the Dart class representing the service `final`

### DIFF
--- a/internal/sidekick/internal/dart/templates/lib/service.mustache
+++ b/internal/sidekick/internal/dart/templates/lib/service.mustache
@@ -17,7 +17,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} {
+final class {{Codec.Name}} {
   static const String _host = '{{DefaultHost}}';
 
   final ServiceClient _client;


### PR DESCRIPTION
Dart classes are, by default, also interfaces. This means that adding a new method to a class will break any code that implements it.

The most conservative approach is to make the class `final` - we can relax that restriction and make it `base` later, if it makes sense.