### PR TITLE
feat: Force release for a specific library even if there are no releasable changes

### DIFF
--- a/internal/librarian/help.go
+++ b/internal/librarian/help.go
@@ -89,8 +89,8 @@ to the configured language-specific container.
 If a specific library is configured for release via the '--library' flag, a single
 releasable change is needed to automatically calculate a version bump. If there are
 no releasable changes since the last release, the '--version' flag should be included
-to set a new version for the library. If the '--version' flag is not set, then the
-next minor version is used as the next version.
+to set a new version for the library. The new version must be "SemVer" greater than the
+current version.
 
 By default, 'release init' leaves the changes in your local working directory
 for inspection. Use the '--push' flag to automatically commit the changes to

--- a/internal/librarian/help.go
+++ b/internal/librarian/help.go
@@ -86,6 +86,12 @@ according to semver rules. It then delegates all language-specific file
 modifications, such as updating a CHANGELOG.md or bumping the version in a pom.xml,
 to the configured language-specific container.
 
+If a specific library is configured for release via the '--library' flag, a single
+releasable change is needed to automatically calculate a version bump. If there are
+no releasable changes since the last release, the '--version' flag should be included
+to set a new version for the library. If the '--version' flag is not set, then the
+next minor version is used as the next version.
+
 By default, 'release init' leaves the changes in your local working directory
 for inspection. Use the '--push' flag to automatically commit the changes to
 a new branch and create a pull request on GitHub. The '--commit' flag may be

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -227,7 +227,8 @@ func (r *initRunner) updateLibrary(library *config.LibraryState, commits []*conv
 		slog.Info("Library version override inputted", "currentVersion", library.Version, "inputVersion", r.libraryVersion)
 		nextVersion = semver.MaxVersion(library.Version, r.libraryVersion)
 		slog.Debug("Determined the library's next version from version input", "library", library.ID, "nextVersion", nextVersion)
-		// Inputted version is either equal or less than current version and cannot be used for release
+		// Currently, nextVersion is the max of current version or input version. If nextVersion is equal to the current version,
+		// then the input version is either equal or less than current version and cannot be used for release
 		if nextVersion == library.Version {
 			return fmt.Errorf("inputted version is not SemVer greater than the current version. Set a version SemVer greater than current than: %s", library.Version)
 		}

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -232,20 +232,16 @@ func (r *initRunner) updateLibrary(library *config.LibraryState, commits []*conv
 	if nextVersion == library.Version {
 		// No library is specified for release. No releasable units found and will not continue with release
 		if r.library == "" {
-			slog.Info("Library does not have any releasable units since the last release and will not be released.",
+			slog.Info("Library does not have any releasable units and will not be released.",
 				"library", library.ID, "version", library.Version)
 			return nil
+		} else {
+			// Library was inputted for release, but a version was not specified or the version was not
+			// SemVer greater than the current version
+			slog.Error("Inputted library does not have a releasable unit and will not be released. Use the --version flag to set a specific version.",
+				"library", library.ID, "nextVersion", nextVersion)
+			return fmt.Errorf("library does not have a releasable unit and will not be released. Use the version flag to set the version for this library: %s", library.ID)
 		}
-
-		// Library is specified for release, but the next version is calculated to be the same as the
-		// current one. It is possible that version override is not specified or there are no releasable
-		// units found. If so, automatically bump to the next minor version and continue with the release.
-		nextVersion, err = semver.DeriveNext(semver.Minor, library.Version)
-		if err != nil {
-			return err
-		}
-		slog.Warn("Unable to find a releasable unit and bumping to next minor version. Use the --version flag to set a specific version other than the next minor.",
-			"library", library.ID, "nextVersion", nextVersion)
 	}
 	slog.Info("Updating library to the next version", "library", r.library, "currentVersion", library.Version, "nextVersion", nextVersion)
 

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -229,7 +229,6 @@ func (r *initRunner) updateLibrary(library *config.LibraryState, commits []*conv
 		slog.Debug("Determined the library's next version from version input", "library", library.ID, "nextVersion", nextVersion)
 		// Inputted version is either equal or less than current version and cannot be used for release
 		if nextVersion == library.Version {
-			slog.Error("Inputted version is not SemVer greater than the current version", "library", library.ID, "currentVersion", library.Version, "inputVersion", r.libraryVersion)
 			return fmt.Errorf("inputted version is not SemVer greater than the current version. Set a version SemVer greater than current than: %s", library.Version)
 		}
 	} else {
@@ -247,8 +246,6 @@ func (r *initRunner) updateLibrary(library *config.LibraryState, commits []*conv
 				return nil
 			}
 			// Library was inputted for release, but does not contain a releasable unit
-			slog.Error("Inputted library does not have a releasable unit and will not be released. Use the version flag to force a release.",
-				"library", library.ID, "nextVersion", nextVersion)
 			return fmt.Errorf("library does not have a releasable unit and will not be released. Use the version flag to force a release for: %s", library.ID)
 		}
 		slog.Info("Updating library to the next version", "library", r.library, "currentVersion", library.Version, "nextVersion", nextVersion)

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -1236,7 +1236,7 @@ func TestUpdateLibrary(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Error("updateLibrary() should return error")
+					t.Fatal("updateLibrary() should return error")
 				}
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message: %q, got %q", test.wantErrMsg, err.Error())

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -721,7 +721,7 @@ func TestInitRun(t *testing.T) {
 				}
 			},
 			wantErr:    true,
-			wantErrMsg: "library does not have a releasable unit and will not be released. Use the version flag to set the version for this library",
+			wantErrMsg: "library does not have a releasable unit and will not be released. Use the version flag to force a release for",
 		},
 		{
 			name:            "failed to commit and push",
@@ -1067,7 +1067,7 @@ func TestUpdateLibrary(t *testing.T) {
 			},
 		},
 		{
-			name: "update a library with releasable units, version inputted",
+			name: "update a library with releasable units, valid version inputted",
 			libraryState: &config.LibraryState{
 				ID:      "one-id",
 				Version: "1.2.3",
@@ -1103,6 +1103,28 @@ func TestUpdateLibrary(t *testing.T) {
 				},
 				ReleaseTriggered: true,
 			},
+		},
+		{
+			name: "update a library with releasable units, invalid version inputted",
+			libraryState: &config.LibraryState{
+				ID:      "one-id",
+				Version: "1.2.3",
+			},
+			libraryVersion: "1.0.0",
+			commits: []*conventionalcommits.ConventionalCommit{
+				{
+					Type:    "fix",
+					Subject: "change a typo",
+				},
+				{
+					Type:    "feat",
+					Subject: "add a config file",
+					Body:    "This is the body.",
+					Footers: map[string]string{"PiperOrigin-RevId": "12345"},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "inputted version is not SemVer greater than the current version. Set a version SemVer greater than current than",
 		},
 		{
 			name: "library has breaking changes",
@@ -1175,7 +1197,7 @@ func TestUpdateLibrary(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "library does not have a releasable unit and will not be released. Use the version flag to set the version for this library",
+			wantErrMsg: "library does not have a releasable unit and will not be released. Use the version flag to force a release for",
 		},
 		{
 			name: "library has no releasable units and is inputted for release with a specific version",
@@ -1465,49 +1487,6 @@ func TestDetermineNextVersion(t *testing.T) {
 			},
 			currentVersion: "1.0.0",
 			wantVersion:    "1.1.0",
-			wantErr:        false,
-		},
-		{
-			name: "with CLI override version",
-			commits: []*conventionalcommits.ConventionalCommit{
-				{Type: "feat"},
-			},
-			config: &config.Config{
-				Library:        "some-library",
-				LibraryVersion: "1.2.3",
-			},
-			libraryID: "some-library",
-			librarianConfig: &config.LibrarianConfig{
-				Libraries: []*config.LibraryConfig{
-					&config.LibraryConfig{
-						LibraryID:   "some-library",
-						NextVersion: "2.3.4",
-					},
-				},
-			},
-			currentVersion: "1.0.0",
-			wantVersion:    "1.2.3",
-			wantErr:        false,
-		},
-		{
-			name: "with CLI override version cannot revert version",
-			commits: []*conventionalcommits.ConventionalCommit{
-				{Type: "feat"},
-			},
-			config: &config.Config{
-				Library:        "some-library",
-				LibraryVersion: "1.2.3",
-			},
-			libraryID: "some-library",
-			librarianConfig: &config.LibrarianConfig{
-				Libraries: []*config.LibraryConfig{
-					&config.LibraryConfig{
-						LibraryID: "some-library",
-					},
-				},
-			},
-			currentVersion: "2.4.0",
-			wantVersion:    "2.5.0",
 			wantErr:        false,
 		},
 		{

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -1244,7 +1244,7 @@ func TestUpdateLibrary(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("failed to run updateLibrary(): %q", err.Error())
+				t.Fatalf("failed to run updateLibrary(): %q", err.Error())
 			}
 			if diff := cmp.Diff(test.want, test.libraryState); diff != "" {
 				t.Errorf("state mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -1003,7 +1003,7 @@ func TestProcessLibrary(t *testing.T) {
 		err := r.processLibrary(test.libraryState)
 		if test.wantErr {
 			if err == nil {
-				t.Error("processLibrary() should return error")
+				t.Fatal("processLibrary() should return error")
 			}
 			if !strings.Contains(err.Error(), test.wantErrMsg) {
 				t.Errorf("want error message: %q, got %q", test.wantErrMsg, err.Error())


### PR DESCRIPTION
Fixes: https://github.com/googleapis/librarian/issues/2032

Changes:
- Split updateLibrary's GetCommits functionality into a separate function for easier testing (inject commits directly without having to setup a repo)

Logic:
If a library is specified for release, force a release for it. Use the library version override if provided as the new version. If the override is not specified, report an error back to the user to use the version flag.