### PR TITLE
build: dispatcher uses latest image and updates command args

### DIFF
--- a/infra/prod/generate-worker.yaml
+++ b/infra/prod/generate-worker.yaml
@@ -15,12 +15,9 @@
 # This runs the `librarian generate` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:00aa886a70e110e9e8cfb888a232a1c508031e58cfeee60870ef7a11ca3d5656
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
     id: generate-dispatcher
-    entrypoint: go
     args:
-      - 'run'
-      - './cmd/automation'
       - '--project=$PROJECT_ID'
       - '--command=generate'
       - '--push=$_PUSH'

--- a/infra/prod/publish-release-worker.yaml
+++ b/infra/prod/publish-release-worker.yaml
@@ -15,12 +15,9 @@
 # This runs the `librarian release tag-and-release` command with a provided repository,
 # secret name, and optional PR
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:00aa886a70e110e9e8cfb888a232a1c508031e58cfeee60870ef7a11ca3d5656
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
     id: publish-release-dispatcher
-    entrypoint: go
     args:
-      - 'run'
-      - './cmd/automation'
       - '--project=$PROJECT_ID'
       - '--command=publish-release'
     secretEnv: ['LIBRARIAN_GITHUB_TOKEN']

--- a/infra/prod/stage-release-worker.yaml
+++ b/infra/prod/stage-release-worker.yaml
@@ -15,12 +15,9 @@
 # This runs the `librarian release init` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:00aa886a70e110e9e8cfb888a232a1c508031e58cfeee60870ef7a11ca3d5656
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
     id: stage-release-dispatcher
-    entrypoint: go
     args:
-      - 'run'
-      - './cmd/automation'
       - '--project=$PROJECT_ID'
       - '--command=stage-release'
       - '--push=$_PUSH'


### PR DESCRIPTION
Towards #2142

The new entrypoint is the pre-built go binary which replaces `go run ./cmd/automation`