### PR TITLE
fix(internal/config): validate library IDs are unique

### DIFF
--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -47,10 +47,15 @@ func (s *LibrarianState) Validate() error {
 	if len(s.Libraries) == 0 {
 		return fmt.Errorf("libraries cannot be empty")
 	}
+	seenLibraryIDs := make(map[string]bool)
 	for i, l := range s.Libraries {
 		if l == nil {
 			return fmt.Errorf("library at index %d cannot be nil", i)
 		}
+		if _, exists := seenLibraryIDs[l.ID]; exists {
+			return fmt.Errorf("duplicate library ID %s", l.ID)
+		}
+		seenLibraryIDs[l.ID] = true
 		if err := l.Validate(); err != nil {
 			return fmt.Errorf("invalid library at index %d: %w", i, err)
 		}

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -71,14 +71,31 @@ func TestLibrarianState_Validate(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "libraries cannot be empty",
 		},
+		{
+			name: "duplicate library IDs",
+			state: &LibrarianState{
+				Image: "gcr.io/test/image:v1.2.3",
+				Libraries: []*LibraryState{
+					{
+						ID:          "x",
+						SourceRoots: []string{"src/x"},
+					},
+					{
+						ID:          "x",
+						SourceRoots: []string{"src/x"},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "duplicate library ID",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.state.Validate()
 			if test.wantErr {
 				if err == nil {
 					t.Error("Librarian.Validate() should fail")
-				}
-				if !strings.Contains(err.Error(), test.wantErrMsg) {
+				} else if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message %q, got %q", test.wantErrMsg, err.Error())
 				}
 


### PR DESCRIPTION
Fixes #2186

(Additionally, fixes a panic if a test that wants an error doesn't produce one.)