### PR TITLE
refactor(librarian): allow dependency injection of GitHub client

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -49,8 +49,8 @@ type generateRunner struct {
 	workRoot        string
 }
 
-func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
-	runner, err := newCommandRunner(cfg)
+func newGenerateRunner(cfg *config.Config, ghClient GitHubClient) (*generateRunner, error) {
+	runner, err := newCommandRunner(cfg, ghClient)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -497,7 +497,7 @@ func TestNewGenerateRunner(t *testing.T) {
 				}
 			}
 
-			r, err := newGenerateRunner(test.cfg)
+			r, err := newGenerateRunner(test.cfg, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("newGenerateRunner() error = %v, wantErr %v", err, test.wantErr)
 			}

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -78,7 +78,7 @@ func newCmdGenerate() *cli.Command {
 			if _, err := cmd.Config.IsValid(); err != nil {
 				return fmt.Errorf("failed to validate config: %s", err)
 			}
-			runner, err := newGenerateRunner(cmd.Config)
+			runner, err := newGenerateRunner(cmd.Config, nil)
 			if err != nil {
 				return err
 			}
@@ -111,7 +111,7 @@ func newCmdTagAndRelease() *cli.Command {
 			if _, err := cmd.Config.IsValid(); err != nil {
 				return fmt.Errorf("failed to validate config: %s", err)
 			}
-			runner, err := newTagAndReleaseRunner(cmd.Config)
+			runner, err := newTagAndReleaseRunner(cmd.Config, nil)
 			if err != nil {
 				return err
 			}
@@ -136,7 +136,7 @@ func newCmdInit() *cli.Command {
 			if _, err := cmd.Config.IsValid(); err != nil {
 				return fmt.Errorf("failed to validate config: %s", err)
 			}
-			runner, err := newInitRunner(cmd.Config)
+			runner, err := newInitRunner(cmd.Config, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -69,12 +69,11 @@ func TestGenerate_DefaultBehavior(t *testing.T) {
 	cfg.WorkRoot = repoDir
 	cfg.Repo = repoDir
 	cfg.APISource = apiSourceDir
-	runner, err := newGenerateRunner(cfg)
+	runner, err := newGenerateRunner(cfg, mockGH)
 	if err != nil {
 		t.Fatalf("newGenerateRunner() failed: %v", err)
 	}
 
-	runner.ghClient = mockGH
 	runner.containerClient = mockContainer
 	if err := runner.run(ctx); err != nil {
 		t.Fatalf("runner.run() failed: %v", err)

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -46,8 +46,8 @@ type initRunner struct {
 	workRoot        string
 }
 
-func newInitRunner(cfg *config.Config) (*initRunner, error) {
-	runner, err := newCommandRunner(cfg)
+func newInitRunner(cfg *config.Config, ghClient GitHubClient) (*initRunner, error) {
+	runner, err := newCommandRunner(cfg, ghClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create init runner: %w", err)
 	}

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -65,7 +65,7 @@ func TestNewInitRunner(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := newInitRunner(test.cfg)
+			_, err := newInitRunner(test.cfg, nil)
 			if test.wantErr {
 				if err == nil {
 					t.Error("newInitRunner() should return error")

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -49,8 +49,8 @@ type tagAndReleaseRunner struct {
 	state       *config.LibrarianState
 }
 
-func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
-	runner, err := newCommandRunner(cfg)
+func newTagAndReleaseRunner(cfg *config.Config, ghClient GitHubClient) (*tagAndReleaseRunner, error) {
+	runner, err := newCommandRunner(cfg, ghClient)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/tag_and_release_test.go
+++ b/internal/librarian/tag_and_release_test.go
@@ -51,7 +51,7 @@ func TestNewTagAndReleaseRunner(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			r, err := newTagAndReleaseRunner(tc.cfg)
+			r, err := newTagAndReleaseRunner(tc.cfg, nil)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("newTagAndReleaseRunner() error = %v, wantErr %v", err, tc.wantErr)
 				return


### PR DESCRIPTION
Refactors the command runners (generate, release init, tag-and-release) to allow a GitHub client to be injected as a parameter.

This change facilitates testing by enabling the use of mock clients, and involves updating the function signatures in the runners and their call sites in both the main application and the unit tests.

Note: 
I tried to increase code coverage for the codecov failure, but concluded this is not worth the effort. The challenge lies in testing the error paths for `github.ParseRemote` and `github.FetchGitHubRepoFromRemote`. These functions are called after `cloneOrOpenRepo`, which has its own logic for handling remote URLs and local paths that complicates testing the subsequent error conditions in isolation. To test the error path for `github.ParseRemote`, for example, we would need to create a test setup where `cloneOrOpenRepo` succeeds with a URL, but `ParseRemote` fails. This requires workarounds, like creating a local directory that mimics the structure of a cloned repository, which feels more complex than this refactoring warrants.