### PR TITLE
feat(sidekick): split `model.rs` into modules

### DIFF
--- a/internal/sidekick/internal/api/model.go
+++ b/internal/sidekick/internal/api/model.go
@@ -154,6 +154,14 @@ type API struct {
 	State *APIState
 }
 
+// HasMessages returns true if the API contains messages (most do).
+//
+// This is useful in the mustache templates to skip code that only makes sense
+// when per-message code follows.
+func (api *API) HasMessages() bool {
+	return len(api.Messages) != 0
+}
+
 // APIState contains helpful information that can be used when generating
 // clients.
 type APIState struct {

--- a/internal/sidekick/internal/api/mustache_helpers_test.go
+++ b/internal/sidekick/internal/api/mustache_helpers_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import "testing"
+
+func TestHasMessages(t *testing.T) {
+	m := &Message{
+		Name:    "Message",
+		Package: "test",
+		ID:      ".test.Message",
+	}
+	model := NewTestAPI([]*Message{m}, []*Enum{}, []*Service{})
+
+	if !model.HasMessages() {
+		t.Errorf("expected HasMessages() == true for: %v", model)
+	}
+
+	e := &Enum{
+		Name:    "Enum",
+		Package: "test",
+		ID:      ".test.Enum",
+	}
+	model = NewTestAPI([]*Message{}, []*Enum{e}, []*Service{})
+	if model.HasMessages() {
+		t.Errorf("expected HasMessages() == false for: %v", model)
+	}
+}

--- a/internal/sidekick/internal/rust/generate_test.go
+++ b/internal/sidekick/internal/rust/generate_test.go
@@ -19,6 +19,8 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/sidekick/internal/config"
@@ -26,7 +28,48 @@ import (
 )
 
 var (
-	testdataDir, _ = filepath.Abs("../../testdata")
+	testdataDir, _  = filepath.Abs("../../testdata")
+	expectedInNosvc = []string{
+		"README.md",
+		"Cargo.toml",
+		path.Join("src", "lib.rs"),
+		path.Join("src", "model.rs"),
+		path.Join("src", "model", "debug.rs"),
+		path.Join("src", "model", "deserialize.rs"),
+		path.Join("src", "model", "serialize.rs"),
+	}
+	expectedInCrate = append(expectedInNosvc,
+		path.Join("src", "builder.rs"),
+		path.Join("src", "client.rs"),
+		path.Join("src", "tracing.rs"),
+		path.Join("src", "transport.rs"),
+		path.Join("src", "stub.rs"),
+		path.Join("src", "stub", "dynamic.rs"),
+	)
+	expectedInClient = []string{
+		path.Join("mod.rs"),
+		path.Join("model.rs"),
+		path.Join("model", "debug.rs"),
+		path.Join("model", "deserialize.rs"),
+		path.Join("model", "serialize.rs"),
+		path.Join("builder.rs"),
+		path.Join("client.rs"),
+		path.Join("tracing.rs"),
+		path.Join("transport.rs"),
+		path.Join("stub.rs"),
+		path.Join("stub", "dynamic.rs"),
+	}
+	unexpectedInClient = []string{
+		"README.md",
+		"Cargo.toml",
+		path.Join("src", "lib.rs"),
+	}
+	expectedInModule = []string{
+		path.Join("mod.rs"),
+		path.Join("debug.rs"),
+		path.Join("deserialize.rs"),
+		path.Join("serialize.rs"),
+	}
 )
 
 func TestRustFromOpenAPI(t *testing.T) {
@@ -47,7 +90,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 	if err := Generate(model, outDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	for _, expected := range []string{"README.md", "Cargo.toml", "src/lib.rs"} {
+	for _, expected := range expectedInCrate {
 		filename := path.Join(outDir, expected)
 		stat, err := os.Stat(filename)
 		if os.IsNotExist(err) {
@@ -57,6 +100,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
+	importsModelModules(t, path.Join(outDir, "src", "model.rs"))
 }
 
 func TestRustFromProtobuf(t *testing.T) {
@@ -80,7 +124,7 @@ func TestRustFromProtobuf(t *testing.T) {
 	if err := Generate(model, outDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	for _, expected := range []string{"README.md", "Cargo.toml", "src/lib.rs"} {
+	for _, expected := range expectedInCrate {
 		filename := path.Join(outDir, expected)
 		stat, err := os.Stat(filename)
 		if os.IsNotExist(err) {
@@ -90,6 +134,91 @@ func TestRustFromProtobuf(t *testing.T) {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
+	importsModelModules(t, path.Join(outDir, "src", "model.rs"))
+}
+
+func TestRustClient(t *testing.T) {
+	requireProtoc(t)
+	for _, override := range []string{"http-client", "grpc-client"} {
+		outDir := t.TempDir()
+
+		cfg := &config.Config{
+			General: config.GeneralConfig{
+				SpecificationFormat: "protobuf",
+				ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				SpecificationSource: "google/cloud/secretmanager/v1",
+			},
+			Source: map[string]string{
+				"googleapis-root": path.Join(testdataDir, "googleapis"),
+			},
+			Codec: map[string]string{
+				"copyright-year":    "2025",
+				"template-override": path.Join("templates", override),
+			},
+		}
+		model, err := parser.CreateModel(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := Generate(model, outDir, cfg); err != nil {
+			t.Fatal(err)
+		}
+		for _, expected := range expectedInClient {
+			filename := path.Join(outDir, expected)
+			stat, err := os.Stat(filename)
+			if os.IsNotExist(err) {
+				t.Errorf("missing %s: %s", filename, err)
+			}
+			if stat.Mode().Perm()|0666 != 0666 {
+				t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
+			}
+		}
+		for _, unexpected := range unexpectedInClient {
+			filename := path.Join(outDir, unexpected)
+			if stat, err := os.Stat(filename); err == nil {
+				t.Errorf("did not expect file %s, got=%v", unexpected, stat)
+			}
+		}
+		importsModelModules(t, path.Join(outDir, "model.rs"))
+	}
+}
+
+func TestRustNosvc(t *testing.T) {
+	requireProtoc(t)
+	outDir := t.TempDir()
+
+	cfg := &config.Config{
+		General: config.GeneralConfig{
+			SpecificationFormat: "protobuf",
+			ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+			SpecificationSource: "google/cloud/secretmanager/v1",
+		},
+		Source: map[string]string{
+			"googleapis-root": path.Join(testdataDir, "googleapis"),
+		},
+		Codec: map[string]string{
+			"copyright-year":    "2025",
+			"template-override": path.Join("templates", "nosvc"),
+		},
+	}
+	model, err := parser.CreateModel(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Generate(model, outDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range expectedInNosvc {
+		filename := path.Join(outDir, expected)
+		stat, err := os.Stat(filename)
+		if os.IsNotExist(err) {
+			t.Errorf("missing %s: %s", filename, err)
+		}
+		if stat.Mode().Perm()|0666 != 0666 {
+			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
+		}
+	}
+	importsModelModules(t, path.Join(outDir, "src", "model.rs"))
 }
 
 func TestRustModuleRpc(t *testing.T) {
@@ -118,7 +247,7 @@ func TestRustModuleRpc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, expected := range []string{"mod.rs"} {
+	for _, expected := range expectedInModule {
 		filename := path.Join(outDir, "rpc", expected)
 		stat, err := os.Stat(filename)
 		if os.IsNotExist(err) {
@@ -128,6 +257,7 @@ func TestRustModuleRpc(t *testing.T) {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
+	importsModelModules(t, path.Join(outDir, "rpc", "mod.rs"))
 }
 
 func TestRustBootstrapWkt(t *testing.T) {
@@ -157,7 +287,7 @@ func TestRustBootstrapWkt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, expected := range []string{"mod.rs"} {
+	for _, expected := range expectedInModule {
 		filename := path.Join(outDir, "wkt", expected)
 		stat, err := os.Stat(filename)
 		if os.IsNotExist(err) {
@@ -165,6 +295,20 @@ func TestRustBootstrapWkt(t *testing.T) {
 		}
 		if stat.Mode().Perm()|0666 != 0666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
+		}
+	}
+}
+
+func importsModelModules(t *testing.T, filename string) {
+	t.Helper()
+	contents, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(contents), "\n")
+	for _, want := range []string{"mod debug;", "mod serialize;", "mod deserialize;"} {
+		if !slices.Contains(lines, want) {
+			t.Errorf("expected file %s to have a line matching %q, got:\n%s", filename, want, contents)
 		}
 	}
 }

--- a/internal/sidekick/internal/rust/templates/common/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/message.mustache
@@ -48,7 +48,7 @@ pub struct {{Codec.Name}} {
     pub {{Codec.FieldName}}: std::option::Option<{{{Codec.FieldType}}}>,
     {{/OneOfs}}
 
-    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+    pub(crate) _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
 {{> /templates/common/feature_gate}}
@@ -249,112 +249,6 @@ impl gax::paginator::internal::PageableResponse for {{Codec.Name}} {
     {{/NextPageToken}}
 }
 {{/Pagination}}
-
-{{!
-    We will grow this code over multiple PRs to complete the serialization and
-    deserialization of message types via code generation.
-}}
-{{> /templates/common/feature_gate}}
-#[doc(hidden)]
-impl<'de> serde::de::Deserialize<'de> for {{Codec.Name}} {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        {{> /templates/common/deser_field_tag}}
-        {{! This is the visitor for the message }}
-        struct Visitor;
-        impl<'de> serde::de::Visitor<'de> for Visitor {
-            type Value = {{Codec.Name}};
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("struct {{Codec.Name}}")
-            }
-            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                use std::option::Option::Some;
-                #[allow(unused_imports)]
-                use serde::de::Error;
-                {{#HasFields}}
-                let mut fields = std::collections::HashSet::new();
-                {{/HasFields}}
-                let mut result = Self::Value::new();
-                while let Some(tag) = map.next_key::<__FieldTag>()? {
-                    #[allow(clippy::match_single_binding)]
-                    match tag {
-                        {{#Fields}}
-                        __FieldTag::__{{Codec.SetterName}} => {
-                            if !fields.insert(__FieldTag::__{{Codec.SetterName}}) {
-                                return std::result::Result::Err(A::Error::duplicate_field("multiple values for {{Codec.SetterName}}"));
-                            }
-                            {{^Codec.RequiresSerdeAs}}
-                            {{> /templates/common/deser_plain_message_field}}
-                            {{/Codec.RequiresSerdeAs}}
-                            {{#Codec.RequiresSerdeAs}}
-                            {{> /templates/common/deser_with_message_field}}
-                            {{/Codec.RequiresSerdeAs}}
-                        },
-                        {{/Fields}}
-                        __FieldTag::Unknown(key) => {
-                            let value = map.next_value::<serde_json::Value>()?;
-                            result._unknown_fields.insert(key, value);
-                        },
-                    }
-                }
-                std::result::Result::Ok(result)
-            }
-        }
-        deserializer.deserialize_any(Visitor)
-    }
-}
-
-{{> /templates/common/feature_gate}}
-#[doc(hidden)]
-impl serde::ser::Serialize for {{Codec.Name}} {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        #[allow(unused_imports)]
-        use std::option::Option::Some;
-        use serde::ser::SerializeMap;
-        let mut state = serializer.serialize_map(std::option::Option::None)?;
-        {{#Fields}}
-        {{^Synthetic}}
-        {{^Codec.RequiresSerdeAs}}
-        {{> /templates/common/ser_plain_message_field}}
-        {{/Codec.RequiresSerdeAs}}
-        {{#Codec.RequiresSerdeAs}}
-        {{> /templates/common/ser_with_message_field}}
-        {{/Codec.RequiresSerdeAs}}
-        {{/Synthetic}}
-        {{/Fields}}
-        if !self._unknown_fields.is_empty() {
-            for (key, value) in self._unknown_fields.iter() {
-                state.serialize_entry(key, &value)?;
-            }
-        }
-        state.end()
-    }
-}
-
-{{> /templates/common/feature_gate}}
-impl std::fmt::Debug for {{Codec.Name}} {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug_struct = f.debug_struct("{{Codec.Name}}");
-        {{#Codec.BasicFields}}
-        debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
-        {{/Codec.BasicFields}}
-        {{#OneOfs}}
-        debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
-        {{/OneOfs}}
-        if !self._unknown_fields.is_empty() {
-            debug_struct.field("_unknown_fields", &self._unknown_fields);
-        }
-        debug_struct.finish()
-    }
-}
 {{#Codec.HasNestedTypes}}
 
 /// Defines additional types related to [{{Name}}].

--- a/internal/sidekick/internal/rust/templates/common/model/debug.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/debug.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,23 +17,11 @@ limitations under the License.
 {{#Codec.BoilerPlate}}
 //{{{.}}}
 {{/Codec.BoilerPlate}}
+{{#HasMessages}}
 
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
+#[allow(unused_imports)]
+use super::*;
+{{/HasMessages}}
 {{#Messages}}
-{{> message}}
+{{> /templates/common/model/debug/message}}
 {{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}

--- a/internal/sidekick/internal/rust/templates/common/model/debug/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/debug/message.mustache
@@ -1,0 +1,39 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
+{{> /templates/common/feature_gate}}
+impl std::fmt::Debug for super::{{Codec.RelativeName}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_struct = f.debug_struct("{{Codec.Name}}");
+        {{#Codec.BasicFields}}
+        debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
+        {{/Codec.BasicFields}}
+        {{#OneOfs}}
+        debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
+        {{/OneOfs}}
+        if !self._unknown_fields.is_empty() {
+            debug_struct.field("_unknown_fields", &self._unknown_fields);
+        }
+        debug_struct.finish()
+    }
+}
+{{#Codec.HasNestedTypes}}
+{{#Messages}}
+{{^IsMap}}
+{{> /templates/common/model/debug/message}}
+{{/IsMap}}
+{{/Messages}}
+{{/Codec.HasNestedTypes}}

--- a/internal/sidekick/internal/rust/templates/common/model/deserialize.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/deserialize.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,23 +17,11 @@ limitations under the License.
 {{#Codec.BoilerPlate}}
 //{{{.}}}
 {{/Codec.BoilerPlate}}
+{{#HasMessages}}
 
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
+#[allow(unused_imports)]
+use super::*;
+{{/HasMessages}}
 {{#Messages}}
-{{> message}}
+{{> /templates/common/model/deserialize/message}}
 {{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}

--- a/internal/sidekick/internal/rust/templates/common/model/deserialize/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/deserialize/message.mustache
@@ -1,0 +1,77 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
+{{> /templates/common/feature_gate}}
+#[doc(hidden)]
+impl<'de> serde::de::Deserialize<'de> for super::{{Codec.RelativeName}} {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        {{> /templates/common/deser_field_tag}}
+        {{! This is the visitor for the message }}
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = super::{{Codec.RelativeName}};
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct {{Codec.Name}}")
+            }
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                use std::option::Option::Some;
+                #[allow(unused_imports)]
+                use serde::de::Error;
+                {{#HasFields}}
+                let mut fields = std::collections::HashSet::new();
+                {{/HasFields}}
+                let mut result = Self::Value::new();
+                while let Some(tag) = map.next_key::<__FieldTag>()? {
+                    #[allow(clippy::match_single_binding)]
+                    match tag {
+                        {{#Fields}}
+                        __FieldTag::__{{Codec.SetterName}} => {
+                            if !fields.insert(__FieldTag::__{{Codec.SetterName}}) {
+                                return std::result::Result::Err(A::Error::duplicate_field("multiple values for {{Codec.SetterName}}"));
+                            }
+                            {{^Codec.RequiresSerdeAs}}
+                            {{> /templates/common/deser_plain_message_field}}
+                            {{/Codec.RequiresSerdeAs}}
+                            {{#Codec.RequiresSerdeAs}}
+                            {{> /templates/common/deser_with_message_field}}
+                            {{/Codec.RequiresSerdeAs}}
+                        },
+                        {{/Fields}}
+                        __FieldTag::Unknown(key) => {
+                            let value = map.next_value::<serde_json::Value>()?;
+                            result._unknown_fields.insert(key, value);
+                        },
+                    }
+                }
+                std::result::Result::Ok(result)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+{{#Codec.HasNestedTypes}}
+{{#Messages}}
+{{^IsMap}}
+{{> /templates/common/model/deserialize/message}}
+{{/IsMap}}
+{{/Messages}}
+{{/Codec.HasNestedTypes}}

--- a/internal/sidekick/internal/rust/templates/common/model/serialize.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/serialize.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,23 +17,11 @@ limitations under the License.
 {{#Codec.BoilerPlate}}
 //{{{.}}}
 {{/Codec.BoilerPlate}}
+{{#HasMessages}}
 
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
+#[allow(unused_imports)]
+use super::*;
+{{/HasMessages}}
 {{#Messages}}
-{{> message}}
+{{> /templates/common/model/serialize/message}}
 {{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}

--- a/internal/sidekick/internal/rust/templates/common/model/serialize/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/serialize/message.mustache
@@ -1,0 +1,52 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
+{{> /templates/common/feature_gate}}
+#[doc(hidden)]
+impl serde::ser::Serialize for super::{{Codec.RelativeName}} {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        #[allow(unused_imports)]
+        use std::option::Option::Some;
+        use serde::ser::SerializeMap;
+        let mut state = serializer.serialize_map(std::option::Option::None)?;
+        {{#Fields}}
+        {{^Synthetic}}
+        {{^Codec.RequiresSerdeAs}}
+        {{> /templates/common/ser_plain_message_field}}
+        {{/Codec.RequiresSerdeAs}}
+        {{#Codec.RequiresSerdeAs}}
+        {{> /templates/common/ser_with_message_field}}
+        {{/Codec.RequiresSerdeAs}}
+        {{/Synthetic}}
+        {{/Fields}}
+        if !self._unknown_fields.is_empty() {
+            for (key, value) in self._unknown_fields.iter() {
+                state.serialize_entry(key, &value)?;
+            }
+        }
+        state.end()
+    }
+}
+{{#Codec.HasNestedTypes}}
+{{#Messages}}
+{{^IsMap}}
+{{> /templates/common/model/serialize/message}}
+{{/IsMap}}
+{{/Messages}}
+{{/Codec.HasNestedTypes}}

--- a/internal/sidekick/internal/rust/templates/crate/src/model/debug.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/model/debug.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/debug}}

--- a/internal/sidekick/internal/rust/templates/crate/src/model/deserialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/model/deserialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/deserialize}}

--- a/internal/sidekick/internal/rust/templates/crate/src/model/serialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/model/serialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/serialize}}

--- a/internal/sidekick/internal/rust/templates/grpc-client/model/debug.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/grpc-client/model/debug.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/debug}}

--- a/internal/sidekick/internal/rust/templates/grpc-client/model/deserialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/grpc-client/model/deserialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/deserialize}}

--- a/internal/sidekick/internal/rust/templates/grpc-client/model/serialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/grpc-client/model/serialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/serialize}}

--- a/internal/sidekick/internal/rust/templates/http-client/model/debug.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/model/debug.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/debug}}

--- a/internal/sidekick/internal/rust/templates/http-client/model/deserialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/model/deserialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/deserialize}}

--- a/internal/sidekick/internal/rust/templates/http-client/model/serialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/http-client/model/serialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/serialize}}

--- a/internal/sidekick/internal/rust/templates/mod/debug.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/mod/debug.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/debug}}

--- a/internal/sidekick/internal/rust/templates/mod/deserialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/mod/deserialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/deserialize}}

--- a/internal/sidekick/internal/rust/templates/mod/mod.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/mod/mod.rs.mustache
@@ -27,6 +27,10 @@ This file is used to bootstrap the `google-cloud-wkt` crate. In all other crates
 `wkt` is well-defined and refers to said crate.}}
 use crate as wkt;
 {{/Codec.IsWktCrate}}
+
+mod debug;
+mod deserialize;
+mod serialize;
 {{#Messages}}
 {{> message}}
 {{/Messages}}

--- a/internal/sidekick/internal/rust/templates/mod/serialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/mod/serialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/serialize}}

--- a/internal/sidekick/internal/rust/templates/nosvc/src/model/debug.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/nosvc/src/model/debug.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/debug}}

--- a/internal/sidekick/internal/rust/templates/nosvc/src/model/deserialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/nosvc/src/model/deserialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/deserialize}}

--- a/internal/sidekick/internal/rust/templates/nosvc/src/model/serialize.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/nosvc/src/model/serialize.rs.mustache
@@ -1,5 +1,5 @@
 {{!
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,27 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
-
-{{! Disable warnings that are known to cause trouble }}
-{{#Codec.DisabledRustdocWarnings}}
-#![allow(rustdoc::{{.}})]
-{{/Codec.DisabledRustdocWarnings}}
-#![no_implicit_prelude]
-extern crate std;
-{{#Codec.ExternPackages}}
-extern crate {{.}};
-{{/Codec.ExternPackages}}
-
-mod debug;
-mod deserialize;
-mod serialize;
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{> /templates/common/model/serialize}}


### PR DESCRIPTION
In Rust, the documentation browser shows the code, and this code was
getting too large to render effectively. For some crates, the module is
also too large for some IDE defaults.

Motivated by https://github.com/googleapis/google-cloud-rust/issues/2550