### PR TITLE
chore: increase timeout for librarian generate jobs to 2 hours

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -72,3 +72,4 @@ availableSecrets:
       env: 'LIBRARIAN_GITHUB_TOKEN'
 options:
   logging: CLOUD_LOGGING_ONLY
+timeout: 2h


### PR DESCRIPTION
To support the onboarding of additional libraries in mono repo