### PR TITLE
tests(internal): avoid a panic when expecting an error

### DIFF
--- a/internal/automation/cli_test.go
+++ b/internal/automation/cli_test.go
@@ -142,7 +142,7 @@ func TestParseArgs(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := parseFlags(test.args)
 			if test.wantErr && err == nil {
-				t.Errorf("expected error, but did not return one")
+				t.Fatal("expected error, but did not return one")
 			} else if !test.wantErr && err != nil {
 				t.Errorf("did not expect error, but received one: %s", err)
 			}

--- a/internal/automation/trigger_test.go
+++ b/internal/automation/trigger_test.go
@@ -195,7 +195,7 @@ func TestRunCommandWithClient(t *testing.T) {
 			}
 			err := runCommandWithClient(ctx, client, ghClient, test.command, "some-project", test.push, test.build, test.forceRun, test.dateTime)
 			if test.wantErr && err == nil {
-				t.Errorf("expected error, but did not return one")
+				t.Fatal("expected error, but did not return one")
 			} else if !test.wantErr && err != nil {
 				t.Errorf("did not expect error, but received one: %s", err)
 			}
@@ -345,7 +345,7 @@ func TestRunCommandWithConfig(t *testing.T) {
 			}
 			err := runCommandWithConfig(ctx, client, ghClient, test.command, "some-project", true, true, test.forceRun, test.config, test.dateTime)
 			if test.wantErr && err == nil {
-				t.Errorf("expected error, but did not return one")
+				t.Fatal("expected error, but did not return one")
 			} else if !test.wantErr && err != nil {
 				t.Errorf("did not expect error, but received one: %s", err)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -545,7 +545,7 @@ func TestValidateHostMount(t *testing.T) {
 			ok, err := validateHostMount(test.hostMount, test.defaultMount)
 			if test.wantErr {
 				if err == nil {
-					t.Error("validateHostMount() should return error")
+					t.Fatal("validateHostMount() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/config/librarian_config_test.go
+++ b/internal/config/librarian_config_test.go
@@ -86,7 +86,7 @@ func TestGlobalConfig_Validate(t *testing.T) {
 			err := test.config.Validate()
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("GlobalConfig.Validate() should return error")
+					t.Fatal("GlobalConfig.Validate() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -94,8 +94,9 @@ func TestLibrarianState_Validate(t *testing.T) {
 			err := test.state.Validate()
 			if test.wantErr {
 				if err == nil {
-					t.Error("Librarian.Validate() should fail")
-				} else if !strings.Contains(err.Error(), test.wantErrMsg) {
+					t.Fatal("Librarian.Validate() should fail")
+				}
+				if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message %q, got %q", test.wantErrMsg, err.Error())
 				}
 
@@ -316,7 +317,7 @@ func TestLibrary_Validate(t *testing.T) {
 			err := test.library.Validate()
 			if test.wantErr {
 				if err == nil {
-					t.Error("Library.Validate() should fail")
+					t.Fatal("Library.Validate() should fail")
 				}
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message %q, got %q", test.wantErrMsg, err.Error())
@@ -362,7 +363,7 @@ func TestAPI_Validate(t *testing.T) {
 			err := test.api.Validate()
 			if test.wantErr {
 				if err == nil {
-					t.Error("API.Validate() should fail")
+					t.Fatal("API.Validate() should fail")
 				}
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message %q, got %q", test.wantErrMsg, err.Error())

--- a/internal/conventionalcommits/conventional_commits_test.go
+++ b/internal/conventionalcommits/conventional_commits_test.go
@@ -463,7 +463,7 @@ END_COMMIT_OVERRIDE`,
 			got, err := ParseCommits(commit, "example-id")
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrPhrase) {
 					t.Errorf("ParseCommits(%q) returned error %q, want to contain %q", test.message, err.Error(), test.wantErrPhrase)

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -521,7 +521,7 @@ func TestDockerRun(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message: %s, got: %s", test.wantErrMsg, err.Error())
@@ -620,7 +620,7 @@ func TestWriteLibraryState(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("writeLibraryState() shoud fail")
+					t.Fatalf("writeLibraryState() shoud fail")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -731,7 +731,7 @@ func TestWriteLibrarianState(t *testing.T) {
 			err := writeLibrarianState(test.state, filePath)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("writeLibrarianState() shoud fail")
+					t.Fatalf("writeLibrarianState() shoud fail")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -105,8 +105,9 @@ func TestGetRawContent(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("GetRawContent() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("GetRawContent() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("GetRawContent() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else {
@@ -220,8 +221,9 @@ func TestFetchGitHubRepoFromRemote(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("FetchGitHubRepoFromRemote() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("FetchGitHubRepoFromRemote() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("FetchGitHubRepoFromRemote() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else {
@@ -276,8 +278,9 @@ func TestParseURL(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("ParseURL() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("ParseURL() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("ParseURL() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else {
@@ -335,8 +338,9 @@ func TestParseSSHRemote(t *testing.T) {
 			repo, err := parseSSHRemote(test.remote)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("ParseSSHRemote() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("ParseSSHRemote() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("ParseSSHRemote() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else {
@@ -440,8 +444,9 @@ func TestCreatePullRequest(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("CreatePullRequest() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("CreatePullRequest() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("CreatePullRequest() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else if err != nil {
@@ -507,7 +512,7 @@ func TestAddLabelsToIssue(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("AddLabelsToIssue() should return an error")
+					t.Fatal("AddLabelsToIssue() should return an error")
 				}
 				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("AddLabelsToIssue() err = %v, want error containing %q", err, test.wantErrSubstr)
@@ -582,7 +587,7 @@ func TestGetLabels(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("GetLabels() should return an error")
+					t.Fatal("GetLabels() should return an error")
 				}
 				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("GetLabels() err = %v, want error containing %q", err, test.wantErrSubstr)
@@ -655,7 +660,7 @@ func TestReplaceLabels(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("ReplaceLabels() should return an error")
+					t.Fatal("ReplaceLabels() should return an error")
 				}
 				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("ReplaceLabels() err = %v, want error containing %q", err, test.wantErrSubstr)
@@ -761,8 +766,9 @@ func TestSearchPullRequests(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("SearchPullRequests() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("SearchPullRequests() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("SearchPullRequests() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else if err != nil {
@@ -824,8 +830,9 @@ func TestGetPullRequest(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("GetPullRequest() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("GetPullRequest() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("GetPullRequest() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else if err != nil {
@@ -901,8 +908,9 @@ func TestCreateRelease(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("CreateRelease() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("CreateRelease() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("CreateRelease() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else if err != nil {
@@ -970,8 +978,9 @@ func TestCreateIssueComment(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("CreateComment() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("CreateComment() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("CreateComment() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else if err != nil {
@@ -1033,8 +1042,9 @@ func TestFindMergedPullRequestsWithPendingReleaseLabel(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("FindMergedPullRequestsWithPendingReleaseLabel() err = nil, want error containing %q", test.wantErrSubstr)
-				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Fatalf("FindMergedPullRequestsWithPendingReleaseLabel() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
 					t.Errorf("FindMergedPullRequestsWithPendingReleaseLabel() err = %v, want error containing %q", err, test.wantErrSubstr)
 				}
 			} else if err != nil {
@@ -1100,7 +1110,7 @@ func TestCreateTag(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("CreateTag() err = nil, expected error")
+					t.Fatal("CreateTag() err = nil, expected error")
 				}
 			} else if err != nil {
 				t.Errorf("CreateTag() err = %v, want nil", err)

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -662,7 +662,7 @@ func TestGetCommit(t *testing.T) {
 			got, err := repo.GetCommit(commitHash)
 			if test.wantErr {
 				if err == nil {
-					t.Error("GetCommit() should fail")
+					t.Fatal("GetCommit() should fail")
 				}
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message %s, got %s", test.wantErrMsg, err.Error())
@@ -991,7 +991,7 @@ func TestGetCommitsForPathsSinceCommit(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrPhrase) {
 					t.Errorf("GetCommitsForPathsSinceCommit() returned error %q, want to contain %q", err.Error(), test.wantErrPhrase)
@@ -1053,7 +1053,7 @@ func TestGetCommitsForPathsSinceTag(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrPhrase) {
 					t.Errorf("GetCommitsForPathsSinceTag() returned error %q, want to contain %q", err.Error(), test.wantErrPhrase)
@@ -1099,7 +1099,7 @@ func TestCreateBranchAndCheckout(t *testing.T) {
 			err := repo.CreateBranchAndCheckout(test.branchName)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrPhrase) {
 					t.Errorf("CreateBranchAndCheckout() returned error %q, want to contain %q", err.Error(), test.wantErrPhrase)

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -244,7 +244,7 @@ func TestCloneOrOpenLanguageRepo(t *testing.T) {
 			repo, err := cloneOrOpenRepo(workRoot, test.repo, 1, test.ci, "main", "")
 			if test.wantErr {
 				if err == nil {
-					t.Error("cloneOrOpenLanguageRepo() expected an error but got nil")
+					t.Fatal("cloneOrOpenLanguageRepo() expected an error but got nil")
 				}
 				return
 			}
@@ -493,7 +493,7 @@ func TestCleanAndCopyLibrary(t *testing.T) {
 			err := cleanAndCopyLibrary(test.state, repoDir, test.libraryID, outputDir)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.errContains) {
 					t.Errorf("want: %s, got %s", test.errContains, err.Error())
@@ -792,7 +792,7 @@ func TestClean(t *testing.T) {
 			err := clean(tmpDir, test.sourceRoots, test.removePatterns, test.preservePatterns)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				return
 			}
@@ -979,7 +979,7 @@ func TestFindSubDirRelPaths(t *testing.T) {
 			paths, err := findSubDirRelPaths(rootDirPath, subDirPath)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.errorString) {
 					t.Errorf("runConfigureCommand() err = %v, want error containing %q", err, test.errorString)
@@ -1134,7 +1134,7 @@ func TestFilterPathsForRemoval(t *testing.T) {
 			gotToRemove, err := filterPathsForRemoval(sourceRootPaths, test.removePatterns, test.preservePatterns)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				return
 			}
@@ -1205,7 +1205,7 @@ func TestSeparateFilesAndDirs(t *testing.T) {
 			gotFiles, gotDirs, err := separateFilesAndDirs(paths)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				return
 			}
@@ -1594,8 +1594,9 @@ func TestCommitAndPush(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("commitAndPush() expected error, got nil")
-				} else if test.expectedErrMsg != "" && !strings.Contains(err.Error(), test.expectedErrMsg) {
+					t.Fatal("commitAndPush() expected error, got nil")
+				}
+				if test.expectedErrMsg != "" && !strings.Contains(err.Error(), test.expectedErrMsg) {
 					t.Errorf("commitAndPush() error = %v, expected to contain: %q", err, test.expectedErrMsg)
 				}
 				return
@@ -1654,7 +1655,7 @@ func TestAddLabelsToPullRequest(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("addLabelsToPullRequest() expected error, got nil")
+					t.Fatal("addLabelsToPullRequest() expected error, got nil")
 				}
 				if test.expectedErrMsg != "" && !strings.Contains(err.Error(), test.expectedErrMsg) {
 					t.Errorf("addLabelsToPullRequest() error = %v, expected to contain: %q", err, test.expectedErrMsg)
@@ -1847,11 +1848,9 @@ func TestCopyLibraryFiles(t *testing.T) {
 			err := copyLibraryFiles(test.state, test.repoDir, test.libraryID, test.outputDir)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("copyLibraryFiles() shoud fail")
-					return
+					t.Fatal("copyLibraryFiles() shoud fail")
 				}
-				e := err.Error()
-				if !strings.Contains(e, test.wantErrMsg) {
+				if !strings.Contains(err.Error(), test.wantErrMsg) {
 					t.Errorf("want error message: %s, got: %s", test.wantErrMsg, err.Error())
 				}
 
@@ -1930,7 +1929,7 @@ func TestCopyFile(t *testing.T) {
 			err := copyFile(test.dst, test.foo)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("copyFile() shoud fail")
+					t.Fatal("copyFile() should fail")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -190,7 +190,7 @@ func TestRunBuildCommand(t *testing.T) {
 			err := r.runBuildCommand(context.Background(), test.libraryID)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				return
 			}
@@ -357,7 +357,7 @@ func TestRunConfigureCommand(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("runConfigureCommand() should return error")
+					t.Fatal("runConfigureCommand() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -913,7 +913,7 @@ func TestGenerateScenarios(t *testing.T) {
 			err := r.run(context.Background())
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -70,7 +70,7 @@ func TestNewInitRunner(t *testing.T) {
 			_, err := newInitRunner(test.cfg)
 			if test.wantErr {
 				if err == nil {
-					t.Error("newInitRunner() should return error")
+					t.Fatal("newInitRunner() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -875,7 +875,7 @@ func TestInitRun(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Error("run() should return error")
+					t.Fatal("run() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -1070,7 +1070,7 @@ func TestUpdateLibrary(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Error("getChangesOf() should return error")
+					t.Fatal("getChangesOf() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -1261,7 +1261,7 @@ func TestCopyGlobalAllowlist(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Error("cleanAndCopyGlobalAllowlist() should return error")
+					t.Fatal("cleanAndCopyGlobalAllowlist() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -1420,7 +1420,7 @@ func TestDetermineNextVersion(t *testing.T) {
 			got, err := runner.determineNextVersion(test.commits, test.currentVersion, test.libraryID)
 			if test.wantErr {
 				if err == nil {
-					t.Error("determineNextVersion() should return error")
+					t.Fatal("determineNextVersion() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/librarian/release_notes_test.go
+++ b/internal/librarian/release_notes_test.go
@@ -356,7 +356,7 @@ END_COMMIT_OVERRIDE`,
 			got, err := formatGenerationPRBody(test.repo, test.state, test.idToCommits, test.failedLibraries)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrPhrase) {
 					t.Errorf("formatGenerationPRBody() returned error %q, want to contain %q", err.Error(), test.wantErrPhrase)
@@ -460,7 +460,7 @@ func TestFindLatestCommit(t *testing.T) {
 			got, err := findLatestGenerationCommit(test.repo, test.state, test.idToCommits)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrPhrase) {
 					t.Errorf("findLatestCommit() returned error %q, want to contain %q", err.Error(), test.wantErrPhrase)
@@ -772,7 +772,7 @@ Language Image: go:1.21
 			got, err := formatReleaseNotes(test.repo, test.state)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("%s should return error", test.name)
+					t.Fatalf("%s should return error", test.name)
 				}
 				if !strings.Contains(err.Error(), test.wantErrPhrase) {
 					t.Errorf("formatReleaseNotes() returned error %q, want to contain %q", err.Error(), test.wantErrPhrase)

--- a/internal/librarian/state_test.go
+++ b/internal/librarian/state_test.go
@@ -143,7 +143,7 @@ func TestFindServiceConfigIn(t *testing.T) {
 			got, err := findServiceConfigIn(test.path)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("findServiceConfigIn() should return error")
+					t.Fatal("findServiceConfigIn() should return error")
 				}
 
 				return
@@ -191,7 +191,7 @@ func TestParseGlobalConfig(t *testing.T) {
 			got, err := parseLibrarianConfig(path)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("parseGlobalConfig() should return error")
+					t.Fatal("parseGlobalConfig() should return error")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -278,7 +278,7 @@ func TestPopulateServiceConfig(t *testing.T) {
 			err := populateServiceConfigIfEmpty(test.state, test.path)
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("findServiceConfigIn() should return error")
+					t.Fatal("findServiceConfigIn() should return error")
 				}
 
 				return
@@ -393,7 +393,7 @@ func TestReadLibraryState(t *testing.T) {
 
 			if test.name == "load content with an error message" {
 				if err == nil {
-					t.Errorf("readLibraryState() expected an error but got nil")
+					t.Fatal("readLibraryState() expected an error but got nil")
 				}
 
 				if g, w := err.Error(), "failed with error message"; !strings.Contains(g, w) {
@@ -405,7 +405,7 @@ func TestReadLibraryState(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Errorf("readLibraryState() should fail")
+					t.Fatal("readLibraryState() should fail")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/sidekick/internal/api/dependencies_test.go
+++ b/internal/sidekick/internal/api/dependencies_test.go
@@ -30,7 +30,7 @@ func TestFindDependenciesUnknownIdErrors(t *testing.T) {
 
 	_, err := FindDependencies(model, []string{".test.UnknownId"})
 	if err == nil {
-		t.Errorf("FindDependencies should error on unknown IDs")
+		t.Fatal("FindDependencies should error on unknown IDs")
 	}
 
 	msg := err.Error()

--- a/internal/sidekick/internal/api/skip_test.go
+++ b/internal/sidekick/internal/api/skip_test.go
@@ -232,7 +232,7 @@ func TestIncludeUnknownIdError(t *testing.T) {
 		"included-ids": ".test.UnknownId",
 	})
 	if err == nil {
-		t.Errorf("SkipModelElements should error on unknown IDs")
+		t.Fatal("SkipModelElements should error on unknown IDs")
 	}
 
 	msg := err.Error()


### PR DESCRIPTION
These changes all use Fatal or Fatalf to abort a test when an expected error isn't returned (i.e. `err == nil`). This avoids a panic when further checks are performed on the error, typically checking its message.

Some tests used if/else-if to avoid this panic. This change updates all tests to a consistent style.

For internal/sidekick, this only changes the "definitely wrong" cases. There are some other tests which are currently fine due to only checking whether or not there *is* an error, but which would need modification if the test were changed to check for a particular error message.

Some other tests are

Fixes #2216