### PR TITLE
feat: generate_blocked field in per-library configuration

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -29,6 +29,7 @@ Each object in the `libraries` list represents a single library and has the foll
 |-------------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
 | `id`           | string | A unique identifier for the library, in a language-specific format. It should not be empty and only contains alphanumeric characters, slashes, periods, underscores, and hyphens. | Yes      | Must be a valid library ID.                               |
 | `next_version` | string | The next released version of the library. Ignored unless it would increase the release version.                                                                                   | No       | Must be a valid semantic version, "v" prefix is optional. |
+| `generate_blocked` | bool | Set this to `true` to skip the generation of this library. It's `false` by default. | No       |  |
 
 ## Example
 
@@ -54,4 +55,5 @@ global_files_allowlist:
 libraries:
   - id: "example-library"
     next_version: "2.3.4"
+    generate_blocked: false
 ```

--- a/internal/config/librarian_config.go
+++ b/internal/config/librarian_config.go
@@ -32,8 +32,9 @@ type LibrarianConfig struct {
 
 // LibraryConfig defines configuration for a single library, identified by its ID.
 type LibraryConfig struct {
-	LibraryID   string `yaml:"id"`
-	NextVersion string `yaml:"next_version"`
+	LibraryID       string `yaml:"id"`
+	NextVersion     string `yaml:"next_version"`
+	GenerateBlocked bool   `yaml:"generate_blocked"`
 }
 
 // GlobalFile defines the global files in language repositories.

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -46,7 +46,7 @@ type generateRunner struct {
 	repo            gitrepo.Repository
 	sourceRepo      gitrepo.Repository
 	state           *config.LibrarianState
-	libraryConfig   *config.LibrarianConfig
+	librarianConfig *config.LibrarianConfig
 	workRoot        string
 }
 
@@ -70,7 +70,7 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 		repo:            runner.repo,
 		sourceRepo:      runner.sourceRepo,
 		state:           runner.state,
-		libraryConfig:   runner.librarianConfig,
+		librarianConfig: runner.librarianConfig,
 		workRoot:        runner.workRoot,
 	}, nil
 }
@@ -104,8 +104,8 @@ func (r *generateRunner) run(ctx context.Context) error {
 		succeededGenerations := 0
 		failedGenerations := 0
 		for _, library := range r.state.Libraries {
-			if r.libraryConfig != nil {
-				libConfig := r.libraryConfig.LibraryConfigFor(library.ID)
+			if r.librarianConfig != nil {
+				libConfig := r.librarianConfig.LibraryConfigFor(library.ID)
 				if libConfig != nil && libConfig.GenerateBlocked {
 					slog.Info("library has generate_blocked, skipping", "id", library.ID)
 					continue

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -46,7 +46,7 @@ type generateRunner struct {
 	repo            gitrepo.Repository
 	sourceRepo      gitrepo.Repository
 	state           *config.LibrarianState
-	librarianConfig *config.LibrarianConfig
+	libraryConfig   *config.LibrarianConfig
 	workRoot        string
 }
 
@@ -70,7 +70,7 @@ func newGenerateRunner(cfg *config.Config) (*generateRunner, error) {
 		repo:            runner.repo,
 		sourceRepo:      runner.sourceRepo,
 		state:           runner.state,
-		librarianConfig: runner.librarianConfig,
+		libraryConfig:   runner.librarianConfig,
 		workRoot:        runner.workRoot,
 	}, nil
 }
@@ -104,8 +104,8 @@ func (r *generateRunner) run(ctx context.Context) error {
 		succeededGenerations := 0
 		failedGenerations := 0
 		for _, library := range r.state.Libraries {
-			if r.librarianConfig != nil {
-				libConfig := r.librarianConfig.LibraryConfigFor(library.ID)
+			if r.libraryConfig != nil {
+				libConfig := r.libraryConfig.LibraryConfigFor(library.ID)
 				if libConfig != nil && libConfig.GenerateBlocked {
 					slog.Info("library has generate_blocked, skipping", "id", library.ID)
 					continue

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -945,7 +945,7 @@ func TestGenerateScenarios(t *testing.T) {
 				repo:            repo,
 				sourceRepo:      newTestGitRepo(t),
 				state:           test.state,
-				libraryConfig:   test.librarianConfig,
+				librarianConfig: test.librarianConfig,
 				containerClient: test.container,
 				ghClient:        test.ghClient,
 				workRoot:        t.TempDir(),

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -945,7 +945,7 @@ func TestGenerateScenarios(t *testing.T) {
 				repo:            repo,
 				sourceRepo:      newTestGitRepo(t),
 				state:           test.state,
-				librarianConfig: test.librarianConfig,
+				libraryConfig:   test.librarianConfig,
 				containerClient: test.container,
 				ghClient:        test.ghClient,
 				workRoot:        t.TempDir(),

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -551,6 +551,7 @@ func TestGenerateScenarios(t *testing.T) {
 		api                string
 		library            string
 		state              *config.LibrarianState
+		librarianConfig    *config.LibrarianConfig
 		container          *mockContainerClient
 		ghClient           GitHubClient
 		build              bool
@@ -831,6 +832,65 @@ func TestGenerateScenarios(t *testing.T) {
 			wantBuildCalls:    1,
 		},
 		{
+			name: "generate skips blocked libraries",
+			state: &config.LibrarianState{
+				Image: "gcr.io/test/image:v1.2.3",
+				Libraries: []*config.LibraryState{
+					{
+						ID:   "google.cloud.texttospeech.v1",
+						APIs: []*config.API{{Path: "google/cloud/texttospeech/v1"}},
+					},
+					{
+						ID:   "google.cloud.vision.v1",
+						APIs: []*config.API{{Path: "google/cloud/vision/v1"}},
+					},
+				},
+			},
+			librarianConfig: &config.LibrarianConfig{
+				Libraries: []*config.LibraryConfig{
+					{LibraryID: "google.cloud.texttospeech.v1"},
+					{LibraryID: "google.cloud.vision.v1", GenerateBlocked: true},
+				},
+			},
+			container: &mockContainerClient{
+				wantLibraryGen: true,
+			},
+			ghClient:          &mockGitHubClient{},
+			build:             true,
+			wantGenerateCalls: 1,
+			wantBuildCalls:    1,
+		},
+		{
+			name:    "generate runs blocked libraries if explicitly requested",
+			library: "google.cloud.vision.v1",
+			state: &config.LibrarianState{
+				Image: "gcr.io/test/image:v1.2.3",
+				Libraries: []*config.LibraryState{
+					{
+						ID:   "google.cloud.texttospeech.v1",
+						APIs: []*config.API{{Path: "google/cloud/texttospeech/v1"}},
+					},
+					{
+						ID:   "google.cloud.vision.v1",
+						APIs: []*config.API{{Path: "google/cloud/vision/v1"}},
+					},
+				},
+			},
+			librarianConfig: &config.LibrarianConfig{
+				Libraries: []*config.LibraryConfig{
+					{LibraryID: "google.cloud.texttospecech.v1"},
+					{LibraryID: "google.cloud.vision.v1", GenerateBlocked: true},
+				},
+			},
+			container: &mockContainerClient{
+				wantLibraryGen: true,
+			},
+			ghClient:          &mockGitHubClient{},
+			build:             true,
+			wantGenerateCalls: 1,
+			wantBuildCalls:    1,
+		},
+		{
 			name: "generate all, all fail should report error",
 			state: &config.LibrarianState{
 				Image: "gcr.io/test/image:v1.2.3",
@@ -885,6 +945,7 @@ func TestGenerateScenarios(t *testing.T) {
 				repo:            repo,
 				sourceRepo:      newTestGitRepo(t),
 				state:           test.state,
+				librarianConfig: test.librarianConfig,
 				containerClient: test.container,
 				ghClient:        test.ghClient,
 				workRoot:        t.TempDir(),


### PR DESCRIPTION
For #897. This change implements the "generate" command part (`generate_blocked`).

When library config has generate_blocked field set to true, the generate command skips the library processing.

If the library is explicitly specified in the argument via "--library", then this Librarian CLI processes the library.
