### PR TITLE
refactor: Change `annotateModel.imports` into a set

### DIFF
--- a/internal/sidekick/internal/dart/annotate.go
+++ b/internal/sidekick/internal/dart/annotate.go
@@ -174,8 +174,9 @@ type annotateModel struct {
 	model *api.API
 	// Mappings from IDs to types.
 	state *api.APIState
-	// The set of imports that have been calculated.
-	imports map[string]string
+	// The set of required imports (e.g. "package:google_cloud_type/type.dart" or
+	// "package:http/http.dart as http") that have been calculated.
+	imports map[string]bool
 	// The mapping from protobuf packages to Dart import statements.
 	packageMapping map[string]string
 	// The protobuf packages that need to be imported with prefixes.
@@ -190,7 +191,7 @@ func newAnnotateModel(model *api.API) *annotateModel {
 	return &annotateModel{
 		model:                 model,
 		state:                 model.State,
-		imports:               map[string]string{},
+		imports:               map[string]bool{},
 		packageMapping:        map[string]string{},
 		packagePrefixes:       map[string]string{},
 		requiredFields:        map[string]*api.Field{},
@@ -290,7 +291,7 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 	devDependencies = append(devDependencies, "lints")
 
 	// Add the import for the google_cloud_gax package.
-	annotate.imports["cloud_gax"] = commonImport
+	annotate.imports[commonImport] = true
 
 	packageDependencies := calculateDependencies(annotate.imports, annotate.dependencyConstraints)
 
@@ -347,10 +348,10 @@ func calculateRequiredFields(model *api.API) map[string]*api.Field {
 }
 
 // calculateDependencies calculates package dependencies based on `package:` imports.
-func calculateDependencies(imports map[string]string, constraints map[string]string) []packageDependency {
+func calculateDependencies(imports map[string]bool, constraints map[string]string) []packageDependency {
 	deps := []packageDependency{}
 
-	for _, imp := range imports {
+	for imp := range imports {
 		if name, hadPrefix := strings.CutPrefix(imp, "package:"); hadPrefix {
 			name = strings.Split(name, "/")[0]
 
@@ -375,9 +376,9 @@ func calculateDependencies(imports map[string]string, constraints map[string]str
 	return deps
 }
 
-func calculateImports(imports map[string]string) []string {
+func calculateImports(imports map[string]bool) []string {
 	var dartImports []string
-	for _, imp := range imports {
+	for imp := range imports {
 		dartImports = append(dartImports, imp)
 	}
 	sort.Strings(dartImports)
@@ -409,7 +410,7 @@ func calculateImports(imports map[string]string) []string {
 
 func (annotate *annotateModel) annotateService(s *api.Service) {
 	// Add a package:http import if we're generating a service.
-	annotate.imports["http"] = httpImport
+	annotate.imports[httpImport] = true
 
 	// Some methods are skipped.
 	methods := language.FilterSlice(s.Methods, func(m *api.Method) bool {
@@ -430,9 +431,9 @@ func (annotate *annotateModel) annotateService(s *api.Service) {
 	s.Codec = ann
 }
 
-func (annotate *annotateModel) annotateMessage(m *api.Message, imports map[string]string) {
+func (annotate *annotateModel) annotateMessage(m *api.Message, imports map[string]bool) {
 	// Add the import for the common JSON helpers.
-	imports["cloud_gax_helpers"] = commonHelpersImport
+	imports[commonHelpersImport] = true
 
 	for _, f := range m.Fields {
 		annotate.annotateField(f)
@@ -504,7 +505,7 @@ func createToStringLines(message *api.Message) []string {
 
 func (annotate *annotateModel) annotateMethod(method *api.Method) {
 	// Ignore imports added from the input and output messages.
-	tempImports := map[string]string{}
+	tempImports := map[string]bool{}
 	if method.InputType.Codec == nil {
 		annotate.annotateMessage(method.InputType, tempImports)
 	}
@@ -894,7 +895,7 @@ func (annotate *annotateModel) updateUsedPackages(packageName string) {
 			if needsImportPrefix {
 				dartImport += " as " + importPrefix
 			}
-			annotate.imports[packageName] = dartImport
+			annotate.imports[dartImport] = true
 		}
 	}
 }

--- a/internal/sidekick/internal/dart/annotate_test.go
+++ b/internal/sidekick/internal/dart/annotate_test.go
@@ -165,9 +165,9 @@ func TestCalculateDependencies(t *testing.T) {
 		}, want: []packageDependency{{Name: "google_cloud_foo", Constraint: "any"}, {Name: "http", Constraint: "^1.3.0"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			deps := map[string]string{}
+			deps := map[string]bool{}
 			for _, imp := range test.imports {
-				deps[imp] = imp
+				deps[imp] = true
 			}
 			got := calculateDependencies(deps, map[string]string{"http": "^1.3.0"})
 
@@ -204,9 +204,9 @@ func TestCalculateImports(t *testing.T) {
 		}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			deps := map[string]string{}
+			deps := map[string]bool{}
 			for _, imp := range test.imports {
-				deps[imp] = imp
+				deps[imp] = true
 			}
 			got := calculateImports(deps)
 
@@ -238,7 +238,7 @@ func TestAnnotateMessageToString(t *testing.T) {
 		{message: sample.Automatic(), expected: 0},
 	} {
 		t.Run(test.message.Name, func(t *testing.T) {
-			imports := map[string]string{}
+			imports := map[string]bool{}
 			annotate.annotateMessage(test.message, imports)
 
 			codec := test.message.Codec.(*messageAnnotation)

--- a/internal/sidekick/internal/dart/dart_test.go
+++ b/internal/sidekick/internal/dart/dart_test.go
@@ -208,11 +208,11 @@ func TestResolveTypeName_ImportsMessages(t *testing.T) {
 		typeId string
 		want   string
 	}{
-		{".google.protobuf.Any", "google.protobuf"},
-		{".google.rpc.Status", "google.rpc"},
-		{".google.type.Expr", "google.type"},
+		{".google.protobuf.Any", "package:google_cloud_protobuf/protobuf.dart"},
+		{".google.rpc.Status", "package:google_cloud_rpc/rpc.dart"},
+		{".google.type.Expr", "package:google_cloud_type/type.dart"},
 	} {
-		annotate.imports = map[string]string{}
+		annotate.imports = map[string]bool{}
 		annotate.resolveTypeName(state.MessageByID[test.typeId], true)
 		if _, ok := annotate.imports[test.want]; !ok {
 			t.Errorf("import not added, got: %v want: %s", annotate.imports, test.want)
@@ -244,9 +244,9 @@ func TestResolveTypeName_ImportsEnum(t *testing.T) {
 		Typez:   api.ENUM_TYPE,
 		TypezID: ".google.type.DayOfWeek",
 	}
-	annotate.imports = map[string]string{}
+	annotate.imports = map[string]bool{}
 	annotate.fieldType(field)
-	want := "google.type"
+	want := "package:google_cloud_type/type.dart"
 	if _, ok := annotate.imports[want]; !ok {
 		t.Errorf("import not added, got: %v want: %s", annotate.imports, want)
 	}
@@ -432,7 +432,7 @@ func TestFieldType_Bytes(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	annotate := newAnnotateModel(model)
 	annotate.annotateModel(map[string]string{})
-	annotate.imports = map[string]string{}
+	annotate.imports = map[string]bool{}
 
 	{
 		got := annotate.fieldType(field)


### PR DESCRIPTION
The key of `annotateModel.imports` is not used so make the value a key and make the value a bool (as is Golang style for sets).