### PR TITLE
refactor(sidekick): Avoid passing many parameters when annotating.

### DIFF
--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -27,6 +27,10 @@ func TestPackageNames(t *testing.T) {
 	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{},
 		[]*api.Service{{Name: "Workflows", Package: "google.cloud.workflows.v1"}})
+	err := api.CrossReference(model)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Override the default name for test APIs ("Test").
 	model.Name = "workflows-v1"
 	codec, err := newCodec(true, map[string]string{
@@ -259,6 +263,11 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 		ID:      ".test.OperationMetadata",
 		Package: "test",
 	}
+	operation := &api.Message{
+		Name:    "Operation",
+		ID:      ".google.longrunning.Operation",
+		Package: "google.longrunning",
+	}
 	service := &api.Service{
 		Name:    "LroService",
 		ID:      ".test.LroService",
@@ -290,8 +299,11 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 			},
 		},
 	}
-	model := api.NewTestAPI([]*api.Message{create, delete, resource, metadata}, []*api.Enum{}, []*api.Service{service})
-	api.CrossReference(model)
+	model := api.NewTestAPI([]*api.Message{create, delete, resource, metadata, operation}, []*api.Enum{}, []*api.Service{service})
+	err := api.CrossReference(model)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	codec, err := newCodec(true, map[string]string{
 		"include-grpc-only-methods": "true",
@@ -1787,6 +1799,9 @@ func TestRoutingRequired(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{message},
 		[]*api.Enum{},
 		[]*api.Service{service})
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
 	codec, err := newCodec(true, map[string]string{
 		"include-grpc-only-methods": "true",
 		"routing-required":          "true",

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -1423,6 +1423,15 @@ func PackageName(api *api.API, packageNameOverride string) string {
 	return "google-cloud-" + name
 }
 
+func (c *codec) packageName(model *api.API) string {
+	return PackageName(model, c.packageNameOverride)
+}
+
+func (c *codec) packageNamespace(model *api.API) string {
+	packageName := c.packageName(model)
+	return strings.ReplaceAll(packageName, "-", "_")
+}
+
 // ServiceName returns the service name.
 func (c *codec) ServiceName(service *api.Service) string {
 	if override, ok := c.nameOverrides[service.ID]; ok {

--- a/internal/sidekick/internal/rust_release/update_sidekick_config_test.go
+++ b/internal/sidekick/internal/rust_release/update_sidekick_config_test.go
@@ -17,6 +17,7 @@ package rustrelease
 import (
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -120,6 +121,9 @@ func TestUpdateSidekickConfigNoErrorOnMissingConfig(t *testing.T) {
 }
 
 func TestUpdateSidekickConfigStatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows, file permissions are not the same as on Unix")
+	}
 	tmpDir := path.Join(t.TempDir(), "not-readable")
 	_ = os.MkdirAll(tmpDir, 0000)
 	manifest := path.Join(tmpDir, "Cargo.toml")


### PR DESCRIPTION
Note this change generates no diff on Rust generated code.