### PR TITLE
feat(rust): Set url.template in RequestOptions

### DIFF
--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -80,7 +80,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             true,
         );
         {{/HasAutoPopulatedFields}}
-        let (builder, method) = None
+        let (builder, method, path_template) = None
         {{#PathInfo.Bindings}}
         .or_else(|| {
             {{#Codec.HasVariablePath}}
@@ -94,6 +94,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{^Codec.HasVariablePath}}
             let path = "{{Codec.PathFmt}}".to_string();
             {{/Codec.HasVariablePath}}
+            let path_template = "{{Codec.PathTemplate}}".to_string();
 
             let builder = self
                 .inner
@@ -112,7 +113,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{/Codec.QueryParams}}
             let builder = Ok(builder);
             {{/Codec.QueryParamsCanFail}}
-            Some(builder.map(|b| (b, reqwest::Method::{{Verb}})))
+            Some(builder.map(|b| (b, reqwest::Method::{{Verb}}, path_template)))
         })
         {{/PathInfo.Bindings}}
         .ok_or_else(|| {
@@ -132,6 +133,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{/PathInfo.Bindings}}
             gax::error::Error::binding(BindingError { paths })
         })??;
+        let options = gax::options::internal::set_path_template(options, Some(path_template));
         let options = gax::options::internal::set_default_idempotency(
             options,
             {{! TODO(#2588) - return idempotency from the above closure }}


### PR DESCRIPTION
Modifies the transport.rs.mustache template to call google_cloud_gax::options::internal::set_path_template() for each binding.

This provides the url.template attribute for OpenTelemetry spans.  See #2212 and https://github.com/googleapis/google-cloud-rust/pull/3346

Tested with https://github.com/googleapis/librarian/pull/2247