### PR TITLE
feat(sidekick): Inject InstrumentationClientInfo for tracing

### DIFF
--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -109,6 +109,7 @@ const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}/";
 pub(crate) mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
+
     lazy_static::lazy_static! {
         pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
             let ac = gaxi::api_header::XGoogApiClient{
@@ -119,6 +120,13 @@ pub(crate) mod info {
             ac.rest_header_value()
         };
     }
+
+    pub(crate) static INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = gaxi::options::InstrumentationClientInfo {
+        service_name: "{{Name}}",
+        client_version: VERSION,
+        client_artifact: NAME,
+        default_host: "{{Codec.DefaultHostShort}}",
+    };
 }
 
 {{/Codec.HasServices}}

--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -126,6 +126,7 @@ pub(crate) mod info {
         client_version: VERSION,
         client_artifact: NAME,
         default_host: "{{Codec.DefaultHostShort}}",
+        ..Default::default()
     };
 }
 

--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -109,7 +109,6 @@ const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}/";
 pub(crate) mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
-
     lazy_static::lazy_static! {
         pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
             let ac = gaxi::api_header::XGoogApiClient{
@@ -120,7 +119,7 @@ pub(crate) mod info {
             ac.rest_header_value()
         };
     }
-
+{{#Codec.DetailedTracingAttributes}}
     pub(crate) static INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = gaxi::options::InstrumentationClientInfo {
         service_name: "{{Name}}",
         client_version: VERSION,
@@ -128,6 +127,7 @@ pub(crate) mod info {
         default_host: "{{Codec.DefaultHostShort}}",
         ..Default::default()
     };
+{{/Codec.DetailedTracingAttributes}}
 }
 
 {{/Codec.HasServices}}

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -53,7 +53,13 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
+        let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
+        let inner = if tracing_is_enabled {
+            inner.with_instrumentation(Some(crate::info::INSTRUMENTATION_CLIENT_INFO))
+        } else {
+            inner
+        };
         Ok(Self { inner })
     }
 }

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -53,6 +53,7 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
+        {{#Codec.DetailedTracingAttributes}}
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         let inner = if tracing_is_enabled {
@@ -61,6 +62,11 @@ impl {{Codec.Name}} {
             inner
         };
         Ok(Self { inner })
+        {{/Codec.DetailedTracingAttributes}}
+        {{^Codec.DetailedTracingAttributes}}
+        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
+        Ok(Self { inner })
+        {{/Codec.DetailedTracingAttributes}}
     }
 }
 


### PR DESCRIPTION
- Add static INSTRUMENTATION_CLIENT_INFO to lib.rs.mustache.
- Use INSTRUMENTATION_CLIENT_INFO in transport.rs.mustache if tracing is enabled.

For #2212 see also https://github.com/googleapis/google-cloud-rust/pull/3347 and https://github.com/googleapis/google-cloud-rust/pull/3376