### PR TITLE
doc: add missing link in language-onboarding.md

### DIFF
--- a/doc/language-onboarding.md
+++ b/doc/language-onboarding.md
@@ -307,7 +307,7 @@ global file edits. The libraries that are being released will be marked by the `
   "error": "An optional field to share error context back to Librarian."
 }
 ```
-
+[config-schema.md]:config-schema.md
 [state-schema.md]: state-schema.md
 
 ## Language repository settings


### PR DESCRIPTION
Add missing link to doc/config-schema.md