### PR TITLE
cleanup(sidekick): consistent management of WKT

### DIFF
--- a/internal/sidekick/internal/api/test.go
+++ b/internal/sidekick/internal/api/test.go
@@ -59,7 +59,7 @@ func NewTestAPI(messages []*Message, enums []*Enum, services []*Service) *API {
 		}
 	}
 
-	return &API{
+	model := &API{
 		Name:        "Test",
 		PackageName: packageName,
 		Messages:    messages,
@@ -67,6 +67,8 @@ func NewTestAPI(messages []*Message, enums []*Enum, services []*Service) *API {
 		Services:    services,
 		State:       state,
 	}
+	model.LoadWellKnownTypes()
+	return model
 }
 
 // parentName returns the parent's name from a fully qualified identifier.

--- a/internal/sidekick/internal/api/well_known_types.go
+++ b/internal/sidekick/internal/api/well_known_types.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// LoadWellKnownTypes adds well-known types to `state`.
+//
+// Some source specification formats (Discovery, OpenAPI) must manually add the
+// well-known types. In Protobuf these types are automatically defined in the
+// protoc output.
+func (model *API) LoadWellKnownTypes() {
+	for _, message := range wellKnownMessages {
+		model.State.MessageByID[message.ID] = message
+	}
+	model.State.EnumByID[".google.protobuf.NullValue"] = &Enum{
+		Name:    "NullValue",
+		Package: "google.protobuf",
+		ID:      ".google.protobuf.NullValue",
+	}
+}
+
+var wellKnownMessages = []*Message{
+	{
+		ID:      ".google.protobuf.Any",
+		Name:    "Any",
+		Package: "google.protobuf",
+	},
+	{
+		ID:      ".google.protobuf.Struct",
+		Name:    "Struct",
+		Package: "google.protobuf",
+	},
+	{
+		ID:      ".google.protobuf.Value",
+		Name:    "Value",
+		Package: "google.protobuf",
+	},
+	{
+		ID:      ".google.protobuf.ListValue",
+		Name:    "ListValue",
+		Package: "google.protobuf",
+	},
+	{
+		ID:      ".google.protobuf.Empty",
+		Name:    "Empty",
+		Package: "google.protobuf",
+	},
+	{
+		ID:      ".google.protobuf.FieldMask",
+		Name:    "FieldMask",
+		Package: "google.protobuf",
+		Fields: []*Field{
+			{
+				Name:     "paths",
+				JSONName: "paths",
+				Typez:    STRING_TYPE,
+				Repeated: true,
+			},
+		},
+	},
+	{
+		ID:      ".google.protobuf.Duration",
+		Name:    "Duration",
+		Package: "google.protobuf",
+	},
+	{
+		ID:      ".google.protobuf.Timestamp",
+		Name:    "Timestamp",
+		Package: "google.protobuf",
+	},
+	{ID: ".google.protobuf.BytesValue", Name: "BytesValue", Package: "google.protobuf"},
+	{ID: ".google.protobuf.UInt64Value", Name: "UInt64Value", Package: "google.protobuf"},
+	{ID: ".google.protobuf.Int64Value", Name: "Int64Value", Package: "google.protobuf"},
+	{ID: ".google.protobuf.UInt32Value", Name: "UInt32Value", Package: "google.protobuf"},
+	{ID: ".google.protobuf.Int32Value", Name: "Int32Value", Package: "google.protobuf"},
+	{ID: ".google.protobuf.FloatValue", Name: "FloatValue", Package: "google.protobuf"},
+	{ID: ".google.protobuf.DoubleValue", Name: "DoubleValue", Package: "google.protobuf"},
+	{ID: ".google.protobuf.BoolValue", Name: "BoolValue", Package: "google.protobuf"},
+}

--- a/internal/sidekick/internal/dart/annotate_test.go
+++ b/internal/sidekick/internal/dart/annotate_test.go
@@ -411,7 +411,7 @@ func TestBuildQueryLinesMessages(t *testing.T) {
 	payload := sample.SecretPayload()
 	model := api.NewTestAPI(
 		[]*api.Message{r, a, sample.CustomerManagedEncryption(), secretVersion,
-			updateRequest, sample.Secret(), fieldMaskMessage(), payload},
+			updateRequest, sample.Secret(), payload},
 		[]*api.Enum{sample.EnumState()},
 		[]*api.Service{})
 	model.PackageName = "test"
@@ -464,21 +464,5 @@ func TestBuildQueryLinesMessages(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
-	}
-}
-
-func fieldMaskMessage() *api.Message {
-	return &api.Message{
-		Name:    "FieldMask",
-		ID:      ".google.protobuf.FieldMask",
-		Package: sample.Package,
-		Fields: []*api.Field{
-			{
-				Name:     "paths",
-				JSONName: "paths",
-				Typez:    api.STRING_TYPE,
-				Repeated: true,
-			},
-		},
 	}
 }

--- a/internal/sidekick/internal/parser/discovery/discovery.go
+++ b/internal/sidekick/internal/parser/discovery/discovery.go
@@ -45,6 +45,11 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte) (*api.API, er
 			EnumByID:    make(map[string]*api.Enum),
 		},
 	}
+	// Discovery docs use some well-known types inspired by Protobuf. With
+	// protoc these types are automatically included via `import` statements.
+	// In the Discovery docs JSON inputs, these types are not automatically
+	// included.
+	result.LoadWellKnownTypes()
 
 	// Discovery docs do not define a service name or package name. The service
 	// config may provide one.

--- a/internal/sidekick/internal/parser/openapi.go
+++ b/internal/sidekick/internal/parser/openapi.go
@@ -79,6 +79,11 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 			EnumByID:    make(map[string]*api.Enum),
 		},
 	}
+	// OpenAPI (for Google) uses some well-known types inspired by Protobuf.
+	// With protoc these types are automatically included via `import`
+	// statements. In the OpenAPI JSON inputs, these types are not automatically
+	// included.
+	result.LoadWellKnownTypes()
 
 	if serviceConfig != nil {
 		result.Name = strings.TrimSuffix(serviceConfig.Name, ".googleapis.com")

--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -450,7 +450,6 @@ type enumValueAnnotation struct {
 func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 	codec.hasServices = len(model.State.ServiceByID) > 0
 
-	loadWellKnownTypes(model.State)
 	resolveUsedPackages(model, codec.extraPackages)
 	// Only annotate enums and messages that we intend to generate. In the
 	// process we discover the external dependencies and trim the list of

--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -140,7 +140,6 @@ func serviceAnnotationsModel() *api.API {
 		[]*api.Message{request, response},
 		[]*api.Enum{usedEnum, extraEnum},
 		[]*api.Service{service})
-	loadWellKnownTypes(model.State)
 	api.CrossReference(model)
 	return model
 }
@@ -1141,7 +1140,6 @@ func TestWrapperFieldAnnotations(t *testing.T) {
 			Fields:        []*api.Field{singular_field},
 		}
 		model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
-		loadWellKnownTypes(model.State)
 		api.CrossReference(model)
 		api.LabelRecursiveFields(model)
 		codec := createRustCodec()

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -284,68 +284,6 @@ type packagez struct {
 	usedIf []string
 }
 
-var wellKnownMessages = []*api.Message{
-	{
-		ID:      ".google.protobuf.Any",
-		Name:    "Any",
-		Package: "google.protobuf",
-	},
-	{
-		ID:      ".google.protobuf.Struct",
-		Name:    "Struct",
-		Package: "google.protobuf",
-	},
-	{
-		ID:      ".google.protobuf.Value",
-		Name:    "Value",
-		Package: "google.protobuf",
-	},
-	{
-		ID:      ".google.protobuf.ListValue",
-		Name:    "ListValue",
-		Package: "google.protobuf",
-	},
-	{
-		ID:      ".google.protobuf.Empty",
-		Name:    "Empty",
-		Package: "google.protobuf",
-	},
-	{
-		ID:      ".google.protobuf.FieldMask",
-		Name:    "FieldMask",
-		Package: "google.protobuf",
-	},
-	{
-		ID:      ".google.protobuf.Duration",
-		Name:    "Duration",
-		Package: "google.protobuf",
-	},
-	{
-		ID:      ".google.protobuf.Timestamp",
-		Name:    "Timestamp",
-		Package: "google.protobuf",
-	},
-	{ID: ".google.protobuf.BytesValue", Name: "BytesValue", Package: "google.protobuf"},
-	{ID: ".google.protobuf.UInt64Value", Name: "UInt64Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.Int64Value", Name: "Int64Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.UInt32Value", Name: "UInt32Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.Int32Value", Name: "Int32Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.FloatValue", Name: "FloatValue", Package: "google.protobuf"},
-	{ID: ".google.protobuf.DoubleValue", Name: "DoubleValue", Package: "google.protobuf"},
-	{ID: ".google.protobuf.BoolValue", Name: "BoolValue", Package: "google.protobuf"},
-}
-
-func loadWellKnownTypes(s *api.APIState) {
-	for _, message := range wellKnownMessages {
-		s.MessageByID[message.ID] = message
-	}
-	s.EnumByID[".google.protobuf.NullValue"] = &api.Enum{
-		Name:    "NullValue",
-		Package: "google.protobuf",
-		ID:      ".google.protobuf.NullValue",
-	}
-}
-
 func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
 	hasServices := len(model.State.ServiceByID) > 0
 	hasLROs := false

--- a/internal/sidekick/internal/rust/used_by_test.go
+++ b/internal/sidekick/internal/rust/used_by_test.go
@@ -35,7 +35,6 @@ func TestUsedByServicesWithServices(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loadWellKnownTypes(model.State)
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
@@ -64,7 +63,6 @@ func TestUsedByServicesNoServices(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loadWellKnownTypes(model.State)
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
@@ -101,7 +99,6 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loadWellKnownTypes(model.State)
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
@@ -138,7 +135,6 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loadWellKnownTypes(model.State)
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
@@ -179,7 +175,6 @@ func TestUsedByUuidWithAutoPopulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loadWellKnownTypes(model.State)
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
@@ -217,7 +212,6 @@ func TestUsedByUuidWithoutAutoPopulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loadWellKnownTypes(model.State)
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
@@ -323,7 +317,6 @@ func TestFindUsedPackages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loadWellKnownTypes(model.State)
 	findUsedPackages(model, c)
 	want := []*packagez{
 		{


### PR DESCRIPTION
All the current service specifications (Protobuf, OpenAPI, Discovery)
use the same WKT (well-known types). In Protobuf the proto descriptors
of the WKT are loaded by the `import "google/protobuf/...";` directives.
In other specifications, the types need to be defined by the parser.
Likewise, in tests we need to define these types ahead of time.

Part of the work for #1850