### PR TITLE
impl(sidekick): bindings for discovery methods

### DIFF
--- a/internal/sidekick/internal/parser/discovery/discovery.go
+++ b/internal/sidekick/internal/parser/discovery/discovery.go
@@ -88,7 +88,7 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte) (*api.API, er
 	}
 
 	for _, resource := range doc.Resources {
-		if err := addServiceRecursive(result, resource); err != nil {
+		if err := addServiceRecursive(result, doc, resource); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/sidekick/internal/parser/discovery/methods.go
+++ b/internal/sidekick/internal/parser/discovery/methods.go
@@ -16,14 +16,15 @@ package discovery
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
 )
 
-func makeServiceMethods(model *api.API, serviceID string, resource *resource) ([]*api.Method, error) {
+func makeServiceMethods(model *api.API, serviceID string, doc *document, resource *resource) ([]*api.Method, error) {
 	var methods []*api.Method
 	for _, input := range resource.Methods {
-		method, err := makeMethod(model, serviceID, input)
+		method, err := makeMethod(model, serviceID, doc, input)
 		if err != nil {
 			return nil, err
 		}
@@ -33,7 +34,7 @@ func makeServiceMethods(model *api.API, serviceID string, resource *resource) ([
 	return methods, nil
 }
 
-func makeMethod(model *api.API, serviceID string, input *method) (*api.Method, error) {
+func makeMethod(model *api.API, serviceID string, doc *document, input *method) (*api.Method, error) {
 	id := fmt.Sprintf("%s.%s", serviceID, input.Name)
 	if input.MediaUpload != nil {
 		return nil, fmt.Errorf("media upload methods are not supported, id=%s", id)
@@ -46,6 +47,27 @@ func makeMethod(model *api.API, serviceID string, input *method) (*api.Method, e
 	if err != nil {
 		return nil, err
 	}
+	var uriTemplate string
+	if strings.HasSuffix(doc.ServicePath, "/") {
+		uriTemplate = fmt.Sprintf("%s%s", doc.ServicePath, input.Path)
+	} else {
+		uriTemplate = fmt.Sprintf("%s/%s", doc.ServicePath, input.Path)
+	}
+	uriTemplate = strings.TrimPrefix(uriTemplate, "/")
+	path, err := ParseUriTemplate(uriTemplate)
+	if err != nil {
+		return nil, err
+	}
+	binding := &api.PathBinding{
+		Verb:            input.HTTPMethod,
+		PathTemplate:    path,
+		QueryParameters: map[string]bool{},
+	}
+	for _, p := range input.Parameters {
+		if p.Location != "path" {
+			binding.QueryParameters[p.Name] = true
+		}
+	}
 	method := &api.Method{
 		ID:            id,
 		Name:          input.Name,
@@ -54,6 +76,10 @@ func makeMethod(model *api.API, serviceID string, input *method) (*api.Method, e
 		// Deprecated: ...,
 		InputTypeID:  inputID,
 		OutputTypeID: outputID,
+		PathInfo: &api.PathInfo{
+			Bindings:      []*api.PathBinding{binding},
+			BodyFieldPath: "*",
+		},
 	}
 	return method, nil
 }

--- a/internal/sidekick/internal/parser/discovery/methods_test.go
+++ b/internal/sidekick/internal/parser/discovery/methods_test.go
@@ -21,6 +21,7 @@ func TestMakeServiceMethodsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	doc := document{}
 	input := &resource{
 		Name: "testResource",
 		Methods: []*method{
@@ -30,7 +31,7 @@ func TestMakeServiceMethodsError(t *testing.T) {
 			},
 		},
 	}
-	if methods, err := makeServiceMethods(model, "..testResource", input); err == nil {
+	if methods, err := makeServiceMethods(model, "..testResource", &doc, input); err == nil {
 		t.Errorf("expected error on method with media upload, got=%v", methods)
 	}
 }
@@ -48,8 +49,10 @@ func TestMakeMethodError(t *testing.T) {
 		{"mediaUploadMustBeNil", method{MediaUpload: &mediaUpload{}}},
 		{"requestMustHaveRef", method{Request: &schema{}}},
 		{"responseMustHaveRef", method{Response: &schema{}}},
+		{"badPath", method{Path: "{+var"}},
 	} {
-		if method, err := makeMethod(model, "..Test", &test.Input); err == nil {
+		doc := document{}
+		if method, err := makeMethod(model, "..Test", &doc, &test.Input); err == nil {
 			t.Errorf("expected error on method[%s], got=%v", test.Name, method)
 		}
 	}

--- a/internal/sidekick/internal/parser/discovery/services.go
+++ b/internal/sidekick/internal/parser/discovery/services.go
@@ -20,23 +20,23 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
 )
 
-func addServiceRecursive(model *api.API, resource *resource) error {
+func addServiceRecursive(model *api.API, doc *document, resource *resource) error {
 	if len(resource.Methods) != 0 {
-		if err := addService(model, resource); err != nil {
+		if err := addService(model, doc, resource); err != nil {
 			return err
 		}
 	}
 	for _, child := range resource.Resources {
-		if err := addServiceRecursive(model, child); err != nil {
+		if err := addServiceRecursive(model, doc, child); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func addService(model *api.API, resource *resource) error {
+func addService(model *api.API, doc *document, resource *resource) error {
 	id := fmt.Sprintf(".%s.%s", model.PackageName, resource.Name)
-	methods, err := makeServiceMethods(model, id, resource)
+	methods, err := makeServiceMethods(model, id, doc, resource)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/internal/parser/discovery/services_test.go
+++ b/internal/sidekick/internal/parser/discovery/services_test.go
@@ -47,8 +47,14 @@ func TestService(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:            "GET",
-							PathTemplate:    api.NewPathTemplate().WithLiteral("compute").WithLiteral("v1").WithLiteral("projects").WithVariable(api.NewPathVariable("project")).WithLiteral("zones").WithVariable(api.NewPathVariable("zone")),
+							Verb: "GET",
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("compute").
+								WithLiteral("v1").
+								WithLiteral("projects").
+								WithVariableNamed("project").
+								WithLiteral("zones").
+								WithVariableNamed("zone"),
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -64,8 +70,13 @@ func TestService(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:         "GET",
-							PathTemplate: api.NewPathTemplate().WithLiteral("compute").WithLiteral("v1").WithLiteral("projects").WithVariable(api.NewPathVariable("project")).WithLiteral("zones"),
+							Verb: "GET",
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("compute").
+								WithLiteral("v1").
+								WithLiteral("projects").
+								WithVariableNamed("project").
+								WithLiteral("zones"),
 							QueryParameters: map[string]bool{
 								"filter":               true,
 								"maxResults":           true,

--- a/internal/sidekick/internal/parser/discovery/services_test.go
+++ b/internal/sidekick/internal/parser/discovery/services_test.go
@@ -44,6 +44,16 @@ func TestService(t *testing.T) {
 				Documentation: "Returns the specified Zone resource.",
 				InputTypeID:   ".google.protobuf.Empty",
 				OutputTypeID:  "..Zone",
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							Verb:            "GET",
+							PathTemplate:    api.NewPathTemplate().WithLiteral("compute").WithLiteral("v1").WithLiteral("projects").WithVariable(api.NewPathVariable("project")).WithLiteral("zones").WithVariable(api.NewPathVariable("zone")),
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "*",
+				},
 			},
 			{
 				ID:            "..zones.list",
@@ -51,6 +61,22 @@ func TestService(t *testing.T) {
 				Documentation: "Retrieves the list of Zone resources available to the specified project.",
 				InputTypeID:   ".google.protobuf.Empty",
 				OutputTypeID:  "..ZoneList",
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							Verb:         "GET",
+							PathTemplate: api.NewPathTemplate().WithLiteral("compute").WithLiteral("v1").WithLiteral("projects").WithVariable(api.NewPathVariable("project")).WithLiteral("zones"),
+							QueryParameters: map[string]bool{
+								"filter":               true,
+								"maxResults":           true,
+								"orderBy":              true,
+								"pageToken":            true,
+								"returnPartialSuccess": true,
+							},
+						},
+					},
+					BodyFieldPath: "*",
+				},
 			},
 		},
 	}
@@ -62,12 +88,13 @@ func TestServiceTopLevelMethodErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	doc := document{}
 	input := resource{
 		Methods: []*method{
 			{MediaUpload: &mediaUpload{}},
 		},
 	}
-	if err := addServiceRecursive(model, &input); err == nil {
+	if err := addServiceRecursive(model, &doc, &input); err == nil {
 		t.Errorf("expected error in addServiceRecursive invalid top-level method, got=%v", model.Services)
 	}
 }
@@ -77,6 +104,7 @@ func TestServiceChildMethodErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	doc := document{}
 	input := resource{
 		Resources: []*resource{
 			{
@@ -86,7 +114,7 @@ func TestServiceChildMethodErrors(t *testing.T) {
 			},
 		},
 	}
-	if err := addServiceRecursive(model, &input); err == nil {
+	if err := addServiceRecursive(model, &doc, &input); err == nil {
 		t.Errorf("expected error in addServiceRecursive invalid child method, got=%v", model.Services)
 	}
 }


### PR DESCRIPTION
Parse the `path` field in a discovery method into the `PathInfo` field
of the `api.Method` objects.

Part of the work for #1850
