### PR TITLE
test: place the want in the first argument of cmp.Diff()

### DIFF
--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -935,7 +935,7 @@ func TestInitRun(t *testing.T) {
 			// we expect this to be 1. Otherwise, the dockerInitCalls should be 0. Run this check even
 			// if there is an error that is wanted to ensure that a docker request is only made when
 			// we want it to.
-			if diff := cmp.Diff(test.containerClient.initCalls, test.dockerInitCalls); diff != "" {
+			if diff := cmp.Diff(test.dockerInitCalls, test.containerClient.initCalls); diff != "" {
 				t.Errorf("docker init calls mismatch (-want +got):\n%s", diff)
 			}
 

--- a/internal/sidekick/internal/parser/routing_info_test.go
+++ b/internal/sidekick/internal/parser/routing_info_test.go
@@ -248,7 +248,7 @@ func TestExamples(t *testing.T) {
 			if !ok {
 				t.Fatalf("Cannot find method %s in API State", test.methodID)
 			}
-			if diff := cmp.Diff(got.Routing, test.want); diff != "" {
+			if diff := cmp.Diff(test.want, got.Routing); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}
 		})
@@ -527,7 +527,7 @@ func TestParseRoutingPathSpecSuccess(t *testing.T) {
 	} {
 		t.Run(test.path, func(t *testing.T) {
 			got, width := parseRoutingPathSpec(test.path)
-			if diff := cmp.Diff(got.Segments, test.wantSegments); diff != "" {
+			if diff := cmp.Diff(test.wantSegments, got.Segments); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s\n", diff)
 			}
 			if test.path[width:] != test.wantTrailer {


### PR DESCRIPTION
The error message becomes correct if we put the "want" in the first
argument of cmp.Diff() function.

See code snippet in https://pkg.go.dev/github.com/google/go-cmp/cmp#Diff

```
	if diff := cmp.Diff(want, got); diff != "" {
		t.Errorf("MakeGatewayInfo() mismatch (-want +got):\n%s", diff)
```
