### PR TITLE
chore: refactor `gitrepo.go`

### DIFF
--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -343,10 +343,10 @@ func (r *LocalRepository) GetCommitsForPathsSinceCommit(paths []string, sinceCom
 
 		return nil
 	})
-	if err != nil && errors.Is(err, ErrStopIterating) {
+	if err != nil && !errors.Is(err, ErrStopIterating) {
 		return nil, err
 	}
-	if sinceCommit != "" && errors.Is(err, ErrStopIterating) {
+	if sinceCommit != "" && !errors.Is(err, ErrStopIterating) {
 		return nil, fmt.Errorf("did not find commit %s when iterating", sinceCommit)
 	}
 	return commits, nil

--- a/internal/librarian/commit_version_analyzer_test.go
+++ b/internal/librarian/commit_version_analyzer_test.go
@@ -152,7 +152,7 @@ func TestGetConventionalCommitsSinceLastRelease(t *testing.T) {
 		wantErrPhrase string
 	}{
 		{
-			name: "get commits for foo",
+			name: "get_commits_for_foo",
 			repo: repoWithCommits,
 			library: &config.LibraryState{
 				ID:                  "foo",


### PR DESCRIPTION
- Replace `==` to `errors.Is()` when comparing errors.