### PR TITLE
impl(sidekick): search roots for discovery files

### DIFF
--- a/internal/sidekick/internal/parser/disco.go
+++ b/internal/sidekick/internal/parser/disco.go
@@ -16,8 +16,10 @@ package parser
 
 import (
 	"os"
+	"path"
 
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+	"github.com/googleapis/librarian/internal/sidekick/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/internal/parser/discovery"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 )
@@ -25,6 +27,18 @@ import (
 // ParseDisco reads discovery docs specifications and converts them into
 // the `api.API` model.
 func ParseDisco(source, serviceConfigFile string, options map[string]string) (*api.API, error) {
+	for _, opt := range config.SourceRoots(options) {
+		location, ok := options[opt]
+		if !ok {
+			// Ignore options that are not set
+			continue
+		}
+		fullName := path.Join(location, source)
+		if _, err := os.Stat(fullName); err == nil {
+			source = fullName
+			break
+		}
+	}
 	contents, err := os.ReadFile(source)
 	if err != nil {
 		return nil, err

--- a/internal/sidekick/internal/parser/disco_test.go
+++ b/internal/sidekick/internal/parser/disco_test.go
@@ -44,6 +44,29 @@ func TestDisco_Parse(t *testing.T) {
 	}
 }
 
+func TestDisco_FindSources(t *testing.T) {
+	got, err := ParseDisco(discoSourceFileRelative, "", map[string]string{
+		"test-root": testdataDir,
+		"roots":     "undefined,test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantName := "compute"
+	wantTitle := "Compute Engine API"
+	wantDescription := "Creates and runs virtual machines on Google Cloud Platform. "
+	if got.Name != wantName {
+		t.Errorf("want = %q; got = %q", wantName, got.Name)
+	}
+	if got.Title != wantTitle {
+		t.Errorf("want = %q; got = %q", wantTitle, got.Title)
+	}
+	if diff := cmp.Diff(wantDescription, got.Description); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+}
+
 func TestDisco_ParseNoServiceConfig(t *testing.T) {
 	got, err := ParseDisco(discoSourceFile, "", map[string]string{})
 	if err != nil {

--- a/internal/sidekick/internal/parser/parser_test.go
+++ b/internal/sidekick/internal/parser/parser_test.go
@@ -25,7 +25,8 @@ import (
 
 var (
 	testdataDir, _            = filepath.Abs("../../testdata")
-	discoSourceFile           = path.Join(testdataDir, "disco/compute.v1.json")
+	discoSourceFileRelative   = "disco/compute.v1.json"
+	discoSourceFile           = path.Join(testdataDir, discoSourceFileRelative)
 	secretManagerYamlRelative = "google/cloud/secretmanager/v1/secretmanager_v1.yaml"
 	secretManagerYamlFullPath = path.Join(testdataDir, "googleapis", secretManagerYamlRelative)
 )


### PR DESCRIPTION
Search any configured `*-root` directories for the discovery file
sources. We will use this to download the discovery specifications from

https://github.com/googleapis/discovery-artifact-manager

Fixes #2276