### PR TITLE
fix(sidekick): sort discovery doc elements

### DIFF
--- a/internal/sidekick/internal/parser/discovery/discovery.go
+++ b/internal/sidekick/internal/parser/discovery/discovery.go
@@ -86,12 +86,18 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte) (*api.API, er
 		result.Messages = append(result.Messages, message)
 		result.State.MessageByID[id] = message
 	}
+	// The messages must be sorted otherwise the generated code gets different
+	// output on each run.
+	slices.SortStableFunc(result.Messages, compareMessages)
 
 	for _, resource := range doc.Resources {
 		if err := addServiceRecursive(result, doc, resource); err != nil {
 			return nil, err
 		}
 	}
+	// The services must be sorted otherwise the generated code gets different
+	// output on each run.
+	slices.SortStableFunc(result.Services, compareServices)
 
 	return result, nil
 }

--- a/internal/sidekick/internal/parser/discovery/discovery_test.go
+++ b/internal/sidekick/internal/parser/discovery/discovery_test.go
@@ -16,6 +16,7 @@ package discovery
 
 import (
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -25,6 +26,19 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/internal/sample"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 )
+
+func TestSorted(t *testing.T) {
+	got, err := ComputeDisco(t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.IsSortedFunc(got.Messages, compareMessages) {
+		t.Fatalf("unsorted messages after parsing")
+	}
+	if !slices.IsSortedFunc(got.Services, compareServices) {
+		t.Fatalf("unsorted messages after parsing")
+	}
+}
 
 func TestInfo(t *testing.T) {
 	got, err := ComputeDisco(t, nil)

--- a/internal/sidekick/internal/parser/discovery/sort.go
+++ b/internal/sidekick/internal/parser/discovery/sort.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"strings"
+
+	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+)
+
+func compareMessages(a, b *api.Message) int {
+	return strings.Compare(a.Name, b.Name)
+}
+
+func compareServices(a, b *api.Service) int {
+	return strings.Compare(a.Name, b.Name)
+}


### PR DESCRIPTION
This is to preserve their order in the generated code. We want to avoid
spurious changes due to hash table salt.

Fixes #2274
