### PR TITLE
impl(sidekick): capture query and path parameters

### DIFF
--- a/internal/sidekick/internal/api/apitest/apitest.go
+++ b/internal/sidekick/internal/api/apitest/apitest.go
@@ -54,11 +54,16 @@ func CheckEnum(t *testing.T, got api.Enum, want api.Enum) {
 // CheckService compares two `Service` instances ignoring method order.
 func CheckService(t *testing.T, got *api.Service, want *api.Service) {
 	t.Helper()
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Service{}, "Methods")); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Service{}, "Methods", "Requests")); diff != "" {
 		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
 	}
 	less := func(a, b *api.Method) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(want.Methods, got.Methods, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+	}
+
+	lessRequests := func(a, b *api.Method) bool { return a.Name < b.Name }
+	if diff := cmp.Diff(want.Requests, got.Requests, cmpopts.SortSlices(lessRequests), cmpopts.IgnoreFields(api.Message{}, "Parent")); diff != "" {
 		t.Errorf("method mismatch (-want, +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/internal/api/model.go
+++ b/internal/sidekick/internal/api/model.go
@@ -191,11 +191,30 @@ type Service struct {
 	DefaultHost string
 	// The Protobuf package this service belongs to.
 	Package string
+
+	// Synthetic messages for the parameters and body of each request.
+	//
+	// When using discovery docs or OpenAPI:
+	// 1. Not all methods have a request message.
+	// 2. The request message does not include the path and query parameters.
+	// 3. The request message may be shared, so it is risky to modify it.
+	//
+	// Sidekick creates synthetic messages for these specifications. The codecs
+	// need to generate these messages separate from "normal" messages. They
+	// should keep in mind that name clashes are possible.
+	Requests []*Message
+
 	// The model this service belongs to, mustache templates use this field to
 	// navigate the data structure.
 	Model *API
 	// Language specific annotations
 	Codec any
+}
+
+// HasRequests is used by mustache templates to optional emit code depending on
+// whether a service has synthetic request messages.
+func (service *Service) HasRequests() bool {
+	return len(service.Requests) != 0
 }
 
 // Method defines a RPC belonging to a Service.

--- a/internal/sidekick/internal/parser/discovery/services.go
+++ b/internal/sidekick/internal/parser/discovery/services.go
@@ -37,7 +37,7 @@ func addServiceRecursive(model *api.API, doc *document, resource *resource) erro
 
 func addService(model *api.API, doc *document, resource *resource) error {
 	id := fmt.Sprintf(".%s.%s", model.PackageName, resource.Name)
-	methods, err := makeServiceMethods(model, id, doc, resource)
+	methods, requests, err := makeServiceMethods(model, resource.Name, id, doc, resource)
 	if err != nil {
 		return err
 	}
@@ -51,6 +51,7 @@ func addService(model *api.API, doc *document, resource *resource) error {
 			Documentation: fmt.Sprintf("Service for the `%s` resource.", resource.Name),
 			DefaultHost:   strings.TrimSuffix(strings.TrimPrefix(doc.RootURL, "https://"), "/"),
 			Methods:       methods,
+			Requests:      requests,
 		}
 		model.Services = append(model.Services, service)
 		model.State.ServiceByID[id] = service

--- a/internal/sidekick/internal/parser/discovery/services_test.go
+++ b/internal/sidekick/internal/parser/discovery/services_test.go
@@ -32,6 +32,17 @@ func TestService(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected service %s in the API model", id)
 	}
+	if got.HasRequests() == false {
+		t.Errorf("service should have synthetic request messages")
+	}
+	wantGet, ok := model.State.MessageByID["..zones.getRequest"]
+	if !ok {
+		t.Fatalf("expected message %s in the API model", "..zones.getRequest")
+	}
+	wantList, ok := model.State.MessageByID["..zones.listRequest"]
+	if !ok {
+		t.Fatalf("expected message %s in the API model", "..zones.listRequest")
+	}
 	want := &api.Service{
 		Name:          "zones",
 		ID:            id,
@@ -43,7 +54,7 @@ func TestService(t *testing.T) {
 				ID:            "..zones.get",
 				Name:          "get",
 				Documentation: "Returns the specified Zone resource.",
-				InputTypeID:   ".google.protobuf.Empty",
+				InputTypeID:   "..zones.getRequest",
 				OutputTypeID:  "..Zone",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
@@ -59,14 +70,14 @@ func TestService(t *testing.T) {
 							QueryParameters: map[string]bool{},
 						},
 					},
-					BodyFieldPath: "*",
+					BodyFieldPath: "",
 				},
 			},
 			{
 				ID:            "..zones.list",
 				Name:          "list",
 				Documentation: "Retrieves the list of Zone resources available to the specified project.",
-				InputTypeID:   ".google.protobuf.Empty",
+				InputTypeID:   "..zones.listRequest",
 				OutputTypeID:  "..ZoneList",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
@@ -87,10 +98,11 @@ func TestService(t *testing.T) {
 							},
 						},
 					},
-					BodyFieldPath: "*",
+					BodyFieldPath: "",
 				},
 			},
 		},
+		Requests: []*api.Message{wantGet, wantList},
 	}
 	apitest.CheckService(t, got, want)
 }

--- a/internal/sidekick/internal/parser/protobuf_test.go
+++ b/internal/sidekick/internal/parser/protobuf_test.go
@@ -439,6 +439,9 @@ func TestProtobuf_Comments(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.Service")
 	}
+	if service.HasRequests() {
+		t.Errorf("protobuf services should not have synthetic request messages")
+	}
 	apitest.CheckService(t, service, &api.Service{
 		Name:          "Service",
 		ID:            ".test.Service",
@@ -832,6 +835,9 @@ func TestProtobuf_Service(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
 	}
+	if service.HasRequests() {
+		t.Errorf("protobuf services should not have synthetic request messages")
+	}
 	apitest.CheckService(t, service, &api.Service{
 		Name:          "TestService",
 		Package:       "test",
@@ -1083,6 +1089,9 @@ func TestProtobuf_Pagination(t *testing.T) {
 	service, ok := test.State.ServiceByID[".test.TestService"]
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
+	}
+	if service.HasRequests() {
+		t.Errorf("protobuf services should not have synthetic request messages")
 	}
 	apitest.CheckService(t, service, &api.Service{
 		Name:        "TestService",
@@ -1428,6 +1437,9 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.LroService")
 	}
+	if service.HasRequests() {
+		t.Errorf("protobuf services should not have synthetic request messages")
+	}
 	apitest.CheckService(t, service, &api.Service{
 		Documentation: "A service to unit test the protobuf translator.",
 		DefaultHost:   "test.googleapis.com",
@@ -1688,6 +1700,9 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.ServiceA")
 	}
+	if s.HasRequests() {
+		t.Errorf("protobuf services should not have synthetic request messages")
+	}
 	apitest.CheckService(t, s, &api.Service{
 		Name:       "ServiceA",
 		ID:         ".test.ServiceA",
@@ -1698,6 +1713,9 @@ func TestProtobuf_Deprecated(t *testing.T) {
 	s, ok = test.State.ServiceByID[".test.ServiceB"]
 	if !ok {
 		t.Fatalf("Cannot find %s in API State", ".test.ServiceB")
+	}
+	if s.HasRequests() {
+		t.Errorf("protobuf services should not have synthetic request messages")
 	}
 	apitest.CheckService(t, s, &api.Service{
 		Name:       "ServiceB",


### PR DESCRIPTION
Capture the query and path parameters of each method into a synthetic
request message.

Fixes #2275 and fixes #2267 