### PR TITLE
chore: remove unnecessary log

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -535,7 +535,6 @@ END_COMMIT_OVERRIDE
 			}
 			if test.push {
 				cmdArgs = append(cmdArgs, "--push")
-				t.Logf("zle: server.URL: %s", server.URL)
 			}
 
 			cmd := exec.Command("go", cmdArgs...)


### PR DESCRIPTION
The log was merged by mistake.