### PR TITLE
fix(internal): skip write LastGeneratedCommit field to json

### DIFF
--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -110,7 +110,7 @@ type LibraryState struct {
 	// The last released version of the library, following SemVer.
 	Version string `yaml:"version" json:"version"`
 	// The commit hash from the API definition repository at which the library was last generated.
-	LastGeneratedCommit string `yaml:"last_generated_commit" json:"last_generated_commit"`
+	LastGeneratedCommit string `yaml:"last_generated_commit" json:"-"`
 	// The changes from the language repository since the library was last released.
 	// This field is ignored when writing to state.yaml.
 	Changes []*conventionalcommits.ConventionalCommit `yaml:"-" json:"changes,omitempty"`

--- a/internal/librarian/state_test.go
+++ b/internal/librarian/state_test.go
@@ -353,9 +353,8 @@ func TestReadLibraryState(t *testing.T) {
 			name:     "successful load content",
 			filename: "successful-unmarshal-libraryState.json",
 			want: &config.LibraryState{
-				ID:                  "google-cloud-go",
-				Version:             "1.0.0",
-				LastGeneratedCommit: "abcd123",
+				ID:      "google-cloud-go",
+				Version: "1.0.0",
 				APIs: []*config.API{
 					{
 						Path:          "google/cloud/compute/v1",

--- a/testdata/docker/release-init-request/release-init-request.json
+++ b/testdata/docker/release-init-request/release-init-request.json
@@ -4,7 +4,6 @@
     {
       "id": "my-library",
       "version": "1.1.0",
-      "last_generated_commit": "",
       "changes": [
         {
           "type": "feat",

--- a/testdata/test-read-library-state/successful-unmarshal-libraryState.json
+++ b/testdata/test-read-library-state/successful-unmarshal-libraryState.json
@@ -1,7 +1,6 @@
 {
   "id": "google-cloud-go",
   "version": "1.0.0",
-  "last_generated_commit": "abcd123",
   "apis": [
     {
       "path": "google/cloud/compute/v1",

--- a/testdata/test-read-library-state/unmarshal-libraryState-with-error-msg.json
+++ b/testdata/test-read-library-state/unmarshal-libraryState-with-error-msg.json
@@ -1,7 +1,6 @@
 {
   "id": "google-cloud-go",
   "version": "1.0.0",
-  "last_generated_commit": "abcd123",
   "apis": [
     {
       "path": "google/cloud/compute/v1",

--- a/testdata/test-write-librarian-state/write-librarian-state-example.json
+++ b/testdata/test-write-librarian-state/write-librarian-state-example.json
@@ -4,7 +4,6 @@
     {
       "id": "google-cloud-go",
       "version": "1.0.0",
-      "last_generated_commit": "abcd123",
       "apis": [
         {
           "path": "google/cloud/compute/v1",
@@ -25,7 +24,6 @@
     {
       "id": "google-cloud-storage",
       "version": "1.2.3",
-      "last_generated_commit": "",
       "apis": [
         {
           "path": "google/storage/v1",

--- a/testdata/test-write-library-state/successful-marshaling-and-writing.json
+++ b/testdata/test-write-library-state/successful-marshaling-and-writing.json
@@ -1,7 +1,6 @@
 {
   "id": "google-cloud-go",
   "version": "1.0.0",
-  "last_generated_commit": "abcd123",
   "apis": [
     {
       "path": "google/cloud/compute/v1",


### PR DESCRIPTION
`last_generated_commit` field should be omitted from all generated JSON request files: release-init-request.json, configure-request.json, generate-request.json, and build-request.json. Ref [language-onboarding.md](https://github.com/googleapis/librarian/blob/main/doc/language-onboarding.md)

Fixes #2081