### PR TITLE
fix(sidekick/rust): bad link for parent messages

### DIFF
--- a/internal/sidekick/internal/rust/templates/common/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/message.mustache
@@ -251,7 +251,7 @@ impl gax::paginator::internal::PageableResponse for {{Codec.Name}} {
 {{/Pagination}}
 {{#Codec.HasNestedTypes}}
 
-/// Defines additional types related to [{{Name}}].
+/// Defines additional types related to [{{Codec.Name}}].
 {{> /templates/common/feature_gate}}
 pub mod {{Codec.ModuleName}} {
     {{! Very rarely, this is unused. It is easier to always disable the warning. }}


### PR DESCRIPTION
For most messages `Name == Codec.Name`, but there are a handful of
messages that are all uppercase in Protobuf (e.g. `CVSS` in grafeas),
and the naming conventions for Rust convert these to `CamelCase`
(`Cvss` in that example).