### PR TITLE
feat(sidekick/disco): parse most object fields

### DIFF
--- a/internal/sidekick/internal/parser/discovery/discovery.go
+++ b/internal/sidekick/internal/parser/discovery/discovery.go
@@ -72,7 +72,7 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte) (*api.API, er
 		if schema.Type != "object" {
 			return nil, fmt.Errorf("schema %s is not an object: %q", id, schema.Type)
 		}
-		fields, err := makeMessageFields(id, schema)
+		fields, err := makeMessageFields(result, id, schema)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sidekick/internal/parser/discovery/discovery_test.go
+++ b/internal/sidekick/internal/parser/discovery/discovery_test.go
@@ -146,14 +146,14 @@ func TestMessage(t *testing.T) {
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
 			},
-			// TODO(#1850) - parse object fields.
-			// {
-			// 	Name:          "headerAction",
-			// 	JSONName:      "headerAction",
-			// 	Documentation: "Specifies changes to request and response headers that need to take effect for the selected backendService. headerAction specified here take effect before headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap. headerAction is not supported for load balancers that have their loadBalancingScheme set to EXTERNAL. Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.",
-			// 	Typez:         api.MESSAGE_TYPE,
-			// 	TypezID:       "..HttpHeaderAction",
-			// },
+			{
+				Name:          "headerAction",
+				JSONName:      "headerAction",
+				Documentation: "Specifies changes to request and response headers that need to take effect for the selected backendService. headerAction specified here take effect before headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap. headerAction is not supported for load balancers that have their loadBalancingScheme set to EXTERNAL. Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.",
+				Typez:         api.MESSAGE_TYPE,
+				TypezID:       "..HttpHeaderAction",
+				Optional:      true,
+			},
 			{
 				Name:          "weight",
 				JSONName:      "weight",

--- a/internal/sidekick/internal/parser/discovery/message_fields_test.go
+++ b/internal/sidekick/internal/parser/discovery/message_fields_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestMakeMessageFields(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	input := &schema{
 		Properties: []*property{
 			{
@@ -45,7 +46,7 @@ func TestMakeMessageFields(t *testing.T) {
 			},
 		},
 	}
-	got, err := makeMessageFields(".package.Message", input)
+	got, err := makeMessageFields(model, ".package.Message", input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,6 +73,7 @@ func TestMakeMessageFields(t *testing.T) {
 }
 
 func TestMakeMessageFieldsError(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	input := &schema{
 		Properties: []*property{
 			{
@@ -85,12 +87,13 @@ func TestMakeMessageFieldsError(t *testing.T) {
 			},
 		},
 	}
-	if got, err := makeMessageFields(".package.Message", input); err == nil {
+	if got, err := makeMessageFields(model, ".package.Message", input); err == nil {
 		t.Errorf("expected error makeScalarField(), got=%v, Input=%v", got, input)
 	}
 }
 
 func TestMakeScalarFieldError(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	input := &property{
 		Name: "field",
 		Schema: &schema{
@@ -100,7 +103,7 @@ func TestMakeScalarFieldError(t *testing.T) {
 			Format:      "--unused--",
 		},
 	}
-	if got, err := makeScalarField(".package.Message", input); err == nil {
+	if got, err := makeScalarField(model, ".package.Message", input); err == nil {
 		t.Errorf("expected error makeScalarField(), got=%v, Input=%v", got, input)
 	}
 }
@@ -128,7 +131,11 @@ func TestScalarTypes(t *testing.T) {
 		{"string", "google-fieldmask", api.MESSAGE_TYPE, ".google.protobuf.FieldMask"},
 		{"string", "int64", api.INT64_TYPE, "int64"},
 		{"string", "uint64", api.UINT64_TYPE, "uint64"},
+		{"any", "google.protobuf.Value", api.MESSAGE_TYPE, ".google.protobuf.Value"},
+		{"object", "google.protobuf.Struct", api.MESSAGE_TYPE, ".google.protobuf.Struct"},
+		{"object", "google.protobuf.Any", api.MESSAGE_TYPE, ".google.protobuf.Any"},
 	} {
+		model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 		input := &property{
 			Name: "field",
 			Schema: &schema{
@@ -138,7 +145,7 @@ func TestScalarTypes(t *testing.T) {
 				Format:      test.Format,
 			},
 		}
-		gotTypez, gotTypeID, err := scalarType(".package.Message", input)
+		gotTypez, gotTypeID, err := scalarType(model, ".package.Message", input)
 		if err != nil {
 			t.Errorf("error in scalarType(), Type=%q, Format=%q: %v", test.Type, test.Format, err)
 		}
@@ -154,6 +161,7 @@ func TestScalarTypes(t *testing.T) {
 }
 
 func TestScalarUnknownType(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	input := &property{
 		Name: "field",
 		Schema: &schema{
@@ -163,18 +171,21 @@ func TestScalarUnknownType(t *testing.T) {
 			Format:      "--unused--",
 		},
 	}
-	if gotTypez, gotTypeID, err := scalarType(".package.Message", input); err == nil {
+	if gotTypez, gotTypeID, err := scalarType(model, ".package.Message", input); err == nil {
 		t.Errorf("expected error scalarType(), gotTypez=%d, gotTypezID=%q, Input=%v", gotTypez, gotTypeID, input)
 	}
 }
 
 func TestScalarUnknownFormats(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	for _, test := range []struct {
 		Type string
 	}{
 		{"integer"},
 		{"number"},
 		{"string"},
+		{"any"},
+		{"object"},
 	} {
 		input := &property{
 			Name: "field",
@@ -185,7 +196,7 @@ func TestScalarUnknownFormats(t *testing.T) {
 				Format:      "--invalid--",
 			},
 		}
-		if gotTypez, gotTypeID, err := scalarType(".package.Message", input); err == nil {
+		if gotTypez, gotTypeID, err := scalarType(model, ".package.Message", input); err == nil {
 			t.Errorf("expected error scalarType(), gotTypez=%d, gotTypezID=%q, Input=%v", gotTypez, gotTypeID, input)
 		}
 	}

--- a/internal/sidekick/internal/parser/discovery/methods.go
+++ b/internal/sidekick/internal/parser/discovery/methods.go
@@ -98,7 +98,7 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 			Name:   p.Name,
 			Schema: &p.schema,
 		}
-		field, err := makeField(fmt.Sprintf(requestMessage.ID, id), prop)
+		field, err := makeField(model, fmt.Sprintf(requestMessage.ID, id), prop)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sidekick/internal/parser/discovery/methods_test.go
+++ b/internal/sidekick/internal/parser/discovery/methods_test.go
@@ -271,7 +271,7 @@ func TestMakeMethodError(t *testing.T) {
 		{"responseMustHaveRef", method{Response: &schema{}}},
 		{"badPath", method{Path: "{+var"}},
 		{"badParameter", method{Path: "a/b", Parameters: []*parameter{
-			{Name: "badParameter", schema: schema{Type: "--invalid--"}},
+			{Name: "badParameter", schema: schema{Type: "string", Format: "--invalid--"}},
 		}}},
 		{"badParameterName", method{
 			Path:    "a/b",


### PR DESCRIPTION
Parse most fields of object in a discovery doc. Fields with an inline
type definition still need some custom work.

Part of the work for #2265
