### PR TITLE
fix(sidekick): missing `Debug` for discovery requests

### DIFF
--- a/internal/sidekick/internal/api/model.go
+++ b/internal/sidekick/internal/api/model.go
@@ -572,18 +572,19 @@ type Message struct {
 	// OpenAPI specifications. The query and request parameters for each method
 	// are grouped into a synthetic message.
 	SyntheticRequest bool
-	// If true, this message is only intended as a namespace to group child
-	// messages.
+	// If true, this message is a placeholder / doppelganger for a `api.Service`.
 	//
 	// These messages are created by sidekick when parsing Discovery docs and
 	// OpenAPI specifications. All the synthetic messages for a service need to
 	// be grouped under a unique namespace to avoid clashes with similar
-	// synthetic messages in other service.
+	// synthetic messages in other service. Sidekick creates a placeholder
+	// message that represents "the service".
 	//
 	// That is, `service1` and `service2` may both have a synthetic `getRequest`
 	// message, with different attributes. We need these to be different
-	// messages, with different names.
-	ChildrenOnly bool
+	// messages, with different names. So we create a different parent message
+	// for each.
+	ServicePlaceholder bool
 	// Enums associated with the Message.
 	Enums []*Enum
 	// Messages associated with the Message. In protobuf these are referred to as

--- a/internal/sidekick/internal/parser/discovery/methods.go
+++ b/internal/sidekick/internal/parser/discovery/methods.go
@@ -25,11 +25,11 @@ func makeServiceMethods(model *api.API, service *api.Service, doc *document, res
 	// It is Okay to reuse the ID, sidekick uses different the namespaces
 	// for messages vs. services.
 	parent := &api.Message{
-		Name:          service.Name,
-		ID:            service.ID,
-		Package:       service.Package,
-		Documentation: fmt.Sprintf("Synthetic messages for the [%s][%s] service", service.Name, service.ID[1:]),
-		ChildrenOnly:  true,
+		Name:               service.Name,
+		ID:                 service.ID,
+		Package:            service.Package,
+		Documentation:      fmt.Sprintf("Synthetic messages for the [%s][%s] service", service.Name, service.ID[1:]),
+		ServicePlaceholder: true,
 	}
 	model.State.MessageByID[parent.ID] = parent
 	model.Messages = append(model.Messages, parent)

--- a/internal/sidekick/internal/parser/discovery/services_test.go
+++ b/internal/sidekick/internal/parser/discovery/services_test.go
@@ -111,12 +111,12 @@ func TestServiceMessages(t *testing.T) {
 	}
 
 	want := &api.Message{
-		Name:          "zones",
-		ID:            "..zones",
-		Package:       "",
-		Documentation: "Synthetic messages for the [zones][.zones] service",
-		ChildrenOnly:  true,
-		Messages:      []*api.Message{getMessage, listMessage},
+		Name:               "zones",
+		ID:                 "..zones",
+		Package:            "",
+		Documentation:      "Synthetic messages for the [zones][.zones] service",
+		ServicePlaceholder: true,
+		Messages:           []*api.Message{getMessage, listMessage},
 	}
 
 	got, ok := model.State.MessageByID[want.ID]

--- a/internal/sidekick/internal/rust/templates/common/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/message.mustache
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 {{^IsMap}}
-{{^ChildrenOnly}}
+{{^ServicePlaceholder}}
 
 {{#Codec.DocLines}}
 {{{.}}}
@@ -250,17 +250,17 @@ impl gax::paginator::internal::PageableResponse for {{Codec.Name}} {
     {{/NextPageToken}}
 }
 {{/Pagination}}
-{{/ChildrenOnly}}
+{{/ServicePlaceholder}}
 {{#Codec.HasNestedTypes}}
 
-{{#ChildrenOnly}}
+{{#ServicePlaceholder}}
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-{{/ChildrenOnly}}
-{{^ChildrenOnly}}
+{{/ServicePlaceholder}}
+{{^ServicePlaceholder}}
 /// Defines additional types related to [{{Codec.Name}}].
-{{/ChildrenOnly}}
+{{/ServicePlaceholder}}
 {{> /templates/common/feature_gate}}
 pub mod {{Codec.ModuleName}} {
     {{! Very rarely, this is unused. It is easier to always disable the warning. }}

--- a/internal/sidekick/internal/rust/templates/common/model/debug/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/debug/message.mustache
@@ -15,7 +15,7 @@ limitations under the License.
 }}
 
 {{^IsMap}}
-{{^ChildrenOnly}}
+{{^ServicePlaceholder}}
 {{> /templates/common/feature_gate}}
 impl std::fmt::Debug for super::{{Codec.RelativeName}} {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -32,10 +32,10 @@ impl std::fmt::Debug for super::{{Codec.RelativeName}} {
         debug_struct.finish()
     }
 }
+{{/ServicePlaceholder}}
+{{/IsMap}}
 {{#Codec.HasNestedTypes}}
 {{#Messages}}
 {{> /templates/common/model/debug/message}}
 {{/Messages}}
 {{/Codec.HasNestedTypes}}
-{{/ChildrenOnly}}
-{{/IsMap}}

--- a/internal/sidekick/internal/rust/templates/common/model/deserialize/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/deserialize/message.mustache
@@ -15,7 +15,7 @@ limitations under the License.
 }}
 
 {{^IsMap}}
-{{^ChildrenOnly}}
+{{^ServicePlaceholder}}
 {{> /templates/common/feature_gate}}
 #[doc(hidden)]
 impl<'de> serde::de::Deserialize<'de> for super::{{Codec.RelativeName}} {
@@ -75,5 +75,5 @@ impl<'de> serde::de::Deserialize<'de> for super::{{Codec.RelativeName}} {
 {{> /templates/common/model/deserialize/message}}
 {{/Messages}}
 {{/Codec.HasNestedTypes}}
-{{/ChildrenOnly}}
+{{/ServicePlaceholder}}
 {{/IsMap}}

--- a/internal/sidekick/internal/rust/templates/common/model/serialize/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/serialize/message.mustache
@@ -15,7 +15,7 @@ limitations under the License.
 }}
 
 {{^IsMap}}
-{{^ChildrenOnly}}
+{{^ServicePlaceholder}}
 {{> /templates/common/feature_gate}}
 #[doc(hidden)]
 impl serde::ser::Serialize for super::{{Codec.RelativeName}} {
@@ -50,5 +50,5 @@ impl serde::ser::Serialize for super::{{Codec.RelativeName}} {
 {{> /templates/common/model/serialize/message}}
 {{/Messages}}
 {{/Codec.HasNestedTypes}}
-{{/ChildrenOnly}}
+{{/ServicePlaceholder}}
 {{/IsMap}}


### PR DESCRIPTION
We want to generate the `Debug` implementation for children of the
discovery request.

Part of the work for #1850