### PR TITLE
chore: update the state.yaml to match the existing release version

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-release-container@sha256:50dd9b59bcf4f55178f9a35dcd4f81a8db20609da386357fa05a457a8da3b4e9
 libraries:
   - id: librarian
-    version: 0.1.1
+    version: 0.1.0
     last_generated_commit: 97a83d76a09a7f6dcab43675c87bdfeb5bcf1cb5
     source_roots:
       - "internal"


### PR DESCRIPTION
This was updated during testing, but should be reset