### PR TITLE
feat: Add the ability to insert text after the package title

### DIFF
--- a/internal/sidekick/internal/dart/annotate.go
+++ b/internal/sidekick/internal/dart/annotate.go
@@ -47,12 +47,13 @@ type modelAnnotations struct {
 	DefaultHost       string
 	DocLines          []string
 	// A reference to an optional hand-written part file.
-	PartFileReference   string
-	PackageDependencies []packageDependency
-	Imports             []string
-	DevDependencies     []string
-	DoNotPublish        bool
-	RepositoryURL       string
+	PartFileReference    string
+	PackageDependencies  []packageDependency
+	Imports              []string
+	DevDependencies      []string
+	DoNotPublish         bool
+	RepositoryURL        string
+	ReadMeAfterTitleText string
 }
 
 // HasServices returns true if the model has services.
@@ -206,13 +207,14 @@ func newAnnotateModel(model *api.API) *annotateModel {
 // [Template.Services] field.
 func (annotate *annotateModel) annotateModel(options map[string]string) error {
 	var (
-		packageNameOverride string
-		generationYear      string
-		packageVersion      string
-		partFileReference   string
-		doNotPublish        bool
-		devDependencies     = []string{}
-		repositoryURL       string
+		packageNameOverride  string
+		generationYear       string
+		packageVersion       string
+		partFileReference    string
+		doNotPublish         bool
+		devDependencies      = []string{}
+		repositoryURL        string
+		readMeAfterTitleText string
 	)
 
 	for key, definition := range options {
@@ -237,6 +239,9 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 				)
 			}
 			doNotPublish = value
+		case key == "readme-after-title-text":
+			// Markdown that will be inserted into the README.md after the title section.
+			readMeAfterTitleText = definition
 		case key == "repository-url":
 			repositoryURL = definition
 		case strings.HasPrefix(key, "proto:"):
@@ -314,13 +319,14 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 			}
 			return ""
 		}(),
-		DocLines:            formatDocComments(model.Description, model.State),
-		Imports:             calculateImports(annotate.imports),
-		PartFileReference:   partFileReference,
-		PackageDependencies: packageDependencies,
-		DevDependencies:     devDependencies,
-		DoNotPublish:        doNotPublish,
-		RepositoryURL:       repositoryURL,
+		DocLines:             formatDocComments(model.Description, model.State),
+		Imports:              calculateImports(annotate.imports),
+		PartFileReference:    partFileReference,
+		PackageDependencies:  packageDependencies,
+		DevDependencies:      devDependencies,
+		DoNotPublish:         doNotPublish,
+		RepositoryURL:        repositoryURL,
+		ReadMeAfterTitleText: readMeAfterTitleText,
 	}
 
 	model.Codec = ann

--- a/internal/sidekick/internal/dart/annotate_test.go
+++ b/internal/sidekick/internal/dart/annotate_test.go
@@ -85,6 +85,15 @@ func TestAnnotateModel_Options(t *testing.T) {
 			},
 		},
 		{
+			map[string]string{"readme-after-title-text": "> [!TIP] Still beta!"},
+			func(t *testing.T, am *annotateModel) {
+				codec := model.Codec.(*modelAnnotations)
+				if diff := cmp.Diff("> [!TIP] Still beta!", codec.ReadMeAfterTitleText); diff != "" {
+					t.Errorf("mismatch in Codec.ReadMeAfterTitleText (-want, +got)\n:%s", diff)
+				}
+			},
+		},
+		{
 			map[string]string{"repository-url": "http://example.com/repo"},
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)

--- a/internal/sidekick/internal/dart/templates/README.md.mustache
+++ b/internal/sidekick/internal/dart/templates/README.md.mustache
@@ -26,6 +26,10 @@ The Google Cloud client library for the {{{Title}}}.
 
 We welcome feedback about the APIs, documentation, missing features, bugs, etc.
 
+{{#Codec.ReadMeAfterTitleText}}
+{{{Codec.ReadMeAfterTitleText}}}
+
+{{/Codec.ReadMeAfterTitleText}}
 ## What's this?
 
 The Google Cloud client library for the {{{Title}}}.


### PR DESCRIPTION
The current use case for this is to advise users of equivalent Firebase packages. For example:

```toml
readme-after-title-text = """> [!TIP]
> Flutter applications should use [Firebase AI Logic](https://firebase.google.com/products/firebase-ai-logic).
>
> The Generate Language API is meant for Dart desktop and cloud applications.
> Firebase AI Logic provides client-side access to both the Gemini Developer
> API and Vertex AI. """
```

Which results in a README.md that looks like:

<img width="1485" height="909" alt="image" src="https://github.com/user-attachments/assets/a1c9120e-eafd-4394-9562-48c595ab4960" />
