### PR TITLE
fix(librarian): temporarily use short SHA for release links

### DIFF
--- a/internal/librarian/release_notes.go
+++ b/internal/librarian/release_notes.go
@@ -76,9 +76,9 @@ Language Image: {{.ImageVersion}}
 ### {{.Heading}}
 {{ range .Commits }}
 {{ if index .Footers "PiperOrigin-RevId" -}}
-* {{.Subject}} {{.Body}} (PiperOrigin-RevId: {{index .Footers "PiperOrigin-RevId"}}) ([{{shortSHA .CommitHash}}]({{"https://github.com/"}}{{$noteSection.RepoOwner}}/{{$noteSection.RepoName}}/commit/{{.CommitHash}}))
+* {{.Subject}} {{.Body}} (PiperOrigin-RevId: {{index .Footers "PiperOrigin-RevId"}}) ([{{shortSHA .CommitHash}}]({{"https://github.com/"}}{{$noteSection.RepoOwner}}/{{$noteSection.RepoName}}/commit/{{shortSHA .CommitHash}}))
 {{- else -}}
-* {{.Subject}} {{.Body}} ([{{shortSHA .CommitHash}}]({{"https://github.com/"}}{{$noteSection.RepoOwner}}/{{$noteSection.RepoName}}/commit/{{.CommitHash}}))
+* {{.Subject}} {{.Body}} ([{{shortSHA .CommitHash}}]({{"https://github.com/"}}{{$noteSection.RepoOwner}}/{{$noteSection.RepoName}}/commit/{{shortSHA .CommitHash}}))
 {{- end }}
 {{ end }}
 

--- a/internal/librarian/release_notes_test.go
+++ b/internal/librarian/release_notes_test.go
@@ -529,11 +529,11 @@ Language Image: go:1.21
 
 ### Features
 
-* new feature  ([1234567](https://github.com/owner/repo/commit/1234567890abcdef000000000000000000000000))
+* new feature  ([1234567](https://github.com/owner/repo/commit/1234567))
 
 ### Bug Fixes
 
-* a bug fix  ([fedcba0](https://github.com/owner/repo/commit/fedcba0987654321000000000000000000000000))
+* a bug fix  ([fedcba0](https://github.com/owner/repo/commit/fedcba0))
 
 </details>`,
 				librarianVersion, today),
@@ -579,11 +579,11 @@ Language Image: go:1.21
 
 ### Features
 
-* new feature  (PiperOrigin-RevId: 123456) ([1234567](https://github.com/owner/repo/commit/1234567890abcdef000000000000000000000000))
+* new feature  (PiperOrigin-RevId: 123456) ([1234567](https://github.com/owner/repo/commit/1234567))
 
 ### Bug Fixes
 
-* a bug fix  (PiperOrigin-RevId: 987654) ([fedcba0](https://github.com/owner/repo/commit/fedcba0987654321000000000000000000000000))
+* a bug fix  (PiperOrigin-RevId: 987654) ([fedcba0](https://github.com/owner/repo/commit/fedcba0))
 
 </details>`,
 				librarianVersion, today),
@@ -623,9 +623,9 @@ Language Image: go:1.21
 
 ### Features
 
-* new feature  ([1234567](https://github.com/owner/repo/commit/1234567890abcdef000000000000000000000000))
+* new feature  ([1234567](https://github.com/owner/repo/commit/1234567))
 
-* another new feature  ([fedcba0](https://github.com/owner/repo/commit/fedcba0987654321000000000000000000000000))
+* another new feature  ([fedcba0](https://github.com/owner/repo/commit/fedcba0))
 
 </details>`,
 				librarianVersion, today),
@@ -674,7 +674,7 @@ Language Image: go:1.21
 
 ### Features
 
-* feature for a  ([1234567](https://github.com/owner/repo/commit/1234567890abcdef000000000000000000000000))
+* feature for a  ([1234567](https://github.com/owner/repo/commit/1234567))
 
 </details>
 
@@ -685,7 +685,7 @@ Language Image: go:1.21
 
 ### Bug Fixes
 
-* fix for b  ([fedcba0](https://github.com/owner/repo/commit/fedcba0987654321000000000000000000000000))
+* fix for b  ([fedcba0](https://github.com/owner/repo/commit/fedcba0))
 
 </details>`,
 				librarianVersion, today, today),
@@ -725,7 +725,7 @@ Language Image: go:1.21
 
 ### Features
 
-* new feature  ([1234567](https://github.com/owner/repo/commit/1234567890abcdef000000000000000000000000))
+* new feature  ([1234567](https://github.com/owner/repo/commit/1234567))
 
 </details>`,
 				librarianVersion, today),
@@ -761,7 +761,7 @@ Language Image: go:1.21
 
 ### Features
 
-* new feature this is the body ([1234567](https://github.com/owner/repo/commit/1234567890abcdef000000000000000000000000))
+* new feature this is the body ([1234567](https://github.com/owner/repo/commit/1234567))
 
 </details>`,
 				librarianVersion, today),


### PR DESCRIPTION
We noticed that we were not able to open the release init PR today because the character limit exceeds what github allows. For now, by shortening the SHA links we can get under this limit. We should have a more robust solution in the future.

Related-disscussion: https://github.com/orgs/community/discussions/27190
Related: #2234
Fixes: #2321