### PR TITLE
refactor(sidekick): directly add fields to message

### DIFF
--- a/internal/sidekick/internal/parser/discovery/discovery.go
+++ b/internal/sidekick/internal/parser/discovery/discovery.go
@@ -72,16 +72,15 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte) (*api.API, er
 		if schema.Type != "object" {
 			return nil, fmt.Errorf("schema %s is not an object: %q", id, schema.Type)
 		}
-		fields, err := makeMessageFields(result, id, schema)
-		if err != nil {
-			return nil, err
-		}
 		message := &api.Message{
 			Name:          name,
 			ID:            id,
 			Package:       packageName,
 			Documentation: schema.Description,
-			Fields:        fields,
+		}
+		err := makeMessageFields(result, message, schema)
+		if err != nil {
+			return nil, err
 		}
 		result.Messages = append(result.Messages, message)
 		result.State.MessageByID[id] = message

--- a/internal/sidekick/internal/parser/discovery/message_fields_test.go
+++ b/internal/sidekick/internal/parser/discovery/message_fields_test.go
@@ -69,7 +69,8 @@ func TestMakeMessageFields(t *testing.T) {
 			},
 		},
 	}
-	got, err := makeMessageFields(model, ".package.Message", input)
+	message := &api.Message{ID: ".package.Message"}
+	err := makeMessageFields(model, message, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +107,7 @@ func TestMakeMessageFields(t *testing.T) {
 		},
 	}
 	less := func(a, b *api.Field) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+	if diff := cmp.Diff(want, message.Fields, cmpopts.SortSlices(less)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -126,8 +127,9 @@ func TestMakeMessageFieldsError(t *testing.T) {
 			},
 		},
 	}
-	if got, err := makeMessageFields(model, ".package.Message", input); err == nil {
-		t.Errorf("expected error makeScalarField(), got=%v, Input=%v", got, input)
+	message := &api.Message{ID: ".package.Message"}
+	if err := makeMessageFields(model, message, input); err == nil {
+		t.Errorf("expected error makeScalarField(), got=%v, Input=%v", message, input)
 	}
 }
 
@@ -145,7 +147,8 @@ func TestMakeArrayFieldError(t *testing.T) {
 			},
 		},
 	}
-	if got, err := makeArrayField(model, ".package.Message", input); err == nil {
+	message := &api.Message{ID: ".package.Message"}
+	if got, err := makeArrayField(model, message, input); err == nil {
 		t.Errorf("expected error makeScalarField(), got=%v, Input=%v", got, input)
 	}
 }
@@ -161,7 +164,8 @@ func TestMakeScalarFieldError(t *testing.T) {
 			Format:      "--unused--",
 		},
 	}
-	if got, err := makeScalarField(model, ".package.Message", input); err == nil {
+	message := &api.Message{ID: ".package.Message"}
+	if got, err := makeScalarField(model, message, input.Name, input.Schema); err == nil {
 		t.Errorf("expected error makeScalarField(), got=%v, Input=%v", got, input)
 	}
 }

--- a/internal/sidekick/internal/parser/discovery/methods.go
+++ b/internal/sidekick/internal/parser/discovery/methods.go
@@ -98,7 +98,7 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 			Name:   p.Name,
 			Schema: &p.schema,
 		}
-		field, err := makeField(model, fmt.Sprintf(requestMessage.ID, id), prop)
+		field, err := makeField(model, requestMessage, prop)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We will want to add child types to a message, such as enums and inline
messages. Consuming the message object in `makemessageFields()` allows
us to add types and fields as we parse the fields.

Part of the work for #2269 