### PR TITLE
cleanup(sidekick): no synthetic fields

### DIFF
--- a/internal/sidekick/internal/api/model.go
+++ b/internal/sidekick/internal/api/model.go
@@ -697,10 +697,6 @@ type Field struct {
 	// IsOneOf is true if the field is related to a one-of and not
 	// a proto3 optional field.
 	IsOneOf bool
-	// The OpenAPI specifications have incomplete `*Request` messages. We inject
-	// some helper fields. These need to be marked so they can be excluded
-	// from serialized messages and in other places.
-	Synthetic bool
 	// Some fields have a type that refers (sometimes indirectly) to the
 	// containing message. That triggers slightly different code generation for
 	// some languages.

--- a/internal/sidekick/internal/parser/disco_test.go
+++ b/internal/sidekick/internal/parser/disco_test.go
@@ -99,12 +99,11 @@ func TestDisco_ParsePagination(t *testing.T) {
 		t.Fatalf("expected method %s in the API model", wantID)
 	}
 	wantPagination := &api.Field{
-		Name:      "pageToken",
-		JSONName:  "pageToken",
-		Typez:     api.STRING_TYPE,
-		TypezID:   "string",
-		Optional:  true,
-		Synthetic: true,
+		Name:     "pageToken",
+		JSONName: "pageToken",
+		Typez:    api.STRING_TYPE,
+		TypezID:  "string",
+		Optional: true,
 	}
 	if diff := cmp.Diff(wantPagination, got.Pagination, cmpopts.IgnoreFields(api.Field{}, "Documentation")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/internal/parser/discovery/methods.go
+++ b/internal/sidekick/internal/parser/discovery/methods.go
@@ -102,7 +102,6 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 		if err != nil {
 			return nil, err
 		}
-		field.Synthetic = true
 		field.Optional = !p.Required
 		requestMessage.Fields = append(requestMessage.Fields, field)
 		fieldNames[field.Name] = true

--- a/internal/sidekick/internal/parser/discovery/methods_test.go
+++ b/internal/sidekick/internal/parser/discovery/methods_test.go
@@ -77,7 +77,6 @@ func TestMethodEmptyBody(t *testing.T) {
 				Documentation: "Project ID for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 			},
 			{
 				Name:          "zone",
@@ -85,7 +84,6 @@ func TestMethodEmptyBody(t *testing.T) {
 				Documentation: "Name of the zone resource to return.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 			},
 		},
 	}
@@ -122,7 +120,6 @@ func TestMethodWithQueryParameters(t *testing.T) {
 				Documentation: "A filter expression that filters resources listed in the response. Most Compute resources support two types of filter expressions: expressions that support regular expressions and expressions that follow API improvement proposal AIP-160. These two types of filter expressions cannot be mixed in one request. If you want to use AIP-160, your expression must specify the field name, an operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The operator must be either `=`, `!=`, `>`, `<`, `<=`, `>=` or `:`. For example, if you are filtering Compute Engine instances, you can exclude instances named `example-instance` by specifying `name != example-instance`. The `:*` comparison can be used to test whether a key has been defined. For example, to find all objects with `owner` label use: ``` labels.owner:* ``` You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels. To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = \"Intel Skylake\") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = \"Intel Skylake\") OR (cpuPlatform = \"Intel Broadwell\") AND (scheduling.automaticRestart = true) ``` If you want to use a regular expression, use the `eq` (equal) or `ne` (not equal) operator against a single un-parenthesized expression with or without quotes or against multiple parenthesized expressions. Examples: `fieldname eq unquoted literal` `fieldname eq 'single quoted literal'` `fieldname eq \"double quoted literal\"` `(fieldname1 eq literal) (fieldname2 ne \"literal\")` The literal value is interpreted as a regular expression using Google RE2 library syntax. The literal value must match the entire field. For example, to filter for instances that do not end with name \"instance\", you would use `name ne .*instance`. You cannot combine constraints on multiple fields using regular expressions.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Optional:      true,
 			},
 			{
@@ -131,7 +128,6 @@ func TestMethodWithQueryParameters(t *testing.T) {
 				Documentation: "The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)",
 				Typez:         api.UINT32_TYPE,
 				TypezID:       "uint32",
-				Synthetic:     true,
 				Optional:      true,
 			},
 			{
@@ -140,7 +136,6 @@ func TestMethodWithQueryParameters(t *testing.T) {
 				Documentation: "Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name. You can also sort results in descending order based on the creation timestamp using `orderBy=\"creationTimestamp desc\"`. This sorts results based on the `creationTimestamp` field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first. Currently, only sorting by `name` or `creationTimestamp desc` is supported.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Optional:      true,
 			},
 			{
@@ -149,7 +144,6 @@ func TestMethodWithQueryParameters(t *testing.T) {
 				Documentation: "Specifies a page token to use. Set `pageToken` to the `nextPageToken` returned by a previous list request to get the next page of results.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Optional:      true,
 			},
 			{
@@ -158,7 +152,6 @@ func TestMethodWithQueryParameters(t *testing.T) {
 				Documentation: "Project ID for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 			},
 			{
 				Name:          "returnPartialSuccess",
@@ -166,7 +159,6 @@ func TestMethodWithQueryParameters(t *testing.T) {
 				Documentation: "Opt-in for partial success behavior which provides partial results in case of failure. The default value is false. For example, when partial success behavior is enabled, aggregatedList for a single zone scope either returns all resources in the zone or no resources, with an error code.",
 				Typez:         api.BOOL_TYPE,
 				TypezID:       "bool",
-				Synthetic:     true,
 				Optional:      true,
 			},
 		},
@@ -204,7 +196,6 @@ func TestMethodWithBody(t *testing.T) {
 				Documentation: "Project ID for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 			},
 			{
 				Name:          "region",
@@ -212,7 +203,6 @@ func TestMethodWithBody(t *testing.T) {
 				Documentation: "Name of the region for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 			},
 			{
 				Name:          "requestId",
@@ -220,7 +210,6 @@ func TestMethodWithBody(t *testing.T) {
 				Documentation: "An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Optional:      true,
 			},
 		},

--- a/internal/sidekick/internal/parser/openapi.go
+++ b/internal/sidekick/internal/parser/openapi.go
@@ -291,7 +291,6 @@ func makeRequestMessage(a *api.API, parent *api.Message, operation *v3.Operation
 			Optional:      openapiFieldIsOptional(p),
 			Typez:         typez,
 			TypezID:       typezID,
-			Synthetic:     true,
 			AutoPopulated: openapiIsAutoPopulated(typez, schema, p),
 			Behavior:      openapiParameterBehavior(p),
 		}

--- a/internal/sidekick/internal/parser/openapi_test.go
+++ b/internal/sidekick/internal/parser/openapi_test.go
@@ -658,7 +658,6 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations`.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -668,10 +667,9 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 					"\nThe filtering language accepts strings like `\"displayName=tokyo" +
 					"\"`, and\nis documented in more detail in [AIP-160](https://google" +
 					".aip.dev/160).",
-				Typez:     api.STRING_TYPE,
-				TypezID:   "string",
-				Optional:  true,
-				Synthetic: true,
+				Typez:    api.STRING_TYPE,
+				TypezID:  "string",
+				Optional: true,
 			},
 			{
 				Name:          "pageSize",
@@ -680,7 +678,6 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 				Typez:         api.INT32_TYPE,
 				TypezID:       "int32",
 				Optional:      true,
-				Synthetic:     true,
 			},
 			{
 				Name:          "pageToken",
@@ -689,7 +686,6 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
 				Optional:      true,
-				Synthetic:     true,
 			},
 		},
 	}
@@ -753,7 +749,6 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			Typez:         api.STRING_TYPE,
 			TypezID:       "string",
 			Optional:      true,
-			Synthetic:     true,
 		},
 	})
 
@@ -864,7 +859,6 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -873,7 +867,6 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 				Documentation: "The `{location}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -882,7 +875,6 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 				Documentation: "The `{secret}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -914,7 +906,6 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -923,7 +914,6 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 				Documentation: "The `{secret}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -992,7 +982,6 @@ func TestOpenAPI_Pagination(t *testing.T) {
 					Typez:         api.STRING_TYPE,
 					TypezID:       "string",
 					Optional:      true,
-					Synthetic:     true,
 				},
 			},
 		},
@@ -1087,7 +1076,6 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 		Documentation: "Test-only Description",
 		Typez:         api.STRING_TYPE,
 		TypezID:       "string",
-		Synthetic:     true,
 		Optional:      true,
 		AutoPopulated: true,
 	}
@@ -1097,7 +1085,6 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 		Documentation: "Test-only Description",
 		Typez:         api.STRING_TYPE,
 		TypezID:       "string",
-		Synthetic:     true,
 		Optional:      true,
 		AutoPopulated: true,
 	}
@@ -1114,7 +1101,6 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/foos`.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -1123,7 +1109,6 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 				Documentation: "Test-only Description",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			request_id,
@@ -1134,7 +1119,6 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
 				JSONName:      "notRequestIdRequired",
-				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
 			{
@@ -1143,7 +1127,6 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
 				JSONName:      "notRequestIdMissingFormat",
-				Synthetic:     true,
 				Optional:      true,
 			},
 			{
@@ -1152,7 +1135,6 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
 				JSONName:      "notRequestIdMissingServiceConfig",
-				Synthetic:     true,
 				Optional:      true,
 				// This just denotes that the field is eligible
 				// to be auto-populated

--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -183,9 +183,6 @@ type messageAnnotation struct {
 	HasNestedTypes bool
 	// All the fields except OneOfs.
 	BasicFields []*api.Field
-	// If true, this is a synthetic message, some generation is skipped for
-	// synthetic messages
-	HasSyntheticFields bool
 	// If set, this message is only enabled when some features are enabled.
 	FeatureGates   []string
 	FeatureGatesOp string
@@ -720,13 +717,6 @@ func (c *codec) annotateMessage(m *api.Message, model *api.API, full bool) {
 	for _, child := range m.Messages {
 		c.annotateMessage(child, model, true)
 	}
-	hasSyntheticFields := false
-	for _, f := range m.Fields {
-		if f.Synthetic {
-			hasSyntheticFields = true
-			break
-		}
-	}
 	basicFields := language.FilterSlice(m.Fields, func(f *api.Field) bool {
 		return !f.IsOneOf
 	})
@@ -734,7 +724,6 @@ func (c *codec) annotateMessage(m *api.Message, model *api.API, full bool) {
 	annotations.DocLines = c.formatDocComments(m.Documentation, m.ID, model.State, m.Scopes())
 	annotations.HasNestedTypes = language.HasNestedTypes(m)
 	annotations.BasicFields = basicFields
-	annotations.HasSyntheticFields = hasSyntheticFields
 	annotations.Internal = slices.Contains(c.internalTypes, m.ID)
 }
 

--- a/internal/sidekick/internal/rust/templates/common/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/message.mustache
@@ -214,7 +214,7 @@ impl {{Codec.Name}} {
     {{/Fields}}
     {{/OneOfs}}
 }
-{{^Codec.HasSyntheticFields}}
+{{^SyntheticRequest}}
 
 {{> /templates/common/feature_gate}}
 impl wkt::message::Message for {{Codec.Name}} {
@@ -222,7 +222,7 @@ impl wkt::message::Message for {{Codec.Name}} {
         "type.googleapis.com/{{Codec.SourceFQN}}"
     }
 }
-{{/Codec.HasSyntheticFields}}
+{{/SyntheticRequest}}
 {{#Pagination}}
 
 {{> /templates/common/feature_gate}}

--- a/internal/sidekick/internal/rust/templates/common/model/serialize/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/model/serialize/message.mustache
@@ -28,14 +28,12 @@ impl serde::ser::Serialize for super::{{Codec.RelativeName}} {
         use serde::ser::SerializeMap;
         let mut state = serializer.serialize_map(std::option::Option::None)?;
         {{#Fields}}
-        {{^Synthetic}}
         {{^Codec.RequiresSerdeAs}}
         {{> /templates/common/ser_plain_message_field}}
         {{/Codec.RequiresSerdeAs}}
         {{#Codec.RequiresSerdeAs}}
         {{> /templates/common/ser_with_message_field}}
         {{/Codec.RequiresSerdeAs}}
-        {{/Synthetic}}
         {{/Fields}}
         if !self._unknown_fields.is_empty() {
             for (key, value) in self._unknown_fields.iter() {


### PR DESCRIPTION
We no longer need to label fields as synthetic because either the full
message is synthetic or not.