### PR TITLE
chore: librarian release pull request: 20250925T155209Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-release-container:latest
 libraries:
   - id: librarian
-    version: 0.2.0
+    version: 0.3.0
     last_generated_commit: 97a83d76a09a7f6dcab43675c87bdfeb5bcf1cb5
     apis: []
     source_roots:


### PR DESCRIPTION
Librarian Version: v0.2.1-0.20250925143604-757e49375ec8
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-release-container:latest
<details><summary>librarian: 0.3.0</summary>

## [0.3.0](https://github.com/googleapis/librarian/compare/v0.2.0...v0.3.0) (2025-09-25)

### Features

* add container req/resp debug logging (#2363) ([757e493](https://github.com/googleapis/librarian/commit/757e493))

* parse discovery doc enums (#2358) ([13962d7](https://github.com/googleapis/librarian/commit/13962d7))

* discovery-based APIs and pagination (#2350) ([cb21cf1](https://github.com/googleapis/librarian/commit/cb21cf1))

* Make generated `ProtoMessage` and `ProtoEnum` classes `final` (#2349) ([7d0520b](https://github.com/googleapis/librarian/commit/7d0520b))

* Require that all imports have a version contraints (#2331) ([00828d5](https://github.com/googleapis/librarian/commit/00828d5))

* Generate samples for single value setters (#2263) ([f7c0b84](https://github.com/googleapis/librarian/commit/f7c0b84))

* discovery doc arrays (#2337) ([da69195](https://github.com/googleapis/librarian/commit/da69195))

* Inject InstrumentationClientInfo for tracing (#2252) ([1358226](https://github.com/googleapis/librarian/commit/1358226))

* parse most object fields (#2318) ([f2d1a10](https://github.com/googleapis/librarian/commit/f2d1a10))

* Add the ability to insert text after the package title (#2323) ([756e72f](https://github.com/googleapis/librarian/commit/756e72f))

### Bug Fixes

* missing field for discovery enums (#2361) ([659ea3a](https://github.com/googleapis/librarian/commit/659ea3a))

* use empty line as a title-body separator (#2345) ([19ab9b0](https://github.com/googleapis/librarian/commit/19ab9b0))

* read version from version.txt file (#2347) ([014b5f4](https://github.com/googleapis/librarian/commit/014b5f4))

* race condition in createWorkRoot() (#2338) ([46428ca](https://github.com/googleapis/librarian/commit/46428ca))

* parse github remote from local directory (#2328) ([1c71bd9](https://github.com/googleapis/librarian/commit/1c71bd9))

</details>