### PR TITLE
feat(config): define LIBRARIAN_GITHUB_TOKEN as a constant

### DIFF
--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -81,7 +81,7 @@ in '.librarian/state.yaml'.
 
 Example with build and push:
 
-	SDK_LIBRARIAN_GITHUB_TOKEN=xxx librarian generate --push --build
+	LIBRARIAN_GITHUB_TOKEN=xxx librarian generate --push --build
 
 Usage:
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -102,7 +102,7 @@ func TestRunGenerate(t *testing.T) {
 			}
 
 			cmd := exec.Command("go", cmdArgs...)
-			cmd.Env = append(os.Environ(), "LIBRARIAN_GITHUB_TOKEN=fake-token")
+			cmd.Env = append(os.Environ(), fmt.Sprintf("%s=fake-token", config.LibrarianGithubToken))
 			cmd.Env = append(cmd.Env, "LIBRARIAN_GITHUB_BASE_URL="+server.URL)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
@@ -540,7 +540,7 @@ func TestReleaseInit(t *testing.T) {
 
 			cmd := exec.Command("go", cmdArgs...)
 			cmd.Env = os.Environ()
-			cmd.Env = append(cmd.Env, "LIBRARIAN_GITHUB_TOKEN=fake-token")
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=fake-token", config.LibrarianGithubToken))
 			cmd.Env = append(cmd.Env, "LIBRARIAN_GITHUB_BASE_URL="+server.URL)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
@@ -741,7 +741,7 @@ libraries:
 			}
 
 			cmd := exec.Command("go", cmdArgs...)
-			cmd.Env = append(os.Environ(), "LIBRARIAN_GITHUB_TOKEN=fake-token")
+			cmd.Env = append(os.Environ(), fmt.Sprintf("%s=fake-token", config.LibrarianGithubToken))
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			if err := cmd.Run(); err != nil {

--- a/internal/automation/trigger.go
+++ b/internal/automation/trigger.go
@@ -27,6 +27,7 @@ import (
 	cloudbuild "cloud.google.com/go/cloudbuild/apiv1/v2"
 	"cloud.google.com/go/cloudbuild/apiv1/v2/cloudbuildpb"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/github"
 )
 
@@ -73,7 +74,7 @@ func RunCommand(ctx context.Context, command string, projectId string, push bool
 	wrappedClient := &wrappedCloudBuildClient{
 		client: c,
 	}
-	ghClient := github.NewClient(os.Getenv("LIBRARIAN_GITHUB_TOKEN"), nil)
+	ghClient := github.NewClient(os.Getenv(config.LibrarianGithubToken), nil)
 	return runCommandWithClient(ctx, wrappedClient, ghClient, command, projectId, push, build, forceRun, time.Now())
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,8 @@ const (
 	ReleaseInitResponse = "release-init-response.json"
 	// LibrarianStateFile is the name of the pipeline state file.
 	LibrarianStateFile = "state.yaml"
+	// LibrarianGithubToken is the name of the env var used to store the github token.
+	LibrarianGithubToken = "LIBRARIAN_GITHUB_TOKEN"
 )
 
 // are variables so it can be replaced during testing.
@@ -248,7 +250,7 @@ type Config struct {
 func New(cmdName string) *Config {
 	return &Config{
 		CommandName: cmdName,
-		GitHubToken: os.Getenv("LIBRARIAN_GITHUB_TOKEN"),
+		GitHubToken: os.Getenv(LibrarianGithubToken),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	t.Setenv("LIBRARIAN_GITHUB_TOKEN", "")
+	t.Setenv(LibrarianGithubToken, "")
 	for _, test := range []struct {
 		name    string
 		envVars map[string]string
@@ -35,7 +35,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "All environment variables set",
 			envVars: map[string]string{
-				"LIBRARIAN_GITHUB_TOKEN":    "gh_token",
+				LibrarianGithubToken:        "gh_token",
 				"LIBRARIAN_SYNC_AUTH_TOKEN": "sync_token",
 			},
 			want: Config{
@@ -54,7 +54,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "Some environment variables set",
 			envVars: map[string]string{
-				"LIBRARIAN_GITHUB_TOKEN": "gh_token",
+				LibrarianGithubToken: "gh_token",
 			},
 			want: Config{
 				GitHubToken: "gh_token",

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -16,6 +16,7 @@ package librarian
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/googleapis/librarian/internal/config"
 )
@@ -86,9 +87,9 @@ If not specified, will search for all merged pull requests with the label
 
 func addFlagPush(fs *flag.FlagSet, cfg *config.Config) {
 	fs.BoolVar(&cfg.Push, "push", false,
-		`If true, Librarian will create a commit and a pull request for the changes.
+		fmt.Sprintf(`If true, Librarian will create a commit and a pull request for the changes.
 A GitHub token with push access must be provided via the
-LIBRARIAN_GITHUB_TOKEN environment variable.`)
+%s environment variable.`, config.LibrarianGithubToken))
 }
 
 func addFlagRepo(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/help.go
+++ b/internal/librarian/help.go
@@ -71,7 +71,7 @@ in '.librarian/state.yaml'.
   your local working directory for inspection.
 
 Example with build and push:
-  SDK_LIBRARIAN_GITHUB_TOKEN=xxx librarian generate --push --build`
+  LIBRARIAN_GITHUB_TOKEN=xxx librarian generate --push --build`
 
 	releaseInitLongHelp = `The 'release init' command is the primary entry point for initiating
 a new release. It automates the creation of a release pull request by parsing

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -51,7 +51,7 @@ type tagAndReleaseRunner struct {
 
 func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
 	if cfg.GitHubToken == "" {
-		return nil, fmt.Errorf("`LIBRARIAN_GITHUB_TOKEN` must be set")
+		return nil, fmt.Errorf("`%s` must be set", config.LibrarianGithubToken)
 	}
 	repo, err := parseRemote(cfg.Repo)
 	if err != nil {


### PR DESCRIPTION
This change introduces a constant for the LIBRARIAN_GITHUB_TOKEN environment variable to improve maintainability and reduce duplication.

Fixes https://github.com/googleapis/librarian/issues/2089.