### PR TITLE
fix: release init provides read-only full repository

### DIFF
--- a/doc/language-onboarding.md
+++ b/doc/language-onboarding.md
@@ -249,7 +249,7 @@ global files that reference the libraries being released.
 | Context      | Type                | Description                                                                     |
 | :----------- | :------------------ | :------------------------------------------------------------------------------ |
 | `/librarian` | Mount (Read/Write)  | Contains `release-init-request.json`. Container writes back a `release-init-response.json`. |
-| `/repo`      | Mount (Read)        | Read-only contents of the language repo. This directory will contain all directories that make up a library, the .librarian folder, and any global file declared in the `config.yaml`. |
+| `/repo`      | Mount (Read)        | Read-only contents of the language repo including any global files declared in the `config.yaml`. |
 | `/output`    | Mount (Write)       | Any files updated during the release phase should be moved to this directory, preserving their original paths. |
 | `command`    | Positional Argument | The value will always be `release-init`. |
 | flags.       | Flags               | Flags indicating the locations of the mounts: `--librarian`, `--repo`, `--output` |

--- a/doc/language-onboarding.md
+++ b/doc/language-onboarding.md
@@ -249,7 +249,7 @@ global files that reference the libraries being released.
 | Context      | Type                | Description                                                                     |
 | :----------- | :------------------ | :------------------------------------------------------------------------------ |
 | `/librarian` | Mount (Read/Write)  | Contains `release-init-request.json`. Container writes back a `release-init-response.json`. |
-| `/repo`      | Mount (Read)        | Parts of the language repo. This directory will contain all directories that make up a library, the .librarian folder, and any global file declared in the `config.yaml`. |
+| `/repo`      | Mount (Read)        | Read-only contents of the language repo. This directory will contain all directories that make up a library, the .librarian folder, and any global file declared in the `config.yaml`. |
 | `/output`    | Mount (Write)       | Any files updated during the release phase should be moved to this directory, preserving their original paths. |
 | `command`    | Positional Argument | The value will always be `release-init`. |
 | flags.       | Flags               | Flags indicating the locations of the mounts: `--librarian`, `--repo`, `--output` |
@@ -307,10 +307,12 @@ global file edits. The libraries that are being released will be marked by the `
   "error": "An optional field to share error context back to Librarian."
 }
 ```
+
 [config-schema.md]:config-schema.md
 [state-schema.md]: state-schema.md
 
 ## Language repository settings
+
 To correctly parse the commit message of a merge commit, only allow squash merging
 and set the default commit message to **Pull request title and description**.
 ![Pull request settings](assets/setting-pull-requests.webp)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -157,10 +157,10 @@ type ReleaseInitRequest struct {
 	// generate code.
 	Output string
 
-	// PartialRepoDir is the local root directory of language repository contains
+	// RepoDir is the local root directory of language repository contains
 	// files that make up libraries and global files.
 	// This is the directory that container can access.
-	PartialRepoDir string
+	RepoDir string
 
 	// Push determines whether to push changes to GitHub.
 	Push bool
@@ -292,7 +292,7 @@ func (c *Docker) Configure(ctx context.Context, request *ConfigureRequest) (stri
 
 // ReleaseInit initiates a release for a given language repository.
 func (c *Docker) ReleaseInit(ctx context.Context, request *ReleaseInitRequest) error {
-	reqFilePath := filepath.Join(request.PartialRepoDir, config.LibrarianDir, config.ReleaseInitRequest)
+	reqFilePath := filepath.Join(request.RepoDir, config.LibrarianDir, config.ReleaseInitRequest)
 	if err := writeLibrarianState(request.State, reqFilePath); err != nil {
 		return err
 	}
@@ -311,10 +311,10 @@ func (c *Docker) ReleaseInit(ctx context.Context, request *ReleaseInitRequest) e
 		"--output=/output",
 	}
 
-	librarianDir := filepath.Join(request.PartialRepoDir, config.LibrarianDir)
+	librarianDir := filepath.Join(request.RepoDir, config.LibrarianDir)
 	mounts := []string{
 		fmt.Sprintf("%s:/librarian", librarianDir),
-		fmt.Sprintf("%s:/repo:ro", request.PartialRepoDir), // readonly volume
+		fmt.Sprintf("%s:/repo:ro", request.RepoDir), // readonly volume
 		fmt.Sprintf("%s:/output", request.Output),
 	}
 

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -377,7 +377,7 @@ func TestDockerRun(t *testing.T) {
 					State:           state,
 					Output:          testOutput,
 					LibrarianConfig: &config.LibrarianConfig{},
-					PartialRepoDir:  partialRepoDir,
+					RepoDir:         partialRepoDir,
 				}
 
 				defer os.RemoveAll(partialRepoDir)
@@ -409,7 +409,7 @@ func TestDockerRun(t *testing.T) {
 
 				releaseInitRequest := &ReleaseInitRequest{
 					State:           state,
-					PartialRepoDir:  partialRepoDir,
+					RepoDir:         partialRepoDir,
 					Output:          testOutput,
 					LibrarianConfig: &config.LibrarianConfig{},
 				}
@@ -427,9 +427,9 @@ func TestDockerRun(t *testing.T) {
 			},
 			runCommand: func(ctx context.Context, d *Docker) error {
 				releaseInitRequest := &ReleaseInitRequest{
-					State:          state,
-					PartialRepoDir: "/non-exist-dir",
-					Output:         testOutput,
+					State:   state,
+					RepoDir: "/non-exist-dir",
+					Output:  testOutput,
 				}
 
 				return d.ReleaseInit(ctx, releaseInitRequest)
@@ -449,7 +449,7 @@ func TestDockerRun(t *testing.T) {
 				}
 				releaseInitRequest := &ReleaseInitRequest{
 					State:           state,
-					PartialRepoDir:  partialRepoDir,
+					RepoDir:         partialRepoDir,
 					Output:          testOutput,
 					LibraryID:       testLibraryID,
 					LibrarianConfig: &config.LibrarianConfig{},
@@ -483,7 +483,7 @@ func TestDockerRun(t *testing.T) {
 
 				releaseInitRequest := &ReleaseInitRequest{
 					State:           state,
-					PartialRepoDir:  partialRepoDir,
+					RepoDir:         partialRepoDir,
 					Output:          testOutput,
 					LibraryID:       testLibraryID,
 					LibraryVersion:  "1.2.3",
@@ -860,7 +860,7 @@ func TestReleaseInitRequestContent(t *testing.T) {
 
 	req := &ReleaseInitRequest{
 		State:           stateWithChanges,
-		PartialRepoDir:  partialRepoDir,
+		RepoDir:         partialRepoDir,
 		Output:          filepath.Join(tmpDir, "output"),
 		LibrarianConfig: &config.LibrarianConfig{},
 	}

--- a/internal/librarian/mocks_test.go
+++ b/internal/librarian/mocks_test.go
@@ -281,7 +281,7 @@ func (m *mockContainerClient) ReleaseInit(ctx context.Context, request *docker.R
 		return m.initErr
 	}
 	// Write a release-init-response.json unless we're configured not to.
-	if err := os.MkdirAll(filepath.Join(request.PartialRepoDir, ".librarian"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(request.RepoDir, ".librarian"), 0755); err != nil {
 		return err
 	}
 
@@ -293,7 +293,7 @@ func (m *mockContainerClient) ReleaseInit(ctx context.Context, request *docker.R
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(request.PartialRepoDir, ".librarian", config.ReleaseInitResponse), b, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(request.RepoDir, ".librarian", config.ReleaseInitResponse), b, 0755); err != nil {
 		return err
 	}
 	return m.initErr

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -38,7 +38,6 @@ type initRunner struct {
 	librarianConfig *config.LibrarianConfig
 	library         string
 	libraryVersion  string
-	partialRepo     string
 	push            bool
 	repo            gitrepo.Repository
 	sourceRepo      gitrepo.Repository
@@ -60,7 +59,6 @@ func newInitRunner(cfg *config.Config) (*initRunner, error) {
 		librarianConfig: runner.librarianConfig,
 		library:         cfg.Library,
 		libraryVersion:  cfg.LibraryVersion,
-		partialRepo:     filepath.Join(runner.workRoot, "release-init"),
 		push:            cfg.Push,
 		repo:            runner.repo,
 		sourceRepo:      runner.sourceRepo,
@@ -125,11 +123,6 @@ func hasLibrariesToRelease(libraryStates []*config.LibraryState) bool {
 }
 
 func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error {
-	dst := r.partialRepo
-	if err := os.MkdirAll(dst, 0755); err != nil {
-		return fmt.Errorf("failed to make directory: %w", err)
-	}
-
 	src := r.repo.GetDir()
 	librariesToRelease := r.state.Libraries
 	if r.library != "" {
@@ -157,23 +150,12 @@ func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error
 		// Copy the library files over if a release is needed
 		if library.ReleaseTriggered {
 			foundReleasableLibrary = true
-			if err := copyLibraryFiles(r.state, dst, library.ID, src); err != nil {
-				return err
-			}
 		}
 	}
 
 	if !foundReleasableLibrary {
 		slog.Info("No libraries need to be released")
 		return nil
-	}
-
-	if err := copyLibrarianDir(dst, src); err != nil {
-		return fmt.Errorf("failed to copy librarian dir from %s to %s: %w", src, dst, err)
-	}
-
-	if err := copyGlobalAllowlist(r.librarianConfig, dst, src, true); err != nil {
-		return fmt.Errorf("failed to copy global allowlist  from %s to %s: %w", src, dst, err)
 	}
 
 	initRequest := &docker.ReleaseInitRequest{
@@ -183,7 +165,7 @@ func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error
 		LibraryID:       r.library,
 		LibraryVersion:  r.libraryVersion,
 		Output:          outputDir,
-		PartialRepoDir:  dst,
+		RepoDir:         src,
 		Push:            r.push,
 		State:           r.state,
 	}
@@ -194,7 +176,7 @@ func (r *initRunner) runInitCommand(ctx context.Context, outputDir string) error
 
 	// Read the response file.
 	if _, err := readLibraryState(
-		filepath.Join(initRequest.PartialRepoDir, config.LibrarianDir, config.ReleaseInitResponse)); err != nil {
+		filepath.Join(initRequest.RepoDir, config.LibrarianDir, config.ReleaseInitResponse)); err != nil {
 		return err
 	}
 
@@ -325,10 +307,4 @@ func copyGlobalAllowlist(cfg *config.LibrarianConfig, dst, src string, copyReadO
 		}
 	}
 	return nil
-}
-
-func copyLibrarianDir(dst, src string) error {
-	return os.CopyFS(
-		filepath.Join(dst, config.LibrarianDir),
-		os.DirFS(filepath.Join(src, config.LibrarianDir)))
 }

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -179,7 +179,6 @@ func TestInitRun(t *testing.T) {
 						},
 					},
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			files: map[string]string{
@@ -257,7 +256,6 @@ func TestInitRun(t *testing.T) {
 					},
 					repo:            mockRepoWithReleasableUnit,
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			files: map[string]string{
@@ -346,7 +344,6 @@ func TestInitRun(t *testing.T) {
 							{LibraryID: "example-id"},
 						},
 					},
-					partialRepo: t.TempDir(),
 				}
 			},
 			want: &config.LibrarianState{
@@ -409,7 +406,6 @@ func TestInitRun(t *testing.T) {
 							{LibraryID: "blocked-example-id", ReleaseBlocked: true},
 						},
 					},
-					partialRepo: t.TempDir(),
 				}
 			},
 			want: &config.LibrarianState{
@@ -447,7 +443,6 @@ func TestInitRun(t *testing.T) {
 						Dir: t.TempDir(),
 					},
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			wantErr:    true,
@@ -486,8 +481,7 @@ func TestInitRun(t *testing.T) {
 							},
 						},
 					},
-					repo:        mockRepoWithReleasableUnit,
-					partialRepo: t.TempDir(),
+					repo: mockRepoWithReleasableUnit,
 				}
 			},
 			files: map[string]string{
@@ -545,7 +539,6 @@ func TestInitRun(t *testing.T) {
 						},
 					},
 					repo:            mockRepoWithReleasableUnit,
-					partialRepo:     t.TempDir(),
 					librarianConfig: &config.LibrarianConfig{},
 				}
 			},
@@ -572,7 +565,6 @@ func TestInitRun(t *testing.T) {
 						},
 					},
 					repo:            mockRepoWithReleasableUnit,
-					partialRepo:     t.TempDir(),
 					librarianConfig: &config.LibrarianConfig{},
 				}
 			},
@@ -613,7 +605,6 @@ func TestInitRun(t *testing.T) {
 						Dir:                             t.TempDir(),
 						GetCommitsForPathsSinceTagError: errors.New("simulated error when getting commits"),
 					},
-					partialRepo: t.TempDir(),
 				}
 			},
 			wantErr:    true,
@@ -637,7 +628,6 @@ func TestInitRun(t *testing.T) {
 						Dir:                             t.TempDir(),
 						GetCommitsForPathsSinceTagError: errors.New("simulated error when getting commits"),
 					},
-					partialRepo: t.TempDir(),
 				}
 			},
 			wantErr:    true,
@@ -678,7 +668,6 @@ func TestInitRun(t *testing.T) {
 					},
 					ghClient:        &mockGitHubClient{},
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 		},
@@ -720,7 +709,6 @@ func TestInitRun(t *testing.T) {
 					},
 					ghClient:        &mockGitHubClient{},
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			want: &config.LibrarianState{
@@ -784,7 +772,6 @@ func TestInitRun(t *testing.T) {
 					},
 					ghClient:        &mockGitHubClient{},
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			want: &config.LibrarianState{
@@ -847,7 +834,6 @@ func TestInitRun(t *testing.T) {
 					},
 					ghClient:        &mockGitHubClient{},
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			wantErr:    true,
@@ -888,27 +874,10 @@ func TestInitRun(t *testing.T) {
 						AddAllError: errors.New("unable to add all files"),
 					},
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			wantErr:    true,
 			wantErrMsg: "failed to commit and push",
-		},
-		{
-			name:            "failed to make partial repo",
-			containerClient: &mockContainerClient{},
-			setupRunner: func(containerClient *mockContainerClient) *initRunner {
-				return &initRunner{
-					workRoot:        t.TempDir(),
-					containerClient: containerClient,
-					repo: &MockRepository{
-						Dir: t.TempDir(),
-					},
-					partialRepo: "/invalid/path",
-				}
-			},
-			wantErr:    true,
-			wantErrMsg: "failed to make directory",
 		},
 		{
 			name:            "run release init command with symbolic link",
@@ -932,7 +901,6 @@ func TestInitRun(t *testing.T) {
 					},
 					repo:            mockRepoWithReleasableUnit,
 					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
 				}
 			},
 			files: map[string]string{
@@ -953,65 +921,6 @@ func TestInitRun(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:            "copy library files returns error",
-			containerClient: &mockContainerClient{},
-			setupRunner: func(containerClient *mockContainerClient) *initRunner {
-				return &initRunner{
-					workRoot:        t.TempDir(),
-					containerClient: containerClient,
-					library:         "example-id",
-					state: &config.LibrarianState{
-						Libraries: []*config.LibraryState{
-							{
-								Version: "1.0.0",
-								ID:      "example-id",
-								SourceRoots: []string{
-									"dir1",
-								},
-							},
-						},
-					},
-					repo:            mockRepoWithReleasableUnit,
-					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
-				}
-			},
-			files: map[string]string{
-				"dir1/file1.txt": "hello",
-			},
-			wantErr:    true,
-			wantErrMsg: "failed to copy file",
-		},
-		{
-			name:            "copy library files returns error (no library id in cfg)",
-			containerClient: &mockContainerClient{},
-			setupRunner: func(containerClient *mockContainerClient) *initRunner {
-				return &initRunner{
-					workRoot:        t.TempDir(),
-					containerClient: containerClient,
-					state: &config.LibrarianState{
-						Libraries: []*config.LibraryState{
-							{
-								Version: "1.0.0",
-								ID:      "example-id",
-								SourceRoots: []string{
-									"dir1",
-								},
-							},
-						},
-					},
-					repo:            mockRepoWithReleasableUnit,
-					librarianConfig: &config.LibrarianConfig{},
-					partialRepo:     t.TempDir(),
-				}
-			},
-			files: map[string]string{
-				"dir1/file1.txt": "hello",
-			},
-			wantErr:    true,
-			wantErrMsg: "failed to copy file",
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			runner := test.setupRunner(test.containerClient)
@@ -1030,12 +939,6 @@ func TestInitRun(t *testing.T) {
 					if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
 						t.Fatalf("os.WriteFile() = %v", err)
 					}
-				}
-			}
-			if strings.HasPrefix(test.name, "copy library files returns error") {
-				// Make the directory non-writable so that the copy operations fail.
-				if err := os.Chmod(runner.partialRepo, 0555); err != nil {
-					t.Fatalf("os.Chmod() = %v", err)
 				}
 			}
 			// Create a symbolic link for the test case with symbolic links.


### PR DESCRIPTION
Fixes #2025 
Fixes #2429
Related to #2218

Skips copy of repository for `release init`. We pass the entire repo (already as read-only) to the language container.