### PR TITLE
refactor(internal/gitrepo): define a Remote type and use it

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -226,10 +226,9 @@ func FetchGitHubRepoFromRemote(repo gitrepo.Repository) (*Repository, error) {
 	}
 
 	for _, remote := range remotes {
-		if remote.Config().Name == "origin" {
-			urls := remote.Config().URLs
-			if len(urls) > 0 {
-				return ParseRemote(urls[0])
+		if remote.Name == "origin" {
+			if len(remote.URLs) > 0 {
+				return ParseRemote(remote.URLs[0])
 			}
 		}
 	}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -37,7 +37,7 @@ type Repository interface {
 	AddAll() (git.Status, error)
 	Commit(msg string) error
 	IsClean() (bool, error)
-	Remotes() ([]*git.Remote, error)
+	Remotes() ([]*Remote, error)
 	GetDir() string
 	HeadHash() (string, error)
 	ChangedFilesInCommit(commitHash string) ([]string, error)
@@ -63,6 +63,12 @@ type Commit struct {
 	Hash    plumbing.Hash
 	Message string
 	When    time.Time
+}
+
+// Remote represent a git remote.
+type Remote struct {
+	Name string
+	URLs []string
 }
 
 // RepositoryOptions are used to configure a [LocalRepository].
@@ -222,8 +228,17 @@ func (r *LocalRepository) IsClean() (bool, error) {
 }
 
 // Remotes returns the remotes within the repository.
-func (r *LocalRepository) Remotes() ([]*git.Remote, error) {
-	return r.repo.Remotes()
+func (r *LocalRepository) Remotes() ([]*Remote, error) {
+	gitRemotes, err := r.repo.Remotes()
+	if err != nil {
+		return nil, err
+	}
+	var remotes []*Remote
+	for _, remote := range gitRemotes {
+		remotes = append(remotes, &Remote{Name: remote.Config().Name, URLs: remote.Config().URLs})
+	}
+
+	return remotes, nil
 }
 
 // HeadHash returns hash of the commit for the repository's HEAD.

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -588,7 +588,7 @@ func TestRemotes(t *testing.T) {
 
 			gotRemotes := make(map[string][]string)
 			for _, r := range got {
-				gotRemotes[r.Config().Name] = r.Config().URLs
+				gotRemotes[r.Name] = r.URLs
 			}
 			if diff := cmp.Diff(test.setupRemotes, gotRemotes); diff != "" {
 				t.Errorf("Remotes() mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
-	gogitConfig "github.com/go-git/go-git/v5/config"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/github"
@@ -1322,16 +1320,16 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "create a commit",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {
@@ -1345,16 +1343,16 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "create a generate pull request",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {
@@ -1369,16 +1367,16 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "create a release pull request",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {
@@ -1398,7 +1396,7 @@ func TestCommitAndPush(t *testing.T) {
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{}, // No remotes
+					RemotesValue: []*gitrepo.Remote{}, // No remotes
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {
@@ -1413,13 +1411,13 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "AddAll error",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 					AddAllError:  errors.New("mock add all error"),
 				}
 			},
@@ -1434,17 +1432,17 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "Create branch error",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:                          t.TempDir(),
 					AddAllStatus:                 status,
-					RemotesValue:                 []*git.Remote{remote},
+					RemotesValue:                 []*gitrepo.Remote{remote},
 					CreateBranchAndCheckoutError: errors.New("create branch error"),
 				}
 			},
@@ -1459,17 +1457,17 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "Commit error",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 					CommitError:  errors.New("commit error"),
 				}
 			},
@@ -1484,17 +1482,17 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "Push error",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 					PushError:    errors.New("push error"),
 				}
 			},
@@ -1509,17 +1507,17 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "Create PR body error",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {
@@ -1534,17 +1532,17 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "Create pull request error",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {
@@ -1561,14 +1559,14 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "No changes to commit",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: git.Status{}, // Clean status
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {
@@ -1580,16 +1578,16 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "create_a_comment_on_generation_pr_error",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				remote := git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
+				remote := &gitrepo.Remote{
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
-				})
+				}
 				status := make(git.Status)
 				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
 					AddAllStatus: status,
-					RemotesValue: []*git.Remote{remote},
+					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
 			setupMockClient: func(t *testing.T) GitHubClient {

--- a/internal/librarian/mocks_test.go
+++ b/internal/librarian/mocks_test.go
@@ -307,7 +307,7 @@ type MockRepository struct {
 	AddAllStatus                           git.Status
 	AddAllError                            error
 	CommitError                            error
-	RemotesValue                           []*git.Remote
+	RemotesValue                           []*gitrepo.Remote
 	RemotesError                           error
 	CommitCalls                            int
 	GetCommitError                         error
@@ -346,7 +346,7 @@ func (m *MockRepository) Commit(msg string) error {
 	return m.CommitError
 }
 
-func (m *MockRepository) Remotes() ([]*git.Remote, error) {
+func (m *MockRepository) Remotes() ([]*gitrepo.Remote, error) {
 	if m.RemotesError != nil {
 		return nil, m.RemotesError
 	}

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -22,20 +22,13 @@ import (
 	"strings"
 	"testing"
 
-	gogitConfig "github.com/go-git/go-git/v5/config"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/storage/memory"
-	"gopkg.in/yaml.v3"
-
-	"github.com/googleapis/librarian/internal/conventionalcommits"
-
 	"github.com/go-git/go-git/v5"
-
-	"github.com/googleapis/librarian/internal/gitrepo"
-
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/conventionalcommits"
+	"github.com/googleapis/librarian/internal/gitrepo"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewInitRunner(t *testing.T) {
@@ -93,10 +86,12 @@ func TestInitRun(t *testing.T) {
 	mockRepoWithReleasableUnit := &MockRepository{
 		Dir:          t.TempDir(),
 		AddAllStatus: gitStatus,
-		RemotesValue: []*git.Remote{git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
-			Name: "origin",
-			URLs: []string{"https://github.com/googleapis/librarian.git"},
-		})},
+		RemotesValue: []*gitrepo.Remote{
+			{
+				Name: "origin",
+				URLs: []string{"https://github.com/googleapis/librarian.git"},
+			},
+		},
 		ChangedFilesInCommitValue: []string{"dir1/file.txt"},
 		GetCommitsForPathsSinceTagValue: []*gitrepo.Commit{
 			{
@@ -667,10 +662,12 @@ func TestInitRun(t *testing.T) {
 					},
 					repo: &MockRepository{
 						Dir: t.TempDir(),
-						RemotesValue: []*git.Remote{git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
-							Name: "origin",
-							URLs: []string{"https://github.com/googleapis/librarian.git"},
-						})},
+						RemotesValue: []*gitrepo.Remote{
+							{
+								Name: "origin",
+								URLs: []string{"https://github.com/googleapis/librarian.git"},
+							},
+						},
 						ChangedFilesInCommitValue: []string{"file.txt"},
 						GetCommitsForPathsSinceTagValue: []*gitrepo.Commit{
 							{
@@ -888,10 +885,12 @@ func TestInitRun(t *testing.T) {
 					repo: &MockRepository{
 						Dir:          t.TempDir(),
 						AddAllStatus: gitStatus,
-						RemotesValue: []*git.Remote{git.NewRemote(memory.NewStorage(), &gogitConfig.RemoteConfig{
-							Name: "origin",
-							URLs: []string{"https://github.com/googleapis/librarian.git"},
-						})},
+						RemotesValue: []*gitrepo.Remote{
+							{
+								Name: "origin",
+								URLs: []string{"https://github.com/googleapis/librarian.git"},
+							},
+						},
 						ChangedFilesInCommitValue: []string{"dir1/file.txt"},
 						GetCommitsForPathsSinceTagValue: []*gitrepo.Commit{
 							{

--- a/internal/librarian/release_notes_test.go
+++ b/internal/librarian/release_notes_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/googleapis/librarian/internal/conventionalcommits"
 
-	"github.com/go-git/go-git/v5"
-	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/cli"
@@ -69,7 +67,7 @@ func TestFormatGenerationPRBody(t *testing.T) {
 				},
 			},
 			repo: &MockRepository{
-				RemotesValue: []*git.Remote{git.NewRemote(nil, &gitconfig.RemoteConfig{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}})},
+				RemotesValue: []*gitrepo.Remote{{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}}},
 				GetCommitByHash: map[string]*gitrepo.Commit{
 					"1234567890": {
 						Hash: plumbing.NewHash("1234567890"),
@@ -140,7 +138,7 @@ Language Image: %s`,
 				},
 			},
 			repo: &MockRepository{
-				RemotesValue: []*git.Remote{git.NewRemote(nil, &gitconfig.RemoteConfig{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}})},
+				RemotesValue: []*gitrepo.Remote{{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}}},
 				GetCommitByHash: map[string]*gitrepo.Commit{
 					"1234567890": {
 						Hash: plumbing.NewHash("1234567890"),
@@ -214,7 +212,7 @@ Language Image: %s
 				},
 			},
 			repo: &MockRepository{
-				RemotesValue: []*git.Remote{git.NewRemote(nil, &gitconfig.RemoteConfig{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}})},
+				RemotesValue: []*gitrepo.Remote{{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}}},
 				GetCommitByHash: map[string]*gitrepo.Commit{
 					"1234567890": {
 						Hash: plumbing.NewHash("1234567890"),
@@ -295,7 +293,7 @@ Language Image: %s`,
 				},
 			},
 			repo: &MockRepository{
-				RemotesValue:   []*git.Remote{git.NewRemote(nil, &gitconfig.RemoteConfig{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}})},
+				RemotesValue:   []*gitrepo.Remote{{Name: "origin", URLs: []string{"https://github.com/owner/repo.git"}}},
 				GetCommitError: errors.New("simulated get commit error"),
 				GetCommitsForPathsSinceLastGenByCommit: map[string][]*gitrepo.Commit{
 					"1234567890": {


### PR DESCRIPTION
We should avoid putting other packages types in APIs of our types. This breaks encapalation of the library we are trying to wrap. This package has more types like this that I will follow up with in future PRs.

Updates: #2372