### PR TITLE
refactor(internal/gitrepo): remove returning status from AddAll

### DIFF
--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -34,7 +34,7 @@ import (
 
 // Repository defines the interface for git repository operations.
 type Repository interface {
-	AddAll() (git.Status, error)
+	AddAll() error
 	Commit(msg string) error
 	IsClean() (bool, error)
 	Remotes() ([]*Remote, error)
@@ -173,16 +173,16 @@ func clone(dir, url, branch, ci string, depth int) (*LocalRepository, error) {
 
 // AddAll adds all pending changes from the working tree to the index,
 // so that the changes can later be committed.
-func (r *LocalRepository) AddAll() (git.Status, error) {
+func (r *LocalRepository) AddAll() error {
 	worktree, err := r.repo.Worktree()
 	if err != nil {
-		return git.Status{}, err
+		return err
 	}
 	err = worktree.AddWithOptions(&git.AddOptions{All: true})
 	if err != nil {
-		return git.Status{}, err
+		return err
 	}
-	return worktree.Status()
+	return nil
 }
 
 // Commit creates a new commit with the provided message and author

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -356,7 +356,7 @@ func TestAddAll(t *testing.T) {
 
 			test.setup(t, dir)
 
-			status, err := r.AddAll()
+			err := r.AddAll()
 			if (err != nil) != test.wantErr {
 				t.Errorf("AddAll() error = %v, wantErr %v", err, test.wantErr)
 				return
@@ -364,9 +364,12 @@ func TestAddAll(t *testing.T) {
 			if err != nil {
 				return
 			}
-
-			if status.IsClean() != test.wantStatusIsClean {
-				t.Errorf("AddAll() status.IsClean() = %v, want %v", status.IsClean(), test.wantStatusIsClean)
+			isClean, err := r.IsClean()
+			if err != nil {
+				t.Fatalf("IsClean() returned an error: %v", err)
+			}
+			if isClean != test.wantStatusIsClean {
+				t.Errorf("AddAll() status.IsClean() = %v, want %v", isClean, test.wantStatusIsClean)
 			}
 		})
 	}
@@ -1226,7 +1229,7 @@ func TestCleanUntracked(t *testing.T) {
 				}
 			}
 
-			if _, err := localRepo.AddAll(); err != nil {
+			if err := localRepo.AddAll(); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -334,11 +334,15 @@ func commitAndPush(ctx context.Context, info *commitInfo) error {
 	}
 
 	repo := info.repo
-	status, err := repo.AddAll()
+	if err := repo.AddAll(); err != nil {
+		return err
+	}
+	isClean, err := repo.IsClean()
 	if err != nil {
 		return err
 	}
-	if status.IsClean() {
+
+	if isClean {
 		slog.Info("No changes to commit, skipping commit and push.")
 		return nil
 	}

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/github"
@@ -1324,11 +1323,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
@@ -1347,11 +1343,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
@@ -1371,11 +1364,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
@@ -1391,11 +1381,8 @@ func TestCommitAndPush(t *testing.T) {
 		{
 			name: "No GitHub Remote",
 			setupMockRepo: func(t *testing.T) gitrepo.Repository {
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{}, // No remotes
 				}
 			},
@@ -1436,12 +1423,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:                          t.TempDir(),
-					AddAllStatus:                 status,
 					RemotesValue:                 []*gitrepo.Remote{remote},
 					CreateBranchAndCheckoutError: errors.New("create branch error"),
 				}
@@ -1461,12 +1444,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 					CommitError:  errors.New("commit error"),
 				}
@@ -1486,12 +1465,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 					PushError:    errors.New("push error"),
 				}
@@ -1511,12 +1486,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
@@ -1536,12 +1507,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
@@ -1565,7 +1532,7 @@ func TestCommitAndPush(t *testing.T) {
 				}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: git.Status{}, // Clean status
+					IsCleanValue: true,
 					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},
@@ -1582,11 +1549,8 @@ func TestCommitAndPush(t *testing.T) {
 					Name: "origin",
 					URLs: []string{"https://github.com/googleapis/librarian.git"},
 				}
-				status := make(git.Status)
-				status["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 				return &MockRepository{
 					Dir:          t.TempDir(),
-					AddAllStatus: status,
 					RemotesValue: []*gitrepo.Remote{remote},
 				}
 			},

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -196,7 +196,7 @@ func TestRunBuildCommand(t *testing.T) {
 					}
 				}
 			}
-			if _, err := r.repo.AddAll(); err != nil {
+			if err := r.repo.AddAll(); err != nil {
 				t.Fatal(err)
 			}
 			if err := r.repo.Commit("test commit"); err != nil {

--- a/internal/librarian/mocks_test.go
+++ b/internal/librarian/mocks_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/docker"
 	"github.com/googleapis/librarian/internal/github"
@@ -304,7 +303,6 @@ type MockRepository struct {
 	Dir                                    string
 	IsCleanValue                           bool
 	IsCleanError                           error
-	AddAllStatus                           git.Status
 	AddAllError                            error
 	CommitError                            error
 	RemotesValue                           []*gitrepo.Remote
@@ -334,11 +332,11 @@ func (m *MockRepository) IsClean() (bool, error) {
 	return m.IsCleanValue, nil
 }
 
-func (m *MockRepository) AddAll() (git.Status, error) {
+func (m *MockRepository) AddAll() error {
 	if m.AddAllError != nil {
-		return git.Status{}, m.AddAllError
+		return m.AddAllError
 	}
-	return m.AddAllStatus, nil
+	return nil
 }
 
 func (m *MockRepository) Commit(msg string) error {

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
@@ -80,12 +79,9 @@ func TestNewInitRunner(t *testing.T) {
 
 func TestInitRun(t *testing.T) {
 	t.Parallel()
-	gitStatus := make(git.Status)
-	gitStatus["file.txt"] = &git.FileStatus{Worktree: git.Modified}
 
 	mockRepoWithReleasableUnit := &MockRepository{
-		Dir:          t.TempDir(),
-		AddAllStatus: gitStatus,
+		Dir: t.TempDir(),
 		RemotesValue: []*gitrepo.Remote{
 			{
 				Name: "origin",
@@ -883,8 +879,7 @@ func TestInitRun(t *testing.T) {
 						},
 					},
 					repo: &MockRepository{
-						Dir:          t.TempDir(),
-						AddAllStatus: gitStatus,
+						Dir: t.TempDir(),
 						RemotesValue: []*gitrepo.Remote{
 							{
 								Name: "origin",

--- a/system_test.go
+++ b/system_test.go
@@ -148,7 +148,7 @@ func TestPullRequestSystem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error writing a file to git repo %s", err)
 	}
-	_, err = localRepository.AddAll()
+	err = localRepository.AddAll()
 	if err != nil {
 		t.Fatalf("unexepected error in AddAll() %s", err)
 	}


### PR DESCRIPTION
We should avoid returning other packages types in our wrappers.

Updates: #2372