### PR TITLE
fix(sidekick): missing IDs in discovery doc fields

### DIFF
--- a/internal/sidekick/internal/parser/disco_test.go
+++ b/internal/sidekick/internal/parser/disco_test.go
@@ -101,6 +101,7 @@ func TestDisco_ParsePagination(t *testing.T) {
 	wantPagination := &api.Field{
 		Name:     "pageToken",
 		JSONName: "pageToken",
+		ID:       "..zones.listRequest.pageToken",
 		Typez:    api.STRING_TYPE,
 		TypezID:  "string",
 		Optional: true,

--- a/internal/sidekick/internal/parser/discovery/discovery_test.go
+++ b/internal/sidekick/internal/parser/discovery/discovery_test.go
@@ -142,6 +142,7 @@ func TestMessage(t *testing.T) {
 			{
 				Name:          "backendService",
 				JSONName:      "backendService",
+				ID:            "..WeightedBackendService.backendService",
 				Documentation: "The full or partial URL to the default BackendService resource. Before forwarding the request to backendService, the load balancer applies any relevant headerActions specified as part of this backendServiceWeight.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -149,6 +150,7 @@ func TestMessage(t *testing.T) {
 			{
 				Name:          "headerAction",
 				JSONName:      "headerAction",
+				ID:            "..WeightedBackendService.headerAction",
 				Documentation: "Specifies changes to request and response headers that need to take effect for the selected backendService. headerAction specified here take effect before headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap. headerAction is not supported for load balancers that have their loadBalancingScheme set to EXTERNAL. Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.",
 				Typez:         api.MESSAGE_TYPE,
 				TypezID:       "..HttpHeaderAction",
@@ -157,6 +159,7 @@ func TestMessage(t *testing.T) {
 			{
 				Name:          "weight",
 				JSONName:      "weight",
+				ID:            "..WeightedBackendService.weight",
 				Documentation: "Specifies the fraction of traffic sent to a backend service, computed as weight / (sum of all weightedBackendService weights in routeAction) . The selection of a backend service is determined only for new traffic. Once a user's request has been directed to a backend service, subsequent requests are sent to the same backend service as determined by the backend service's session affinity policy. Don't configure session affinity if you're using weighted traffic splitting. If you do, the weighted traffic splitting configuration takes precedence. The value must be from 0 to 1000.",
 				Typez:         api.UINT32_TYPE,
 				TypezID:       "uint32",

--- a/internal/sidekick/internal/parser/discovery/enum_field_test.go
+++ b/internal/sidekick/internal/parser/discovery/enum_field_test.go
@@ -106,6 +106,7 @@ func TestMakeEnumFields(t *testing.T) {
 			{
 				Name:          "networkTier",
 				JSONName:      "networkTier",
+				ID:            ".package.Message.networkTier",
 				Documentation: "The networking tier.",
 				Typez:         api.ENUM_TYPE,
 				TypezID:       ".package.Message.networkTier",

--- a/internal/sidekick/internal/parser/discovery/message_fields.go
+++ b/internal/sidekick/internal/parser/discovery/message_fields.go
@@ -74,6 +74,7 @@ func makeScalarField(model *api.API, message *api.Message, name string, schema *
 	return &api.Field{
 		Name:          name,
 		JSONName:      name, // OpenAPI field names are always camelCase
+		ID:            fmt.Sprintf("%s.%s", message.ID, name),
 		Documentation: schema.Description,
 		Typez:         typez,
 		TypezID:       typezID,

--- a/internal/sidekick/internal/parser/discovery/message_fields_test.go
+++ b/internal/sidekick/internal/parser/discovery/message_fields_test.go
@@ -78,6 +78,7 @@ func TestMakeMessageFields(t *testing.T) {
 		{
 			Name:          "intField",
 			JSONName:      "intField",
+			ID:            ".package.Message.intField",
 			Documentation: "The field description.",
 			Typez:         api.INT32_TYPE,
 			TypezID:       "int32",
@@ -85,6 +86,7 @@ func TestMakeMessageFields(t *testing.T) {
 		{
 			Name:          "longField",
 			JSONName:      "longField",
+			ID:            ".package.Message.longField",
 			Documentation: "The field description.",
 			Typez:         api.UINT64_TYPE,
 			TypezID:       "uint64",
@@ -92,6 +94,7 @@ func TestMakeMessageFields(t *testing.T) {
 		{
 			Name:          "arrayFieldString",
 			JSONName:      "arrayFieldString",
+			ID:            ".package.Message.arrayFieldString",
 			Documentation: "The field description.",
 			Typez:         api.STRING_TYPE,
 			TypezID:       "string",
@@ -100,6 +103,7 @@ func TestMakeMessageFields(t *testing.T) {
 		{
 			Name:          "arrayFieldObject",
 			JSONName:      "arrayFieldObject",
+			ID:            ".package.Message.arrayFieldObject",
 			Documentation: "The field description.",
 			Typez:         api.MESSAGE_TYPE,
 			TypezID:       ".package.AnotherMessage",

--- a/internal/sidekick/internal/parser/discovery/methods_test.go
+++ b/internal/sidekick/internal/parser/discovery/methods_test.go
@@ -74,6 +74,7 @@ func TestMethodEmptyBody(t *testing.T) {
 			{
 				Name:          "project",
 				JSONName:      "project",
+				ID:            "..zones.getRequest.project",
 				Documentation: "Project ID for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -81,6 +82,7 @@ func TestMethodEmptyBody(t *testing.T) {
 			{
 				Name:          "zone",
 				JSONName:      "zone",
+				ID:            "..zones.getRequest.zone",
 				Documentation: "Name of the zone resource to return.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -117,6 +119,7 @@ func TestMethodWithQueryParameters(t *testing.T) {
 			{
 				Name:          "filter",
 				JSONName:      "filter",
+				ID:            "..zones.listRequest.filter",
 				Documentation: "A filter expression that filters resources listed in the response. Most Compute resources support two types of filter expressions: expressions that support regular expressions and expressions that follow API improvement proposal AIP-160. These two types of filter expressions cannot be mixed in one request. If you want to use AIP-160, your expression must specify the field name, an operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The operator must be either `=`, `!=`, `>`, `<`, `<=`, `>=` or `:`. For example, if you are filtering Compute Engine instances, you can exclude instances named `example-instance` by specifying `name != example-instance`. The `:*` comparison can be used to test whether a key has been defined. For example, to find all objects with `owner` label use: ``` labels.owner:* ``` You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels. To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = \"Intel Skylake\") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = \"Intel Skylake\") OR (cpuPlatform = \"Intel Broadwell\") AND (scheduling.automaticRestart = true) ``` If you want to use a regular expression, use the `eq` (equal) or `ne` (not equal) operator against a single un-parenthesized expression with or without quotes or against multiple parenthesized expressions. Examples: `fieldname eq unquoted literal` `fieldname eq 'single quoted literal'` `fieldname eq \"double quoted literal\"` `(fieldname1 eq literal) (fieldname2 ne \"literal\")` The literal value is interpreted as a regular expression using Google RE2 library syntax. The literal value must match the entire field. For example, to filter for instances that do not end with name \"instance\", you would use `name ne .*instance`. You cannot combine constraints on multiple fields using regular expressions.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -125,6 +128,7 @@ func TestMethodWithQueryParameters(t *testing.T) {
 			{
 				Name:          "maxResults",
 				JSONName:      "maxResults",
+				ID:            "..zones.listRequest.maxResults",
 				Documentation: "The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)",
 				Typez:         api.UINT32_TYPE,
 				TypezID:       "uint32",
@@ -133,6 +137,7 @@ func TestMethodWithQueryParameters(t *testing.T) {
 			{
 				Name:          "orderBy",
 				JSONName:      "orderBy",
+				ID:            "..zones.listRequest.orderBy",
 				Documentation: "Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name. You can also sort results in descending order based on the creation timestamp using `orderBy=\"creationTimestamp desc\"`. This sorts results based on the `creationTimestamp` field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first. Currently, only sorting by `name` or `creationTimestamp desc` is supported.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -141,6 +146,7 @@ func TestMethodWithQueryParameters(t *testing.T) {
 			{
 				Name:          "pageToken",
 				JSONName:      "pageToken",
+				ID:            "..zones.listRequest.pageToken",
 				Documentation: "Specifies a page token to use. Set `pageToken` to the `nextPageToken` returned by a previous list request to get the next page of results.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -149,6 +155,7 @@ func TestMethodWithQueryParameters(t *testing.T) {
 			{
 				Name:          "project",
 				JSONName:      "project",
+				ID:            "..zones.listRequest.project",
 				Documentation: "Project ID for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -156,6 +163,7 @@ func TestMethodWithQueryParameters(t *testing.T) {
 			{
 				Name:          "returnPartialSuccess",
 				JSONName:      "returnPartialSuccess",
+				ID:            "..zones.listRequest.returnPartialSuccess",
 				Documentation: "Opt-in for partial success behavior which provides partial results in case of failure. The default value is false. For example, when partial success behavior is enabled, aggregatedList for a single zone scope either returns all resources in the zone or no resources, with an error code.",
 				Typez:         api.BOOL_TYPE,
 				TypezID:       "bool",
@@ -193,6 +201,7 @@ func TestMethodWithBody(t *testing.T) {
 			{
 				Name:          "project",
 				JSONName:      "project",
+				ID:            "..addresses.insertRequest.project",
 				Documentation: "Project ID for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -200,6 +209,7 @@ func TestMethodWithBody(t *testing.T) {
 			{
 				Name:          "region",
 				JSONName:      "region",
+				ID:            "..addresses.insertRequest.region",
 				Documentation: "Name of the region for this request.",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",
@@ -207,6 +217,7 @@ func TestMethodWithBody(t *testing.T) {
 			{
 				Name:          "requestId",
 				JSONName:      "requestId",
+				ID:            "..addresses.insertRequest.requestId",
 				Documentation: "An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).",
 				Typez:         api.STRING_TYPE,
 				TypezID:       "string",


### PR DESCRIPTION
Part of the work for #1850
