### PR TITLE
fix(internal/conventionalcommits): relax footer regex to allow line broke footers to be properly recognized

### DIFF
--- a/internal/conventionalcommits/conventional_commits.go
+++ b/internal/conventionalcommits/conventional_commits.go
@@ -261,6 +261,8 @@ func parseHeader(headerLine string) (*parsedHeader, bool) {
 }
 
 // separateBodyAndFooters splits the lines after the header into body and footer sections.
+// It identifies the footer section by looking for a blank line followed by a
+// line that matches the conventional commit footer format.
 func separateBodyAndFooters(lines []string) (bodyLines, footerLines []string) {
 	inFooterSection := false
 	for i, line := range lines {

--- a/internal/conventionalcommits/conventional_commits.go
+++ b/internal/conventionalcommits/conventional_commits.go
@@ -38,9 +38,9 @@ var (
 	commitRegex = regexp.MustCompile(`^(?P<type>\w+)(?:\((?P<scope>.*)\))?(?P<breaking>!)?:\s(?P<description>.*)`)
 	// footerRegex defines the format for a conventional commit footer.
 	// A footer key consists of letters and hyphens, or is the "BREAKING CHANGE"
-	// literal. The key is followed by ": " and then the value.
+	// literal. The key is followed by ":" and then the value.
 	// e.g., "Reviewed-by: G. Gemini" or "BREAKING CHANGE: an API was changed".
-	footerRegex     = regexp.MustCompile(`^([A-Za-z-]+|` + breakingChangeKey + `):\s*(.*)`)
+	footerRegex     = regexp.MustCompile(`^([A-Za-z-]+|` + breakingChangeKey + `):(.*)`)
 	sourceLinkRegex = regexp.MustCompile(`^\[googleapis\/googleapis@(?P<shortSHA>.*)\]\(https:\/\/github\.com\/googleapis\/googleapis\/commit\/(?P<sha>.*)\)$`)
 )
 

--- a/internal/conventionalcommits/conventional_commits.go
+++ b/internal/conventionalcommits/conventional_commits.go
@@ -40,7 +40,7 @@ var (
 	// A footer key consists of letters and hyphens, or is the "BREAKING CHANGE"
 	// literal. The key is followed by ": " and then the value.
 	// e.g., "Reviewed-by: G. Gemini" or "BREAKING CHANGE: an API was changed".
-	footerRegex     = regexp.MustCompile(`^([A-Za-z-]+|` + breakingChangeKey + `):\s(.*)`)
+	footerRegex     = regexp.MustCompile(`^([A-Za-z-]+|` + breakingChangeKey + `):\s*(.*)`)
 	sourceLinkRegex = regexp.MustCompile(`^\[googleapis\/googleapis@(?P<shortSHA>.*)\]\(https:\/\/github\.com\/googleapis\/googleapis\/commit\/(?P<sha>.*)\)$`)
 )
 

--- a/internal/conventionalcommits/conventional_commits_test.go
+++ b/internal/conventionalcommits/conventional_commits_test.go
@@ -674,19 +674,19 @@ func TestParseFooters(t *testing.T) {
 		{
 			name: "multiple footers with key on one line, value on the next",
 			footerLines: []string{
-				"PiperOrigin-RevId: 802200836",
+				"PiperOrigin-RevId: 123456",
 				"",
 				"Source-Link:",
 				"",
-				"googleapis/googleapis@d300b15",
+				"googleapis/googleapis@a12b345",
 				"",
 				"",
 				"Copy-Tag:",
 				"eyJwIjoic",
 			},
 			wantFooters: map[string]string{
-				"PiperOrigin-RevId": "802200836",
-				"Source-Link":       "\ngoogleapis/googleapis@d300b15",
+				"PiperOrigin-RevId": "123456",
+				"Source-Link":       "\ngoogleapis/googleapis@a12b345",
 				"Copy-Tag":          "\neyJwIjoic"},
 		},
 	} {

--- a/internal/conventionalcommits/conventional_commits_test.go
+++ b/internal/conventionalcommits/conventional_commits_test.go
@@ -672,7 +672,7 @@ func TestParseFooters(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple footers with key on one line, value on the next",
+			name: "multi-line footers with key on one line, value on the next",
 			footerLines: []string{
 				"PiperOrigin-RevId: 123456",
 				"",

--- a/internal/conventionalcommits/conventional_commits_test.go
+++ b/internal/conventionalcommits/conventional_commits_test.go
@@ -621,7 +621,7 @@ func TestConventionalCommit_MarshalJSON(t *testing.T) {
 }
 
 func TestParseFooters(t *testing.T) {
-	for _, tt := range []struct {
+	for _, test := range []struct {
 		name           string
 		footerLines    []string
 		wantFooters    map[string]string
@@ -677,6 +677,7 @@ func TestParseFooters(t *testing.T) {
 				"PiperOrigin-RevId: 802200836",
 				"",
 				"Source-Link:",
+				"",
 				"googleapis/googleapis@d300b15",
 				"",
 				"",
@@ -689,13 +690,13 @@ func TestParseFooters(t *testing.T) {
 				"Copy-Tag":          "\neyJwIjoic"},
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			gotFooters, gotIsBreaking := parseFooters(tt.footerLines)
-			if diff := cmp.Diff(tt.wantFooters, gotFooters); diff != "" {
+		t.Run(test.name, func(t *testing.T) {
+			gotFooters, gotIsBreaking := parseFooters(test.footerLines)
+			if diff := cmp.Diff(test.wantFooters, gotFooters); diff != "" {
 				t.Errorf("parseFooters() footers mismatch (-want +got):%s", diff)
 			}
-			if gotIsBreaking != tt.wantIsBreaking {
-				t.Errorf("parseFooters() isBreaking = %v, want %v", gotIsBreaking, tt.wantIsBreaking)
+			if gotIsBreaking != test.wantIsBreaking {
+				t.Errorf("parseFooters() isBreaking = %v, want %v", gotIsBreaking, test.wantIsBreaking)
 			}
 		})
 	}


### PR DESCRIPTION
The original logic expect footer to follow `key: value` (exactly one space before value) format as conventionalcommit specs. For multi-line footers, when parsing ([logic](https://github.com/googleapis/librarian/blob/9b28aa4a3619579dfa59c430afa612589b353598/internal/conventionalcommits/conventional_commits.go#L336)), the line content "Source-Link:" would fail the regex match and thus not properly recognized as footer, and gets appended to the value of the previous footer.

By relaxing the regex a bit to allow any number of spaces before "value" in footer, the multiline footer can be recognized. 

note: this format below from owlbot PR ([example](https://github.com/googleapis/google-cloud-python/commit/34a7916fa58727a01a7d32c6a1adff59a351fd54)) is technically not valid footer according to conventionalcommits.org spec [here](https://www.conventionalcommits.org/en/v1.0.0/#:~:text=Each%20footer%20MUST%20consist%20of%20a%20word%20token%2C%20followed%20by%20either%20a%20%3A%3Cspace%3E%20or%20%3Cspace%3E%23%20separator%2C%20followed%20by%20a%20string%20value). But we are relaxing to allow it for onboarding libraries.
```
Source-Link:
googleapis/googleapis@d300b15
```

This should solve the first issue causing this bug, see [comment](https://github.com/googleapis/librarian/issues/2080#issuecomment-3321551055)

For #2080