### PR TITLE
refactor(internal/github): remove dep on gitrepo package

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v69/github"
-	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
 // PullRequest is a type alias for the go-github type.
@@ -213,27 +212,6 @@ func (c *Client) AddLabelsToIssue(ctx context.Context, repo *Repository, number 
 	slog.Info("Labels added to issue", "number", number, "labels", labels)
 	_, _, err := c.Issues.AddLabelsToIssue(ctx, repo.Owner, repo.Name, number, labels)
 	return err
-}
-
-// FetchGitHubRepoFromRemote parses the GitHub repo name from the remote for this repository.
-// There must be a remote named 'origin' with a GitHub URL (as the first URL), in order to
-// provide an unambiguous result.
-// Remotes without any URLs, or where the first URL does not start with https://github.com/ are ignored.
-func FetchGitHubRepoFromRemote(repo gitrepo.Repository) (*Repository, error) {
-	remotes, err := repo.Remotes()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, remote := range remotes {
-		if remote.Name == "origin" {
-			if len(remote.URLs) > 0 {
-				return ParseRemote(remote.URLs[0])
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("could not find an 'origin' remote pointing to a GitHub https URL")
 }
 
 // SearchPullRequests searches for pull requests in the repository using the provided raw query.

--- a/internal/librarian/repository_test.go
+++ b/internal/librarian/repository_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	gogitConfig "github.com/go-git/go-git/v5/config"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/github"
+	"github.com/googleapis/librarian/internal/gitrepo"
+)
+
+func TestGetGitHubRepositoryFromGitRepo(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name          string
+		remotes       map[string][]string
+		wantRepo      *github.Repository
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name: "origin is a GitHub remote",
+			remotes: map[string][]string{
+				"origin": {"https://github.com/owner/repo.git"},
+			},
+			wantRepo: &github.Repository{Owner: "owner", Name: "repo"},
+		},
+		{
+			name:          "No remotes",
+			remotes:       map[string][]string{},
+			wantErr:       true,
+			wantErrSubstr: "could not find an 'origin' remote",
+		},
+		{
+			name: "origin is not a GitHub remote",
+			remotes: map[string][]string{
+				"origin": {"https://gitlab.com/owner/repo.git"},
+			},
+			wantErr:       true,
+			wantErrSubstr: "is not a GitHub remote",
+		},
+		{
+			name: "upstream is GitHub, but no origin",
+			remotes: map[string][]string{
+				"gitlab":   {"https://gitlab.com/owner/repo.git"},
+				"upstream": {"https://github.com/gh-owner/gh-repo.git"},
+			},
+			wantErr:       true,
+			wantErrSubstr: "could not find an 'origin' remote",
+		},
+		{
+			name: "origin and upstream are GitHub remotes, should use origin",
+			remotes: map[string][]string{
+				"origin":   {"https://github.com/owner/repo.git"},
+				"upstream": {"https://github.com/owner2/repo2.git"},
+			},
+			wantRepo: &github.Repository{Owner: "owner", Name: "repo"},
+		},
+		{
+			name: "origin is not GitHub, but upstream is",
+			remotes: map[string][]string{
+				"origin":   {"https://gitlab.com/owner/repo.git"},
+				"upstream": {"https://github.com/gh-owner/gh-repo.git"},
+			},
+			wantErr:       true,
+			wantErrSubstr: "is not a GitHub remote",
+		},
+		{
+			name: "origin has multiple URLs, first is GitHub",
+			remotes: map[string][]string{
+				"origin": {"https://github.com/owner/repo.git", "https://gitlab.com/owner/repo.git"},
+			},
+			wantRepo: &github.Repository{Owner: "owner", Name: "repo"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			repo := newTestGitRepoWithRemotes(t, test.remotes)
+
+			got, err := GetGitHubRepositoryFromGitRepo(repo)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("FetchGitHubRepoFromRemote() err = nil, want error containing %q", test.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Errorf("FetchGitHubRepoFromRemote() err = %v, want error containing %q", err, test.wantErrSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("FetchGitHubRepoFromRemote() err = %v, want nil", err)
+				}
+				if diff := cmp.Diff(test.wantRepo, got); diff != "" {
+					t.Errorf("FetchGitHubRepoFromRemote() repo mismatch (-want +got): %s", diff)
+				}
+			}
+		})
+	}
+}
+
+// newTestGitRepo creates a new git repository in a temporary directory with the given remotes.
+func newTestGitRepoWithRemotes(t *testing.T, remotes map[string][]string) *gitrepo.LocalRepository {
+	t.Helper()
+	dir := t.TempDir()
+
+	r, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("git.PlainInit failed: %v", err)
+	}
+
+	for name, urls := range remotes {
+		_, err := r.CreateRemote(&gogitConfig.RemoteConfig{
+			Name: name,
+			URLs: urls,
+		})
+		if err != nil {
+			t.Fatalf("CreateRemote failed: %v", err)
+		}
+	}
+
+	repo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{Dir: dir})
+	if err != nil {
+		t.Fatalf("gitrepo.NewRepository failed: %v", err)
+	}
+	return repo
+}

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -88,7 +88,7 @@ func parseRemote(repo string) (*github.Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return github.FetchGitHubRepoFromRemote(githubRepo)
+	return GetGitHubRepositoryFromGitRepo(githubRepo)
 }
 
 func (r *tagAndReleaseRunner) run(ctx context.Context) error {


### PR DESCRIPTION
The git and github packages should be standalone and not depend on eachother. Instead the thing that uses both of them, librarian, is responsible for converting the types and whatnot.

Updates: #2372