### PR TITLE
feat: allow "." as valid `source_roots` entry

### DIFF
--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/conventionalcommits"
+	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
 const (
@@ -239,6 +240,10 @@ const invalidPathChars = "<>:\"|?*/\\\x00"
 func isValidRelativePath(pathString string) bool {
 	if pathString == "" {
 		return false
+	}
+
+	if pathString == gitrepo.RootPath {
+		return true
 	}
 
 	// The paths are expected to be relative and use the OS-specific path separator.

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -392,7 +392,7 @@ func TestIsValidDirPath(t *testing.T) {
 		{"absolute", "/a/b", false},
 		{"up traversal", "../a", false},
 		{"double dot", "..", false},
-		{"single dot", ".", false},
+		{"single dot", ".", true},
 		{"invalid chars", "a/b<c", false},
 		{"invalid null byte", "a/b\x00c", false},
 	} {

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -975,6 +975,13 @@ func TestGetCommitsForPathsSinceCommit(t *testing.T) {
 			wantErr:       true,
 			wantErrPhrase: "did not find commit",
 		},
+		{
+			name:        "root path matches all commits",
+			paths:       []string{"."},
+			sinceCommit: "",
+			// The current implementation skips the initial commit.
+			wantCommits: []string{"feat: commit 3", "feat: commit 2"},
+		},
 	} {
 
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Towards #2218