### PR TITLE
chore: tag "release-<PR number>" (new format)

### DIFF
--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -162,10 +162,10 @@ func (r *tagAndReleaseRunner) processPullRequest(ctx context.Context, p *github.
 		return err
 	}
 
-	// Add a tag to the release commit to trigger louhi flow: "release-please-{pr number}"
-	// TODO: remove this logic as part of https://github.com/googleapis/librarian/issues/2044
+	// Add a tag to the release commit to trigger louhi flow: "release-{pr number}".
+	// See: go/sdk-librarian:louhi-trigger for details.
 	commitSha := p.GetMergeCommitSHA()
-	tagName := fmt.Sprintf("release-please-%d", p.GetNumber())
+	tagName := fmt.Sprintf("release-%d", p.GetNumber())
 	if err := r.ghClient.CreateTag(ctx, tagName, commitSha); err != nil {
 		return fmt.Errorf("failed to create tag %s: %w", tagName, err)
 	}


### PR DESCRIPTION
When we tag a release, create an additional tag `release-<PR number>`, not `release-please-<PR number>`, because Librarian will replace Release Pleasae. This is the second step in go/sdk-librarian:louhi-trigger.

Fixes https://github.com/googleapis/librarian/issues/2044.
