### PR TITLE
chore: librarian release pull request: 20250926T190454Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-release-container:latest
 libraries:
   - id: librarian
-    version: 0.3.0
+    version: 0.4.0
     last_generated_commit: 97a83d76a09a7f6dcab43675c87bdfeb5bcf1cb5
     apis: []
     source_roots:


### PR DESCRIPTION
Librarian Version: v0.3.1-0.20250926172146-97629914673e
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-release-container:latest
<details><summary>librarian: 0.4.0</summary>

## [0.4.0](https://github.com/googleapis/librarian/compare/v0.3.0...v0.4.0) (2025-09-26)

### Features

* allow &#34;.&#34; as valid `source_roots` entry (#2396) ([2f52aa7](https://github.com/googleapis/librarian/commit/2f52aa7))

* inline messages in discovery docs (#2394) ([043cf65](https://github.com/googleapis/librarian/commit/043cf65))

* write pr-body.txt to the work root when not pushing (#2395) ([862c7d7](https://github.com/googleapis/librarian/commit/862c7d7))

* define LIBRARIAN_GITHUB_TOKEN as a constant (#2367) ([5979bfd](https://github.com/googleapis/librarian/commit/5979bfd))

### Bug Fixes

* missing IDs in discovery doc fields (#2386) ([d579dd7](https://github.com/googleapis/librarian/commit/d579dd7))

</details>