### PR TITLE
feat(sidekick): enum serialization for non-proto sources

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -448,10 +448,11 @@ type enumAnnotation struct {
 }
 
 type enumValueAnnotation struct {
-	Name        string
-	VariantName string
-	EnumType    string
-	DocLines    []string
+	Name              string
+	VariantName       string
+	EnumType          string
+	DocLines          []string
+	SerializeAsString bool
 }
 
 // annotateModel creates a struct used as input for Mustache templates.
@@ -1091,9 +1092,10 @@ func (c *codec) annotateEnum(e *api.Enum, model *api.API, full bool) {
 
 func (c *codec) annotateEnumValue(ev *api.EnumValue, model *api.API, full bool) {
 	annotations := &enumValueAnnotation{
-		Name:        enumValueName(ev),
-		EnumType:    enumName(ev.Parent),
-		VariantName: enumValueVariantName(ev),
+		Name:              enumValueName(ev),
+		EnumType:          enumName(ev.Parent),
+		VariantName:       enumValueVariantName(ev),
+		SerializeAsString: c.serializeEnumsAsStrings,
 	}
 	ev.Codec = annotations
 

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -53,25 +53,29 @@ var commentUrlRegex = regexp.MustCompile(
 
 func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 	var sysParams []systemParameter
+	var serializeEnumsAsStrings bool
 	if protobufSource {
 		sysParams = append(sysParams, systemParameter{
 			Name: "$alt", Value: "json;enum-encoding=int",
 		})
+		serializeEnumsAsStrings = false
 	} else {
 		sysParams = append(sysParams, systemParameter{
 			Name: "$alt", Value: "json",
 		})
+		serializeEnumsAsStrings = true
 	}
 
 	year, _, _ := time.Now().Date()
 	codec := &codec{
-		generationYear:   fmt.Sprintf("%04d", year),
-		modulePath:       "crate::model",
-		extraPackages:    []*packagez{},
-		packageMapping:   map[string]*packagez{},
-		version:          "0.0.0",
-		releaseLevel:     "preview",
-		systemParameters: sysParams,
+		generationYear:          fmt.Sprintf("%04d", year),
+		modulePath:              "crate::model",
+		extraPackages:           []*packagez{},
+		packageMapping:          map[string]*packagez{},
+		version:                 "0.0.0",
+		releaseLevel:            "preview",
+		systemParameters:        sysParams,
+		serializeEnumsAsStrings: serializeEnumsAsStrings,
 	}
 
 	for key, definition := range options {
@@ -248,6 +252,8 @@ type codec struct {
 	disabledRustdocWarnings []string
 	// The default system parameters included in all requests.
 	systemParameters []systemParameter
+	// If true, enums are serialized as strings.
+	serializeEnumsAsStrings bool
 	// Overrides the template subdirectory.
 	templateOverride string
 	// If true, this includes gRPC-only methods, such as methods without HTTP

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -53,17 +53,14 @@ var commentUrlRegex = regexp.MustCompile(
 
 func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 	var sysParams []systemParameter
-	var serializeEnumsAsStrings bool
 	if protobufSource {
 		sysParams = append(sysParams, systemParameter{
 			Name: "$alt", Value: "json;enum-encoding=int",
 		})
-		serializeEnumsAsStrings = false
 	} else {
 		sysParams = append(sysParams, systemParameter{
 			Name: "$alt", Value: "json",
 		})
-		serializeEnumsAsStrings = true
 	}
 
 	year, _, _ := time.Now().Date()
@@ -75,7 +72,7 @@ func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 		version:                 "0.0.0",
 		releaseLevel:            "preview",
 		systemParameters:        sysParams,
-		serializeEnumsAsStrings: serializeEnumsAsStrings,
+		serializeEnumsAsStrings: !protobufSource,
 	}
 
 	for key, definition := range options {

--- a/internal/sidekick/internal/rust/codec_test.go
+++ b/internal/sidekick/internal/rust/codec_test.go
@@ -128,6 +128,7 @@ func TestParseOptionsOpenAPI(t *testing.T) {
 		systemParameters: []systemParameter{
 			{Name: "$alt", Value: "json"},
 		},
+		serializeEnumsAsStrings: true,
 	}
 	sort.Slice(want.extraPackages, func(i, j int) bool {
 		return want.extraPackages[i].name < want.extraPackages[j].name
@@ -166,7 +167,8 @@ func TestParseOptionsTemplateOverride(t *testing.T) {
 		systemParameters: []systemParameter{
 			{Name: "$alt", Value: "json"},
 		},
-		templateOverride: "templates/fancy-templates",
+		serializeEnumsAsStrings: true,
+		templateOverride:        "templates/fancy-templates",
 	}
 	sort.Slice(want.extraPackages, func(i, j int) bool {
 		return want.extraPackages[i].name < want.extraPackages[j].name

--- a/internal/sidekick/internal/rust/templates/common/enum.mustache
+++ b/internal/sidekick/internal/rust/templates/common/enum.mustache
@@ -146,7 +146,12 @@ impl serde::ser::Serialize for {{Codec.Name}} {
     {
         match self {
             {{#Codec.UniqueNames}}
+            {{#Codec.SerializeAsString}}
+            Self::{{Codec.VariantName}} => serializer.serialize_str("{{Name}}"),
+            {{/Codec.SerializeAsString}}
+            {{^Codec.SerializeAsString}}
             Self::{{Codec.VariantName}} => serializer.serialize_i32({{Number}}),
+            {{/Codec.SerializeAsString}}
             {{/Codec.UniqueNames}}
             Self::UnknownValue(u) => u.0.serialize(serializer),
         }


### PR DESCRIPTION
Change the serialization of enums for non-proto sources (discovery docs
and OpenAPI) to use strings. The main motivation to use integers in the
case of Protobuf is roundstrips where we receive an unknown enum from
a Protobuf / gRPC response, copy that to a request, and want to
serialize it without loss. That scenario is not a consideration for
OpenAPI or Discovery docs, and serializing enums as integers just does
not work.

Fixes #2406
