### PR TITLE
refactor(sidekick): rust codec initialization

### DIFF
--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -33,7 +33,7 @@ func TestPackageNames(t *testing.T) {
 	}
 	// Override the default name for test APIs ("Test").
 	model.Name = "workflows-v1"
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"per-service-features": "true",
 		"copyright-year":       "2035",
 	})
@@ -158,7 +158,7 @@ func TestServiceAnnotations(t *testing.T) {
 	if !ok {
 		t.Fatal("cannot find .test.v1.ResourceService.DeleteResource")
 	}
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestServiceAnnotationsPerServiceFeatures(t *testing.T) {
 	if !ok {
 		t.Fatal("cannot find .test.v1.ResourceService")
 	}
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"per-service-features": "true",
 	})
 	if err != nil {
@@ -304,7 +304,7 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"include-grpc-only-methods": "true",
 	})
 	if err != nil {
@@ -341,7 +341,7 @@ func TestServiceAnnotationsNameOverrides(t *testing.T) {
 		t.Fatal("cannot find .test.v1.ResourceService.GetResource")
 	}
 
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"name-overrides": ".test.v1.ResourceService=Renamed",
 	})
 	if err != nil {
@@ -566,7 +566,7 @@ func TestOneOfConflictAnnotations(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	api.CrossReference(model)
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"name-overrides": ".test.Message.nested_thing=NestedThingOneOf",
 	})
 	if err != nil {
@@ -632,7 +632,7 @@ func TestEnumAnnotations(t *testing.T) {
 
 	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -725,7 +725,7 @@ func TestDuplicateEnumValueAnnotations(t *testing.T) {
 
 	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -787,7 +787,7 @@ func TestJsonNameAnnotations(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	api.CrossReference(model)
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -887,7 +887,7 @@ func TestMessageAnnotations(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	api.CrossReference(model)
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -976,7 +976,7 @@ func TestFieldAnnotations(t *testing.T) {
 	model.State.MessageByID[map_message.ID] = map_message
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1095,7 +1095,7 @@ func TestPrimitiveFieldAnnotations(t *testing.T) {
 		model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 		api.CrossReference(model)
 		api.LabelRecursiveFields(model)
-		codec, err := newCodec(true, map[string]string{})
+		codec, err := newCodec("protobuf", map[string]string{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1248,7 +1248,7 @@ func TestEnumFieldAnnotations(t *testing.T) {
 	model.State.MessageByID[map_message.ID] = map_message
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"package:wkt": "force-used=true,package=google-cloud-wkt,source=google.protobuf",
 	})
 	if err != nil {
@@ -1407,7 +1407,7 @@ func TestPathInfoAnnotations(t *testing.T) {
 			[]*api.Enum{},
 			[]*api.Service{service})
 		api.CrossReference(model)
-		codec, err := newCodec(true, map[string]string{
+		codec, err := newCodec("protobuf", map[string]string{
 			"include-grpc-only-methods": "true",
 		})
 		if err != nil {
@@ -1617,7 +1617,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 		[]*api.Enum{},
 		[]*api.Service{service})
 	api.CrossReference(model)
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1707,7 +1707,7 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 			[]*api.Enum{},
 			[]*api.Service{service})
 		api.CrossReference(model)
-		codec, err := newCodec(true, map[string]string{})
+		codec, err := newCodec("protobuf", map[string]string{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1879,7 +1879,7 @@ func TestInternalMessageOverrides(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{public, private1, private2},
 		[]*api.Enum{},
 		[]*api.Service{})
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"internal-types": ".test.Private1,.test.Private2",
 	})
 	if err != nil {
@@ -1922,7 +1922,7 @@ func TestRoutingRequired(t *testing.T) {
 	if err := api.CrossReference(model); err != nil {
 		t.Fatal(err)
 	}
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"include-grpc-only-methods": "true",
 		"routing-required":          "true",
 	})
@@ -1938,7 +1938,7 @@ func TestRoutingRequired(t *testing.T) {
 
 func TestGenerateSetterSamples(t *testing.T) {
 	model := serviceAnnotationsModel()
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"generate-setter-samples": "true",
 	})
 	if err != nil {
@@ -1978,7 +1978,7 @@ func TestSetterSampleAnnotations(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enum}, []*api.Service{})
 	api.CrossReference(model)
-	codec, err := newCodec(true, map[string]string{
+	codec, err := newCodec("protobuf", map[string]string{
 		"generate-setter-samples": "true",
 	})
 	if err != nil {

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -51,9 +51,9 @@ var commentUrlRegex = regexp.MustCompile(
 		`[a-zA-Z]{2,63}` + // The root domain is far more strict
 		`(/[-a-zA-Z0-9@:%_\+.~#?&/={}\$]*)?`) // Accept just about anything on the query and URL fragments
 
-func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
+func newCodec(specificationFormat string, options map[string]string) (*codec, error) {
 	var sysParams []systemParameter
-	if protobufSource {
+	if specificationFormat == "protobuf" {
 		sysParams = append(sysParams, systemParameter{
 			Name: "$alt", Value: "json;enum-encoding=int",
 		})
@@ -72,7 +72,7 @@ func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 		version:                 "0.0.0",
 		releaseLevel:            "preview",
 		systemParameters:        sysParams,
-		serializeEnumsAsStrings: !protobufSource,
+		serializeEnumsAsStrings: specificationFormat != "protobuf",
 	}
 
 	for key, definition := range options {

--- a/internal/sidekick/internal/rust/codec_test.go
+++ b/internal/sidekick/internal/rust/codec_test.go
@@ -54,7 +54,7 @@ func TestParseOptionsProtobuf(t *testing.T) {
 		"include-grpc-only-methods": "true",
 		"per-service-features":      "true",
 	}
-	got, err := newCodec(true, options)
+	got, err := newCodec("protobuf", options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestParseOptionsOpenAPI(t *testing.T) {
 		"package-name-override": "test-only",
 		"copyright-year":        "2035",
 	}
-	got, err := newCodec(false, options)
+	got, err := newCodec("openapi", options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestParseOptionsTemplateOverride(t *testing.T) {
 		"copyright-year":        "2038",
 		"template-override":     "templates/fancy-templates",
 	}
-	got, err := newCodec(false, options)
+	got, err := newCodec("disco", options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestParseOptionsDetailedTracingAttributes(t *testing.T) {
 	options := map[string]string{
 		"detailed-tracing-attributes": "true",
 	}
-	got, err := newCodec(false, options)
+	got, err := newCodec("", options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestParseOptionsDetailedTracingAttributes(t *testing.T) {
 	options = map[string]string{
 		"detailed-tracing-attributes": "--invalid--",
 	}
-	if got, err := newCodec(false, options); err == nil {
+	if got, err := newCodec("", options); err == nil {
 		t.Errorf("expected an error with an invalid detailed-tracing-attributes flag, got=%v", got)
 	}
 }
@@ -224,7 +224,7 @@ func TestPackageName(t *testing.T) {
 
 func rustPackageNameImpl(t *testing.T, want string, opts map[string]string, api *api.API) {
 	t.Helper()
-	c, err := newCodec(true, opts)
+	c, err := newCodec("protobuf", opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func rustPackageNameImpl(t *testing.T, want string, opts map[string]string, api 
 }
 
 func TestServiceName(t *testing.T) {
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"name-overrides": ".google.testing.BadName=GoodName,.google.testing.Old=New",
 	})
 	if err != nil {
@@ -245,7 +245,7 @@ func TestServiceName(t *testing.T) {
 	testServiceNameImpl(t, c, "Old", "New")
 	testServiceNameImpl(t, c, "Unchanged", "Unchanged")
 
-	c2, err := newCodec(true, map[string]string{})
+	c2, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func testServiceNameImpl(t *testing.T, c *codec, serviceName string, want string
 }
 
 func TestOneOfEnumName(t *testing.T) {
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"name-overrides": ".google.testing.Message.conflict=ConflictOneOf",
 	})
 	if err != nil {
@@ -275,7 +275,7 @@ func TestOneOfEnumName(t *testing.T) {
 	testOneOfEnumNameImpl(t, c, "conflict", "ConflictOneOf")
 	testOneOfEnumNameImpl(t, c, "basic_case", "BasicCase")
 
-	c2, err := newCodec(true, map[string]string{})
+	c2, err := newCodec("protobuf", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1875,7 +1875,7 @@ func TestParseOptionsGenerateSetterSamples(t *testing.T) {
 	options := map[string]string{
 		"generate-setter-samples": "true",
 	}
-	got, err := newCodec(false, options)
+	got, err := newCodec("", options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/internal/rust/generate.go
+++ b/internal/sidekick/internal/rust/generate.go
@@ -28,7 +28,7 @@ var templates embed.FS
 
 // Generate generates Rust code from the model.
 func Generate(model *api.API, outdir string, cfg *config.Config) error {
-	codec, err := newCodec(cfg.General.SpecificationFormat == "protobuf", cfg.Codec)
+	codec, err := newCodec(cfg.General.SpecificationFormat, cfg.Codec)
 	if err != nil {
 		return err
 	}
@@ -40,12 +40,12 @@ func Generate(model *api.API, outdir string, cfg *config.Config) error {
 
 // GenerateStorage generates Rust code for the storage service.
 func GenerateStorage(outdir string, storageModel *api.API, storageConfig *config.Config, controlModel *api.API, controlConfig *config.Config) error {
-	storageCodec, err := newCodec(storageConfig.General.SpecificationFormat == "protobuf", storageConfig.Codec)
+	storageCodec, err := newCodec(storageConfig.General.SpecificationFormat, storageConfig.Codec)
 	if err != nil {
 		return err
 	}
 	annotateModel(storageModel, storageCodec)
-	controlCodec, err := newCodec(controlConfig.General.SpecificationFormat == "protobuf", controlConfig.Codec)
+	controlCodec, err := newCodec(controlConfig.General.SpecificationFormat, controlConfig.Codec)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/internal/rust/used_by_test.go
+++ b/internal/sidekick/internal/rust/used_by_test.go
@@ -28,7 +28,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 		ID:   ".test.Service",
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"package:tracing":  "used-if=services,package=tracing",
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 	})
@@ -56,7 +56,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 
 func TestUsedByServicesNoServices(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"package:tracing":  "used-if=services,package=tracing",
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 	})
@@ -92,7 +92,7 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 		"package:lro":      "used-if=lro,package=google-cloud-lro",
 	})
@@ -128,7 +128,7 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 		"package:lro":      "used-if=lro,package=google-cloud-lro",
 	})
@@ -168,7 +168,7 @@ func TestUsedByUuidWithAutoPopulation(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 		"package:uuid":     "used-if=autopopulated,package=uuid,feature=v4",
 	})
@@ -205,7 +205,7 @@ func TestUsedByUuidWithoutAutoPopulation(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 		"package:uuid":     "used-if=autopopulated,package=uuid,feature=v4",
 	})
@@ -240,7 +240,7 @@ func TestRequiredPackages(t *testing.T) {
 		"package:gax":         "package=gcp-sdk-gax,force-used=true",
 		"package:auth":        "ignore=true",
 	}
-	c, err := newCodec(true, options)
+	c, err := newCodec("protobuf", options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +262,7 @@ func TestRequiredPackagesLocal(t *testing.T) {
 	options := map[string]string{
 		"package:gtype": "package=types,source=google.type,source=test-only,force-used=true",
 	}
-	c, err := newCodec(true, options)
+	c, err := newCodec("protobuf", options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func TestFindUsedPackages(t *testing.T) {
 		Package: "google.cloud.common",
 	}
 
-	c, err := newCodec(true, map[string]string{
+	c, err := newCodec("protobuf", map[string]string{
 		"package:common":      "package=google-cloud-common,source=google.cloud.common",
 		"package:longrunning": "package=google-longrunning,source=google.longrunning",
 	})


### PR DESCRIPTION
Use the source specification name to initialize the Rust codec. We will
need slightly different serialization of discovery doc bytes, and I
suspect this is not the last difference we will need to deal with.

part of the work for #2407
