### PR TITLE
Revert "feat(sidekick): Inject InstrumentationClientInfo for tracing"

### DIFF
--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -119,15 +119,6 @@ pub(crate) mod info {
             ac.rest_header_value()
         };
     }
-{{#Codec.DetailedTracingAttributes}}
-    pub(crate) static INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = gaxi::options::InstrumentationClientInfo {
-        service_name: "{{Name}}",
-        client_version: VERSION,
-        client_artifact: NAME,
-        default_host: "{{Codec.DefaultHostShort}}",
-        ..Default::default()
-    };
-{{/Codec.DetailedTracingAttributes}}
 }
 
 {{/Codec.HasServices}}

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -53,20 +53,8 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
-        {{#Codec.DetailedTracingAttributes}}
-        let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
-        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
-        let inner = if tracing_is_enabled {
-            inner.with_instrumentation(Some(crate::info::INSTRUMENTATION_CLIENT_INFO))
-        } else {
-            inner
-        };
-        Ok(Self { inner })
-        {{/Codec.DetailedTracingAttributes}}
-        {{^Codec.DetailedTracingAttributes}}
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
-        {{/Codec.DetailedTracingAttributes}}
     }
 }
 


### PR DESCRIPTION
Reverts googleapis/librarian#2252

My automated testing was wrong, it was happily disabled in both the lib.rs and transport.rs because the feature flag wasn't propagated.  I have prepared a fix for the generator, but I'm finding this code incorrect and so I'd like to revert if it can be done cleanly.