### PR TITLE
fix(sidekick/rust): Ensure detailed-tracing-attributes flag is fully propagated

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -57,6 +57,9 @@ type modelAnnotations struct {
 	Incomplete bool
 	// If true, the generator will produce reference documentation samples for message fields setters.
 	GenerateSetterSamples bool
+	// If true, the generated code includes detailed tracing attributes on HTTP
+	// requests.
+	DetailedTracingAttributes bool
 }
 
 // IsWktCrate returns true when bootstrapping the well-known types crate the templates add some
@@ -107,6 +110,9 @@ type serviceAnnotations struct {
 	HasVeneer bool
 	// If true, the service has a method we cannot wrap (yet).
 	Incomplete bool
+	// If true, the generated code includes detailed tracing attributes on HTTP
+	// requests.
+	DetailedTracingAttributes bool
 }
 
 // HasBindingSubstitutions returns true if the method has binding substitutions.
@@ -554,7 +560,8 @@ func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 		Incomplete: slices.ContainsFunc(model.Services, func(s *api.Service) bool {
 			return slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !codec.generateMethod(m) })
 		}),
-		GenerateSetterSamples: codec.generateSetterSamples,
+		GenerateSetterSamples:     codec.generateSetterSamples,
+		DetailedTracingAttributes: codec.detailedTracingAttributes,
 	}
 
 	codec.addFeatureAnnotations(model, ann)
@@ -668,13 +675,14 @@ func (c *codec) annotateService(s *api.Service) {
 		ModuleName:        moduleName,
 		DocLines: c.formatDocComments(
 			s.Documentation, s.ID, s.Model.State, []string{s.ID, s.Package}),
-		Methods:            methods,
-		DefaultHost:        s.DefaultHost,
-		LROTypes:           lroTypes,
-		APITitle:           s.Model.Title,
-		PerServiceFeatures: c.perServiceFeatures,
-		HasVeneer:          c.hasVeneer,
-		Incomplete:         slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !c.generateMethod(m) }),
+		Methods:                   methods,
+		DefaultHost:               s.DefaultHost,
+		LROTypes:                  lroTypes,
+		APITitle:                  s.Model.Title,
+		PerServiceFeatures:        c.perServiceFeatures,
+		HasVeneer:                 c.hasVeneer,
+		Incomplete:                slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !c.generateMethod(m) }),
+		DetailedTracingAttributes: c.detailedTracingAttributes,
 	}
 	s.Codec = ann
 }

--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -164,11 +164,10 @@ func TestServiceAnnotations(t *testing.T) {
 	}
 	annotateModel(model, codec)
 	wantService := &serviceAnnotations{
-		Name:                      "ResourceService",
-		PackageModuleName:         "test::v1",
-		ModuleName:                "resource_service",
-		Incomplete:                true,
-		DetailedTracingAttributes: false,
+		Name:              "ResourceService",
+		PackageModuleName: "test::v1",
+		ModuleName:        "resource_service",
+		Incomplete:        true,
 	}
 	if diff := cmp.Diff(wantService, service.Codec, cmpopts.IgnoreFields(serviceAnnotations{}, "Methods")); diff != "" {
 		t.Errorf("mismatch in service annotations (-want, +got)\n:%s", diff)
@@ -190,11 +189,10 @@ func TestServiceAnnotations(t *testing.T) {
 		SystemParameters: []systemParameter{
 			{Name: "$alt", Value: "json;enum-encoding=int"},
 		},
-		ServiceNameToPascal:       "ResourceService",
-		ServiceNameToCamel:        "resourceService",
-		ServiceNameToSnake:        "resource_service",
-		ReturnType:                "crate::model::Response",
-		DetailedTracingAttributes: false,
+		ServiceNameToPascal: "ResourceService",
+		ServiceNameToCamel:  "resourceService",
+		ServiceNameToSnake:  "resource_service",
+		ReturnType:          "crate::model::Response",
 	}
 	if diff := cmp.Diff(wantMethod, method.Codec); diff != "" {
 		t.Errorf("mismatch in method annotations (-want, +got)\n:%s", diff)
@@ -208,11 +206,10 @@ func TestServiceAnnotations(t *testing.T) {
 		SystemParameters: []systemParameter{
 			{Name: "$alt", Value: "json;enum-encoding=int"},
 		},
-		ServiceNameToPascal:       "ResourceService",
-		ServiceNameToCamel:        "resourceService",
-		ServiceNameToSnake:        "resource_service",
-		ReturnType:                "()",
-		DetailedTracingAttributes: false,
+		ServiceNameToPascal: "ResourceService",
+		ServiceNameToCamel:  "resourceService",
+		ServiceNameToSnake:  "resource_service",
+		ReturnType:          "()",
 	}
 	if diff := cmp.Diff(wantMethod, emptyMethod.Codec); diff != "" {
 		t.Errorf("mismatch in method annotations (-want, +got)\n:%s", diff)
@@ -1127,7 +1124,6 @@ func TestPathBindingAnnotations(t *testing.T) {
 				Template:      []string{"projects", "*", "locations", "*"},
 			},
 		},
-		DetailedTracingAttributes: false,
 	}
 
 	b1 := &api.PathBinding{
@@ -1161,9 +1157,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 				Template:      []string{"*"},
 			},
 		},
-		DetailedTracingAttributes: false,
 	}
-
 	b2 := &api.PathBinding{
 		Verb: "POST",
 		PathTemplate: api.NewPathTemplate().
@@ -1195,9 +1189,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 				Template:      []string{"*"},
 			},
 		},
-		DetailedTracingAttributes: false,
 	}
-
 	b3 := &api.PathBinding{
 		Verb: "GET",
 		PathTemplate: api.NewPathTemplate().
@@ -1210,9 +1202,8 @@ func TestPathBindingAnnotations(t *testing.T) {
 		},
 	}
 	want_b3 := &pathBindingAnnotation{
-		PathFmt:                   "/v2/foos",
-		QueryParams:               []*api.Field{f_name, f_optional, f_child},
-		DetailedTracingAttributes: false,
+		PathFmt:     "/v2/foos",
+		QueryParams: []*api.Field{f_name, f_optional, f_child},
 	}
 	method := &api.Method{
 		Name:         "DoFoo",


### PR DESCRIPTION
This commit fixes the propagation of the `detailed-tracing-attributes` flag to all necessary annotation structs and updates the templates to correctly utilize the flag. See #2435 and #2252 

For https://github.com/googleapis/google-cloud-rust/issues/3239

Specifically:
- Adds `DetailedTracingAttributes` field to `modelAnnotations` and `serviceAnnotations` in `annotate.go` to make the flag accessible in `lib.rs.mustache` and service-level sections of `transport.rs.mustache`.
- Updates `annotateModel` and `annotateService` to populate the new fields.
- Adds comprehensive unit tests in `annotate_test.go` to verify the `DetailedTracingAttributes` flag is correctly set across `modelAnnotations`, `serviceAnnotations`, `methodAnnotation`, and `pathBindingAnnotation` based on the codec options.
- Modifies `lib.rs.mustache` to initialize the static `INSTRUMENTATION_CLIENT_INFO` using `std::sync::LazyLock` to accommodate the non-const `default()` function.
- Updates `transport.rs.mustache` to correctly dereference the `LazyLock` when calling `with_instrumentation` (i.e., `&*crate::info::INSTRUMENTATION_CLIENT_INFO`).

These changes ensure that the conditional code blocks in both `lib.rs.mustache` and `transport.rs.mustache` related to detailed tracing are generated correctly based on the `detailed-tracing-attributes` flag.

Tested:
  - Ran `go test -race ./...` in the librarian repository to ensure all unit tests pass, including new tests for flag propagation in annotations.
  - Manually regenerated the `google-cloud-showcase-v1beta1` client in a local `google-cloud-rust` clone using the modified librarian:
    1.  With `--codec-option=detailed-tracing-attributes=true`: - Verified `src/generated/showcase/src/lib.rs` contains the `INSTRUMENTATION_CLIENT_INFO` static (using `LazyLock`). - Verified `src/generated/showcase/src/transport.rs` includes `.with_instrumentation(&*crate::info::INSTRUMENTATION_CLIENT_INFO)` calls within the `if tracing_is_enabled` blocks in the `new` methods. - Confirmed the crate builds and tests pass: `cargo build -p google-cloud-showcase-v1beta1` `cargo test -p google-cloud-showcase-v1beta1`
    2.  With the flag off (default):
        - Verified the above tracing-specific code is absent.
    3.  By setting `detailed-tracing-attributes = "true"` in `src/generated/showcase/.sidekick.toml` and running refresh without the codec option, confirming the config file is also respected.