### PR TITLE
fix(internal/conventionalcommits): keep first value for repeated footer keys

### DIFF
--- a/internal/conventionalcommits/conventional_commits.go
+++ b/internal/conventionalcommits/conventional_commits.go
@@ -62,6 +62,7 @@ type ConventionalCommit struct {
 	// Scope is the scope of the change.
 	Scope string `yaml:"-" json:"-"`
 	// Footers contain metadata (e.g,"BREAKING CHANGE", "Reviewed-by").
+	// Repeated footer keys not supported, only first value is kept
 	Footers map[string]string `yaml:"-" json:"-"`
 	// IsBreaking indicates if the commit introduces a breaking change.
 	IsBreaking bool `yaml:"-" json:"-"`
@@ -346,6 +347,12 @@ func parseFooters(footerLines []string) (footers map[string]string, isBreaking b
 		}
 		// This is a new footer.
 		key := strings.TrimSpace(footerMatches[1])
+		if _, ok := footers[key]; ok {
+			// Key already exists. Invalidate lastKey to prevent any subsequent
+			// continuation lines from being appended to the wrong footer.
+			lastKey = ""
+			continue
+		}
 		value := strings.TrimSpace(footerMatches[2])
 		footers[key] = value
 		lastKey = key

--- a/internal/conventionalcommits/conventional_commits_test.go
+++ b/internal/conventionalcommits/conventional_commits_test.go
@@ -722,6 +722,18 @@ func TestParseFooters(t *testing.T) {
 			},
 		},
 		{
+			name: "repeated footer keys, keep first",
+			footerLines: []string{
+				"PiperOrigin-RevId: 123456",
+				"Source-Link: first value",
+				"Source-Link: second value",
+			},
+			wantFooters: map[string]string{
+				"PiperOrigin-RevId": "123456",
+				"Source-Link":       "first value",
+			},
+		},
+		{
 			name: "multiline footer",
 			footerLines: []string{
 				"BREAKING CHANGE: something broke",


### PR DESCRIPTION
Footer with repeated keys is not supported with current implementation, this fix let the first value be kept instead of last. Clarify in doc comment about this limitation.

When onboarding libraries that has generation pr with owlbot and release with Librarian, [commit](https://github.com/googleapis/google-cloud-python/commit/34a7916fa58727a01a7d32c6a1adff59a351fd54), the first `Source-Link:` is useful.

Alternative is to refactor `Footer` with type `map[string][]string`. It's probably not worth it because the keys we care for Librarian are not expected to repeat. This can be added as enhancement when needed.

For #2080