### PR TITLE
feat(sidekick): override pagination items field

### DIFF
--- a/internal/sidekick/internal/config/config.go
+++ b/internal/sidekick/internal/config/config.go
@@ -51,14 +51,23 @@ type DocumentationOverride struct {
 	Replace string `toml:"replace"`
 }
 
+// PaginationOverrides describes overrides for pagination config of a method.
+type PaginationOverride struct {
+	// The method ID.
+	ID string `toml:"id"`
+	// The name of the field used for `items`.
+	ItemField string `toml:"item-field"`
+}
+
 // Config is the main configuration struct.
 type Config struct {
 	General GeneralConfig `toml:"general"`
 
-	Source           map[string]string       `toml:"source,omitempty"`
-	Codec            map[string]string       `toml:"codec,omitempty"`
-	CommentOverrides []DocumentationOverride `toml:"documentation-overrides,omitempty"`
-	Release          *Release                `toml:"release,omitempty"`
+	Source              map[string]string       `toml:"source,omitempty"`
+	Codec               map[string]string       `toml:"codec,omitempty"`
+	CommentOverrides    []DocumentationOverride `toml:"documentation-overrides,omitempty"`
+	PaginationOverrides []PaginationOverride    `toml:"pagination-overrides,omitempty"`
+	Release             *Release                `toml:"release,omitempty"`
 
 	// Gcloud is used to pass data into gcloud.Generate. It does not use the
 	// normal .sidekick.toml file, but instead reads a gcloud.yaml file.
@@ -131,9 +140,10 @@ func mergeConfigs(rootConfig, local *Config) *Config {
 			SpecificationFormat: rootConfig.General.SpecificationFormat,
 			IgnoredDirectories:  rootConfig.General.IgnoredDirectories,
 		},
-		Source:           map[string]string{},
-		Codec:            map[string]string{},
-		CommentOverrides: local.CommentOverrides,
+		Source:              map[string]string{},
+		Codec:               map[string]string{},
+		CommentOverrides:    local.CommentOverrides,
+		PaginationOverrides: local.PaginationOverrides,
 		// Release does not accept local overrides
 		Release: rootConfig.Release,
 	}

--- a/internal/sidekick/internal/config/config_test.go
+++ b/internal/sidekick/internal/config/config_test.go
@@ -260,6 +260,61 @@ func TestMergeLocalForDocumentationOverrides(t *testing.T) {
 	}
 }
 
+func TestMergeLocalForPaginationOverrides(t *testing.T) {
+	root := Config{
+		General: GeneralConfig{
+			Language:            "root-language",
+			SpecificationFormat: "root-specification-format",
+		},
+		PaginationOverrides: []PaginationOverride{
+			{
+				ID:        ".package.Service.FromGlobal",
+				ItemField: "features",
+			},
+		},
+	}
+
+	local := Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			SpecificationFormat: "local-specification-format",
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+		PaginationOverrides: []PaginationOverride{
+			{
+				ID:        ".google.sql.v1.SqlAdmin.ListInstances",
+				ItemField: "items",
+			},
+		},
+	}
+
+	got, err := mergeTestConfigs(t, &root, &local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			SpecificationFormat: "local-specification-format",
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+		Codec:  map[string]string{},
+		Source: map[string]string{},
+		PaginationOverrides: []PaginationOverride{
+			{
+				ID:        ".google.sql.v1.SqlAdmin.ListInstances",
+				ItemField: "items",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}
+
 func TestMergeConfigAndFileBadRead(t *testing.T) {
 	root := Config{
 		General: GeneralConfig{

--- a/internal/sidekick/internal/parser/disco.go
+++ b/internal/sidekick/internal/parser/disco.go
@@ -55,7 +55,6 @@ func ParseDisco(source, serviceConfigFile string, options map[string]string) (*a
 	if err != nil {
 		return nil, err
 	}
-	updateMethodPagination(result)
 	updateAutoPopulatedFields(serviceConfig, result)
 	return result, nil
 }

--- a/internal/sidekick/internal/parser/disco_test.go
+++ b/internal/sidekick/internal/parser/disco_test.go
@@ -93,6 +93,7 @@ func TestDisco_ParsePagination(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	updateMethodPagination(nil, model)
 	wantID := "..zones.list"
 	got, ok := model.State.MethodByID[wantID]
 	if !ok {

--- a/internal/sidekick/internal/parser/openapi.go
+++ b/internal/sidekick/internal/parser/openapi.go
@@ -129,7 +129,6 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 	if err != nil {
 		return nil, err
 	}
-	updateMethodPagination(result)
 	updateAutoPopulatedFields(serviceConfig, result)
 	return result, nil
 }

--- a/internal/sidekick/internal/parser/openapi_test.go
+++ b/internal/sidekick/internal/parser/openapi_test.go
@@ -537,6 +537,7 @@ func openapiSecretManagerAPI(t *testing.T) *api.API {
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
+	updateMethodPagination(nil, test)
 	return test
 }
 
@@ -947,6 +948,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
+	updateMethodPagination(nil, test)
 
 	service, ok := test.State.ServiceByID["..Service"]
 	if !ok {

--- a/internal/sidekick/internal/parser/pagination.go
+++ b/internal/sidekick/internal/parser/pagination.go
@@ -15,7 +15,10 @@
 package parser
 
 import (
+	"slices"
+
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+	"github.com/googleapis/librarian/internal/sidekick/internal/config"
 )
 
 const (
@@ -27,7 +30,7 @@ const (
 
 // updateMethodPagination marks all methods that conform to
 // [AIP-4233](https://google.aip.dev/client-libraries/4233) as pageable.
-func updateMethodPagination(a *api.API) {
+func updateMethodPagination(overrides []config.PaginationOverride, a *api.API) {
 	for _, m := range a.State.MethodByID {
 		reqMsg := a.State.MessageByID[m.InputTypeID]
 		pageTokenField := paginationRequestInfo(reqMsg)
@@ -36,7 +39,7 @@ func updateMethodPagination(a *api.API) {
 		}
 
 		respMsg := a.State.MessageByID[m.OutputTypeID]
-		paginationInfo := paginationResponseInfo(respMsg)
+		paginationInfo := paginationResponseInfo(overrides, m.ID, respMsg)
 		if paginationInfo == nil {
 			continue
 		}
@@ -93,11 +96,11 @@ func paginationRequestToken(request *api.Message) *api.Field {
 	return nil
 }
 
-func paginationResponseInfo(response *api.Message) *api.PaginationInfo {
+func paginationResponseInfo(overrides []config.PaginationOverride, methodID string, response *api.Message) *api.PaginationInfo {
 	if response == nil {
 		return nil
 	}
-	pageableItem := paginationResponseItem(response)
+	pageableItem := paginationResponseItem(overrides, methodID, response)
 	nextPageToken := paginationResponseNextPageToken(response)
 	if pageableItem == nil || nextPageToken == nil {
 		return nil
@@ -108,7 +111,17 @@ func paginationResponseInfo(response *api.Message) *api.PaginationInfo {
 	}
 }
 
-func paginationResponseItem(response *api.Message) *api.Field {
+func paginationResponseItem(overrides []config.PaginationOverride, methodID string, response *api.Message) *api.Field {
+	idx := slices.IndexFunc(overrides, func(o config.PaginationOverride) bool { return o.ID == methodID })
+	if idx != -1 {
+		overrideName := overrides[idx].ItemField
+		fieldIdx := slices.IndexFunc(response.Fields, func(f *api.Field) bool { return f.Name == overrideName })
+		if fieldIdx == -1 {
+			return nil
+		}
+		return response.Fields[fieldIdx]
+	}
+
 	for _, field := range response.Fields {
 		if field.Repeated && field.Typez == api.MESSAGE_TYPE {
 			return field

--- a/internal/sidekick/internal/parser/pagination_test.go
+++ b/internal/sidekick/internal/parser/pagination_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+	"github.com/googleapis/librarian/internal/sidekick/internal/config"
 )
 
 func TestPageSimple(t *testing.T) {
@@ -82,13 +83,98 @@ func TestPageSimple(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(model)
+	updateMethodPagination(nil, model)
 	if method.Pagination != request.Fields[1] {
 		t.Errorf("mismatch, want=%v, got=%v", request.Fields[1], method.Pagination)
 	}
 	want := &api.PaginationInfo{
 		NextPageToken: response.Fields[0],
 		PageableItem:  response.Fields[1],
+	}
+	if diff := cmp.Diff(want, response.Pagination); diff != "" {
+		t.Errorf("mismatch, (-want, +got):\n%s", diff)
+	}
+}
+
+func TestPageWithOverride(t *testing.T) {
+	resource := &api.Message{
+		Name: "Resource",
+		ID:   ".package.Resource",
+	}
+	request := &api.Message{
+		Name: "Request",
+		ID:   ".package.Request",
+		Fields: []*api.Field{
+			{
+				Name:     "parent",
+				JSONName: "parent",
+				ID:       ".package.Request.parent",
+				Typez:    api.STRING_TYPE,
+			},
+			{
+				Name:     "page_token",
+				JSONName: "pageToken",
+				ID:       ".package.Request.pageToken",
+				Typez:    api.STRING_TYPE,
+			},
+			{
+				Name:     "page_size",
+				JSONName: "pageSize",
+				ID:       ".package.Request.pageSize",
+				Typez:    api.INT32_TYPE,
+			},
+		},
+	}
+	response := &api.Message{
+		Name: "Response",
+		ID:   ".package.Response",
+		Fields: []*api.Field{
+			{
+				Name:     "next_page_token",
+				JSONName: "nextPageToken",
+				ID:       ".package.Request.nextPageToken",
+				Typez:    api.STRING_TYPE,
+			},
+			{
+				Name:     "warnings",
+				JSONName: "warnings",
+				ID:       ".package.Request.warnings",
+				Typez:    api.MESSAGE_TYPE,
+				TypezID:  ".package.Warning",
+				Repeated: true,
+			},
+			{
+				Name:     "items",
+				JSONName: "items",
+				ID:       ".package.Request.items",
+				Typez:    api.MESSAGE_TYPE,
+				TypezID:  ".package.Resource",
+				Repeated: true,
+			},
+		},
+	}
+	method := &api.Method{
+		Name:         "List",
+		ID:           ".package.Service.List",
+		InputTypeID:  ".package.Request",
+		OutputTypeID: ".package.Response",
+	}
+	service := &api.Service{
+		Name:    "Service",
+		ID:      ".package.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
+	overrides := []config.PaginationOverride{
+		{ID: ".package.Service.List", ItemField: "items"},
+	}
+	updateMethodPagination(overrides, model)
+	if method.Pagination != request.Fields[1] {
+		t.Errorf("mismatch, want=%v, got=%v", request.Fields[1], method.Pagination)
+	}
+	want := &api.PaginationInfo{
+		NextPageToken: response.Fields[0],
+		PageableItem:  response.Fields[2],
 	}
 	if diff := cmp.Diff(want, response.Pagination); diff != "" {
 		t.Errorf("mismatch, (-want, +got):\n%s", diff)
@@ -132,7 +218,7 @@ func TestPageMissingInputType(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(model)
+	updateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
@@ -179,7 +265,7 @@ func TestPageMissingOutputType(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{request, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(model)
+	updateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
@@ -227,7 +313,7 @@ func TestPageBadRequest(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(model)
+	updateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
@@ -279,7 +365,7 @@ func TestPageBadResponse(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(model)
+	updateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
@@ -444,7 +530,7 @@ func TestPaginationResponseErrors(t *testing.T) {
 	}
 
 	for _, input := range []*api.Message{badToken, badItems, nil} {
-		if got := paginationResponseInfo(input); got != nil {
+		if got := paginationResponseInfo(nil, ".package.Service.List", input); got != nil {
 			t.Errorf("expected paginationResponseInfo(...) == nil, got=%v, input=%v", got, input)
 		}
 	}
@@ -472,7 +558,7 @@ func TestPaginationResponseItem(t *testing.T) {
 				},
 			},
 		}
-		got := paginationResponseItem(response)
+		got := paginationResponseItem(nil, ".package.Service.List", response)
 		if got != nil {
 			t.Errorf("the field should not be a pagination item, got=%v", got)
 		}

--- a/internal/sidekick/internal/parser/pagination_test.go
+++ b/internal/sidekick/internal/parser/pagination_test.go
@@ -537,14 +537,19 @@ func TestPaginationResponseErrors(t *testing.T) {
 }
 
 func TestPaginationResponseItem(t *testing.T) {
+	overrides := []config.PaginationOverride{
+		{ID: ".package.Service.List", ItemField: "--invalid--"},
+	}
 	for _, test := range []struct {
-		Name     string
-		Repeated bool
-		Typez    api.Typez
+		Name      string
+		Repeated  bool
+		Typez     api.Typez
+		Overrides []config.PaginationOverride
 	}{
-		{"badRepeated", false, api.MESSAGE_TYPE},
-		{"badType", true, api.STRING_TYPE},
-		{"bothBad", false, api.ENUM_TYPE},
+		{"badRepeated", false, api.MESSAGE_TYPE, nil},
+		{"badType", true, api.STRING_TYPE, nil},
+		{"bothBad", false, api.ENUM_TYPE, nil},
+		{"badOverride", true, api.MESSAGE_TYPE, overrides},
 	} {
 		response := &api.Message{
 			Name: "Response",
@@ -558,7 +563,7 @@ func TestPaginationResponseItem(t *testing.T) {
 				},
 			},
 		}
-		got := paginationResponseItem(nil, ".package.Service.List", response)
+		got := paginationResponseItem(test.Overrides, ".package.Service.List", response)
 		if got != nil {
 			t.Errorf("the field should not be a pagination item, got=%v", got)
 		}

--- a/internal/sidekick/internal/parser/parser.go
+++ b/internal/sidekick/internal/parser/parser.go
@@ -42,6 +42,7 @@ func CreateModel(config *config.Config) (*api.API, error) {
 	if err != nil {
 		return nil, err
 	}
+	updateMethodPagination(config.PaginationOverrides, model)
 	api.LabelRecursiveFields(model)
 	if err := api.CrossReference(model); err != nil {
 		return nil, err

--- a/internal/sidekick/internal/parser/protobuf.go
+++ b/internal/sidekick/internal/parser/protobuf.go
@@ -331,7 +331,6 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		result.Name = strings.TrimSuffix(serviceConfig.Name, ".googleapis.com")
 	}
 	updatePackageName(result)
-	updateMethodPagination(result)
 	updateAutoPopulatedFields(serviceConfig, result)
 	return result
 }

--- a/internal/sidekick/internal/parser/protobuf_test.go
+++ b/internal/sidekick/internal/parser/protobuf_test.go
@@ -1080,6 +1080,7 @@ func TestProtobuf_TrimLeadingSpacesInDocumentation(t *testing.T) {
 func TestProtobuf_Pagination(t *testing.T) {
 	requireProtoc(t)
 	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "pagination.proto"))
+	updateMethodPagination(nil, test)
 	service, ok := test.State.ServiceByID[".test.TestService"]
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")


### PR DESCRIPTION
In one API (SqlAdmin) the default field for pagination is completely
wrong:

https://github.com/googleapis/googleapis/blob/a4ded737527f57207f37ba9e9c9b44732a0eb70f/google/cloud/sql/v1/cloud_sql_instances.proto#L857-L861

We need a mechanism to override the default choice.

Part of the work for https://github.com/googleapis/google-cloud-rust/issues/3430
