### PR TITLE
feat(sidekick/rust): Update templates for otel

### DIFF
--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -119,6 +119,18 @@ pub(crate) mod info {
             ac.rest_header_value()
         };
     }
+{{#Codec.DetailedTracingAttributes}}
+    lazy_static::lazy_static! {
+        pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
+            let mut info = gaxi::options::InstrumentationClientInfo::default();
+            info.service_name = "{{Name}}";
+            info.client_version = VERSION;
+            info.client_artifact = NAME;
+            info.default_host = "{{Codec.DefaultHostShort}}";
+            info
+        };
+    }
+{{/Codec.DetailedTracingAttributes}}
 }
 
 {{/Codec.HasServices}}

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -53,8 +53,20 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
+        {{#Codec.DetailedTracingAttributes}}
+        let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
+        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
+        let inner = if tracing_is_enabled {
+            inner.with_instrumentation(&*crate::info::INSTRUMENTATION_CLIENT_INFO)
+        } else {
+            inner
+        };
+        Ok(Self { inner })
+        {{/Codec.DetailedTracingAttributes}}
+        {{^Codec.DetailedTracingAttributes}}
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
+        {{/Codec.DetailedTracingAttributes}}
     }
 }
 
@@ -167,7 +179,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{#ReturnsEmpty}}
         .map(|r: gax::response::Response<{{OutputType.Codec.QualifiedName}}>| {
             let (parts, _) = r.into_parts();
-            gax::response::Response::from_parts(parts, ()) 
+            gax::response::Response::from_parts(parts, ())
         })
         {{/ReturnsEmpty}}
     }


### PR DESCRIPTION
- Conditionally include `INSTRUMENTATION_CLIENT_INFO` static in `lib.rs.mustache` using `lazy_static!` based on the `DetailedTracingAttributes` flag.
- Conditionally add `.with_instrumentation()` call in `transport.rs.mustache` based on the `DetailedTracingAttributes` flag.

Tested:
1.  **Flag ON Test:**
    - Reset showcase: `git reset --hard HEAD && git clean -fdx` in `google-cloud-rust/src/generated/showcase`
    - Regenerate: `go run ./cmd/sidekick refresh -project-root ../google-cloud-rust -output src/generated/showcase -codec-option detailed-tracing-attributes=true` in `librarian`
    - Format: `cargo fmt -p google-cloud-showcase-v1beta1` in `google-cloud-rust`
    - Build & Test: `cargo build -p google-cloud-showcase-v1beta1 && cargo test -p google-cloud-showcase-v1beta1` in `google-cloud-rust` - PASSED

2.  **Flag OFF Test:**
    - Reset showcase: `git reset --hard HEAD && git clean -fdx` in `google-cloud-rust/src/generated/showcase`
    - Modified `google-cloud-rust/src/generated/showcase/.sidekick.toml` to set `detailed-tracing-attributes = false`
    - Regenerate: `go run ./cmd/sidekick refresh -project-root ../google-cloud-rust -output src/generated/showcase` in `librarian`
    - Format: `cargo fmt -p google-cloud-showcase-v1beta1` in `google-cloud-rust`
    - Diff: `git diff` in `google-cloud-rust/src/generated/showcase` - Showed no instrumentation code added, confirming the flag works.