### PR TITLE
build: bump generate timeout to 10 hours

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -72,4 +72,4 @@ availableSecrets:
       env: 'LIBRARIAN_GITHUB_TOKEN'
 options:
   logging: CLOUD_LOGGING_ONLY
-timeout: 6h
+timeout: 10h


### PR DESCRIPTION
Similar to https://github.com/googleapis/librarian/pull/2445

Towards https://github.com/googleapis/librarian/issues/2444