### PR TITLE
fix(librarian): shorten SHAs in generate commit msgs

### DIFF
--- a/internal/librarian/release_notes.go
+++ b/internal/librarian/release_notes.go
@@ -98,7 +98,7 @@ BEGIN_NESTED_COMMIT
 
 PiperOrigin-RevId: {{index .Footers "PiperOrigin-RevId"}}
 
-Source-link: [googleapis/googleapis@{{shortSHA .CommitHash}}](https://github.com/googleapis/googleapis/commit/{{.CommitHash}})
+Source-link: [googleapis/googleapis@{{shortSHA .CommitHash}}](https://github.com/googleapis/googleapis/commit/{{shortSHA .CommitHash}})
 END_NESTED_COMMIT
 {{ end }}
 END_COMMIT_OVERRIDE

--- a/internal/librarian/release_notes_test.go
+++ b/internal/librarian/release_notes_test.go
@@ -115,7 +115,7 @@ This is another body.
 
 PiperOrigin-RevId: 573342
 
-Source-link: [googleapis/googleapis@fedcba0](https://github.com/googleapis/googleapis/commit/fedcba0987654321000000000000000000000000)
+Source-link: [googleapis/googleapis@fedcba0](https://github.com/googleapis/googleapis/commit/fedcba0)
 END_NESTED_COMMIT
 
 END_COMMIT_OVERRIDE
@@ -197,7 +197,7 @@ This is another body.
 
 PiperOrigin-RevId: 573342
 
-Source-link: [googleapis/googleapis@fedcba0](https://github.com/googleapis/googleapis/commit/fedcba0987654321000000000000000000000000)
+Source-link: [googleapis/googleapis@fedcba0](https://github.com/googleapis/googleapis/commit/fedcba0)
 END_NESTED_COMMIT
 
 END_COMMIT_OVERRIDE
@@ -275,7 +275,7 @@ This is another body.
 
 PiperOrigin-RevId: 573342
 
-Source-link: [googleapis/googleapis@fedcba0](https://github.com/googleapis/googleapis/commit/fedcba0987654321000000000000000000000000)
+Source-link: [googleapis/googleapis@fedcba0](https://github.com/googleapis/googleapis/commit/fedcba0)
 END_NESTED_COMMIT
 
 BEGIN_NESTED_COMMIT
@@ -284,7 +284,7 @@ This is body.
 
 PiperOrigin-RevId: 98765
 
-Source-link: [googleapis/googleapis@1234567](https://github.com/googleapis/googleapis/commit/1234567890abcdef000000000000000000000000)
+Source-link: [googleapis/googleapis@1234567](https://github.com/googleapis/googleapis/commit/1234567)
 END_NESTED_COMMIT
 
 END_COMMIT_OVERRIDE


### PR DESCRIPTION
This mirrors the change we made in #2325.

Updates: #2470