### PR TITLE
feat: Generate methods that use server-side streaming

### DIFF
--- a/internal/sidekick/internal/dart/annotate.go
+++ b/internal/sidekick/internal/dart/annotate.go
@@ -120,7 +120,7 @@ type methodAnnotation struct {
 	BodyMessageName     string
 	QueryLines          []string
 	IsLROGetOperation   bool
-	ServerSideStreaming bool
+	ServerSideStreaming bool // Whether the server supports streaming via server-sent events (SSE).
 }
 
 // HasBody returns true if the method has a body.

--- a/internal/sidekick/internal/dart/annotate.go
+++ b/internal/sidekick/internal/dart/annotate.go
@@ -111,15 +111,16 @@ func (m *messageAnnotation) HasToStringLines() bool {
 type methodAnnotation struct {
 	Parent *api.Method
 	// The method name using Dart naming conventions.
-	Name              string
-	RequestMethod     string
-	RequestType       string
-	ResponseType      string
-	DocLines          []string
-	ReturnsValue      bool
-	BodyMessageName   string
-	QueryLines        []string
-	IsLROGetOperation bool
+	Name                string
+	RequestMethod       string
+	RequestType         string
+	ResponseType        string
+	DocLines            []string
+	ReturnsValue        bool
+	BodyMessageName     string
+	QueryLines          []string
+	IsLROGetOperation   bool
+	ServerSideStreaming bool
 }
 
 // HasBody returns true if the method has a body.
@@ -563,16 +564,17 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 	}
 
 	annotation := &methodAnnotation{
-		Parent:            method,
-		Name:              strcase.ToLowerCamel(method.Name),
-		RequestMethod:     strings.ToLower(method.PathInfo.Bindings[0].Verb),
-		RequestType:       annotate.resolveTypeName(state.MessageByID[method.InputTypeID], true),
-		ResponseType:      annotate.resolveTypeName(state.MessageByID[method.OutputTypeID], true),
-		DocLines:          formatDocComments(method.Documentation, state),
-		ReturnsValue:      !method.ReturnsEmpty,
-		BodyMessageName:   bodyMessageName,
-		QueryLines:        queryLines,
-		IsLROGetOperation: isGetOperation,
+		Parent:              method,
+		Name:                strcase.ToLowerCamel(method.Name),
+		RequestMethod:       strings.ToLower(method.PathInfo.Bindings[0].Verb),
+		RequestType:         annotate.resolveTypeName(state.MessageByID[method.InputTypeID], true),
+		ResponseType:        annotate.resolveTypeName(state.MessageByID[method.OutputTypeID], true),
+		DocLines:            formatDocComments(method.Documentation, state),
+		ReturnsValue:        !method.ReturnsEmpty,
+		BodyMessageName:     bodyMessageName,
+		QueryLines:          queryLines,
+		IsLROGetOperation:   isGetOperation,
+		ServerSideStreaming: method.ServerSideStreaming,
 	}
 	method.Codec = annotation
 }

--- a/internal/sidekick/internal/dart/dart.go
+++ b/internal/sidekick/internal/dart/dart.go
@@ -234,7 +234,7 @@ func shouldGenerateMethod(m *api.Method) bool {
 	// Ignore methods without HTTP annotations; we cannot generate working RPCs
 	// for them.
 	// TODO(#499) Switch to explicitly excluding such functions.
-	if m.ClientSideStreaming || m.ServerSideStreaming || m.PathInfo == nil {
+	if m.ClientSideStreaming || m.PathInfo == nil {
 		return false
 	}
 	if len(m.PathInfo.Bindings) == 0 {

--- a/internal/sidekick/internal/dart/templates/lib/method.mustache
+++ b/internal/sidekick/internal/dart/templates/lib/method.mustache
@@ -17,6 +17,22 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
+{{#Codec.ServerSideStreaming}}
+Stream<{{Codec.ResponseType}}> {{Codec.Name}}({{Codec.RequestType}} request) {
+  final url = Uri.https(_host, '{{PathInfo.Codec.PathFmt}}'
+    {{#Codec.HasQueryLines}}, {
+      {{#Codec.QueryLines}}
+        {{{.}}},
+      {{/Codec.QueryLines}}
+    }
+    {{/Codec.HasQueryLines}}
+  );
+  return _client
+      .{{Codec.RequestMethod}}Streaming(url{{#Codec.HasBody}}, body: {{Codec.BodyMessageName}}{{/Codec.HasBody}})
+      .map({{Codec.ResponseType}}.fromJson);
+}
+{{/Codec.ServerSideStreaming}}
+{{^Codec.ServerSideStreaming}}
 {{#Codec.IsLROGetOperation}}
 ///
 /// This method can be used to get the current status of a long-running
@@ -51,3 +67,4 @@ Future<{{Codec.ResponseType}}{{#OperationInfo}}<{{Codec.ResponseType}}, {{Codec.
   {{/Codec.ReturnsValue}}
 }
 {{/Codec.IsLROGetOperation}}
+{{/Codec.ServerSideStreaming}}


### PR DESCRIPTION
The generated methods look like this:

```dart
  /// Generates a [streamed response](https://ai.google.dev/gemini-api/docs/text-generation?lang=python#generate-a-text-stream)
  /// from the model given an input `GenerateContentRequest`.
  Stream<GenerateContentResponse> streamGenerateContent(
    GenerateContentRequest request,
  ) {
    final url = Uri.https(_host, '/v1/${request.model}:streamGenerateContent');
    return _client
        .postStreaming(url, body: request)
        .map(GenerateContentResponse.fromJson);
  }
```