### PR TITLE
Revert "feat(sidekick/rust): Update templates for otel"

### DIFF
--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -119,18 +119,6 @@ pub(crate) mod info {
             ac.rest_header_value()
         };
     }
-{{#Codec.DetailedTracingAttributes}}
-    lazy_static::lazy_static! {
-        pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
-            let mut info = gaxi::options::InstrumentationClientInfo::default();
-            info.service_name = "{{Name}}";
-            info.client_version = VERSION;
-            info.client_artifact = NAME;
-            info.default_host = "{{Codec.DefaultHostShort}}";
-            info
-        };
-    }
-{{/Codec.DetailedTracingAttributes}}
 }
 
 {{/Codec.HasServices}}

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -53,20 +53,8 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
-        {{#Codec.DetailedTracingAttributes}}
-        let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
-        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
-        let inner = if tracing_is_enabled {
-            inner.with_instrumentation(&*crate::info::INSTRUMENTATION_CLIENT_INFO)
-        } else {
-            inner
-        };
-        Ok(Self { inner })
-        {{/Codec.DetailedTracingAttributes}}
-        {{^Codec.DetailedTracingAttributes}}
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
-        {{/Codec.DetailedTracingAttributes}}
     }
 }
 
@@ -179,7 +167,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{#ReturnsEmpty}}
         .map(|r: gax::response::Response<{{OutputType.Codec.QualifiedName}}>| {
             let (parts, _) = r.into_parts();
-            gax::response::Response::from_parts(parts, ())
+            gax::response::Response::from_parts(parts, ()) 
         })
         {{/ReturnsEmpty}}
     }


### PR DESCRIPTION
Reverts googleapis/librarian#2443

This caused clippy warnings in google-cloud-rust.

https://github.com/googleapis/google-cloud-rust/actions/runs/18226945878/job/51900522484?pr=3457