### PR TITLE
fix(sidekick/rust): Remove unnecessary dereference in transport template

### DIFF
--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -57,7 +57,7 @@ impl {{Codec.Name}} {
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         let inner = if tracing_is_enabled {
-            inner.with_instrumentation(&*crate::info::INSTRUMENTATION_CLIENT_INFO)
+            inner.with_instrumentation(&crate::info::INSTRUMENTATION_CLIENT_INFO)
         } else {
             inner
         };


### PR DESCRIPTION
Removes an unnecessary `&*` in the `with_instrumentation` call within the generated `transport.rs` file. This was causing a `clippy::explicit_auto_deref` warning.

This issue was highlighted in the google-cloud-rust CI after merging librarian PR #2443. See https://github.com/googleapis/google-cloud-rust/actions/runs/18226945878/job/51900522484?pr=3457

Tested:
  - Regenerated showcase with detailed-tracing-attributes=true, confirmed clippy passes.
  - Regenerated showcase with detailed-tracing-attributes=false, confirmed clippy passes and no tracing code was added.