### PR TITLE
fix(sidekick): real runs for `rust-publish`

### DIFF
--- a/internal/sidekick/rust_publish.go
+++ b/internal/sidekick/rust_publish.go
@@ -37,5 +37,5 @@ the dependency order.
 
 // rustBumpVersions increments the version numbers as needed.
 func rustPublish(rootConfig *config.Config, cmdLine *CommandLine) error {
-	return rustrelease.Publish(rootConfig.Release, true) // cmdLine.DryRun)
+	return rustrelease.Publish(rootConfig.Release, cmdLine.DryRun)
 }


### PR DESCRIPTION
During testing I hard-coded `-dry-run` to true, eventually we need to
run for realsies.