### PR TITLE
feat(sidekick): support extra modules for Rust

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -53,6 +53,8 @@ type modelAnnotations struct {
 	DefaultSystemParameters []systemParameter
 	// Enables per-service features
 	PerServiceFeatures bool
+	// A list of additional modules loaded by the `lib.rs` file.
+	ExtraModules []string
 	// If true, at lease one service has a method we cannot wrap (yet).
 	Incomplete bool
 	// If true, the generator will produce reference documentation samples for message fields setters.
@@ -568,6 +570,7 @@ func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 		NotForPublication:       codec.doNotPublish,
 		DisabledRustdocWarnings: codec.disabledRustdocWarnings,
 		PerServiceFeatures:      codec.perServiceFeatures && len(servicesSubset) > 0,
+		ExtraModules:            codec.extraModules,
 		Incomplete: slices.ContainsFunc(model.Services, func(s *api.Service) bool {
 			return slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !codec.generateMethod(m) })
 		}),

--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -34,24 +34,33 @@ func TestPackageNames(t *testing.T) {
 	// Override the default name for test APIs ("Test").
 	model.Name = "workflows-v1"
 	codec, err := newCodec("protobuf", map[string]string{
-		"per-service-features": "true",
-		"copyright-year":       "2035",
+		"version":                     "1.2.3",
+		"release-level":               "stable",
+		"copyright-year":              "2035",
+		"per-service-features":        "true",
+		"extra-modules":               "operation",
+		"generate-setter-samples":     "true",
+		"detailed-tracing-attributes": "true",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	got := annotateModel(model, codec)
 	want := &modelAnnotations{
-		PackageName:        "google-cloud-workflows-v1",
-		PackageNamespace:   "google_cloud_workflows_v1",
-		PackageVersion:     "0.0.0",
-		ReleaseLevel:       "preview",
-		RequiredPackages:   []string{},
-		ExternPackages:     []string{},
-		CopyrightYear:      "2035",
-		Services:           []*api.Service{},
-		NameToLower:        "workflows-v1",
-		PerServiceFeatures: false,
+		PackageName:               "google-cloud-workflows-v1",
+		PackageVersion:            "1.2.3",
+		ReleaseLevel:              "stable",
+		PackageNamespace:          "google_cloud_workflows_v1",
+		RequiredPackages:          []string{},
+		ExternPackages:            []string{},
+		HasLROs:                   false,
+		CopyrightYear:             "2035",
+		Services:                  []*api.Service{},
+		NameToLower:               "workflows-v1",
+		PerServiceFeatures:        false, // no services
+		ExtraModules:              []string{"operation"},
+		GenerateSetterSamples:     true,
+		DetailedTracingAttributes: true,
 	}
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(modelAnnotations{}, "BoilerPlate")); diff != "" {
 		t.Errorf("mismatch in modelAnnotations list (-want, +got)\n:%s", diff)

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -144,6 +144,8 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `has-veneer` value %q to boolean: %w", definition, err)
 			}
 			codec.hasVeneer = value
+		case key == "extra-modules":
+			codec.extraModules = strings.Split(definition, ",")
 		case key == "internal-types":
 			codec.internalTypes = strings.Split(definition, ",")
 		case key == "routing-required":
@@ -269,6 +271,8 @@ type codec struct {
 	detailedTracingAttributes bool
 	// If true, there is a handwritten client surface.
 	hasVeneer bool
+	// Additional modules, maybe with hand-crafted code.
+	extraModules []string
 	// A list of types which should only be `pub(crate)`.
 	//
 	// In rare cases, it is easiest to manage type visibility via the codec

--- a/internal/sidekick/internal/rust/codec_test.go
+++ b/internal/sidekick/internal/rust/codec_test.go
@@ -227,6 +227,15 @@ func TestParseOptions(t *testing.T) {
 		{
 			Format: "protobuf",
 			Options: map[string]string{
+				"extra-modules": "a,b,c",
+			},
+			Update: func(c *codec) {
+				c.extraModules = []string{"a", "b", "c"}
+			},
+		},
+		{
+			Format: "protobuf",
+			Options: map[string]string{
 				"internal-types": "a,b,c",
 			},
 			Update: func(c *codec) {

--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -134,3 +134,6 @@ pub(crate) mod info {
 }
 
 {{/Codec.HasServices}}
+{{#Codec.ExtraModules}}
+mod {{{.}}};
+{{/Codec.ExtraModules}}

--- a/internal/sidekick/internal/rust/templates/nosvc/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/nosvc/src/lib.rs.mustache
@@ -39,3 +39,6 @@ limitations under the License.
 #[allow(deprecated)]
 {{/HasDeprecatedEntities}}
 pub mod model;
+{{#Codec.ExtraModules}}
+mod {{{.}}};
+{{/Codec.ExtraModules}}


### PR DESCRIPTION
Add option and modify mustache templates to support extra modules.

Part of the work for #2380 