### PR TITLE
chore(e2e_test): add PR body validation to generate E2E tests

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -821,7 +821,7 @@ func runGit(t *testing.T, dir string, args ...string) string {
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("failed to get git commit SHA: %v", err)
+		t.Fatalf("failed to run git command: %s, %v", args, err)
 	}
 	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
This is an initial setup for a single use case of validating that CLI creates PRs with appropriate body elements.

It includes:
1) setting up a state.yaml to correctly track new commits
2) creating commits that should show up in PR body
3) creating validation that appropriate messages show up in PR body

part of #2250 