### PR TITLE
feat(sidekick): add default Rust features option

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -49,10 +49,13 @@ type modelAnnotations struct {
 	// If true, disable rustdoc warnings known to be triggered by our generated
 	// documentation.
 	DisabledRustdocWarnings []string
-	// Sets the default system parameters
+	// Sets the default system parameters.
 	DefaultSystemParameters []systemParameter
-	// Enables per-service features
+	// Enables per-service features.
 	PerServiceFeatures bool
+	// The set of default features, only applicable if `PerServiceFeatures` is
+	// true.
+	DefaultFeatures []string
 	// A list of additional modules loaded by the `lib.rs` file.
 	ExtraModules []string
 	// If true, at lease one service has a method we cannot wrap (yet).
@@ -665,6 +668,10 @@ func (c *codec) addFeatureAnnotations(model *api.API, ann *modelAnnotations) {
 		}
 		annotation.FeatureGatesOp = "all"
 		annotation.FeatureGates = allFeatures
+	}
+	ann.DefaultFeatures = c.defaultFeatures
+	if ann.DefaultFeatures == nil {
+		ann.DefaultFeatures = allFeatures
 	}
 }
 

--- a/internal/sidekick/internal/rust/annotate_model_test.go
+++ b/internal/sidekick/internal/rust/annotate_model_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/internal/api"
+)
+
+func TestDefaultFeatures(t *testing.T) {
+	for _, test := range []struct {
+		Options map[string]string
+		Want    []string
+	}{
+		{
+			Options: map[string]string{
+				"per-service-features": "true",
+			},
+			Want: []string{"service-0", "service-1"},
+		},
+		{
+			Options: map[string]string{
+				"per-service-features": "false",
+			},
+			Want: nil,
+		},
+		{
+			Options: map[string]string{
+				"per-service-features": "true",
+				"default-features":     "service-1",
+			},
+			Want: []string{"service-1"},
+		},
+		{
+			Options: map[string]string{
+				"per-service-features": "true",
+				"default-features":     "",
+			},
+			Want: []string{},
+		},
+	} {
+		model := newTestAnnotateModelAPI()
+		codec, err := newCodec("protobuf", test.Options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := annotateModel(model, codec)
+		t.Logf("Options=%v", test.Options)
+		if diff := cmp.Diff(test.Want, got.DefaultFeatures); diff != "" {
+			t.Errorf("mismatch (-want, +got):\n%s", diff)
+		}
+	}
+}
+
+func newTestAnnotateModelAPI() *api.API {
+	service0 := &api.Service{
+		Name: "Service0",
+		ID:   "..Service0",
+		Methods: []*api.Method{
+			{
+				Name:         "get",
+				ID:           "..Service0.get",
+				InputTypeID:  ".google.protobuf.Empty",
+				OutputTypeID: ".google.protobuf.Empty",
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							Verb:         "GET",
+							PathTemplate: api.NewPathTemplate().WithLiteral("resource"),
+						},
+					},
+				},
+			},
+		},
+	}
+	service1 := &api.Service{
+		Name: "Service1",
+		ID:   "..Service1",
+		Methods: []*api.Method{
+			{
+				Name:         "get",
+				ID:           "..Service1.get",
+				InputTypeID:  ".google.protobuf.Empty",
+				OutputTypeID: ".google.protobuf.Empty",
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							Verb:         "GET",
+							PathTemplate: api.NewPathTemplate().WithLiteral("resource"),
+						},
+					},
+				},
+			},
+		},
+	}
+	model := api.NewTestAPI(
+		[]*api.Message{},
+		[]*api.Enum{},
+		[]*api.Service{service0, service1})
+	api.CrossReference(model)
+	return model
+}

--- a/internal/sidekick/internal/rust/codec.go
+++ b/internal/sidekick/internal/rust/codec.go
@@ -132,6 +132,12 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `per-service-features` value %q to boolean: %w", definition, err)
 			}
 			codec.perServiceFeatures = value
+		case key == "default-features":
+			if definition == "" {
+				codec.defaultFeatures = []string{}
+			} else {
+				codec.defaultFeatures = strings.Split(definition, ",")
+			}
 		case key == "detailed-tracing-attributes":
 			value, err := strconv.ParseBool(definition)
 			if err != nil {
@@ -263,6 +269,8 @@ type codec struct {
 	includeGrpcOnlyMethods bool
 	// If true, the generator will produce per-client features.
 	perServiceFeatures bool
+	// If not empty, and if `perServiceFeatures` is true, the default features
+	defaultFeatures []string
 	// If true, the generated code includes detailed tracing attributes on HTTP
 	// requests. This feature flag exists to reduce unexpected changes to the
 	// generated code until the feature is ready and well-tested.

--- a/internal/sidekick/internal/rust/codec_test.go
+++ b/internal/sidekick/internal/rust/codec_test.go
@@ -209,6 +209,24 @@ func TestParseOptions(t *testing.T) {
 		{
 			Format: "protobuf",
 			Options: map[string]string{
+				"default-features": "a,b,c",
+			},
+			Update: func(c *codec) {
+				c.defaultFeatures = []string{"a", "b", "c"}
+			},
+		},
+		{
+			Format: "protobuf",
+			Options: map[string]string{
+				"default-features": "",
+			},
+			Update: func(c *codec) {
+				c.defaultFeatures = []string{}
+			},
+		},
+		{
+			Format: "protobuf",
+			Options: map[string]string{
 				"detailed-tracing-attributes": "true",
 			},
 			Update: func(c *codec) {

--- a/internal/sidekick/internal/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/internal/rust/templates/common/Cargo.toml.mustache
@@ -36,9 +36,9 @@ publish                = false
 
 [features]
 default = [
-    {{#Codec.Services}}
-    "{{Codec.FeatureName}}",
-    {{/Codec.Services}}
+    {{#Codec.DefaultFeatures}}
+    "{{{.}}}",
+    {{/Codec.DefaultFeatures}}
 ]
 {{#Codec.Services}}
 # Enables `client::{{Codec.Name}}` and all the types it depends on.


### PR DESCRIPTION
In Rust sometimes we add per-service features to only compile the
services one needs. Before this change, all the services are enabled
by default. That won't fly for the Compute API, there are too many
services.

Fixes #2560
