### PR TITLE
fix(sidekick): mangled method names and doc links

### DIFF
--- a/internal/sidekick/internal/rust/annotate.go
+++ b/internal/sidekick/internal/rust/annotate.go
@@ -203,6 +203,7 @@ type messageAnnotation struct {
 
 type methodAnnotation struct {
 	Name                      string
+	NameNoMangling            string
 	BuilderName               string
 	DocLines                  []string
 	PathInfo                  *api.PathInfo
@@ -784,6 +785,7 @@ func (c *codec) annotateMethod(m *api.Method) {
 	serviceName := c.ServiceName(m.Service)
 	annotation := &methodAnnotation{
 		Name:                      toSnake(m.Name),
+		NameNoMangling:            toSnakeNoMangling(m.Name),
 		BuilderName:               toPascal(m.Name),
 		Body:                      bodyAccessor(m),
 		DocLines:                  c.formatDocComments(m.Documentation, m.ID, m.Model.State, m.Service.Scopes()),

--- a/internal/sidekick/internal/rust/annotate_method_test.go
+++ b/internal/sidekick/internal/rust/annotate_method_test.go
@@ -44,6 +44,7 @@ func TestAnnotateMethodNames(t *testing.T) {
 			MethodID: ".test.v1.ResourceService.move",
 			Want: &methodAnnotation{
 				Name:                "r#move",
+				NameNoMangling:      "move",
 				BuilderName:         "Move",
 				Body:                "None::<gaxi::http::NoBody>",
 				ServiceNameToPascal: "ResourceService",
@@ -56,6 +57,7 @@ func TestAnnotateMethodNames(t *testing.T) {
 			MethodID: ".test.v1.ResourceService.Delete",
 			Want: &methodAnnotation{
 				Name:                "delete",
+				NameNoMangling:      "delete",
 				BuilderName:         "Delete",
 				Body:                "None::<gaxi::http::NoBody>",
 				ServiceNameToPascal: "ResourceService",
@@ -68,6 +70,7 @@ func TestAnnotateMethodNames(t *testing.T) {
 			MethodID: ".test.v1.ResourceService.Self",
 			Want: &methodAnnotation{
 				Name:                "r#self",
+				NameNoMangling:      "self",
 				BuilderName:         "r#Self",
 				Body:                "None::<gaxi::http::NoBody>",
 				ServiceNameToPascal: "ResourceService",

--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -191,10 +191,11 @@ func TestServiceAnnotations(t *testing.T) {
 	}
 
 	wantMethod := &methodAnnotation{
-		Name:        "get_resource",
-		BuilderName: "GetResource",
-		Body:        "None::<gaxi::http::NoBody>",
-		PathInfo:    method.PathInfo,
+		Name:           "get_resource",
+		NameNoMangling: "get_resource",
+		BuilderName:    "GetResource",
+		Body:           "None::<gaxi::http::NoBody>",
+		PathInfo:       method.PathInfo,
 		SystemParameters: []systemParameter{
 			{Name: "$alt", Value: "json;enum-encoding=int"},
 		},
@@ -208,10 +209,11 @@ func TestServiceAnnotations(t *testing.T) {
 	}
 
 	wantMethod = &methodAnnotation{
-		Name:        "delete_resource",
-		BuilderName: "DeleteResource",
-		Body:        "None::<gaxi::http::NoBody>",
-		PathInfo:    emptyMethod.PathInfo,
+		Name:           "delete_resource",
+		NameNoMangling: "delete_resource",
+		BuilderName:    "DeleteResource",
+		Body:           "None::<gaxi::http::NoBody>",
+		PathInfo:       emptyMethod.PathInfo,
 		SystemParameters: []systemParameter{
 			{Name: "$alt", Value: "json;enum-encoding=int"},
 		},
@@ -406,7 +408,7 @@ func TestServiceAnnotationsNameOverrides(t *testing.T) {
 		t.Errorf("mismatch in service annotations (-want, +got)\n:%s", diff)
 	}
 
-	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "BuilderName", "Body", "PathInfo", "SystemParameters", "ReturnType")
+	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "NameNoMangling", "BuilderName", "Body", "PathInfo", "SystemParameters", "ReturnType")
 	wantMethod := &methodAnnotation{
 		ServiceNameToPascal: "Renamed",
 		ServiceNameToCamel:  "renamed",

--- a/internal/sidekick/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/builder.rs.mustache
@@ -76,7 +76,7 @@ pub mod {{Codec.ModuleName}} {
     }
 
     {{#Codec.Methods}}
-    /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.Name}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}] calls.
+    /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}] calls.
     ///
     /// # Example
     /// ```no_run


### PR DESCRIPTION
In documentation links we do not want to use the mangled name for each
method.
