### PR TITLE
refactor(librarian): decouple commits data type in state

### DIFF
--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -113,7 +113,7 @@ type LibraryState struct {
 	LastGeneratedCommit string `yaml:"last_generated_commit" json:"-"`
 	// The changes from the language repository since the library was last released.
 	// This field is ignored when writing to state.yaml.
-	Changes []*gitrepo.ConventionalCommit `yaml:"-" json:"changes,omitempty"`
+	Changes []*Commit `yaml:"-" json:"changes,omitempty"`
 	// A list of APIs that are part of this library.
 	APIs []*API `yaml:"apis" json:"apis"`
 	// A list of directories in the language repository where Librarian contributes code.
@@ -140,6 +140,20 @@ type LibraryState struct {
 	// An error message from the docker response.
 	// This field is ignored when writing to state.yaml.
 	ErrorMessage string `yaml:"-" json:"error,omitempty"`
+}
+
+// Commit represents a single commit in the release notes.
+type Commit struct {
+	// Type is the type of change (e.g., "feat", "fix", "docs").
+	Type string `json:"type"`
+	// Subject is the short summary of the change.
+	Subject string `json:"subject"`
+	// Body is the long-form description of the change.
+	Body string `json:"body"`
+	// CommitHash is the full commit hash.
+	CommitHash string `json:"commit_hash,omitempty"`
+	// PiperCLNumber is the Piper CL number associated with the commit.
+	PiperCLNumber string `json:"piper_cl_number,omitempty"`
 }
 
 var (

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/gitrepo"
 )
 
 func TestNew(t *testing.T) {
@@ -929,15 +928,13 @@ func TestReleaseInitRequestContent(t *testing.T) {
 				ID:               "my-library",
 				Version:          "1.1.0",
 				ReleaseTriggered: true,
-				Changes: []*gitrepo.ConventionalCommit{
+				Changes: []*config.Commit{
 					{
-						Type:    "feat",
-						Subject: "new feature",
-						Body:    "body of feature",
-						Footers: map[string]string{
-							"PiperOrigin-RevId": "12345",
-						},
-						CommitHash: "1234",
+						Type:          "feat",
+						Subject:       "new feature",
+						Body:          "body of feature",
+						PiperCLNumber: "12345",
+						CommitHash:    "1234",
 					},
 				},
 			},

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -266,7 +266,7 @@ func (r *initRunner) updateLibrary(library *config.LibraryState, commits []*gitr
 
 	// Update the previous version, we need this value when creating release note.
 	library.PreviousVersion = library.Version
-	library.Changes = commits
+	library.Changes = toCommit(commits)
 	library.Version = nextVersion
 	library.ReleaseTriggered = true
 	return nil
@@ -294,4 +294,22 @@ func (r *initRunner) determineNextVersion(commits []*gitrepo.ConventionalCommit,
 
 	// Compare versions and pick latest
 	return semver.MaxVersion(nextVersionFromCommits, libraryConfig.NextVersion), nil
+}
+
+// toCommit converts a slice of gitrepo.ConventionalCommit to a slice of config.Commit.
+// If the ConventionalCommit has NestedCommits, they are also extracted and
+// converted.
+func toCommit(c []*gitrepo.ConventionalCommit) []*config.Commit {
+	var commits []*config.Commit
+	for _, cc := range c {
+		commits = append(commits, &config.Commit{
+			Type:          cc.Type,
+			Subject:       cc.Subject,
+			Body:          cc.Body,
+			CommitHash:    cc.CommitHash,
+			PiperCLNumber: cc.Footers["PiperOrigin-RevId"],
+		})
+	}
+	return commits
+
 }

--- a/internal/librarian/release_init_test.go
+++ b/internal/librarian/release_init_test.go
@@ -1258,16 +1258,16 @@ func TestUpdateLibrary(t *testing.T) {
 				ID:              "one-id",
 				Version:         "1.3.0",
 				PreviousVersion: "1.2.3",
-				Changes: []*gitrepo.ConventionalCommit{
+				Changes: []*config.Commit{
 					{
 						Type:    "fix",
 						Subject: "change a typo",
 					},
 					{
-						Type:    "feat",
-						Subject: "add a config file",
-						Body:    "This is the body.",
-						Footers: map[string]string{"PiperOrigin-RevId": "12345"},
+						Type:          "feat",
+						Subject:       "add a config file",
+						Body:          "This is the body.",
+						PiperCLNumber: "12345",
 					},
 				},
 				ReleaseTriggered: true,
@@ -1296,16 +1296,16 @@ func TestUpdateLibrary(t *testing.T) {
 				ID:              "one-id",
 				Version:         "5.0.0", // Use the `--version` value`
 				PreviousVersion: "1.2.3",
-				Changes: []*gitrepo.ConventionalCommit{
+				Changes: []*config.Commit{
 					{
 						Type:    "fix",
 						Subject: "change a typo",
 					},
 					{
-						Type:    "feat",
-						Subject: "add a config file",
-						Body:    "This is the body.",
-						Footers: map[string]string{"PiperOrigin-RevId": "12345"},
+						Type:          "feat",
+						Subject:       "add a config file",
+						Body:          "This is the body.",
+						PiperCLNumber: "12345",
 					},
 				},
 				ReleaseTriggered: true,
@@ -1359,20 +1359,15 @@ func TestUpdateLibrary(t *testing.T) {
 				ID:              "one-id",
 				Version:         "2.0.0",
 				PreviousVersion: "1.2.3",
-				Changes: []*gitrepo.ConventionalCommit{
+				Changes: []*config.Commit{
 					{
 						Type:    "feat",
 						Subject: "add another config file",
 						Body:    "This is the body",
-						Footers: map[string]string{
-							"BREAKING CHANGE": "this is a breaking change",
-						},
-						IsBreaking: true,
 					},
 					{
-						Type:       "feat",
-						Subject:    "change a typo",
-						IsBreaking: true,
+						Type:    "feat",
+						Subject: "change a typo",
 					},
 				},
 				ReleaseTriggered: true,
@@ -1424,7 +1419,7 @@ func TestUpdateLibrary(t *testing.T) {
 				PreviousVersion:  "1.2.3",
 				Version:          "5.0.0", // Use the `--version` override value
 				ReleaseTriggered: true,
-				Changes: []*gitrepo.ConventionalCommit{
+				Changes: []*config.Commit{
 					{
 						Type:    "chore",
 						Subject: "a chore",

--- a/internal/librarian/release_notes.go
+++ b/internal/librarian/release_notes.go
@@ -79,8 +79,8 @@ Language Image: {{.ImageVersion}}
 {{ range .CommitSections }}
 ### {{.Heading}}
 {{ range .Commits }}
-{{ if index .Footers "PiperOrigin-RevId" -}}
-* {{.Subject}} (PiperOrigin-RevId: {{index .Footers "PiperOrigin-RevId"}}) ([{{shortSHA .CommitHash}}]({{"https://github.com/"}}{{$noteSection.RepoOwner}}/{{$noteSection.RepoName}}/commit/{{shortSHA .CommitHash}}))
+{{ if .PiperCLNumber -}}
+* {{.Subject}} (PiperOrigin-RevId: {{.PiperCLNumber}}) ([{{shortSHA .CommitHash}}]({{"https://github.com/"}}{{$noteSection.RepoOwner}}/{{$noteSection.RepoName}}/commit/{{shortSHA .CommitHash}}))
 {{- else -}}
 * {{.Subject}} ([{{shortSHA .CommitHash}}]({{"https://github.com/"}}{{$noteSection.RepoOwner}}/{{$noteSection.RepoName}}/commit/{{shortSHA .CommitHash}}))
 {{- end }}
@@ -184,7 +184,7 @@ type releaseNoteSection struct {
 
 type commitSection struct {
 	Heading string
-	Commits []*gitrepo.ConventionalCommit
+	Commits []*config.Commit
 }
 
 // formatOnboardPRBody creates the body of an onboarding pull request.
@@ -376,7 +376,7 @@ func formatLibraryReleaseNotes(library *config.LibraryState, ghRepo *github.Repo
 	newTag := config.FormatTag(tagFormat, library.ID, newVersion)
 	previousTag := config.FormatTag(tagFormat, library.ID, library.PreviousVersion)
 
-	commitsByType := make(map[string][]*gitrepo.ConventionalCommit)
+	commitsByType := make(map[string][]*config.Commit)
 	for _, commit := range library.Changes {
 		commitsByType[commit.Type] = append(commitsByType[commit.Type], commit)
 	}

--- a/internal/librarian/release_notes_test.go
+++ b/internal/librarian/release_notes_test.go
@@ -923,7 +923,7 @@ func TestFormatReleaseNotes(t *testing.T) {
 						// this is the NewVersion in the release note.
 						Version:         "1.1.0",
 						PreviousVersion: "1.0.0",
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
 								Type:       "feat",
 								Subject:    "new feature",
@@ -967,22 +967,18 @@ Language Image: go:1.21
 						// this is the NewVersion in the release note.
 						Version:         "1.1.0",
 						PreviousVersion: "1.0.0",
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
-								Type:       "feat",
-								Subject:    "new feature",
-								CommitHash: hash1.String(),
-								Footers: map[string]string{
-									"PiperOrigin-RevId": "123456",
-								},
+								Type:          "feat",
+								Subject:       "new feature",
+								CommitHash:    hash1.String(),
+								PiperCLNumber: "123456",
 							},
 							{
-								Type:       "fix",
-								Subject:    "a bug fix",
-								CommitHash: hash2.String(),
-								Footers: map[string]string{
-									"PiperOrigin-RevId": "987654",
-								},
+								Type:          "fix",
+								Subject:       "a bug fix",
+								CommitHash:    hash2.String(),
+								PiperCLNumber: "987654",
 							},
 						},
 						ReleaseTriggered: true,
@@ -1017,7 +1013,7 @@ Language Image: go:1.21
 						// this is the NewVersion in the release note.
 						Version:         "1.1.0",
 						PreviousVersion: "1.0.0",
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
 								Type:       "feat",
 								Subject:    "new feature",
@@ -1060,7 +1056,7 @@ Language Image: go:1.21
 						Version:          "1.1.0",
 						PreviousVersion:  "1.0.0",
 						ReleaseTriggered: true,
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
 								Type:       "feat",
 								Subject:    "feature for a",
@@ -1074,7 +1070,7 @@ Language Image: go:1.21
 						Version:          "2.0.1",
 						PreviousVersion:  "2.0.0",
 						ReleaseTriggered: true,
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
 								Type:       "fix",
 								Subject:    "fix for b",
@@ -1120,7 +1116,7 @@ Language Image: go:1.21
 						Version:          "1.1.0",
 						PreviousVersion:  "1.0.0",
 						ReleaseTriggered: true,
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
 								Type:       "feat",
 								Subject:    "new feature",
@@ -1160,7 +1156,7 @@ Language Image: go:1.21
 						Version:          "1.1.0",
 						PreviousVersion:  "1.0.0",
 						ReleaseTriggered: true,
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
 								Type:       "feat",
 								Subject:    "new feature",
@@ -1205,13 +1201,12 @@ Language Image: go:1.21
 						Version:          "1.1.0",
 						PreviousVersion:  "1.0.0",
 						ReleaseTriggered: true,
-						Changes: []*gitrepo.ConventionalCommit{
+						Changes: []*config.Commit{
 							{
 								Type:       "chore",
 								Subject:    "some chore",
 								Body:       "this is the body",
 								CommitHash: hash1.String(),
-								IsNested:   true,
 							},
 						},
 					},


### PR DESCRIPTION
This package should have its own representation of commits that is simplified down to just the information it needs.

Updates: #2543