### PR TITLE
chore: fix librarian-image-test

### DIFF
--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -49,3 +49,5 @@ steps:
       - '.'
       - '-f'
       - 'infra/dispatcher/Dockerfile'
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
failing due to  missing logging options