### PR TITLE
fix(sidekick): Fixes several issues with oneof main setter samples

### DIFF
--- a/internal/sidekick/internal/rust/annotate_test.go
+++ b/internal/sidekick/internal/rust/annotate_test.go
@@ -495,6 +495,7 @@ func TestOneOfAnnotations(t *testing.T) {
 		QualifiedName:       "crate::model::message::Type",
 		RelativeName:        "message::Type",
 		StructQualifiedName: "crate::model::Message",
+		ScopeInExamples:     "google_cloud_test::model::message",
 		FieldType:           "crate::model::message::Type",
 		DocLines:            []string{"/// Say something clever about this oneof."},
 		ExampleField:        singular,
@@ -644,6 +645,7 @@ func TestOneOfConflictAnnotations(t *testing.T) {
 		QualifiedName:       "crate::model::message::NestedThingOneOf",
 		RelativeName:        "message::NestedThingOneOf",
 		StructQualifiedName: "crate::model::Message",
+		ScopeInExamples:     "google_cloud_test::model::message",
 		FieldType:           "crate::model::message::NestedThingOneOf",
 		DocLines:            []string{"/// Say something clever about this oneof."},
 		ExampleField:        singular,
@@ -1877,6 +1879,13 @@ func TestOneOfExampleFieldSelection(t *testing.T) {
 		Name:    "message_field",
 		ID:      ".test.Message.message_field",
 		Typez:   api.MESSAGE_TYPE,
+		TypezID: ".test.OneMessage",
+		IsOneOf: true,
+	}
+	another_message_field := &api.Field{
+		Name:    "another_message_field",
+		ID:      ".test.Message.another_message_field",
+		Typez:   api.MESSAGE_TYPE,
 		TypezID: ".test.AnotherMessage",
 		IsOneOf: true,
 	}
@@ -1889,6 +1898,16 @@ func TestOneOfExampleFieldSelection(t *testing.T) {
 		{
 			name:   "all types",
 			fields: []*api.Field{deprecated, map_field, repeated, scalar, message_field},
+			want:   scalar,
+		},
+		{
+			name:   "no primitives",
+			fields: []*api.Field{deprecated, map_field, repeated, message_field},
+			want:   message_field,
+		},
+		{
+			name:   "only scalars and messages",
+			fields: []*api.Field{message_field, scalar, another_message_field},
 			want:   scalar,
 		},
 		{
@@ -1922,7 +1941,17 @@ func TestOneOfExampleFieldSelection(t *testing.T) {
 				Fields:  tc.fields,
 				OneOfs:  []*api.OneOf{group},
 			}
-			model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+			oneMesage := &api.Message{
+				Name:    "OneMessage",
+				ID:      ".test.OneMessage",
+				Package: "test",
+			}
+			anotherMessage := &api.Message{
+				Name:    "AnotherMessage",
+				ID:      ".test.AnotherMessage",
+				Package: "test",
+			}
+			model := api.NewTestAPI([]*api.Message{message, oneMesage, anotherMessage}, []*api.Enum{}, []*api.Service{})
 			api.CrossReference(model)
 			codec := createRustCodec()
 			annotateModel(model, codec)

--- a/internal/sidekick/internal/rust/templates/common/setter_preamble/oneof.mustache
+++ b/internal/sidekick/internal/rust/templates/common/setter_preamble/oneof.mustache
@@ -24,28 +24,20 @@ limitations under the License.
 {{#Codec.ExampleField}}
 {{#IsString}}
 /// # use {{Parent.Codec.NameInExamples}};
-/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}("value".to_string())));
+/// use {{Group.Codec.ScopeInExamples}};
+/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}("example".to_string())));
 {{/IsString}}
 {{#IsLikeInt}}
 /// # use {{Parent.Codec.NameInExamples}};
-/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(123)));
+/// use {{Group.Codec.ScopeInExamples}};
+/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(42)));
 {{/IsLikeInt}}
 {{#IsObject}}
 /// # use {{Parent.Codec.NameInExamples}};
+/// use {{Group.Codec.ScopeInExamples}};
 /// use {{MessageType.Codec.NameInExamples}};
-/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}({{MessageType.Codec.Name}}::default()/* use setters */)));
+/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}({{MessageType.Codec.Name}}::default().into())));
 {{/IsObject}}
-{{#Repeated}}
-/// # use {{Parent.Codec.NameInExamples}};
-/// use {{MessageType.Codec.NameInExamples}};
-/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(vec![{{MessageType.Codec.Name}}::default()])));
-{{/Repeated}}
-{{#Map}}
-/// # use {{Parent.Codec.NameInExamples}};
-/// use {{KeyField.MessageType.Codec.NameInExamples}};
-/// use {{ValueField.MessageType.Codec.NameInExamples}};
-/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(std::collections::HashMap::from([({{KeyField.MessageType.Codec.Name}}::default(), {{ValueField.MessageType.Codec.Name}}::default())]))));
-{{/Map}}
 {{/Codec.ExampleField}}
 /// ```
 {{/ModelCodec.GenerateSetterSamples}}


### PR DESCRIPTION
- Uses the right import for the oneof group
- Takes boxing of the oneof message variants into account.
- Messages variants are now deprioritized for selection as a oneof example variant.
- Makes the values shown match the ones used in other samples

This also removes the sample generation for when the example one of varinat that's use on the main setter is repeated or map, as that needs bigger improvements that will be done in a subsequent PR. Note that the samples for each specific variant, including repeated and map, continue to be generated.