### PR TITLE
refactor(rust): use unstable tracing cfg

### DIFF
--- a/internal/sidekick/internal/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/internal/rust/templates/common/Cargo.toml.mustache
@@ -32,6 +32,11 @@ rust-version.workspace = true
 {{#Codec.NotForPublication}}
 publish                = false
 {{/Codec.NotForPublication}}
+{{#Codec.DetailedTracingAttributes}}
+
+[lints]
+workspace = true
+{{/Codec.DetailedTracingAttributes}}
 {{#Codec.PerServiceFeatures}}
 
 [features]

--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -42,7 +42,7 @@ limitations under the License.
 //! This crate contains traits, types, and functions to interact with {{{Title}}}
 //! Most applications will use the structs defined in the [client] module.
 //! {{#Codec.ReleaseLevelIsGA}}
-//! 
+//!
 //! The client library types and functions are stable and not expected to change.
 //! Please note that Google Cloud services do change from time to time. The client
 //! libraries are designed to preserve backwards compatibility when the service
@@ -120,6 +120,7 @@ pub(crate) mod info {
         };
     }
 {{#Codec.DetailedTracingAttributes}}
+    #[cfg(google_cloud_unstable_tracing)]
     lazy_static::lazy_static! {
         pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
             let mut info = gaxi::options::InstrumentationClientInfo::default();

--- a/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/transport.rs.mustache
@@ -54,8 +54,10 @@ impl std::fmt::Debug for {{Codec.Name}} {
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
         {{#Codec.DetailedTracingAttributes}}
+        #[cfg(google_cloud_unstable_tracing)]
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
+        #[cfg(google_cloud_unstable_tracing)]
         let inner = if tracing_is_enabled {
             inner.with_instrumentation(&crate::info::INSTRUMENTATION_CLIENT_INFO)
         } else {
@@ -93,7 +95,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
         {{/HasAutoPopulatedFields}}
         {{#Codec.DetailedTracingAttributes}}
-        let (builder, method, path_template) = None
+        let (builder, method, _path_template) = None
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         let (builder, method) = None
@@ -158,7 +160,8 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             gax::error::Error::binding(BindingError { paths })
         })??;
         {{#Codec.DetailedTracingAttributes}}
-        let options = gax::options::internal::set_path_template(options, path_template);
+        #[cfg(google_cloud_unstable_tracing)]
+        let options = gax::options::internal::set_path_template(options, _path_template);
         {{/Codec.DetailedTracingAttributes}}
         let options = gax::options::internal::set_default_idempotency(
             options,


### PR DESCRIPTION
This change introduces conditional compilation to the Rust code generation templates to support the `google_cloud_unstable_tracing` cfg flag.

-   Updates `common/Cargo.toml.mustache` to include `[lints] workspace = true` when `Codec.DetailedTracingAttributes` is true.
-   Refactors `crate/src/transport.rs.mustache` to use `if cfg!(google_cloud_unstable_tracing)` blocks for expression-level conditional compilation, ensuring `path_template` is handled correctly in both branches.
-   Adds `#[allow(unused_variables)]` to suppress warnings when `google_cloud_unstable_tracing` is not enabled.

This allows for the inclusion of detailed tracing attributes only when the unstable flag is active, while ensuring the code compiles and runs correctly in all configurations.

Testing:

Pushed https://github.com/googleapis/google-cloud-rust/pull/3545 and ran integration tests.

The following tests were performed on the `google-cloud-showcase-v1beta1` crate in the `google-cloud-rust` repository:

1.  **DetailedTracingAttributes On, google_cloud_unstable_tracing On:**
    *   Regenerate: `go run ./cmd/sidekick refresh -project-root ../google-cloud-rust -output src/generated/showcase -codec-option detailed-tracing-attributes=true` (in librarian directory)
    *   Format: `cargo fmt -p google-cloud-showcase-v1beta1` (in google-cloud-rust directory)
    *   Test: `RUSTFLAGS="--cfg google_cloud_unstable_tracing" cargo clippy -p google-cloud-showcase-v1beta1 -- -D warnings && RUSTFLAGS="--cfg google_cloud_unstable_tracing" cargo test -p google-cloud-showcase-v1beta1` (in google-cloud-rust directory)
    *   Result: Passed

2.  **DetailedTracingAttributes On, google_cloud_unstable_tracing Off:**
    *   Regenerate: (Same as above)
    *   Format: (Same as above)
    *   Test: `cargo clippy -p google-cloud-showcase-v1beta1 -- -D warnings && cargo test -p google-cloud-showcase-v1beta1` (in google-cloud-rust directory)
    *   Result: Passed

3.  **DetailedTracingAttributes Off, google_cloud_unstable_tracing On:**
    *   Regenerate: `go run ./cmd/sidekick refresh -project-root ../google-cloud-rust -output src/generated/showcase -codec-option detailed-tracing-attributes=false` (in librarian directory)
    *   Format: `cargo fmt -p google-cloud-showcase-v1beta1` (in google-cloud-rust directory)
    *   Test: `RUSTFLAGS="--cfg google_cloud_unstable_tracing" cargo clippy -p google-cloud-showcase-v1beta1 -- -D warnings && RUSTFLAGS="--cfg google_cloud_unstable_tracing" cargo test -p google-cloud-showcase-v1beta1` (in google-cloud-rust directory)
    *   Result: Passed

4.  **DetailedTracingAttributes Off, google_cloud_unstable_tracing Off:**
    *   Regenerate: (Same as above)
    *   Format: (Same as above)
    *   Test: `cargo clippy -p google-cloud-showcase-v1beta1 -- -D warnings && cargo test -p google-cloud-showcase-v1beta1` (in google-cloud-rust directory)
    *   Result: Passed