### PR TITLE
feat(sidekick):  Generate more samples for oneof main setters.

### DIFF
--- a/internal/sidekick/internal/rust/templates/common/setter_preamble/oneof.mustache
+++ b/internal/sidekick/internal/rust/templates/common/setter_preamble/oneof.mustache
@@ -27,11 +27,34 @@ limitations under the License.
 /// use {{Group.Codec.ScopeInExamples}};
 /// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}("example".to_string())));
 {{/IsString}}
+{{#IsBytes}}
+/// # use {{Parent.Codec.NameInExamples}};
+/// use {{Group.Codec.ScopeInExamples}};
+/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(bytes::Bytes::from_static(b"example"))));
+{{/IsBytes}}
+{{#IsBool}}
+/// # use {{Parent.Codec.NameInExamples}};
+/// use {{Group.Codec.ScopeInExamples}};
+/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(true)));
+{{/IsBool}}
 {{#IsLikeInt}}
 /// # use {{Parent.Codec.NameInExamples}};
 /// use {{Group.Codec.ScopeInExamples}};
 /// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(42)));
 {{/IsLikeInt}}
+{{#IsLikeFloat}}
+/// # use {{Parent.Codec.NameInExamples}};
+/// use {{Group.Codec.ScopeInExamples}};
+/// let x = {{Parent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{Codec.BranchName}}(42.0)));
+{{/IsLikeFloat}}
+{{#IsEnum}}
+/// # use {{Parent.Codec.NameInExamples}};
+/// use {{Group.Codec.ScopeInExamples}};
+/// use {{EnumType.Codec.NameInExamples}};
+{{#EnumType.Codec.ValuesForExamples}}
+/// let x{{Index}} = {{FieldParent.Codec.Name}}::new().set_{{Group.Codec.SetterName}}(Some({{{Group.Codec.RelativeName}}}::{{FieldCodec.BranchName}}({{EnumValue.Codec.EnumType}}::{{EnumValue.Codec.VariantName}})));
+{{/EnumType.Codec.ValuesForExamples}}
+{{/IsEnum}}
 {{#IsObject}}
 /// # use {{Parent.Codec.NameInExamples}};
 /// use {{Group.Codec.ScopeInExamples}};


### PR DESCRIPTION
This now generates samples for the main setters of a oneof where the `ExampleField` (i.e. variant) is byte, bool, like float or enum.

This currently will have no effect on Rust generated code because Secret Manager and Workflows do not have oneof to which these changes apply.