### PR TITLE
feat(sidekick): Add conditional instrumentation to gRPC clients

### DIFF
--- a/internal/sidekick/internal/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/internal/rust/templates/common/Cargo.toml.mustache
@@ -32,6 +32,11 @@ rust-version.workspace = true
 {{#Codec.NotForPublication}}
 publish                = false
 {{/Codec.NotForPublication}}
+{{#Codec.DetailedTracingAttributes}}
+
+[lints]
+workspace = true
+{{/Codec.DetailedTracingAttributes}}
 {{#Codec.PerServiceFeatures}}
 
 [features]

--- a/internal/sidekick/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -50,6 +50,19 @@ mod info {
             ac.grpc_header_value()
         };
     }
+    {{#Codec.DetailedTracingAttributes}}
+    #[cfg(google_cloud_unstable_tracing)]
+    lazy_static::lazy_static! {
+        pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
+            let mut info = gaxi::options::InstrumentationClientInfo::default();
+            info.service_name = "{{Name}}";
+            info.client_version = VERSION;
+            info.client_artifact = NAME;
+            info.default_host = "{{Codec.DefaultHostShort}}";
+            info
+        };
+    }
+    {{/Codec.DetailedTracingAttributes}}
 }
 
 {{/Codec.HasServices}}
@@ -79,7 +92,20 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
+        {{#Codec.DetailedTracingAttributes}}
+        #[cfg(google_cloud_unstable_tracing)]
+        let tracing_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
+        #[cfg(google_cloud_unstable_tracing)]
+        let inner = if tracing_enabled {
+            inner.with_instrumentation(&info::INSTRUMENTATION_CLIENT_INFO)
+        } else {
+            inner
+        };
+        {{/Codec.DetailedTracingAttributes}}
+        {{^Codec.DetailedTracingAttributes}}
+        let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
+        {{/Codec.DetailedTracingAttributes}}
         Ok(Self { inner })
     }
 }


### PR DESCRIPTION
This PR introduces feature-gated instrumentation support for gRPC clients generated by Librarian, specifically targeting gRPC-only clients using the `grpc-client` template set.

For https://github.com/googleapis/google-cloud-rust/issues/3418

**Changes:**

1.  **`internal/sidekick/internal/rust/templates/grpc-client/transport.rs.mustache`:**
    *   Added a `lazy_static` definition for `INSTRUMENTATION_CLIENT_INFO` within the existing `info` module. This static is conditionally compiled based on the `google_cloud_unstable_tracing` cfg flag and the `Codec.DetailedTracingAttributes` Sidekick option.
    *   Modified the `StorageControl::new` function to call `.with_instrumentation()` on the `gaxi::grpc::Client` instance (`inner`). This call is conditional based on `gaxi::options::tracing_enabled(&config)` at runtime, and the entire block is guarded by `{{#Codec.DetailedTracingAttributes}}` and `#[cfg(google_cloud_unstable_tracing)]`.

2.  **`internal/sidekick/internal/rust/templates/common/Cargo.toml.mustache`:**
    *   Added `[lints] workspace = true` to ensure generated crates inherit workspace lint configurations, including the `unexpected_cfgs` allowance for `google_cloud_unstable_tracing`. This is also guarded by `{{#Codec.DetailedTracingAttributes}}`.

**Testing Steps:**

Test PR: https://github.com/googleapis/google-cloud-rust/pull/3546

The following steps were performed to test these template changes, using the `google-cloud-storage` crate's `StorageControl` client as a test case, as it uses the `grpc-client` templates.

**Setup:**

*   Librarian repo on branch `feat/t4-grpc-conditional-instr`.
*   `google-cloud-rust` repo on branch `feat/t4-grpc-client-with-instr` (which contains the `with_instrumentation` method on `gaxi::grpc::Client`).

**Test Case 1: DetailedTracingAttributes ON**

1.  **Configure:** Modify `/usr/local/google/home/westarle/src/otel-rust/projects/t4-grpc-network-span/google-cloud-rust/src/storage/src/generated/gapic/.sidekick.toml` to ensure `detailed-tracing-attributes = true`.
2.  **Regenerate:** From the Librarian repo root:
    ```bash
    go run ./cmd/sidekick refresh -project-root /usr/local/google/home/westarle/src/otel-rust/projects/t4-grpc-network-span/google-cloud-rust -output src/storage/src/generated/gapic
    ```
3.  **Format:** In the `google-cloud-rust` repo:
    ```bash
    cargo fmt -p google-cloud-storage
    ```
4.  **Verify Diffs:** In the `google-cloud-rust` repo:
    ```bash
    git diff src/storage/src/generated/gapic/transport.rs
    ```
    Confirmed that the `INSTRUMENTATION_CLIENT_INFO` static and the call to `inner.with_instrumentation(Some(&info::INSTRUMENTATION_CLIENT_INFO))` were present and correctly guarded.

5.  **Test with RUSTFLAGS:** In the `google-cloud-rust` repo:
    ```bash
    RUSTFLAGS="--cfg google_cloud_unstable_tracing" cargo test -p google-cloud-storage
    RUSTFLAGS="--cfg google_cloud_unstable_tracing" cargo clippy -p google-cloud-storage -- -D warnings
    cargo semver-checks check-release -p google-cloud-storage
    ```
    All checks passed.

6.  **Test without RUSTFLAGS:** In the `google-cloud-rust` repo:
    ```bash
    cargo test -p google-cloud-storage
    cargo clippy -p google-cloud-storage -- -D warnings
    cargo semver-checks check-release -p google-cloud-storage
    ```
    All checks passed.

**Test Case 2: DetailedTracingAttributes OFF**

1.  **Configure:** Modify `/usr/local/google/home/westarle/src/otel-rust/projects/t4-grpc-network-span/google-cloud-rust/src/storage/src/generated/gapic/.sidekick.toml` to set `detailed-tracing-attributes = false`.
2.  **Regenerate:** Repeat step 3 from Test Case 1.
3.  **Format:** Repeat step 4 from Test Case 1.
4.  **Verify Diffs:** In the `google-cloud-rust` repo:
    ```bash
    git diff src/storage/src/generated/gapic/transport.rs
    ```
    Confirmed that the guarded blocks are now absent in `src/storage/src/generated/gapic/transport.rs`.
5.  **Test without RUSTFLAGS:** Repeat step 7 from Test Case 1.
    ```bash
    cargo test -p google-cloud-storage
    cargo clippy -p google-cloud-storage -- -D warnings
    cargo semver-checks check-release -p google-cloud-storage
    ```
    All checks passed.

**Cleanup:**
*   Restored `google-cloud-rust/src/storage/src/generated/gapic/.sidekick.toml` to its original state.

These tests confirm that the template changes correctly inject the instrumentation logic only when both the Sidekick option and the compile-time cfg flag are active, and do not affect the build when disabled.