### PR TITLE
chore(sidekick): Remove unreachable code

### DIFF
--- a/internal/sidekick/internal/rust/templates/common/message.mustache
+++ b/internal/sidekick/internal/rust/templates/common/message.mustache
@@ -166,37 +166,6 @@ impl {{Codec.Name}} {
         self
     }
     {{/Singular}}
-    {{#Repeated}}
-    pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
-    {
-        use std::iter::Iterator;
-        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
-            {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                v.into_iter().map(|i| i.into()).collect()
-            )
-        );
-        self
-    }
-    {{/Repeated}}
-    {{#Map}}
-    pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<{{{Codec.KeyType}}}>,
-        V: std::convert::Into<{{{Codec.ValueType}}}>,
-    {
-        use std::iter::Iterator;
-        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
-            {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
-            )
-        );
-        self
-    }
-    {{/Map}}
     {{/Fields}}
     {{/OneOfs}}
 }

--- a/internal/sidekick/internal/rust/templates/common/setter_preamble/oneof_variants.mustache
+++ b/internal/sidekick/internal/rust/templates/common/setter_preamble/oneof_variants.mustache
@@ -19,23 +19,17 @@ limitations under the License.
 /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
 /// mutually exclusive.
 {{#ModelCodec.GenerateSetterSamples}}
+{{#Singular}}
 ///
 /// # Example
 /// ```
-{{#Singular}}
 {{> /templates/common/setter_preamble/singular_value_samples}}
-{{/Singular}}
-{{#Repeated}}
-{{> /templates/common/setter_preamble/repeated_samples}}
-{{/Repeated}}
-{{#Map}}
-{{> /templates/common/setter_preamble/map_samples}}
-{{/Map}}
 /// assert!(x.{{Codec.FieldName}}().is_some());
 {{#Codec.OtherFieldsInGroup}}
 /// assert!(x.{{Codec.FieldName}}().is_none());
 {{/Codec.OtherFieldsInGroup}}
 /// ```
+{{/Singular}}
 {{/ModelCodec.GenerateSetterSamples}}
 {{#Deprecated}}
 #[deprecated]


### PR DESCRIPTION
The specs that we currently support do not support repeated or map fields within a oneof. We don't need to generate code for those cases.