### PR TITLE
fix(sidekick): bad version bump edits

### DIFF
--- a/internal/sidekick/internal/rust_release/update_sidekick_config.go
+++ b/internal/sidekick/internal/rust_release/update_sidekick_config.go
@@ -45,7 +45,7 @@ func updateSidekickConfig(manifest, newVersion string) error {
 	var result []string
 	result = append(result, lines[:iCodec+1]...)
 	tail := lines[iCodec+1:]
-	iVersion := slices.IndexFunc(tail, func(a string) bool { return strings.HasPrefix(a, "version = ") })
+	iVersion := slices.IndexFunc(tail, func(a string) bool { return strings.HasPrefix(a, "version ") && strings.Contains(a, " = ") })
 	verLine := fmt.Sprintf(`version        = '%s'`, newVersion)
 	if iVersion == -1 {
 		result = append(result, verLine)

--- a/internal/sidekick/internal/rust_release/update_sidekick_config_test.go
+++ b/internal/sidekick/internal/rust_release/update_sidekick_config_test.go
@@ -24,33 +24,42 @@ import (
 )
 
 func TestUpdateSidekickConfigSuccess(t *testing.T) {
-	tmpDir := t.TempDir()
-	manifest := path.Join(tmpDir, "Cargo.toml")
-	sidekick := path.Join(tmpDir, ".sidekick.toml")
-	const contents = `# With version line
+	const contentsA = `# With version line
 [codec]
 a = 123
 version = "1.2.3"
 copyright-year = '2038'
 `
-	const want = `# With version line
+	const contentsB = `# With version line
+[codec]
+a = 123
+version        = "1.2.3"
+copyright-year = '2038'
+`
+
+	for _, contents := range []string{contentsA, contentsB} {
+		tmpDir := t.TempDir()
+		manifest := path.Join(tmpDir, "Cargo.toml")
+		sidekick := path.Join(tmpDir, ".sidekick.toml")
+		const want = `# With version line
 [codec]
 a = 123
 version        = '2.3.4'
 copyright-year = '2038'
 `
-	if err := os.WriteFile(sidekick, []byte(contents), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := updateSidekickConfig(manifest, "2.3.4"); err != nil {
-		t.Fatal(err)
-	}
-	got, err := os.ReadFile(sidekick)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(want, string(got)); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+		if err := os.WriteFile(sidekick, []byte(contents), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := updateSidekickConfig(manifest, "2.3.4"); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(sidekick)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(want, string(got)); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
 	}
 }
 
@@ -91,6 +100,35 @@ func TestUpdateSidekickConfigSuccessEmptyCodec(t *testing.T) {
 	const contents = `# With version line
 
 [codec]
+`
+	const want = `# With version line
+
+[codec]
+version        = '2.3.4'
+`
+	if err := os.WriteFile(sidekick, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateSidekickConfig(manifest, "2.3.4"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(sidekick)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateSidekickConfigSuccessOnlyVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	manifest := path.Join(tmpDir, "Cargo.toml")
+	sidekick := path.Join(tmpDir, ".sidekick.toml")
+	const contents = `# With version line
+
+[codec]
+version        = '1.2.3'
 `
 	const want = `# With version line
 


### PR DESCRIPTION
Sometimes we were introducing two version lines in `rust-version-bump`.
