### PR TITLE
feat(sidekick): make extra modules public

### DIFF
--- a/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/crate/src/lib.rs.mustache
@@ -144,5 +144,5 @@ pub(crate) mod info {
 
 {{/Codec.HasServices}}
 {{#Codec.ExtraModules}}
-mod {{{.}}};
+pub mod {{{.}}};
 {{/Codec.ExtraModules}}

--- a/internal/sidekick/internal/rust/templates/nosvc/src/lib.rs.mustache
+++ b/internal/sidekick/internal/rust/templates/nosvc/src/lib.rs.mustache
@@ -40,5 +40,5 @@ limitations under the License.
 {{/HasDeprecatedEntities}}
 pub mod model;
 {{#Codec.ExtraModules}}
-mod {{{.}}};
+pub mod {{{.}}};
 {{/Codec.ExtraModules}}


### PR DESCRIPTION
In the far future we may want some public and some private modules, but this is what we need now.

Part of the work for https://github.com/googleapis/google-cloud-rust/issues/3505
