### PR TITLE
chore: set timeout for stage release to 2 hours

### DIFF
--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -64,3 +64,4 @@ availableSecrets:
       env: 'LIBRARIAN_GITHUB_TOKEN'
 options:
   logging: CLOUD_LOGGING_ONLY
+timeout: 2h


### PR DESCRIPTION
This is to accommodate large mono repo releases