### PR TITLE
feat(dart): minor whitespace and doc changes to the Dart templates

### DIFF
--- a/internal/sidekick/internal/dart/templates/lib/main.dart.mustache
+++ b/internal/sidekick/internal/dart/templates/lib/main.dart.mustache
@@ -36,7 +36,7 @@ part '{{Codec.PartFileReference}}';
 {{#Codec.HasServices}}
 const _apiKeys = [
 {{#Codec.ApiKeyEnvironmentVariables}}
-"{{{.}}}",
+'{{{.}}}',
 {{/Codec.ApiKeyEnvironmentVariables}}
 ];
 {{/Codec.HasServices}}

--- a/internal/sidekick/internal/dart/templates/lib/method.mustache
+++ b/internal/sidekick/internal/dart/templates/lib/method.mustache
@@ -20,8 +20,7 @@ limitations under the License.
 ///
 /// Throws a [http.ClientException] if there were problems communicating with
 /// the API service. Throws a [StatusException] if the API failed with a
-/// [Status] message. Throws a [ServiceException] if the API failed for any
-/// other reason.
+/// [Status] message. Throws a [ServiceException] for any other failure.
 {{#Codec.ServerSideStreaming}}
 Stream<{{Codec.ResponseType}}> {{Codec.Name}}({{Codec.RequestType}} request) {
   final url = Uri.https(_host, '{{PathInfo.Codec.PathFmt}}'

--- a/internal/sidekick/internal/dart/templates/lib/service.mustache
+++ b/internal/sidekick/internal/dart/templates/lib/service.mustache
@@ -19,13 +19,13 @@ limitations under the License.
 {{/Codec.DocLines}}
 final class {{Codec.Name}} {
   static const _host = '{{DefaultHost}}';
+
   final ServiceClient _client;
 
   /// Creates a `{{Codec.Name}}` using [client] for transport.
   ///
   /// The provided [http.Client] must be configured to provide whatever
-  /// authentication is required by `{{Codec.Name}}`. You can do that
-  /// using
+  /// authentication is required by `{{Codec.Name}}`. You can do that using
   /// [`package:googleapis_auth`](https://pub.dev/packages/googleapis_auth).
   {{Codec.Name}}({required http.Client client})
       : _client = ServiceClient(client: client);
@@ -34,8 +34,9 @@ final class {{Codec.Name}} {
   ///
   /// If called without arguments, the API key is taken from these environment
   /// variables:
+  ///
 {{#Model.Codec.ApiKeyEnvironmentVariables}}
-  ///   * `{{{.}}}`
+  /// - `{{{.}}}`
 {{/Model.Codec.ApiKeyEnvironmentVariables}}
   ///
   /// Throws [ArgumentError] if called without arguments and none of the above
@@ -46,7 +47,7 @@ final class {{Codec.Name}} {
     apiKey ??= _apiKeys.map(environmentVariable).nonNulls.firstOrNull;
     if (apiKey == null) {
       throw ArgumentError('apiKey or one of these environment variables must '
-        'be set to an API key: ${_apiKeys.join(", ")}');
+        'be set to an API key: ${_apiKeys.join(', ')}');
     }
     return {{Codec.Name}}(client: auth.clientViaApiKey(apiKey));
   }

--- a/internal/sidekick/internal/dart/templates/pubspec.yaml.mustache
+++ b/internal/sidekick/internal/dart/templates/pubspec.yaml.mustache
@@ -20,17 +20,18 @@ limitations under the License.
 
 name: {{Codec.PackageName}}
 description: The Google Cloud client library for the {{{Title}}}.
+{{^Codec.DoNotPublish}}
+version: {{Codec.PackageVersion}}
+{{/Codec.DoNotPublish}}
 {{#Codec.RepositoryURL}}
 repository: {{Codec.RepositoryURL}}
 {{/Codec.RepositoryURL}}
 issue_tracker: {{{Codec.IssueTrackerURL}}}
-{{^Codec.DoNotPublish}}
-version: {{Codec.PackageVersion}}
-{{/Codec.DoNotPublish}}
+
 {{#Codec.DoNotPublish}}
 publish_to: none
-{{/Codec.DoNotPublish}}
 
+{{/Codec.DoNotPublish}}
 environment:
   sdk: ^3.9.0
 


### PR DESCRIPTION
Minor whitespace and doc changes to the Dart templates:

- add some whitespace between field definitions
- update doc comments to avoid orphaned trailing lines
- normalize the pubspec field order a bit (tracking what we've done in other packages)

cc @brianquinlan 
