### PR TITLE
chore(librarian): streamline logging

### DIFF
--- a/internal/gitrepo/conventional_commits.go
+++ b/internal/gitrepo/conventional_commits.go
@@ -217,9 +217,9 @@ func parseSimpleCommit(commitPart commitPart, commit *Commit, libraryID string) 
 	for _, bodyLine := range bodyLines {
 		header, ok := parseHeader(bodyLine)
 		if !ok {
-			slog.Warn("bodyLine is not a header", "bodyLine", bodyLine, "hash", commit.Hash.String())
 			if len(commits) == 0 {
 				// This should not happen as we expect a conventional commit message inside a nested commit.
+				slog.Warn("bodyLine is not a header, not in a commit", "bodyLine", bodyLine, "hash", commit.Hash.String())
 				continue
 			}
 

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -239,7 +239,7 @@ func (r *LocalRepository) IsClean() (bool, error) {
 // ChangedFiles returns a list of files that have been modified, added, or deleted
 // in the working tree, including both staged and unstaged changes.
 func (r *LocalRepository) ChangedFiles() ([]string, error) {
-	slog.Info("Getting changed files")
+	slog.Debug("Getting changed files")
 	worktree, err := r.repo.Worktree()
 	if err != nil {
 		return nil, err
@@ -450,7 +450,7 @@ func getHashForPath(commit *object.Commit, path string) (string, error) {
 
 // ChangedFilesInCommit returns the files changed in the given commit.
 func (r *LocalRepository) ChangedFilesInCommit(commitHash string) ([]string, error) {
-	slog.Info("Getting changed files in commit", "hash", commitHash)
+	slog.Debug("Getting changed files in commit", "hash", commitHash)
 	commit, err := r.repo.CommitObject(plumbing.NewHash(commitHash))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit object for hash %s: %w", commitHash, err)

--- a/internal/librarian/release_init.go
+++ b/internal/librarian/release_init.go
@@ -272,7 +272,7 @@ func (r *initRunner) updateLibrary(library *config.LibraryState, commits []*gitr
 			// Library was inputted for release, but does not contain a releasable unit
 			return fmt.Errorf("library does not have a releasable unit and will not be released. Use the version flag to force a release for: %s", library.ID)
 		}
-		slog.Info("Updating library to the next version", "library", r.library, "currentVersion", library.Version, "nextVersion", nextVersion)
+		slog.Info("Updating library to the next version", "library", library.ID, "currentVersion", library.Version, "nextVersion", nextVersion)
 	}
 
 	// Update the previous version, we need this value when creating release note.
@@ -292,13 +292,13 @@ func (r *initRunner) determineNextVersion(commits []*gitrepo.ConventionalCommit,
 	}
 
 	if r.librarianConfig == nil {
-		slog.Info("No librarian config")
+		slog.Debug("No librarian config")
 		return nextVersionFromCommits, nil
 	}
 
 	// Look for next_version override from config.yaml
 	libraryConfig := r.librarianConfig.LibraryConfigFor(libraryID)
-	slog.Info("Looking up library config", "library", libraryID, slog.Any("config", libraryConfig))
+	slog.Debug("Looking up library config", "library", libraryID, slog.Any("config", libraryConfig))
 	if libraryConfig == nil || libraryConfig.NextVersion == "" {
 		return nextVersionFromCommits, nil
 	}


### PR DESCRIPTION
- A lot of Info lines were really only relevant when debugging.
- The log entry saying that a library would be released was effectively reporting the command-line `-library` option value, instead of the library that would be released.
- The warning for commit message lines not being conventional commit headers should only be a warning if we haven't already found a conventional commit heading.

These changes make it much easier to see what's going on when running release init.