### PR TITLE
feat: speed up finding changed files in commits

### DIFF
--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -490,7 +490,7 @@ func (r *LocalRepository) ChangedFilesInCommit(commitHash string) ([]string, err
 			files = append(files, from)
 		}
 		// Insertion or rename
-		if from != to {
+		if to != "" && from != to {
 			files = append(files, to)
 		}
 	}


### PR DESCRIPTION
We don't need the actual diffs between commits - only the names of the changed files. This massively improves performance of "release init".

While there *may* be other things we want to do in the future, this makes enough of a difference that we can probably hold off on larger changes (at least for the sake of performance).

Fixes #2634