### PR TITLE
fix: fix the reference to the old "librariangen" folder

### DIFF
--- a/internal/container/java/Dockerfile
+++ b/internal/container/java/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This Dockerfile creates a MOSS-compliant image for the Go librariangen,
-# which is invoked by the Librarian tool. It uses a multi-stage build to
-# create a minimal final image.
+# This Dockerfile creates a MOSS-compliant image for the Java
+# language container, which is invoked by the Librarian tool.
+# It uses a multi-stage build to create a minimal final image.
 
 # --- Builder Stage ---
 # This stage builds the librariangen binary using the MOSS-compliant base image.

--- a/internal/container/java/cloudbuild-exitgate.yaml
+++ b/internal/container/java/cloudbuild-exitgate.yaml
@@ -24,7 +24,7 @@ steps:
         docker pull us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest || exit 0
   - name: gcr.io/cloud-builders/docker
     args: ["build", "--cache-from", "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest", "-t", "us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/librarian-java:latest", "-f", "Dockerfile", "."]
-    dir: internal/librariangen
+    dir: internal/container/java
 options:
   machineType: 'E2_HIGHCPU_8'
   requestedVerifyOption: VERIFIED # For provenance attestation generation

--- a/internal/container/java/languagecontainer/generate/generate.go
+++ b/internal/container/java/languagecontainer/generate/generate.go
@@ -33,7 +33,7 @@ type Context struct {
 	// InputDir is the path to the .librarian/generator-input directory from the
 	// language repository.
 	InputDir string
-	// OutputDir is the path to the empty directory where librariangen writes
+	// OutputDir is the path to the empty directory where a language container writes
 	// its output.
 	OutputDir string
 	// SourceDir is the path to a complete checkout of the googleapis repository.

--- a/internal/container/java/languagecontainer/languagecontainer.go
+++ b/internal/container/java/languagecontainer/languagecontainer.go
@@ -85,7 +85,7 @@ func handleGenerate(flags []string, container *LanguageContainer) int {
 	generateFlags := flag.NewFlagSet("generate", flag.ContinueOnError)
 	generateFlags.StringVar(&genCtx.LibrarianDir, "librarian", "/librarian", "Path to the librarian-tool input directory. Contains generate-request.json.")
 	generateFlags.StringVar(&genCtx.InputDir, "input", "/input", "Path to the .librarian/generator-input directory from the language repository.")
-	generateFlags.StringVar(&genCtx.OutputDir, "output", "/output", "Path to the empty directory where librariangen writes its output.")
+	generateFlags.StringVar(&genCtx.OutputDir, "output", "/output", "Path to the empty directory where a language container writes its output.")
 	generateFlags.StringVar(&genCtx.SourceDir, "source", "/source", "Path to a complete checkout of the googleapis repository.")
 	if err := generateFlags.Parse(flags); err != nil {
 		slog.Error("failed to parse flags", "error", err)

--- a/internal/container/java/message/message.go
+++ b/internal/container/java/message/message.go
@@ -82,12 +82,12 @@ type Change struct {
 func ParseLibrary(path string) (*Library, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("librariangen: failed to read request file from %s: %w", path, err)
+		return nil, fmt.Errorf("languagecontainer: failed to read request file from %s: %w", path, err)
 	}
 
 	var req Library
 	if err := json.Unmarshal(data, &req); err != nil {
-		return nil, fmt.Errorf("librariangen: failed to unmarshal request file %s: %w", path, err)
+		return nil, fmt.Errorf("languagecontainer: failed to unmarshal request file %s: %w", path, err)
 	}
 
 	return &req, nil


### PR DESCRIPTION
The cloudbuild-exitgate.yaml was referencing the old folder
librariangen.

This should resolve Cloud Build failure in b/454950041:

```
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /workspace/internal/librariangen/Dockerfile: no such file or directory
"gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
```

This change also updates the reference to "librariangen" as it's just the binary name of Java and Go language containers.
The term "librariangen" should not be used in a package to be shared with other language containers.
