### PR TITLE
fix(dart): Changed docs to ConfigurationException

### DIFF
--- a/internal/sidekick/internal/dart/templates/lib/service.mustache
+++ b/internal/sidekick/internal/dart/templates/lib/service.mustache
@@ -39,8 +39,9 @@ final class {{Codec.Name}} {
   /// - `{{{.}}}`
 {{/Model.Codec.ApiKeyEnvironmentVariables}}
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory {{Codec.Name}}.fromApiKey([String? apiKey]) {


### PR DESCRIPTION
Changes the dartdoc for `fromApiKey` to indicate that `ConfigurationException` can be thrown rather than `ArgumentError `.