### PR TITLE
ci: go 1.25.3 in the 1st step of infra/dispatcher/Dockerfile

### DIFF
--- a/infra/dispatcher/Dockerfile
+++ b/infra/dispatcher/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.25.0 AS build
+FROM golang:1.25.3 AS build
 
 WORKDIR /src
 


### PR DESCRIPTION
Previous https://github.com/googleapis/librarian/pull/2724 missed the 1st occurrence of `golang:1.25.0`.