### PR TITLE
refactor(internal/librarian): rename tag-and-release command to tag

### DIFF
--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -144,7 +144,7 @@ Usage:
 Commands:
 
 	init                       initiates a release by creating a release pull request.
-	tag-and-release            tags and creates a GitHub release for a merged pull request.
+	tag                        tags and creates a GitHub release for a merged pull request.
 
 # release init
 
@@ -224,9 +224,9 @@ Flags:
 	  	is configured as a language repository.
 	-v	enables verbose logging
 
-# release tag-and-release
+# release tag
 
-The 'tag-and-release' command is the final step in the release
+The 'tag' command is the final step in the release
 process. It is designed to be run after a release pull request, created by
 'release init', has been merged.
 
@@ -245,14 +245,14 @@ merged pull requests with the 'release:pending' label from the last 30 days.
 Examples:
 
 	# Tag and create a GitHub release for a specific merged PR.
-	librarian release tag-and-release --repo=https://github.com/googleapis/google-cloud-go --pr=https://github.com/googleapis/google-cloud-go/pull/123
+	librarian release tag --repo=https://github.com/googleapis/google-cloud-go --pr=https://github.com/googleapis/google-cloud-go/pull/123
 
 	# Find and process all pending merged release PRs in a repository.
-	librarian release tag-and-release --repo=https://github.com/googleapis/google-cloud-go
+	librarian release tag --repo=https://github.com/googleapis/google-cloud-go
 
 Usage:
 
-	librarian release tag-and-release [arguments]
+	librarian release tag [arguments]
 
 Flags:
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -617,7 +617,7 @@ func TestReleaseTagAndRelease(t *testing.T) {
 			// Set up a mock GitHub API server using httptest.
 			// This server will intercept HTTP requests made by the librarian command
 			// and provide canned responses, avoiding any real calls to the GitHub API.
-			// The handlers below simulate the endpoints that 'release tag-and-release' interacts with.
+			// The handlers below simulate the endpoints that 'release tag' interacts with.
 			var server *httptest.Server
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Verify that the GitHub token is being sent correctly.
@@ -727,7 +727,7 @@ libraries:
 				"run",
 				"github.com/googleapis/librarian/cmd/librarian",
 				"release",
-				"tag-and-release",
+				"tag",
 				fmt.Sprintf("--repo=%s", repo),
 				fmt.Sprintf("--github-api-endpoint=%s/", server.URL),
 				"--pr=https://github.com/googleapis/librarian/pull/123",
@@ -742,7 +742,7 @@ libraries:
 			cmd.Stdout = os.Stdout
 			if err := cmd.Run(); err != nil {
 				if !test.wantErr {
-					t.Fatalf("Failed to run release tag-and-release: %v", err)
+					t.Fatalf("Failed to run release tag: %v", err)
 				}
 			}
 		})

--- a/infra/prod/publish-release-worker.yaml
+++ b/infra/prod/publish-release-worker.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This runs the `librarian release tag-and-release` command with a provided repository,
+# This runs the `librarian release tag` command with a provided repository,
 # secret name, and optional PR
 steps:
   - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher

--- a/infra/prod/publish-release.yaml
+++ b/infra/prod/publish-release.yaml
@@ -14,7 +14,7 @@
 # This Cloud Build configuration is used by a Louhi flow for the Artifact
 # Registry (AR) Exit Gate process (go/cloud-sdk-ar-exit-gate-onboarding).
 #
-# This runs the `librarian release tag-and-release` command with a provided repository,
+# This runs the `librarian release tag` command with a provided repository,
 # secret name, and optional PR
 steps:
   - name: gcr.io/cloud-builders/git
@@ -31,7 +31,7 @@ steps:
     waitFor: ['clone-language-repo']
     args:
       - 'release'
-      - 'tag-and-release'
+      - 'tag'
       - '-repo'
       - '/workspace/$_REPOSITORY'
       - '-pr'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,7 +190,7 @@ type Config struct {
 	// PullRequest to target and operate one in the context of a release.
 	//
 	// The pull request should be in the format `https://github.com/{owner}/{repo}/pull/{number}`.
-	// Setting this field for `tag-and-release` means librarian will only attempt
+	// Setting this field for `tag` means librarian will only attempt
 	// to process this exact pull request and not search for other pull requests
 	// that may be ready for tagging and releasing.
 	PullRequest string

--- a/internal/librarian/help.go
+++ b/internal/librarian/help.go
@@ -112,7 +112,7 @@ Examples:
   # Manually specify a version for a single library, overriding the calculation.
   librarian release init --library=secretmanager --library-version=2.0.0 --push`
 
-	tagAndReleaseLongHelp = `The 'tag-and-release' command is the final step in the release
+	tagAndReleaseLongHelp = `The 'tag' command is the final step in the release
 process. It is designed to be run after a release pull request, created by
 'release init', has been merged.
 
@@ -130,10 +130,10 @@ merged pull requests with the 'release:pending' label from the last 30 days.
 
 Examples:
   # Tag and create a GitHub release for a specific merged PR.
-  librarian release tag-and-release --repo=https://github.com/googleapis/google-cloud-go --pr=https://github.com/googleapis/google-cloud-go/pull/123
+  librarian release tag --repo=https://github.com/googleapis/google-cloud-go --pr=https://github.com/googleapis/google-cloud-go/pull/123
 
   # Find and process all pending merged release PRs in a repository.
-  librarian release tag-and-release --repo=https://github.com/googleapis/google-cloud-go`
+  librarian release tag --repo=https://github.com/googleapis/google-cloud-go`
 
 	updateImageLongHelp = `The 'update-image' command is used to update the 'image' SHA
 of the language container for a language repository.

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -119,12 +119,12 @@ func newCmdGenerate() *cli.Command {
 func newCmdTagAndRelease() *cli.Command {
 	var verbose bool
 	cmdTagAndRelease := &cli.Command{
-		Short:     "tag-and-release tags and creates a GitHub release for a merged pull request.",
-		UsageLine: "librarian release tag-and-release [arguments]",
+		Short:     "tag tags and creates a GitHub release for a merged pull request.",
+		UsageLine: "librarian release tag [arguments]",
 		Long:      tagAndReleaseLongHelp,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			setupLogger(verbose)
-			slog.Debug("tag-and-release command verbose logging")
+			slog.Debug("tag command verbose logging")
 			if err := cmd.Config.SetDefaults(); err != nil {
 				return fmt.Errorf("failed to initialize config: %w", err)
 			}

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -74,14 +74,14 @@ func TestVerboseFlag(t *testing.T) {
 			expectDebugLog: false,
 		},
 		{
-			name:              "release tag-and-release with -v flag",
-			args:              []string{"release", "tag-and-release", "-v"},
+			name:              "release tag with -v flag",
+			args:              []string{"release", "tag", "-v"},
 			expectDebugLog:    true,
-			expectDebugSubstr: "tag-and-release command verbose logging",
+			expectDebugSubstr: "tag command verbose logging",
 		},
 		{
-			name:           "release tag-and-release without -v flag",
-			args:           []string{"release", "tag-and-release"},
+			name:           "release tag without -v flag",
+			args:           []string{"release", "tag"},
 			expectDebugLog: false,
 		},
 	} {

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	pullRequestSegments  = 7
-	tagAndReleaseCmdName = "tag-and-release"
+	tagAndReleaseCmdName = "tag"
 	releasePendingLabel  = "release:pending"
 	releaseDoneLabel     = "release:done"
 )
@@ -120,7 +120,7 @@ func parseRemote(repo string) (*github.Repository, error) {
 }
 
 func (r *tagAndReleaseRunner) run(ctx context.Context) error {
-	slog.Info("running tag-and-release command")
+	slog.Info("running tag command")
 	prs, err := r.determinePullRequestsToProcess(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
The release subcommand tag-and-release is renamed to tag for brevity and improved user experience. Functionality is not changed. Variables will be renamed in a follow up PR.

For https://github.com/googleapis/librarian/issues/1926