### PR TITLE
chore: add a check to enforce golang version

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -166,7 +166,7 @@ func hasValidHeader(path string, r io.Reader) (bool, error) {
 // TestConsistentGoVersions walks the directory tree and checks Dockerfiles and go.mod files for specified Go versions.
 // It ensures that only one unique Go version is specified across all found files to maintain consistency. The test
 // fails if multiple Go versions are detected.
-// TODO: remove this test once https://github.com/googleapis/librarian/issues/2739 is resolved.
+// TODO(https://github.com/googleapis/librarian/issues/2739): remove this test once is resolved.
 func TestConsistentGoVersions(t *testing.T) {
 	goVersions := make(map[string][]string)
 	sfs := os.DirFS(".")


### PR DESCRIPTION
Add a test to enforce golang version in `go.mod` and Dockerfile.

Fixes #2737