### PR TITLE
test: remove build line from e2e_test.go

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package librarian
 


### PR DESCRIPTION
This PR is needed to resolve the failures in https://github.com/googleapis/librarian/pull/2676 which appear in https://github.com/googleapis/librarian/actions/runs/18978339208/job/54204796819?pr=2676

```
Error:         e2e_test.go:16:1: buildtag: +build line is no longer needed (govet)
        // +build e2e
```