### PR TITLE
refactor(internal/librarian): rename tag-and-release variables to tag

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -585,7 +585,7 @@ func TestReleaseInit(t *testing.T) {
 	}
 }
 
-func TestReleaseTagAndRelease(t *testing.T) {
+func TestReleaseTag(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		prBody   string

--- a/internal/librarian/help.go
+++ b/internal/librarian/help.go
@@ -112,7 +112,7 @@ Examples:
   # Manually specify a version for a single library, overriding the calculation.
   librarian release init --library=secretmanager --library-version=2.0.0 --push`
 
-	tagAndReleaseLongHelp = `The 'tag' command is the final step in the release
+	tagLongHelp = `The 'tag' command is the final step in the release
 process. It is designed to be run after a release pull request, created by
 'release init', has been merged.
 

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -58,7 +58,7 @@ func newLibrarianCommand() *cli.Command {
 		Long:      releaseLongHelp,
 		Commands: []*cli.Command{
 			newCmdInit(),
-			newCmdTagAndRelease(),
+			newCmdTag(),
 		},
 	}
 	cmdRelease.Init()
@@ -116,12 +116,12 @@ func newCmdGenerate() *cli.Command {
 	return cmdGenerate
 }
 
-func newCmdTagAndRelease() *cli.Command {
+func newCmdTag() *cli.Command {
 	var verbose bool
-	cmdTagAndRelease := &cli.Command{
+	cmdTag := &cli.Command{
 		Short:     "tag tags and creates a GitHub release for a merged pull request.",
 		UsageLine: "librarian release tag [arguments]",
-		Long:      tagAndReleaseLongHelp,
+		Long:      tagLongHelp,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			setupLogger(verbose)
 			slog.Debug("tag command verbose logging")
@@ -131,19 +131,19 @@ func newCmdTagAndRelease() *cli.Command {
 			if _, err := cmd.Config.IsValid(); err != nil {
 				return fmt.Errorf("failed to validate config: %s", err)
 			}
-			runner, err := newTagAndReleaseRunner(cmd.Config)
+			runner, err := newTagRunner(cmd.Config)
 			if err != nil {
 				return err
 			}
 			return runner.run(ctx)
 		},
 	}
-	cmdTagAndRelease.Init()
-	addFlagRepo(cmdTagAndRelease.Flags, cmdTagAndRelease.Config)
-	addFlagPR(cmdTagAndRelease.Flags, cmdTagAndRelease.Config)
-	addFlagGitHubAPIEndpoint(cmdTagAndRelease.Flags, cmdTagAndRelease.Config)
-	addFlagVerbose(cmdTagAndRelease.Flags, &verbose)
-	return cmdTagAndRelease
+	cmdTag.Init()
+	addFlagRepo(cmdTag.Flags, cmdTag.Config)
+	addFlagPR(cmdTag.Flags, cmdTag.Config)
+	addFlagGitHubAPIEndpoint(cmdTag.Flags, cmdTag.Config)
+	addFlagVerbose(cmdTag.Flags, &verbose)
+	return cmdTag
 }
 
 func newCmdInit() *cli.Command {

--- a/internal/librarian/tag_and_release.go
+++ b/internal/librarian/tag_and_release.go
@@ -36,10 +36,10 @@ import (
 )
 
 const (
-	pullRequestSegments  = 7
-	tagAndReleaseCmdName = "tag"
-	releasePendingLabel  = "release:pending"
-	releaseDoneLabel     = "release:done"
+	pullRequestSegments = 7
+	tagCmdName          = "tag"
+	releasePendingLabel = "release:pending"
+	releaseDoneLabel    = "release:done"
 )
 
 var (
@@ -56,7 +56,7 @@ var (
 `))
 )
 
-type tagAndReleaseRunner struct {
+type tagRunner struct {
 	ghClient    GitHubClient
 	pullRequest string
 }
@@ -77,7 +77,7 @@ type libraryReleaseBuilder struct {
 	version        string
 }
 
-func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
+func newTagRunner(cfg *config.Config) (*tagRunner, error) {
 	if cfg.GitHubToken == "" {
 		return nil, fmt.Errorf("`%s` must be set", config.LibrarianGithubToken)
 	}
@@ -95,7 +95,7 @@ func newTagAndReleaseRunner(cfg *config.Config) (*tagAndReleaseRunner, error) {
 		}
 		ghClient.BaseURL = endpoint
 	}
-	return &tagAndReleaseRunner{
+	return &tagRunner{
 		ghClient:    ghClient,
 		pullRequest: cfg.PullRequest,
 	}, nil
@@ -119,7 +119,7 @@ func parseRemote(repo string) (*github.Repository, error) {
 	return GetGitHubRepositoryFromGitRepo(githubRepo)
 }
 
-func (r *tagAndReleaseRunner) run(ctx context.Context) error {
+func (r *tagRunner) run(ctx context.Context) error {
 	slog.Info("running tag command")
 	prs, err := r.determinePullRequestsToProcess(ctx)
 	if err != nil {
@@ -147,7 +147,7 @@ func (r *tagAndReleaseRunner) run(ctx context.Context) error {
 	return nil
 }
 
-func (r *tagAndReleaseRunner) determinePullRequestsToProcess(ctx context.Context) ([]*github.PullRequest, error) {
+func (r *tagRunner) determinePullRequestsToProcess(ctx context.Context) ([]*github.PullRequest, error) {
 	slog.Info("determining pull requests to process")
 	if r.pullRequest != "" {
 		slog.Info("processing a single pull request", "pr", r.pullRequest)
@@ -176,7 +176,7 @@ func (r *tagAndReleaseRunner) determinePullRequestsToProcess(ctx context.Context
 	return prs, nil
 }
 
-func (r *tagAndReleaseRunner) processPullRequest(ctx context.Context, p *github.PullRequest) error {
+func (r *tagRunner) processPullRequest(ctx context.Context, p *github.PullRequest) error {
 	slog.Info("processing pull request", "pr", p.GetNumber())
 	releases := parsePullRequestBody(p.GetBody())
 	if len(releases) == 0 {
@@ -315,7 +315,7 @@ func parsePullRequestBody(body string) []libraryRelease {
 }
 
 // replacePendingLabel is a helper function that replaces the `release:pending` label with `release:done`.
-func (r *tagAndReleaseRunner) replacePendingLabel(ctx context.Context, p *github.PullRequest) error {
+func (r *tagRunner) replacePendingLabel(ctx context.Context, p *github.PullRequest) error {
 	var currentLabels []string
 	for _, label := range p.Labels {
 		currentLabels = append(currentLabels, label.GetName())

--- a/internal/librarian/tag_test.go
+++ b/internal/librarian/tag_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/googleapis/librarian/internal/github"
 )
 
-func TestNewTagAndReleaseRunner(t *testing.T) {
+func TestNewTagRunner(t *testing.T) {
 	testcases := []struct {
 		name    string
 		cfg     *config.Config
@@ -37,27 +37,27 @@ func TestNewTagAndReleaseRunner(t *testing.T) {
 				GitHubToken: "some-token",
 				Repo:        "https://github.com/googleapis/some-test-repo",
 				WorkRoot:    t.TempDir(),
-				CommandName: tagAndReleaseCmdName,
+				CommandName: tagCmdName,
 			},
 			wantErr: false,
 		},
 		{
 			name: "missing github token",
 			cfg: &config.Config{
-				CommandName: tagAndReleaseCmdName,
+				CommandName: tagCmdName,
 			},
 			wantErr: true,
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			r, err := newTagAndReleaseRunner(tc.cfg)
+			r, err := newTagRunner(tc.cfg)
 			if (err != nil) != tc.wantErr {
-				t.Errorf("newTagAndReleaseRunner() error = %v, wantErr %v", err, tc.wantErr)
+				t.Errorf("newTagRunner() error = %v, wantErr %v", err, tc.wantErr)
 				return
 			}
 			if !tc.wantErr && r == nil {
-				t.Errorf("newTagAndReleaseRunner() got nil runner, want non-nil")
+				t.Errorf("newTagRunner() got nil runner, want non-nil")
 			}
 		})
 	}
@@ -130,7 +130,7 @@ func TestDeterminePullRequestsToProcess(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			r := &tagAndReleaseRunner{
+			r := &tagRunner{
 				pullRequest: test.cfg.PullRequest,
 				ghClient:    test.ghClient,
 			}
@@ -151,7 +151,7 @@ func TestDeterminePullRequestsToProcess(t *testing.T) {
 	}
 }
 
-func Test_tagAndReleaseRunner_run(t *testing.T) {
+func Test_tagRunner_run(t *testing.T) {
 	pr123 := &github.PullRequest{}
 	pr456 := &github.PullRequest{}
 
@@ -191,7 +191,7 @@ func Test_tagAndReleaseRunner_run(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			r := &tagAndReleaseRunner{
+			r := &tagRunner{
 				ghClient: test.ghClient,
 			}
 			err := r.run(t.Context())
@@ -594,7 +594,7 @@ func TestProcessPullRequest(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			r := &tagAndReleaseRunner{
+			r := &tagRunner{
 				ghClient: test.ghClient,
 			}
 			err := r.processPullRequest(t.Context(), test.pr)
@@ -655,7 +655,7 @@ func TestReplacePendingLabel(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			r := &tagAndReleaseRunner{
+			r := &tagRunner{
 				ghClient: test.ghClient,
 			}
 			err := r.replacePendingLabel(t.Context(), test.pr)
@@ -674,7 +674,7 @@ func TestReplacePendingLabel(t *testing.T) {
 	}
 }
 
-func Test_tagAndReleaseRunner_run_processPullRequests(t *testing.T) {
+func Test_tagRunner_run_processPullRequests(t *testing.T) {
 	branch := "main"
 	pr1 := &github.PullRequest{
 		Body:           gh.Ptr(`<details><summary>google-cloud-storage: v1.2.3</summary>release notes</details>`),
@@ -709,7 +709,7 @@ func Test_tagAndReleaseRunner_run_processPullRequests(t *testing.T) {
 		},
 	}
 
-	r := &tagAndReleaseRunner{
+	r := &tagRunner{
 		ghClient: ghClient,
 	}
 	err := r.run(t.Context())


### PR DESCRIPTION
In https://github.com/googleapis/librarian/pull/2731, the `tag-and-release` command was renamed to `tag`. Update all related variables to reflect this change.

For https://github.com/googleapis/librarian/issues/1926