### PR TITLE
fix: temporarily skip TestFindLatestImage

### DIFF
--- a/system_test.go
+++ b/system_test.go
@@ -447,8 +447,7 @@ func TestCreateRelease(t *testing.T) {
 }
 
 func TestFindLatestImage(t *testing.T) {
-	// TODO(https://github.com/googleapis/librarian/issues/2720): fix this test
-	t.Skip()
+	t.Skip("Temporarily skipping until we can run it reliably. See https://github.com/googleapis/librarian/issues/2720")
 
 	// If we are able to configure system tests on GitHub actions, then update this
 	// guard clause.


### PR DESCRIPTION
Skip TestFindLatestImage for now until we determine how to run it reliably.

For https://github.com/googleapis/librarian/issues/2720