### PR TITLE
refactor(internal/cli): make Init idempotent and remove redundant calls

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -113,11 +113,18 @@ func (c *Command) usage(w io.Writer) {
 // them such that any parsing failures result in the command usage being
 // displayed.
 func (c *Command) Init() *Command {
-	c.Flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
-	c.Flags.Usage = func() {
-		c.usage(c.Flags.Output())
+	if c.Flags == nil {
+		c.Flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		c.Flags.Usage = func() {
+			c.usage(c.Flags.Output())
+		}
 	}
-	c.Config = config.New(c.Name())
+	if c.Config == nil {
+		c.Config = config.New(c.Name())
+	}
+	for _, sub := range c.Commands {
+		sub.Init()
+	}
 	return c
 }
 

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -50,7 +50,6 @@ func newLibrarianCommand() *cli.Command {
 			return nil
 		},
 	}
-	cmdVersion.Init()
 
 	cmdRelease := &cli.Command{
 		Short:     "release manages releases of libraries.",
@@ -61,7 +60,6 @@ func newLibrarianCommand() *cli.Command {
 			newCmdTagAndRelease(),
 		},
 	}
-	cmdRelease.Init()
 
 	cmd := &cli.Command{
 		Short:     "librarian manages client libraries for Google APIs",


### PR DESCRIPTION
The Init method now recursively initializes all subcommands and is idempotent, checking if Flags and Config are nil before creating them.

This allows calling Init once on the root command to initialize the entire command tree.

This change simplifies command initialization in newLibrarianCommand by removing redundant Init calls on cmdVersion and cmdRelease.

For https://github.com/googleapis/librarian/issues/2176