### PR TITLE
doc: clarify issue prefix conventions for container code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,6 @@ example, `librarian:` or `cli:`).
 
 For issues related to code outside this
 repository, use the repository name (for example, `google-cloud-python`).
-
 This repository also contains language-specific container-related code under
 [internal/container](https://github.com/googleapis/librarian/tree/main/internal/container).
 For these issues, use the lowercase language name as a prefix for brevity (for


### PR DESCRIPTION
Update CONTRIBUTING.md to document that container-related code lives at `internal/container`, and issues for this area should use the lowercase language name (e.g. `java:`) as a prefix for brevity.

For https://github.com/googleapis/librarian/issues/2722