### PR TITLE
fix: upgrade golangci-lint to v2.6.0

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -221,7 +221,7 @@ func recordGoVersion(path string, sfs fs.FS, re *regexp.Regexp, goVersions map[s
 }
 
 func TestGolangCILint(t *testing.T) {
-	rungo(t, "run", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0", "run")
+	rungo(t, "run", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.0", "run")
 }
 
 func TestGoImports(t *testing.T) {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package librarian
 


### PR DESCRIPTION
Upgrade TestGolangCILint to use golangci-lint@v2.6.0 (github.com/golangci/golangci-lint/releases/tag/v2.6.0).