### PR TITLE
fix: run godoclint via golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - containedctx
     - contextcheck
     - fatcontext
+    - godoclint
     - godot
     - govet
     - ineffassign

--- a/all_test.go
+++ b/all_test.go
@@ -246,13 +246,6 @@ func TestGovulncheck(t *testing.T) {
 	rungo(t, "run", "golang.org/x/vuln/cmd/govulncheck@v1.1.4", "./...")
 }
 
-func TestGodocLint(t *testing.T) {
-	rungo(t, "run", "github.com/godoc-lint/godoc-lint/cmd/godoclint@v0.3.0",
-		// TODO(https://github.com/googleapis/librarian/issues/1510): fix test
-		"-exclude", "internal/sidekick",
-		"./...")
-}
-
 func rungo(t *testing.T, args ...string) {
 	t.Helper()
 

--- a/internal/container/java/pom/pom_test.go
+++ b/internal/container/java/pom/pom_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pom
 
 import (

--- a/internal/images/images_test.go
+++ b/internal/images/images_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package images provides operations around docker images.
 package images
 
 import (

--- a/internal/sidekick/internal/config/config.go
+++ b/internal/sidekick/internal/config/config.go
@@ -43,7 +43,7 @@ type DocumentationOverride struct {
 	Replace string `toml:"replace"`
 }
 
-// PaginationOverrides describes overrides for pagination config of a method.
+// PaginationOverride describes overrides for pagination config of a method.
 type PaginationOverride struct {
 	// The method ID.
 	ID string `toml:"id"`

--- a/internal/sidekick/internal/config/gcloudyaml/gcloud_test.go
+++ b/internal/sidekick/internal/config/gcloudyaml/gcloud_test.go
@@ -26,9 +26,6 @@ import (
 )
 
 func TestGcloudConfig(t *testing.T) {
-	// TODO(https://github.com/googleapis/librarian/issues/1510): fix test
-	t.Skip()
-
 	data, err := os.ReadFile("testdata/gcloud.yaml")
 	if err != nil {
 		t.Fatalf("failed to read temporary YAML file: %v", err)

--- a/internal/sidekick/internal/config/update_root_config.go
+++ b/internal/sidekick/internal/config/update_root_config.go
@@ -83,7 +83,7 @@ func UpdateRootConfig(rootConfig *Config, rootName string) error {
 	return os.WriteFile(configName, newContents, 0644)
 }
 
-// githubConfig returns the API endpoint the browser endpoint for GitHub.
+// githubConfig returns the GitHub API and download endpoints.
 // In tests, these are replaced with a fake.
 func githubConfig(rootConfig *Config) *githubEndpoints {
 	api, ok := rootConfig.Source["github-api"]

--- a/internal/sidekick/internal/parser/svcconfig/svcconfig.go
+++ b/internal/sidekick/internal/parser/svcconfig/svcconfig.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// serviceconfig contains helper functions to parse service config files.
+// Package svcconfig contains helper functions to parse service config files.
 package svcconfig
 
 import (
@@ -27,7 +27,7 @@ type ServiceNames struct {
 	ServiceName string
 }
 
-// ExtractServiceNames determines the package name and service implied by a
+// ExtractPackageName determines the package name and service implied by a
 // service config file.
 func ExtractPackageName(serviceConfig *serviceconfig.Service) *ServiceNames {
 	if serviceConfig == nil {
@@ -43,7 +43,7 @@ func ExtractPackageName(serviceConfig *serviceconfig.Service) *ServiceNames {
 	return nil
 }
 
-// SplitQualifiedServiceName splits a service name into the package name and the
+// splitQualifiedServiceName splits a service name into the package name and the
 // unqualified service name.
 func splitQualifiedServiceName(name string) ServiceNames {
 	li := strings.LastIndex(name, ".")
@@ -53,7 +53,7 @@ func splitQualifiedServiceName(name string) ServiceNames {
 	return ServiceNames{PackageName: name[:li], ServiceName: name[li+1:]}
 }
 
-// WellKnownmixin returns true if the qualified service name is one of the
+// wellKnownMixin returns true if the qualified service name is one of the
 // well-known mixins.
 func wellKnownMixin(qualifiedServiceName string) bool {
 	return strings.HasPrefix(qualifiedServiceName, "google.cloud.location.Location") ||


### PR DESCRIPTION
godoclint is now bundled with golangci-lint, so switch to using it through golangci-lint directly.

This change also resolves existing lint errors surfaced by the new configuration.

Additionally, remove a stale TODO referenced in #1510.

Fixes https://github.com/googleapis/librarian/issues/2371