### PR TITLE
docs: change PR review time to 8 business hours

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,7 +356,7 @@ encourage it!
 ### Reviewing a pull request
 
 While we don’t have strict SLOs, we aim to review pull requests within **8
-business hours**.  Internal ONLY: If you need a PR review expidited please post it in 
+business hours**.  Internal ONLY: If you need a PR review expedited please post it in 
 [SDK Librarian Chat](https://mail.google.com/mail/u/0/#chat/space/AAQAYjxNRS8).
 
 When reviewing a pull request:


### PR DESCRIPTION
The plan going forward is to make reviewing PRs part of platform on call rotation, which is a daily checklist of items to do.  It would be easiest to review and less disruptive to people's daily work day if it is only required 1x a day.