### PR TITLE
fix(internal/librarian): use t.Fatal in tests for proper failure handling

### DIFF
--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"math/rand"
 	"os"
@@ -40,7 +39,7 @@ import (
 
 func TestRun(t *testing.T) {
 	if err := Run(t.Context(), []string{"version"}...); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Use t.Fatal instead of log.Fatal in TestRun.
Came across this when working on #2754. 