### PR TITLE
fix: use T.Context in tests

### DIFF
--- a/internal/automation/cloudbuild_test.go
+++ b/internal/automation/cloudbuild_test.go
@@ -78,7 +78,7 @@ func TestRunCloudBuildTrigger(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client := &mockCloudBuildClient{
 				runError:      test.runError,
 				buildTriggers: make([]*cloudbuildpb.BuildTrigger, 0),
@@ -144,7 +144,7 @@ func TestFindTriggerIdByName(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client := &mockCloudBuildClient{
 				runError:      test.runError,
 				buildTriggers: test.buildTriggers,
@@ -209,7 +209,7 @@ func TestRunCloudBuildTriggerByName(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client := &mockCloudBuildClient{
 				runError:      test.runError,
 				buildTriggers: test.buildTriggers,

--- a/internal/automation/trigger_test.go
+++ b/internal/automation/trigger_test.go
@@ -184,7 +184,7 @@ func TestRunCommandWithClient(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client := &mockCloudBuildClient{
 				runError:      test.runError,
 				buildTriggers: test.buildTriggers,
@@ -334,7 +334,7 @@ func TestRunCommandWithConfig(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client := &mockCloudBuildClient{
 				runError:      test.runError,
 				buildTriggers: buildTriggers,

--- a/internal/container/java/execv/execv_test.go
+++ b/internal/container/java/execv/execv_test.go
@@ -15,7 +15,6 @@
 package execv
 
 import (
-	"context"
 	"errors"
 	"os/exec"
 	"strings"
@@ -56,7 +55,7 @@ func TestRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := Run(context.Background(), tt.args, ".")
+			err := Run(t.Context(), tt.args, ".")
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Run() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/container/java/generate/generator_test.go
+++ b/internal/container/java/generate/generator_test.go
@@ -274,7 +274,7 @@ java_gapic_library(
 			if err != nil {
 				t.Fatalf("failed to create generate config: %v", err)
 			}
-			if err := Generate(context.Background(), cfg); (err != nil) != tt.wantErr {
+			if err := Generate(t.Context(), cfg); (err != nil) != tt.wantErr {
 				t.Errorf("Generate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if protocRunCount != tt.wantProtocRunCount {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -1020,7 +1020,7 @@ func TestReleaseStageRequestContent(t *testing.T) {
 		Output:          filepath.Join(tmpDir, "output"),
 		LibrarianConfig: &config.LibrarianConfig{},
 	}
-	if err := d.ReleaseStage(context.Background(), req); err != nil {
+	if err := d.ReleaseStage(t.Context(), req); err != nil {
 		t.Fatalf("d.ReleaseStage() failed: %v", err)
 	}
 }

--- a/internal/librarian/command_test.go
+++ b/internal/librarian/command_test.go
@@ -15,7 +15,6 @@
 package librarian
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -1564,7 +1563,7 @@ func TestCommitAndPush(t *testing.T) {
 				prBodyBuilder:     test.prBodyBuilder,
 			}
 
-			err := commitAndPush(context.Background(), commitInfo)
+			err := commitAndPush(t.Context(), commitInfo)
 
 			if test.wantErr {
 				if err == nil {
@@ -1746,7 +1745,7 @@ func TestAddLabelsToPullRequest(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := test.mockGithubClient
 			prMetadata := test.prMetadata
-			err := addLabelsToPullRequest(context.Background(), client, test.wantPullRequestLabels, &prMetadata)
+			err := addLabelsToPullRequest(t.Context(), client, test.wantPullRequestLabels, &prMetadata)
 
 			if test.wantErr {
 				if err == nil {

--- a/internal/librarian/generate_command_test.go
+++ b/internal/librarian/generate_command_test.go
@@ -15,7 +15,6 @@
 package librarian
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -358,7 +357,7 @@ func TestRunConfigureCommand(t *testing.T) {
 				}
 			}
 
-			_, err := r.runConfigureCommand(context.Background(), outputDir)
+			_, err := r.runConfigureCommand(t.Context(), outputDir)
 
 			if test.wantErr {
 				if err == nil {
@@ -949,7 +948,7 @@ func TestGenerateScenarios(t *testing.T) {
 				}
 			}
 
-			err := r.run(context.Background())
+			err := r.run(t.Context())
 			if test.wantErr {
 				if err == nil {
 					t.Fatalf("%s should return error", test.name)
@@ -1066,7 +1065,7 @@ func TestGenerateSingleLibraryCommand(t *testing.T) {
 				}
 			}
 
-			status, err := r.generateSingleLibrary(context.Background(), r.library, r.workRoot)
+			status, err := r.generateSingleLibrary(t.Context(), r.library, r.workRoot)
 			if test.wantErr {
 				if err == nil {
 					t.Fatalf("%s should return error", test.name)

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -16,7 +16,6 @@ package librarian
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -92,7 +91,7 @@ func TestVerboseFlag(t *testing.T) {
 			// Reset logger to default for test isolation.
 			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
 
-			_ = Run(context.Background(), test.args...)
+			_ = Run(t.Context(), test.args...)
 
 			// Restore stderr and read the output.
 			w.Close()
@@ -119,7 +118,7 @@ func TestVerboseFlag(t *testing.T) {
 }
 
 func TestGenerate_DefaultBehavior(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// 1. Set up a mock repository with a state file
 	repo := newTestGitRepo(t)

--- a/internal/librarian/state_test.go
+++ b/internal/librarian/state_test.go
@@ -15,7 +15,6 @@
 package librarian
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,7 +74,7 @@ libraries:
       - src/b
     apis:
       - path: a/b/v1
-        service_config: 
+        service_config:
 `,
 			source:  "/non-existed-path",
 			want:    nil,
@@ -478,7 +477,7 @@ func TestLoadRepoStateFromGitHub(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := loadRepoStateFromGitHub(context.Background(), test.ghClient, test.branch)
+			got, err := loadRepoStateFromGitHub(t.Context(), test.ghClient, test.branch)
 			if test.wantErr {
 				if err == nil {
 					t.Fatal("loadRepoStateFromGitHub() should fail")

--- a/system_test.go
+++ b/system_test.go
@@ -15,7 +15,6 @@
 package librarian
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -79,7 +78,7 @@ func TestGetRawContentSystem(t *testing.T) {
 					}
 
 					client := github.NewClient(testToken, repo)
-					got, err := client.GetRawContent(context.Background(), test.path, "main")
+					got, err := client.GetRawContent(t.Context(), test.path, "main")
 
 					if test.wantErr {
 						if err == nil {


### PR DESCRIPTION
T.Context returns a context that is canceled just before Cleanup-registered functions are called, and is intended to be used in tests. See https://pkg.go.dev/testing#T.Context. 

