### PR TITLE
fix: pass context as the first argument

### DIFF
--- a/cmd/automation/main.go
+++ b/cmd/automation/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -26,7 +27,7 @@ import (
 )
 
 func main() {
-	if err := automation.Run(os.Args[1:]); err != nil {
+	if err := automation.Run(context.Background(), os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/automation/cli.go
+++ b/internal/automation/cli.go
@@ -26,8 +26,7 @@ import (
 var runCommandFn = RunCommand
 
 // Run parses the command line arguments and triggers the specified command.
-func Run(args []string) error {
-	ctx := context.Background()
+func Run(ctx context.Context, args []string) error {
 	options, err := parseFlags(args)
 	if err != nil {
 		slog.Error("error parsing command", slog.Any("err", err))

--- a/internal/automation/cli_test.go
+++ b/internal/automation/cli_test.go
@@ -52,7 +52,7 @@ func TestRun(t *testing.T) {
 			runCommandFn = func(ctx context.Context, command string, projectId string, push bool, build bool, forceRun bool) error {
 				return tt.runCommandErr
 			}
-			if err := Run(tt.args); (err != nil) != tt.wantErr {
+			if err := Run(context.Background(), tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/container/java/languagecontainer/languagecontainer.go
+++ b/internal/container/java/languagecontainer/languagecontainer.go
@@ -44,7 +44,7 @@ type LanguageContainer struct {
 // Run accepts an implementation of the LanguageContainer.
 // The args parameter contains the command-line arguments passed to the container,
 // without including the program name. Usually it's os.Args[1:].
-func Run(args []string, container *LanguageContainer) int {
+func Run(ctx context.Context, args []string, container *LanguageContainer) int {
 	// Logic to parse args and call the appropriate method on the container.
 	// For example, if args[1] is "generate":
 	//   request := ... // unmarshal the request from the expected location
@@ -61,7 +61,7 @@ func Run(args []string, container *LanguageContainer) int {
 			slog.Error("languagecontainer: generate command is not implemented")
 			return 1
 		}
-		return handleGenerate(flags, container)
+		return handleGenerate(ctx, flags, container)
 	case "configure":
 		slog.Warn("languagecontainer: configure command is missing")
 		return 1
@@ -70,7 +70,7 @@ func Run(args []string, container *LanguageContainer) int {
 			slog.Error("languagecontainer: generate command is missing")
 			return 1
 		}
-		return handleReleaseStage(flags, container)
+		return handleReleaseStage(ctx, flags, container)
 	case "build":
 		slog.Warn("languagecontainer: build command is not yet implemented")
 		return 1
@@ -80,7 +80,7 @@ func Run(args []string, container *LanguageContainer) int {
 	}
 }
 
-func handleGenerate(flags []string, container *LanguageContainer) int {
+func handleGenerate(ctx context.Context, flags []string, container *LanguageContainer) int {
 	genCtx := &generate.Context{}
 	generateFlags := flag.NewFlagSet("generate", flag.ContinueOnError)
 	generateFlags.StringVar(&genCtx.LibrarianDir, "librarian", "/librarian", "Path to the librarian-tool input directory. Contains generate-request.json.")
@@ -96,7 +96,7 @@ func handleGenerate(flags []string, container *LanguageContainer) int {
 		slog.Error("failed to create generate config", "error", err)
 		return 1
 	}
-	if err := container.Generate(context.Background(), cfg); err != nil {
+	if err := container.Generate(ctx, cfg); err != nil {
 		slog.Error("generate failed", "error", err)
 		return 1
 	}
@@ -104,7 +104,7 @@ func handleGenerate(flags []string, container *LanguageContainer) int {
 	return 0
 }
 
-func handleReleaseStage(flags []string, container *LanguageContainer) int {
+func handleReleaseStage(ctx context.Context, flags []string, container *LanguageContainer) int {
 	cfg := &release.Context{}
 	releaseInitFlags := flag.NewFlagSet("release-stage", flag.ContinueOnError)
 	releaseInitFlags.StringVar(&cfg.LibrarianDir, "librarian", "/librarian", "Path to the librarian-tool input directory. Contains release-stage-request.json.")
@@ -129,7 +129,7 @@ func handleReleaseStage(flags []string, container *LanguageContainer) int {
 		Context: cfg,
 		Request: request,
 	}
-	response, err := container.ReleaseStage(context.Background(), config)
+	response, err := container.ReleaseStage(ctx, config)
 	if err != nil {
 		slog.Error("release-stage failed", "error", err)
 		return 1

--- a/internal/container/java/languagecontainer/languagecontainer_test.go
+++ b/internal/container/java/languagecontainer/languagecontainer_test.go
@@ -100,7 +100,7 @@ func TestRun(t *testing.T) {
 					return &message.ReleaseStageResponse{}, nil
 				},
 			}
-			if gotCode := Run(tt.args, &container); gotCode != tt.wantCode {
+			if gotCode := Run(context.Background(), tt.args, &container); gotCode != tt.wantCode {
 				t.Errorf("Run() = %v, want %v", gotCode, tt.wantCode)
 			}
 		})
@@ -113,7 +113,7 @@ func TestRun_noArgs(t *testing.T) {
 			t.Errorf("The code did not panic")
 		}
 	}()
-	Run([]string{}, &LanguageContainer{})
+	Run(context.Background(), []string{}, &LanguageContainer{})
 }
 
 func TestRun_ReleaseStageWritesResponse(t *testing.T) {
@@ -129,7 +129,7 @@ func TestRun_ReleaseStageWritesResponse(t *testing.T) {
 		},
 	}
 
-	if code := Run(args, &container); code != 0 {
+	if code := Run(context.Background(), args, &container); code != 0 {
 		t.Errorf("Run() = %v, want 0", code)
 	}
 
@@ -172,7 +172,7 @@ func TestRun_ReleaseStageReadsContextArgs(t *testing.T) {
 			return &message.ReleaseStageResponse{}, nil
 		},
 	}
-	if code := Run(args, &container); code != 0 {
+	if code := Run(context.Background(), args, &container); code != 0 {
 		t.Errorf("Run() = %v, want 0", code)
 	}
 	if got, want := gotConfig.Context.LibrarianDir, librarianDir; got != want {
@@ -216,7 +216,7 @@ func TestRun_GenerateReadsContextArgs(t *testing.T) {
 			return nil
 		},
 	}
-	if code := Run(args, &container); code != 0 {
+	if code := Run(context.Background(), args, &container); code != 0 {
 		t.Errorf("Run() = %v, want 0", code)
 	}
 	if got, want := gotConfig.Context.LibrarianDir, librarianDir; got != want {
@@ -260,7 +260,7 @@ func TestRun_unimplementedCommands(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotCode := Run(tt.args, tt.container); gotCode != 1 {
+			if gotCode := Run(context.Background(), tt.args, tt.container); gotCode != 1 {
 				t.Errorf("Run() = %v, want 1", gotCode)
 			}
 		})

--- a/internal/container/java/main.go
+++ b/internal/container/java/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -52,7 +53,7 @@ func runCLI(args []string) int {
 		Generate:     generate.Generate,
 		ReleaseStage: release.Stage,
 	}
-	return languagecontainer.Run(args[1:], &container)
+	return languagecontainer.Run(context.Background(), args[1:], &container)
 }
 
 func parseLogLevel(logLevelEnv string) slog.Level {


### PR DESCRIPTION
The idiomatic way to pass a context.Context is as the first argument to functions. See https://go.dev/blog/context-and-structs.

Update relevant functions to follow this approach.