### PR TITLE
chore: update jq cmd in workflow

### DIFF
--- a/.github/workflows/govulcheck.yaml.yml
+++ b/.github/workflows/govulcheck.yaml.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     # 8:00 every day.
     - cron: '0 8 * * *'
-  pull_request:
 jobs:
   scan-and-report:
     name: Run govulncheck and Create Issue


### PR DESCRIPTION
Update `govulncheck` command only output vulnerability findings in workflow.