### PR TITLE
feat(librarian): allow update-image to be a no-op

### DIFF
--- a/internal/librarian/update_image.go
+++ b/internal/librarian/update_image.go
@@ -101,8 +101,7 @@ func (r *updateImageRunner) run(ctx context.Context) error {
 	}
 
 	if r.image == r.state.Image {
-		slog.Info("no update to the image, aborting.")
-		return nil
+		slog.Info("no update to the image; assuming diagnostic run")
 	}
 
 	r.state.Image = r.image

--- a/internal/librarian/update_image_test.go
+++ b/internal/librarian/update_image_test.go
@@ -253,9 +253,9 @@ func TestUpdateImageRunnerRun(t *testing.T) {
 			imagesClient:        &mockImagesClient{},
 			ghClient:            &mockGitHubClient{},
 			wantFindLatestCalls: 0,
-			wantGenerateCalls:   0,
+			wantGenerateCalls:   1,
 			wantBuildCalls:      0,
-			wantCheckoutCalls:   0,
+			wantCheckoutCalls:   2,
 		},
 		{
 			name: "finds latest image",


### PR DESCRIPTION
The update-image command is really useful for container authors, in terms of checking performance, behavior, and configuration. It's useful to be able to run it even without a new image - because if everything is in a steady state, we shouldn't see any changes at all.

We still log that the image is the same, but don't count it as an error.