### PR TITLE
fix: revert change to use tag command

### DIFF
--- a/infra/prod/publish-release.yaml
+++ b/infra/prod/publish-release.yaml
@@ -31,7 +31,7 @@ steps:
     waitFor: ['clone-language-repo']
     args:
       - 'release'
-      - 'tag'
+      - 'tag-and-release'
       - '-repo'
       - '/workspace/$_REPOSITORY'
       - '-pr'


### PR DESCRIPTION
We have not rolled out the new Librarian image, so we should still be using the tag-and-release command in automation

fixes #2811 