### PR TITLE
test: add integration build tag

### DIFF
--- a/system_test.go
+++ b/system_test.go
@@ -448,7 +448,7 @@ func TestCreateRelease(t *testing.T) {
 }
 
 func TestFindLatestImage(t *testing.T) {
-	t.Skip("Temporarily skipping until we can run it reliably. See https://github.com/googleapis/librarian/issues/2720")
+	t.Logf("Note: This test requires authentication with the Artifact Registry in project 'cloud-sdk-librarian-prod'.")
 
 	// If we are able to configure system tests on GitHub actions, then update this
 	// guard clause.


### PR DESCRIPTION
This test verify the integration of the librarian tool with external systems, GitHub and Artifact Registry. It has expectation setups in env vars and auth to properly work.
With an `integration` build tag, all tests in system_test.go will be skipped when running `go test ./...` locally. Which is same behavior for most developers who does not have relevant env vars setup.

Also remove the temp skip for TestFindLatestImage because it is no longer triggered with standard `go test ./...`. Added a note to make debugging easier.

Fixes #2720