### PR TITLE
test: replace test case for missing state file instead of missing image

### DIFF
--- a/internal/librarian/generate_command_test.go
+++ b/internal/librarian/generate_command_test.go
@@ -60,6 +60,19 @@ func TestNewGenerateRunner(t *testing.T) {
 			wantErrMsg: "repository does not exist",
 		},
 		{
+			name: "no state file",
+			cfg: &config.Config{
+				API:         "some/api",
+				APISource:   newTestGitRepo(t).GetDir(),
+				Branch:      "test-branch",
+				Repo:        newTestGitRepoWithState(t, nil).GetDir(),
+				WorkRoot:    t.TempDir(),
+				CommandName: generateCmdName,
+			},
+			wantErr:    true,
+			wantErrMsg: ".librarian/state.yaml: no such file or directory",
+		},
+		{
 			name: "valid config with github token",
 			cfg: &config.Config{
 				API:         "some/api",

--- a/internal/librarian/librarian_test.go
+++ b/internal/librarian/librarian_test.go
@@ -256,6 +256,18 @@ func newTestGitRepoWithState(t *testing.T, state *config.LibrarianState) gitrepo
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("test"), 0644); err != nil {
 		t.Fatalf("os.WriteFile: %v", err)
 	}
+	// If state is nil, skip creating the .librarian directory
+	// and the state.yaml/config.yaml files and return with a initial commit
+	if state == nil {
+		runGit(t, dir, "add", ".")
+		runGit(t, dir, "commit", "-m", "initial commit")
+		runGit(t, dir, "remote", "add", "origin", remoteURL)
+		repo, err := gitrepo.NewRepository(&gitrepo.RepositoryOptions{Dir: dir})
+		if err != nil {
+			t.Fatalf("gitrepo.Open(%q) = %v", dir, err)
+		}
+		return repo
+	}
 	// Create a state.yaml and config.yaml file in .librarian dir.
 	librarianDir := filepath.Join(dir, config.LibrarianDir)
 	if err := os.MkdirAll(librarianDir, 0755); err != nil {


### PR DESCRIPTION
Based on [deriveImage](https://github.com/googleapis/librarian/blob/1289914cad447ffd1c7b0e2968ed8f6c7c3a8a84/internal/librarian/command.go#L178), image can be provided as override or read from state.yaml. It will only be empty and cause problem is there is no override and not present in state.yaml. 

However, this situation is not practical as `image` is a required field and validated in parsing state.yaml. This [test case](https://github.com/googleapis/librarian/blob/34fe816a8b8d509b9d6b59b65998b1bdc3f46059/internal/config/state_test.go#L48-L65) validates it is required.

Removing this test case as "missing image" is not practical here, replacing with case where state.yaml is missing from code repo.

Fixes #2204