### PR TITLE
all: add missing line breaks to cloudbuild-* files

### DIFF
--- a/cloudbuild-exitgate-deprecated.yaml
+++ b/cloudbuild-exitgate-deprecated.yaml
@@ -19,7 +19,6 @@
 # 'images-dev' repository, which serves as the entry point for the AR Exit Gate.
 # After passing the gate's security checks, the image is promoted and
 # published to the 'images-prod' repository.
-
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'us-central1-docker.pkg.dev/cloud-sdk-production-pipeline/images-dev/librarian', '.']

--- a/cloudbuild-exitgate-dispatcher.yaml
+++ b/cloudbuild-exitgate-dispatcher.yaml
@@ -19,7 +19,6 @@
 # 'images-dev' repository, which serves as the entry point for the AR Exit Gate.
 # After passing the gate's security checks, the image is promoted and
 # published to the 'images-prod' repository.
-
 steps:
   - id: build-dispatcher
     name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild-exitgate-release-container.yaml
+++ b/cloudbuild-exitgate-release-container.yaml
@@ -19,7 +19,6 @@
 # 'images-dev' repository, which serves as the entry point for the AR Exit Gate.
 # After passing the gate's security checks, the image is promoted and
 # published to the 'images-prod' repository.
-
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     waitFor: ['-']

--- a/cloudbuild-exitgate.yaml
+++ b/cloudbuild-exitgate.yaml
@@ -19,7 +19,6 @@
 # 'images-dev' repository, which serves as the entry point for the AR Exit Gate.
 # After passing the gate's security checks, the image is promoted and
 # published to the 'images-prod' repository.
-
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     waitFor: ['-']

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -22,7 +22,6 @@
 #
 # Local test:
 #   gcloud --project=<my-project> builds submit . --config=cloudbuild-test.yaml
-
 steps:
   - id: 'build'
     name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
At the moment the description in the cloudbuild-* files look like they are a continuation of the license header. Add a line break to make it clear this is a different paragraph.