### PR TITLE
chore(codeowners): adding cloud-sdk-librarian-team as a co-owner for sidekick

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 # The owners for all files in the repo.
 * @googleapis/cloud-sdk-librarian-team
 
-/cmd/sidekick/ @googleapis/cloud-sdk-sidekick-team
-/internal/sidekick/ @googleapis/cloud-sdk-sidekick-team
+/cmd/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-team
+/internal/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
Adding @googleapis/cloud-sdk-librarian-team as a co-owner on sidekick directories so either team can approve to speed up development for cross-cutting changes.

For #2753