### PR TITLE
fix(librarian): use a test-output directory for tests in update-image

### DIFF
--- a/internal/librarian/test_container_generate.go
+++ b/internal/librarian/test_container_generate.go
@@ -67,7 +67,10 @@ func (r *testGenerateRunner) run(ctx context.Context) error {
 // listing the failed libraries, preserving the generated files. If all tests
 // pass or are skipped, it cleans up the work directory.
 func (r *testGenerateRunner) runTests(ctx context.Context, sourceRepoHead string) error {
-	outputDir := filepath.Join(r.workRoot, "output")
+	outputDir := filepath.Join(r.workRoot, "test-output")
+	if err := os.Mkdir(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to make output directory, %s: %w", outputDir, err)
+	}
 	if r.library != "" {
 		err := r.testSingleLibrary(ctx, r.library, sourceRepoHead, outputDir)
 		if errors.Is(err, errGenerateBlocked) {

--- a/internal/librarian/update_image_test.go
+++ b/internal/librarian/update_image_test.go
@@ -910,7 +910,9 @@ func TestRunContainerGenerateTest(t *testing.T) {
 			mockRepo: &MockRepository{
 				AddAllError: fmt.Errorf("add all failed"),
 			},
-			testRunner: &testGenerateRunner{},
+			testRunner: &testGenerateRunner{
+				workRoot: t.TempDir(),
+			},
 			wantErrMsg: "failed to stage changes",
 		},
 		{
@@ -918,7 +920,9 @@ func TestRunContainerGenerateTest(t *testing.T) {
 			mockRepo: &MockRepository{
 				CommitError: fmt.Errorf("unexpected commit error"),
 			},
-			testRunner: &testGenerateRunner{},
+			testRunner: &testGenerateRunner{
+				workRoot: t.TempDir(),
+			},
 			wantErrMsg: "failed to create temporary commit",
 		},
 		{
@@ -934,6 +938,7 @@ func TestRunContainerGenerateTest(t *testing.T) {
 				sourceRepo:      &MockRepository{},
 				librarianConfig: &config.LibrarianConfig{},
 				state:           &config.LibrarianState{},
+				workRoot:        t.TempDir(),
 			},
 			wantErrMsg:     "failed to reset temporary commit",
 			wantResetCalls: 1,
@@ -949,6 +954,7 @@ func TestRunContainerGenerateTest(t *testing.T) {
 				librarianConfig: &config.LibrarianConfig{},
 				repo:            &MockRepository{},
 				state:           &config.LibrarianState{},
+				workRoot:        t.TempDir(),
 			},
 			wantResetCalls: 1,
 		},
@@ -963,6 +969,7 @@ func TestRunContainerGenerateTest(t *testing.T) {
 				librarianConfig: &config.LibrarianConfig{},
 				repo:            &MockRepository{},
 				state:           &config.LibrarianState{},
+				workRoot:        t.TempDir(),
 			},
 			wantResetCalls: 0,
 		},


### PR DESCRIPTION
This avoids reusing existing directories under output, which will have been populated by the container prior to running tests.

Fixes #2851