### PR TITLE
test: specify docker API version 1.41 for structure test

### DIFF
--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -20,6 +20,8 @@ commandTests:
     command: ["docker", "version"]
     expectedOutput: ["Docker Engine", "Version:"]
     envVars:
+      # Pin the Docker API version to match the one supported by the
+      # Docker server in the Cloud Build environment.
       - key: "DOCKER_API_VERSION"
         value: "1.41"
   - name: "gcloud"


### PR DESCRIPTION
This test was failing at head (#2856) with error "Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.41" since Dockerfile is pulling 29.0.0. It's likely that the new major version removed some backward-compatibility logic that allowed the client to auto downgrade its API version. 

The Docker client inside librarian image is too new (1.52) for the Docker server environment (1.41) provided by Cloud Build, pin the version for the test.
This change is tested with `gcloud --project=<my-project> builds submit . --config=cloudbuild-test.yaml` , see success [log](https://screenshot.googleplex.com/C9yXpqpa4sb9Yax).

Fixes #2860