### PR TITLE
all: group consecutive var declarations

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -38,8 +38,10 @@ import (
 )
 
 // regexps for parsing commit messages
-var nestedCommitRegex = regexp.MustCompile(`(?s)BEGIN_NESTED_COMMIT\n(.*?)\nEND_NESTED_COMMIT`)
-var conventionalCommitRegex = regexp.MustCompile(`^(feat|fix|docs|chore): (.+)$`)
+var (
+	nestedCommitRegex       = regexp.MustCompile(`(?s)BEGIN_NESTED_COMMIT\n(.*?)\nEND_NESTED_COMMIT`)
+	conventionalCommitRegex = regexp.MustCompile(`^(feat|fix|docs|chore): (.+)$`)
+)
 
 const mockGithubTag = "mock_github"
 

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -26,11 +26,13 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-var typedDataImport = "dart:typed_data"
-var httpImport = "package:http/http.dart as http"
-var serviceClientImport = "package:google_cloud_rpc/service_client.dart"
-var encodingImport = "package:google_cloud_protobuf/src/encoding.dart"
-var protobufImport = "package:google_cloud_protobuf/protobuf.dart"
+var (
+	typedDataImport     = "dart:typed_data"
+	httpImport          = "package:http/http.dart as http"
+	serviceClientImport = "package:google_cloud_rpc/service_client.dart"
+	encodingImport      = "package:google_cloud_protobuf/src/encoding.dart"
+	protobufImport      = "package:google_cloud_protobuf/protobuf.dart"
+)
 
 var needsCtorValidation = map[string]string{
 	".google.protobuf.Duration":  "",
@@ -57,14 +59,16 @@ var usesCustomEncoding = map[string]string{
 	".google.protobuf.Value":       "",
 }
 
-// nestedMessageChar is used to concatenate a message and a child message.
-var nestedMessageChar = "_"
+var (
+	// nestedMessageChar is used to concatenate a message and a child message.
+	nestedMessageChar = "_"
 
-// nestedEnumChar is used to concatenate a message and a child enum.
-var nestedEnumChar = "_"
+	// nestedEnumChar is used to concatenate a message and a child enum.
+	nestedEnumChar = "_"
 
-// deconflictChar is appended to a name to avoid conflicting with a Dart identifier.
-var deconflictChar = "$"
+	// deconflictChar is appended to a name to avoid conflicting with a Dart identifier.
+	deconflictChar = "$"
+)
 
 // reservedNames is a blocklist of Dart reserved words.
 //

--- a/system_test.go
+++ b/system_test.go
@@ -32,8 +32,10 @@ import (
 	"github.com/googleapis/librarian/internal/images"
 )
 
-var testToken = os.Getenv("LIBRARIAN_TEST_GITHUB_TOKEN")
-var githubAction = os.Getenv("LIBRARIAN_GITHUB_ACTION")
+var (
+	testToken    = os.Getenv("LIBRARIAN_TEST_GITHUB_TOKEN")
+	githubAction = os.Getenv("LIBRARIAN_GITHUB_ACTION")
+)
 
 func TestGetRawContentSystem(t *testing.T) {
 	if testToken == "" {


### PR DESCRIPTION
Consecutive var declarations are grouped into var blocks, which is more idiomatic in Go. See https://go.dev/doc/effective_go#variables.