### PR TITLE
refactor: convert var to const where appropriate

### DIFF
--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -26,7 +26,7 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-var (
+const (
 	typedDataImport     = "dart:typed_data"
 	httpImport          = "package:http/http.dart as http"
 	serviceClientImport = "package:google_cloud_rpc/service_client.dart"
@@ -59,7 +59,7 @@ var usesCustomEncoding = map[string]string{
 	".google.protobuf.Value":       "",
 }
 
-var (
+const (
 	// nestedMessageChar is used to concatenate a message and a child message.
 	nestedMessageChar = "_"
 

--- a/internal/sidekick/parser/parser_test.go
+++ b/internal/sidekick/parser/parser_test.go
@@ -23,11 +23,14 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
+const (
+	discoSourceFileRelative   = "disco/compute.v1.json"
+	secretManagerYamlRelative = "google/cloud/secretmanager/v1/secretmanager_v1.yaml"
+)
+
 var (
 	testdataDir, _            = filepath.Abs("../testdata")
-	discoSourceFileRelative   = "disco/compute.v1.json"
 	discoSourceFile           = path.Join(testdataDir, discoSourceFileRelative)
-	secretManagerYamlRelative = "google/cloud/secretmanager/v1/secretmanager_v1.yaml"
 	secretManagerYamlFullPath = path.Join(testdataDir, "googleapis", secretManagerYamlRelative)
 	openAPIFile               = path.Join(testdataDir, "openapi", "secretmanager_openapi_v1.json")
 	protobufFile              = path.Join("testdata", "scalar.proto")

--- a/internal/sidekick/sidekick/sidekick_test.go
+++ b/internal/sidekick/sidekick/sidekick_test.go
@@ -21,12 +21,15 @@ import (
 	"testing"
 )
 
-var (
-	testdataDir, _             = filepath.Abs("../testdata")
-	googleapisRoot             = fmt.Sprintf("%s/googleapis", testdataDir)
-	outputDir                  = fmt.Sprintf("%s/test-only", testdataDir)
+const (
 	secretManagerServiceConfig = "googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml"
-	specificationSource        = fmt.Sprintf("%s/openapi/secretmanager_openapi_v1.json", testdataDir)
+)
+
+var (
+	testdataDir, _      = filepath.Abs("../testdata")
+	googleapisRoot      = fmt.Sprintf("%s/googleapis", testdataDir)
+	outputDir           = fmt.Sprintf("%s/test-only", testdataDir)
+	specificationSource = fmt.Sprintf("%s/openapi/secretmanager_openapi_v1.json", testdataDir)
 )
 
 func requireCommand(t *testing.T, command string) {


### PR DESCRIPTION
Convert several `var` declarations to `const` to improve code clarity and enforce immutability for these values.

Fixes https://github.com/googleapis/librarian/issues/2871