### PR TITLE
fix(internal/librarian): inline errBuilderNotProvided

### DIFF
--- a/internal/librarian/command.go
+++ b/internal/librarian/command.go
@@ -46,8 +46,6 @@ For each failed library, open a ticket in that library’s repository and then y
 `
 )
 
-var errBuilderNotProvided = fmt.Errorf("no prBodyBuilder provided")
-
 type pullRequestType int
 
 const (
@@ -444,7 +442,7 @@ func commitAndPush(ctx context.Context, info *commitInfo) error {
 // caller.
 func writePRBody(info *commitInfo) error {
 	if info.prBodyBuilder == nil {
-		return errBuilderNotProvided
+		return fmt.Errorf("no prBodyBuilder provided")
 	}
 
 	prBody, err := info.prBodyBuilder()


### PR DESCRIPTION
`errBuilderNotProvided` does not need to be a named error. Inline it directly in the function to simplify the code.