### PR TITLE
fix(rust): prevent panic in doc link parsing

### DIFF
--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -1020,7 +1020,15 @@ func escapeUrls(line string) string {
 
 // isLinkDestination verifies whether the url is part of a link destination.
 func isLinkDestination(line string, matchStart, matchEnd int) bool {
-	return strings.HasSuffix(line[:matchStart], "](") && line[matchEnd] == ')'
+	if !strings.HasSuffix(line[:matchStart], "](") {
+		return false
+	}
+	// If the url is at the end of the line, we assume the user meant to close
+	// the link.
+	if matchEnd == len(line) {
+		return true
+	}
+	return line[matchEnd] == ')'
 }
 
 func processList(list *ast.List, indentLevel int, documentationBytes []byte, elementID string) []string {

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -1756,7 +1756,9 @@ http://www.unicode.org/cldr/charts/30/supplemental/territory_information.html
 http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
 https://cloud.google.com/apis/design/design_patterns#integer_types
 https://cloud.google.com/apis/design/design_patterns#integer_types.
-Hyperlink: <a href="https://hyperlink.com">Content</a>`
+Hyperlink: <a href="https://hyperlink.com">Content</a>
+URL at end of line: https://example10.com
+Truncated link: [text](https://example11.com`
 	want := []string{
 		"/// blah blah <https://cloud.google.com> foo bar",
 		"/// [link](https://example1.com)",
@@ -1773,6 +1775,8 @@ Hyperlink: <a href="https://hyperlink.com">Content</a>`
 		"/// <https://cloud.google.com/apis/design/design_patterns#integer_types>",
 		"/// <https://cloud.google.com/apis/design/design_patterns#integer_types>.",
 		"/// Hyperlink: <a href=\"https://hyperlink.com\">Content</a>",
+		"/// URL at end of line: <https://example10.com>",
+		"/// Truncated link: [text](https://example11.com",
 	}
 
 	wkt := &packagez{


### PR DESCRIPTION
This commit fixes a panic in the `isLinkDestination` function that occurred when a URL was located at the very end of a line. The function was attempting to access the character after the URL without checking bounds, leading to an index out of range error.

The fix involves:
1.  Checking if the URL is preceded by `](` to confirm it is part of a link destination.
2.  Safely handling the case where the URL is at the end of the line (inferring a closing parenthesis).
3.  Checking for the closing `)` only if the index is within bounds.

This ensures that truncated links or bare URLs at the end of lines are handled gracefully without crashing the generator.