### PR TITLE
impl(rust): Update templates to create structured client request spans.

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -51,7 +51,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
 impl<T> super::stub::{{Codec.Name}} for {{Codec.Name}}<T>
 where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     {{#Codec.Methods}}
-      {{#Codec.DetailedTracingAttributes}}
+    {{#Codec.DetailedTracingAttributes}}
     #[cfg(google_cloud_unstable_tracing)]
     async fn {{Codec.Name}}(
         &self,
@@ -87,8 +87,8 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     ) -> Result<gax::response::Response<{{Codec.ReturnType}}>> {
         self.inner.{{Codec.Name}}(req, options).await
     }
-      {{/Codec.DetailedTracingAttributes }}
-      {{^Codec.DetailedTracingAttributes }}
+    {{/Codec.DetailedTracingAttributes }}
+    {{^Codec.DetailedTracingAttributes }}
     #[tracing::instrument(ret)]
     async fn {{Codec.Name}}(
         &self,
@@ -98,7 +98,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         self.inner.{{Codec.Name}}(req, options).await
     }
 
-      {{/Codec.DetailedTracingAttributes }}
+    {{/Codec.DetailedTracingAttributes }}
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}
 


### PR DESCRIPTION
These replace the spans created with the #[tracing] macro with contents managed by the client library.

Tested in https://github.com/googleapis/google-cloud-rust/pull/3779