### PR TITLE
chore: update librarian automation to use latest librarian image

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -47,7 +47,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:3ac04cc552c7979c178d322a9ca6a3739e1847e82eb4b485f99bc785190ff905'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
     id: generate
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
     dir: tmp

--- a/infra/prod/publish-release.yaml
+++ b/infra/prod/publish-release.yaml
@@ -26,7 +26,7 @@ steps:
       - '--single-branch'
       - '--branch=$_BRANCH'
       - $_FULL_REPOSITORY
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:3ac04cc552c7979c178d322a9ca6a3739e1847e82eb4b485f99bc785190ff905'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
     id: publish-release
     waitFor: ['clone-language-repo']
     args:

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -41,7 +41,7 @@ steps:
       - 'config'
       - 'user.email'
       - 'cloud-sdk-librarian-robot@google.com'
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:3ac04cc552c7979c178d322a9ca6a3739e1847e82eb4b485f99bc785190ff905'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
     id: stage-release
     waitFor: ['configure-language-repo-email']
     dir: tmp

--- a/infra/prod/update-image.yaml
+++ b/infra/prod/update-image.yaml
@@ -47,7 +47,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:3ac04cc552c7979c178d322a9ca6a3739e1847e82eb4b485f99bc785190ff905'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
     id: update-image
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
     dir: tmp


### PR DESCRIPTION
Update librarian automation to use latest librarian image in order to pick up new repositories onboarded to automation.