### PR TITLE
doc(librarian): document current behavior when using local repo with push flag

### DIFF
--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -36,10 +36,6 @@ Librarian is environment aware and will check if the current directory is the
 root of a librarian repository. If you are not executing in such a directory the
 '--repo' flag must be provided.
 
-Note: When using a local repository, this command creates a new branch from the currently
-checked-out branch and commits changes there. If the -push flag is also specified,
-a pull request is created against the main branch.
-
 # Onboarding a new library
 
 To configure and generate a new library for the first time, you must specify the
@@ -102,9 +98,9 @@ Flags:
 	  	The location of an API specification repository.
 	  	Can be a remote URL or a local file path. (default "https://github.com/googleapis/googleapis")
 	-branch string
-	  	The branch to use with remote code repositories. This is used to specify
-	  	which branch to clone and which branch to use as the base for a pull
-	  	request. (default "main")
+	  	The branch to use with remote code repositories. It is ignored if
+	  	you are using a local repository. This is used to specify which branch to clone
+	  	and which branch to use as the base for a pull request. (default "main")
 	-build
 	  	If true, Librarian will build each generated library by invoking the
 	  	language-specific container.
@@ -136,9 +132,9 @@ Flags:
 	  	supported. If not specified, will try to detect if the current working directory
 	  	is configured as a language repository.
 	  	Note: When using a local repository (either by providing a path or by defaulting
-	  	to the current directory), Librarian creates a new branch from the currently
-	  	checked-out branch and commits changes there. If the -push flag is also specified,
-	  	a pull request is created against the main branch.
+	  	to the current directory), Librarian creates a new branch from the currently checked-out
+	  	branch and commits changes. If the --push flag is also specified, a pull request is
+	  	created against the main branch. The --branch flag is ignored for local repositories.
 	-v	enables verbose logging
 
 # release
@@ -183,10 +179,6 @@ ignored if '--push' is also specified. When pushing to a remote branch,
 you have the option of using HTTPS or SSH. Librarian will automatically determine
 whether to use HTTPS or SSH based on the remote URI.
 
-Note: When using a local repository, this command creates a new branch from the currently
-checked-out branch and commits changes there. If the -push flag is also specified,
-a pull request is created against the main branch.
-
 Examples:
 
 	# Create a release PR for all libraries with pending changes.
@@ -205,9 +197,9 @@ Usage:
 Flags:
 
 	-branch string
-	  	The branch to use with remote code repositories. This is used to specify
-	  	which branch to clone and which branch to use as the base for a pull
-	  	request. (default "main")
+	  	The branch to use with remote code repositories. It is ignored if
+	  	you are using a local repository. This is used to specify which branch to clone
+	  	and which branch to use as the base for a pull request. (default "main")
 	-commit
 	  	If true, librarian will create a commit for the change but not create
 	  	a pull request. This flag is ignored if push is set to true.
@@ -235,9 +227,9 @@ Flags:
 	  	supported. If not specified, will try to detect if the current working directory
 	  	is configured as a language repository.
 	  	Note: When using a local repository (either by providing a path or by defaulting
-	  	to the current directory), Librarian creates a new branch from the currently
-	  	checked-out branch and commits changes there. If the -push flag is also specified,
-	  	a pull request is created against the main branch.
+	  	to the current directory), Librarian creates a new branch from the currently checked-out
+	  	branch and commits changes. If the --push flag is also specified, a pull request is
+	  	created against the main branch. The --branch flag is ignored for local repositories.
 	-v	enables verbose logging
 
 # release tag
@@ -287,9 +279,9 @@ Flags:
 	  	supported. If not specified, will try to detect if the current working directory
 	  	is configured as a language repository.
 	  	Note: When using a local repository (either by providing a path or by defaulting
-	  	to the current directory), Librarian creates a new branch from the currently
-	  	checked-out branch and commits changes there. If the -push flag is also specified,
-	  	a pull request is created against the main branch.
+	  	to the current directory), Librarian creates a new branch from the currently checked-out
+	  	branch and commits changes. If the --push flag is also specified, a pull request is
+	  	created against the main branch. The --branch flag is ignored for local repositories.
 	-v	enables verbose logging
 
 # update-image
@@ -321,9 +313,9 @@ Flags:
 	  	The location of an API specification repository.
 	  	Can be a remote URL or a local file path. (default "https://github.com/googleapis/googleapis")
 	-branch string
-	  	The branch to use with remote code repositories. This is used to specify
-	  	which branch to clone and which branch to use as the base for a pull
-	  	request. (default "main")
+	  	The branch to use with remote code repositories. It is ignored if
+	  	you are using a local repository. This is used to specify which branch to clone
+	  	and which branch to use as the base for a pull request. (default "main")
 	-build
 	  	If true, Librarian will build each generated library by invoking the
 	  	language-specific container.
@@ -360,9 +352,9 @@ Flags:
 	  	supported. If not specified, will try to detect if the current working directory
 	  	is configured as a language repository.
 	  	Note: When using a local repository (either by providing a path or by defaulting
-	  	to the current directory), Librarian creates a new branch from the currently
-	  	checked-out branch and commits changes there. If the -push flag is also specified,
-	  	a pull request is created against the main branch.
+	  	to the current directory), Librarian creates a new branch from the currently checked-out
+	  	branch and commits changes. If the --push flag is also specified, a pull request is
+	  	created against the main branch. The --branch flag is ignored for local repositories.
 	-test
 	  	If true, run container tests after generation but before committing and pushing.
 	  	These tests verify the interaction between language containers and the Librarian CLI's

--- a/internal/librarian/flags.go
+++ b/internal/librarian/flags.go
@@ -41,9 +41,9 @@ language-specific container.`)
 
 func addFlagBranch(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.Branch, "branch", "main",
-		`The branch to use with remote code repositories. This is used to specify
-which branch to clone and which branch to use as the base for a pull
-request.`)
+		`The branch to use with remote code repositories. It is ignored if
+you are using a local repository. This is used to specify which branch to clone
+and which branch to use as the base for a pull request.`)
 }
 
 func addFlagCheckUnexpectedChanges(fs *flag.FlagSet, cfg *config.Config) {
@@ -128,9 +128,9 @@ local file path like /path/to/repo. Both absolute and relative paths are
 supported. If not specified, will try to detect if the current working directory
 is configured as a language repository.
 Note: When using a local repository (either by providing a path or by defaulting
-to the current directory), Librarian creates a new branch from the currently
-checked-out branch and commits changes there. If the -push flag is also specified,
-a pull request is created against the main branch.`)
+to the current directory), Librarian creates a new branch from the currently checked-out
+branch and commits changes. If the --push flag is also specified, a pull request is
+created against the main branch. The --branch flag is ignored for local repositories.`)
 }
 
 func addFlagTest(fs *flag.FlagSet, cfg *config.Config) {

--- a/internal/librarian/help.go
+++ b/internal/librarian/help.go
@@ -29,10 +29,6 @@ Librarian is environment aware and will check if the current directory is the
 root of a librarian repository. If you are not executing in such a directory the
 '--repo' flag must be provided.
 
-Note: When using a local repository, this command creates a new branch from the currently
-checked-out branch and commits changes there. If the -push flag is also specified,
-a pull request is created against the main branch.
-
 # Onboarding a new library
 
 To configure and generate a new library for the first time, you must specify the
@@ -105,10 +101,6 @@ used to create a local commit without creating a pull request; this flag is
 ignored if '--push' is also specified. When pushing to a remote branch,
 you have the option of using HTTPS or SSH. Librarian will automatically determine
 whether to use HTTPS or SSH based on the remote URI.
-
-Note: When using a local repository, this command creates a new branch from the currently
-checked-out branch and commits changes there. If the -push flag is also specified,
-a pull request is created against the main branch.
 
 Examples:
   # Create a release PR for all libraries with pending changes.


### PR DESCRIPTION
Documents current behavior that when using local repo, Librarian will branch-off the checked-out branch for commits, but will attempt to create PR against main branch if `push` flag is set.

Add clarification to `branch` flag description that it is ignored with local repo.

Fixes #2877