### PR TITLE
Revert "feat(infra/prod): onboard 5 repositories to automation for `publish-release` (#2864)"

### DIFF
--- a/internal/automation/prod/repositories.yaml
+++ b/internal/automation/prod/repositories.yaml
@@ -1,28 +1,10 @@
 repositories:
-  - name: "gapic-generator-go"
-    full-name: https://github.com/googleapis/gapic-generator-go
-    github-token-secret-name: "gapic-generator-go-github-token"
+  - name: "google-cloud-python"
+    full-name: https://github.com/googleapis/google-cloud-python
+    github-token-secret-name: "google-cloud-python-github-token"
     supported-commands:
-      - publish-release
-  - name: "gax-go"
-    full-name: https://github.com/googleapis/gax-go
-    github-token-secret-name: "gax-go-github-token"
-    supported-commands:
-      - publish-release
-  - name: "google-auth-library-python"
-    full-name: https://github.com/googleapis/google-auth-library-python
-    github-token-secret-name: "google-auth-library-python-github-token"
-    supported-commands:
-      - publish-release
-  - name: "google-auth-library-python-httplib2"
-    full-name: https://github.com/googleapis/google-auth-library-python-httplib2
-    github-token-secret-name: "google-auth-library-python-httplib2-github-token"
-    supported-commands:
-      - publish-release
-  - name: "google-auth-library-python-oauthlib"
-    full-name: https://github.com/googleapis/google-auth-library-python-oauthlib
-    github-token-secret-name: "google-auth-library-python-oauthlib-github-token"
-    supported-commands:
+      - generate
+      - stage-release
       - publish-release
   - name: "google-cloud-go"
     full-name: https://github.com/googleapis/google-cloud-go
@@ -31,26 +13,19 @@ repositories:
       - generate
       - stage-release
       - publish-release
-  - name: "google-cloud-python"
-    full-name: https://github.com/googleapis/google-cloud-python
-    github-token-secret-name: "google-cloud-python-github-token"
-    supported-commands:
-      - generate
-      - stage-release
-      - publish-release
-  - name: "google-resumable-media-python"
-    full-name: https://github.com/googleapis/google-resumable-media-python
-    github-token-secret-name: "google-resumable-media-python-github-token"
-    supported-commands:
-      - publish-release
   - name: "librarian"
     full-name: https://github.com/googleapis/librarian
     github-token-secret-name: "librarian-github-token"
     supported-commands:
       - stage-release
       - publish-release
-  - name: "python-db-dtypes-pandas"
-    full-name: https://github.com/googleapis/python-db-dtypes-pandas
-    github-token-secret-name: "python-db-dtypes-pandas-github-token"
+  - name: "gax-go"
+    full-name: https://github.com/googleapis/gax-go
+    github-token-secret-name: "gax-go-github-token"
+    supported-commands:
+      - publish-release
+  - name: "gapic-generator-go"
+    full-name: https://github.com/googleapis/gapic-generator-go
+    github-token-secret-name: "gapic-generator-go-github-token"
     supported-commands:
       - publish-release


### PR DESCRIPTION
This reverts commit 79e527a5116784b720ebcdcdd0abdaefec21b807.

The secrets needed to onboard these repositories to automation have not been created, so tests are failing at head.  Reverting this commit until secrets have been created.

cc @parthea 