### PR TITLE
fix: remove '--force-run' argument from stage-release worker

### DIFF
--- a/infra/prod/stage-release-worker.yaml
+++ b/infra/prod/stage-release-worker.yaml
@@ -21,7 +21,6 @@ steps:
       - '--project=$PROJECT_ID'
       - '--command=stage-release'
       - '--push=$_PUSH'
-      - '--force-run=$_FORCE_RUN'
 tags: ['stage-release-dispatcher']
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Removed the '--force-run' argument from the stage-release worker configuration.  This is no longer needed since we removed logic to not run releases on a bi-weekly schedule.