### PR TITLE
chore: remove librarian repository from automation

### DIFF
--- a/internal/automation/prod/repositories.yaml
+++ b/internal/automation/prod/repositories.yaml
@@ -13,12 +13,6 @@ repositories:
       - generate
       - stage-release
       - publish-release
-  - name: "librarian"
-    full-name: https://github.com/googleapis/librarian
-    github-token-secret-name: "librarian-github-token"
-    supported-commands:
-      - stage-release
-      - publish-release
   - name: "gax-go"
     full-name: https://github.com/googleapis/gax-go
     github-token-secret-name: "gax-go-github-token"


### PR DESCRIPTION
In order to reduce support as we make changes to librarian CLI, let's remove Librarian project from automation.  We will no longer use it as dogfood until we have upgraded to the new CLI.