### PR TITLE
chore: retract librarian release v1.0.0

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -65,11 +65,6 @@ steps:
       - '-push=$_PUSH'
       - '-build=$_BUILD'
     secretEnv: ['LIBRARIAN_GITHUB_TOKEN']
-    envVars:
-      # Pin the Docker API version to match the one supported by the
-      # Docker server in the Cloud Build environment.
-      - key: "DOCKER_API_VERSION"
-        value: "1.41"
 tags: ['generate-$_REPOSITORY']
 availableSecrets:
   secretManager:


### PR DESCRIPTION
We are not yet stable, so we will continue to release pre major release until then.