### PR TITLE
chore: revert Librarian CLI release to pre-major release

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-release-container:latest
 libraries:
   - id: librarian
-    version: 1.0.0
+    version: 0.6.0
     last_generated_commit: 97a83d76a09a7f6dcab43675c87bdfeb5bcf1cb5
     apis: []
     source_roots:


### PR DESCRIPTION
We prematurely released 1.0.0 version of Librarian CLI, when it is not yet stable. We have retracted this release and will continue on with pre 1.0 releases, starting with 0.6.0.