### PR TITLE
chore: update Librarian automation to use Librarian 0.6.0 release.

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -47,7 +47,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
     id: generate
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
     dir: tmp

--- a/infra/prod/publish-release.yaml
+++ b/infra/prod/publish-release.yaml
@@ -26,7 +26,7 @@ steps:
       - '--single-branch'
       - '--branch=$_BRANCH'
       - $_FULL_REPOSITORY
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
     id: publish-release
     waitFor: ['clone-language-repo']
     args:

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -41,7 +41,7 @@ steps:
       - 'config'
       - 'user.email'
       - 'cloud-sdk-librarian-robot@google.com'
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
     id: stage-release
     waitFor: ['configure-language-repo-email']
     dir: tmp

--- a/infra/prod/update-image.yaml
+++ b/infra/prod/update-image.yaml
@@ -47,7 +47,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:c2e77e3fc0b7248c9173226b2dcfb7d74f8fd558869ef1b2a388c9bb90156cf0'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
     id: update-image
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
     dir: tmp


### PR DESCRIPTION
Update Librarian automation to use Librarian 0.6.0 release.

This contains fix to pin docker image to a supported version.