### PR TITLE
chore: pin docker-ce docker-ce-cli and docker-ce-rootless-extras versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,10 @@ RUN echo \
 
 # Install Docker and pin version
 RUN apt update && \
-    apt-get -y install docker-ce=5:28.5.2-1~debian.13~trixie && \
+    apt-get -y install \
+    docker-ce=5:28.5.2-1~debian.13~trixie \
+    docker-ce-cli=5:28.5.2-1~debian.13~trixie \
+    docker-ce-rootless-extras=5:28.5.2-1~debian.13~trixie && \
     rm -rf /var/lib/apt/lists/*
 
 # Add the Google Cloud SDK distribution URI as a package source


### PR DESCRIPTION
Previous #2899 only pin version for docker-ce. The docker command is provided by the docker-ce-cli package, which is at version 29.0.0. The Docker engine (docker-ce) is at the correct version, but the command-line interface is not.

Now with this change, run `docker run --rm --entrypoint /bin/bash librarian -c "docker --version" ` after build, get 

`Docker version 28.5.2, build ecc6942 `