### PR TITLE
chore: add v1.0.1 to retraction list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-retract v1.0.0 // Retracted because the 1.0.0 release was published prematurely.
+retract (
+	v1.0.1 // Version bump to roll out retractions only.
+	v1.0.0 // Retracted because the 1.0.0 release was published prematurely.
+)


### PR DESCRIPTION
In order to roll out retraction for v1.0.0, we need to deploy and retract higher version of v1.0.1. 