### PR TITLE
chore: update librarian image for automation

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -47,7 +47,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:8ae52838e466022dd701cab8c3f002cb727b3e0e5688864b3d0d68f645541035'
     id: generate
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
     dir: tmp

--- a/infra/prod/publish-release.yaml
+++ b/infra/prod/publish-release.yaml
@@ -26,7 +26,7 @@ steps:
       - '--single-branch'
       - '--branch=$_BRANCH'
       - $_FULL_REPOSITORY
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:8ae52838e466022dd701cab8c3f002cb727b3e0e5688864b3d0d68f645541035'
     id: publish-release
     waitFor: ['clone-language-repo']
     args:

--- a/infra/prod/stage-release.yaml
+++ b/infra/prod/stage-release.yaml
@@ -41,7 +41,7 @@ steps:
       - 'config'
       - 'user.email'
       - 'cloud-sdk-librarian-robot@google.com'
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:8ae52838e466022dd701cab8c3f002cb727b3e0e5688864b3d0d68f645541035'
     id: stage-release
     waitFor: ['configure-language-repo-email']
     dir: tmp

--- a/infra/prod/update-image.yaml
+++ b/infra/prod/update-image.yaml
@@ -47,7 +47,7 @@ steps:
       - '--single-branch'
       - '--branch=master'
       - https://github.com/googleapis/googleapis
-  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:98b6dce4f90f7c6cd02488ec0aeb95a2f2720db1ed2387e9721cc30234c56b9d'
+  - name: 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@sha256:8ae52838e466022dd701cab8c3f002cb727b3e0e5688864b3d0d68f645541035'
     id: update-image
     waitFor: ['configure-language-repo-email', 'clone-googleapis']
     dir: tmp


### PR DESCRIPTION
This includes the fix to pin docker to a compatible version.