### PR TITLE
docs: Update documentation to include triaging information and support contact information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ clear owner. Otherwise, leave it for triage. Issues are triaged daily, Monday th
 
 If an issue is critical and needs immediate attention, please use the label `critical`. If the issue is high priority, please use the label `needs fix soon`.
 
-If you disagree with the labels applied during triage, please reach out to cloud-sdk-librarian-admin@google.com.
+If you disagree with the labels applied during triage, please reach out to cloud-sdk-librarian-oncall@google.com.
 
 ## Leaving a TODO
 

--- a/doc/library-maintainer-guide.md
+++ b/doc/library-maintainer-guide.md
@@ -187,4 +187,4 @@ Maintainers.  This can potentially block generation/release until issue has been
 resolved.
 
 ## Support
-If you need support on any issues please reach out to cloud-sdk-librarian-admin@google.com.
+If you need support please reach out to cloud-sdk-librarian-oncall@google.com.

--- a/doc/repository-library-onboarding.md
+++ b/doc/repository-library-onboarding.md
@@ -30,4 +30,4 @@ and set the default commit message to **Pull request title and description**.
 3) Be aware of the `generate_blocked` and `release_blocked` fields in the [config.yaml file](https://github.com/googleapis/librarian/blob/main/doc/config-schema.md#libraries-object). If these are not set and automation is enabled for the repository ([check here](https://github.com/googleapis/librarian/blob/main/internal/automation/prod/repositories.yaml)), then generate and release PRs will be created and merged automatically. If these actions are blocked, or your repository is not set up for automation, you will have to perform these actions manually. See this [guide](https://github.com/googleapis/librarian/blob/main/doc/library-maintainer-guide.md) for details.
 
 ## Support
-If you need support on any issues please reach out to cloud-sdk-librarian-admin@google.com.
+If you need support please reach out to cloud-sdk-librarian-oncall@google.com.


### PR DESCRIPTION
This updates the contributing guidelines to specify how/when issues are triaged.  Additionally it adds support e-mail to issue triaging, maintainers guide and repo/librarian onboarding guide.