### PR TITLE
chore: add comment to provide context for recent change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@ RUN echo \
       tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Install Docker and pin version
-# Cloud Build is running Docker engine version 20.10.24, which max supported API version is 1.41
+# Cloud Build runs Docker Engine v20.10.24, which supports a maximum API version of v1.41.
 # https://docs.cloud.google.com/build/docs/overview#docker
-# Starting docker 29.0.0 supports API version v1.44+ 
+# Docker client v29.0.0 and newer require API version v1.44 or later.
 # https://docs.docker.com/engine/release-notes/29/#2900
 RUN apt update && \
     apt-get -y install \


### PR DESCRIPTION
Add a comment for context on changes made in #2899, #2903

We recently pinned docker version when building Librarian image [here](https://github.com/googleapis/librarian/blob/ee0500655e52d5c60fe82942eb17fecdce25ddb9/Dockerfile#L54-L60). Because in newer 29.0.0, the daemon now requires API version v1.44 or later (Docker v25.0+). However, our automation runs on Cloud Build, where is running Docker engine version 20.10.24. https://docs.cloud.google.com/build/docs/overview#docker
This caused compatibility issues (see #2893)

Local dev flow does not have this issue because developer has control over both docker server and client side.