### PR TITLE
chore: Update CODEOWNERS to change team ownership to cloud-sdk-librarian-admin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # is the same as .gitignore.
 
 # The owners for all files in the repo.
-* @googleapis/cloud-sdk-librarian-team
+* @googleapis/cloud-sdk-librarian-admin
 
 /cmd/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-team
 /internal/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
Going forward only smaller Librarian team (cloud-sdk-librarian-admin) should have ownership of the full project.