### PR TITLE
fix: separate stdout and stderr for TestGoImports

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -226,15 +226,15 @@ func TestGolangCILint(t *testing.T) {
 
 func TestGoImports(t *testing.T) {
 	cmd := exec.Command("go", "run", "golang.org/x/tools/cmd/goimports@v0.38.0", "-d", ".")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("goimports failed to run: %v\nOutput:\n%s", err, out.String())
+		t.Fatalf("goimports failed to run: %v\nStdout:\n%s\nStderr:\n%s", err, stdout.String(), stderr.String())
 	}
-	if out.Len() > 0 {
-		t.Errorf("goimports found unformatted files:\n%s", out.String())
+	if stdout.Len() > 0 {
+		t.Errorf("goimports found unformatted files:\n%s", stdout.String())
 	}
 }
 


### PR DESCRIPTION
Separate stdout and stderr from the `goimports` command, so that only the actual list of unformatted files from stdout is checked, while download progress messages in stderr are ignored unless an error occurs. 

This issue was first observed [here](https://github.com/googleapis/librarian/pull/2913#issuecomment-3534293562) that download progress messages is reported as unformatted lines.
This change is verified in #2913 ([log](https://github.com/googleapis/librarian/actions/runs/19375966778/job/55443348855)) .