### PR TITLE
Revert "chore: Update CODEOWNERS to change team ownership to cloud-sdk-librarian-admin (#2914)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # is the same as .gitignore.
 
 # The owners for all files in the repo.
-* @googleapis/cloud-sdk-librarian-admin
+* @googleapis/cloud-sdk-librarian-team
 
 /cmd/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-team
 /internal/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
As mentioned in [comment](https://github.com/googleapis/librarian/pull/2914#issuecomment-3534956358), this is not how we want to handle codeowners in librarian.  We want a larger group to be able to approve PRs, but instead just route PRs to a smaller team.

This reverts commit d5001e1db9bbe138c3345b52e47a41f2e04e5bae.