### PR TITLE
chore: Update CODEOWNERS to streamline team assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,10 @@
 # The owners for all files in the repo.
 * @googleapis/cloud-sdk-librarian-team
 
+# Locations for all sidekick code.
 /cmd/sidekick/ @googleapis/cloud-sdk-sidekick-team
 /internal/sidekick/ @googleapis/cloud-sdk-sidekick-team
 
+# Locations for all surfer code.
 /cmd/surfer/ @googleapis/cloud-sdk-surfer-team
 /internal/surfer/ @googleapis/cloud-sdk-surfer-team


### PR DESCRIPTION
Removed Librarian ownership entries for sidekick and added ownership for surfer.  This should allow for the correct teams to get assigned PRs.

We have updated the Librarian repository settings so anyone in cloud SDK org can approve a PR even if they aren't a code owner.