### PR TITLE
chore: add a structure test for automation CLI

### DIFF
--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -31,8 +31,6 @@ steps:
       - '-t'
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/librarian'
       - '.'
-    env:
-      - "DOCKER_BUILDKIT=1"
   - id: structure-test
     name: gcr.io/gcp-runtimes/structure_test
     waitFor: ['build']

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -13,18 +13,6 @@
 # limitations under the License.
 schemaVersion: 1.0.0
 commandTests:
-  - name: "automation version"
-    command: ["/app/automation", "version"]
-    expectedOutput: ["\\d+\\.\\d+\\.\\d+"]
-  - name: "automation generate"
-    command: ["/app/automation", "generate", "--help"]
-    expectedError: ["automation generate [flags]"]
-  - name: "automation publish-release"
-    command: ["/app/automation", "publish-release", "--help"]
-    expectedError: ["automation publish-release [flags]"]
-  - name: "automation stage-release"
-    command: ["/app/automation", "stage-release", "--help"]
-    expectedError: ["automation stage-release [flags]"]
   - name: "librarian version"
     command: ["/app/librarian", "version"]
     expectedOutput: ["\\d+\\.\\d+\\.\\d+"]


### PR DESCRIPTION
Add structure tests for automation CLI, the test will fail if the underlying librarian CLI change but automation CLI remains the same.

Fixes #2813