### PR TITLE
chore: Modify CODEOWNERS to add cloud-sdk-librarian-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,7 @@
 * @googleapis/cloud-sdk-librarian-reviewers
 
 # Locations for all sidekick code.
-/cmd/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-reviewers
-/internal/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-reviewers
+/*/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-librarian-reviewers
 
 # Locations for all surfer code.
-/cmd/surfer/ @googleapis/cloud-sdk-surfer-team @googleapis/cloud-sdk-librarian-reviewers
-/internal/surfer/ @googleapis/cloud-sdk-surfer-team @googleapis/cloud-sdk-librarian-reviewers
+/*/surfer/ @googleapis/cloud-sdk-surfer-team @googleapis/cloud-sdk-librarian-reviewers


### PR DESCRIPTION
Adding new team cloud-sdk-librarian-reviewers to have overall approval access. This removes the need for multiple reviews when a change is made to sidekick/surfer & librarian code.

Due to Google policy we need codeowners approval in order to merge a PR.