### PR TITLE
chore(internal/config): clean up config command correlations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ type Config struct {
 	// is expected to contain a service config YAML file.
 	// Example: "google/cloud/functions/v2"
 	//
-	// API is used by generate and configure commands.
+	// API is used by generate, configure, release init, and update-image commands.
 	//
 	// API Path is specified with the -api flag.
 	API string


### PR DESCRIPTION
The `Config` documentation referenced outdated commands and did not list some of the newer commands that the properties are used for. The former are removed and the latter are updated.