### PR TITLE
refactor: mv system_test.go to internal/integration

### DIFF
--- a/internal/integration/doc.go
+++ b/internal/integration/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package integration contains integration and e2e tests for the Librarian project.
+package integration

--- a/internal/integration/system_test.go
+++ b/internal/integration/system_test.go
@@ -14,7 +14,7 @@
 
 //go:build integration
 
-package librarian
+package integration_test
 
 import (
 	"fmt"


### PR DESCRIPTION
Moves `system_test.go` to internal/integration package. Introducing `doc.go` to explicitly define the internal/integration directory as a Go package.This ensures all integration and e2e tests in that directory are reliably found and executed by the Go tool.
Without the `doc.go` file, the fact we only have 2 test files with mutually exclusive build tags seems to be hitting some edge case scenario in Go tooling directory mechanism. Where `go test -tags e2e ./...` correctly discovers e2e_test.go, but `go test -tags integration ./...` cannot correctly run tests within system_test.go.

Since this test is not part of CI, manually run following testing.md instructions. Here is [tags created](https://github.com/zhumin8/librarian/tree/create-tag-test-20251118104307) in my fork repo to test.

Fixes #2842