### PR TITLE
chore(test): remove redundant step in test workflow

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -36,8 +36,6 @@ jobs:
           go install golang.org/x/tools/cmd/goimports@latest
       - name: Run tests
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
-      - name: Detect formatting changes
-        run: git diff --exit-code
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
This step is redundant now, as the yaml format and check result step is reformatted in #2920 and moved into `all_test.go`.
https://github.com/googleapis/librarian/blob/7df4cf74f1d8cb5c1edddd773741c1253d8e20d4/all_test.go#L245-L257

However, the `Detect formatting changes` step is not deleted from the workflow. This causes #2933 in rare cases because test inside `cmd/doc_generate_test.go` writes to non-test file as part of the test (to verify no change).  "Detect formatting changes" can kick in too soon and run into corrupt files.

Fixes #2933