### PR TITLE
chore: Update release container Dockerfile to remove chmod on run.sh copy command

### DIFF
--- a/infra/imagebuilders/container/Dockerfile
+++ b/infra/imagebuilders/container/Dockerfile
@@ -21,6 +21,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY --chmod=755 infra/imagebuilders/container/run.sh /app/run.sh
+COPY infra/imagebuilders/container/run.sh /app/run.sh
 
 ENTRYPOINT [ "/app/run.sh" ]


### PR DESCRIPTION
Removed the chmod option from the COPY command for run.sh.  This requires BuildKit to be installed and is unnecessary.