### PR TITLE
feat(internal/rust): add BumpPackageVersion

### DIFF
--- a/internal/sideflip/internal/rust/release.go
+++ b/internal/sideflip/internal/rust/release.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/sideflip/config"
+	rustrelease "github.com/googleapis/librarian/internal/sidekick/rust_release"
+	"github.com/pelletier/go-toml/v2"
+)
+
+type cargoPackage struct {
+	Name    string `toml:"name"`
+	Version string `toml:"version"`
+}
+
+type cargoManifest struct {
+	Package *cargoPackage `toml:"package"`
+}
+
+// BumpVersions bumps versions for all Cargo.toml files and updates
+// librarian.yaml.
+func BumpVersions(ctx context.Context, cfg *config.Config, configPath string) error {
+	if cfg.Versions == nil {
+		cfg.Versions = make(map[string]string)
+	}
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "Cargo.toml" {
+			return nil
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		var manifest cargoManifest
+		if err := toml.Unmarshal(contents, &manifest); err != nil {
+			return err
+		}
+		if manifest.Package == nil {
+			return nil
+		}
+		newVersion, err := rustrelease.BumpPackageVersion(manifest.Package.Version)
+		if err != nil {
+			return err
+		}
+
+		lines := strings.Split(string(contents), "\n")
+		idx := slices.IndexFunc(lines, func(a string) bool {
+			return strings.HasPrefix(a, "version ")
+		})
+		if idx == -1 {
+			return fmt.Errorf("no version line found in %s", path)
+		}
+		lines[idx] = fmt.Sprintf(`version                = "%s"`, newVersion)
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+			return err
+		}
+		cfg.Versions[manifest.Package.Name] = newVersion
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+	return cfg.Write(configPath)
+}

--- a/internal/sideflip/internal/rust/release_test.go
+++ b/internal/sideflip/internal/rust/release_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sideflip/config"
+)
+
+func TestBumpVersions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	createCrate(t, "src/storage", "google-cloud-storage", "1.0.0")
+	createCrate(t, "src/secretmanager", "google-cloud-secretmanager-v1", "1.5.3")
+
+	cfg := &config.Config{
+		Version:  "v1",
+		Language: "rust",
+		Versions: map[string]string{
+			"google-cloud-storage":          "1.0.0",
+			"google-cloud-secretmanager-v1": "1.5.3",
+		},
+	}
+	configPath := "librarian.yaml"
+	if err := cfg.Write(configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := BumpVersions(t.Context(), cfg, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	checkCargoVersion(t, "src/storage/Cargo.toml", "1.1.0")
+	checkCargoVersion(t, "src/secretmanager/Cargo.toml", "1.6.0")
+
+	updatedCfg, err := config.Read(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantVersions := map[string]string{
+		"google-cloud-storage":          "1.1.0",
+		"google-cloud-secretmanager-v1": "1.6.0",
+	}
+	if diff := cmp.Diff(wantVersions, updatedCfg.Versions); diff != "" {
+		t.Errorf("versions mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func createCrate(t *testing.T, dir, name, version string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cargo := fmt.Sprintf(`[package]
+name                   = "%s"
+version                = "%s"
+edition                = "2021"
+`, name, version)
+
+	if err := os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkCargoVersion(t *testing.T, path, wantVersion string) {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := fmt.Sprintf(`version                = "%s"`, wantVersion)
+	if !contains(string(contents), want) {
+		t.Errorf("%s does not contain %q\nGot:\n%s", path, want, string(contents))
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsInner(s, substr))
+}
+
+func containsInner(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sidekick/rust_release/update_manifest.go
+++ b/internal/sidekick/rust_release/update_manifest.go
@@ -60,7 +60,7 @@ func updateManifest(config *config.Release, lastTag, manifest string) ([]string,
 	if !info.Package.Publish {
 		return nil, nil
 	}
-	newVersion, err := bumpPackageVersion(info.Package.Version)
+	newVersion, err := BumpPackageVersion(info.Package.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,8 @@ func updateManifest(config *config.Release, lastTag, manifest string) ([]string,
 	return []string{info.Package.Name}, nil
 }
 
-func bumpPackageVersion(version string) (string, error) {
+// BumpPackageVersion increments the minor version and resets the patch version.
+func BumpPackageVersion(version string) (string, error) {
 	components := strings.SplitN(version, ".", 3)
 	if len(components) != 3 {
 		return version, nil

--- a/internal/sidekick/rust_release/update_manifest_test.go
+++ b/internal/sidekick/rust_release/update_manifest_test.go
@@ -243,7 +243,7 @@ func TestBumpPackageVersion(t *testing.T) {
 		{"0.1.2", "0.2.0"},
 		{"0.1.2-alpha", "0.2.0-alpha"},
 	} {
-		got, err := bumpPackageVersion(test.Input)
+		got, err := BumpPackageVersion(test.Input)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
BumpVersions is added,which walks all Cargo.toml files, bumps their minor versions, and updates librarian.yaml with the new version numbers.

For https://github.com/googleapis/librarian/issues/2966