### PR TITLE
chore: update automation images to 0.7.0 release

### DIFF
--- a/infra/prod/generate-worker.yaml
+++ b/infra/prod/generate-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian generate` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher:0.7.0
     id: generate-dispatcher
     args:
       - '--project=$PROJECT_ID'

--- a/infra/prod/publish-release-worker.yaml
+++ b/infra/prod/publish-release-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian release tag` command with a provided repository,
 # secret name, and optional PR
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher:0.7.0
     id: publish-release-dispatcher
     args:
       - '--project=$PROJECT_ID'

--- a/infra/prod/stage-release-worker.yaml
+++ b/infra/prod/stage-release-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian release stage` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher:0.7.0
     id: stage-release-dispatcher
     args:
       - '--project=$PROJECT_ID'

--- a/infra/prod/update-image-worker.yaml
+++ b/infra/prod/update-image-worker.yaml
@@ -15,7 +15,7 @@
 # This triggers the `update-image` workflow for all repositories registered
 # to automate the `librarian update-image` command 
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher:0.7.0
     id: update-image-dispatcher
     args:
       - '--project=$PROJECT_ID'

--- a/internal/automation/prod/repositories.yaml
+++ b/internal/automation/prod/repositories.yaml
@@ -1,4 +1,4 @@
-librarian-image-sha: sha256:8ae52838e466022dd701cab8c3f002cb727b3e0e5688864b3d0d68f645541035
+librarian-image-sha: sha256:a1efd1029a66c1200e23d88d9eeb12b740aa7e47038bfdd9119c3ce46d46d918
 repositories:
   - name: "gapic-generator-go"
     full-name: https://github.com/googleapis/gapic-generator-go


### PR DESCRIPTION
This updates both librarian CLI image and librarian dispatch image to use final release off main branch (0.7.0).