### PR TITLE
fix(rust): correct docs link from landing page

### DIFF
--- a/internal/sidekick/rust/templates/common/README.md.mustache
+++ b/internal/sidekick/rust/templates/common/README.md.mustache
@@ -68,8 +68,8 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/{{Codec.PackageName}}/latest/{{Codec.PackageName}})
+- Read the [crate's documentation](https://docs.rs/{{Codec.PackageName}}/{{Codec.PackageVersion}})
 
 {{#Codec.Services}}
-[{{Codec.Name}}]: https://docs.rs/{{Model.Codec.PackageName}}/latest/{{Model.Codec.PackageNamespace}}/client/struct.{{Codec.Name}}.html
+[{{Codec.Name}}]: https://docs.rs/{{Model.Codec.PackageName}}/{{Model.Codec.PackageVersion}}/{{Model.Codec.PackageNamespace}}/client/struct.{{Codec.Name}}.html
 {{/Codec.Services}}


### PR DESCRIPTION
Links to docs.rs from our crates.io landing pages are broken. Try for yourself: https://crates.io/crates/google-cloud-kms-v1

And then nit: the landing page for `vX.Y.Z` should point to the docs for `vX.Y.Z`, not `latest`.