### PR TITLE
chore: add a cloud build test to verify librarian command

### DIFF
--- a/infra/test/librarian-image-test.yaml
+++ b/infra/test/librarian-image-test.yaml
@@ -35,7 +35,7 @@ steps:
   - id: test-release-stage
     name: gcr.io/cloud-builders/docker
     entrypoint: bash
-    waitFor: [ 'get-librarian-image-sha' ]
+    waitFor: ['get-librarian-image-sha']
     args:
       - -c
       - |
@@ -46,7 +46,7 @@ steps:
   - id: test-release-tag
     name: gcr.io/cloud-builders/docker
     entrypoint: bash
-    waitFor: [ 'get-librarian-image-sha' ]
+    waitFor: ['get-librarian-image-sha']
     args:
       - -c
       - |


### PR DESCRIPTION
Add a presubmit check to verify the librarian image used by Automation support `generate`, `release stage` and `release tag` commands.

Example run [log](https://pantheon.corp.google.com/cloud-build/builds;region=global/cd048b73-e289-4e57-a777-b7546f7091da;step=1?e=RetailSupportToolLaunch::RetailSupportToolEnabled,RetailDataQualityGaLaunch::RetailDataQualityGaEnabled&mods=allow_workbench_image_override&project=librarian-dev-joewa-u0cll5).

The Cloud Build Trigger will be added separately.

For #2813