### PR TITLE
chore(infra/prod): enable generation for onboarded python repos

### DIFF
--- a/internal/legacylibrarian/legacyautomation/prod/repositories.yaml
+++ b/internal/legacylibrarian/legacyautomation/prod/repositories.yaml
@@ -49,11 +49,6 @@ repositories:
     github-token-secret-name: "google-resumable-media-python-github-token"
     supported-commands:
       - publish-release
-  - name: "python-aiplatform"
-    full-name: https://github.com/googleapis/python-aiplatform
-    github-token-secret-name: "python-aiplatform-github-token"
-    supported-commands:
-      - publish-release
   - name: "python-api-core"
     full-name: https://github.com/googleapis/python-api-core
     github-token-secret-name: "python-api-core-github-token"


### PR DESCRIPTION
This PR enables automation for `librarian generate` for repos which support it.

Note that this PR also cleans up `python-aiplatform` which is not onboarded to librarian.