### PR TITLE
feat(internal/fetch): implement caching

### DIFF
--- a/internal/fetch/cache.go
+++ b/internal/fetch/cache.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetch
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const envLibrarianCache = "LIBRARIAN_CACHE"
+
+// RepoDir downloads a repository tarball and returns the path to the extracted
+// directory.
+//
+// The cache directory is determined by LIBRARIAN_CACHE environment variable,
+// or defaults to $HOME/.cache/librarian if not set.
+//
+// The diagrams below explains the structure of the librarian cache. For each
+// path, $repo is a repository path (i.e. github.com/googleapis/googleapis),
+// and $commit is a commit hash in that repository.
+//
+// Cache structure:
+//
+//	$LIBRARIAN_CACHE/
+//	├── download/                    # Downloaded artifacts
+//	│   └── $repo@$commit.tar.gz     # Source tarball (kept for re-extraction)
+//	└── $repo@$commit/               # Extracted source files
+//	    └── {files...}
+//
+// Example for github.com/googleapis/googleapis at commit abc123:
+//
+//	$HOME/.cache/librarian/
+//	├── download/
+//	│   └── github.com/googleapis/googleapis@abc123.tar.gz
+//	└── github.com/googleapis/googleapis@abc123/
+//	    └── google/
+//	        └── api/
+//	            └── annotations.proto
+//
+// Cache lookup order:
+//  1. Check if extracted directory exists and contains files. If so, return it.
+//  2. Check if tarball exists. Verify its SHA256 matches expectedSHA256. If yes,
+//     extract tarball and return the directory. If the hash mismatches, fall
+//     through to step 3.
+//  3. Download tarball, compute SHA256, verify it matches expectedSHA256 from
+//     librarian.yaml, extract, and return the path.
+func RepoDir(repo, commit, expectedSHA256 string) (string, error) {
+	cacheDir, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	tgz := tarballPath(cacheDir, repo, commit)
+	outdir := filepath.Join(cacheDir, fmt.Sprintf("%s@%s", repo, commit))
+
+	// Step 1: Check if extracted directory exists and contains files.
+	if cached, err := extractedDir(cacheDir, repo, commit); err == nil {
+		return cached, nil
+	}
+
+	// Step 2: Check if tarball exists. Verify its SHA256 matches expectedSHA256.
+	// If hash doesn't match, fall through to re-download.
+	if _, err := os.Stat(tgz); err == nil {
+		sha, err := computeSHA256(tgz)
+		if err == nil && sha == expectedSHA256 {
+			if err := os.MkdirAll(outdir, 0755); err != nil {
+				return "", fmt.Errorf("failed creating %q: %w", outdir, err)
+			}
+			if err := ExtractTarball(tgz, outdir); err == nil {
+				return outdir, nil
+			}
+		}
+	}
+
+	// Step 3: Download tarball, compute SHA256, verify against expected, extract.
+	sourceURL := fmt.Sprintf("https://%s/archive/%s.tar.gz", repo, commit)
+	if err := os.MkdirAll(filepath.Dir(tgz), 0755); err != nil {
+		return "", fmt.Errorf("failed creating %q: %w", filepath.Dir(tgz), err)
+	}
+	if err := os.MkdirAll(outdir, 0755); err != nil {
+		return "", fmt.Errorf("failed creating %q: %w", outdir, err)
+	}
+	if err := DownloadTarball(tgz, sourceURL, expectedSHA256); err != nil {
+		return "", err
+	}
+	if err := ExtractTarball(tgz, outdir); err != nil {
+		return "", fmt.Errorf("failed to extract tarball: %w", err)
+	}
+	return outdir, nil
+}
+
+// cacheDir returns the root cache directory for librarian operations. It
+// checks the $LIBRARIAN_CACHE environment variable, falling back to
+// $HOME/.cache/librarian if not set.
+func cacheDir() (string, error) {
+	if cache := os.Getenv(envLibrarianCache); cache != "" {
+		return cache, nil
+	}
+
+	home, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user cache directory: %w", err)
+	}
+	return filepath.Join(home, "librarian"), nil
+}
+
+// tarballPath returns the path to a cached tarball for the given repo and
+// commit.
+//
+// The returned path has the format
+// $LIBRARIAN_CACHE/download/$repo@$commit.tar.gz.
+func tarballPath(cacheDir, repo, commit string) string {
+	downloadDir := filepath.Join(cacheDir, "download", filepath.Dir(repo))
+	return filepath.Join(downloadDir, fmt.Sprintf("%s@%s.tar.gz", filepath.Base(repo), commit))
+}
+
+// extractedDir returns the directory containing the extracted files for the
+// given repo and commit. It validates that the directory exists and contains
+// files.
+//
+// The returned path has the format $LIBRARIAN_CACHE/$repo@$commit/.
+func extractedDir(cacheDir, repo, commit string) (string, error) {
+	dir := filepath.Join(cacheDir, fmt.Sprintf("%s@%s", repo, commit))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("directory %q does not exist or is empty: %w", dir, err)
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("directory %q does not exist or is empty", dir)
+	}
+	return dir, nil
+}
+
+// computeSHA256 computes the SHA256 checksum of a file and returns it as a hex
+// string.
+func computeSHA256(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}

--- a/internal/fetch/cache_test.go
+++ b/internal/fetch/cache_test.go
@@ -1,0 +1,208 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetch
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	testCommit = "abc123"
+	testRepo   = "github.com/googleapis/googleapis"
+	testSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	testExtractedDir = "github.com/googleapis/googleapis@abc123/"
+	testTarball      = "download/github.com/googleapis/googleapis@abc123.tar.gz"
+)
+
+func TestCacheDir(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		env     string
+		wantDir string
+	}{
+		{
+			name:    "uses LIBRARIAN_CACHE when set",
+			env:     "/custom/cache",
+			wantDir: "/custom/cache",
+		},
+		{
+			name: "uses UserCacheDir/librarian when LIBRARIAN_CACHE not set",
+			env:  "",
+			wantDir: func() string {
+				cache, _ := os.UserCacheDir()
+				return filepath.Join(cache, "librarian")
+			}(),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.env != "" {
+				t.Setenv("LIBRARIAN_CACHE", test.env)
+			}
+			got, err := cacheDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(test.wantDir, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTarballPath(t *testing.T) {
+	const cachedir = "/tmp/cache"
+
+	got := tarballPath(cachedir, testRepo, testCommit)
+	want := filepath.Join(cachedir, testTarball)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestExtractedDir(t *testing.T) {
+	cachedir := t.TempDir()
+	want := filepath.Join(cachedir, testExtractedDir)
+	if err := os.MkdirAll(want, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(want, "test.txt"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := extractedDir(cachedir, testRepo, testCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestExtractDir_Empty(t *testing.T) {
+	cachedir := t.TempDir()
+	if _, err := extractedDir(cachedir, testRepo, testCommit); err == nil {
+		t.Fatal("expected error for non-existent directory")
+	}
+}
+
+func TestRepoDir_ExtractedDirExists(t *testing.T) {
+	cachedir := t.TempDir()
+	t.Setenv(envLibrarianCache, cachedir)
+
+	extractedDir := filepath.Join(cachedir, testExtractedDir)
+	if err := os.MkdirAll(extractedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extractedDir, "test.txt"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := RepoDir(testRepo, testCommit, testSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(extractedDir, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRepoDir_TarballExists(t *testing.T) {
+	cachedir := t.TempDir()
+	t.Setenv(envLibrarianCache, cachedir)
+
+	tarballPath := filepath.Join(cachedir, testTarball)
+	if err := os.MkdirAll(filepath.Dir(tarballPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tarballData := createTestTarball(t, "test-repo-abc123", map[string]string{
+		"README.md": "# Test Repo",
+		"main.go":   "package main",
+	})
+	if err := os.WriteFile(tarballPath, tarballData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sha := fmt.Sprintf("%x", sha256.Sum256(tarballData))
+	got, err := RepoDir(testRepo, testCommit, sha)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	extractedDir := filepath.Join(cachedir, testExtractedDir)
+	if diff := cmp.Diff(extractedDir, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+	if _, err := os.Stat(filepath.Join(got, "README.md")); err != nil {
+		t.Errorf("expected README.md to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(got, "main.go")); err != nil {
+		t.Errorf("expected main.go to exist: %v", err)
+	}
+}
+
+func TestRepoDir_Download(t *testing.T) {
+	cachedir := t.TempDir()
+	t.Setenv(envLibrarianCache, cachedir)
+
+	tarballData := createTestTarball(t, "googleapis-"+testCommit, map[string]string{
+		"README.md":                    "# googleapis",
+		"google/api/annotations.proto": "syntax = \"proto3\";",
+	})
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/archive/"+testCommit+".tar.gz") {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(tarballData)
+	}))
+	defer server.Close()
+
+	defer func(t http.RoundTripper) { http.DefaultTransport = t }(http.DefaultTransport)
+	http.DefaultTransport = server.Client().Transport
+
+	repo := strings.TrimPrefix(server.URL, "https://")
+	expectedSHA := fmt.Sprintf("%x", sha256.Sum256(tarballData))
+	got, err := RepoDir(repo, testCommit, expectedSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(got, "README.md")); err != nil {
+		t.Errorf("expected README.md to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(got, "google/api/annotations.proto")); err != nil {
+		t.Errorf("expected google/api/annotations.proto to exist: %v", err)
+	}
+
+	tarballPath := tarballPath(cachedir, repo, testCommit)
+	if _, err := os.Stat(tarballPath); err != nil {
+		t.Errorf("expected tarball to be cached at %q: %v", tarballPath, err)
+	}
+}


### PR DESCRIPTION
fetch.RepoDir is added, which downloads the repository tarball and caches it for future use.

 The cache structure is as follows:

 ```
   $HOME/.cache/librarian/
   ├── download/
   │   └── $repo@$commit.tar.gz     # Source tarball (kept for re-extraction)
   └── $repo@$commit/               # Extracted source files
 ```

 The cache lookup order is:
   1. Check if extracted directory exists. If so, return it.
   2. Check if tarball exists. Verify its SHA256 matches the expected value from librarian.yaml. If yes, extract and return. If hash mismatches, fall through to re-download.
   3. Download tarball, compute SHA256, verify it matches the expected value from librarian.yaml, extract, and return.

For https://github.com/googleapis/librarian/issues/2966