### PR TITLE
fix(cmd/librarian): pass full os.Args to Run

### DIFF
--- a/cmd/librarian/main.go
+++ b/cmd/librarian/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	if err := librarian.Run(ctx, os.Args[1:]...); err != nil {
+	if err := librarian.Run(ctx, os.Args...); err != nil {
 		slog.Error("librarian command failed", "err", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
The Run function expects the complete `os.Args` slice including the program name, not just the arguments. Fix the argument parsing by the command handler.