### PR TITLE
refactor(internal/config): use Library.Version instead of Versions map

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,11 +42,6 @@ type Config struct {
 	// Only include libraries that differ from defaults.
 	// Versions are looked up from the Versions map below.
 	Libraries []*Library `yaml:"libraries,omitempty"`
-
-	// Versions contains version numbers for all libraries.
-	// This is the source of truth for release versions.
-	// Key is library name, value is version string.
-	Versions map[string]string `yaml:"versions,omitempty"`
 }
 
 // Sources contains references to external source repositories.

--- a/internal/language/internal/rust/release.go
+++ b/internal/language/internal/rust/release.go
@@ -46,10 +46,6 @@ func ReleaseLibrary(cfg *config.Config, name string) (*config.Config, error) {
 }
 
 func release(cfg *config.Config, name string) (*config.Config, error) {
-	if cfg.Versions == nil {
-		cfg.Versions = make(map[string]string)
-	}
-
 	shouldRelease := func(pkgName string) bool {
 		// If name is the empty string, release everything.
 		if name == "" {
@@ -59,6 +55,13 @@ func release(cfg *config.Config, name string) (*config.Config, error) {
 			return true
 		}
 		return false
+	}
+
+	libByName := make(map[string]*config.Library)
+	for _, lib := range cfg.Libraries {
+		if lib.Name != "" {
+			libByName[lib.Name] = lib
+		}
 	}
 
 	var found bool
@@ -93,7 +96,9 @@ func release(cfg *config.Config, name string) (*config.Config, error) {
 		if err := rustrelease.UpdateCargoVersion(path, newVersion); err != nil {
 			return err
 		}
-		cfg.Versions[manifest.Package.Name] = newVersion
+		if lib, ok := libByName[manifest.Package.Name]; ok {
+			lib.Version = newVersion
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/language/internal/rust/release_test.go
+++ b/internal/language/internal/rust/release_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	cmdtest "github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 )
@@ -49,13 +48,8 @@ func TestReleaseAll(t *testing.T) {
 
 	checkCargoVersion(t, storageCargo, storageReleased)
 	checkCargoVersion(t, secretmanagerCargo, secretmanagerReleased)
-	want := map[string]string{
-		storageName:       storageReleased,
-		secretmanagerName: secretmanagerReleased,
-	}
-	if diff := cmp.Diff(want, got.Versions); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
+	checkLibraryVersion(t, got, storageName, storageReleased)
+	checkLibraryVersion(t, got, secretmanagerName, secretmanagerReleased)
 }
 
 func TestReleaseOne(t *testing.T) {
@@ -67,13 +61,8 @@ func TestReleaseOne(t *testing.T) {
 
 	checkCargoVersion(t, storageCargo, storageReleased)
 	checkCargoVersion(t, secretmanagerCargo, secretmanagerInitial)
-	want := map[string]string{
-		storageName:       storageReleased,
-		secretmanagerName: secretmanagerInitial,
-	}
-	if diff := cmp.Diff(want, got.Versions); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
+	checkLibraryVersion(t, got, storageName, storageReleased)
+	checkLibraryVersion(t, got, secretmanagerName, secretmanagerInitial)
 }
 
 func setupRelease(t *testing.T) *config.Config {
@@ -86,9 +75,9 @@ func setupRelease(t *testing.T) *config.Config {
 	createCrate(t, storageDir, storageName, storageInitial)
 	createCrate(t, secretmanagerDir, secretmanagerName, secretmanagerInitial)
 	return &config.Config{
-		Versions: map[string]string{
-			storageName:       storageInitial,
-			secretmanagerName: secretmanagerInitial,
+		Libraries: []*config.Library{
+			{Name: storageName, Version: storageInitial},
+			{Name: secretmanagerName, Version: secretmanagerInitial},
 		},
 	}
 }
@@ -121,4 +110,17 @@ func checkCargoVersion(t *testing.T, path, wantVersion string) {
 	if !strings.Contains(got, wantLine) {
 		t.Errorf("%s version mismatch:\nwant line: %q\ngot:\n%s", path, wantLine, got)
 	}
+}
+
+func checkLibraryVersion(t *testing.T, cfg *config.Config, name, wantVersion string) {
+	t.Helper()
+	for _, lib := range cfg.Libraries {
+		if lib.Name == name {
+			if lib.Version != wantVersion {
+				t.Errorf("library %q version mismatch: want %q, got %q", name, wantVersion, lib.Version)
+			}
+			return
+		}
+	}
+	t.Errorf("library %q not found in config", name)
 }

--- a/internal/language/release_test.go
+++ b/internal/language/release_test.go
@@ -24,20 +24,20 @@ import (
 func TestReleaseAll(t *testing.T) {
 	cfg := &config.Config{
 		Language: "testhelper",
-		Versions: map[string]string{
-			"lib1": "0.1.0",
-			"lib2": "0.2.0",
+		Libraries: []*config.Library{
+			{Name: "lib1", Version: "0.1.0"},
+			{Name: "lib2", Version: "0.2.0"},
 		},
 	}
 	cfg, err := ReleaseAll(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := map[string]string{
-		"lib1": TestReleaseVersion,
-		"lib2": TestReleaseVersion,
+	want := []*config.Library{
+		{Name: "lib1", Version: TestReleaseVersion},
+		{Name: "lib2", Version: TestReleaseVersion},
 	}
-	if diff := cmp.Diff(want, cfg.Versions); diff != "" {
+	if diff := cmp.Diff(want, cfg.Libraries); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -45,20 +45,20 @@ func TestReleaseAll(t *testing.T) {
 func TestReleaseLibrary(t *testing.T) {
 	cfg := &config.Config{
 		Language: "testhelper",
-		Versions: map[string]string{
-			"lib1": "0.1.0",
-			"lib2": "0.2.0",
+		Libraries: []*config.Library{
+			{Name: "lib1", Version: "0.1.0"},
+			{Name: "lib2", Version: "0.2.0"},
 		},
 	}
 	cfg, err := ReleaseLibrary(cfg, "lib1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := map[string]string{
-		"lib1": TestReleaseVersion,
-		"lib2": "0.2.0",
+	want := []*config.Library{
+		{Name: "lib1", Version: TestReleaseVersion},
+		{Name: "lib2", Version: "0.2.0"},
 	}
-	if diff := cmp.Diff(want, cfg.Versions); diff != "" {
+	if diff := cmp.Diff(want, cfg.Libraries); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/language/testhelper.go
+++ b/internal/language/testhelper.go
@@ -27,20 +27,19 @@ import (
 const TestReleaseVersion = "1.2.3"
 
 func testReleaseAll(cfg *config.Config) (*config.Config, error) {
-	if cfg.Versions == nil {
-		cfg.Versions = make(map[string]string)
-	}
-	for k := range cfg.Versions {
-		cfg.Versions[k] = TestReleaseVersion
+	for _, lib := range cfg.Libraries {
+		lib.Version = TestReleaseVersion
 	}
 	return cfg, nil
 }
 
 func testReleaseLibrary(cfg *config.Config, name string) (*config.Config, error) {
-	if cfg.Versions == nil {
-		cfg.Versions = make(map[string]string)
+	for _, lib := range cfg.Libraries {
+		if lib.Name == name {
+			lib.Version = TestReleaseVersion
+			return cfg, nil
+		}
 	}
-	cfg.Versions[name] = TestReleaseVersion
 	return cfg, nil
 }
 

--- a/internal/librarian/release_test.go
+++ b/internal/librarian/release_test.go
@@ -66,8 +66,9 @@ func TestReleaseCommand(t *testing.T) {
 
 			configPath := filepath.Join(tempDir, librarianConfigPath)
 			configContent := fmt.Sprintf(`language: testhelper
-versions:
-  %s: 0.1.0
+libraries:
+  - name: %s
+    version: 0.1.0
 `, testlib)
 			if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 				t.Fatal(err)
@@ -86,7 +87,11 @@ versions:
 				if err != nil {
 					t.Fatal(err)
 				}
-				if diff := cmp.Diff(test.wantVersions, cfg.Versions); diff != "" {
+				gotVersions := make(map[string]string)
+				for _, lib := range cfg.Libraries {
+					gotVersions[lib.Name] = lib.Version
+				}
+				if diff := cmp.Diff(test.wantVersions, gotVersions); diff != "" {
 					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			}


### PR DESCRIPTION
Version information was stored in Config.Versions and on. Library.Version. Consolidate the data to Library.Version.

For https://github.com/googleapis/librarian/issues/2966