### PR TITLE
chore: verify checksum after downloads

### DIFF
--- a/.github/workflows/sidekick.yaml
+++ b/.github/workflows/sidekick.yaml
@@ -44,11 +44,14 @@ jobs:
       - name: Install protoc
         run: |
           set -e
-          curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-linux-x86_64.zip
-          sha512sum -c <(echo "f149c4a69910c8d241d27869d2cdf6791187a7a9434ad0f392b4a61e1697c3844e60bce634bd7147cb4cb7f2ad2530fc933be4976f67ac75d9ad78bb8b412f24 /tmp/protoc.zip")
+          curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip
+          sha512sum -c <(echo "$CHECKSUM /tmp/protoc.zip")
           cd /usr/local
           sudo unzip -o /tmp/protoc.zip
           protoc --version
+        env:
+          VERSION: 29.3
+          CHECKSUM: f149c4a69910c8d241d27869d2cdf6791187a7a9434ad0f392b4a61e1697c3844e60bce634bd7147cb4cb7f2ad2530fc933be4976f67ac75d9ad78bb8b412f24
       - name: Verify git and tar are available
         run: |
           git --version


### PR DESCRIPTION
Verify checksum of downloaded binary in Actions.

Fixes #3047