### PR TITLE
fix(sidekick): bad comments on `nosvc` libraries

### DIFF
--- a/internal/sidekick/rust/templates/nosvc/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/nosvc/src/lib.rs.mustache
@@ -20,10 +20,16 @@ limitations under the License.
 
 //! Google Cloud Client Libraries for Rust - {{{Title}}}
 //!
-//! **WARNING:** this crate is under active development. We expect multiple
-//! breaking changes in the upcoming releases. Testing is also incomplete, we do
-//! **not** recommend that you use this crate in production. We welcome feedback
-//! about the APIs, documentation, missing features, bugs, etc.
+{{^Codec.ReleaseLevelIsGA}}
+//!
+//! **FEEDBACK WANTED:** We believe the APIs in this crate are stable, and
+//! do not anticipate any breaking changes are needed. We are looking for
+//! feedback before labeling the APIs "1.0". Changes (even breaking changes)
+//! are still possible, but not expected.
+//!
+//! We also believe the implementation is ready for production, bugs are
+//! still possible, but not expected.
+{{/Codec.ReleaseLevelIsGA}}
 //!
 //! This crate defines types and functions used by one or more Google Cloud
 //! services. Most applications will use the structs defined in the [model]


### PR DESCRIPTION
The libraries without services have a different `lib.rs.mustache` template, and I neglected to update their comments when we declared GA.