### PR TITLE
cleanup(sidekick): reduce logging

### DIFF
--- a/internal/sidekick/rust_prost/generate.go
+++ b/internal/sidekick/rust_prost/generate.go
@@ -81,7 +81,6 @@ func buildRS(rootName, tmpDir, outDir string) error {
 	cmd.Dir = tmpDir
 	cmd.Env = append(os.Environ(), fmt.Sprintf("SOURCE_ROOT=%s", absRoot))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("DEST=%s", absOutDir))
-	fmt.Fprintf(os.Stderr, "Running: %s\n", cmd.String())
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%v: %v\n%s", cmd, err, output)
 	}


### PR DESCRIPTION
Logging each command gets noisy in `google-cloud-rust`.