### PR TITLE
fix(sidekick): one blank line too many

### DIFF
--- a/internal/sidekick/rust/templates/nosvc/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/nosvc/src/lib.rs.mustache
@@ -19,7 +19,6 @@ limitations under the License.
 {{/Codec.BoilerPlate}}
 
 //! Google Cloud Client Libraries for Rust - {{{Title}}}
-//!
 {{^Codec.ReleaseLevelIsGA}}
 //!
 //! **FEEDBACK WANTED:** We believe the APIs in this crate are stable, and


### PR DESCRIPTION
Blegh, the output now has two blank lines. Not urgent, but here is the fix.
