### PR TITLE
fix(internal/yaml): fix license header

### DIFF
--- a/internal/yaml/ref.go
+++ b/internal/yaml/ref.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
https://github.com/googleapis/librarian/pull/3089 was merged after https://github.com/googleapis/librarian/pull/3094, and therefore the new goheader license checks did not apply to the new internal/yaml package.

Fix the license headers in internal/yaml.

Fixes https://github.com/googleapis/librarian/issues/3099