### PR TITLE
feat(internal/librarian): add tidy command

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -99,12 +99,6 @@ type RustCrate struct {
 
 // RustPackageDependency represents a package dependency configuration.
 type RustPackageDependency struct {
-	// Feature is the feature name for the dependency.
-	Feature string `yaml:"feature,omitempty"`
-
-	// ForceUsed forces the dependency to be used even if not referenced.
-	ForceUsed bool `yaml:"force_used,omitempty"`
-
 	// Name is the dependency name.
 	Name string `yaml:"name"`
 
@@ -113,6 +107,12 @@ type RustPackageDependency struct {
 
 	// Source is the dependency source.
 	Source string `yaml:"source,omitempty"`
+
+	// Feature is the feature name for the dependency.
+	Feature string `yaml:"feature,omitempty"`
+
+	// ForceUsed forces the dependency to be used even if not referenced.
+	ForceUsed bool `yaml:"force_used,omitempty"`
 
 	// UsedIf specifies a condition for when the dependency is used.
 	UsedIf string `yaml:"used_if,omitempty"`

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -33,9 +33,10 @@ func Run(ctx context.Context, args ...string) error {
 		UsageText: "librarian [command]",
 		Version:   Version(),
 		Commands: []*cli.Command{
-			versionCommand(),
 			generateCommand(),
 			releaseCommand(),
+			tidyCommand(),
+			versionCommand(),
 		},
 	}
 	return cmd.Run(ctx, args)

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/yaml"
+	"github.com/urfave/cli/v3"
+)
+
+var (
+	errDuplicateLibraryName = errors.New("duplicate library name")
+	errDuplicateChannelPath = errors.New("duplicate channel path")
+)
+
+func tidyCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "tidy",
+		Usage:     "format and validate librarian.yaml",
+		UsageText: "librarian tidy [path]",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return runTidy()
+		},
+	}
+}
+
+func runTidy() error {
+	cfg, err := yaml.Read[config.Config](librarianConfigPath)
+	if err != nil {
+		return err
+	}
+	if err := validateLibraries(cfg); err != nil {
+		return err
+	}
+	return yaml.Write(librarianConfigPath, formatConfig(cfg))
+}
+
+func validateLibraries(cfg *config.Config) error {
+	var (
+		errs      []error
+		nameCount = make(map[string]int)
+		pathCount = make(map[string]int)
+	)
+	for _, lib := range cfg.Libraries {
+		if lib.Name != "" {
+			nameCount[lib.Name]++
+		}
+		for _, ch := range lib.Channels {
+			if ch.Path != "" {
+				pathCount[ch.Path]++
+			}
+		}
+	}
+	for name, count := range nameCount {
+		if count > 1 {
+			errs = append(errs, fmt.Errorf("%w: %s (appears %d times)", errDuplicateLibraryName, name, count))
+		}
+	}
+	for path, count := range pathCount {
+		if count > 1 {
+			errs = append(errs, fmt.Errorf("%w: %s (appears %d times)", errDuplicateChannelPath, path, count))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func formatConfig(cfg *config.Config) *config.Config {
+	if cfg.Default != nil && cfg.Default.Rust != nil {
+		slices.SortFunc(cfg.Default.Rust.PackageDependencies, func(a, b *config.RustPackageDependency) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+	}
+
+	slices.SortFunc(cfg.Libraries, func(a, b *config.Library) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	for _, lib := range cfg.Libraries {
+		slices.SortFunc(lib.Channels, func(a, b *config.Channel) int {
+			return strings.Compare(a.Path, b.Path)
+		})
+		if lib.Rust != nil {
+			slices.SortFunc(lib.Rust.PackageDependencies, func(a, b *config.RustPackageDependency) int {
+				return strings.Compare(a.Name, b.Name)
+			})
+		}
+	}
+	return cfg
+}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/yaml"
+)
+
+func TestValidateLibraries(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		libraries []*config.Library
+		wantErr   error
+	}{
+		{
+			name: "valid libraries",
+			libraries: []*config.Library{
+				{Name: "google-cloud-secretmanager-v1"},
+				{Name: "google-cloud-storage-v1"},
+			},
+		},
+		{
+			name: "duplicate library names",
+			libraries: []*config.Library{
+				{Name: "google-cloud-secretmanager-v1"},
+				{Name: "google-cloud-secretmanager-v1"},
+			},
+			wantErr: errDuplicateLibraryName,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{Libraries: test.libraries}
+			err := validateLibraries(cfg)
+			if test.wantErr == nil {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected %v, got nil", test.wantErr)
+			}
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("expected %v, got %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestFormatConfig(t *testing.T) {
+	cfg := formatConfig(&config.Config{
+		Libraries: []*config.Library{
+			{Name: "google-cloud-storage-v1", Version: "1.0.0"},
+			{Name: "google-cloud-bigquery-v1", Version: "2.0.0"},
+			{Name: "google-cloud-secretmanager-v1", Version: "3.0.0"},
+		},
+	})
+	want := []string{
+		"google-cloud-bigquery-v1",
+		"google-cloud-secretmanager-v1",
+		"google-cloud-storage-v1",
+	}
+	var got []string
+	for _, lib := range cfg.Libraries {
+		got = append(got, lib.Name)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTidyCommand(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	configPath := filepath.Join(tempDir, librarianConfigPath)
+	configContent := `language: rust
+sources:
+  googleapis:
+    commit: abc123
+libraries:
+  - name: google-cloud-storage-v1
+    version: "1.0.0"
+  - name: google-cloud-bigquery-v1
+    version: "2.0.0"
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run(t.Context(), "librarian", "tidy"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := yaml.Read[config.Config](configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []string
+	for _, lib := range cfg.Libraries {
+		got = append(got, lib.Name)
+	}
+	want := []string{
+		"google-cloud-bigquery-v1",
+		"google-cloud-storage-v1",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTidyCommandDuplicateError(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	configPath := filepath.Join(tempDir, librarianConfigPath)
+	configContent := `language: rust
+sources:
+  googleapis:
+    commit: abc123
+libraries:
+  - name: google-cloud-storage-v1
+  - name: google-cloud-storage-v1
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := Run(t.Context(), "librarian", "tidy")
+	if err == nil {
+		t.Fatal("expected error for duplicate library")
+	}
+	if !errors.Is(err, errDuplicateLibraryName) {
+		t.Errorf("expected %v, got %v", errDuplicateLibraryName, err)
+	}
+}


### PR DESCRIPTION
The librarian tidy command is added, which validates and formats the librarian.yaml file. It checks for duplicate library names and channel paths, then sorts libraries by name, channels by path, and Rust package dependencies by name.

Reorder fields in `config.RustPackageDependency` so that when librarian tidy runs, `Name` is the first field.