### PR TITLE
feat(internal/config,rust): add ignore field to RustPackageDependency

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -102,6 +102,12 @@ type RustPackageDependency struct {
 	// Name is the dependency name.
 	Name string `yaml:"name"`
 
+	// Ignore prevents this package from being mapped to an external crate.
+	// When true, references to this package stay as `crate::` instead of being
+	// mapped to the external crate name. This is used for self-referencing
+	// packages like location and longrunning.
+	Ignore bool `yaml:"ignore,omitempty"`
+
 	// Package is the package name.
 	Package string `yaml:"package"`
 

--- a/internal/librarian/internal/rust/codec.go
+++ b/internal/librarian/internal/rust/codec.go
@@ -160,5 +160,8 @@ func formatPackageDependency(dep *config.RustPackageDependency) string {
 	if dep.Feature != "" {
 		parts = append(parts, "feature="+dep.Feature)
 	}
+	if dep.Ignore {
+		parts = append(parts, "ignore=true")
+	}
 	return strings.Join(parts, ",")
 }

--- a/internal/librarian/internal/rust/codec_test.go
+++ b/internal/librarian/internal/rust/codec_test.go
@@ -529,8 +529,17 @@ func TestFormatPackageDependency(t *testing.T) {
 				ForceUsed: true,
 				UsedIf:    "feature = \"async\"",
 				Feature:   "async",
+				Ignore:    true,
 			},
-			want: "package=tokio,source=1.0,force-used=true,used-if=feature = \"async\",feature=async",
+			want: "package=tokio,source=1.0,force-used=true,used-if=feature = \"async\",feature=async,ignore=true",
+		},
+		{
+			name: "with ignore for self-referencing package",
+			dep: config.RustPackageDependency{
+				Name:   "longrunning",
+				Ignore: true,
+			},
+			want: "ignore=true",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Add support for the ignore codec to prevent a package from being mapped to an external crate.