### PR TITLE
feat(internal/config): add discovery LRO polling configuration for Rust

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -95,6 +95,9 @@ type RustCrate struct {
 
 	// NameOverrides contains codec-level overrides for type and service names.
 	NameOverrides string `yaml:"name_overrides,omitempty"`
+
+	// Discovery contains discovery-specific configuration for LRO polling.
+	Discovery *RustDiscovery `yaml:"discovery,omitempty"`
 }
 
 // RustPackageDependency represents a package dependency configuration.
@@ -137,4 +140,22 @@ type RustPaginationOverride struct {
 
 	// ItemField is the name of the field used for items.
 	ItemField string `yaml:"item_field"`
+}
+
+// RustDiscovery contains discovery-specific configuration for LRO polling.
+type RustDiscovery struct {
+	// OperationID is the ID of the LRO operation type (e.g., ".google.cloud.compute.v1.Operation").
+	OperationID string `yaml:"operation_id"`
+
+	// Pollers is a list of LRO polling configurations.
+	Pollers []RustPoller `yaml:"pollers,omitempty"`
+}
+
+// RustPoller defines how to find a suitable poller RPC for discovery APIs.
+type RustPoller struct {
+	// Prefix is an acceptable prefix for the URL path (e.g., "compute/v1/projects/{project}/zones/{zone}").
+	Prefix string `yaml:"prefix"`
+
+	// MethodID is the corresponding method ID (e.g., ".google.cloud.compute.v1.zoneOperations.get").
+	MethodID string `yaml:"method_id"`
 }

--- a/internal/librarian/internal/rust/codec.go
+++ b/internal/librarian/internal/rust/codec.go
@@ -72,6 +72,19 @@ func toSidekickConfig(library *config.Library, channel *config.Channel, googleap
 				}
 			}
 		}
+		if library.Rust.Discovery != nil {
+			pollers := make([]*sidekickconfig.Poller, len(library.Rust.Discovery.Pollers))
+			for i, poller := range library.Rust.Discovery.Pollers {
+				pollers[i] = &sidekickconfig.Poller{
+					Prefix:   poller.Prefix,
+					MethodID: poller.MethodID,
+				}
+			}
+			sidekickCfg.Discovery = &sidekickconfig.Discovery{
+				OperationID: library.Rust.Discovery.OperationID,
+				Pollers:     pollers,
+			}
+		}
 	}
 	return sidekickCfg
 }

--- a/internal/librarian/internal/rust/codec_test.go
+++ b/internal/librarian/internal/rust/codec_test.go
@@ -460,6 +460,71 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with discovery LRO polling config",
+			library: &config.Library{
+				Name:                "google-cloud-compute-v1",
+				SpecificationFormat: "discovery",
+				Rust: &config.RustCrate{
+					Discovery: &config.RustDiscovery{
+						OperationID: ".google.cloud.compute.v1.Operation",
+						Pollers: []config.RustPoller{
+							{
+								Prefix:   "compute/v1/projects/{project}/zones/{zone}",
+								MethodID: ".google.cloud.compute.v1.zoneOperations.get",
+							},
+							{
+								Prefix:   "compute/v1/projects/{project}/regions/{region}",
+								MethodID: ".google.cloud.compute.v1.regionOperations.get",
+							},
+							{
+								Prefix:   "compute/v1/projects/{project}",
+								MethodID: ".google.cloud.compute.v1.globalOperations.get",
+							},
+						},
+					},
+				},
+			},
+			channel: &config.Channel{
+				Path:          "discoveries/compute.v1.json",
+				ServiceConfig: "google/cloud/compute/v1/compute_v1.yaml",
+			},
+			googleapisDir: "/tmp/googleapis",
+			discoveryDir:  "/tmp/discovery-artifact-manager",
+			want: &sidekickconfig.Config{
+				General: sidekickconfig.GeneralConfig{
+					Language:            "rust",
+					SpecificationFormat: "disco",
+					ServiceConfig:       "google/cloud/compute/v1/compute_v1.yaml",
+					SpecificationSource: "discoveries/compute.v1.json",
+				},
+				Source: map[string]string{
+					"googleapis-root": "/tmp/googleapis",
+					"discovery-root":  "/tmp/discovery-artifact-manager",
+					"roots":           "discovery,googleapis",
+				},
+				Codec: map[string]string{
+					"package-name-override": "google-cloud-compute-v1",
+				},
+				Discovery: &sidekickconfig.Discovery{
+					OperationID: ".google.cloud.compute.v1.Operation",
+					Pollers: []*sidekickconfig.Poller{
+						{
+							Prefix:   "compute/v1/projects/{project}/zones/{zone}",
+							MethodID: ".google.cloud.compute.v1.zoneOperations.get",
+						},
+						{
+							Prefix:   "compute/v1/projects/{project}/regions/{region}",
+							MethodID: ".google.cloud.compute.v1.regionOperations.get",
+						},
+						{
+							Prefix:   "compute/v1/projects/{project}",
+							MethodID: ".google.cloud.compute.v1.globalOperations.get",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := toSidekickConfig(test.library, test.channel, test.googleapisDir, test.discoveryDir)


### PR DESCRIPTION
Add RustDiscovery and RustPoller types to support LRO polling for discovery-based APIs (e.g., Compute Engine), which use different polling endpoints based on resource scope.