### PR TITLE
fix(internal/config): explain why Name fields are listed first

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,7 +84,8 @@ type Default struct {
 
 // Library represents a library configuration.
 type Library struct {
-	// Name is the library name, such as "secretmanager" or "storage".
+	// Name is the library name, such as "secretmanager" or "storage". It is
+	// listed first so it appears at the top of each library entry in YAML.
 	Name string `yaml:"name"`
 
 	// Channel specifies which googleapis Channel to generate from (for generated

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -102,7 +102,8 @@ type RustCrate struct {
 
 // RustPackageDependency represents a package dependency configuration.
 type RustPackageDependency struct {
-	// Name is the dependency name.
+	// Name is the dependency name. It is listed first so it appears at the top
+	// of each dependency entry in YAML.
 	Name string `yaml:"name"`
 
 	// Ignore prevents this package from being mapped to an external crate.


### PR DESCRIPTION
Name fields in Library and RustPackageDependency structs are listed first so they appear at the top of each entry when marshaling and unmarshaling YAML.

Fixes https://github.com/googleapis/librarian/issues/3108