### PR TITLE
fix(cmd): doc genererate and test to point to updated dirs

### DIFF
--- a/cmd/doc_generate.go
+++ b/cmd/doc_generate.go
@@ -131,7 +131,7 @@ func processFile(cmdPath *string) error {
 	}
 
 	var pkg string
-	if filepath.Base(pkgPath) == "automation" {
+	if filepath.Base(pkgPath) == "legacyautomation" {
 		pkg = automationDescription
 	} else {
 		pkg = librarianDescription

--- a/cmd/doc_generate_test.go
+++ b/cmd/doc_generate_test.go
@@ -27,11 +27,11 @@ func TestGoGenerateLibrarianDoc(t *testing.T) {
 	}{
 		{
 			name:    "automation_doc",
-			docFile: "cmd/automation/doc.go",
+			docFile: "cmd/legacyautomation/doc.go",
 		},
 		{
 			name:    "librarian_doc",
-			docFile: "cmd/librarian/doc.go",
+			docFile: "cmd/legacylibrarian/doc.go",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
We recently moved code to /legacyautomation and /legacylibrarian. Update `cmd/doc_generate.go` and tests.
This should get rid of the annoying invalid doc update when running `go test ./...` 