### PR TITLE
feat(internal/librarian): derive default output for Rust

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -124,7 +124,7 @@ func generateLibrary(ctx context.Context, cfg *config.Config, libraryName string
 // src/generated/cloud/secretmanager/v1.
 //
 // TODO(https://github.com/googleapis/librarian/issues/2966): refactor and move
-// to internal/rust package
+// to internal/rust package.
 func deriveDefaultRustOutput(channel, defaultOutput string) string {
 	return filepath.Join(defaultOutput, strings.TrimPrefix(channel, "google/"))
 }


### PR DESCRIPTION
Add deriveDefaultRustOutput to derive the output path for Rust libraries from the channel path when no explicit output is configured.

For example: google/cloud/secretmanager/v1 -> src/generated/cloud/secretmanager/v1

For https://github.com/googleapis/librarian/issues/2966
For https://github.com/googleapis/librarian/issues/3130