### PR TITLE
feat(internal/serviceconfig): add GRPCServiceConfig map

### DIFF
--- a/internal/serviceconfig/grpcserviceconfig.go
+++ b/internal/serviceconfig/grpcserviceconfig.go
@@ -14,8 +14,8 @@
 
 package serviceconfig
 
-// grpcServiceConfigMap maps channels to their gRPC service config filename.
-var grpcServiceConfigMap = map[string]string{
+// GRPCServiceConfig maps channels to their gRPC service config filename.
+var GRPCServiceConfig = map[string]string{
 	"google/ai/generativelanguage/v1":                    "generativeai_grpc_service_config.json",
 	"google/ai/generativelanguage/v1alpha":               "generativeai_grpc_service_config.json",
 	"google/ai/generativelanguage/v1beta":                "generativeai_grpc_service_config.json",


### PR DESCRIPTION
serviceconfig.GRPCServiceConfig is added, which provides a map of the channel to its *_grpc_service_config.json. In a future PR, we will create a function to derive the filename based on the channel if it follows a standard naming convention, so that only exceptions are listed.

For https://github.com/googleapis/librarian/issues/3142