### PR TITLE
chore: update go to 1.25.5 to fix security vulnerability in crypto/x509

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/librarian
 
-go 1.25.3
+go 1.25.5
 
 require (
 	cloud.google.com/go/artifactregistry v1.17.2


### PR DESCRIPTION
Update go to 1.25.5 to fix security vulnerability in crypto/x509.

Fixes #3144 