### PR TITLE
test(internal/sidekick): add more test cases to cover errors

### DIFF
--- a/internal/sidekick/sidekick/downloads_cache.go
+++ b/internal/sidekick/sidekick/downloads_cache.go
@@ -28,6 +28,10 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
+var (
+	downloadTarball = fetch.DownloadTarball
+)
+
 func makeSourceRoot(ctx context.Context, rootConfig *config.Config, configPrefix string) (string, error) {
 	sourceRoot, ok := rootConfig.Source[fmt.Sprintf("%s-root", configPrefix)]
 	if !ok {
@@ -55,7 +59,7 @@ func makeSourceRoot(ctx context.Context, rootConfig *config.Config, configPrefix
 		return target, nil
 	}
 	tgz := target + ".tar.gz"
-	if err := fetch.DownloadTarball(ctx, tgz, sourceRoot, source); err != nil {
+	if err := downloadTarball(ctx, tgz, sourceRoot, source); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Adding some test cases to cover error handling in internal/sidekick/sidekick/downloads_cache.go.

Fix #3020