### PR TITLE
feat(internal/config): add Python configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,9 @@ type Library struct {
 
 	// Rust contains Rust-specific library configuration.
 	Rust *RustCrate `yaml:"rust,omitempty"`
+
+	// Python contains Python-specific library configuration.
+	Python *PythonPackage `yaml:"python,omitempty"`
 }
 
 // Channel describes a Channel to include in a library.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -163,3 +163,22 @@ type RustPoller struct {
 	// MethodID is the corresponding method ID (e.g., ".google.cloud.compute.v1.zoneOperations.get").
 	MethodID string `yaml:"method_id"`
 }
+
+// PythonPackage contains Python-specific library configuration.
+type PythonPackage struct {
+	// OptArgs contains additional options passed to the generator, where
+	// the options are common to all channels.
+	// Example: ["warehouse-package-name=google-cloud-batch"]
+	OptArgs []string `yaml:"opt_args,omitempty"`
+
+	// OptArgsByChannel contains additional options passed to the generator,
+	// where the options vary by channel. In each entry, the key is the channel
+	// (API path) and the value is the list of options to pass when generating
+	// that API channel.
+	// Example: {"google/cloud/secrets/v1beta": ["python-gapic-name=secretmanager"]}
+	OptArgsByChannel map[string][]string `yaml:"opt_args_by_channel,omitempty"`
+
+	// IsProtoOnly indicates this library only contains proto files (no GAPIC
+	// generation).
+	IsProtoOnly bool `yaml:"is_proto_only,omitempty"`
+}


### PR DESCRIPTION
PythonPackage is added as a new struct, with a field of that type in Library. Currently there is no Python equivalent of RustDefault, but we may wish to add one later.