### PR TITLE
feat(librarian): set a default version for repo metadata

### DIFF
--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -74,7 +74,11 @@ type RepoMetadata struct {
 
 // GenerateRepoMetadata generates the .repo-metadata.json file by parsing the
 // service YAML.
-func GenerateRepoMetadata(library *config.Library, language, repo, serviceConfigPath, outdir string) error {
+func GenerateRepoMetadata(library *config.Library, language, repo, serviceConfigPath, defaultVersion, outdir string) error {
+	// TODO(https://github.com/googleapis/librarian/issues/3146):
+	// Compute the default version, potentially with an override, instead of
+	// taking it as a parameter.
+
 	svcCfg, err := serviceconfig.Read(serviceConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to read service config: %w", err)
@@ -85,6 +89,7 @@ func GenerateRepoMetadata(library *config.Library, language, repo, serviceConfig
 	metadata := &RepoMetadata{
 		APIID:               svcCfg.GetName(),
 		NamePretty:          cleanTitle(svcCfg.GetTitle()),
+		DefaultVersion:      defaultVersion,
 		ClientDocumentation: clientDocURL,
 		ReleaseLevel:        library.ReleaseLevel,
 		Language:            language,
@@ -92,8 +97,6 @@ func GenerateRepoMetadata(library *config.Library, language, repo, serviceConfig
 		Repo:                repo,
 		DistributionName:    library.Name,
 	}
-
-	// TODO(https://github.com/googleapis/librarian/issues/3146): set DefaultVersion
 
 	if svcCfg.GetPublishing() != nil {
 		publishing := svcCfg.GetPublishing()

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -26,9 +26,10 @@ import (
 
 func TestGenerateRepoMetadata(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		library *config.Library
-		want    RepoMetadata
+		name           string
+		defaultVersion string
+		library        *config.Library
+		want           RepoMetadata
 	}{
 		{
 			name: "no overrides",
@@ -59,11 +60,13 @@ func TestGenerateRepoMetadata(t *testing.T) {
 				ReleaseLevel:        "stable",
 				DescriptionOverride: "Stores, manages, and secures access to application secrets.",
 			},
+			defaultVersion: "v1",
 			want: RepoMetadata{
 				Name:                 "secretmanager",
 				NamePretty:           "Secret Manager",
 				ProductDocumentation: "https://cloud.google.com/secret-manager/",
 				ClientDocumentation:  "https://cloud.google.com/python/docs/reference/secretmanager/latest",
+				DefaultVersion:       "v1",
 				IssueTracker:         "",
 				ReleaseLevel:         "stable",
 				Language:             "python",
@@ -85,7 +88,7 @@ func TestGenerateRepoMetadata(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := GenerateRepoMetadata(test.library, "python", "googleapis/google-cloud-python", serviceYAMLPath, outDir); err != nil {
+			if err := GenerateRepoMetadata(test.library, "python", "googleapis/google-cloud-python", serviceYAMLPath, test.defaultVersion, outDir); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
A new parameter is added to repometadata.GenerateRepoMetadata to set the default version. The longer term plan is still to compute this, but until that's ready we will allow the caller to specify it. Callers who want to generate repo metadata without a default version can pass in an empty string.