### PR TITLE
fix: add parsing of sidekick.toml package ignore field to migrate-sidekick

### DIFF
--- a/devtools/cmd/migrate-sidekick/main.go
+++ b/devtools/cmd/migrate-sidekick/main.go
@@ -196,6 +196,8 @@ func parsePackageDependency(name, spec string) *config.RustPackageDependency {
 			dep.UsedIf = value
 		case "feature":
 			dep.Feature = value
+		case "ignore":
+			dep.Ignore = value == "true"
 		}
 	}
 

--- a/devtools/cmd/migrate-sidekick/main_test.go
+++ b/devtools/cmd/migrate-sidekick/main_test.go
@@ -209,6 +209,7 @@ func TestReadSidekickFiles(t *testing.T) {
 									Name:      "lazy_static",
 									Package:   "lazy_static",
 									UsedIf:    "services",
+									Ignore:    true,
 								},
 							},
 						},

--- a/devtools/cmd/migrate-sidekick/testdata/read-sidekick-files/success-read/.sidekick.toml
+++ b/devtools/cmd/migrate-sidekick/testdata/read-sidekick-files/success-read/.sidekick.toml
@@ -9,7 +9,7 @@ item-field = 'items'
 [codec]
 version        = '1.2.0'
 copyright-year = '2025'
-'package:lazy_static' = 'used-if=services,package=lazy_static,force-used=true'
+'package:lazy_static' = 'used-if=services,package=lazy_static,force-used=true,ignore=true'
 'package:gaxi'        = 'used-if=services,package=google-cloud-gax-internal,feature=_internal-http-client,source=internal'
 
 


### PR DESCRIPTION
Including ignore field in parsing of sidekick.toml package field, and store in librarian.yaml file.  This will be set as part of the migrate-sidekick command.

Fixes: #3129

Output:

```
- name: google-cloud-location
    channels:
      - path: google/cloud/location
        service_config: google/cloud/location/cloud.yaml
    version: 1.1.0
    copyright_year: "2024"
    rust:
      package_dependencies:
        - name: location
          ignore: true
          package: ""
```