### PR TITLE
fix(internal/librarian): derive Rust output path before fillDefaults

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -120,7 +120,7 @@ func generateLibrary(ctx context.Context, cfg *config.Config, libraryName string
 func prepareLibrary(language string, lib *config.Library, defaults *config.Default) *config.Library {
 	// TODO(https://github.com/googleapis/librarian/issues/2966):
 	// refactor so that the switch statement logic is in one place
-	if language == "rust" && lib.Output == "" {
+	if language == "rust" && lib.Output == "" && len(lib.Channels) > 0 {
 		lib.Output = deriveDefaultRustOutput(lib.Channels[0].Path, defaults.Output)
 	}
 	return fillDefaults(lib, defaults)

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -221,32 +221,40 @@ func TestPrepareLibrary(t *testing.T) {
 		name     string
 		language string
 		output   string
+		channels []*config.Channel
 		want     string
 	}{
 		{
 			name:     "empty output derives path from channel",
 			language: "rust",
+			channels: []*config.Channel{{Path: "google/cloud/secretmanager/v1"}},
 			want:     "src/generated/cloud/secretmanager/v1",
 		},
 		{
 			name:     "explicit output keeps explicit path",
 			language: "rust",
 			output:   "custom/output",
+			channels: []*config.Channel{{Path: "google/cloud/secretmanager/v1"}},
 			want:     "custom/output",
 		},
 		{
 			name:     "empty output uses default for non-rust",
 			language: "go",
+			channels: []*config.Channel{{Path: "google/cloud/secretmanager/v1"}},
+			want:     "src/generated",
+		},
+		{
+			name:     "rust with no channels uses default",
+			language: "rust",
+			channels: nil,
 			want:     "src/generated",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			lib := &config.Library{
-				Name:   "test-lib",
-				Output: test.output,
-				Channels: []*config.Channel{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
+				Name:     "test-lib",
+				Output:   test.output,
+				Channels: test.channels,
 			}
 			defaults := &config.Default{
 				Output: "src/generated",


### PR DESCRIPTION
The Rust specific output path derivation was happening after fillDefaults, which sets lib.Output to the default value if empty. This caused the derivation check `lib.Output == ""` to always be false, resulting in libraries using the raw default output path (e.g., "src/generated/") instead of the derived path (e.g., "src/generated/cloud/accessapproval/v1").

Move the Rust output derivation before fillDefaults so it runs when lib.Output is actually empty.