### PR TITLE
fix: set output path based on currently generated output path

### DIFF
--- a/devtools/cmd/migrate-sidekick/main.go
+++ b/devtools/cmd/migrate-sidekick/main.go
@@ -97,7 +97,6 @@ func run(args []string) error {
 
 	slog.Info("Reading sidekick.toml...", "path", repoPath)
 
-	// Read root .sidekick.toml for defaults
 	defaults, err := readRootSidekick(repoPath)
 	if err != nil {
 		return fmt.Errorf("failed to read root .sidekick.toml: %w", err)
@@ -110,7 +109,7 @@ func run(args []string) error {
 	}
 
 	// Read all sidekick.toml files
-	libraries, err := readSidekickFiles(sidekickFiles, *repoPath)
+	libraries, err := readSidekickFiles(sidekickFiles, repoPath)
 	if err != nil {
 		return fmt.Errorf("failed to read sidekick.toml files: %w", err)
 	}
@@ -299,8 +298,7 @@ func readSidekickFiles(files []string, repoPath string) (map[string]*config.Libr
 		lib.SpecificationFormat = specificationFormat
 		relativePath, err := filepath.Rel(repoPath, dir)
 		if err != nil {
-			slog.Error("Failed to calculate relative path", "dir", dir, "base", repoPath, "error", err)
-			return nil, errUnableToCalculateOutputPath
+			return nil, fmt.Errorf("failed to calculate relative path: %w", errUnableToCalculateOutputPath)
 		}
 		lib.Output = relativePath
 

--- a/devtools/cmd/migrate-sidekick/main_test.go
+++ b/devtools/cmd/migrate-sidekick/main_test.go
@@ -153,7 +153,6 @@ func TestReadSidekickFiles(t *testing.T) {
 				"testdata/read-sidekick-files/success-read/.sidekick.toml",
 				"testdata/read-sidekick-files/success-read/nested/.sidekick.toml",
 			},
-			repoName: "",
 			want: map[string]*config.Library{
 				"google-cloud-security-publicca-v1": {
 					Name: "google-cloud-security-publicca-v1",
@@ -255,16 +254,14 @@ func TestReadSidekickFiles(t *testing.T) {
 			files: []string{
 				"testdata/read-sidekick-files/no-api-path/.sidekick.toml",
 			},
-			repoName: "",
-			want:     map[string]*config.Library{},
+			want: map[string]*config.Library{},
 		},
 		{
 			name: "no_package_name",
 			files: []string{
 				"testdata/read-sidekick-files/no-package-name/.sidekick.toml",
 			},
-			repoName: "",
-			want:     map[string]*config.Library{},
+			want: map[string]*config.Library{},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
The output path should be where the code gets generated.  This doesn't match a specific pattern, so for the sake of migration easiest to set it to the existing output path.

See https://paste.googleplex.com/6379904404946944

Fixes #3130