### PR TITLE
fix(internal/fetch): validate SHA256 in download

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -34,6 +34,7 @@ const branch = "master"
 
 var (
 	errChecksumMismatch = errors.New("checksum mismatch")
+	errMissingSHA256    = errors.New("expectedSha256 is required")
 	defaultBackoff      = 10 * time.Second
 )
 
@@ -145,6 +146,9 @@ func TarballLink(githubDownload string, repo *Repo, sha string) string {
 func DownloadTarball(ctx context.Context, target, url, expectedSha256 string) error {
 	if fileExists(target) {
 		return nil
+	}
+	if expectedSha256 == "" {
+		return errMissingSHA256
 	}
 	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 		return err

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -530,6 +530,14 @@ func TestDownloadTarballErrors(t *testing.T) {
 	}
 }
 
+func TestDownloadTarballEmptySha(t *testing.T) {
+	target := path.Join(t.TempDir(), "target")
+	err := DownloadTarball(t.Context(), target, "https://any-url", "")
+	if !errors.Is(err, errMissingSHA256) {
+		t.Errorf("expected errMissingSHA256, got: %v", err)
+	}
+}
+
 func TestLatestCommitAndChecksum(t *testing.T) {
 	const (
 		expectedCommit          = "testcommit123"


### PR DESCRIPTION
DownloadTarball now returns an error early if expectedSha256 is empty, avoiding unnecessary download attempts.