### PR TITLE
fix(internal/librarian): improve error messages with library context

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -176,7 +176,7 @@ func dirExists(path string) bool {
 	return info.IsDir()
 }
 
-func generateLibrary(ctx context.Context, cfg *config.Config, libraryName string) (*config.Library, error) {
+func generateLibrary(ctx context.Context, cfg *config.Config, libraryName string) (_ *config.Library, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("library %q: %w", libraryName, err)


### PR DESCRIPTION
Error messages for librarian generate now include actionable context to help diagnose issues.