### PR TITLE
feat(librarian): add support for veneers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,12 @@ type Library struct {
 	// libraries).
 	Channels []*Channel `yaml:"channels,omitempty"`
 
+	// Veneer indicates this library has hand-written code with generated
+	// submodules. When true, the library uses language-specific module
+	// configuration (e.g., rust.modules) instead of generating a complete crate
+	// from channels.
+	Veneer bool `yaml:"veneer,omitempty"`
+
 	// SkipGenerate disables code generation for this library.
 	SkipGenerate bool `yaml:"skip_generate,omitempty"`
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,6 +73,32 @@ func TestRead(t *testing.T) {
 					},
 				},
 			},
+			{
+				Name:    "google-cloud-storage",
+				Version: "1.4.0",
+				Veneer:  true,
+				Rust: &RustCrate{
+					Modules: []*RustModule{
+						{
+							Source:          "google/storage/v2",
+							ServiceConfig:   "google/storage/v2/storage_v2.yaml",
+							Output:          "src/storage/src/generated/gapic",
+							Template:        "grpc-client",
+							HasVeneer:       true,
+							RoutingRequired: true,
+							IncludedIds: []string{
+								".google.storage.v2.Storage.GetBucket",
+								".google.storage.v2.Storage.ListBuckets",
+							},
+						},
+						{
+							Source:   "google/storage/v2",
+							Output:   "src/storage/src/generated/protos/storage",
+							Template: "prost",
+						},
+					},
+				},
+			},
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -23,9 +23,61 @@ type RustDefault struct {
 	DisabledRustdocWarnings []string `yaml:"disabled_rustdoc_warnings,omitempty"`
 }
 
+// RustModule defines a generation target within a veneer crate.
+// Each module specifies what proto source to use, which template to apply,
+// and where to output the generated code.
+type RustModule struct {
+	// HasVeneer indicates whether this module has a hand-written wrapper.
+	HasVeneer bool `yaml:"has_veneer,omitempty"`
+
+	// IncludedIds is a list of proto IDs to include in generation.
+	IncludedIds []string `yaml:"included_ids,omitempty"`
+
+	// IncludeGrpcOnlyMethods indicates whether to include gRPC-only methods.
+	IncludeGrpcOnlyMethods bool `yaml:"include_grpc_only_methods,omitempty"`
+
+	// IncludeList is a list of proto files to include (e.g., "date.proto,expr.proto").
+	IncludeList string `yaml:"include_list,omitempty"`
+
+	// ModulePath is the Rust module path for converters
+	// (e.g., "crate::generated::gapic::model").
+	ModulePath string `yaml:"module_path,omitempty"`
+
+	// NameOverrides contains codec-level overrides for type and service names.
+	NameOverrides string `yaml:"name_overrides,omitempty"`
+
+	// Output is the directory where generated code is written
+	// (e.g., "src/storage/src/generated/gapic").
+	Output string `yaml:"output"`
+
+	// PostProcessProtos contains code to post-process generated protos.
+	PostProcessProtos string `yaml:"post_process_protos,omitempty"`
+
+	// RoutingRequired indicates whether routing is required.
+	RoutingRequired bool `yaml:"routing_required,omitempty"`
+
+	// ServiceConfig is the path to the service config file.
+	ServiceConfig string `yaml:"service_config,omitempty"`
+
+	// SkippedIds is a list of proto IDs to skip in generation.
+	SkippedIds []string `yaml:"skipped_ids,omitempty"`
+
+	// Source is the proto path to generate from (e.g., "google/storage/v2").
+	Source string `yaml:"source"`
+
+	// Template specifies which generator template to use.
+	// Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod".
+	Template string `yaml:"template"`
+}
+
 // RustCrate contains Rust-specific library configuration.
 type RustCrate struct {
 	RustDefault `yaml:",inline"`
+
+	// Modules specifies generation targets for veneer crates. Each module
+	// defines a source proto path, output location, and template to use.
+	// This is only used when the library has veneer: true.
+	Modules []*RustModule `yaml:"modules,omitempty"`
 
 	// PerServiceFeatures enables per-service feature flags.
 	PerServiceFeatures bool `yaml:"per_service_features,omitempty"`

--- a/internal/config/testdata/rust/librarian.yaml
+++ b/internal/config/testdata/rust/librarian.yaml
@@ -46,3 +46,20 @@ libraries:
     rust:
       disabled_rustdoc_warnings:
         - rustdoc::bare_urls
+  - name: google-cloud-storage
+    version: 1.4.0
+    veneer: true
+    rust:
+      modules:
+        - source: google/storage/v2
+          service_config: google/storage/v2/storage_v2.yaml
+          output: src/storage/src/generated/gapic
+          template: grpc-client
+          has_veneer: true
+          routing_required: true
+          included_ids:
+            - .google.storage.v2.Storage.GetBucket
+            - .google.storage.v2.Storage.ListBuckets
+        - source: google/storage/v2
+          output: src/storage/src/generated/protos/storage
+          template: prost

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -221,6 +221,7 @@ func TestPrepareLibrary(t *testing.T) {
 		name     string
 		language string
 		output   string
+		veneer   bool
 		channels []*config.Channel
 		want     string
 		wantErr  bool
@@ -250,11 +251,23 @@ func TestPrepareLibrary(t *testing.T) {
 			channels: nil,
 			wantErr:  true,
 		},
+		{
+			name:    "veneer without output returns error",
+			veneer:  true,
+			wantErr: true,
+		},
+		{
+			name:   "veneer with explicit output succeeds",
+			veneer: true,
+			output: "src/storage",
+			want:   "src/storage",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			lib := &config.Library{
 				Name:     "test-lib",
 				Output:   test.output,
+				Veneer:   test.veneer,
 				Channels: test.channels,
 			}
 			defaults := &config.Default{


### PR DESCRIPTION
Add support for creating Rust veneers with generated modules.

The current functionality supports google-cloud-storage with the configuration below. Redundant fields will be removed in future PRs. Other veneers will also be tested and fixed in future PRs:

```
  - name: google-cloud-storage
    output: src/storage
    veneer: true
    version: 0.3.0
    copyright_year: "2025"
    rust:
      disabled_rustdoc_warnings:
        - redundant_explicit_links
        - broken_intra_doc_links
      package_dependencies:
        - name: wkt
          package: google-cloud-wkt
          source: google.protobuf
          force_used: true
        - name: gtype
          package: google-cloud-type
          source: google.type
        - name: iam_v1
          package: google-cloud-iam-v1
          source: google.iam.v1
        - name: rpc
          package: google-cloud-rpc
          source: google.rpc
      modules:
        - source: google/storage/v2
          service_config: google/storage/v2/storage_v2.yaml
          output: src/storage/src/generated/gapic
          template: grpc-client
          has_veneer: true
          routing_required: true
          include_grpc_only_methods: true
          name_overrides: .google.storage.v2.Storage=StorageControl
          included_ids:
            - .google.storage.v2.Storage.DeleteBucket
            - .google.storage.v2.Storage.GetBucket
            - .google.storage.v2.Storage.CreateBucket
            - .google.storage.v2.Storage.ListBuckets
            - .google.storage.v2.Storage.LockBucketRetentionPolicy
            - .google.storage.v2.Storage.UpdateBucket
            - .google.storage.v2.Storage.ComposeObject
            - .google.storage.v2.Storage.DeleteObject
            - .google.storage.v2.Storage.RestoreObject
            - .google.storage.v2.Storage.GetObject
            - .google.storage.v2.Storage.UpdateObject
            - .google.storage.v2.Storage.ListObjects
            - .google.storage.v2.Storage.RewriteObject
            - .google.storage.v2.Storage.MoveObject
            - .google.storage.v2.ReadObjectRequest
            - .google.storage.v2.WriteObjectSpec
        - source: google/storage/control/v2
          service_config: google/storage/control/v2/storage_v2.yaml
          output: src/storage/src/generated/gapic_control
          template: grpc-client
          has_veneer: true
          routing_required: true
          include_grpc_only_methods: true
          name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf
        - source: google/storage/v2
          output: src/storage/src/generated/protos/storage
          template: prost
        - source: google/storage/control/v2
          output: src/storage/src/generated/protos/control
          template: prost
          post_process_protos: |
            let name = format!("{destination}/google.storage.control.v2.rs");
            let content = std::fs::read_to_string(&name)
                .expect(format!("should be able to read '{name}'").as_str());
            // Rename CloudStorageLocations
            let content = content.replace(
                "pub enum CloudStorageLocations ", "pub enum CloudStorageLocationsOneOf ");
            let content = content.replace(
                "prost(oneof = \"filter::CloudStorageLocations\"",
                "prost(oneof = \"filter::CloudStorageLocationsOneOf\"",
            );
            let content = content.replace(
                "    filter::CloudStorageLocations,",
                "    filter::CloudStorageLocationsOneOf,",
            );
            // Rename CloudStorageBuckets
            let content = content.replace(
                "pub enum CloudStorageBuckets ", "pub enum CloudStorageBucketsOneOf ");
            let content = content.replace(
                "prost(oneof = \"filter::CloudStorageBuckets\"",
                "prost(oneof = \"filter::CloudStorageBucketsOneOf\"",
            );
            let content = content.replace(
                "pub cloud_storage_buckets: ::core::option::Option<filter::CloudStorageBuckets>",
                "pub cloud_storage_buckets: ::core::option::Option<filter::CloudStorageBucketsOneOf>",
            );
            std::fs::write(&name, content.as_bytes())
                .expect(format!("should be able to write '{name}'").as_str());
        - source: google/storage/v2
          output: src/storage/src/generated/convert/storage
          template: convert-prost
          module_path: crate::generated::gapic::model
          included_ids:
            - .google.storage.v2.Storage.DeleteBucket
            - .google.storage.v2.Storage.GetBucket
            - .google.storage.v2.Storage.CreateBucket
            - .google.storage.v2.Storage.ListBuckets
            - .google.storage.v2.Storage.LockBucketRetentionPolicy
            - .google.storage.v2.Storage.GetIamPolicy
            - .google.storage.v2.Storage.SetIamPolicy
            - .google.storage.v2.Storage.TestIamPermissions
            - .google.storage.v2.Storage.UpdateBucket
            - .google.storage.v2.Storage.ComposeObject
            - .google.storage.v2.Storage.DeleteObject
            - .google.storage.v2.Storage.RestoreObject
            - .google.storage.v2.Storage.GetObject
            - .google.storage.v2.Storage.UpdateObject
            - .google.storage.v2.Storage.ListObjects
            - .google.storage.v2.Storage.RewriteObject
            - .google.storage.v2.Storage.MoveObject
        - source: google/storage/control/v2
          output: src/storage/src/generated/convert/control
          template: convert-prost
          module_path: crate::generated::gapic_control::model
          name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf
        - source: google/iam/v1
          output: src/storage/src/generated/convert/iam
          template: convert-prost
          module_path: iam_v1::model
          skipped_ids:
            - .google.iam.v1.ResourcePolicyMember
        - source: google/type
          output: src/storage/src/generated/convert/type
          template: convert-prost
          module_path: gtype::model
          include_list: date.proto,expr.proto
        - source: google/longrunning
          output: src/storage/src/generated/convert/longrunning
          template: convert-prost
          module_path: longrunning::model
          skipped_ids:
            - .google.longrunning.Operation
```

Fixes https://github.com/googleapis/librarian/issues/3196