### PR TITLE
feat(librarian/tidy): remove channel from librarian.yaml if can be derived from library name

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -68,7 +68,6 @@ func RunTidy() error {
 //     If an explicitly set service_config matches this pattern, it is removed.
 func removeDerivableChannelFields(lib *config.Library) {
 	derivedPath := strings.ReplaceAll(lib.Name, "-", "/")
-	var nonEmptyChannels []*config.Channel
 	for _, ch := range lib.Channels {
 		resolvedPath := ch.Path
 		if resolvedPath == "" {
@@ -92,12 +91,10 @@ func removeDerivableChannelFields(lib *config.Library) {
 		if ch.Path == derivedPath {
 			ch.Path = ""
 		}
-
-		if ch.Path != "" || ch.ServiceConfig != "" {
-			nonEmptyChannels = append(nonEmptyChannels, ch)
-		}
 	}
-	lib.Channels = nonEmptyChannels
+	lib.Channels = slices.DeleteFunc(lib.Channels, func(ch *config.Channel) bool {
+		return ch.Path == "" && ch.ServiceConfig == ""
+	})
 }
 
 func validateLibraries(cfg *config.Config) error {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -129,14 +129,12 @@ libraries:
 
 func TestTidy_DerivableFields(t *testing.T) {
 	for _, test := range []struct {
-		name           string
-		configContent  string
-		wantPath       string
-		wantSvcCfg     string
-		wantNumLibs    int
-		wantNumChnls   int
-		pathShouldBe   string
-		svcCfgShouldBe string
+		name          string
+		configContent string
+		wantPath      string
+		wantSvcCfg    string
+		wantNumLibs   int
+		wantNumChnls  int
 	}{
 		{
 			name: "derivable fields removed",


### PR DESCRIPTION
Let `librarian tidy` remove redundant fields in Channel if can be derived from library name.
Rules used go derive Channel:
- path:  replacing all '-' in the library's name with '/'.
- service_config:  '[resolved_path]/[service_name]_[version].yaml'.
- If both the path and service_config fields of a channel are removed, the entire channel entry will be removed from the configuration.

For #3139