### PR TITLE
fix(sidekick): ReturnsEmpty  on disco methods

### DIFF
--- a/internal/sidekick/parser/discovery/methods.go
+++ b/internal/sidekick/parser/discovery/methods.go
@@ -133,6 +133,7 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 		Deprecated:    input.Deprecated,
 		InputTypeID:   requestMessage.ID,
 		OutputTypeID:  outputID,
+		ReturnsEmpty:  outputID == ".google.protobuf.Empty",
 		PathInfo: &api.PathInfo{
 			Bindings:      []*api.PathBinding{binding},
 			BodyFieldPath: bodyPathField,

--- a/internal/sidekick/parser/discovery/methods_test.go
+++ b/internal/sidekick/parser/discovery/methods_test.go
@@ -59,6 +59,46 @@ func TestMakeServiceMethods(t *testing.T) {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 }
+func TestMakeServiceMethodsReturnsEmpty(t *testing.T) {
+	model, err := ComputeDisco(t, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := "..zoneOperations.delete"
+	got, ok := model.State.MethodByID[id]
+	if !ok {
+		t.Fatalf("expected method %s in the API model", id)
+	}
+	want := &api.Method{
+		ID:            "..zoneOperations.delete",
+		Name:          "delete",
+		Documentation: "Deletes the specified zone-specific Operations resource.",
+		InputTypeID:   "..zoneOperations.deleteRequest",
+		OutputTypeID:  ".google.protobuf.Empty",
+		ReturnsEmpty:  true,
+		PathInfo: &api.PathInfo{
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "DELETE",
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("compute").
+						WithLiteral("v1").
+						WithLiteral("projects").
+						WithVariableNamed("project").
+						WithLiteral("zones").
+						WithVariableNamed("zone").
+						WithLiteral("operations").
+						WithVariableNamed("operation"),
+					QueryParameters: map[string]bool{},
+				},
+			},
+			BodyFieldPath: "",
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want, +got):\n%s", diff)
+	}
+}
 
 func TestMakeServiceMethodsDeprecated(t *testing.T) {
 	model, err := ComputeDisco(t, nil)


### PR DESCRIPTION
Sets the `ReturnsEmpty` field on the `api.Method` struct for discovery doc APIs.