### PR TITLE
fix(librarian): canonicalize entries when constructing keep set

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -334,7 +334,15 @@ func cleanOutput(dir string, keep []string) error {
 		if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("%s: file %q in keep list does not exist", dir, k)
 		}
-		keepSet[k] = true
+		// Effectively get a canonical relative path. While in most cases
+		// this will be equal to k, it might not be - in particular,
+		// on Windows the directory separator in paths returned by Rel
+		// will be a backslash.
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		keepSet[rel] = true
 	}
 	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -380,6 +380,16 @@ func TestCleanOutput(t *testing.T) {
 			keep:  []string{"src/operation.rs", "src/endpoint.rs"},
 			want:  []string{"src/endpoint.rs", "src/operation.rs"},
 		},
+		{
+			// While it would definitely be odd to use "./" here, the
+			// most common case for canonicalizing is for Windows where
+			// the directory separator is a backslash. This test ensures
+			// the logic is tested even on Unix.
+			name:  "keep entries are canonicalized",
+			files: []string{"Cargo.toml", "README.md", "src/lib.rs"},
+			keep:  []string{"./Cargo.toml"},
+			want:  []string{"Cargo.toml"},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()


### PR DESCRIPTION
This uses `filepath.Rel` when constructing the set of files to keep, given that we'll be using the result of `filepath.Rel` when testing that set.

Fixes #3234