### PR TITLE
fix(internal/semver): add DeriveNextPreview function

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -316,7 +316,8 @@ func (o DeriveNextOptions) DeriveNextPreview(previewVersion, stableVersion strin
 		// Stable caught up to preview, so bump preview version core.
 		nextVerOpts.BumpVersionCore = true
 	case 1:
-		// Preview is ahead, normal bump behavior, defer to provided options.
+		// Preview is ahead, so only bump the prerelease version.
+		nextVerOpts.BumpVersionCore = false
 	case -1:
 		// Catch up to stable version's core, then bump and
 		// reset prerelease, if set.

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -474,6 +474,13 @@ func TestDeriveNextOptions_DeriveNextPreview(t *testing.T) {
 			want:           "1.2.4-rc.2",
 		},
 		{
+			name:           "preview ahead, ignore BumpVersionCore, bump prerelease number",
+			previewVersion: "1.2.4-rc.1",
+			stableVersion:  "1.2.3",
+			want:           "1.2.4-rc.2",
+			opts:           DeriveNextOptions{BumpVersionCore: true},
+		},
+		{
 			name:           "preview ahead, pre-GA, bump prerelease number",
 			previewVersion: "0.1.3-rc.1",
 			stableVersion:  "0.1.2",
@@ -484,6 +491,13 @@ func TestDeriveNextOptions_DeriveNextPreview(t *testing.T) {
 			previewVersion: "1.2.4-rc",
 			stableVersion:  "1.2.3",
 			want:           "1.2.4-rc.1",
+		},
+		{
+			name:           "preview ahead, pre-GA, ignore BumpVersionCore, downgrade pre-GA, append prerelease number",
+			previewVersion: "0.1.2-rc",
+			stableVersion:  "0.1.1",
+			want:           "0.1.2-rc.1",
+			opts:           DeriveNextOptions{BumpVersionCore: true, DowngradePreGAChanges: true},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Adds new `DeriveNextPreview` APIs to `internal/semver` to begin implementing Preview client distribution support #2764. Preview versions are stable version-relative - the Preview version core always leads the Stable version core - and only takes minor version bumps when stable has caught up. There isn't a clear place to add use of `DeriveNextPreview` as the librarian release command surface is not completed.

This also refactors the `version` string printing logic into an Options-based pattern similar to `DeriveNextOptions`. This allows us to print only the core version and to include a `v` prefix for use with the https://pkg.go.dev/golang.org/x/mod/semver#Compare API. This design pattern will be useful for #3239 as well.

Finally, this refactors the `DeriveNext` implementations to reduce the amount of duplicate version string parsing.

Updates #2764.