### PR TITLE
refactor: Centralize tracing instrumentation client info in `tracing.rs`

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -127,19 +127,6 @@ pub(crate) mod info {
             ac.rest_header_value()
         };
     }
-{{#Codec.DetailedTracingAttributes}}
-    #[cfg(google_cloud_unstable_tracing)]
-    lazy_static::lazy_static! {
-        pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
-            let mut info = gaxi::options::InstrumentationClientInfo::default();
-            info.service_name = "{{Name}}";
-            info.client_version = VERSION;
-            info.client_artifact = NAME;
-            info.default_host = "{{Codec.DefaultHostShort}}";
-            info
-        };
-    }
-{{/Codec.DetailedTracingAttributes}}
 }
 
 {{/Codec.HasServices}}

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -68,7 +68,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         let client_request_span = gaxi::observability::create_client_request_span(
             span_name,
             "{{Codec.Name}}",
-            &crate::info::INSTRUMENTATION_CLIENT_INFO,
+            &info::INSTRUMENTATION_CLIENT_INFO,
         );
 
         let result = self.inner.{{Codec.Name}}(req, options)
@@ -119,3 +119,22 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
 }
 
 {{/Codec.Services}}
+{{#Codec.HasServices}}
+{{#Codec.DetailedTracingAttributes}}
+#[cfg(google_cloud_unstable_tracing)]
+pub(crate) mod info {
+    const NAME: &str = env!("CARGO_PKG_NAME");
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    lazy_static::lazy_static! {
+        pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
+            let mut info = gaxi::options::InstrumentationClientInfo::default();
+            info.service_name = "{{Name}}";
+            info.client_version = VERSION;
+            info.client_artifact = NAME;
+            info.default_host = "{{Codec.DefaultHostShort}}";
+            info
+        };
+    }
+}
+{{/Codec.DetailedTracingAttributes}}
+{{/Codec.HasServices}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -59,7 +59,7 @@ impl {{Codec.Name}} {
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         #[cfg(google_cloud_unstable_tracing)]
         let inner = if tracing_is_enabled {
-            inner.with_instrumentation(&crate::info::INSTRUMENTATION_CLIENT_INFO)
+            inner.with_instrumentation(&super::tracing::info::INSTRUMENTATION_CLIENT_INFO)
         } else {
             inner
         };

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -50,19 +50,6 @@ mod info {
             ac.grpc_header_value()
         };
     }
-    {{#Codec.DetailedTracingAttributes}}
-    #[cfg(google_cloud_unstable_tracing)]
-    lazy_static::lazy_static! {
-        pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
-            let mut info = gaxi::options::InstrumentationClientInfo::default();
-            info.service_name = "{{Name}}";
-            info.client_version = VERSION;
-            info.client_artifact = NAME;
-            info.default_host = "{{Codec.DefaultHostShort}}";
-            info
-        };
-    }
-    {{/Codec.DetailedTracingAttributes}}
 }
 
 {{/Codec.HasServices}}
@@ -94,14 +81,13 @@ impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
         {{#Codec.DetailedTracingAttributes}}
         #[cfg(google_cloud_unstable_tracing)]
-        let tracing_enabled = gaxi::options::tracing_enabled(&config);
-        let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
-        #[cfg(google_cloud_unstable_tracing)]
-        let inner = if tracing_enabled {
-            inner.with_instrumentation(&info::INSTRUMENTATION_CLIENT_INFO)
+        let inner = if gaxi::options::tracing_enabled(&config) {
+            gaxi::grpc::Client::new_with_instrumentation(config, DEFAULT_HOST, &super::tracing::info::INSTRUMENTATION_CLIENT_INFO).await?
         } else {
-            inner
+            gaxi::grpc::Client::new(config, DEFAULT_HOST).await?
         };
+        #[cfg(not(google_cloud_unstable_tracing))]
+        let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;


### PR DESCRIPTION
Testing full output (all APIs have DetailedTracingAttributes enabled) in https://github.com/googleapis/google-cloud-rust/pull/4077

detailed-tracing-attributes enabled for ALL libraries: https://github.com/googleapis/google-cloud-rust/pull/4077/checks?check_run_id=58306558771
DEFAULT state for detailed-tracing-attributes: https://github.com/googleapis/google-cloud-rust/pull/4077/checks?check_run_id=58304500052