### PR TITLE
fix(internal/semver): add semver v1 string support

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -62,13 +62,13 @@ var (
 	// prerelease - https://semver.org/spec/v1.0.0.html#spec-item-4.
 	semverV1PrereleaseNumberRegexp = regexp.MustCompile(`^(.*?)(\d+)$`)
 
-	// ErrInvalidVersion is returned when the version string provided is invalid as
+	// errInvalidVersion is returned when the version string provided is invalid as
 	// per the SemVer spec - https://semver.org.
-	ErrInvalidVersion = errors.New("invalid version format")
+	errInvalidVersion = errors.New("invalid version format")
 
-	// ErrInvalidPrereleaseNumber is returned when the prerelease number of a
+	// errInvalidPrereleaseNumber is returned when the prerelease number of a
 	// version string is invalid.
-	ErrInvalidPrereleaseNumber = errors.New("invalid prerelease number")
+	errInvalidPrereleaseNumber = errors.New("invalid prerelease number")
 )
 
 // parse deconstructs the SemVer 1.0.0 or 2.0.0 version string into a [version]
@@ -76,7 +76,7 @@ var (
 func parse(versionString string) (version, error) {
 	// Our client versions must not have a "v" prefix.
 	if strings.HasPrefix(versionString, "v") {
-		return version{}, fmt.Errorf("%w: %s", ErrInvalidVersion, versionString)
+		return version{}, fmt.Errorf("%w: %s", errInvalidVersion, versionString)
 	}
 
 	// Prepend "v" internally so that we can use various [semver] APIs.
@@ -84,7 +84,7 @@ func parse(versionString string) (version, error) {
 	// Strips build metadata if present - we do not use build metadata suffixes.
 	vPrefixedVersion := "v" + versionString
 	if !semver.IsValid(vPrefixedVersion) {
-		return version{}, fmt.Errorf("%w: %s", ErrInvalidVersion, versionString)
+		return version{}, fmt.Errorf("%w: %s", errInvalidVersion, versionString)
 	}
 	vPrefixedVersion = semver.Canonical(vPrefixedVersion)
 
@@ -140,7 +140,7 @@ func parse(versionString string) (version, error) {
 	if numStr != "" {
 		num, err := strconv.Atoi(numStr)
 		if err != nil {
-			return version{}, errors.Join(ErrInvalidPrereleaseNumber, err)
+			return version{}, errors.Join(errInvalidPrereleaseNumber, err)
 		}
 		v.PrereleaseNumber = &num
 	}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -110,27 +110,27 @@ func TestParse_Errors(t *testing.T) {
 		{
 			name:    "invalid version with v prefix",
 			version: "v1.2.3",
-			wantErr: ErrInvalidVersion,
+			wantErr: errInvalidVersion,
 		},
 		{
 			name:    "invalid prerelease number with separator",
 			version: "1.2.3-rc.abc",
-			wantErr: ErrInvalidPrereleaseNumber,
+			wantErr: errInvalidPrereleaseNumber,
 		},
 		{
 			name:    "invalid major number",
 			version: "a.2.3",
-			wantErr: ErrInvalidVersion,
+			wantErr: errInvalidVersion,
 		},
 		{
 			name:    "invalid minor number",
 			version: "1.a.3",
-			wantErr: ErrInvalidVersion,
+			wantErr: errInvalidVersion,
 		},
 		{
 			name:    "invalid patch number",
 			version: "1.2.a",
-			wantErr: ErrInvalidVersion,
+			wantErr: errInvalidVersion,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -428,7 +428,7 @@ func TestDeriveNextOptions_DeriveNext_Error(t *testing.T) {
 			name:           "bad version",
 			changeLevel:    Minor,
 			currentVersion: "abc123",
-			wantErr:        ErrInvalidVersion,
+			wantErr:        errInvalidVersion,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Adds support for printing SemVer 1.0.0 strings, specifically in how the prerelease numbers are `0` padded. C# is the only language that uses this and should eventually adopt SemVer 2.0.0 versioning for prereleases.

Adds constants for the two support SemVer spec versions, and a corresponding `version` property that is set during `parse` and defaults to SemVer spec 2.0.0.

Also refactors `parse` error mode testing into its own test (reduces logic in tests, https://testing.googleblog.com/2014/07/testing-on-toilet-dont-put-logic-in.html, separate singular, disjointed table tests http://shortn/_Poh7fSYhkO), and switches to use of sentinel errors, wrapping, and `errors.Is` checks in tests.

Fixes #3239

cc @jskeet just as fyi