### PR TITLE
chore(devtools/cmd/migrate-sidekick): add showcase, protobuf, conformance source

### DIFF
--- a/devtools/cmd/migrate-sidekick/main.go
+++ b/devtools/cmd/migrate-sidekick/main.go
@@ -34,13 +34,14 @@ import (
 )
 
 const (
-	sidekickFile            = ".sidekick.toml"
-	cargoFile               = "Cargo.toml"
-	discoveryArchivePrefix  = "https://github.com/googleapis/discovery-artifact-manager/archive/"
-	googleapisArchivePrefix = "https://github.com/googleapis/googleapis/archive/"
-	showcaseArchivePrefix   = "https://github.com/googleapis/gapic-showcase/archive/"
-	protobufArchivePrefix   = "https://github.com/protocolbuffers/protobuf/archive/"
-	tarballSuffix           = ".tar.gz"
+	sidekickFile             = ".sidekick.toml"
+	cargoFile                = "Cargo.toml"
+	discoveryArchivePrefix   = "https://github.com/googleapis/discovery-artifact-manager/archive/"
+	googleapisArchivePrefix  = "https://github.com/googleapis/googleapis/archive/"
+	showcaseArchivePrefix    = "https://github.com/googleapis/gapic-showcase/archive/"
+	protobufArchivePrefix    = "https://github.com/protocolbuffers/protobuf/archive/"
+	conformanceArchivePrefix = "https://github.com/protocolbuffers/protobuf/archive/"
+	tarballSuffix            = ".tar.gz"
 )
 
 var (
@@ -169,12 +170,15 @@ func readRootSidekick(repoPath string) (*config.Config, error) {
 	protobufRoot, _ := sidekick.Source["protobuf-src-root"].(string)
 	protobufSHA256, _ := sidekick.Source["protobuf-src-sha256"].(string)
 	protobufSubDir, _ := sidekick.Source["protobuf-src-subdir"].(string)
+	conformanceRoot, _ := sidekick.Source["conformance-root"].(string)
+	conformanceSHA256, _ := sidekick.Source["conformance-sha256"].(string)
 	generateSetterSamples, _ := sidekick.Codec["generate-setter-samples"].(string)
 
 	discoveryCommit := strings.TrimSuffix(strings.TrimPrefix(discoveryRoot, discoveryArchivePrefix), tarballSuffix)
 	googleapisCommit := strings.TrimSuffix(strings.TrimPrefix(googleapisRoot, googleapisArchivePrefix), tarballSuffix)
 	showcaseCommit := strings.TrimSuffix(strings.TrimPrefix(showcaseRoot, showcaseArchivePrefix), tarballSuffix)
 	protobufCommit := strings.TrimSuffix(strings.TrimPrefix(protobufRoot, protobufArchivePrefix), tarballSuffix)
+	conformanceCommit := strings.TrimSuffix(strings.TrimPrefix(conformanceRoot, conformanceArchivePrefix), tarballSuffix)
 
 	// Parse package dependencies
 	packageDependencies := parsePackageDependencies(sidekick.Codec)
@@ -198,6 +202,10 @@ func readRootSidekick(repoPath string) (*config.Config, error) {
 				Commit:  protobufCommit,
 				SHA256:  protobufSHA256,
 				Subpath: protobufSubDir,
+			},
+			Conformance: &config.Source{
+				Commit: conformanceCommit,
+				SHA256: conformanceSHA256,
 			},
 		},
 		Default: &config.Default{

--- a/devtools/cmd/migrate-sidekick/main_test.go
+++ b/devtools/cmd/migrate-sidekick/main_test.go
@@ -53,6 +53,10 @@ func TestReadRootSidekick(t *testing.T) {
 						SHA256:  "55912546338433f465a552e9ef09930c63b9eb697053937416890cff83a8622d",
 						Subpath: "src",
 					},
+					Conformance: &config.Source{
+						Commit: "b407e8416e3893036aee5af9a12bd9b6a0e2b2e6",
+						SHA256: "55912546338433f465a552e9ef09930c63b9eb697053937416890cff83a8622d",
+					},
 				},
 				Default: &config.Default{
 					Output:       "src/generated/",

--- a/devtools/cmd/migrate-sidekick/testdata/root-sidekick/success/.sidekick.toml
+++ b/devtools/cmd/migrate-sidekick/testdata/root-sidekick/success/.sidekick.toml
@@ -8,6 +8,8 @@ discovery-sha256            = '67c8d3792f0ebf5f0582dce675c379d0f486604eb0143814c
 protobuf-src-root           = 'https://github.com/protocolbuffers/protobuf/archive/b407e8416e3893036aee5af9a12bd9b6a0e2b2e6.tar.gz'
 protobuf-src-sha256         = '55912546338433f465a552e9ef09930c63b9eb697053937416890cff83a8622d'
 protobuf-src-subdir         = 'src'
+conformance-root           = 'https://github.com/protocolbuffers/protobuf/archive/b407e8416e3893036aee5af9a12bd9b6a0e2b2e6.tar.gz'
+conformance-sha256         = '55912546338433f465a552e9ef09930c63b9eb697053937416890cff83a8622d'
 
 [codec]
 # The default version for all crates. This can be overridden in the crate's


### PR DESCRIPTION
Parse showcase, protobuf and conformace source root from `.sidekick.toml`.

For #3200 