### PR TITLE
fix: update conformance repo to point to protobuf repository

### DIFF
--- a/internal/librarian/internal/rust/generate.go
+++ b/internal/librarian/internal/rust/generate.go
@@ -33,8 +33,8 @@ const (
 	googleapisRepo = "github.com/googleapis/googleapis"
 	discoveryRepo  = "github.com/googleapis/discovery-artifact-manager"
 	protobufRepo   = "github.com/protocolbuffers/protobuf"
-	// Note this is used for fetching protos such as https://github.com/protocolbuffers/protobuf/blob/26.x/conformance/conformance.proto
-	conformanceRepo = "github.com/protocolbuffers/protobuf"
+	// Used for fetching protos such as https://github.com/protocolbuffers/protobuf/blob/26.x/conformance/conformance.proto
+	conformanceRepo = protobufRepo
 	showcaseRepo    = "github.com/googleapis/gapic-showcase"
 )
 


### PR DESCRIPTION
Per [this comment](https://github.com/googleapis/google-cloud-rust/pull/4087#discussion_r26274978200) when specification source is conformance its referring to [protobuf](https://github.com/protocolbuffers/protobuf/) repository.

Fixes 3270