### PR TITLE
feat(internal/command): introduce RunWithEnv

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -31,11 +31,13 @@ func Run(ctx context.Context, command string, arg ...string) error {
 // RunWithEnv executes a program (with arguments) and optional environment
 // variables and captures any error output. If env is nil or empty, the command
 // inherits the environment of the calling process.
-func RunWithEnv(ctx context.Context, env []string, command string, arg ...string) error {
+func RunWithEnv(ctx context.Context, env map[string]string, command string, arg ...string) error {
 	cmd := exec.CommandContext(ctx, command, arg...)
 	if len(env) > 0 {
 		cmd.Env = os.Environ()
-		cmd.Env = append(cmd.Env, env...)
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
 	}
 	fmt.Fprintf(os.Stderr, "Running: %s\n", cmd.String())
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -42,7 +42,7 @@ func TestRunWithEnv_SetsAndVerifiesVariable(t *testing.T) {
 		name  = "LIBRARIAN_TEST_VAR"
 		value = "value"
 	)
-	err := RunWithEnv(ctx, []string{fmt.Sprintf("%s=%s", name, value)},
+	err := RunWithEnv(ctx, map[string]string{name: value},
 		"sh", "-c", fmt.Sprintf("test \"$%s\" = \"%s\"", name, value))
 	if err != nil {
 		t.Fatalf("RunWithEnv() = %v, want %v", err, nil)
@@ -55,7 +55,7 @@ func TestRunWithEnv_VariableNotSetFailsValidation(t *testing.T) {
 		name  = "LIBRARIAN_TEST_VAR"
 		value = "value"
 	)
-	err := RunWithEnv(ctx, []string{}, "sh", "-c", fmt.Sprintf("test \"$%s\" = \"%s\"", name, value))
+	err := RunWithEnv(ctx, map[string]string{}, "sh", "-c", fmt.Sprintf("test \"$%s\" = \"%s\"", name, value))
 	if err == nil {
 		t.Fatalf("RunWithEnv() = %v, want non-nil", err)
 	}

--- a/internal/librarian/rust/helper.go
+++ b/internal/librarian/rust/helper.go
@@ -82,7 +82,7 @@ func FormatAndValidateLibrary(ctx context.Context, outputDir string) error {
 	if err := command.Run(ctx, "cargo", "test", "--manifest-path", manifestPath); err != nil {
 		return err
 	}
-	if err := command.RunWithEnv(ctx, []string{"RUSTDOCFLAGS=-D warnings"}, "cargo", "doc", "--manifest-path", manifestPath, "--no-deps"); err != nil {
+	if err := command.RunWithEnv(ctx, map[string]string{"RUSTDOCFLAGS": "-D warnings"}, "cargo", "doc", "--manifest-path", manifestPath, "--no-deps"); err != nil {
 		return err
 	}
 	if err := command.Run(ctx, "cargo", "clippy", "--manifest-path", manifestPath, "--", "--deny", "warnings"); err != nil {


### PR DESCRIPTION
Introduce `RunWithEnv` to be able to set env vars for commands without  putting in `env` command directly.
Keep the original `command.Run` as convenience wrapper.

Fixes https://github.com/googleapis/librarian/issues/3250