### PR TITLE
Revert "fix(librarian): handle protobuf-src, conformance and showcase…

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,15 +88,6 @@ type Sources struct {
 
 	// Googleapis is the googleapis repository configuration.
 	Googleapis *Source `yaml:"googleapis,omitempty"`
-
-	// Showcase is the showcase repository configuration.
-	Showcase *Source `yaml:"showcase,omitempty"`
-
-	// ProtobufSrc is the path to the `protobuf` repository, used as include directory for `protoc`.
-	ProtobufSrc *Source `yaml:"protobuf,omitempty"`
-
-	// Conformance is the path to the `conformance-tests` repository, used as include directory for `protoc`.
-	Conformance *Source `yaml:"conformance,omitempty"`
 }
 
 // Source represents a source repository.
@@ -110,10 +101,6 @@ type Source struct {
 	// Dir is a local directory path to use instead of fetching.
 	// If set, Commit and SHA256 are ignored.
 	Dir string `yaml:"dir,omitempty"`
-
-	// Subpath is a directory inside the fetched archive that should be treated as
-	// the root for operations.
-	Subpath string `yaml:"subpath,omitempty"`
 }
 
 // Default contains default settings for all libraries.
@@ -180,9 +167,6 @@ type Library struct {
 	// SpecificationFormat specifies the API specification format. Valid values
 	// are "protobuf" (default) or "discovery".
 	SpecificationFormat string `yaml:"specification_format,omitempty"`
-
-	// Roots specifies the source roots to use for generation. Defaults to googleapis.
-	Roots []string `yaml:"roots,omitempty"`
 
 	// Transport is the transport protocol, such as "grpc+rest" or "grpc". This
 	// overrides Default.Transport.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,19 +37,6 @@ func TestRead(t *testing.T) {
 				Commit: "9fcfbea0aa5b50fa22e190faceb073d74504172b",
 				SHA256: "81e6057ffd85154af5268c2c3c8f2408745ca0f7fa03d43c68f4847f31eb5f98",
 			},
-			Showcase: &Source{
-				Commit: "3f4e3f4f5e2f4c6e8b6f4e2f4c6e8b6f4e2f4c6e",
-				SHA256: "d41d8cd98f00b204e9800998ecf8427e",
-			},
-			ProtobufSrc: &Source{
-				Commit:  "4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b",
-				SHA256:  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-				Subpath: "src",
-			},
-			Conformance: &Source{
-				Commit: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
-				SHA256: "f572d396fae9206628714fb2ce00f72e94f2258f",
-			},
 		},
 		Default: &Default{
 			Output:       "src/generated/",
@@ -77,7 +64,6 @@ func TestRead(t *testing.T) {
 			{
 				Name:    "google-cloud-storage-v2",
 				Version: "2.3.4",
-				Roots:   []string{"googleapis"},
 				Channels: []*Channel{
 					{Path: "google/cloud/storage/v2"},
 				},

--- a/internal/config/testdata/rust/librarian.yaml
+++ b/internal/config/testdata/rust/librarian.yaml
@@ -19,16 +19,6 @@ sources:
   googleapis:
     commit: 9fcfbea0aa5b50fa22e190faceb073d74504172b
     sha256: 81e6057ffd85154af5268c2c3c8f2408745ca0f7fa03d43c68f4847f31eb5f98
-  showcase:
-    commit: 3f4e3f4f5e2f4c6e8b6f4e2f4c6e8b6f4e2f4c6e
-    sha256: d41d8cd98f00b204e9800998ecf8427e
-  protobuf:
-    commit: 4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b
-    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-    subpath: src
-  conformance:
-    commit: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
-    sha256: f572d396fae9206628714fb2ce00f72e94f2258f
 default:
   output: src/generated/
   release_level: stable
@@ -50,8 +40,6 @@ libraries:
       - path: google/cloud/secretmanager/v1
     version: 1.2.3
   - name: google-cloud-storage-v2
-    roots:
-      - googleapis
     channels:
       - path: google/cloud/storage/v2
     version: 2.3.4

--- a/internal/librarian/internal/rust/codec.go
+++ b/internal/librarian/internal/rust/codec.go
@@ -21,43 +21,16 @@ import (
 	sidekickconfig "github.com/googleapis/librarian/internal/sidekick/config"
 )
 
-func toSidekickConfig(library *config.Library, channel *config.Channel, googleapisDir, discoveryDir, protobufRootDir, protobufSubDir, conformanceDir, showcaseDir string) *sidekickconfig.Config {
-	source := map[string]string{}
+func toSidekickConfig(library *config.Library, channel *config.Channel, googleapisDir, discoveryDir string) *sidekickconfig.Config {
+	source := map[string]string{
+		"googleapis-root": googleapisDir,
+	}
 	specFormat := "protobuf"
-	if library.SpecificationFormat != "" {
-		specFormat = library.SpecificationFormat
-	}
-	if specFormat == "discovery" {
+	if library.SpecificationFormat == "discovery" {
 		specFormat = "disco"
+		source["discovery-root"] = discoveryDir
+		source["roots"] = "discovery,googleapis"
 	}
-
-	if len(library.Roots) == 0 && googleapisDir != "" {
-		// Default to googleapis if no roots are specified.
-		source["googleapis-root"] = googleapisDir
-		source["roots"] = "googleapis"
-	} else {
-		source["roots"] = strings.Join(library.Roots, ",")
-		rootMap := map[string]struct {
-			path   string
-			subdir string
-			keys   []string
-		}{
-			"googleapis":   {path: googleapisDir, keys: []string{"googleapis-root"}},
-			"discovery":    {path: discoveryDir, keys: []string{"discovery-root"}},
-			"showcase":     {path: showcaseDir, keys: []string{"showcase-root"}},
-			"protobuf-src": {path: protobufRootDir, subdir: protobufSubDir, keys: []string{"protobuf-src-root", "protobuf-src-subdir"}},
-			"conformance":  {path: conformanceDir, keys: []string{"conformance-root"}},
-		}
-		for _, root := range library.Roots {
-			if r, ok := rootMap[root]; ok && r.path != "" {
-				source[r.keys[0]] = r.path
-				if len(r.keys) > 1 {
-					source[r.keys[1]] = r.subdir
-				}
-			}
-		}
-	}
-
 	if library.DescriptionOverride != "" {
 		source["description-override"] = library.DescriptionOverride
 	}

--- a/internal/librarian/internal/rust/codec_test.go
+++ b/internal/librarian/internal/rust/codec_test.go
@@ -23,16 +23,13 @@ import (
 )
 
 func TestToSidekickConfig(t *testing.T) {
-	for _, tt := range []struct {
-		name           string
-		library        *config.Library
-		channel        *config.Channel
-		googleapisDir  string
-		discoveryDir   string
-		protobufDir    string
-		conformanceDir string
-		showcaseDir    string
-		want           *sidekickconfig.Config
+	for _, test := range []struct {
+		name          string
+		library       *config.Library
+		channel       *config.Channel
+		googleapisDir string
+		discoveryDir  string
+		want          *sidekickconfig.Config
 	}{
 		{
 			name: "minimal config",
@@ -53,7 +50,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-storage",
@@ -66,7 +62,6 @@ func TestToSidekickConfig(t *testing.T) {
 				Name:         "google-cloud-storage",
 				Version:      "0.1.0",
 				ReleaseLevel: "preview",
-				Roots:        []string{"googleapis"},
 			},
 			channel: &config.Channel{
 				Path:          "google/cloud/storage/v1",
@@ -82,7 +77,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"version":               "0.1.0",
@@ -96,7 +90,6 @@ func TestToSidekickConfig(t *testing.T) {
 			library: &config.Library{
 				Name:          "google-cloud-storage",
 				CopyrightYear: "2024",
-				Roots:         []string{"googleapis"},
 			},
 			channel: &config.Channel{
 				Path:          "google/cloud/storage/v1",
@@ -112,7 +105,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"copyright-year":        "2024",
@@ -156,7 +148,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"module-path":                 "gcs",
@@ -181,7 +172,6 @@ func TestToSidekickConfig(t *testing.T) {
 			library: &config.Library{
 				Name:        "google-cloud-storage",
 				SkipPublish: true,
-				Roots:       []string{"googleapis"},
 				Rust:        &config.RustCrate{},
 			},
 			channel: &config.Channel{
@@ -198,7 +188,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"not-for-publication":   "true",
@@ -239,7 +228,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"package:tokio":         "package=tokio,source=1.0,force-used=true,used-if=feature = \"async\",feature=async",
@@ -265,11 +253,7 @@ func TestToSidekickConfig(t *testing.T) {
 				Path:          "google/cloud/storage/v1",
 				ServiceConfig: "google/cloud/storage/v1/storage_v1.yaml",
 			},
-			googleapisDir:  "/tmp/googleapis",
-			discoveryDir:   "",
-			protobufDir:    "",
-			conformanceDir: "",
-			showcaseDir:    "",
+			googleapisDir: "/tmp/googleapis",
 			want: &sidekickconfig.Config{
 				General: sidekickconfig.GeneralConfig{
 					Language:            "rust",
@@ -279,7 +263,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-storage",
@@ -310,11 +293,7 @@ func TestToSidekickConfig(t *testing.T) {
 				Path:          "google/cloud/storage/v1",
 				ServiceConfig: "google/cloud/storage/v1/storage_v1.yaml",
 			},
-			googleapisDir:  "/tmp/googleapis",
-			discoveryDir:   "",
-			protobufDir:    "",
-			conformanceDir: "",
-			showcaseDir:    "",
+			googleapisDir: "/tmp/googleapis",
 			want: &sidekickconfig.Config{
 				General: sidekickconfig.GeneralConfig{
 					Language:            "rust",
@@ -324,7 +303,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-storage",
@@ -342,7 +320,6 @@ func TestToSidekickConfig(t *testing.T) {
 			library: &config.Library{
 				Name:                "google-cloud-compute-v1",
 				SpecificationFormat: "discovery",
-				Roots:               []string{"googleapis", "discovery"},
 			},
 			channel: &config.Channel{
 				Path:          "discoveries/compute.v1.json",
@@ -360,39 +337,7 @@ func TestToSidekickConfig(t *testing.T) {
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
 					"discovery-root":  "/tmp/discovery-artifact-manager",
-					"roots":           "googleapis,discovery",
-				},
-				Codec: map[string]string{
-					"package-name-override": "google-cloud-compute-v1",
-				},
-			},
-		},
-		{
-			name: "with multiple formats",
-			library: &config.Library{
-				Name:                "google-cloud-compute-v1",
-				SpecificationFormat: "discovery",
-				Roots:               []string{"googleapis", "discovery", "showcase"},
-			},
-			channel: &config.Channel{
-				Path:          "discoveries/compute.v1.json",
-				ServiceConfig: "google/cloud/compute/v1/compute_v1.yaml",
-			},
-			googleapisDir: "/tmp/googleapis",
-			discoveryDir:  "/tmp/discovery-artifact-manager",
-			showcaseDir:   "/tmp/showcase",
-			want: &sidekickconfig.Config{
-				General: sidekickconfig.GeneralConfig{
-					Language:            "rust",
-					SpecificationFormat: "disco",
-					ServiceConfig:       "google/cloud/compute/v1/compute_v1.yaml",
-					SpecificationSource: "discoveries/compute.v1.json",
-				},
-				Source: map[string]string{
-					"googleapis-root": "/tmp/googleapis",
-					"discovery-root":  "/tmp/discovery-artifact-manager",
-					"showcase-root":   "/tmp/showcase",
-					"roots":           "googleapis,discovery,showcase",
+					"roots":           "discovery,googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-compute-v1",
@@ -420,7 +365,6 @@ func TestToSidekickConfig(t *testing.T) {
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
 					"title-override":  "Google Apps Script Types",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-apps-script-type-gmail",
@@ -448,7 +392,6 @@ func TestToSidekickConfig(t *testing.T) {
 				Source: map[string]string{
 					"googleapis-root":      "/tmp/googleapis",
 					"description-override": "Defines types and an abstract service to handle long-running operations.",
-					"roots":                "googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-longrunning",
@@ -482,7 +425,6 @@ func TestToSidekickConfig(t *testing.T) {
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
 					"skipped-ids":     ".google.spanner.admin.database.v1.DatabaseAdmin.InternalUpdateGraphOperation,.google.spanner.admin.database.v1.InternalUpdateGraphOperationRequest,.google.spanner.admin.database.v1.InternalUpdateGraphOperationResponse",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-spanner-admin-database-v1",
@@ -511,7 +453,6 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
-					"roots":           "googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-storageinsights-v1",
@@ -524,7 +465,6 @@ func TestToSidekickConfig(t *testing.T) {
 			library: &config.Library{
 				Name:                "google-cloud-compute-v1",
 				SpecificationFormat: "discovery",
-				Roots:               []string{"googleapis", "discovery"},
 				Rust: &config.RustCrate{
 					Discovery: &config.RustDiscovery{
 						OperationID: ".google.cloud.compute.v1.Operation",
@@ -561,7 +501,7 @@ func TestToSidekickConfig(t *testing.T) {
 				Source: map[string]string{
 					"googleapis-root": "/tmp/googleapis",
 					"discovery-root":  "/tmp/discovery-artifact-manager",
-					"roots":           "googleapis,discovery",
+					"roots":           "discovery,googleapis",
 				},
 				Codec: map[string]string{
 					"package-name-override": "google-cloud-compute-v1",
@@ -585,69 +525,10 @@ func TestToSidekickConfig(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "with protobuf and conformance",
-			library: &config.Library{
-				Name:  "google-cloud-vision-v1",
-				Roots: []string{"googleapis", "protobuf-src", "conformance"},
-			},
-			channel: &config.Channel{
-				Path:          "google/cloud/vision/v1",
-				ServiceConfig: "google/cloud/vision/v1/vision_v1.yaml",
-			},
-			googleapisDir:  "/tmp/googleapis",
-			protobufDir:    "/tmp/protobuf",
-			conformanceDir: "/tmp/conformance",
-			want: &sidekickconfig.Config{
-				General: sidekickconfig.GeneralConfig{
-					Language:            "rust",
-					SpecificationFormat: "protobuf",
-					ServiceConfig:       "google/cloud/vision/v1/vision_v1.yaml",
-					SpecificationSource: "google/cloud/vision/v1",
-				},
-				Source: map[string]string{
-					"googleapis-root":     "/tmp/googleapis",
-					"protobuf-src-root":   "/tmp/protobuf",
-					"protobuf-src-subdir": "",
-					"conformance-root":    "/tmp/conformance",
-					"roots":               "googleapis,protobuf-src,conformance",
-				},
-				Codec: map[string]string{
-					"package-name-override": "google-cloud-vision-v1",
-				},
-			},
-		},
-		{
-			name: "with showcase as source",
-			library: &config.Library{
-				Name:  "google-cloud-showcase",
-				Roots: []string{"showcase"},
-			},
-			channel: &config.Channel{
-				Path:          "google/showcase/v1beta1",
-				ServiceConfig: "google/showcase/v1beta1/showcase_v1beta1.yaml",
-			},
-			showcaseDir: "/tmp/gapic-showcase",
-			want: &sidekickconfig.Config{
-				General: sidekickconfig.GeneralConfig{
-					Language:            "rust",
-					SpecificationFormat: "protobuf",
-					ServiceConfig:       "google/showcase/v1beta1/showcase_v1beta1.yaml",
-					SpecificationSource: "google/showcase/v1beta1",
-				},
-				Source: map[string]string{
-					"showcase-root": "/tmp/gapic-showcase",
-					"roots":         "showcase",
-				},
-				Codec: map[string]string{
-					"package-name-override": "google-cloud-showcase",
-				},
-			},
-		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			got := toSidekickConfig(tt.library, tt.channel, tt.googleapisDir, tt.discoveryDir, tt.protobufDir, "", tt.conformanceDir, tt.showcaseDir)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+		t.Run(test.name, func(t *testing.T) {
+			got := toSidekickConfig(test.library, test.channel, test.googleapisDir, test.discoveryDir)
+			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -22,7 +22,6 @@ import (
 	"maps"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -113,10 +112,6 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 	for _, name := range config.SourceRoots(options) {
 		if path, ok := options[name]; ok {
 			args = append(args, "--proto_path")
-			prefix := strings.TrimSuffix(name, "-root")
-			if subdir, ok := options[prefix+"-subdir"]; ok {
-				path = filepath.Join(path, subdir)
-			}
 			args = append(args, path)
 		}
 	}


### PR DESCRIPTION
… as roots (#3246)"

This reverts commit a38efc70bdc71a282010dfaf74c62374b845cbee.

revert to unblock Rust team and investigate the failure: https://github.com/googleapis/librarian/pull/3246#issuecomment-3666077144