### PR TITLE
revert: partial revert of #3246

### DIFF
--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -22,7 +22,6 @@ import (
 	"maps"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -113,10 +112,6 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 	for _, name := range config.SourceRoots(options) {
 		if path, ok := options[name]; ok {
 			args = append(args, "--proto_path")
-			prefix := strings.TrimSuffix(name, "-root")
-			if subdir, ok := options[prefix+"-subdir"]; ok {
-				path = filepath.Join(path, subdir)
-			}
 			args = append(args, path)
 		}
 	}


### PR DESCRIPTION
Doing a partial revert to the code that affected sidekick. 
Verified via local run
```
git clone --depth 1 https://github.com/googleapis/google-cloud-rust.git                                                                                                            1 ↵
cd google-cloud-rust

# Run `sidekick` version at HEAD on the repo on src/wkt/src/generated
GOPROXY=direct go run /path/to/repos/librarian/cmd/sidekick refresh \
  -output src/wkt/src/generated \
  -project-root .

Cloning into 'google-cloud-rust'...
remote: Enumerating objects: 5047, done.
remote: Counting objects: 100% (5047/5047), done.
remote: Compressing objects: 100% (2334/2334), done.
remote: Total 5047 (delta 3272), reused 3668 (delta 2301), pack-reused 0 (from 0)
Receiving objects: 100% (5047/5047), 17.16 MiB | 1.65 MiB/s, done.
Resolving deltas: 100% (3272/3272), done.
directory ../../../../librarian/cmd/sidekick is contained in a module that is not one of the workspace modules listed in go.work. You can add the module to the workspace using:
        go work use ../../../../librarian
```

See for context https://github.com/googleapis/librarian/pull/3246#issuecomment-3666077144

Previous attempt: closed https://github.com/googleapis/librarian/pull/3276 because https://github.com/googleapis/librarian/pull/3267 also needs to be reverted together to avoid build errors.