### PR TITLE
fix(dart): Avoid shadowing `contents` field name

### DIFF
--- a/internal/sidekick/dart/templates/lib/message.mustache
+++ b/internal/sidekick/dart/templates/lib/message.mustache
@@ -89,12 +89,12 @@ final class {{Codec.Name}} extends {{Codec.Model.Codec.ProtoPrefix}}ProtoMessage
   @override
   {{#Codec.HasToStringLines}}
   String toString() {
-    final contents = [
+    final $contents = [
       {{#Codec.ToStringLines}}
       {{{.}}}
       {{/Codec.ToStringLines}}
     ].join(',');
-    return '{{Name}}($contents)';
+    return '{{Name}}(${$contents})';
   }
   {{/Codec.HasToStringLines}}
   {{^Codec.HasToStringLines}}


### PR DESCRIPTION
If a message defines a `contents` field then it would be shadowed by a local variable in the generated `toString` method.