### PR TITLE
chore: add handling for converting newlines in documentoverrides from toml to yaml

### DIFF
--- a/devtools/cmd/migrate-sidekick/main.go
+++ b/devtools/cmd/migrate-sidekick/main.go
@@ -80,6 +80,12 @@ type CargoConfig struct {
 	} `toml:"package"`
 }
 
+// RustOverrideData is used to store RustDocumentationOverride data to fix newlines.
+type RustOverrideData struct {
+	Match   string
+	Replace string
+}
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		slog.Error("migrate-sidekick failed", "error", err)
@@ -142,7 +148,7 @@ func run(args []string) error {
 		return errTidyFailed
 	}
 
-	return nil
+	return fixDocumentOverrideNewLines(*outputPath, cfg)
 }
 
 // readRootSidekick reads the root .sidekick.toml file and extracts defaults.
@@ -675,4 +681,82 @@ func readTOML[T any](file string) (*T, error) {
 	}
 
 	return &tomlData, nil
+}
+
+// fixDocumentOverrideNewLines takes any toml content in rust.DocumentationOverrides that contains
+// newlines and appropriately adjusts them in the yaml file.
+func fixDocumentOverrideNewLines(yamlFile string, config *config.Config) error {
+	input, err := os.ReadFile(yamlFile)
+	if err != nil {
+		return err
+	}
+
+	content := string(input)
+	lookup := make(map[string]RustOverrideData)
+	for _, lib := range config.Libraries {
+		if lib.Rust == nil {
+			continue
+		}
+		for _, o := range lib.Rust.DocumentationOverrides {
+			key := o.ID + "|" + strings.Trim(o.Match, " \n\r")
+			lookup[key] = RustOverrideData{
+				Match:   o.Match,
+				Replace: o.Replace,
+			}
+		}
+	}
+	lines := strings.Split(content, "\n")
+	var newLines []string
+	var currentID string
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- id: ") {
+			currentID = strings.TrimPrefix(trimmed, "- id: ")
+			newLines = append(newLines, line)
+			continue
+		}
+		if strings.Contains(line, "match: ") {
+			parts := strings.SplitN(line, "match: ", 2)
+			indent := parts[0]
+			currentVal := strings.Trim(parts[1], " '\"")
+
+			lookupKey := currentID + "|" + currentVal
+
+			if data, ok := lookup[lookupKey]; ok {
+				if strings.Contains(data.Match, "\n") {
+					newLines = append(newLines, fmt.Sprintf("%smatch: |", indent))
+					newLines = append(newLines, "") // Leading newline
+					newLines = append(newLines, indent+"  "+strings.TrimSpace(data.Match))
+				} else {
+					newLines = append(newLines, line) // Keep original if no newline
+				}
+
+				// --- HANDLE REPLACE FIELD ---
+				// We assume the next line in the file is the 'replace' line
+				// We skip the original replace line by incrementing the loop counter 'i'
+				if i+1 < len(lines) && strings.Contains(lines[i+1], "replace: ") {
+					i++ // Skip the original line
+					if strings.Contains(data.Replace, "\n") {
+						newLines = append(newLines, fmt.Sprintf("%sreplace: |", indent))
+						newLines = append(newLines, "") // Leading newline
+						newLines = append(newLines, indent+"  "+strings.TrimSpace(data.Replace))
+					} else {
+						newLines = append(newLines, lines[i])
+					}
+				}
+				continue
+			}
+		}
+
+		newLines = append(newLines, line)
+	}
+
+	content = strings.Join(newLines, "\n")
+	err = os.WriteFile(yamlFile, []byte(content), 0644)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/devtools/cmd/migrate-sidekick/main_test.go
+++ b/devtools/cmd/migrate-sidekick/main_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/yaml"
 )
 
 func TestReadRootSidekick(t *testing.T) {
@@ -573,13 +574,15 @@ func TestBuildConfig(t *testing.T) {
 
 func TestRunMigrateCommand(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		path    string
-		wantErr error
+		name                        string
+		path                        string
+		wantErr                     error
+		checkDocumentOverrideValues []string
 	}{
 		{
-			name: "success",
-			path: "testdata/run/success",
+			name:                        "success",
+			path:                        "testdata/run/success",
+			checkDocumentOverrideValues: []string{"example replace", "\nAncestry subtrees must be in one of the following formats:\n"},
 		},
 		{
 			name:    "tidy_command_fails",
@@ -607,6 +610,27 @@ func TestRunMigrateCommand(t *testing.T) {
 				}
 			} else if test.wantErr != nil {
 				t.Fatalf("expected error containing %q, got nil", test.wantErr)
+			} else {
+				data, err := os.ReadFile(outputPath)
+				if err != nil {
+					t.Fatalf("librarian file does not exist")
+				}
+
+				librarianConfig, err := yaml.Unmarshal[config.Config](data)
+				if err != nil {
+					t.Fatalf("unable to parse librarian file")
+				}
+				if len(librarianConfig.Libraries) != 1 {
+					t.Fatalf("librarian yaml does not contain library")
+				}
+				if len(test.checkDocumentOverrideValues) > 0 {
+					for index, expected := range test.checkDocumentOverrideValues {
+						got := librarianConfig.Libraries[0].Rust.DocumentationOverrides[index].Replace
+						if got != expected {
+							t.Fatalf("expected checkDocumentOverrideValue: %s got: %s", expected, got)
+						}
+					}
+				}
 			}
 
 		})

--- a/devtools/cmd/migrate-sidekick/testdata/run/success/src/generated/api/.sidekick.toml
+++ b/devtools/cmd/migrate-sidekick/testdata/run/success/src/generated/api/.sidekick.toml
@@ -17,3 +17,11 @@ copyright-year = '2025'
 id = '.google.api.ProjectProperties'
 match = 'example match'
 replace = 'example replace'
+
+[[documentation-overrides]]
+id      = '.google.cloud.orgpolicy.v1.Policy.ListPolicy'
+match   = """
+Ancestry subtrees must be in one of the following formats:"""
+replace = """
+
+Ancestry subtrees must be in one of the following formats:"""


### PR DESCRIPTION
Newlines were getting stripped from documentoverrides field.  Originally I had tried the "proper" solution to set this field to LiteralStyle in yaml which should then keep the newlines.  However that was not working properly when we read and wrote back to the file..  Since this is a 1 time migration script I decided just to go with a brute force solution to unblock us as this code will not be used once we migrate the sidekick repo.

Fix #3136