### PR TITLE
fix(internal/legacylibrarian): skip writePRBody when no change when no commit/push specified

### DIFF
--- a/internal/legacylibrarian/legacylibrarian/command_test.go
+++ b/internal/legacylibrarian/legacylibrarian/command_test.go
@@ -1282,6 +1282,30 @@ func TestCommitAndPush(t *testing.T) {
 			wantPRBodyFile: true,
 		},
 		{
+			name: "No push or commit flags, and clean repo",
+			setupMockRepo: func(t *testing.T) legacygitrepo.Repository {
+				return &MockRepository{
+					Dir: t.TempDir(),
+					RemotesValue: []*legacygitrepo.Remote{
+						{
+							Name: "origin",
+							URLs: []string{"https://github.com/googleapis/librarian.git"},
+						},
+					},
+					IsCleanValue: true,
+				}
+			},
+			setupMockClient: func(t *testing.T) GitHubClient {
+				return nil
+			},
+			state:          &legacyconfig.LibrarianState{},
+			prType:         pullRequestRelease,
+			commit:         false,
+			push:           false,
+			wantErr:        false,
+			wantPRBodyFile: false,
+		},
+		{
 			name: "create a commit",
 			setupMockRepo: func(t *testing.T) legacygitrepo.Repository {
 				remote := &legacygitrepo.Remote{


### PR DESCRIPTION
When neither commit/push specified, skip writePRBody when no change created by generate.

Fix #3297