### PR TITLE
chore(internal/librarian/rust): remove unused function

### DIFF
--- a/internal/librarian/rust/helper.go
+++ b/internal/librarian/rust/helper.go
@@ -18,11 +18,9 @@ package rust
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
 
 	"github.com/googleapis/librarian/internal/command"
-	"github.com/pelletier/go-toml/v2"
 )
 
 // RustHelper interface used for mocking in tests.
@@ -43,20 +41,6 @@ func (r *RustHelp) HelperPrepareCargoWorkspace(ctx context.Context, outputDir st
 // HelperFormatAndValidateLibrary encapsulates formatAndValidateLibrary command.
 func (r *RustHelp) HelperFormatAndValidateLibrary(ctx context.Context, outputDir string) error {
 	return FormatAndValidateLibrary(ctx, outputDir)
-}
-
-// getPackageName retrieves the packagename from a Cargo.toml file.
-func getPackageName(output string) (string, error) {
-	cargo := CargoConfig{}
-	filename := path.Join(output, "Cargo.toml")
-	contents, err := os.ReadFile(filename)
-	if err != nil {
-		return "", fmt.Errorf("failed to read %s: %w", filename, err)
-	}
-	if err = toml.Unmarshal(contents, &cargo); err != nil {
-		return "", fmt.Errorf("error unmarshaling %s: %w", filename, err)
-	}
-	return cargo.Package.Name, nil
 }
 
 // PrepareCargoWorkspace creates a new cargo package in the specified output directory.

--- a/internal/librarian/rust/helper_test.go
+++ b/internal/librarian/rust/helper_test.go
@@ -26,17 +26,6 @@ import (
 	"github.com/googleapis/librarian/internal/testhelpers"
 )
 
-func TestGetPackageName(t *testing.T) {
-	expectedPackageName := "new-lib-format"
-	got, err := getPackageName("testdata/new-lib-format")
-	if err != nil {
-		t.Fatalf("error getting package name %v", err)
-	}
-	if got != expectedPackageName {
-		t.Errorf("want packageName %s, got %s", expectedPackageName, got)
-	}
-}
-
 func TestPrepareCargoWorkspace(t *testing.T) {
 	testhelpers.RequireCommand(t, "cargo")
 	testhelpers.RequireCommand(t, "taplo")


### PR DESCRIPTION
Removes getPackageName that retrieves the packagename from a Cargo.toml file. It is never used other than test.

For #3203