### PR TITLE
chore(internal/config): readable property order

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,8 +148,7 @@ type Library struct {
 	// because this order impacts YAML serialization, we keep Name and Version
 	// at the top for ease of consumption in file-form.
 
-	// Name is the library name, such as "secretmanager" or "storage". It is
-	// listed first so it appears at the top of each library entry in YAML.
+	// Name is the library name, such as "secretmanager" or "storage".
 	Name string `yaml:"name"`
 
 	// Version is the library version.


### PR DESCRIPTION
Puts `Name` and `Version` at top of the `struct` definition to ensure they are appear first in file form for improved readability.

In response to https://github.com/googleapis/librarian/issues/3301#issuecomment-3675857273.