### PR TITLE
chore(legacylibrarian): specify more powerful machine for automation generate job

### DIFF
--- a/infra/prod/generate.yaml
+++ b/infra/prod/generate.yaml
@@ -72,4 +72,5 @@ availableSecrets:
       env: 'LIBRARIAN_GITHUB_TOKEN'
 options:
   logging: CLOUD_LOGGING_ONLY
+  machineType: 'E2_HIGHCPU_8'
 timeout: 10h


### PR DESCRIPTION
Change machine type from default standard type to 'E2_HIGHCPU_8' . This is to mitigate recent failures in python generate job failures due to timeout, see b/470127328.

Next step is to update image used for automation.

For https://github.com/googleapis/librarian/issues/2938