### PR TITLE
fix(devtools/cmd/migrate-sidekick): add SkipGenerate if no modules found for veener

### DIFF
--- a/devtools/cmd/migrate-sidekick/main.go
+++ b/devtools/cmd/migrate-sidekick/main.go
@@ -529,10 +529,12 @@ func buildVeneer(files []string) (map[string]*config.Library, error) {
 			Version:       cargo.Package.Version,
 			CopyrightYear: "2025",
 		}
-		if rustModules != nil {
+		if len(rustModules) > 0 {
 			veneers[name].Rust = &config.RustCrate{
 				Modules: rustModules,
 			}
+		} else {
+			veneers[name].SkipGenerate = true
 		}
 	}
 

--- a/devtools/cmd/migrate-sidekick/main_test.go
+++ b/devtools/cmd/migrate-sidekick/main_test.go
@@ -455,6 +455,23 @@ func TestBuildVeneer(t *testing.T) {
 					Output:        "testdata/build-veneer/success/lib-2",
 					Version:       "0.0.0",
 					CopyrightYear: "2025",
+					SkipGenerate:  true,
+				},
+			},
+		},
+		{
+			name: "no_rust_modules",
+			files: []string{
+				"testdata/build-veneer/success/lib-2/Cargo.toml",
+			},
+			want: map[string]*config.Library{
+				"google-cloud-spanner": {
+					Name:          "google-cloud-spanner",
+					Veneer:        true,
+					Output:        "testdata/build-veneer/success/lib-2",
+					Version:       "0.0.0",
+					CopyrightYear: "2025",
+					SkipGenerate:  true,
 				},
 			},
 		},


### PR DESCRIPTION
Adds SkipGenerate true to migrated config if there is no modules found for veener.  

The migration script assumes a veener library for all Cargo.toml files within the `src` directory and not under `src/generated` paths, then determines rust.modules by looks for .sidekick.toml files within the directory of the Cargo.toml. For modules with no .sidekick.toml files, e.g. google-cloud-auth, these are handwritten modules with no generated code. They should be skipped in generate command, setting SkipGenerate to indicate it.

[librarian.yaml](https://paste.googleplex.com/4849268869431296) produced after this change.

Fix #3318
For #3313