### PR TITLE
fix(librarian): add support to doc override in veneer modules

### DIFF
--- a/devtools/cmd/migrate-sidekick/main.go
+++ b/devtools/cmd/migrate-sidekick/main.go
@@ -603,8 +603,17 @@ func buildModules(rootDir string) ([]*config.RustModule, error) {
 		if !ok {
 			generateSetterSamples = "true"
 		}
-
+		// Parse documentation overrides
+		var documentationOverrides []config.RustDocumentationOverride
+		for _, do := range sidekick.DocumentationOverrides {
+			documentationOverrides = append(documentationOverrides, config.RustDocumentationOverride{
+				ID:      do.ID,
+				Match:   do.Match,
+				Replace: do.Replace,
+			})
+		}
 		module := &config.RustModule{
+			DocumentationOverrides: documentationOverrides,
 			GenerateSetterSamples:  strToBool(generateSetterSamples),
 			HasVeneer:              strToBool(hasVeneer),
 			IncludedIds:            strToSlice(includedIds, false),

--- a/devtools/cmd/migrate-sidekick/main_test.go
+++ b/devtools/cmd/migrate-sidekick/main_test.go
@@ -460,6 +460,48 @@ func TestBuildVeneer(t *testing.T) {
 			},
 		},
 		{
+			name: "with_overrides",
+			files: []string{
+				"testdata/build-veneer/with-overrides/lib-1/Cargo.toml",
+			},
+			want: map[string]*config.Library{
+				"google-cloud-storage-overridden": {
+					Name:          "google-cloud-storage-overridden",
+					Veneer:        true,
+					Output:        "testdata/build-veneer/with-overrides/lib-1",
+					Version:       "1.5.0",
+					CopyrightYear: "2025",
+					Rust: &config.RustCrate{
+						Modules: []*config.RustModule{
+							{
+								DocumentationOverrides: []config.RustDocumentationOverride{
+									{
+										ID:      ".google.storage.v2.Storage",
+										Match:   "The service helps to manage cloud storage.",
+										Replace: "The service helps to manage cloud storage resources.",
+									},
+								},
+								GenerateSetterSamples:  true,
+								HasVeneer:              true,
+								IncludeGrpcOnlyMethods: true,
+								NameOverrides:          ".google.storage.v2.Storage=StorageControl",
+								Output:                 "testdata/build-veneer/with-overrides/lib-1/dir-1",
+								RoutingRequired:        true,
+								ServiceConfig:          "google/storage/v2/storage_v2.yaml",
+								SkippedIds:             []string{".google.iam.v1.ResourcePolicyMember"},
+								Source:                 "google/storage/v2",
+								TitleOverride:          "Cloud Firestore API",
+								ModuleRoots: map[string]string{
+									"discovery-root":  "",
+									"googleapis-root": "",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "no_rust_modules",
 			files: []string{
 				"testdata/build-veneer/success/lib-2/Cargo.toml",

--- a/devtools/cmd/migrate-sidekick/testdata/build-veneer/with-overrides/lib-1/Cargo.toml
+++ b/devtools/cmd/migrate-sidekick/testdata/build-veneer/with-overrides/lib-1/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "google-cloud-storage-overridden"
+version = "1.5.0"
+publish = true

--- a/devtools/cmd/migrate-sidekick/testdata/build-veneer/with-overrides/lib-1/dir-1/.sidekick.toml
+++ b/devtools/cmd/migrate-sidekick/testdata/build-veneer/with-overrides/lib-1/dir-1/.sidekick.toml
@@ -1,0 +1,19 @@
+[general]
+specification-source = "google/storage/v2"
+service-config = "google/storage/v2/storage_v2.yaml"
+[source]
+roots = "googleapis,discovery"
+skipped-ids = ".google.iam.v1.ResourcePolicyMember"
+title-override = "Cloud Firestore API"
+googleapis-root = ""
+discovery-root = ""
+included-ids = ""
+[codec]
+has-veneer = "true"
+include-grpc-only-methods = "true"
+name-overrides = ".google.storage.v2.Storage=StorageControl"
+routing-required = "true"
+[[documentation-overrides]]
+id = ".google.storage.v2.Storage"
+match = "The service helps to manage cloud storage."
+replace = "The service helps to manage cloud storage resources."

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -51,6 +51,9 @@ type RustModule struct {
 	// DisabledRustdocWarnings is a list of rustdoc warnings to disable.
 	DisabledRustdocWarnings yaml.StringSlice `yaml:"disabled_rustdoc_warnings,omitempty"`
 
+	// DocumentationOverrides contains overrides for element documentation.
+	DocumentationOverrides []RustDocumentationOverride `yaml:"documentation_overrides,omitempty"`
+
 	// ExtendGrpcTransport indicates whether the transport stub can be
 	// extended (in order to support streams).
 	ExtendGrpcTransport bool `yaml:"extend_grpc_transport,omitempty"`

--- a/internal/librarian/internal/rust/codec.go
+++ b/internal/librarian/internal/rust/codec.go
@@ -263,6 +263,16 @@ func moduleToSidekickConfig(library *config.Library, module *config.RustModule, 
 		Source: source,
 		Codec:  buildModuleCodec(library, module),
 	}
+	if len(module.DocumentationOverrides) > 0 {
+		sidekickCfg.CommentOverrides = make([]sidekickconfig.DocumentationOverride, len(module.DocumentationOverrides))
+		for i, override := range module.DocumentationOverrides {
+			sidekickCfg.CommentOverrides[i] = sidekickconfig.DocumentationOverride{
+				ID:      override.ID,
+				Match:   override.Match,
+				Replace: override.Replace,
+			}
+		}
+	}
 	return sidekickCfg
 }
 


### PR DESCRIPTION
Adds logic in migration script to migrate `documentation-overrides` for veneer modules similar to GAPIC. Then pass down this config in `moduleToSidekickConfig` so that the generator can be aware of it.

This is to fix generation diff in pubsub caused by ignored `documentation-overrides` in  https://github.com/googleapis/google-cloud-rust/blob/main/src/pubsub/src/generated/gapic/.sidekick.toml#L50-L60

For #3330