### PR TITLE
feat(sidekick): Relax AIP checks for samples of get operations

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -394,10 +394,19 @@ func (m *Method) AIPStandardGetInfo() *AIPStandardGetInfo {
 		return nil
 	}
 
-	singular := strings.ToLower(m.OutputType.Resource.Singular)
-	// The method needs to be called getfoo and the request type needs to be called getfoorequest.
-	if strings.ToLower(m.Name) != fmt.Sprintf("get%s", singular) ||
-		strings.ToLower(m.InputType.Name) != fmt.Sprintf("get%srequest", singular) {
+	// Standard get methods for resource "Foo" should be named "GetFoo".
+	maybeSingular, found := strings.CutPrefix(strings.ToLower(m.Name), "get")
+	if !found || maybeSingular == "" {
+		return nil
+	}
+	// The request name should be "GetFooRequest".
+	if strings.ToLower(m.InputType.Name) != fmt.Sprintf("get%srequest", maybeSingular) {
+		return nil
+	}
+
+	// If the resource has a singular name, it must match.
+	if m.OutputType.Resource.Singular != "" &&
+		strings.ToLower(m.OutputType.Resource.Singular) != maybeSingular {
 		return nil
 	}
 

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -386,6 +386,19 @@ func TestAIPStandardGetInfo(t *testing.T) {
 			},
 		},
 		{
+			name: "valid get operation with missing singular name on resource",
+			method: &Method{
+				Name:      "GetSecret",
+				InputType: &Message{Name: "GetSecretRequest", Fields: []*Field{resourceNameField}},
+				OutputType: &Message{
+					Resource: &Resource{Type: resourceType, Singular: ""},
+				},
+			},
+			want: &AIPStandardGetInfo{
+				ResourceNameRequestField: resourceNameField,
+			},
+		},
+		{
 			name: "method name is incorrect",
 			method: &Method{
 				Name:       "Get",


### PR DESCRIPTION
Some reosurces have no singular name configured.