### PR TITLE
fix(devtools/cmd/migrate-sidekick): reuse sidekick structs in migration script

### DIFF
--- a/internal/sidekick/rust_release/published_crate.go
+++ b/internal/sidekick/rust_release/published_crate.go
@@ -25,8 +25,8 @@ func publishedCrate(manifest string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	info := cargo{
-		Package: &crateInfo{
+	info := Cargo{
+		Package: &CrateInfo{
 			Publish: true,
 		},
 	}

--- a/internal/sidekick/rust_release/update_manifest.go
+++ b/internal/sidekick/rust_release/update_manifest.go
@@ -26,15 +26,16 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-// crateInfo contains the package information.
-type crateInfo struct {
+// CrateInfo contains the package information.
+type CrateInfo struct {
 	Name    string `toml:"name"`
 	Version string `toml:"version"`
 	Publish bool   `toml:"publish"`
 }
 
-type cargo struct {
-	Package *crateInfo `toml:"package"`
+// Cargo is a wrapper for CrateInfo for parsing Cargo.toml files.
+type Cargo struct {
+	Package *CrateInfo `toml:"package"`
 }
 
 func updateManifest(config *config.Release, lastTag, manifest string) ([]string, error) {
@@ -49,8 +50,8 @@ func updateManifest(config *config.Release, lastTag, manifest string) ([]string,
 	if err != nil {
 		return nil, err
 	}
-	info := cargo{
-		Package: &crateInfo{
+	info := Cargo{
+		Package: &CrateInfo{
 			Publish: true,
 		},
 	}


### PR DESCRIPTION
Reuses sidekick's structs in migration script instead of recreating the struct within the package, so that sidekick team changes will be reflected in this script.
Reused: 
- Config instead of SidekickConfig
- DocumentationOverride instead of RustOverrideData
- Cargo and CrateInfo instead of CargoConfig and Package (similar to sidekick, initialize Publish to true before unmarshal. This keeps behavior that publish is true when omitted)

Fix #3344