### PR TITLE
chore(internal/librarian): remove skip print statement for librarian generate

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -236,7 +236,6 @@ func generateLibrary(ctx context.Context, cfg *config.Config, libraryName string
 	for _, lib := range cfg.Libraries {
 		if lib.Name == libraryName {
 			if lib.SkipGenerate {
-				fmt.Printf("⊘ Skipping %s (skip_generate is set)\n", lib.Name)
 				return nil, nil
 			}
 			lib, err := prepareLibrary(cfg.Language, lib, cfg.Default)


### PR DESCRIPTION
Removing print statement for debugging the migration tool. 
Verified locally devtools/cmd/migrate-sidekick and librarian generate.

Fix #3150