### PR TITLE
refactor(internal/librarian): remove RustHelper and Generator interfaces

### DIFF
--- a/internal/librarian/create_test.go
+++ b/internal/librarian/create_test.go
@@ -82,7 +82,7 @@ func TestCreateLibrary(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := create(t.Context(), test.libName, "", "", test.output, "", &Generate{}, nil); err != nil {
+			if err := runCreate(t.Context(), test.libName, "", "", test.output, ""); err != nil {
 				t.Fatal(err)
 			}
 
@@ -128,7 +128,7 @@ func TestCreateLibraryNoYaml(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
 
-	err := create(t.Context(), "newlib", "", "", "output/newlib", "protobuf", &Generate{}, nil)
+	err := runCreate(t.Context(), "newlib", "", "", "output/newlib", "protobuf")
 	if !errors.Is(err, errNoYaml) {
 		t.Errorf("want error %v, got %v", errNoYaml, err)
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -40,20 +40,6 @@ var (
 	errEmptySources            = errors.New("sources field is required in librarian.yaml: specify googleapis and/or discovery source commits")
 )
 
-// Generator interface used for mocking in tests.
-type Generator interface {
-	Run(ctx context.Context, all bool, libraryName string) error
-}
-
-// Generate struct implements Generator interface.
-type Generate struct {
-}
-
-// Run encapsulates runGenerate command on Generator interface.
-func (g *Generate) Run(ctx context.Context, all bool, libraryName string) error {
-	return runGenerate(ctx, all, libraryName)
-}
-
 func generateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "generate",

--- a/internal/librarian/rust/helper.go
+++ b/internal/librarian/rust/helper.go
@@ -23,26 +23,6 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 )
 
-// RustHelper interface used for mocking in tests.
-type RustHelper interface {
-	HelperPrepareCargoWorkspace(ctx context.Context, outputDir string) error
-	HelperFormatAndValidateLibrary(ctx context.Context, outputDir string) error
-}
-
-// RustHelp struct implements RustHelper interface.
-type RustHelp struct {
-}
-
-// HelperPrepareCargoWorkspace encapsulates prepareCargoWorkspace command.
-func (r *RustHelp) HelperPrepareCargoWorkspace(ctx context.Context, outputDir string) error {
-	return PrepareCargoWorkspace(ctx, outputDir)
-}
-
-// HelperFormatAndValidateLibrary encapsulates formatAndValidateLibrary command.
-func (r *RustHelp) HelperFormatAndValidateLibrary(ctx context.Context, outputDir string) error {
-	return FormatAndValidateLibrary(ctx, outputDir)
-}
-
 // PrepareCargoWorkspace creates a new cargo package in the specified output directory.
 func PrepareCargoWorkspace(ctx context.Context, outputDir string) error {
 	if err := VerifyRustTools(ctx); err != nil {


### PR DESCRIPTION
The Generator and RustHelper interfaces introduce indirection without adding necessary flexibility, as they only support a single implementation outside of mocks for tests. The same set of tests are now run using the "fake" language as of https://github.com/googleapis/librarian/commit/b5ef4967cecf47b956a810f1646aa33f0d68060b, so these interfaces are removed.