### PR TITLE
chore: do not keep cargo file when generating libraries

### DIFF
--- a/internal/librarian/internal/rust/generate.go
+++ b/internal/librarian/internal/rust/generate.go
@@ -100,9 +100,8 @@ func generateVeneer(ctx context.Context, library *config.Library, googleapisDir,
 // Keep returns the list of files to preserve when cleaning the output directory.
 func Keep(library *config.Library) ([]string, error) {
 	if !library.Veneer {
-		return append(library.Keep, "Cargo.toml"), nil
+		return library.Keep, nil
 	}
-
 	// For veneers, keep all files outside module output directories. We walk
 	// library.Output and keep files not under any module.Output.
 	var keep []string

--- a/internal/librarian/internal/rust/generate_test.go
+++ b/internal/librarian/internal/rust/generate_test.go
@@ -90,7 +90,7 @@ func TestKeepNonVeneer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"src/custom.rs", "Cargo.toml"}
+	want := []string{"src/custom.rs"}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
All cargo file content should be auto generated via create/release commands.

[Initial generation diff](https://github.com/ldetmer/google-cloud-rust/compare/main...ldetmer:google-cloud-rust:test-g-2?expand=1)

After running generate --all without keeping cargo.toml [no diff](https://github.com/ldetmer/google-cloud-rust/compare/test-g-2...ldetmer:google-cloud-rust:new-gen?expand=1)

Fixes #3203