### PR TITLE
chore: update automation to use latest build

### DIFF
--- a/infra/prod/generate-worker.yaml
+++ b/infra/prod/generate-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian generate` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:sha256:cdf8f611d69118bc52ff1cb84d36d355e7a6e94b1d6f2ce6d499589adae0b2f2
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:cdf8f611d69118bc52ff1cb84d36d355e7a6e94b1d6f2ce6d499589adae0b2f2
     id: generate-dispatcher
     args:
       - '--project=$PROJECT_ID'

--- a/infra/prod/publish-release-worker.yaml
+++ b/infra/prod/publish-release-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian release tag` command with a provided repository,
 # secret name, and optional PR
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:sha256:cdf8f611d69118bc52ff1cb84d36d355e7a6e94b1d6f2ce6d499589adae0b2f2
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:cdf8f611d69118bc52ff1cb84d36d355e7a6e94b1d6f2ce6d499589adae0b2f2
     id: publish-release-dispatcher
     args:
       - '--project=$PROJECT_ID'

--- a/infra/prod/stage-release-worker.yaml
+++ b/infra/prod/stage-release-worker.yaml
@@ -15,7 +15,7 @@
 # This runs the `librarian release stage` command with a provided repository,
 # secret name, and optional library ID
 steps:
-  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:sha256:cdf8f611d69118bc52ff1cb84d36d355e7a6e94b1d6f2ce6d499589adae0b2f2
+  - name: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-dispatcher@sha256:cdf8f611d69118bc52ff1cb84d36d355e7a6e94b1d6f2ce6d499589adae0b2f2
     id: stage-release-dispatcher
     args:
       - '--project=$PROJECT_ID'


### PR DESCRIPTION
This is to pick up the new librarian image being used by librarian automation set in [this PR](https://github.com/googleapis/librarian/pull/3302/files).