### PR TITLE
chore(internal): move githelpers to internal/git

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package githelpers provides functions for determining changes in a git repository.
-package githelpers
+// Package git provides functions for determining changes in a git repository.
+package git
 
 import (
 	"bytes"

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package githelpers
+package git
 
 import (
 	"os"

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/librarian/githelpers"
+	"github.com/googleapis/librarian/internal/git"
 	rust "github.com/googleapis/librarian/internal/librarian/internal/rust"
 	sidekickrust "github.com/googleapis/librarian/internal/sidekick/rust_release"
 	"github.com/googleapis/librarian/internal/yaml"
@@ -63,14 +63,14 @@ func publish(ctx context.Context, cfg *config.Config, dryRun bool, skipSemverChe
 		return err
 	}
 	gitExe := cfg.Release.GetExecutablePath("git")
-	if err := githelpers.AssertGitStatusClean(ctx, gitExe); err != nil {
+	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
 		return err
 	}
-	lastTag, err := githelpers.GetLastTag(ctx, gitExe, cfg.Release.Remote, cfg.Release.Branch)
+	lastTag, err := git.GetLastTag(ctx, gitExe, cfg.Release.Remote, cfg.Release.Branch)
 	if err != nil {
 		return err
 	}
-	files, err := githelpers.FilesChangedSince(ctx, lastTag, gitExe, cfg.Release.IgnoredChanges)
+	files, err := git.FilesChangedSince(ctx, lastTag, gitExe, cfg.Release.IgnoredChanges)
 	if err != nil {
 		return err
 	}
@@ -87,10 +87,10 @@ func publish(ctx context.Context, cfg *config.Config, dryRun bool, skipSemverChe
 // verifyRequiredTools verifies all the necessary language-agnostic tools are installed.
 func verifyRequiredTools(ctx context.Context, language string, cfg *config.Release) error {
 	gitExe := cfg.GetExecutablePath("git")
-	if err := githelpers.GitVersion(ctx, gitExe); err != nil {
+	if err := git.GitVersion(ctx, gitExe); err != nil {
 		return err
 	}
-	if err := githelpers.GitRemoteURL(ctx, gitExe, cfg.Remote); err != nil {
+	if err := git.GitRemoteURL(ctx, gitExe, cfg.Remote); err != nil {
 		return err
 	}
 	switch language {

--- a/internal/librarian/release.go
+++ b/internal/librarian/release.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/librarian/githelpers"
+	"github.com/googleapis/librarian/internal/git"
 	"github.com/googleapis/librarian/internal/librarian/internal/rust"
 	"github.com/googleapis/librarian/internal/yaml"
 	"github.com/urfave/cli/v3"
@@ -79,7 +79,7 @@ func runRelease(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 	gitExe := cfg.Release.GetExecutablePath("git")
-	if err := githelpers.AssertGitStatusClean(ctx, gitExe); err != nil {
+	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
 		return err
 	}
 
@@ -175,11 +175,11 @@ func shouldReleaseLibrary(ctx context.Context, cfg *config.Config, path string) 
 		return false, errReleaseConfigEmpty
 	}
 	gitExe := cfg.Release.GetExecutablePath("git")
-	lastTag, err := githelpers.GetLastTag(ctx, gitExe, cfg.Release.Remote, cfg.Release.Branch)
+	lastTag, err := git.GetLastTag(ctx, gitExe, cfg.Release.Remote, cfg.Release.Branch)
 	if err != nil {
 		return false, err
 	}
-	numberOfChanges, err := githelpers.ChangesInDirectorySinceTag(ctx, gitExe, lastTag, path)
+	numberOfChanges, err := git.ChangesInDirectorySinceTag(ctx, gitExe, lastTag, path)
 	if err != nil {
 		return false, err
 	}

--- a/internal/sidekick/rust_release/bump_versions.go
+++ b/internal/sidekick/rust_release/bump_versions.go
@@ -21,7 +21,7 @@ import (
 	"slices"
 
 	"github.com/googleapis/librarian/internal/command"
-	"github.com/googleapis/librarian/internal/librarian/githelpers"
+	"github.com/googleapis/librarian/internal/git"
 	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
@@ -31,11 +31,11 @@ func BumpVersions(ctx context.Context, config *config.Release) error {
 	if err := PreFlight(ctx, config); err != nil {
 		return err
 	}
-	lastTag, err := githelpers.GetLastTag(ctx, gitExe(config), config.Remote, config.Branch)
+	lastTag, err := git.GetLastTag(ctx, gitExe(config), config.Remote, config.Branch)
 	if err != nil {
 		return err
 	}
-	files, err := githelpers.FilesChangedSince(ctx, lastTag, gitExe(config), config.IgnoredChanges)
+	files, err := git.FilesChangedSince(ctx, lastTag, gitExe(config), config.IgnoredChanges)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/rust_release/preflight.go
+++ b/internal/sidekick/rust_release/preflight.go
@@ -20,7 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/googleapis/librarian/internal/command"
-	"github.com/googleapis/librarian/internal/librarian/githelpers"
+	"github.com/googleapis/librarian/internal/git"
 	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
@@ -46,10 +46,10 @@ func CargoPreFlight(ctx context.Context, config *config.Release) error {
 // PreFlight() verifies all the necessary  tools are installed.
 func PreFlight(ctx context.Context, config *config.Release) error {
 	gitExe := gitExe(config)
-	if err := githelpers.GitVersion(ctx, gitExe); err != nil {
+	if err := git.GitVersion(ctx, gitExe); err != nil {
 		return err
 	}
-	if err := githelpers.GitRemoteURL(ctx, gitExe, config.Remote); err != nil {
+	if err := git.GitRemoteURL(ctx, gitExe, config.Remote); err != nil {
 		return err
 	}
 	if err := CargoPreFlight(ctx, config); err != nil {

--- a/internal/sidekick/rust_release/publish.go
+++ b/internal/sidekick/rust_release/publish.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/command"
-	"github.com/googleapis/librarian/internal/librarian/githelpers"
+	"github.com/googleapis/librarian/internal/git"
 	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
@@ -36,14 +36,14 @@ func Publish(ctx context.Context, config *config.Release, dryRun bool, skipSemve
 	if err := PreFlight(ctx, config); err != nil {
 		return err
 	}
-	lastTag, err := githelpers.GetLastTag(ctx, gitExe(config), config.Remote, config.Branch)
+	lastTag, err := git.GetLastTag(ctx, gitExe(config), config.Remote, config.Branch)
 	if err != nil {
 		return err
 	}
-	if err := githelpers.MatchesBranchPoint(ctx, gitExe(config), config.Remote, config.Branch); err != nil {
+	if err := git.MatchesBranchPoint(ctx, gitExe(config), config.Remote, config.Branch); err != nil {
 		return err
 	}
-	files, err := githelpers.FilesChangedSince(ctx, lastTag, gitExe(config), config.IgnoredChanges)
+	files, err := git.FilesChangedSince(ctx, lastTag, gitExe(config), config.IgnoredChanges)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func PublishCrates(ctx context.Context, config *config.Release, dryRun bool, ski
 
 	if !skipSemverChecks {
 		for name, manifest := range manifests {
-			if githelpers.IsNewFile(ctx, gitExe(config), lastTag, manifest) {
+			if git.IsNewFile(ctx, gitExe(config), lastTag, manifest) {
 				continue
 			}
 			slog.Info("runnning cargo semver-checks to detect breaking changes", "crate", name)


### PR DESCRIPTION
Moves internal/librarian/githelpers to internal/git and rename the package, since it is not specific to the librarian package.

Fix #3378