### PR TITLE
test(internal/librarian): use yaml.Write inside setupTestConfig

### DIFF
--- a/internal/librarian/update_test.go
+++ b/internal/librarian/update_test.go
@@ -92,7 +92,6 @@ func setupTestConfig(t *testing.T, conf *config.Config) string {
 	}
 	tempDir := t.TempDir()
 	t.Chdir(tempDir)
-
 	configPath := filepath.Join(tempDir, librarianConfigPath)
 	if err := yaml.Write(configPath, conf); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Calls yaml.Write instead of separately yaml.Marshal and then os.WriteFile in setupTestConfig.

Fix #3381