### PR TITLE
refactor(internal/librarian): remove deriveDefaultLibraries

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -108,15 +108,6 @@ func generateAll(ctx context.Context, cfg *config.Config) error {
 	return nil
 }
 
-func defaultLibraryName(language, channel string) string {
-	switch language {
-	case languageRust:
-		return rust.DefaultLibraryName(channel)
-	default:
-		return channel
-	}
-}
-
 func defaultOutput(language, channel, defaultOut string) string {
 	switch language {
 	case languageRust:
@@ -133,14 +124,6 @@ func deriveChannelPath(language string, lib *config.Library) string {
 	default:
 		return strings.ReplaceAll(lib.Name, "-", "/")
 	}
-}
-
-func dirExists(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	return info.IsDir()
 }
 
 func generateLibrary(ctx context.Context, cfg *config.Config, libraryName string) (*config.Library, error) {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -459,15 +459,3 @@ func TestCleanOutput(t *testing.T) {
 		})
 	}
 }
-
-func writeServiceConfig(t *testing.T, googleapisDir, channel, filename string) {
-	t.Helper()
-	dir := filepath.Join(googleapisDir, channel)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	content := "type: google.api.Service\nname: test.googleapis.com\n"
-	if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-}


### PR DESCRIPTION
Since all libraries must now be explicitly listed in librarian.yaml to be generated, automatic inference of libraries is no longer needed.

Fixes https://github.com/googleapis/librarian/issues/3379