### PR TITLE
refactor(internal/librarian): remove specification-format flag

### DIFF
--- a/internal/librarian/create.go
+++ b/internal/librarian/create.go
@@ -53,11 +53,6 @@ func createCommand() *cli.Command {
 				Name:  "output",
 				Usage: "output directory (optional, will be derived if not provided)",
 			},
-			&cli.StringFlag{
-				Name:  "specification-format",
-				Usage: "specification format (e.g., protobuf, discovery)",
-				Value: "protobuf",
-			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			name := c.Args().First()
@@ -67,13 +62,12 @@ func createCommand() *cli.Command {
 			specSource := c.String("specification-source")
 			serviceConfig := c.String("service-config")
 			output := c.String("output")
-			specFormat := c.String("specification-format")
-			return runCreate(ctx, name, specSource, serviceConfig, output, specFormat)
+			return runCreate(ctx, name, specSource, serviceConfig, output)
 		},
 	}
 }
 
-func runCreate(ctx context.Context, name, specSource, serviceConfig, output, specFormat string) error {
+func runCreate(ctx context.Context, name, specSource, serviceConfig, output string) error {
 	cfg, err := yaml.Read[config.Config](librarianConfigPath)
 	if err != nil {
 		return fmt.Errorf("%w: %v", errNoYaml, err)
@@ -88,7 +82,7 @@ func runCreate(ctx context.Context, name, specSource, serviceConfig, output, spe
 	if output, err = deriveOutput(output, cfg, name, specSource, cfg.Language); err != nil {
 		return err
 	}
-	if err := addLibraryToLibrarianConfig(cfg, name, output, specSource, serviceConfig, specFormat); err != nil {
+	if err := addLibraryToLibrarianConfig(cfg, name, output, specSource, serviceConfig); err != nil {
 		return err
 	}
 	switch cfg.Language {
@@ -132,12 +126,11 @@ func deriveOutput(output string, cfg *config.Config, libraryName string, specSou
 	}
 }
 
-func addLibraryToLibrarianConfig(cfg *config.Config, name, output, specificationSource, serviceConfig, specificationFormat string) error {
+func addLibraryToLibrarianConfig(cfg *config.Config, name, output, specificationSource, serviceConfig string) error {
 	lib := &config.Library{
-		Name:                name,
-		Output:              output,
-		SpecificationFormat: specificationFormat,
-		Version:             "0.1.0",
+		Name:    name,
+		Output:  output,
+		Version: "0.1.0",
 	}
 	if serviceConfig != "" || specificationSource != "" {
 		lib.Channels = []*config.Channel{

--- a/internal/librarian/create_test.go
+++ b/internal/librarian/create_test.go
@@ -81,8 +81,7 @@ func TestCreateLibrary(t *testing.T) {
 			if err := yaml.Write(librarianConfigPath, cfg); err != nil {
 				t.Fatal(err)
 			}
-
-			if err := runCreate(t.Context(), test.libName, "", "", test.output, ""); err != nil {
+			if err := runCreate(t.Context(), test.libName, "", "", test.output); err != nil {
 				t.Fatal(err)
 			}
 
@@ -91,19 +90,12 @@ func TestCreateLibrary(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var found *config.Library
-			for _, lib := range cfg.Libraries {
-				if lib.Name == test.libName {
-					found = lib
-					break
-				}
-			}
+			found := findLibrary(cfg, test.libName)
 			if found == nil {
 				t.Fatal("library not found in config")
 			}
-
 			if found.Output != test.wantOutput {
-				t.Errorf("output = %q, want %q", found.Output, test.wantOutput)
+				t.Fatalf("output = %q, want %q", found.Output, test.wantOutput)
 			}
 
 			readmePath := filepath.Join(test.wantOutput, "README.md")
@@ -128,7 +120,7 @@ func TestCreateLibraryNoYaml(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
 
-	err := runCreate(t.Context(), "newlib", "", "", "output/newlib", "protobuf")
+	err := runCreate(t.Context(), "newlib", "", "", "output/newlib")
 	if !errors.Is(err, errNoYaml) {
 		t.Errorf("want error %v, got %v", errNoYaml, err)
 	}
@@ -270,20 +262,17 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 		output        string
 		specSource    string
 		serviceConfig string
-		specFormat    string
 		want          []*config.Channel
 	}{
 		{
 			name:        "library with no specification-source and service-config",
 			libraryName: "newlib",
 			output:      "output/newlib",
-			specFormat:  "protobuf",
 		},
 		{
 			name:          "library with specification-source and service-config",
 			libraryName:   "newlib",
 			output:        "output/newlib",
-			specFormat:    "protobuf",
 			specSource:    "google/cloud/storage/v1",
 			serviceConfig: "google/cloud/storage/v1/storage_v1.yaml",
 			want: []*config.Channel{
@@ -297,7 +286,6 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 			name:        "library with specification-source",
 			libraryName: "newlib",
 			output:      "output/newlib",
-			specFormat:  "protobuf",
 			specSource:  "google/cloud/storage/v1",
 			want: []*config.Channel{
 				{
@@ -309,7 +297,6 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 			name:          "library with service-config",
 			libraryName:   "newlib",
 			output:        "output/newlib",
-			specFormat:    "protobuf",
 			serviceConfig: "google/cloud/storage/v1/storage_v1.yaml",
 			want: []*config.Channel{
 				{
@@ -335,7 +322,7 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := addLibraryToLibrarianConfig(cfg, test.libraryName, test.output, test.specSource, test.serviceConfig, test.specFormat); err != nil {
+			if err := addLibraryToLibrarianConfig(cfg, test.libraryName, test.output, test.specSource, test.serviceConfig); err != nil {
 				t.Fatal(err)
 			}
 
@@ -348,22 +335,12 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 				t.Errorf("libraries count = %d, want 2", len(cfg.Libraries))
 			}
 
-			var found *config.Library
-			for _, lib := range cfg.Libraries {
-				if lib.Name == test.libraryName {
-					found = lib
-					break
-				}
-			}
+			found := findLibrary(cfg, test.libraryName)
 			if found == nil {
 				t.Fatalf("library %q not found in config", test.libraryName)
 			}
-
 			if found.Output != test.output {
 				t.Errorf("output = %q, want %q", found.Output, test.output)
-			}
-			if found.SpecificationFormat != test.specFormat {
-				t.Errorf("specification format = %q, want %q", found.SpecificationFormat, test.specFormat)
 			}
 			if found.Version != "0.1.0" {
 				t.Errorf("version = %q, want %q", found.Version, "0.1.0")
@@ -373,4 +350,13 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 			}
 		})
 	}
+}
+
+func findLibrary(cfg *config.Config, name string) *config.Library {
+	for i := range cfg.Libraries {
+		if cfg.Libraries[i].Name == name {
+			return cfg.Libraries[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
The specification format is only used for 2 libraries (compute and secretmanager-openapi) so this flag isn't necessary. If a non-protobuf source is ever needed, the librarian.yaml can be edited directly.

For https://github.com/googleapis/librarian/issues/3391