### PR TITLE
impl(rust): feature gate rpc samples

### DIFF
--- a/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+{{#ModelCodec.GenerateRpcSamples}}
 {{#IsSimple}}
 ///
 /// # Example
@@ -40,3 +41,4 @@ limitations under the License.
 /// }
 /// ```
 {{/IsSimple}}
+{{/ModelCodec.GenerateRpcSamples}}


### PR DESCRIPTION
We have a `generate-rpc-samples` codec option, but it doesn't factor into any of the templates. We want it to control this block of code.

We will want to turn it off in veneer-like things like the internal, generated pubsub dataplane.