### PR TITLE
fix(internal/yaml): omit nil and empty string slices

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -14,8 +14,6 @@
 
 package config
 
-import "github.com/googleapis/librarian/internal/yaml"
-
 // GoModule represents the Go-specific configuration for a library.
 type GoModule struct {
 	DeleteGenerationOutputPaths []string `yaml:"delete_generation_output_paths,omitempty"`
@@ -49,7 +47,7 @@ type RustDefault struct {
 // and where to output the generated code.
 type RustModule struct {
 	// DisabledRustdocWarnings is a list of rustdoc warnings to disable.
-	DisabledRustdocWarnings yaml.StringSlice `yaml:"disabled_rustdoc_warnings,omitempty"`
+	DisabledRustdocWarnings []string `yaml:"disabled_rustdoc_warnings,omitempty"`
 
 	// DocumentationOverrides contains overrides for element documentation.
 	DocumentationOverrides []RustDocumentationOverride `yaml:"documentation_overrides,omitempty"`

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -23,23 +23,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// StringSlice is a custom slice of strings that allows for fine-grained control
-// over YAML marshaling when used with the 'omitempty' tag.
-//
-// By implementing the yaml.IsZeroer interface, it ensures that:
-//  1. A nil slice is considered "zero" and is omitted from the output.
-//  2. An empty but initialized slice (e.g., []string{}) is NOT considered "zero"
-//     and is explicitly marshaled as an empty YAML sequence ([]).
-type StringSlice []string
-
-// IsZero implements the yaml.IsZeroer interface, which determines whether a
-// field should be considered "empty" when the 'omitempty' struct tag is used.
-func (s StringSlice) IsZero() bool {
-	// return true ONLY if nil (omit field)
-	// return false if empty slice (keep field)
-	return s == nil
-}
-
 // Unmarshal parses YAML data into a value of type T.
 func Unmarshal[T any](data []byte) (*T, error) {
 	var v T

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -87,19 +87,3 @@ func TestWriteError(t *testing.T) {
 		t.Error("Write() expected error for invalid path")
 	}
 }
-
-func TestStringSlice_EmptySlice(t *testing.T) {
-	strSlice := StringSlice{}
-	got := strSlice.IsZero()
-	if diff := cmp.Diff(false, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}
-
-func TestStringSlice_NilSlice(t *testing.T) {
-	var strSlice StringSlice
-	got := strSlice.IsZero()
-	if diff := cmp.Diff(true, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}


### PR DESCRIPTION
Previously, fields with empty slices (e.g. `disabled_rustdoc_warnings: []`) were included in the generated libarian.yaml. Instead, empty slices should be omitted.