### PR TITLE
fix(internal/fetch): speed up tests by avoiding DNS timeout

### DIFF
--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -117,11 +117,7 @@ func TestSha256Error(t *testing.T) {
 		},
 		{
 			name: "invalid url",
-			url: func() string {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-				server.Close()
-				return server.URL
-			}(),
+			url:  newClosedServerURL(t),
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -179,11 +175,7 @@ func TestLatestShaError(t *testing.T) {
 		},
 		{
 			name: "invalid url",
-			url: func() string {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-				server.Close()
-				return server.URL
-			}(),
+			url:  newClosedServerURL(t),
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -741,4 +733,11 @@ func TestLatestCommitAndChecksumFailure(t *testing.T) {
 			t.Error("expected an error when Sha256 fails, but got nil")
 		}
 	})
+}
+
+func newClosedServerURL(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close()
+	return server.URL
 }


### PR DESCRIPTION
The invalid URL tests were using a fake domain that caused a 5-second
DNS timeout. Instead, use a closed httptest server instead, which fails
immediately with "connection refused" while still testing the same error
handling path.

This reduces the package test time from ~12s to ~0.9s.
