### PR TITLE
fix(internal/librarian): librarian create fails on existing library

### DIFF
--- a/internal/librarian/create.go
+++ b/internal/librarian/create.go
@@ -69,10 +69,7 @@ func runCreate(ctx context.Context, name, output string, channel ...string) erro
 	}
 	// check for existing libraries, if it exists return an error
 	exists := slices.ContainsFunc(cfg.Libraries, func(lib *config.Library) bool {
-		if lib.Name == name {
-			return true
-		}
-		return false
+		return lib.Name == name
 	})
 	if exists {
 		return fmt.Errorf("%w: %s", errLibraryAlreadyExists, name)

--- a/internal/librarian/create_test.go
+++ b/internal/librarian/create_test.go
@@ -92,7 +92,7 @@ func TestCreateLibrary(t *testing.T) {
 				t.Fatalf("runCreate() failed with unexpected error: %v", err)
 			}
 
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err = yaml.Read[config.Config](librarianConfigPath)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
`librarian create` fails if the requested library already exists in the librarian configuration for that library repo.

Note: May want to consider breaking this out into a `TestCreateLibrary_Error` test so that other error modes can be more easily tested without complicating the "normal" logic. LMK if that is preferred.

Fixes #3399