### PR TITLE
test(internal/librarian/python): use t.Short for slow tests

### DIFF
--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -321,6 +321,10 @@ func TestRunPostProcessor(t *testing.T) {
 }
 
 func TestGenerateChannel(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("slow test: Python GAPIC code generation")
+	}
 
 	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "protoc-gen-python_gapic")
@@ -338,6 +342,11 @@ func TestGenerateChannel(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("slow test: Python code generation")
+	}
+
 	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "protoc-gen-python_gapic")
 	testhelper.RequireCommand(t, "python3")


### PR DESCRIPTION
Python tests take ~24 seconds to run due to the Python GAPIC generator. These tests are skipped when running `go test -short` to allow quick validation during local development.