### PR TITLE
perf(cmd): skip TestGoGenerateLibrarianDoc with -short

### DIFF
--- a/cmd/doc_generate_test.go
+++ b/cmd/doc_generate_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestGoGenerateLibrarianDoc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test: runs go generate")
+	}
 	for _, test := range []struct {
 		name    string
 		docFile string


### PR DESCRIPTION
TestGoGenerateLibrarianDoc runs go generate takes ~10s. Skip this test when running with -short for faster local development.