### PR TITLE
perf(sidekick): skip TestRustProstFromProtobuf with -short

### DIFF
--- a/internal/sidekick/sidekick/sidekick_rust_prost_test.go
+++ b/internal/sidekick/sidekick/sidekick_rust_prost_test.go
@@ -24,6 +24,9 @@ import (
 )
 
 func TestRustProstFromProtobuf(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test: Rust Prost code generation")
+	}
 	testhelper.RequireCommand(t, "cargo")
 	testhelper.RequireCommand(t, "protoc")
 	outDir := t.TempDir()


### PR DESCRIPTION
TestRustProstFromProtobuf runs Rust Prost code generation which takes ~7s. Skip this integration test when running with -short for faster local development.