### PR TITLE
test(internal/fetch): use localhost for invalid URL tests

### DIFF
--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -36,6 +36,7 @@ import (
 const (
 	testGitHubDn       = "https://localhost:12345"
 	tarballPathTrailer = "/archive/5d5b1bf126485b0e2c972bac41b376438601e266.tar.gz"
+	closedServerURL    = "https://127.0.0.1:54321"
 )
 
 func TestRepoFromTarballLink(t *testing.T) {
@@ -117,7 +118,7 @@ func TestSha256Error(t *testing.T) {
 		},
 		{
 			name: "invalid url",
-			url:  "http://127.0.0.1:54321",
+			url:  closedServerURL,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -175,7 +176,7 @@ func TestLatestShaError(t *testing.T) {
 		},
 		{
 			name: "invalid url",
-			url:  "http://127.0.0.1:54321",
+			url:  closedServerURL,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Uses `127.0.0.1:54321` for invalid URL tests instead of creating a closed httptest server, which does the equivalent.

Fix #3441