### PR TITLE
chore(internal/git): remove stutter in func names

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -96,13 +96,13 @@ func IsNewFile(ctx context.Context, gitExe, ref, name string) bool {
 	return bytes.HasPrefix(output, []byte(" create mode "))
 }
 
-// Version returns the git version.
-func Version(ctx context.Context, gitExe string) error {
+// CheckVersion checks that the git version command can run.
+func CheckVersion(ctx context.Context, gitExe string) error {
 	return command.Run(ctx, gitExe, "--version")
 }
 
-// GetRemoteURL retrieves the git remote URL.
-func GetRemoteURL(ctx context.Context, gitExe, remote string) error {
+// CheckRemoteURL checks that the git remote URL exists.
+func CheckRemoteURL(ctx context.Context, gitExe, remote string) error {
 	return command.Run(ctx, gitExe, "remote", "get-url", remote)
 }
 

--- a/internal/librarian/rust/verify_cargo_tools.go
+++ b/internal/librarian/rust/verify_cargo_tools.go
@@ -27,10 +27,10 @@ import (
 // PreFlight performs all the necessary checks before a release.
 func PreFlight(ctx context.Context, preinstalled map[string]string, remote string, cargoTools []config.Tool) error {
 	gitExe := command.GetExecutablePath(preinstalled, "git")
-	if err := git.Version(ctx, gitExe); err != nil {
+	if err := git.CheckVersion(ctx, gitExe); err != nil {
 		return err
 	}
-	if err := git.GetRemoteURL(ctx, gitExe, remote); err != nil {
+	if err := git.CheckRemoteURL(ctx, gitExe, remote); err != nil {
 		return err
 	}
 	return cargoPreFlight(ctx, command.GetExecutablePath(preinstalled, "cargo"), cargoTools)


### PR DESCRIPTION
Rename `internal/git` APIs that started with `Git` to avoid stuttering. `GitVersion` -> `CheckVersion` and `GitRemoteURL` -> `CheckRemoteURL` based on style guidance.

Fixes #3458.

Note: There were no tests for these functions.