### PR TITLE
chore(internal/git): add more tests and parallelize some

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -138,6 +138,7 @@ func TestFilesBadRef(t *testing.T) {
 }
 
 func TestFilterNoFilter(t *testing.T) {
+	t.Parallel()
 	input := []string{
 		"src/storage/src/lib.rs",
 		"src/storage/Cargo.toml",
@@ -156,6 +157,7 @@ func TestFilterNoFilter(t *testing.T) {
 }
 
 func TestFilterBasic(t *testing.T) {
+	t.Parallel()
 	input := []string{
 		"src/storage/src/lib.rs",
 		"src/storage/Cargo.toml",
@@ -184,6 +186,7 @@ func TestFilterBasic(t *testing.T) {
 }
 
 func TestFilterSomeGlobs(t *testing.T) {
+	t.Parallel()
 	input := []string{
 		"doc/howto-1.md",
 		"doc/howto-2.md",
@@ -349,5 +352,41 @@ func TestShowFile_Error(t *testing.T) {
 	}
 	if !errors.Is(err, errGitShow) {
 		t.Errorf("expected errGitShow but got %v", err)
+	}
+}
+
+func TestCheckVersion(t *testing.T) {
+	t.Parallel()
+	testhelper.RequireCommand(t, "git")
+
+	if err := CheckVersion(t.Context(), "git"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckVersion_Error(t *testing.T) {
+	t.Parallel()
+	if err := CheckVersion(t.Context(), "command_that_does_not_exist"); err == nil {
+		t.Errorf("expected an error checking git version execution, but did not get one")
+	}
+}
+
+func TestCheckRemoteURL(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+	remoteDir := testhelper.SetupRepo(t)
+	testhelper.CloneRepository(t, remoteDir)
+
+	if err := CheckRemoteURL(t.Context(), "git", testhelper.TestRemote); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckRemoteURL_Error(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+	remoteDir := testhelper.SetupRepo(t)
+	testhelper.CloneRepository(t, remoteDir)
+
+	if err := CheckRemoteURL(t.Context(), "git", "remote_that_does_not_exist"); err == nil {
+		t.Errorf("expected an error checking for a remote URL, but did not get one")
 	}
 }

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -58,6 +58,12 @@ version = "1.0.0"
 	// ReadmeContents is the contents of the [ReadmeFile] initialized in the
 	// test repo.
 	ReadmeContents = "# Empty Repo"
+
+	// TestRemote is the name of a remote source for the test repository.
+	TestRemote = "test"
+
+	// testRemoteURL is the URL set for the [TestRemote] in the test repository.
+	testRemoteURL = "https://example.com/git.git"
 )
 
 // SetupForVersionBump sets up a git repository for testing version bumping scenarios.
@@ -93,6 +99,9 @@ func configNewGitRepository(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := command.Run(t.Context(), "git", "config", "user.name", "Test Account"); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(t.Context(), "git", "remote", "add", TestRemote, testRemoteURL); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Adds tests for `internal/git` APIs `CheckVersion` and `CheckRemoteURL`.

Also adds `t.Parallel()` to those tests in this package that can be run in parallel.

Fixes #3462