### PR TITLE
refactor(internal/librarian): reduce duplicated disk reads when calling generate in create

### DIFF
--- a/internal/librarian/create.go
+++ b/internal/librarian/create.go
@@ -96,14 +96,14 @@ func runCreate(ctx context.Context, name, output string, channel ...string) erro
 }
 
 func runGenerateAndTidy(ctx context.Context, cfg *config.Config, all bool, libraryName string) error {
-	if err := runGenerate(ctx, all, libraryName); err != nil {
-		return err
-	}
 	if cfg.Sources == nil || cfg.Sources.Googleapis == nil {
 		return errNoGoogleapiSourceInfo
 	}
 	googleapisDir, err := fetchSource(ctx, cfg.Sources.Googleapis, googleapisRepo)
 	if err != nil {
+		return err
+	}
+	if err := routeGenerate(ctx, all, cfg, googleapisDir, libraryName); err != nil {
 		return err
 	}
 	for _, lib := range cfg.Libraries {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -81,6 +81,10 @@ func runGenerate(ctx context.Context, all bool, libraryName string) error {
 	if err != nil {
 		return err
 	}
+	return routeGenerate(ctx, all, cfg, googleapisDir, libraryName)
+}
+
+func routeGenerate(ctx context.Context, all bool, cfg *config.Config, googleapisDir, libraryName string) error {
 	if all {
 		return generateAll(ctx, cfg, googleapisDir)
 	}


### PR DESCRIPTION
Refactor and extracts `routeGenerate` from `runGenerate` so create can call directly and avoid yaml.Read and fetchSource

Fix #3463