### PR TITLE
feat(dart): Ability to config extra imports

### DIFF
--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -300,6 +300,13 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 			for i := range exports {
 				exports[i] = strings.TrimSpace(exports[i])
 			}
+		case key == "extra-imports":
+			// extra-imports = "dart:math;package:my_package/my_file.dart"
+			// Dart imports that should be included in the generated file.
+			extraImports := strings.FieldsFunc(definition, func(c rune) bool { return c == ';' })
+			for _, imp := range extraImports {
+				annotate.imports[strings.TrimSpace(imp)] = true
+			}
 		case key == "dependencies":
 			// dependencies = "http, googleapis_auth"
 			// A list of dependencies to add to pubspec.yaml. This can be used to add dependencies for hand-written code.

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -118,6 +118,18 @@ func TestAnnotateModel_Options(t *testing.T) {
 			},
 		},
 		{
+			map[string]string{"extra-imports": "dart:math; package:my_package/my_file.dart", "package:my_package": "^1.0.0"},
+			func(t *testing.T, am *annotateModel) {
+				codec := model.Codec.(*modelAnnotations)
+				if !slices.Contains(codec.Imports, "import 'dart:math';") {
+					t.Errorf("missing 'dart:math' in Codec.Imports, got %v", codec.Imports)
+				}
+				if !slices.Contains(codec.Imports, "import 'package:my_package/my_file.dart';") {
+					t.Errorf("missing 'package:my_package/my_file.dart' in Codec.Imports, got %v", codec.Imports)
+				}
+			},
+		},
+		{
 			map[string]string{"version": "1.2.3"},
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)


### PR DESCRIPTION
This can be used when the generated code is library containing a part and the generated code must do imports for the parts.

For example:

```
extra-imports = 'package:google_cloud_rpc/rpc.dart'
```