### PR TITLE
doc: add guidance on package naming conventions

### DIFF
--- a/doc/howwewritego.md
+++ b/doc/howwewritego.md
@@ -63,13 +63,15 @@ https://go.dev/wiki/Spelling. See
 
 ### Package Names
 
-Go uses package names to provide context. Avoid repeating the package name within a type or function name.
-- **Good**: `git.ShowFile`, `client.New`
-- **Bad**: `git.GitShowFile`, `client.NewClient`
+When naming packages, follow these two principles:
 
-Good package names describe their purpose.
-- **Good:** `command`, `fetch`
-- **Bad:** `common`, `helper`, `util`
+1.  **Avoid redundancy.** Go uses package names to provide context, so avoid repeating the package name within a type or function name.
+    - **Good**: `git.ShowFile`, `client.New`
+    - **Bad**: `git.GitShowFile`, `client.NewClient`
+
+2.  **Describe the purpose.** Good package names are short and descriptive. Avoid generic names.
+    - **Good:** `command`, `fetch`
+    - **Bad:** `common`, `helper`, `util`
 
 See [details](https://go.dev/doc/effective_go#package-names).
 


### PR DESCRIPTION
Update documentation to encourage naming packages based on the  functionality they provide. Discourage the use of generic catch-alls like "common", "helper", or "util" in favor of descriptive names like "command" or "fetch".