### PR TITLE
fix: veneers skipGenerate should be set to true

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -75,8 +75,8 @@ func tidyLibrary(cfg *config.Config, lib *config.Library, googleapisDir string) 
 		lib.Output = ""
 	}
 	if lib.Veneer {
-		// Veneers are never generated, so ensure skip_generate is false.
-		lib.SkipGenerate = false
+		// Veneers are never generated, so ensure skip_generate is true.
+		lib.SkipGenerate = true
 	}
 	for _, ch := range lib.Channels {
 		if isDerivableChannelPath(cfg.Language, lib.Name, ch.Path) {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -504,7 +504,7 @@ libraries:
 	if len(cfg.Libraries) != 1 {
 		t.Fatalf("expected 1 library, got %d", len(cfg.Libraries))
 	}
-	if cfg.Libraries[0].SkipGenerate {
-		t.Errorf("expected skip_generate to be false for veneer library, got true")
+	if !cfg.Libraries[0].SkipGenerate {
+		t.Errorf("expected skip_generate to be true for veneer library, got false")
 	}
 }


### PR DESCRIPTION
It looks like the inverse value was being set for skipGenerate for veneers.  If we want to skip generation, this value need to be true.

Fixes #3469 