### PR TITLE
chore: add a cloud build test to verify librarian command

### DIFF
--- a/infra/test/librarian-image-test.yaml
+++ b/infra/test/librarian-image-test.yaml
@@ -1,0 +1,58 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+steps:
+  - id: get-librarian-image-sha
+    name: bash
+    args:
+      - '-c'
+      - |
+        wget https://github.com/mikefarah/yq/releases/download/v4.48.2/yq_linux_amd64 -O /usr/local/bin/yq
+        chmod +x /usr/local/bin/yq
+        yq -r '.librarian-image-sha' internal/automation/prod/repositories.yaml > /workspace/librarian_image_sha.txt
+        cat /workspace/librarian_image_sha.txt
+  - id: test-generate
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ['get-librarian-image-sha']
+    args:
+      - -c
+      - |
+        docker run \
+          --rm \
+          us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@$(cat /workspace/librarian_image_sha.txt) \
+          generate --help
+  - id: test-release-stage
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ['get-librarian-image-sha']
+    args:
+      - -c
+      - |
+        docker run \
+          --rm \
+          us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@$(cat /workspace/librarian_image_sha.txt) \
+          release stage --help
+  - id: test-release-tag
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ['get-librarian-image-sha']
+    args:
+      - -c
+      - |
+        docker run \
+          --rm \
+          us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian@$(cat /workspace/librarian_image_sha.txt) \
+          release tag --help
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Add a presubmit check to verify the librarian image used by Automation
support `generate`, `release stage` and `release tag` commands.

Example run
[log](https://pantheon.corp.google.com/cloud-build/builds;region=global/cd048b73-e289-4e57-a777-b7546f7091da;step=1?e=RetailSupportToolLaunch::RetailSupportToolEnabled,RetailDataQualityGaLaunch::RetailDataQualityGaEnabled&mods=allow_workbench_image_override&project=librarian-dev-joewa-u0cll5).

The Cloud Build Trigger will be added separately.

For https://github.com/googleapis/librarian/issues/2813

Cherrypicked from legacy-librarian branch.

Updates #3472