### PR TITLE
chore: call testhelper.RequireCommand one time for table-driven tests

### DIFF
--- a/internal/librarian/release_test.go
+++ b/internal/librarian/release_test.go
@@ -114,7 +114,6 @@ func TestReleaseCommand(t *testing.T) {
 			wantErr: errReleaseConfigEmpty,
 		},
 	} {
-
 		t.Run(test.name, func(t *testing.T) {
 			remoteDir := testhelper.SetupRepoWithChange(t, "v1.0.0")
 			testhelper.CloneRepository(t, remoteDir)


### PR DESCRIPTION
Any place that we were calling testhelper.RequireCommand multiple times in table-driven tests we should update it to instead only call 1x per test.

Fixes #3480 