### PR TITLE
feat(internal/testdata): add Secret Manager OpenAPI v1 spec

### DIFF
--- a/internal/testdata/secretmanager_openapi_v1.json
+++ b/internal/testdata/secretmanager_openapi_v1.json
@@ -1,0 +1,3203 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Secret Manager API",
+    "description": "Stores sensitive data such as API keys, passwords, and certificates. Provides convenience while improving security.",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "https://secretmanager.googleapis.com",
+      "description": "Global Endpoint"
+    },
+    {
+      "url": "https://secretmanager.me-central2.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "me-central2"
+    },
+    {
+      "url": "https://secretmanager.me-west1.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "me-west1"
+    },
+    {
+      "url": "https://secretmanager.us-central1.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-central1"
+    },
+    {
+      "url": "https://secretmanager.us-east1.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-east1"
+    },
+    {
+      "url": "https://secretmanager.us-central2.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-central2"
+    },
+    {
+      "url": "https://secretmanager.us-west1.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-west1"
+    },
+    {
+      "url": "https://secretmanager.us-west2.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-west2"
+    },
+    {
+      "url": "https://secretmanager.us-west3.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-west3"
+    },
+    {
+      "url": "https://secretmanager.us-west4.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-west4"
+    },
+    {
+      "url": "https://secretmanager.us-east4.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-east4"
+    },
+    {
+      "url": "https://secretmanager.us-east5.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-east5"
+    },
+    {
+      "url": "https://secretmanager.us-south1.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "us-south1"
+    },
+    {
+      "url": "https://secretmanager.europe-west3.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "europe-west3"
+    },
+    {
+      "url": "https://secretmanager.europe-west8.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "europe-west8"
+    },
+    {
+      "url": "https://secretmanager.europe-west9.rep.googleapis.com/",
+      "description": "Regional Endpoint",
+      "x-google-endpoint-location": "europe-west9"
+    }
+  ],
+  "paths": {
+    "/v1/projects/{project}/locations": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "ListLocations",
+        "description": "Lists information about the supported locations for this service.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "description": "A filter to narrow down results to a preferred subset.\nThe filtering language accepts strings like `\"displayName=tokyo\"`, and\nis documented in more detail in [AIP-160](https://google.aip.dev/160).",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "description": "The maximum number of results to return.\nIf not set, the service selects a default.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageToken",
+            "description": "A page token received from the `next_page_token` field in the response.\nSend that page token to receive the subsequent page.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListLocationsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "GetLocation",
+        "description": "Gets information about a location.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Location"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "ListSecrets",
+        "description": "Lists Secrets.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "description": "Optional. The maximum number of results to be returned in a single page. If\nset to 0, the server decides the number of results to return. If the\nnumber is greater than 25000, it is capped at 25000.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageToken",
+            "description": "Optional. Pagination token, returned earlier via\nListSecretsResponse.next_page_token.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "description": "Optional. Filter string, adhering to the rules in\n[List-operation\nfiltering](https://cloud.google.com/secret-manager/docs/filtering). List\nonly secrets matching the filter. If filter is empty, all secrets are\nlisted.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSecretsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "CreateSecret",
+        "description": "Creates a new Secret containing no SecretVersions.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretId",
+            "description": "Required. This must be unique within the project.\n\nA secret ID is a string with a maximum length of 255 characters and can\ncontain uppercase and lowercase letters, numerals, and the hyphen (`-`) and\nunderscore (`_`) characters.",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required. A Secret with initial field values.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Secret"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Secret"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "ListSecretsByProjectAndLocation",
+        "x-google-operation-name" : "ListSecrets",
+        "description": "Lists Secrets.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "description": "Optional. The maximum number of results to be returned in a single page. If\nset to 0, the server decides the number of results to return. If the\nnumber is greater than 25000, it is capped at 25000.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageToken",
+            "description": "Optional. Pagination token, returned earlier via\nListSecretsResponse.next_page_token.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "description": "Optional. Filter string, adhering to the rules in\n[List-operation\nfiltering](https://cloud.google.com/secret-manager/docs/filtering). List\nonly secrets matching the filter. If filter is empty, all secrets are\nlisted.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSecretsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "CreateSecretByProjectAndLocation",
+        "x-google-operation-name" : "CreateSecret",
+        "description": "Creates a new Secret containing no SecretVersions.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretId",
+            "description": "Required. This must be unique within the project.\n\nA secret ID is a string with a maximum length of 255 characters and can\ncontain uppercase and lowercase letters, numerals, and the hyphen (`-`) and\nunderscore (`_`) characters.",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required. A Secret with initial field values.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Secret"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Secret"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}:addVersion": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "AddSecretVersion",
+        "description": "Creates a new SecretVersion containing secret data and attaches\nit to an existing Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}:addVersion": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "AddSecretVersionByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "AddSecretVersion",
+        "description": "Creates a new SecretVersion containing secret data and attaches\nit to an existing Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "GetSecret",
+        "description": "Gets metadata for a given Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Secret"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["secretmanager"],
+        "operationId": "UpdateSecret",
+        "description": "Updates metadata of an existing Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "updateMask",
+            "description": "Required. Specifies the fields to be updated.",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^(\\s*[^,\\s.]+(\\s*[,.]\\s*[^,\\s.]+)*)?$",
+              "format": "google-fieldmask"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required. Secret with updated field values.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Secret"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Secret"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["secretmanager"],
+        "operationId": "DeleteSecret",
+        "description": "Deletes a Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "etag",
+            "description": "Optional. Etag of the Secret. The request succeeds if it matches\nthe etag of the currently stored secret object. If the etag is omitted,\nthe request succeeds.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "GetSecretByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "GetSecret",
+        "description": "Gets metadata for a given Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Secret"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["secretmanager"],
+        "operationId": "UpdateSecretByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "UpdateSecret",
+        "description": "Updates metadata of an existing Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "updateMask",
+            "description": "Required. Specifies the fields to be updated.",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^(\\s*[^,\\s.]+(\\s*[,.]\\s*[^,\\s.]+)*)?$",
+              "format": "google-fieldmask"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required. Secret with updated field values.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Secret"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Secret"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["secretmanager"],
+        "operationId": "DeleteSecretByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "DeleteSecret",
+        "description": "Deletes a Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "etag",
+            "description": "Optional. Etag of the Secret. The request succeeds if it matches\nthe etag of the currently stored secret object. If the etag is omitted,\nthe request succeeds.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}/versions": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "ListSecretVersions",
+        "description": "Lists SecretVersions. This call does not return secret\ndata.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "description": "Optional. The maximum number of results to be returned in a single page. If\nset to 0, the server decides the number of results to return. If the\nnumber is greater than 25000, it is capped at 25000.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageToken",
+            "description": "Optional. Pagination token, returned earlier via\nListSecretVersionsResponse.next_page_token][].",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "description": "Optional. Filter string, adhering to the rules in\n[List-operation\nfiltering](https://cloud.google.com/secret-manager/docs/filtering). List\nonly secret versions matching the filter. If filter is empty, all secret\nversions are listed.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSecretVersionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}/versions": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "ListSecretVersionsByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "ListSecretVersions",
+        "description": "Lists SecretVersions. This call does not return secret\ndata.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "description": "Optional. The maximum number of results to be returned in a single page. If\nset to 0, the server decides the number of results to return. If the\nnumber is greater than 25000, it is capped at 25000.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageToken",
+            "description": "Optional. Pagination token, returned earlier via\nListSecretVersionsResponse.next_page_token][].",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "description": "Optional. Filter string, adhering to the rules in\n[List-operation\nfiltering](https://cloud.google.com/secret-manager/docs/filtering). List\nonly secret versions matching the filter. If filter is empty, all secret\nversions are listed.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSecretVersionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}/versions/{version}": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "GetSecretVersion",
+        "description": "Gets metadata for a SecretVersion.\n\n`projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently\ncreated SecretVersion.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}/versions/{version}": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "GetSecretVersionByProjectAndLocationAndSecretAndVersion",
+        "x-google-operation-name" : "GetSecretVersion",
+        "description": "Gets metadata for a SecretVersion.\n\n`projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently\ncreated SecretVersion.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}/versions/{version}:access": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "AccessSecretVersion",
+        "description": "Accesses a SecretVersion. This call returns the secret data.\n\n`projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently\ncreated SecretVersion.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessSecretVersionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}/versions/{version}:access": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "AccessSecretVersionByProjectAndLocationAndSecretAndVersion",
+        "x-google-operation-name" : "AccessSecretVersion",
+        "description": "Accesses a SecretVersion. This call returns the secret data.\n\n`projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently\ncreated SecretVersion.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessSecretVersionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}/versions/{version}:disable": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "DisableSecretVersion",
+        "description": "Disables a SecretVersion.\n\nSets the state of the SecretVersion to\nDISABLED.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableSecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}/versions/{version}:disable": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "DisableSecretVersionByProjectAndLocationAndSecretAndVersion",
+        "x-google-operation-name" : "DisableSecretVersion",
+        "description": "Disables a SecretVersion.\n\nSets the state of the SecretVersion to\nDISABLED.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableSecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}/versions/{version}:enable": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "EnableSecretVersion",
+        "description": "Enables a SecretVersion.\n\nSets the state of the SecretVersion to\nENABLED.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnableSecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}/versions/{version}:enable": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "EnableSecretVersionByProjectAndLocationAndSecretAndVersion",
+        "x-google-operation-name" : "EnableSecretVersion",
+        "description": "Enables a SecretVersion.\n\nSets the state of the SecretVersion to\nENABLED.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnableSecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}/versions/{version}:destroy": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "DestroySecretVersion",
+        "description": "Destroys a SecretVersion.\n\nSets the state of the SecretVersion to\nDESTROYED and irrevocably destroys the\nsecret data.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DestroySecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}/versions/{version}:destroy": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "DestroySecretVersionByProjectAndLocationAndSecretAndVersion",
+        "x-google-operation-name" : "DestroySecretVersion",
+        "description": "Destroys a SecretVersion.\n\nSets the state of the SecretVersion to\nDESTROYED and irrevocably destroys the\nsecret data.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DestroySecretVersionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}:setIamPolicy": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "SetIamPolicy",
+        "description": "Sets the access control policy on the specified secret. Replaces any\nexisting policy.\n\nPermissions on SecretVersions are enforced according\nto the policy set on the associated Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetIamPolicyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Policy"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}:setIamPolicy": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "SetIamPolicyByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "SetIamPolicy",
+        "description": "Sets the access control policy on the specified secret. Replaces any\nexisting policy.\n\nPermissions on SecretVersions are enforced according\nto the policy set on the associated Secret.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetIamPolicyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Policy"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}:getIamPolicy": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "GetIamPolicy",
+        "description": "Gets the access control policy for a secret.\nReturns empty policy if the secret exists and does not have a policy set.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "options.requestedPolicyVersion",
+            "description": "Optional. The maximum policy version that will be used to format the\npolicy.\n\nValid values are 0, 1, and 3. Requests specifying an invalid value will be\nrejected.\n\nRequests for policies with any conditional role bindings must specify\nversion 3. Policies with no conditional role bindings may specify any valid\nvalue or leave the field unset.\n\nThe policy in the response might use the policy version that you specified,\nor it might use a lower policy version. For example, if you specify version\n3, but the policy has no conditional role bindings, the response uses\nversion 1.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Policy"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}:getIamPolicy": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "get": {
+        "tags": ["secretmanager"],
+        "operationId": "GetIamPolicyByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "GetIamPolicy",
+        "description": "Gets the access control policy for a secret.\nReturns empty policy if the secret exists and does not have a policy set.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "options.requestedPolicyVersion",
+            "description": "Optional. The maximum policy version that will be used to format the\npolicy.\n\nValid values are 0, 1, and 3. Requests specifying an invalid value will be\nrejected.\n\nRequests for policies with any conditional role bindings must specify\nversion 3. Policies with no conditional role bindings may specify any valid\nvalue or leave the field unset.\n\nThe policy in the response might use the policy version that you specified,\nor it might use a lower policy version. For example, if you specify version\n3, but the policy has no conditional role bindings, the response uses\nversion 1.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Policy"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets/{secret}:testIamPermissions": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "TestIamPermissions",
+        "description": "Returns permissions that a caller has for the specified secret.\nIf the secret does not exist, this call returns an empty set of\npermissions, not a NOT_FOUND error.\n\nNote: This operation is designed to be used for building permission-aware\nUIs and command-line tools, not for authorization checking. This operation\nmay \"fail open\" without warning.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestIamPermissionsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestIamPermissionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/locations/{location}/secrets/{secret}:testIamPermissions": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "TestIamPermissionsByProjectAndLocationAndSecret",
+        "x-google-operation-name" : "TestIamPermissions",
+        "description": "Returns permissions that a caller has for the specified secret.\nIf the secret does not exist, this call returns an empty set of\npermissions, not a NOT_FOUND error.\n\nNote: This operation is designed to be used for building permission-aware\nUIs and command-line tools, not for authorization checking. This operation\nmay \"fail open\" without warning.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestIamPermissionsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestIamPermissionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "alt": {
+        "name": "$alt",
+        "description": "Data format for response.",
+        "schema": {
+          "default": "json",
+          "enum": [
+            "json",
+            "media",
+            "proto"
+          ],
+          "x-google-enum-descriptions": [
+            "Responses with Content-Type of application/json",
+            "Media download with context-dependent Content-Type",
+            "Responses with Content-Type of application/x-protobuf"
+          ],
+          "type": "string"
+        },
+        "in": "query"
+      },
+      "callback": {
+        "name": "$callback",
+        "description": "JSONP",
+        "schema": {
+          "type": "string"
+        },
+        "in": "query"
+      },
+      "prettyPrint": {
+        "name": "$prettyPrint",
+        "description": "Returns response with indentations and line breaks.",
+        "schema": {
+          "default": "true",
+          "type": "boolean"
+        },
+        "in": "query"
+      },
+      "_.xgafv": {
+        "name": "$.xgafv",
+        "description": "V1 error format.",
+        "schema": {
+          "enum": [
+            "1",
+            "2"
+          ],
+          "x-google-enum-descriptions": [
+            "v1 error format",
+            "v2 error format"
+          ],
+          "type": "string"
+        },
+        "in": "query"
+      }
+    },
+    "securitySchemes": {
+      "google_oauth_implicit": {
+        "type": "oauth2",
+        "description": "Google Oauth 2.0 implicit authentication flow.",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "scopes": {
+              "https://www.googleapis.com/auth/cloud-platform": "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account."
+            }
+          }
+        }
+      },
+      "google_oauth_code": {
+        "type": "oauth2",
+        "description": "Google Oauth 2.0 authorizationCode authentication flow.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "tokenUrl": "https://oauth2.googleapis.com/token",
+            "refreshUrl": "https://oauth2.googleapis.com/token",
+            "scopes": {
+              "https://www.googleapis.com/auth/cloud-platform": "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account."
+            }
+          }
+        }
+      },
+      "bearer_auth": {
+        "type": "http",
+        "description": "Http bearer authentication.",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "ListLocationsResponse": {
+        "description": "The response message for Locations.ListLocations.",
+        "type": "object",
+        "properties": {
+          "locations": {
+            "description": "A list of locations that matches the specified filter in the request.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Location"
+            }
+          },
+          "nextPageToken": {
+            "description": "The standard List next-page token.",
+            "type": "string"
+          }
+        }
+      },
+      "Location": {
+        "description": "A resource that represents a Google Cloud location.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Resource name for the location, which may vary between implementations.\nFor example: `\"projects/example-project/locations/us-east1\"`",
+            "type": "string"
+          },
+          "locationId": {
+            "description": "The canonical id for this location. For example: `\"us-east1\"`.",
+            "type": "string"
+          },
+          "displayName": {
+            "description": "The friendly name for this location, typically a nearby city name.\nFor example, \"Tokyo\".",
+            "type": "string"
+          },
+          "labels": {
+            "description": "Cross-service attributes for the location. For example\n\n    {\"cloud.googleapis.com/region\": \"us-east1\"}",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "metadata": {
+            "description": "Service-specific metadata. For example the available capacity at the given\nlocation.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          }
+        }
+      },
+      "ListSecretsResponse": {
+        "description": "Response message for SecretManagerService.ListSecrets.",
+        "type": "object",
+        "properties": {
+          "secrets": {
+            "description": "The list of Secrets sorted in reverse by create_time (newest\nfirst).",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Secret"
+            }
+          },
+          "nextPageToken": {
+            "description": "A token to retrieve the next page of results. Pass this value in\nListSecretsRequest.page_token to retrieve the next page.",
+            "type": "string"
+          },
+          "totalSize": {
+            "description": "The total number of Secrets but 0 when the\nListSecretsRequest.filter field is set.",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Secret": {
+        "description": "A Secret is a logical secret whose value and versions can\nbe accessed.\n\nA Secret is made up of zero or more SecretVersions that\nrepresent the secret data.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Output only. The resource name of the Secret in the format `projects/_*_/secrets/*`.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "replication": {
+            "description": "Optional. Immutable. The replication policy of the secret data attached to the Secret.\n\nThe replication policy cannot be changed after the Secret has been created.",
+            "x-google-immutable": true,
+            "allOf": [{
+              "$ref": "#/components/schemas/Replication"
+            }]
+          },
+          "createTime": {
+            "description": "Output only. The time at which the Secret was created.",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "labels": {
+            "description": "The labels assigned to this Secret.\n\nLabel keys must be between 1 and 63 characters long, have a UTF-8 encoding\nof maximum 128 bytes, and must conform to the following PCRE regular\nexpression: `\\p{Ll}\\p{Lo}{0,62}`\n\nLabel values must be between 0 and 63 characters long, have a UTF-8\nencoding of maximum 128 bytes, and must conform to the following PCRE\nregular expression: `[\\p{Ll}\\p{Lo}\\p{N}_-]{0,63}`\n\nNo more than 64 labels can be assigned to a given resource.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "topics": {
+            "description": "Optional. A list of up to 10 Pub/Sub topics to which messages are published when\ncontrol plane operations are called on the secret or its versions.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Topic"
+            }
+          },
+          "expireTime": {
+            "description": "Optional. Timestamp in UTC when the Secret is scheduled to expire. This is\nalways provided on output, regardless of what was sent on input.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "ttl": {
+            "description": "Input only. The TTL for the Secret.",
+            "writeOnly": true,
+            "type": "string",
+            "format": "google-duration"
+          },
+          "etag": {
+            "description": "Optional. Etag of the currently stored Secret.",
+            "type": "string"
+          },
+          "rotation": {
+            "description": "Optional. Rotation policy attached to the Secret. May be excluded if there is no\nrotation policy.",
+            "allOf": [{
+              "$ref": "#/components/schemas/Rotation"
+            }]
+          },
+          "versionAliases": {
+            "description": "Optional. Mapping from version alias to version name.\n\nA version alias is a string with a maximum length of 63 characters and can\ncontain uppercase and lowercase letters, numerals, and the hyphen (`-`)\nand underscore ('_') characters. An alias string must start with a\nletter and cannot be the string 'latest' or 'NEW'.\nNo more than 50 aliases can be assigned to a given secret.\n\nVersion-Alias pairs will be viewable via GetSecret and modifiable via\nUpdateSecret. Access by alias is only be supported on\nGetSecretVersion and AccessSecretVersion.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "format": "int64"
+            }
+          },
+          "annotations": {
+            "description": "Optional. Custom metadata about the secret.\n\nAnnotations are distinct from various forms of labels.\nAnnotations exist to allow client tools to store their own state\ninformation without requiring a database.\n\nAnnotation keys must be between 1 and 63 characters long, have a UTF-8\nencoding of maximum 128 bytes, begin and end with an alphanumeric character\n([a-z0-9A-Z]), and may have dashes (-), underscores (_), dots (.), and\nalphanumerics in between these symbols.\n\nThe total size of annotation keys and values must be less than 16KiB.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "versionDestroyTtl": {
+            "description": "Optional. Secret Version TTL after destruction request\n\nThis is a part of the Delayed secret version destroy feature.\nFor secret with TTL>0, version destruction doesn't happen immediately\non calling destroy instead the version goes to a disabled state and\ndestruction happens after the TTL expires.",
+            "type": "string",
+            "format": "google-duration"
+          },
+          "customerManagedEncryption": {
+            "description": "Optional. The customer-managed encryption configuration of the Regionalised Secrets.\nIf no configuration is provided, Google-managed default encryption is used.\n\nUpdates to the Secret encryption configuration only apply to\nSecretVersions added afterwards. They do not apply\nretroactively to existing SecretVersions.",
+            "allOf": [{
+              "$ref": "#/components/schemas/CustomerManagedEncryption"
+            }]
+          }
+        }
+      },
+      "Replication": {
+        "description": "A policy that defines the replication and encryption configuration of data.",
+        "type": "object",
+        "properties": {
+          "automatic": {
+            "description": "The Secret will automatically be replicated without any restrictions.",
+            "allOf": [{
+              "$ref": "#/components/schemas/Automatic"
+            }]
+          },
+          "userManaged": {
+            "description": "The Secret will only be replicated into the locations specified.",
+            "allOf": [{
+              "$ref": "#/components/schemas/UserManaged"
+            }]
+          }
+        }
+      },
+      "Automatic": {
+        "description": "A replication policy that replicates the Secret payload without any\nrestrictions.",
+        "type": "object",
+        "properties": {
+          "customerManagedEncryption": {
+            "description": "Optional. The customer-managed encryption configuration of the Secret. If no\nconfiguration is provided, Google-managed default encryption is used.\n\nUpdates to the Secret encryption configuration only apply to\nSecretVersions added afterwards. They do not apply\nretroactively to existing SecretVersions.",
+            "allOf": [{
+              "$ref": "#/components/schemas/CustomerManagedEncryption"
+            }]
+          }
+        }
+      },
+      "CustomerManagedEncryption": {
+        "description": "Configuration for encrypting secret payloads using customer-managed\nencryption keys (CMEK).",
+        "type": "object",
+        "properties": {
+          "kmsKeyName": {
+            "description": "Required. The resource name of the Cloud KMS CryptoKey used to encrypt secret\npayloads.\n\nFor secrets using the UserManaged replication\npolicy type, Cloud KMS CryptoKeys must reside in the same location as the\nreplica location.\n\nFor secrets using the Automatic replication policy\ntype, Cloud KMS CryptoKeys must reside in `global`.\n\nThe expected format is `projects/_*_/locations/_*_/keyRings/_*_/cryptoKeys/*`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kmsKeyName"
+        ]
+      },
+      "UserManaged": {
+        "description": "A replication policy that replicates the Secret payload into the\nlocations specified in Secret.replication.user_managed.replicas",
+        "type": "object",
+        "properties": {
+          "replicas": {
+            "description": "Required. The list of Replicas for this Secret.\n\nCannot be empty.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Replica"
+            }
+          }
+        },
+        "required": [
+          "replicas"
+        ]
+      },
+      "Replica": {
+        "description": "Represents a Replica for this Secret.",
+        "type": "object",
+        "properties": {
+          "location": {
+            "description": "The canonical IDs of the location to replicate data.\nFor example: `\"us-east1\"`.",
+            "type": "string"
+          },
+          "customerManagedEncryption": {
+            "description": "Optional. The customer-managed encryption configuration of the User-Managed\nReplica. If no configuration is\nprovided, Google-managed default encryption is used.\n\nUpdates to the Secret encryption configuration only apply to\nSecretVersions added afterwards. They do not apply\nretroactively to existing SecretVersions.",
+            "allOf": [{
+              "$ref": "#/components/schemas/CustomerManagedEncryption"
+            }]
+          }
+        }
+      },
+      "Topic": {
+        "description": "A Pub/Sub topic which Secret Manager will publish to when control plane\nevents occur on this secret.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Required. The resource name of the Pub/Sub topic that will be published to, in the\nfollowing format: `projects/_*_/topics/*`. For publication to succeed, the\nSecret Manager service agent must have the `pubsub.topic.publish`\npermission on the topic. The Pub/Sub Publisher role\n(`roles/pubsub.publisher`) includes this permission.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "Rotation": {
+        "description": "The rotation time and period for a Secret. At next_rotation_time, Secret\nManager will send a Pub/Sub notification to the topics configured on the\nSecret. Secret.topics must be set to configure rotation.",
+        "type": "object",
+        "properties": {
+          "nextRotationTime": {
+            "description": "Optional. Timestamp in UTC at which the Secret is scheduled to rotate. Cannot be\nset to less than 300s (5 min) in the future and at most 3153600000s (100\nyears).\n\nnext_rotation_time MUST  be set if rotation_period is set.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "rotationPeriod": {
+            "description": "Input only. The Duration between rotation notifications. Must be in seconds\nand at least 3600s (1h) and at most 3153600000s (100 years).\n\nIf rotation_period is set, next_rotation_time must be set.\nnext_rotation_time will be advanced by this period when the service\nautomatically sends rotation notifications.",
+            "writeOnly": true,
+            "type": "string",
+            "format": "google-duration"
+          }
+        }
+      },
+      "AddSecretVersionRequest": {
+        "description": "Request message for SecretManagerService.AddSecretVersion.",
+        "type": "object",
+        "properties": {
+          "payload": {
+            "description": "Required. The secret payload of the SecretVersion.",
+            "allOf": [{
+              "$ref": "#/components/schemas/SecretPayload"
+            }]
+          }
+        },
+        "required": [
+          "payload"
+        ]
+      },
+      "SecretPayload": {
+        "description": "A secret payload resource in the Secret Manager API. This contains the\nsensitive secret payload that is associated with a SecretVersion.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The secret data. Must be no larger than 64KiB.",
+            "type": "string",
+            "format": "byte"
+          },
+          "dataCrc32c": {
+            "description": "Optional. If specified, SecretManagerService will verify the integrity of the\nreceived data on SecretManagerService.AddSecretVersion calls using\nthe crc32c checksum and store it to include in future\nSecretManagerService.AccessSecretVersion responses. If a checksum is\nnot provided in the SecretManagerService.AddSecretVersion request, the\nSecretManagerService will generate and store one for you.\n\nThe CRC32C value is encoded as a Int64 for compatibility, and can be\nsafely downconverted to uint32 in languages that support this type.\nhttps://cloud.google.com/apis/design/design_patterns#integer_types",
+            "type": "string",
+            "format": "int64"
+          }
+        }
+      },
+      "SecretVersion": {
+        "description": "A secret version resource in the Secret Manager API.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Output only. The resource name of the SecretVersion in the\nformat `projects/_*_/secrets/_*_/versions/*`.\n\nSecretVersion IDs in a Secret start at 1 and\nare incremented for each subsequent version of the secret.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "createTime": {
+            "description": "Output only. The time at which the SecretVersion was created.",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "destroyTime": {
+            "description": "Output only. The time this SecretVersion was destroyed.\nOnly present if state is\nDESTROYED.",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "state": {
+            "description": "Output only. The current state of the SecretVersion.",
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Not specified. This value is unused and invalid.",
+              "The SecretVersion may be accessed.",
+              "The SecretVersion may not be accessed, but the secret data\nis still available and can be placed back into the ENABLED\nstate.",
+              "The SecretVersion is destroyed and the secret data is no longer\nstored. A version may not leave this state once entered."
+            ],
+            "enum": [
+              "STATE_UNSPECIFIED",
+              "ENABLED",
+              "DISABLED",
+              "DESTROYED"
+            ]
+          },
+          "replicationStatus": {
+            "description": "The replication status of the SecretVersion.",
+            "allOf": [{
+              "$ref": "#/components/schemas/ReplicationStatus"
+            }]
+          },
+          "etag": {
+            "description": "Output only. Etag of the currently stored SecretVersion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "clientSpecifiedPayloadChecksum": {
+            "description": "Output only. True if payload checksum specified in SecretPayload object has been\nreceived by SecretManagerService on\nSecretManagerService.AddSecretVersion.",
+            "readOnly": true,
+            "type": "boolean"
+          },
+          "scheduledDestroyTime": {
+            "description": "Optional. Output only. Scheduled destroy time for secret version.\nThis is a part of the Delayed secret version destroy feature. For a\nSecret with a valid version destroy TTL, when a secert version is\ndestroyed, version is moved to disabled state and it is scheduled for\ndestruction Version is destroyed only after the scheduled_destroy_time.",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "customerManagedEncryption": {
+            "description": "Output only. The customer-managed encryption status of the SecretVersion. Only\npopulated if customer-managed encryption is used and Secret is\na Regionalised Secret.",
+            "readOnly": true,
+            "allOf": [{
+              "$ref": "#/components/schemas/CustomerManagedEncryptionStatus"
+            }]
+          }
+        }
+      },
+      "ReplicationStatus": {
+        "description": "The replication status of a SecretVersion.",
+        "type": "object",
+        "properties": {
+          "automatic": {
+            "description": "Describes the replication status of a SecretVersion with\nautomatic replication.\n\nOnly populated if the parent Secret has an automatic replication\npolicy.",
+            "allOf": [{
+              "$ref": "#/components/schemas/AutomaticStatus"
+            }]
+          },
+          "userManaged": {
+            "description": "Describes the replication status of a SecretVersion with\nuser-managed replication.\n\nOnly populated if the parent Secret has a user-managed replication\npolicy.",
+            "allOf": [{
+              "$ref": "#/components/schemas/UserManagedStatus"
+            }]
+          }
+        }
+      },
+      "AutomaticStatus": {
+        "description": "The replication status of a SecretVersion using automatic replication.\n\nOnly populated if the parent Secret has an automatic replication\npolicy.",
+        "type": "object",
+        "properties": {
+          "customerManagedEncryption": {
+            "description": "Output only. The customer-managed encryption status of the SecretVersion. Only\npopulated if customer-managed encryption is used.",
+            "readOnly": true,
+            "allOf": [{
+              "$ref": "#/components/schemas/CustomerManagedEncryptionStatus"
+            }]
+          }
+        }
+      },
+      "CustomerManagedEncryptionStatus": {
+        "description": "Describes the status of customer-managed encryption.",
+        "type": "object",
+        "properties": {
+          "kmsKeyVersionName": {
+            "description": "Required. The resource name of the Cloud KMS CryptoKeyVersion used to encrypt the\nsecret payload, in the following format:\n`projects/_*_/locations/_*_/keyRings/_*_/cryptoKeys/_*_/versions/*`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kmsKeyVersionName"
+        ]
+      },
+      "UserManagedStatus": {
+        "description": "The replication status of a SecretVersion using user-managed\nreplication.\n\nOnly populated if the parent Secret has a user-managed replication\npolicy.",
+        "type": "object",
+        "properties": {
+          "replicas": {
+            "description": "Output only. The list of replica statuses for the SecretVersion.",
+            "readOnly": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReplicaStatus"
+            }
+          }
+        }
+      },
+      "ReplicaStatus": {
+        "description": "Describes the status of a user-managed replica for the SecretVersion.",
+        "type": "object",
+        "properties": {
+          "location": {
+            "description": "Output only. The canonical ID of the replica location.\nFor example: `\"us-east1\"`.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "customerManagedEncryption": {
+            "description": "Output only. The customer-managed encryption status of the SecretVersion. Only\npopulated if customer-managed encryption is used.",
+            "readOnly": true,
+            "allOf": [{
+              "$ref": "#/components/schemas/CustomerManagedEncryptionStatus"
+            }]
+          }
+        }
+      },
+      "Empty": {
+        "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }",
+        "type": "object"
+      },
+      "ListSecretVersionsResponse": {
+        "description": "Response message for SecretManagerService.ListSecretVersions.",
+        "type": "object",
+        "properties": {
+          "versions": {
+            "description": "The list of SecretVersions sorted in reverse by\ncreate_time (newest first).",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SecretVersion"
+            }
+          },
+          "nextPageToken": {
+            "description": "A token to retrieve the next page of results. Pass this value in\nListSecretVersionsRequest.page_token to retrieve the next page.",
+            "type": "string"
+          },
+          "totalSize": {
+            "description": "The total number of SecretVersions but 0 when the\nListSecretsRequest.filter field is set.",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "AccessSecretVersionResponse": {
+        "description": "Response message for SecretManagerService.AccessSecretVersion.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The resource name of the SecretVersion in the format\n`projects/_*_/secrets/_*_/versions/*` or\n`projects/_*_/locations/_*_/secrets/_*_/versions/*`.",
+            "type": "string"
+          },
+          "payload": {
+            "description": "Secret payload",
+            "allOf": [{
+              "$ref": "#/components/schemas/SecretPayload"
+            }]
+          }
+        }
+      },
+      "DisableSecretVersionRequest": {
+        "description": "Request message for SecretManagerService.DisableSecretVersion.",
+        "type": "object",
+        "properties": {
+          "etag": {
+            "description": "Optional. Etag of the SecretVersion. The request succeeds if it matches\nthe etag of the currently stored secret version object. If the etag is\nomitted, the request succeeds.",
+            "type": "string"
+          }
+        }
+      },
+      "EnableSecretVersionRequest": {
+        "description": "Request message for SecretManagerService.EnableSecretVersion.",
+        "type": "object",
+        "properties": {
+          "etag": {
+            "description": "Optional. Etag of the SecretVersion. The request succeeds if it matches\nthe etag of the currently stored secret version object. If the etag is\nomitted, the request succeeds.",
+            "type": "string"
+          }
+        }
+      },
+      "DestroySecretVersionRequest": {
+        "description": "Request message for SecretManagerService.DestroySecretVersion.",
+        "type": "object",
+        "properties": {
+          "etag": {
+            "description": "Optional. Etag of the SecretVersion. The request succeeds if it matches\nthe etag of the currently stored secret version object. If the etag is\nomitted, the request succeeds.",
+            "type": "string"
+          }
+        }
+      },
+      "SetIamPolicyRequest": {
+        "description": "Request message for `SetIamPolicy` method.",
+        "type": "object",
+        "properties": {
+          "policy": {
+            "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of\nthe policy is limited to a few 10s of KB. An empty policy is a\nvalid policy but certain Google Cloud services (such as Projects)\nmight reject them.",
+            "allOf": [{
+              "$ref": "#/components/schemas/Policy"
+            }]
+          },
+          "updateMask": {
+            "description": "OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only\nthe fields in the mask will be modified. If no mask is provided, the\nfollowing default mask is used:\n\n`paths: \"bindings, etag\"`",
+            "type": "string",
+            "pattern": "^(\\s*[^,\\s.]+(\\s*[,.]\\s*[^,\\s.]+)*)?$",
+            "format": "google-fieldmask"
+          }
+        }
+      },
+      "Policy": {
+        "description": "An Identity and Access Management (IAM) policy, which specifies access\ncontrols for Google Cloud resources.\n\n\nA `Policy` is a collection of `bindings`. A `binding` binds one or more\n`members`, or principals, to a single `role`. Principals can be user\naccounts, service accounts, Google groups, and domains (such as G Suite). A\n`role` is a named list of permissions; each `role` can be an IAM predefined\nrole or a user-created custom role.\n\nFor some types of Google Cloud resources, a `binding` can also specify a\n`condition`, which is a logical expression that allows access to a resource\nonly if the expression evaluates to `true`. A condition can add constraints\nbased on attributes of the request, the resource, or both. To learn which\nresources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).\n\n**JSON example:**\n\n```\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/resourcemanager.organizationAdmin\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-project-id@appspot.gserviceaccount.com\"\n          ]\n        },\n        {\n          \"role\": \"roles/resourcemanager.organizationViewer\",\n          \"members\": [\n            \"user:eve@example.com\"\n          ],\n          \"condition\": {\n            \"title\": \"expirable access\",\n            \"description\": \"Does not grant access after Sep 2020\",\n            \"expression\": \"request.time < timestamp('2020-10-01T00:00:00.000Z')\",\n          }\n        }\n      ],\n      \"etag\": \"BwWWja0YfJA=\",\n      \"version\": 3\n    }\n```\n\n**YAML example:**\n\n```\n    bindings:\n    - members:\n      - user:mike@example.com\n      - group:admins@example.com\n      - domain:google.com\n      - serviceAccount:my-project-id@appspot.gserviceaccount.com\n      role: roles/resourcemanager.organizationAdmin\n    - members:\n      - user:eve@example.com\n      role: roles/resourcemanager.organizationViewer\n      condition:\n        title: expirable access\n        description: Does not grant access after Sep 2020\n        expression: request.time < timestamp('2020-10-01T00:00:00.000Z')\n    etag: BwWWja0YfJA=\n    version: 3\n```\n\nFor a description of IAM and its features, see the\n[IAM documentation](https://cloud.google.com/iam/docs/).",
+        "type": "object",
+        "properties": {
+          "version": {
+            "description": "Specifies the format of the policy.\n\nValid values are `0`, `1`, and `3`. Requests that specify an invalid value\nare rejected.\n\nAny operation that affects conditional role bindings must specify version\n`3`. This requirement applies to the following operations:\n\n* Getting a policy that includes a conditional role binding\n* Adding a conditional role binding to a policy\n* Changing a conditional role binding in a policy\n* Removing any role binding, with or without a condition, from a policy\n  that includes conditions\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.\n\nIf a policy does not include any conditions, operations on that policy may\nspecify any valid version or leave the field unset.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "bindings": {
+            "description": "Associates a list of `members`, or principals, with a `role`. Optionally,\nmay specify a `condition` that determines how and when the `bindings` are\napplied. Each of the `bindings` must contain at least one principal.\n\nThe `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250\nof these principals can be Google groups. Each occurrence of a principal\ncounts towards these limits. For example, if the `bindings` grant 50\ndifferent roles to `user:alice@example.com`, and not to any other\nprincipal, then you can add another 1,450 principals to the `bindings` in\nthe `Policy`.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binding"
+            }
+          },
+          "auditConfigs": {
+            "description": "Specifies cloud audit logging configuration for this policy.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditConfig"
+            }
+          },
+          "etag": {
+            "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.",
+            "type": "string",
+            "format": "byte"
+          }
+        }
+      },
+      "Binding": {
+        "description": "Associates `members`, or principals, with a `role`.",
+        "type": "object",
+        "properties": {
+          "role": {
+            "description": "Role that is assigned to the list of `members`, or principals.\nFor example, `roles/viewer`, `roles/editor`, or `roles/owner`.\n\nFor an overview of the IAM roles and permissions, see the\n[IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For\na list of the available pre-defined roles, see\n[here](https://cloud.google.com/iam/docs/understanding-roles).",
+            "type": "string"
+          },
+          "members": {
+            "description": "Specifies the principals requesting access for a Google Cloud resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n   Does not include identities that come from external identity providers\n   (IdPs) through identity federation.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@example.com` .\n\n\n* `serviceAccount:{emailid}`: An email address that represents a Google\n   service account. For example,\n   `my-other-app@appspot.gserviceaccount.com`.\n\n* `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An\n   identifier for a\n   [Kubernetes service\n   account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts).\n   For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n\n* `domain:{domain}`: The G Suite domain (primary) that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n\n\n\n* `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`:\n  A single identity in a workforce identity pool.\n\n* `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`:\n  All workforce identities in a group.\n\n* `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`:\n  All workforce identities with a specific attribute value.\n\n* `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`:\n  All identities in a workforce identity pool.\n\n* `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`:\n  A single identity in a workload identity pool.\n\n* `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`:\n  A workload identity pool group.\n\n* `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`:\n  All identities in a workload identity pool with a certain attribute.\n\n* `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`:\n  All identities in a workload identity pool.\n\n* `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a user that has been recently deleted. For\n   example, `alice@example.com?uid=123456789012345678901`. If the user is\n   recovered, this value reverts to `user:{emailid}` and the recovered user\n   retains the role in the binding.\n\n* `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus\n   unique identifier) representing a service account that has been recently\n   deleted. For example,\n   `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.\n   If the service account is undeleted, this value reverts to\n   `serviceAccount:{emailid}` and the undeleted service account retains the\n   role in the binding.\n\n* `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a Google group that has been recently\n   deleted. For example, `admins@example.com?uid=123456789012345678901`. If\n   the group is recovered, this value reverts to `group:{emailid}` and the\n   recovered group retains the role in the binding.\n\n* `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`:\n  Deleted single identity in a workforce identity pool. For example,\n  `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "condition": {
+            "description": "The condition that is associated with this binding.\n\nIf the condition evaluates to `true`, then this binding applies to the\ncurrent request.\n\nIf the condition evaluates to `false`, then this binding does not apply to\nthe current request. However, a different role binding might grant the same\nrole to one or more of the principals in this binding.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+            "allOf": [{
+              "$ref": "#/components/schemas/Expr"
+            }]
+          }
+        }
+      },
+      "Expr": {
+        "description": "Represents a textual expression in the Common Expression Language (CEL)\nsyntax. CEL is a C-like expression language. The syntax and semantics of CEL\nare documented at https://github.com/google/cel-spec.\n\nExample (Comparison):\n\n    title: \"Summary size limit\"\n    description: \"Determines if a summary is less than 100 chars\"\n    expression: \"document.summary.size() < 100\"\n\nExample (Equality):\n\n    title: \"Requestor is owner\"\n    description: \"Determines if requestor is the document owner\"\n    expression: \"document.owner == request.auth.claims.email\"\n\nExample (Logic):\n\n    title: \"Public documents\"\n    description: \"Determine whether the document should be publicly visible\"\n    expression: \"document.type != 'private' && document.type != 'internal'\"\n\nExample (Data Manipulation):\n\n    title: \"Notification string\"\n    description: \"Create a notification string with a timestamp.\"\n    expression: \"'New message received at ' + string(document.create_time)\"\n\nThe exact variables and functions that may be referenced within an expression\nare determined by the service that evaluates it. See the service\ndocumentation for additional information.",
+        "type": "object",
+        "properties": {
+          "expression": {
+            "description": "Textual representation of an expression in Common Expression Language\nsyntax.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Optional. Title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Optional. Description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
+            "type": "string"
+          },
+          "location": {
+            "description": "Optional. String indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
+            "type": "string"
+          }
+        }
+      },
+      "AuditConfig": {
+        "description": "Specifies the audit configuration for a service.\nThe configuration determines which permission types are logged, and what\nidentities, if any, are exempted from logging.\nAn AuditConfig must have one or more AuditLogConfigs.\n\nIf there are AuditConfigs for both `allServices` and a specific service,\nthe union of the two AuditConfigs is used for that service: the log_types\nspecified in each AuditConfig are enabled, and the exempted_members in each\nAuditLogConfig are exempted.\n\nExample Policy with multiple AuditConfigs:\n\n    {\n      \"audit_configs\": [\n        {\n          \"service\": \"allServices\",\n          \"audit_log_configs\": [\n            {\n              \"log_type\": \"DATA_READ\",\n              \"exempted_members\": [\n                \"user:jose@example.com\"\n              ]\n            },\n            {\n              \"log_type\": \"DATA_WRITE\"\n            },\n            {\n              \"log_type\": \"ADMIN_READ\"\n            }\n          ]\n        },\n        {\n          \"service\": \"sampleservice.googleapis.com\",\n          \"audit_log_configs\": [\n            {\n              \"log_type\": \"DATA_READ\"\n            },\n            {\n              \"log_type\": \"DATA_WRITE\",\n              \"exempted_members\": [\n                \"user:aliya@example.com\"\n              ]\n            }\n          ]\n        }\n      ]\n    }\n\nFor sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ\nlogging. It also exempts `jose@example.com` from DATA_READ logging, and\n`aliya@example.com` from DATA_WRITE logging.",
+        "type": "object",
+        "properties": {
+          "service": {
+            "description": "Specifies a service that will be enabled for audit logging.\nFor example, `storage.googleapis.com`, `cloudsql.googleapis.com`.\n`allServices` is a special value that covers all services.",
+            "type": "string"
+          },
+          "auditLogConfigs": {
+            "description": "The configuration for logging of each type of permission.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditLogConfig"
+            }
+          }
+        }
+      },
+      "AuditLogConfig": {
+        "description": "Provides the configuration for logging a type of permissions.\nExample:\n\n    {\n      \"audit_log_configs\": [\n        {\n          \"log_type\": \"DATA_READ\",\n          \"exempted_members\": [\n            \"user:jose@example.com\"\n          ]\n        },\n        {\n          \"log_type\": \"DATA_WRITE\"\n        }\n      ]\n    }\n\nThis enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting\njose@example.com from DATA_READ logging.",
+        "type": "object",
+        "properties": {
+          "logType": {
+            "description": "The log type that this config enables.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Default case. Should never be this.",
+              "Admin reads. Example: CloudIAM getIamPolicy",
+              "Data writes. Example: CloudSQL Users create",
+              "Data reads. Example: CloudSQL Users list"
+            ],
+            "enum": [
+              "LOG_TYPE_UNSPECIFIED",
+              "ADMIN_READ",
+              "DATA_WRITE",
+              "DATA_READ"
+            ]
+          },
+          "exemptedMembers": {
+            "description": "Specifies the identities that do not cause logging for this type of\npermission.\nFollows the same format of Binding.members.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TestIamPermissionsRequest": {
+        "description": "Request message for `TestIamPermissions` method.",
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "description": "The set of permissions to check for the `resource`. Permissions with\nwildcards (such as `*` or `storage.*`) are not allowed. For more\ninformation see\n[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TestIamPermissionsResponse": {
+        "description": "Response message for `TestIamPermissions` method.",
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "description": "A subset of `TestPermissionsRequest.permissions` that the caller is\nallowed.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+,
+  "externalDocs": {
+    "description": "Find more info here.",
+    "url": "https://cloud.google.com/secret-manager/"
+  }
+}


### PR DESCRIPTION
Copy `secretmanager_openapi_v1.json` from googleapis/google-cloud-rust.

This will be used as test input for the OpenAPI implementation in Librarian.