### PR TITLE
fix(sidekick/rust): avoid running samples using ADC

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -30,7 +30,7 @@ pub mod {{Codec.ModuleName}} {
     /// A builder for [{{Codec.Name}}][crate::client::{{Codec.Name}}].
     ///
     /// ```
-    /// # tokio_test::block_on(async {
+    /// # async fn sample() -> gax::client_builder::Result<()> {
     /// # use {{Model.Codec.PackageNamespace}}::*;
     /// # use builder::{{Codec.ModuleName}}::ClientBuilder;
     /// # use client::{{Codec.Name}};
@@ -38,7 +38,7 @@ pub mod {{Codec.ModuleName}} {
     /// let client = builder
     ///     .with_endpoint("https://{{Model.Codec.DefaultHost}}")
     ///     .build().await?;
-    /// # gax::client_builder::Result::<()>::Ok(()) });
+    /// # Ok(()) }
     /// ```
     pub type ClientBuilder =
         gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
@@ -79,10 +79,9 @@ pub mod {{Codec.ModuleName}} {
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}] calls.
     ///
     /// # Example
-    /// ```no_run
-    /// # use {{Model.Codec.PackageNamespace}}::builder;
-    /// use builder::{{Service.Codec.ModuleName}}::{{Codec.BuilderName}};
-    /// # tokio_test::block_on(async {
+    /// ```
+    /// # use {{Model.Codec.PackageNamespace}}::builder::{{Service.Codec.ModuleName}}::{{Codec.BuilderName}};
+    /// # async fn sample() -> gax::Result<()> {
     {{#OperationInfo}}
     /// use lro::Poller;
     ///
@@ -105,7 +104,7 @@ pub mod {{Codec.ModuleName}} {
     /// let response = builder.send().await?;
     {{/Pagination}}
     {{/OperationInfo}}
-    /// # gax::Result::<()>::Ok(()) });
+    /// # Ok(()) }
     ///
     /// fn prepare_request_builder() -> {{Codec.BuilderName}} {
     ///   # panic!();

--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -30,11 +30,11 @@ limitations under the License.
 ///
 /// # Example
 /// ```
-/// # tokio_test::block_on(async {
+/// # async fn sample() -> gax::client_builder::Result<()> {
 /// # use {{Model.Codec.PackageNamespace}}::client::{{Codec.Name}};
 /// let client = {{Codec.Name}}::builder().build().await?;
 /// // use `client` to make requests to the {{Codec.APITitle}}.
-/// # gax::client_builder::Result::<()>::Ok(()) });
+/// # Ok(()) }
 /// ```
 ///
 /// # Service Description
@@ -90,10 +90,10 @@ impl {{Codec.Name}} {
     /// Returns a builder for [{{Codec.Name}}].
     ///
     /// ```
-    /// # tokio_test::block_on(async {
+    /// # async fn sample() -> gax::client_builder::Result<()> {
     /// # use {{Model.Codec.PackageNamespace}}::client::{{Codec.Name}};
     /// let client = {{Codec.Name}}::builder().build().await?;
-    /// # gax::client_builder::Result::<()>::Ok(()) });
+    /// # Ok(()) }
     /// ```
     pub fn builder() -> super::builder::{{Codec.ModuleName}}::ClientBuilder {
         gax::client_builder::internal::new_builder(super::builder::{{Codec.ModuleName}}::client::Factory)

--- a/internal/sidekick/rust/templates/storage/client.rs.mustache
+++ b/internal/sidekick/rust/templates/storage/client.rs.mustache
@@ -23,11 +23,11 @@ use crate::control::client::*;
 impl StorageControl {
     /// Returns a builder for [StorageControl].
     ///
-    /// ```no_run
-    /// # tokio_test::block_on(async {
+    /// ```
+    /// # async fn sample() -> anyhow::Result<()> {
     /// # use google_cloud_storage::client::StorageControl;
     /// let client = StorageControl::builder().build().await?;
-    /// # gax::client_builder::Result::<()>::Ok(()) });
+    /// # Ok(()) }
     /// ```
     pub fn builder() -> ClientBuilder {
         gax::client_builder::internal::new_builder(client_builder::Factory)


### PR DESCRIPTION
Some of the code samples use ADC. We don't want to run them because (a) they are slow, and (b) once the cryptor providers become optional they will panic.