### PR TITLE
fix(librarian/rust): Sample generation flags are propagated all the way

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -42,6 +42,9 @@ type RustDefault struct {
 
 	// GenerateSetterSamples indicates whether to generate setter samples.
 	GenerateSetterSamples string `yaml:"generate_setter_samples,omitempty"`
+
+	// GenerateRpcSamples indicates whether to generate RPC samples.
+	GenerateRpcSamples string `yaml:"generate_rpc_samples,omitempty"`
 }
 
 // RustModule defines a generation target within a veneer crate.
@@ -59,7 +62,10 @@ type RustModule struct {
 	ExtendGrpcTransport bool `yaml:"extend_grpc_transport,omitempty"`
 
 	// GenerateSetterSamples indicates whether to generate setter samples.
-	GenerateSetterSamples bool `yaml:"generate_setter_samples,omitempty"`
+	GenerateSetterSamples string `yaml:"generate_setter_samples,omitempty"`
+
+	// GenerateRpcSamples indicates whether to generate RPC samples.
+	GenerateRpcSamples string `yaml:"generate_rpc_samples,omitempty"`
 
 	// HasVeneer indicates whether this module has a handwritten wrapper.
 	HasVeneer bool `yaml:"has_veneer,omitempty"`
@@ -159,9 +165,6 @@ type RustCrate struct {
 
 	// IncludeGrpcOnlyMethods indicates whether to include gRPC-only methods.
 	IncludeGrpcOnlyMethods bool `yaml:"include_grpc_only_methods,omitempty"`
-
-	// GenerateRpcSamples indicates whether to generate RPC samples.
-	GenerateRpcSamples bool `yaml:"generate_rpc_samples,omitempty"`
 
 	// PostProcessProtos indicates whether to post-process protos.
 	PostProcessProtos string `yaml:"post_process_protos,omitempty"`

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -56,6 +56,17 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Rust.GenerateSetterSamples == "" {
 		lib.Rust.GenerateSetterSamples = d.Rust.GenerateSetterSamples
 	}
+	if lib.Rust.GenerateRpcSamples == "" {
+		lib.Rust.GenerateRpcSamples = d.Rust.GenerateRpcSamples
+	}
+	for _, mod := range lib.Rust.Modules {
+		if mod.GenerateSetterSamples == "" {
+			mod.GenerateSetterSamples = lib.Rust.GenerateSetterSamples
+		}
+		if mod.GenerateRpcSamples == "" {
+			mod.GenerateRpcSamples = lib.Rust.GenerateRpcSamples
+		}
+	}
 	return lib
 }
 

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -93,6 +93,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 			},
 			DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 			GenerateSetterSamples:   "true",
+			GenerateRpcSamples:      "true",
 		},
 	}
 	for _, test := range []struct {
@@ -102,7 +103,11 @@ func TestFillDefaults_Rust(t *testing.T) {
 	}{
 		{
 			name: "fills rust defaults",
-			lib:  &config.Library{},
+			lib: &config.Library{
+				Rust: &config.RustCrate{
+					Modules: []*config.RustModule{{}},
+				},
+			},
 			want: &config.Library{
 				Rust: &config.RustCrate{
 					RustDefault: config.RustDefault{
@@ -112,6 +117,13 @@ func TestFillDefaults_Rust(t *testing.T) {
 						},
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "true",
+						GenerateRpcSamples:      "true",
+					},
+					Modules: []*config.RustModule{
+						{
+							GenerateSetterSamples: "true",
+							GenerateRpcSamples:    "true",
+						},
 					},
 				},
 			},
@@ -125,6 +137,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 							{Name: "custom", Package: "custom-pkg"},
 						},
 						GenerateSetterSamples: "true",
+						GenerateRpcSamples:    "true",
 					},
 				},
 			},
@@ -138,6 +151,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 						},
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "true",
+						GenerateRpcSamples:      "true",
 					},
 				},
 			},
@@ -151,6 +165,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 							{Name: "wkt", Package: "custom-wkt"},
 						},
 						GenerateSetterSamples: "false",
+						GenerateRpcSamples:    "false",
 					},
 				},
 			},
@@ -163,6 +178,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 						},
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "false",
+						GenerateRpcSamples:      "false",
 					},
 				},
 			},
@@ -185,6 +201,39 @@ func TestFillDefaults_Rust(t *testing.T) {
 						},
 						DisabledRustdocWarnings: []string{"custom_warning"},
 						GenerateSetterSamples:   "true",
+						GenerateRpcSamples:      "true",
+					},
+				},
+			},
+		},
+		{
+			name: "module overrides defaults",
+			lib: &config.Library{
+				Rust: &config.RustCrate{
+					Modules: []*config.RustModule{
+						{
+							GenerateSetterSamples: "false",
+							GenerateRpcSamples:    "false",
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				Rust: &config.RustCrate{
+					RustDefault: config.RustDefault{
+						PackageDependencies: []*config.RustPackageDependency{
+							{Name: "wkt", Package: "google-cloud-wkt", Source: "google.protobuf"},
+							{Name: "iam_v1", Package: "google-cloud-iam-v1", Source: "google.iam.v1"},
+						},
+						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
+						GenerateSetterSamples:   "true",
+						GenerateRpcSamples:      "true",
+					},
+					Modules: []*config.RustModule{
+						{
+							GenerateSetterSamples: "false",
+							GenerateRpcSamples:    "false",
+						},
 					},
 				},
 			},

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -158,8 +158,8 @@ func buildCodec(library *config.Library) map[string]string {
 	if rust.GenerateSetterSamples != "" {
 		codec["generate-setter-samples"] = rust.GenerateSetterSamples
 	}
-	if rust.GenerateRpcSamples {
-		codec["generate-rpc-samples"] = "true"
+	if rust.GenerateRpcSamples != "" {
+		codec["generate-rpc-samples"] = rust.GenerateRpcSamples
 	}
 	if rust.NameOverrides != "" {
 		codec["name-overrides"] = rust.NameOverrides
@@ -277,8 +277,11 @@ func moduleToSidekickConfig(library *config.Library, module *config.RustModule, 
 
 func buildModuleCodec(library *config.Library, module *config.RustModule) map[string]string {
 	codec := newLibraryCodec(library)
-	if module.GenerateSetterSamples {
-		codec["generate-setter-samples"] = "true"
+	if module.GenerateSetterSamples != "" {
+		codec["generate-setter-samples"] = module.GenerateSetterSamples
+	}
+	if module.GenerateRpcSamples != "" {
+		codec["generate-rpc-samples"] = module.GenerateRpcSamples
 	}
 	if module.HasVeneer {
 		codec["has-veneer"] = "true"

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -129,6 +129,7 @@ func TestToSidekickConfig(t *testing.T) {
 					RustDefault: config.RustDefault{
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "true",
+						GenerateRpcSamples:      "true",
 					},
 					ModulePath:                "gcs",
 					PerServiceFeatures:        true,
@@ -136,7 +137,6 @@ func TestToSidekickConfig(t *testing.T) {
 					DetailedTracingAttributes: true,
 					HasVeneer:                 true,
 					RoutingRequired:           true,
-					GenerateRpcSamples:        true,
 					DisabledClippyWarnings:    []string{"too_many_arguments"},
 					DefaultFeatures:           []string{"default-feature"},
 					TemplateOverride:          "custom-template",

--- a/tool/cmd/migrate/main.go
+++ b/tool/cmd/migrate/main.go
@@ -423,6 +423,7 @@ func buildGAPIC(files []string, repoPath string) (map[string]*config.Library, er
 				PackageDependencies:     packageDeps,
 				DisabledRustdocWarnings: strToSlice(disabledRustdocWarnings, false),
 				GenerateSetterSamples:   generateSetterSamples,
+				GenerateRpcSamples:      generateRpcSamples,
 			},
 			PerServiceFeatures:        strToBool(perServiceFeatures),
 			ModulePath:                modulePath,
@@ -438,7 +439,6 @@ func buildGAPIC(files []string, repoPath string) (map[string]*config.Library, er
 			HasVeneer:                 strToBool(hasVeneer),
 			RoutingRequired:           strToBool(routingRequired),
 			IncludeGrpcOnlyMethods:    strToBool(includeGrpcOnlyMethods),
-			GenerateRpcSamples:        strToBool(generateRpcSamples),
 			PostProcessProtos:         postProcessProtos,
 			DetailedTracingAttributes: strToBool(detailedTracingAttributes),
 			DocumentationOverrides:    documentationOverrides,
@@ -609,11 +609,8 @@ func buildModules(rootDir string, repoPath string) ([]*config.RustModule, error)
 		nameOverrides := sidekick.Codec["name-overrides"]
 		postProcessProtos := sidekick.Codec["post-process-protos"]
 		templateOverride := sidekick.Codec["template-override"]
+		generateSetterSamples := sidekick.Codec["generate-setter-samples"]
 
-		generateSetterSamples, ok := sidekick.Codec["generate-setter-samples"]
-		if !ok {
-			generateSetterSamples = "true"
-		}
 		// Parse documentation overrides
 		var documentationOverrides []config.RustDocumentationOverride
 		for _, do := range sidekick.CommentOverrides {
@@ -629,7 +626,7 @@ func buildModules(rootDir string, repoPath string) ([]*config.RustModule, error)
 		}
 		module := &config.RustModule{
 			DocumentationOverrides: documentationOverrides,
-			GenerateSetterSamples:  strToBool(generateSetterSamples),
+			GenerateSetterSamples:  generateSetterSamples,
 			HasVeneer:              strToBool(hasVeneer),
 			IncludedIds:            strToSlice(includedIds, false),
 			IncludeGrpcOnlyMethods: strToBool(includeGrpcOnlyMethods),
@@ -683,7 +680,7 @@ func buildConfig(libraries map[string]*config.Library, defaults *config.Config) 
 		// Check if library has extra configuration beyond just name/api/version
 		hasExtraConfig := lib.CopyrightYear != "" ||
 			(lib.Rust != nil && (lib.Rust.PerServiceFeatures || len(lib.Rust.DisabledRustdocWarnings) > 0 ||
-				lib.Rust.GenerateSetterSamples != "" || lib.Rust.GenerateRpcSamples ||
+				lib.Rust.GenerateSetterSamples != "" || lib.Rust.GenerateRpcSamples != "" ||
 				len(lib.Rust.PackageDependencies) > 0 || len(lib.Rust.PaginationOverrides) > 0 ||
 				lib.Rust.NameOverrides != ""))
 		// Only include in libraries section if specific data needs to be retained

--- a/tool/cmd/migrate/main_test.go
+++ b/tool/cmd/migrate/main_test.go
@@ -197,6 +197,7 @@ func TestBuildGAPIC(t *testing.T) {
 						RustDefault: config.RustDefault{
 							DisabledRustdocWarnings: []string{"bare_urls", "broken_intra_doc_links", "redundant_explicit_links"},
 							GenerateSetterSamples:   "true",
+							GenerateRpcSamples:      "true",
 						},
 						PerServiceFeatures:        true,
 						ModulePath:                "crate",
@@ -212,7 +213,6 @@ func TestBuildGAPIC(t *testing.T) {
 						HasVeneer:                 true,
 						RoutingRequired:           true,
 						IncludeGrpcOnlyMethods:    true,
-						GenerateRpcSamples:        true,
 						PostProcessProtos:         "example post processing",
 						DetailedTracingAttributes: true,
 						NameOverrides:             ".google.cloud.security/publicca.v1.Storage=StorageControl",
@@ -458,7 +458,6 @@ func TestBuildVeneer(t *testing.T) {
 						Modules: []*config.RustModule{
 							{
 								DisabledRustdocWarnings: []string{},
-								GenerateSetterSamples:   true,
 								ModuleRoots:             nil,
 								HasVeneer:               true,
 								IncludedIds: []string{
@@ -478,7 +477,7 @@ func TestBuildVeneer(t *testing.T) {
 								TitleOverride:          "Cloud Firestore API",
 							},
 							{
-								GenerateSetterSamples: false,
+								GenerateSetterSamples: "false",
 								ModulePath:            "crate::generated::gapic_control::model",
 								ModuleRoots: map[string]string{
 									"project-root": ".",
@@ -523,7 +522,6 @@ func TestBuildVeneer(t *testing.T) {
 										Replace: "The service helps to manage cloud storage resources.",
 									},
 								},
-								GenerateSetterSamples:  true,
 								HasVeneer:              true,
 								IncludeGrpcOnlyMethods: true,
 								NameOverrides:          ".google.storage.v2.Storage=StorageControl",
@@ -581,9 +579,10 @@ func TestBuildVeneer(t *testing.T) {
 								ModuleRoots: map[string]string{
 									"project-root": ".",
 								},
-								Output:   "tests/common/src/generated",
-								Source:   "src/wkt/tests/protos",
-								Template: "mod",
+								Output:                "tests/common/src/generated",
+								Source:                "src/wkt/tests/protos",
+								Template:              "mod",
+								GenerateSetterSamples: "false",
 							},
 						},
 					},
@@ -597,12 +596,11 @@ func TestBuildVeneer(t *testing.T) {
 					Rust: &config.RustCrate{
 						Modules: []*config.RustModule{
 							{
-								GenerateSetterSamples: true,
-								IncludeList:           "api.proto,source_context.proto,type.proto,descriptor.proto",
-								ModulePath:            "crate",
-								Output:                "src/generated",
-								Source:                "google/protobuf",
-								Template:              "mod",
+								IncludeList: "api.proto,source_context.proto,type.proto,descriptor.proto",
+								ModulePath:  "crate",
+								Output:      "src/generated",
+								Source:      "google/protobuf",
+								Template:    "mod",
 							},
 						},
 					},
@@ -627,7 +625,6 @@ func TestBuildVeneer(t *testing.T) {
 						Modules: []*config.RustModule{
 							{
 								DisabledRustdocWarnings: []string{},
-								GenerateSetterSamples:   true,
 								ModuleRoots:             nil,
 								HasVeneer:               true,
 								IncludedIds: []string{
@@ -647,7 +644,7 @@ func TestBuildVeneer(t *testing.T) {
 								TitleOverride:          "Cloud Firestore API",
 							},
 							{
-								GenerateSetterSamples: false,
+								GenerateSetterSamples: "false",
 								ModulePath:            "crate::generated::gapic_control::model",
 								ModuleRoots: map[string]string{
 									"project-root": ".",
@@ -727,9 +724,9 @@ func TestBuildConfig(t *testing.T) {
 						RustDefault: config.RustDefault{
 							DisabledRustdocWarnings: []string{"bare_urls", "broken_intra_doc_links", "redundant_explicit_links"},
 							GenerateSetterSamples:   "true",
+							GenerateRpcSamples:      "true",
 						},
 						PerServiceFeatures: true,
-						GenerateRpcSamples: true,
 						NameOverrides:      ".google.cloud.security/publicca.v1.Storage=StorageControl",
 					},
 				},
@@ -761,9 +758,9 @@ func TestBuildConfig(t *testing.T) {
 							RustDefault: config.RustDefault{
 								DisabledRustdocWarnings: []string{"bare_urls", "broken_intra_doc_links", "redundant_explicit_links"},
 								GenerateSetterSamples:   "true",
+								GenerateRpcSamples:      "true",
 							},
 							PerServiceFeatures: true,
-							GenerateRpcSamples: true,
 							NameOverrides:      ".google.cloud.security/publicca.v1.Storage=StorageControl",
 						},
 					},
@@ -787,9 +784,9 @@ func TestBuildConfig(t *testing.T) {
 						RustDefault: config.RustDefault{
 							DisabledRustdocWarnings: []string{"bare_urls", "broken_intra_doc_links", "redundant_explicit_links"},
 							GenerateSetterSamples:   "true",
+							GenerateRpcSamples:      "true",
 						},
 						PerServiceFeatures: true,
-						GenerateRpcSamples: true,
 						NameOverrides:      ".google.cloud.orgpolicy.v1.OrgPolicy=OrgPolicyControl",
 					},
 				},
@@ -810,9 +807,9 @@ func TestBuildConfig(t *testing.T) {
 							RustDefault: config.RustDefault{
 								DisabledRustdocWarnings: []string{"bare_urls", "broken_intra_doc_links", "redundant_explicit_links"},
 								GenerateSetterSamples:   "true",
+								GenerateRpcSamples:      "true",
 							},
 							PerServiceFeatures: true,
-							GenerateRpcSamples: true,
 							NameOverrides:      ".google.cloud.orgpolicy.v1.OrgPolicy=OrgPolicyControl",
 						},
 					},


### PR DESCRIPTION
Default values for setter and RPC sample generation propagate all the way, including to Veneer modules.