### PR TITLE
refactor(internal/librarian): simplify release to match sidekick approach

### DIFF
--- a/internal/librarian/release_test.go
+++ b/internal/librarian/release_test.go
@@ -280,7 +280,7 @@ func TestRelease(t *testing.T) {
 			libConfg := &config.Library{
 				Output: test.srcPath,
 			}
-			err := releaseLibrary(t.Context(), cfg, libConfg, test.lastTag, "git", "")
+			err := releaseLibrary(t.Context(), cfg, libConfg, test.lastTag, "git")
 			if err != nil {
 				t.Fatalf("releaseLibrary() error = %v", err)
 			}
@@ -351,7 +351,7 @@ func TestReleaseAll(t *testing.T) {
 			}
 			remoteDir := testhelper.SetupRepoWithChange(t, tag)
 			testhelper.CloneRepository(t, remoteDir)
-			err := releaseAll(t.Context(), config, tag, "git", "")
+			err := releaseAll(t.Context(), config, tag, "git")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/rust/release_test.go
+++ b/internal/librarian/rust/release_test.go
@@ -40,7 +40,8 @@ const (
 
 func TestReleaseOne(t *testing.T) {
 	cfg := setupRelease(t)
-	if err := ReleaseLibrary(cfg.Libraries[0]); err != nil {
+	lib, err := ReleaseLibrary(cfg.Libraries[0])
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -113,7 +114,7 @@ func checkLibraryVersion(t *testing.T, library *config.Library, wantVersion stri
 }
 
 func TestNoCargoFile(t *testing.T) {
-	err := ReleaseLibrary(&config.Library{Version: "1.0.0", Output: "nonexistent/path"})
+	_, err := ReleaseLibrary(&config.Library{Version: "1.0.0", Output: "nonexistent/path"})
 	if err == nil {
 		t.Error("expected error when Cargo.toml doesn't exist")
 	}
@@ -160,7 +161,7 @@ func TestReleaseLibraryNoVersion(t *testing.T) {
 				Name:   libName,
 				Output: libDir,
 			}
-			if err := ReleaseLibrary(lib); err != nil {
+			if _, err := ReleaseLibrary(lib); err != nil {
 				t.Fatal(err)
 			}
 			checkLibraryVersion(t, lib, test.wantVersion)


### PR DESCRIPTION
Previously, the release process cloned the entire config and called generateLibrary to regenerate Cargo.toml and README.md from templates. This required cloning because generateLibrary filled in defaults that we didn't want written back to librarian.yaml.

This change simplifies the release flow to match the sidekick rust-release approach. Instead of regenerating files from templates, ReleaseLibrary now uses simple text manipulation to update version strings in Cargo.toml and .sidekick.toml files. README.md is not updated during release.

Additionally, ReleaseLibrary now returns (*config.Library, error) instead of just error to make the mutation explicit.

Fixes https://github.com/googleapis/librarian/issues/3511