### PR TITLE
refactor(internal/librarian): delete cloneConfig

### DIFF
--- a/internal/librarian/release.go
+++ b/internal/librarian/release.go
@@ -16,7 +16,6 @@ package librarian
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -173,11 +172,7 @@ func releaseLibrary(ctx context.Context, cfg *config.Config, libConfig *config.L
 		if err := rust.ReleaseLibrary(libConfig); err != nil {
 			return err
 		}
-		copyConfig, err := cloneConfig(cfg)
-		if err != nil {
-			return err
-		}
-		if _, err := generateLibrary(ctx, copyConfig, googleapisDir, libConfig.Name); err != nil {
+		if _, err := generateLibrary(ctx, cfg, googleapisDir, libConfig.Name); err != nil {
 			return err
 		}
 		if err := formatLibrary(ctx, cfg.Language, libConfig); err != nil {
@@ -215,16 +210,4 @@ func libraryByName(c *config.Config, name string) (*config.Library, error) {
 		}
 	}
 	return nil, errLibraryNotFound
-}
-
-func cloneConfig(orig *config.Config) (*config.Config, error) {
-	data, err := json.Marshal(orig)
-	if err != nil {
-		return nil, err
-	}
-	var copy config.Config
-	if err := json.Unmarshal(data, &copy); err != nil {
-		return nil, err
-	}
-	return &copy, nil
 }


### PR DESCRIPTION
cloneConfig was performing JSON marshaling that did not seem to have any effect and is now deleted.