### PR TITLE
perf(internal/librarian): parallelize generate command

### DIFF
--- a/internal/librarian/fake_test.go
+++ b/internal/librarian/fake_test.go
@@ -35,7 +35,7 @@ func TestGenerate(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	if _, err := generate(t.Context(), "fake", library, &config.Sources{}); err != nil {
+	if _, err := generate(t.Context(), "fake", library, "", nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/release.go
+++ b/internal/librarian/release.go
@@ -109,8 +109,21 @@ func runRelease(ctx context.Context, cmd *cli.Command) error {
 		return errNoGoogleapiSourceInfo
 	}
 
+	googleapisDir, err := fetchSource(ctx, cfg.Sources.Googleapis, googleapisRepo)
+	if err != nil {
+		return err
+	}
+	var rustSources *rust.Sources
+	if cfg.Language == languageRust {
+		rustSources, err = fetchRustSources(ctx, cfg.Sources)
+		if err != nil {
+			return err
+		}
+		rustSources.Googleapis = googleapisDir
+	}
+
 	if all {
-		if err = releaseAll(ctx, cfg, lastTag, gitExe); err != nil {
+		if err = releaseAll(ctx, cfg, lastTag, gitExe, googleapisDir, rustSources); err != nil {
 			return err
 		}
 	} else {
@@ -122,7 +135,7 @@ func runRelease(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		if err = releaseLibrary(ctx, cfg, libConfg, lastTag, gitExe); err != nil {
+		if err = releaseLibrary(ctx, cfg, libConfg, lastTag, gitExe, googleapisDir, rustSources); err != nil {
 			return err
 		}
 	}
@@ -133,7 +146,7 @@ func runRelease(ctx context.Context, cmd *cli.Command) error {
 	return RunTidyOnConfig(ctx, cfg)
 }
 
-func releaseAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string) error {
+func releaseAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string, googleapisDir string, rustSources *rust.Sources) error {
 	filesChanged, err := git.FilesChangedSince(ctx, lastTag, gitExe, cfg.Release.IgnoredChanges)
 	if err != nil {
 		return err
@@ -144,7 +157,7 @@ func releaseAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string)
 			return err
 		}
 		if shouldRelease(library, filesChanged) {
-			if err := releaseLibrary(ctx, cfg, library, lastTag, gitExe); err != nil {
+			if err := releaseLibrary(ctx, cfg, library, lastTag, gitExe, googleapisDir, rustSources); err != nil {
 				return err
 			}
 		}
@@ -168,7 +181,7 @@ func shouldRelease(library *config.Library, filesChanged []string) bool {
 	return false
 }
 
-func releaseLibrary(ctx context.Context, cfg *config.Config, libConfig *config.Library, lastTag, gitExe string) error {
+func releaseLibrary(ctx context.Context, cfg *config.Config, libConfig *config.Library, lastTag, gitExe string, googleapisDir string, rustSources *rust.Sources) error {
 	// If the language doesn't have bespoke versioning options, a default
 	// [semver.DeriveNextOptions] instance is returned.
 	opts := languageVersioningOptions[cfg.Language]
@@ -193,7 +206,7 @@ func releaseLibrary(ctx context.Context, cfg *config.Config, libConfig *config.L
 		if err := rust.ReleaseLibrary(libConfig); err != nil {
 			return err
 		}
-		if _, err := generateLibrary(ctx, cfg, libConfig.Name); err != nil {
+		if _, err := generateLibrary(ctx, cfg, libConfig.Name, googleapisDir, rustSources); err != nil {
 			return err
 		}
 		if err := formatLibrary(ctx, cfg.Language, libConfig); err != nil {

--- a/internal/librarian/release_test.go
+++ b/internal/librarian/release_test.go
@@ -329,7 +329,7 @@ func TestReleaseLibrary(t *testing.T) {
 
 			targetLibCfg := targetCfg.Libraries[0]
 			// Unused string param: lastTag.
-			err := releaseLibrary(t.Context(), targetCfg, targetLibCfg, testUnusedStringParam, "git")
+			err := releaseLibrary(t.Context(), targetCfg, targetLibCfg, testUnusedStringParam, "git", "", nil)
 			if err != nil {
 				t.Fatalf("releaseLibrary() error = %v", err)
 			}
@@ -409,7 +409,7 @@ func TestReleaseAll(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			err := releaseAll(t.Context(), targetCfg, sinceTag, "git")
+			err := releaseAll(t.Context(), targetCfg, sinceTag, "git", "", nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Improve performance for library generation by parallelizing individual library generations. This required refactoring generation so that required source materials are fetched ahead of running generate.

Fixes https://github.com/googleapis/librarian/issues/3507