### PR TITLE
feat(sidekick/rust): Generate non-LRO undelete samples

### DIFF
--- a/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
@@ -19,6 +19,9 @@ limitations under the License.
 {{#AIPStandardDeleteInfo}}
 ///         .set_{{ResourceNameRequestField.Codec.SetterName}}(resource_name)
 {{/AIPStandardDeleteInfo}}
+{{#AIPStandardUndeleteInfo}}
+///         .set_{{ResourceNameRequestField.Codec.SetterName}}(resource_name)
+{{/AIPStandardUndeleteInfo}}
 {{^IsAIPStandard}}
 ///         /* set fields */
 {{/IsAIPStandard}}

--- a/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
@@ -21,6 +21,10 @@ limitations under the License.
 ///    client: &{{Service.Codec.Name}},
 ///    resource_name: &str
 {{/AIPStandardDeleteInfo}}
+{{#AIPStandardUndeleteInfo}}
+///    client: &{{Service.Codec.Name}},
+///    resource_name: &str
+{{/AIPStandardUndeleteInfo}}
 {{^IsAIPStandard}}
 ///    client: &{{Service.Codec.Name}}
 {{/IsAIPStandard}}


### PR DESCRIPTION
This also takes into account a wildcard resource type to identify AIP standard operations.