### PR TITLE
refactor(internal): remove print statements

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -39,7 +39,6 @@ func RunWithEnv(ctx context.Context, env map[string]string, command string, arg 
 			cmd.Env = append(cmd.Env, k+"="+v)
 		}
 	}
-	fmt.Fprintf(os.Stderr, "Running: %s\n", cmd.String())
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%v: %v\n%s", cmd, err, output)
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -206,7 +206,6 @@ func generate(ctx context.Context, language string, library *config.Library, cfg
 	default:
 		return nil, fmt.Errorf("generate not implemented for %q", language)
 	}
-	fmt.Printf("✓ Successfully generated %s\n", library.Name)
 	return library, nil
 }
 


### PR DESCRIPTION
When running `librarian generate --all`, multiple statements are printed for each library, which adds noise and makes it easy to miss real errors. Remove these to keep output focused on actionable signals.