### PR TITLE
feat(cmd,internal/librarianops): create librarianops CLI

### DIFF
--- a/cmd/librarianops/main.go
+++ b/cmd/librarianops/main.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command librarianops orchestrates librarian operations across multiple repositories.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/googleapis/librarian/internal/librarianops"
+)
+
+func main() {
+	ctx := context.Background()
+	if err := librarianops.Run(ctx, os.Args...); err != nil {
+		log.Fatalf("librarianops: %v", err)
+	}
+}

--- a/internal/librarianops/librarianops.go
+++ b/internal/librarianops/librarianops.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package librarianops provides orchestration for running librarian across
+// multiple repositories.
+package librarianops
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/librarian"
+	"github.com/urfave/cli/v3"
+)
+
+const (
+	repoRust = "google-cloud-rust"
+	repoFake = "fake-repo" // used for testing
+
+	branchPrefix = "librarianops-generateall-"
+	commitTitle  = "chore: run librarian update and generate --all"
+)
+
+var supportedRepositories = map[string]bool{
+	repoRust: true,
+	repoFake: true, // used for testing
+}
+
+// Run executes the librarianops command with the given arguments.
+func Run(ctx context.Context, args ...string) error {
+	cmd := &cli.Command{
+		Name:      "librarianops",
+		Usage:     "orchestrate librarian operations across multiple repositories",
+		UsageText: "librarianops [command]",
+		Commands: []*cli.Command{
+			generateCommand(),
+		},
+	}
+	return cmd.Run(ctx, args)
+}
+
+func generateCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "generate",
+		Usage:     "generate libraries across repositories",
+		UsageText: "librarianops generate [<repo> | --all]",
+		Description: `Examples:
+  librarianops generate google-cloud-rust
+  librarianops generate --all
+  librarianops generate -C ~/workspace/google-cloud-rust google-cloud-rust
+
+Specify a repository name (e.g., google-cloud-rust) to process a single repository,
+or use --all to process all repositories.
+
+Use -C to work in a specific directory (assumes repository already exists there).
+
+For each repository, librarianops will:
+  1. Clone the repository to a temporary directory
+  2. Create a branch: librarianops-generateall-YYYY-MM-DD
+  3. Run librarian update discovery (google-cloud-rust only)
+  4. Run librarian update googleapis
+  5. Run librarian generate --all
+  6. Run cargo update --workspace (google-cloud-rust only)
+  7. Commit changes
+  8. Create a pull request (pushes branch automatically)`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "all",
+				Usage: "process all repositories",
+			},
+			&cli.StringFlag{
+				Name:  "C",
+				Usage: "work in `directory` (assumes repo exists)",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			all := cmd.Bool("all")
+			workDir := cmd.String("C")
+			repoName := ""
+			if cmd.Args().Len() > 0 {
+				repoName = cmd.Args().Get(0)
+			}
+			if all && repoName != "" {
+				return fmt.Errorf("cannot specify both <repo> and --all")
+			}
+			if !all && repoName == "" {
+				return fmt.Errorf("usage: librarianops generate [<repo> | --all]")
+			}
+			if all && workDir != "" {
+				return fmt.Errorf("cannot use -C with --all")
+			}
+			return runGenerate(ctx, all, repoName, workDir)
+		},
+	}
+}
+
+func runGenerate(ctx context.Context, all bool, repoName, repoDir string) error {
+	if all {
+		for name := range supportedRepositories {
+			if err := processRepo(ctx, name, ""); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if !supportedRepositories[repoName] {
+		return fmt.Errorf("repository %q not found in supported repositories list", repoName)
+	}
+	if err := processRepo(ctx, repoName, repoDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func processRepo(ctx context.Context, repoName, repoDir string) (err error) {
+	if repoDir == "" {
+		repoDir, err = os.MkdirTemp("", "librarianops-"+repoName+"-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp directory: %w", err)
+		}
+		defer func() {
+			cerr := os.RemoveAll(repoDir)
+			if err == nil {
+				err = cerr
+			}
+		}()
+		if err := cloneRepo(ctx, repoDir, repoName); err != nil {
+			return err
+		}
+	}
+	originalWD, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+	if err := os.Chdir(repoDir); err != nil {
+		return fmt.Errorf("failed to change directory to %s: %w", repoDir, err)
+	}
+	defer os.Chdir(originalWD)
+
+	if err := createBranch(ctx, time.Now()); err != nil {
+		return err
+	}
+	if repoName == repoRust {
+		if err := librarian.Run(ctx, "librarian", "update", "discovery"); err != nil {
+			return err
+		}
+	}
+	if err := librarian.Run(ctx, "librarian", "update", "googleapis"); err != nil {
+		return err
+	}
+	if err := librarian.Run(ctx, "librarian", "generate", "--all"); err != nil {
+		return err
+	}
+	if repoName == repoRust {
+		if err := runCargoUpdate(ctx); err != nil {
+			return err
+		}
+	}
+
+	if err := commitChanges(ctx); err != nil {
+		return err
+	}
+	if repoName != repoFake {
+		if err := createPR(ctx, repoName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cloneRepo(ctx context.Context, repoDir, repoName string) error {
+	return command.Run(ctx, "gh", "repo", "clone", fmt.Sprintf("googleapis/%s", repoName), repoDir)
+}
+
+func createBranch(ctx context.Context, now time.Time) error {
+	branchName := fmt.Sprintf("%s%s", branchPrefix, now.Format("2006-01-02"))
+	return command.Run(ctx, "git", "checkout", "-b", branchName)
+}
+
+func commitChanges(ctx context.Context) error {
+	if err := command.Run(ctx, "git", "add", "."); err != nil {
+		return err
+	}
+	return command.Run(ctx, "git", "commit", "-m", commitTitle)
+}
+
+func createPR(ctx context.Context, repoName string) error {
+	var body string
+	if repoName == repoRust {
+		body = `Update googleapis/googleapis and googleapis/discovery-artifact-manager
+to the latest commit and regenerate all client libraries.`
+	} else {
+		body = `Update googleapis/googleapis to the latest commit and regenerate all client libraries.`
+	}
+	return command.Run(ctx, "gh", "pr", "create", "--title", commitTitle, "--body", body)
+}
+
+func runCargoUpdate(ctx context.Context) error {
+	return command.Run(ctx, "cargo", "update", "--workspace")
+}

--- a/internal/librarianops/librarianops_test.go
+++ b/internal/librarianops/librarianops_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarianops
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/command"
+)
+
+func TestGenerateCommand(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := command.Run(t.Context(), "git", "init", repoDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(t.Context(), "git", "-C", repoDir, "config", "user.email", "test@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(t.Context(), "git", "-C", repoDir, "config", "user.name", "Test User"); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(t.Context(), "git", "-C", repoDir, "checkout", "-b", "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	googleapisDir := filepath.Join(wd, "..", "testdata", "googleapis")
+	configContent := fmt.Sprintf(`language: fake
+sources:
+  googleapis:
+    dir: %s
+libraries:
+  - name: test-library
+    output: output
+    channels:
+      - path: google/cloud/secretmanager/v1
+`, googleapisDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "librarian.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(t.Context(), "git", "-C", repoDir, "add", "."); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(t.Context(), "git", "-C", repoDir, "commit", "-m", "initial commit"); err != nil {
+		t.Fatal(err)
+	}
+
+	args := []string{"librarianops", "generate", "-C", repoDir, "fake-repo"}
+	if err := Run(t.Context(), args...); err != nil {
+		t.Fatal(err)
+	}
+	readmePath := filepath.Join(repoDir, "output", "README.md")
+	if _, err := os.Stat(readmePath); err != nil {
+		t.Errorf("expected README.md to be generated: %v", err)
+	}
+}
+
+func TestGenerateCommand_Errors(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "both repo and all flag",
+			args: []string{"librarianops", "generate", "--all", "fake-repo"},
+		},
+		{
+			name: "neither repo nor all flag",
+			args: []string{"librarianops", "generate"},
+		},
+		{
+			name: "all flag with C flag",
+			args: []string{"librarianops", "generate", "--all", "-C", "/tmp/foo"},
+		},
+		{
+			name: "unsupported repo",
+			args: []string{"librarianops", "generate", "unsupported-repo"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := Run(t.Context(), test.args...)
+			if err == nil {
+				t.Errorf("expected error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce an initial librarianops CLI to support scaling Librarian operations across multiple repositories.

The CLI currently supports `librarian generate` for google-cloud-rust, following the workflow described in:
https://github.com/googleapis/google-cloud-rust/blob/main/doc/contributor/howto-guide-generated-code-maintenance.md

It also supports a fake repo for testing.

For https://github.com/googleapis/librarian/issues/3605