### PR TITLE
fix(internal/legacylibrarian): change config file name back to what it was

### DIFF
--- a/internal/legacylibrarian/legacylibrarian/librarian_test.go
+++ b/internal/legacylibrarian/legacylibrarian/librarian_test.go
@@ -234,7 +234,7 @@ func newTestGitRepo(t *testing.T) legacygitrepo.Repository {
 				APIs: []*legacyconfig.API{
 					{
 						Path:          "some/api",
-						ServiceConfig: "api_legacyconfig.yaml",
+						ServiceConfig: "api_config.yaml",
 						Status:        legacyconfig.StatusExisting,
 					},
 				},
@@ -257,7 +257,7 @@ func newTestGitRepoWithState(t *testing.T, state *legacyconfig.LibrarianState) l
 		t.Fatalf("os.WriteFile: %v", err)
 	}
 	// If state is nil, skip creating the .librarian directory
-	// and the state.yaml/legacyconfig.yaml files and return with a initial commit
+	// and the state.yaml/config.yaml files and return with a initial commit
 	if state == nil {
 		runGit(t, dir, "add", ".")
 		runGit(t, dir, "commit", "-m", "initial commit")
@@ -268,7 +268,7 @@ func newTestGitRepoWithState(t *testing.T, state *legacyconfig.LibrarianState) l
 		}
 		return repo
 	}
-	// Create a state.yaml and legacyconfig.yaml file in .librarian dir.
+	// Create a state.yaml and config.yaml file in .librarian dir.
 	librarianDir := filepath.Join(dir, legacyconfig.LibrarianDir)
 	if err := os.MkdirAll(librarianDir, 0755); err != nil {
 		t.Fatalf("os.MkdirAll: %v", err)
@@ -296,7 +296,7 @@ func newTestGitRepoWithState(t *testing.T, state *legacyconfig.LibrarianState) l
 	if err := os.WriteFile(stateFile, bytes, 0644); err != nil {
 		t.Fatalf("os.WriteFile: %v", err)
 	}
-	configFile := filepath.Join(librarianDir, "legacyconfig.yaml")
+	configFile := filepath.Join(librarianDir, "config.yaml")
 	if err := os.WriteFile(configFile, []byte{}, 0644); err != nil {
 		t.Fatalf("os.WriteFile: %v", err)
 	}

--- a/internal/legacylibrarian/legacylibrarian/release_stage.go
+++ b/internal/legacylibrarian/legacylibrarian/release_stage.go
@@ -284,7 +284,7 @@ func (r *stageRunner) updateLibrary(library *legacyconfig.LibraryState, commits 
 }
 
 // determineNextVersion determines the next valid SemVer version from the commits or from
-// the next_version override value in the legacyconfig.yaml file.
+// the next_version override value in the config.yaml file.
 func (r *stageRunner) determineNextVersion(commits []*legacygitrepo.ConventionalCommit, currentVersion string, libraryID string) (string, error) {
 	nextVersionFromCommits, err := NextVersion(commits, currentVersion)
 	if err != nil {
@@ -296,7 +296,7 @@ func (r *stageRunner) determineNextVersion(commits []*legacygitrepo.Conventional
 		return nextVersionFromCommits, nil
 	}
 
-	// Look for next_version override from legacyconfig.yaml
+	// Look for next_version override from config.yaml
 	libraryConfig := r.librarianConfig.LibraryConfigFor(libraryID)
 	slog.Debug("looking up library config", "library", libraryID, slog.Any("config", libraryConfig))
 	if libraryConfig == nil || libraryConfig.NextVersion == "" {

--- a/internal/legacylibrarian/legacylibrarian/release_stage_test.go
+++ b/internal/legacylibrarian/legacylibrarian/release_stage_test.go
@@ -567,7 +567,7 @@ func TestStageRun(t *testing.T) {
 			wantErrMsg: "unable to find library for release",
 		},
 		{
-			name:             "run release stage command without librarian config (no legacyconfig.yaml file)",
+			name:             "run release stage command without librarian config (no config.yaml file)",
 			containerClient:  &mockContainerClient{},
 			dockerStageCalls: 1,
 			setupRunner: func(containerClient *mockContainerClient) *stageRunner {
@@ -1818,7 +1818,7 @@ func TestDetermineNextVersion(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "with legacyconfig.yaml override version",
+			name: "with config.yaml override version",
 			commits: []*legacygitrepo.ConventionalCommit{
 				{Type: "feat"},
 			},
@@ -1839,7 +1839,7 @@ func TestDetermineNextVersion(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "with outdated legacyconfig.yaml override version",
+			name: "with outdated config.yaml override version",
 			commits: []*legacygitrepo.ConventionalCommit{
 				{Type: "feat"},
 			},

--- a/internal/legacylibrarian/legacylibrarian/state.go
+++ b/internal/legacylibrarian/legacylibrarian/state.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	librarianConfigFile = "legacyconfig.yaml"
+	librarianConfigFile = "config.yaml"
 	librarianStateFile  = "state.yaml"
 	serviceConfigType   = "type"
 	serviceConfigValue  = "google.api.Service"
@@ -109,7 +109,7 @@ func parseLibrarianConfig(path string) (*legacyconfig.LibrarianConfig, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			slog.Info("legacyconfig.yaml not found, proceeding")
+			slog.Info("config.yaml not found, proceeding")
 			return nil, nil
 		}
 		return nil, err

--- a/internal/legacylibrarian/legacylibrarian/tag_and_release.go
+++ b/internal/legacylibrarian/legacylibrarian/tag_and_release.go
@@ -193,7 +193,7 @@ func (r *tagRunner) processPullRequest(ctx context.Context, p *legacygithub.Pull
 
 	librarianConfig, err := loadLibrarianConfigFromGitHub(ctx, r.ghClient, targetBranch)
 	if err != nil {
-		slog.Warn("error loading .librarian/legacyconfig.yaml", slog.Any("err", err))
+		slog.Warn("error loading .librarian/config.yaml", slog.Any("err", err))
 	}
 
 	// Add a tag to the release commit to trigger louhi flow: "release-{pr number}".


### PR DESCRIPTION
We don't want to introduce more code changes than needed to configured language repos. Let's keep the status quo of the config being named `config.yaml`. This seemed to change in 78bb6c3b7a46f2d680c9227240f3c6e13a6ecf8d without a reason why.

Updates: #3472