### PR TITLE
fix(internal/librarian): avoid ctx shadowing in errgroup

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -124,13 +124,13 @@ func generateAll(ctx context.Context, cfg *config.Config) error {
 		rustSources.Googleapis = googleapisDir
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(ctx)
 	libraries := make([]*config.Library, len(cfg.Libraries))
 	for i, lib := range cfg.Libraries {
 		i := i
 		name := lib.Name
 		g.Go(func() error {
-			lib, err := generateLibrary(ctx, cfg, name, googleapisDir, rustSources)
+			lib, err := generateLibrary(gctx, cfg, name, googleapisDir, rustSources)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Rename the context returned by errgroup.WithContext to prevent shadowing the parent ctx.

This fixes an issue where formatLibrary returned with a context canceled error.