### PR TITLE
fix(codecov): update coverage targets and ignores

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,7 +21,13 @@ coverage:
     patch: off
 ignore:
   # test packages do not need code coverage
+  - internal/librarian/testhelper
+  - internal/sample
   - internal/sidekick/internal/api/apitest
   - internal/sidekick/internal/sample
   # Running tests for this would require installing the Rust toolchain.
   - internal/sidekick/internal/rust_prost
+  # legacy packages with low coverage
+  - internal/legacylibrarian/legacycontainer/java/pom
+  - internal/legacylibrarian/legacycontainer/java/release
+  - internal/legacylibrarian/legacyimages


### PR DESCRIPTION
Expand the ignore list to exclude low-coverage legacylibrarian packages and test helpers that don't require coverage.