### PR TITLE
feat(internal/library): add findLibraryByName

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -265,7 +265,7 @@ func TestAddCommand(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := findLibrary(gotCfg, testName)
+			got := findLibraryByName(gotCfg, testName)
 			if test.wantOutput != "" && got.Output != test.wantOutput {
 				t.Errorf("output = %q, want %q", got.Output, test.wantOutput)
 			}
@@ -353,7 +353,7 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 				t.Errorf("libraries count = %d, want 2", len(cfg.Libraries))
 			}
 
-			found := findLibrary(cfg, test.libraryName)
+			found := findLibraryByName(cfg, test.libraryName)
 			if found == nil {
 				t.Fatalf("library %q not found in config", test.libraryName)
 			}
@@ -368,13 +368,4 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 			}
 		})
 	}
-}
-
-func findLibrary(cfg *config.Config, name string) *config.Library {
-	for i := range cfg.Libraries {
-		if cfg.Libraries[i].Name == name {
-			return cfg.Libraries[i]
-		}
-	}
-	return nil
 }

--- a/internal/librarian/release.go
+++ b/internal/librarian/release.go
@@ -282,3 +282,15 @@ func loadBranchLibraryVersion(ctx context.Context, gitExe, remote, branch, libNa
 	}
 	return branchLibCfg.Version, nil
 }
+
+// findLibraryByName finds a library with the given name in cfg and returns
+// it (as a pointer), or returns nil if cfg does not contain a library with the
+// given name.
+func findLibraryByName(cfg *config.Config, name string) *config.Library {
+	for i := range cfg.Libraries {
+		if cfg.Libraries[i].Name == name {
+			return cfg.Libraries[i]
+		}
+	}
+	return nil
+}

--- a/internal/librarian/release_test.go
+++ b/internal/librarian/release_test.go
@@ -552,3 +552,48 @@ func TestLoadBranchLibraryVersion(t *testing.T) {
 		t.Errorf("got version %s, want %s", got, want)
 	}
 }
+
+func TestFindLibraryByName(t *testing.T) {
+	for _, test := range []struct {
+		testName  string
+		cfg       *config.Config
+		inputName string
+		wantFound bool
+	}{
+		{
+			testName: "library found",
+			cfg: &config.Config{
+				Libraries: []*config.Library{
+					{Name: sample.Lib1Name},
+					{Name: sample.Lib2Name},
+				},
+			},
+			inputName: sample.Lib2Name,
+			wantFound: true,
+		},
+		{
+			testName: "library not found",
+			cfg: &config.Config{
+				Libraries: []*config.Library{
+					{Name: sample.Lib1Name},
+				},
+			},
+			inputName: sample.Lib2Name,
+		},
+	} {
+		t.Run(test.testName, func(t *testing.T) {
+			got := findLibraryByName(test.cfg, test.inputName)
+			if test.wantFound {
+				if got == nil {
+					t.Errorf("findLibraryName(%q) want library; got nil", test.inputName)
+				} else if test.inputName != got.Name {
+					t.Errorf("findLibraryName() want library %q; got library %q", test.inputName, got.Name)
+				}
+			} else {
+				if got != nil {
+					t.Errorf("findLibraryName(%q) want nil; got library", got.Name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a findLibraryByName function to find a library from its Name field within a config. This will be used when determining which libraries are released in a release commit (and may well have use in other contexts too). Remove the equivalent function in add_test.go; the test code using it can now use the production function.

Towards #3597