### PR TITLE
refactor(internal/repometadata): rename GenerateRepoMetadata to Generate

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -63,7 +63,7 @@ func Generate(ctx context.Context, library *config.Library, googleapisDir string
 	// for post processing, or reimplement.
 
 	// TODO(https://github.com/googleapis/librarian/issues/3146):
-	// Remove the default version fudget here, as GenerateRepoMetadata should
+	// Remove the default version fudget here, as Generate should
 	// compute it. For now, use the last component of the first channel path as
 	// the default version.
 	defaultVersion := filepath.Base(library.Channels[0].Path)
@@ -77,7 +77,7 @@ func Generate(ctx context.Context, library *config.Library, googleapisDir string
 		return fmt.Errorf("failed to lookup service config: %w", err)
 	}
 	absoluteServiceConfig := filepath.Join(googleapisDir, channel.ServiceConfig)
-	if err := repometadata.GenerateRepoMetadata(library, "python", "googleapis/google-cloud-python", absoluteServiceConfig, defaultVersion, outdir); err != nil {
+	if err := repometadata.Generate(library, "python", "googleapis/google-cloud-python", absoluteServiceConfig, defaultVersion, outdir); err != nil {
 		return fmt.Errorf("failed to generate .repo-metadata.json: %w", err)
 	}
 

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -72,9 +72,9 @@ type RepoMetadata struct {
 	Repo string `json:"repo,omitempty"`
 }
 
-// GenerateRepoMetadata generates the .repo-metadata.json file by parsing the
+// Generate generates the .repo-metadata.json file by parsing the
 // service YAML.
-func GenerateRepoMetadata(library *config.Library, language, repo, serviceConfigPath, defaultVersion, outdir string) error {
+func Generate(library *config.Library, language, repo, serviceConfigPath, defaultVersion, outdir string) error {
 	// TODO(https://github.com/googleapis/librarian/issues/3146):
 	// Compute the default version, potentially with an override, instead of
 	// taking it as a parameter.

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func TestGenerateRepoMetadata(t *testing.T) {
+func TestGenerate(t *testing.T) {
 	for _, test := range []struct {
 		name           string
 		defaultVersion string
@@ -88,7 +88,7 @@ func TestGenerateRepoMetadata(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := GenerateRepoMetadata(test.library, "python", "googleapis/google-cloud-python", serviceYAMLPath, test.defaultVersion, outDir); err != nil {
+			if err := Generate(test.library, "python", "googleapis/google-cloud-python", serviceYAMLPath, test.defaultVersion, outDir); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Rename GenerateRepoMetadata to Generate, to avoid repetition with the package name when calling repometadata.Generate.