### PR TITLE
fix(internal/serviceconfig): scan entire file in isServiceConfigFile

### DIFF
--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -145,7 +145,7 @@ func isServiceConfigFile(path string) (bool, error) {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	for i := 0; i < 20 && scanner.Scan(); i++ {
+	for scanner.Scan() {
 		if strings.TrimSpace(scanner.Text()) == "type: google.api.Service" {
 			return true, nil
 		}


### PR DESCRIPTION
Update isServiceConfigFile to scan the entire service config file instead of limiting detection to the first 20 lines, to ensure that service configs are correctly identified in the event that the `type: google.api.Service` declaration appears later in the file.