### PR TITLE
feat(internal/librarian): find release commits and libraries released

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -144,6 +144,7 @@ func MatchesBranchPoint(ctx context.Context, gitExe, remote, branch string) erro
 }
 
 // FindCommitsForPath returns the full hashes of all commits affecting the given path.
+// The commits are returned in normal log order, i.e. latest commit first.
 func FindCommitsForPath(ctx context.Context, gitExe, path string) ([]string, error) {
 	cmd := exec.CommandContext(ctx, gitExe, "log", "--pretty=format:%H", "--", path)
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
Add findReleasedLibraries, which determines which libraries are released by a specific commit.

Add findLatestReleaseCommit, which looks back in git history to find the first commit to release either any library, or just a specified library.

These will be used by the tag and publish commands.

Fixes #3597