### PR TITLE
chore(infra): update Dockerfiles for legacy cmds

### DIFF
--- a/infra/imagebuilders/cli/Dockerfile
+++ b/infra/imagebuilders/cli/Dockerfile
@@ -42,6 +42,8 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
+# Renaming the binary to librarian to match the old binary name and avoid
+# breaking existing Cloud Build steps that reference the binary by name.
 RUN CGO_ENABLED=0 GOOS=linux go build -o librarian ./cmd/legacylibrarian
 
 # Using docker:dind so we can run docker from the CLI,

--- a/infra/imagebuilders/dispatcher/Dockerfile
+++ b/infra/imagebuilders/dispatcher/Dockerfile
@@ -41,6 +41,8 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
+# Renaming the binary to automation to match the old binary name and avoid
+# breaking existing Cloud Build steps that reference the binary by name.
 RUN CGO_ENABLED=0 GOOS=linux go build -o automation ./cmd/legacyautomation
 
 FROM marketplace.gcr.io/google/debian12@sha256:326ccf35aa72f7cc8cbd25b69e819a81c5fd9ed675c6c9ffb51f3214a64f23cf


### PR DESCRIPTION
We need to update the Dockerfiles to build legacy librarian code as the sources have moved. To keep diffs smaller we will rename the binaries as thier old names.

Updates: #3472