### PR TITLE
fix(internal/librarian): remove generate step from bump command

### DIFF
--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -135,7 +135,7 @@ func runBump(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if all {
-		if err = bumpAll(ctx, cfg, lastTag, gitExe, googleapisDir, rustSources); err != nil {
+		if err = bumpAll(ctx, cfg, lastTag, gitExe); err != nil {
 			return err
 		}
 	} else {
@@ -147,7 +147,7 @@ func runBump(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		if err = bumpLibrary(ctx, cfg, libConfg, lastTag, gitExe, versionOverride, googleapisDir, rustSources); err != nil {
+		if err = bumpLibrary(ctx, cfg, libConfg, lastTag, gitExe, versionOverride); err != nil {
 			return err
 		}
 	}
@@ -158,7 +158,7 @@ func runBump(ctx context.Context, cmd *cli.Command) error {
 	return RunTidyOnConfig(ctx, cfg)
 }
 
-func bumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string, googleapisDir string, rustSources *rust.Sources) error {
+func bumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string) error {
 	filesChanged, err := git.FilesChangedSince(ctx, lastTag, gitExe, cfg.Release.IgnoredChanges)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func bumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string, go
 			return err
 		}
 		if shouldRelease(library, filesChanged) {
-			if err := bumpLibrary(ctx, cfg, library, lastTag, gitExe, "", googleapisDir, rustSources); err != nil {
+			if err := bumpLibrary(ctx, cfg, library, lastTag, gitExe, ""); err != nil {
 				return err
 			}
 		}
@@ -193,7 +193,7 @@ func shouldRelease(library *config.Library, filesChanged []string) bool {
 	return false
 }
 
-func bumpLibrary(ctx context.Context, cfg *config.Config, libConfig *config.Library, lastTag, gitExe, versionOverride, googleapisDir string, rustSources *rust.Sources) error {
+func bumpLibrary(ctx context.Context, cfg *config.Config, libConfig *config.Library, lastTag, gitExe, versionOverride string) error {
 	// If the language doesn't have bespoke versioning options, a default
 	// [semver.DeriveNextOptions] instance is returned.
 	opts := languageVersioningOptions[cfg.Language]

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -359,7 +359,7 @@ func TestBumpLibrary(t *testing.T) {
 
 			targetLibCfg := targetCfg.Libraries[0]
 			// Unused string param: lastTag.
-			err := bumpLibrary(t.Context(), targetCfg, targetLibCfg, testUnusedStringParam, "git", test.versionOverride, "", nil)
+			err := bumpLibrary(t.Context(), targetCfg, targetLibCfg, testUnusedStringParam, "git", test.versionOverride)
 			if err != nil {
 				t.Fatalf("bumpLibrary() error = %v", err)
 			}
@@ -439,7 +439,7 @@ func TestBumpAll(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			err := bumpAll(t.Context(), targetCfg, sinceTag, "git", "", nil)
+			err := bumpAll(t.Context(), targetCfg, sinceTag, "git")
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Removes generate step inside bump command for clarity. This generate step was previously added to update version in README.
For short term, we should run `librarian bump` and then `librarian generate` to get same behavior.
 
For #3511