### PR TITLE
refactor(internal/sidekick/parser): remove dependency on sidekick config

### DIFF
--- a/internal/librarian/dart/generate.go
+++ b/internal/librarian/dart/generate.go
@@ -33,7 +33,7 @@ func Generate(ctx context.Context, library *config.Library, googleapisDir string
 	if err != nil {
 		return err
 	}
-	model, err := parser.CreateModel(sidekickConfig)
+	model, err := parser.CreateModel(parser.NewConfig(sidekickConfig))
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -51,7 +51,7 @@ func Generate(ctx context.Context, library *config.Library, sources *Sources) er
 	if err != nil {
 		return err
 	}
-	model, err := parser.CreateModel(sidekickConfig)
+	model, err := parser.CreateModel(parser.NewConfig(sidekickConfig))
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *Sourc
 		if err != nil {
 			return fmt.Errorf("module %s: %w", module.Output, err)
 		}
-		model, err := parser.CreateModel(sidekickConfig)
+		model, err := parser.CreateModel(parser.NewConfig(sidekickConfig))
 		if err != nil {
 			return fmt.Errorf("module %s: %w", module.Output, err)
 		}
@@ -172,7 +172,7 @@ func generateRustStorage(ctx context.Context, library *config.Library, moduleOut
 	if err != nil {
 		return fmt.Errorf("failed to create storage sidekick config: %w", err)
 	}
-	storageModel, err := parser.CreateModel(storageConfig)
+	storageModel, err := parser.CreateModel(parser.NewConfig(storageConfig))
 	if err != nil {
 		return fmt.Errorf("failed to create storage model: %w", err)
 	}
@@ -186,7 +186,7 @@ func generateRustStorage(ctx context.Context, library *config.Library, moduleOut
 	if err != nil {
 		return fmt.Errorf("failed to create control sidekick config: %w", err)
 	}
-	controlModel, err := parser.CreateModel(controlConfig)
+	controlModel, err := parser.CreateModel(parser.NewConfig(controlConfig))
 	if err != nil {
 		return fmt.Errorf("failed to create control model: %w", err)
 	}

--- a/internal/sidekick/api/documentation.go
+++ b/internal/sidekick/api/documentation.go
@@ -18,13 +18,18 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
+// DocumentationOverride describes overrides for the documentation of a single element.
+type DocumentationOverride struct {
+	ID      string
+	Match   string
+	Replace string
+}
+
 // PatchDocumentation overrides the documentation of the API model with the provided configuration.
-func PatchDocumentation(model *API, config *config.Config) error {
-	for _, override := range config.CommentOverrides {
+func PatchDocumentation(model *API, commentOverrides []DocumentationOverride) error {
+	for _, override := range commentOverrides {
 		id := override.ID
 		if msg, ok := model.State.MessageByID[id]; ok {
 			if err := patchElementDocs(&msg.Documentation, &override); err != nil {
@@ -73,7 +78,7 @@ func PatchDocumentation(model *API, config *config.Config) error {
 	return nil
 }
 
-func patchFieldDocs(msg *Message, fieldName string, override *config.DocumentationOverride) error {
+func patchFieldDocs(msg *Message, fieldName string, override *DocumentationOverride) error {
 	for _, field := range msg.Fields {
 		if field.Name != fieldName {
 			continue
@@ -86,7 +91,7 @@ func patchFieldDocs(msg *Message, fieldName string, override *config.Documentati
 	return fmt.Errorf("cannot find field %s in message %s to apply comment override", fieldName, msg.ID)
 }
 
-func patchEnumValueDocs(enu *Enum, name string, override *config.DocumentationOverride) error {
+func patchEnumValueDocs(enu *Enum, name string, override *DocumentationOverride) error {
 	for _, v := range enu.Values {
 		if v.Name != name {
 			continue
@@ -99,7 +104,7 @@ func patchEnumValueDocs(enu *Enum, name string, override *config.DocumentationOv
 	return fmt.Errorf("cannot find field %s in message %s to apply comment override", name, enu.ID)
 }
 
-func patchMethodDocs(svc *Service, name string, override *config.DocumentationOverride) error {
+func patchMethodDocs(svc *Service, name string, override *DocumentationOverride) error {
 	for _, m := range svc.Methods {
 		if m.Name != name {
 			continue
@@ -112,7 +117,7 @@ func patchMethodDocs(svc *Service, name string, override *config.DocumentationOv
 	return fmt.Errorf("cannot find field %s in message %s to apply comment override", name, svc.ID)
 }
 
-func patchElementDocs(documentation *string, override *config.DocumentationOverride) error {
+func patchElementDocs(documentation *string, override *DocumentationOverride) error {
 	new := strings.ReplaceAll(*documentation, strings.ReplaceAll(override.Match, "\r\n", "\n"), override.Replace)
 	if *documentation == new {
 		slog.Error("comment override mismatch", "id", override.ID, "want", override.Match, "text", *documentation)

--- a/internal/sidekick/api/documentation_test.go
+++ b/internal/sidekick/api/documentation_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
 const (
@@ -71,16 +70,14 @@ func TestPatchCommentsMessage(t *testing.T) {
 		Documentation: Input,
 	}
 	model := NewTestAPI([]*Message{m0}, []*Enum{}, []*Service{})
-	cfg := config.Config{
-		CommentOverrides: []config.DocumentationOverride{
-			{
-				ID:      ".test.Message0",
-				Match:   Match,
-				Replace: Replace,
-			},
+	commentOverrides := []DocumentationOverride{
+		{
+			ID:      ".test.Message0",
+			Match:   Match,
+			Replace: Replace,
 		},
 	}
-	if err := PatchDocumentation(model, &cfg); err != nil {
+	if err := PatchDocumentation(model, commentOverrides); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,16 +140,14 @@ func TestPatchCommentsMessageNotFound(t *testing.T) {
 		"NotAThing",
 	}
 	for _, id := range missing {
-		cfg := config.Config{
-			CommentOverrides: []config.DocumentationOverride{
-				{
-					ID:      id,
-					Match:   Match,
-					Replace: Replace,
-				},
+		commentOverrides := []DocumentationOverride{
+			{
+				ID:      id,
+				Match:   Match,
+				Replace: Replace,
 			},
 		}
-		if err := PatchDocumentation(model, &cfg); err == nil {
+		if err := PatchDocumentation(model, commentOverrides); err == nil {
 			t.Errorf("expected an error searching for missing entity %q", id)
 		}
 	}
@@ -170,16 +165,14 @@ func TestPatchCommentsNoMatch(t *testing.T) {
 		".test.Service0.Method0",
 	}
 	for _, id := range missing {
-		cfg := config.Config{
-			CommentOverrides: []config.DocumentationOverride{
-				{
-					ID:      id,
-					Match:   "NOT A STRING WE WILL FIND",
-					Replace: Replace,
-				},
+		commentOverrides := []DocumentationOverride{
+			{
+				ID:      id,
+				Match:   "NOT A STRING WE WILL FIND",
+				Replace: Replace,
 			},
 		}
-		if err := PatchDocumentation(model, &cfg); err == nil {
+		if err := PatchDocumentation(model, commentOverrides); err == nil {
 			t.Errorf("expected an error replacing comments for entity %q", id)
 		}
 	}
@@ -198,16 +191,14 @@ func TestPatchCommentsField(t *testing.T) {
 		Fields:  []*Field{f0},
 	}
 	model := NewTestAPI([]*Message{m0}, []*Enum{}, []*Service{})
-	cfg := config.Config{
-		CommentOverrides: []config.DocumentationOverride{
-			{
-				ID:      ".test.Message0.field_name",
-				Match:   Match,
-				Replace: Replace,
-			},
+	commentOverrides := []DocumentationOverride{
+		{
+			ID:      ".test.Message0.field_name",
+			Match:   Match,
+			Replace: Replace,
 		},
 	}
-	if err := PatchDocumentation(model, &cfg); err != nil {
+	if err := PatchDocumentation(model, commentOverrides); err != nil {
 		t.Fatal(err)
 	}
 
@@ -224,16 +215,14 @@ func TestPatchCommentsEnum(t *testing.T) {
 		Documentation: Input,
 	}
 	model := NewTestAPI([]*Message{}, []*Enum{e0}, []*Service{})
-	cfg := config.Config{
-		CommentOverrides: []config.DocumentationOverride{
-			{
-				ID:      ".test.Enum0",
-				Match:   Match,
-				Replace: Replace,
-			},
+	commentOverrides := []DocumentationOverride{
+		{
+			ID:      ".test.Enum0",
+			Match:   Match,
+			Replace: Replace,
 		},
 	}
-	if err := PatchDocumentation(model, &cfg); err != nil {
+	if err := PatchDocumentation(model, commentOverrides); err != nil {
 		t.Fatal(err)
 	}
 
@@ -256,16 +245,14 @@ func TestPatchCommentsEnumValue(t *testing.T) {
 		Documentation: Input,
 	}
 	model := NewTestAPI([]*Message{}, []*Enum{e0}, []*Service{})
-	cfg := config.Config{
-		CommentOverrides: []config.DocumentationOverride{
-			{
-				ID:      ".test.Enum0.ENUM_VALUE",
-				Match:   Match,
-				Replace: Replace,
-			},
+	commentOverrides := []DocumentationOverride{
+		{
+			ID:      ".test.Enum0.ENUM_VALUE",
+			Match:   Match,
+			Replace: Replace,
 		},
 	}
-	if err := PatchDocumentation(model, &cfg); err != nil {
+	if err := PatchDocumentation(model, commentOverrides); err != nil {
 		t.Fatal(err)
 	}
 
@@ -282,16 +269,14 @@ func TestPatchCommentsService(t *testing.T) {
 		Documentation: Input,
 	}
 	model := NewTestAPI([]*Message{}, []*Enum{}, []*Service{s0})
-	cfg := config.Config{
-		CommentOverrides: []config.DocumentationOverride{
-			{
-				ID:      ".test.Service0",
-				Match:   Match,
-				Replace: Replace,
-			},
+	commentOverrides := []DocumentationOverride{
+		{
+			ID:      ".test.Service0",
+			Match:   Match,
+			Replace: Replace,
 		},
 	}
-	if err := PatchDocumentation(model, &cfg); err != nil {
+	if err := PatchDocumentation(model, commentOverrides); err != nil {
 		t.Fatal(err)
 	}
 
@@ -313,16 +298,14 @@ func TestPatchCommentsMethod(t *testing.T) {
 		Methods: []*Method{m0},
 	}
 	model := NewTestAPI([]*Message{}, []*Enum{}, []*Service{s0})
-	cfg := config.Config{
-		CommentOverrides: []config.DocumentationOverride{
-			{
-				ID:      ".test.Service0.Method",
-				Match:   Match,
-				Replace: Replace,
-			},
+	commentOverrides := []DocumentationOverride{
+		{
+			ID:      ".test.Service0.Method",
+			Match:   Match,
+			Replace: Replace,
 		},
 	}
-	if err := PatchDocumentation(model, &cfg); err != nil {
+	if err := PatchDocumentation(model, commentOverrides); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/codec_sample/generate_test.go
+++ b/internal/sidekick/codec_sample/generate_test.go
@@ -53,7 +53,7 @@ func TestFromProtobuf(t *testing.T) {
 			"proto:google.cloud.location": "package:google_cloud_location/location.dart",
 		},
 	}
-	model, err := parser.CreateModel(cfg)
+	model, err := parser.CreateModel(parser.NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/dart/generate_test.go
+++ b/internal/sidekick/dart/generate_test.go
@@ -61,7 +61,7 @@ func TestFromProtobuf(t *testing.T) {
 			"proto:google.cloud.location":    "package:google_cloud_location/location.dart",
 		},
 	}
-	model, err := parser.CreateModel(cfg)
+	model, err := parser.CreateModel(parser.NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/parser/disco_test.go
+++ b/internal/sidekick/parser/disco_test.go
@@ -31,7 +31,7 @@ func TestDisco_Parse(t *testing.T) {
 			ServiceConfig:       secretManagerYamlFullPath,
 		},
 	}
-	got, err := ParseDisco(cfg)
+	got, err := ParseDisco(NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestDisco_FindSources(t *testing.T) {
 			"roots":     "undefined,test",
 		},
 	}
-	got, err := ParseDisco(cfg)
+	got, err := ParseDisco(NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestDisco_ParseNoServiceConfig(t *testing.T) {
 			SpecificationSource: discoSourceFile,
 		},
 	}
-	got, err := ParseDisco(cfg)
+	got, err := ParseDisco(NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestDisco_ParsePagination(t *testing.T) {
 			SpecificationSource: discoSourceFile,
 		},
 	}
-	model, err := ParseDisco(cfg)
+	model, err := ParseDisco(NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestDisco_ParsePaginationAggregate(t *testing.T) {
 			SpecificationSource: discoSourceFile,
 		},
 	}
-	model, err := ParseDisco(cfg)
+	model, err := ParseDisco(NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestDisco_ParseDeprecatedEnum(t *testing.T) {
 			SpecificationSource: discoSourceFile,
 		},
 	}
-	model, err := ParseDisco(cfg)
+	model, err := ParseDisco(NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestDisco_ParseBadFiles(t *testing.T) {
 		{SpecificationSource: discoSourceFile, ServiceConfig: "-invalid-file-name-"},
 		{SpecificationSource: secretManagerYamlFullPath, ServiceConfig: secretManagerYamlFullPath},
 	} {
-		if got, err := ParseDisco(&config.Config{General: cfg}); err == nil {
+		if got, err := ParseDisco(NewConfig(&config.Config{General: cfg})); err == nil {
 			t.Fatalf("expected error with missing source file, got=%v", got)
 		}
 	}

--- a/internal/sidekick/parser/discovery/discovery_test.go
+++ b/internal/sidekick/parser/discovery/discovery_test.go
@@ -240,5 +240,19 @@ func ComputeDiscoWithLros(t *testing.T, cfg *config.Config) (*api.API, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewAPI(nil, contents, cfg)
+	var discovery *Discovery
+	if cfg.Discovery != nil {
+		var pollers []*Poller
+		for _, poller := range cfg.Discovery.Pollers {
+			pollers = append(pollers, &Poller{
+				Prefix:   poller.Prefix,
+				MethodID: poller.MethodID,
+			})
+		}
+		discovery = &Discovery{
+			OperationID: cfg.Discovery.OperationID,
+			Pollers:     pollers,
+		}
+	}
+	return NewAPI(nil, contents, discovery)
 }

--- a/internal/sidekick/parser/discovery/lro.go
+++ b/internal/sidekick/parser/discovery/lro.go
@@ -19,24 +19,23 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
-func lroAnnotations(model *api.API, cfg *config.Config) error {
-	if cfg == nil || cfg.Discovery == nil {
+func lroAnnotations(model *api.API, discovery *Discovery) error {
+	if discovery == nil {
 		return nil
 	}
-	lroServices := cfg.Discovery.LroServices()
+	lroServices := discovery.LroServices()
 	for _, svc := range model.Services {
 		if _, ok := lroServices[svc.ID]; ok {
 			continue
 		}
 		var svcMixin *api.Method
 		for _, method := range svc.Methods {
-			if method.OutputTypeID != cfg.Discovery.OperationID {
+			if method.OutputTypeID != discovery.OperationID {
 				continue
 			}
-			mixin, pathParams := lroFindPoller(method, model, cfg.Discovery)
+			mixin, pathParams := lroFindPoller(method, model, discovery)
 			if mixin == nil {
 				continue
 			}
@@ -72,7 +71,7 @@ func lroAnnotations(model *api.API, cfg *config.Config) error {
 	return nil
 }
 
-func lroFindPoller(method *api.Method, model *api.API, discoveryConfig *config.Discovery) (*api.Method, []string) {
+func lroFindPoller(method *api.Method, model *api.API, discoveryConfig *Discovery) (*api.Method, []string) {
 	var flatPath []string
 	for _, binding := range method.PathInfo.Bindings {
 		flatPath = append(flatPath, binding.PathTemplate.FlatPath())

--- a/internal/sidekick/parser/discovery/lro_test.go
+++ b/internal/sidekick/parser/discovery/lro_test.go
@@ -111,13 +111,11 @@ func TestLroAnnotations(t *testing.T) {
 }
 
 func TestLroAnnotationsError(t *testing.T) {
-	cfg := &config.Config{
-		Discovery: &config.Discovery{
-			OperationID: "..Operation",
-			Pollers: []*config.Poller{
-				{Prefix: "p/{project}/l/{zone}", MethodID: "..Operations.get_1"},
-				{Prefix: "p/{project}/l/{region}", MethodID: "..Operations.get_2"},
-			},
+	cfg := &Discovery{
+		OperationID: "..Operation",
+		Pollers: []*Poller{
+			{Prefix: "p/{project}/l/{zone}", MethodID: "..Operations.get_1"},
+			{Prefix: "p/{project}/l/{region}", MethodID: "..Operations.get_2"},
 		},
 	}
 

--- a/internal/sidekick/parser/openapi.go
+++ b/internal/sidekick/parser/openapi.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 	"github.com/googleapis/librarian/internal/sidekick/parser/httprule"
 	"github.com/googleapis/librarian/internal/sidekick/parser/svcconfig"
 	"github.com/pb33f/libopenapi"
@@ -34,8 +33,8 @@ import (
 )
 
 // ParseOpenAPI parses an OpenAPI specification and returns an API model.
-func ParseOpenAPI(cfg *config.Config) (*api.API, error) {
-	source := cfg.General.SpecificationSource
+func ParseOpenAPI(cfg *Config) (*api.API, error) {
+	source := cfg.SpecificationSource
 	contents, err := os.ReadFile(source)
 	if err != nil {
 		return nil, err
@@ -44,7 +43,7 @@ func ParseOpenAPI(cfg *config.Config) (*api.API, error) {
 	if err != nil {
 		return nil, err
 	}
-	serviceConfig, err := loadServiceConfig(cfg)
+	serviceConfig, err := loadServiceConfig(cfg.ServiceConfig, cfg.Source)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sidekick/parser/openapi_test.go
+++ b/internal/sidekick/parser/openapi_test.go
@@ -1280,7 +1280,7 @@ func TestOpenAPI_ParseBadFiles(t *testing.T) {
 		cfg := &config.Config{
 			General: general,
 		}
-		if got, err := ParseOpenAPI(cfg); err == nil {
+		if got, err := ParseOpenAPI(NewConfig(cfg)); err == nil {
 			t.Fatalf("expected error with missing source file, got=%v", got)
 		}
 	}

--- a/internal/sidekick/parser/pagination.go
+++ b/internal/sidekick/parser/pagination.go
@@ -18,7 +18,6 @@ import (
 	"slices"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
 const (
@@ -30,7 +29,7 @@ const (
 
 // updateMethodPagination marks all methods that conform to
 // [AIP-4233](https://google.aip.dev/client-libraries/4233) as pageable.
-func updateMethodPagination(overrides []config.PaginationOverride, a *api.API) {
+func updateMethodPagination(overrides []PaginationOverride, a *api.API) {
 	for _, m := range a.State.MethodByID {
 		reqMsg := a.State.MessageByID[m.InputTypeID]
 		pageTokenField := paginationRequestInfo(reqMsg)
@@ -96,7 +95,7 @@ func paginationRequestToken(request *api.Message) *api.Field {
 	return nil
 }
 
-func paginationResponseInfo(overrides []config.PaginationOverride, methodID string, response *api.Message) *api.PaginationInfo {
+func paginationResponseInfo(overrides []PaginationOverride, methodID string, response *api.Message) *api.PaginationInfo {
 	if response == nil {
 		return nil
 	}
@@ -111,8 +110,8 @@ func paginationResponseInfo(overrides []config.PaginationOverride, methodID stri
 	}
 }
 
-func paginationResponseItem(overrides []config.PaginationOverride, methodID string, response *api.Message) *api.Field {
-	idx := slices.IndexFunc(overrides, func(o config.PaginationOverride) bool { return o.ID == methodID })
+func paginationResponseItem(overrides []PaginationOverride, methodID string, response *api.Message) *api.Field {
+	idx := slices.IndexFunc(overrides, func(o PaginationOverride) bool { return o.ID == methodID })
 	if idx != -1 {
 		overrideName := overrides[idx].ItemField
 		fieldIdx := slices.IndexFunc(response.Fields, func(f *api.Field) bool { return f.Name == overrideName })

--- a/internal/sidekick/parser/pagination_test.go
+++ b/internal/sidekick/parser/pagination_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
 func TestPageSimple(t *testing.T) {
@@ -165,7 +164,7 @@ func TestPageWithOverride(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	overrides := []config.PaginationOverride{
+	overrides := []PaginationOverride{
 		{ID: ".package.Service.List", ItemField: "items"},
 	}
 	updateMethodPagination(overrides, model)
@@ -627,14 +626,14 @@ func TestPaginationResponseItemMatchingPreferRepeatedOverMap(t *testing.T) {
 }
 
 func TestPaginationResponseItemNotMatching(t *testing.T) {
-	overrides := []config.PaginationOverride{
+	overrides := []PaginationOverride{
 		{ID: ".package.Service.List", ItemField: "--invalid--"},
 	}
 	for _, test := range []struct {
 		Name      string
 		Repeated  bool
 		Typez     api.Typez
-		Overrides []config.PaginationOverride
+		Overrides []PaginationOverride
 	}{
 		{"badRepeated", false, api.MESSAGE_TYPE, nil},
 		{"badType", true, api.STRING_TYPE, nil},

--- a/internal/sidekick/parser/parser.go
+++ b/internal/sidekick/parser/parser.go
@@ -16,54 +16,207 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
+// DocumentationOverride describes overrides for the documentation of a single element.
+//
+// This should be used sparingly. Generally we should prefer updating the
+// comments upstream, and then getting a new version of the services
+// specification. The exception may be when the fixes take a long time, or are
+// specific to one language.
+type DocumentationOverride struct {
+	ID      string
+	Match   string
+	Replace string
+}
+
+// PaginationOverride describes overrides for pagination config of a method.
+type PaginationOverride struct {
+	// The method ID.
+	ID string
+	// The name of the field used for `items`.
+	ItemField string
+}
+
+// Discovery defines the configuration for discovery docs.
+//
+// It is too complex to just use key/value pairs in the `Config.Source` field.
+type Discovery struct {
+	// The ID of the LRO operation type.
+	//
+	// For example: ".google.cloud.compute.v1.Operation".
+	OperationID string
+
+	// Possible prefixes to match the LRO polling RPCs.
+	//
+	// In discovery-based services there may be multiple resources and RPCs that
+	// service as LRO pollers. The order is important, sidekick picks the first
+	// match, so the configuration should list preferred matches first.
+	Pollers []*Poller
+}
+
+// Poller defines how to find a suitable poller RPC.
+//
+// For operations that may be LROs sidekick will match the URL path of the
+// RPC against the prefixes.
+type Poller struct {
+	// An acceptable prefix for the URL path, for example:
+	//     `compute/v1/projects/{project}/zones/{zone}`
+	Prefix string
+
+	// The corresponding method ID.
+	MethodID string
+}
+
+// LroServices returns the set of Discovery LRO services.
+//
+// The discovery doc parser avoids generating LRO annotations for methods in
+// this set. These functions return the LRO operation, but are inserted to that
+// list, poll, wait for, and cancel LROs. They do not need the annotations and
+// generated helpers.
+func (d *Discovery) LroServices() map[string]bool {
+	found := map[string]bool{}
+	for _, poller := range d.Pollers {
+		found[poller.serviceID()] = true
+	}
+	return found
+}
+
+// PathParameters returns the list of path parameters associated with a LRO
+// poller.
+//
+// In discovery-based APIs different LRO functions use different polling
+// methods. Each one of those methods uses a *subset* of the LRO functions to
+// poll the operation. This method returns that subset.
+func (p *Poller) PathParameters() []string {
+	var parameters []string
+	for _, segment := range strings.Split(p.Prefix, "/") {
+		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
+			parameters = append(parameters, segment[1:len(segment)-1])
+		}
+	}
+	return parameters
+}
+
+func (p *Poller) serviceID() string {
+	idx := strings.LastIndex(p.MethodID, ".")
+	if idx == -1 {
+		return p.MethodID
+	}
+	return p.MethodID[:idx]
+}
+
+// Config contains the parser configuration.
+type Config struct {
+	SpecificationFormat string
+	SpecificationSource string
+	ServiceConfig       string
+	Source              map[string]string
+	PaginationOverrides []PaginationOverride
+	CommentOverrides    []DocumentationOverride
+	Discovery           *Discovery
+}
+
+// NewConfig creates a parser.Config from a config.Config.
+func NewConfig(cfg *config.Config) *Config {
+	var paginationOverrides []PaginationOverride
+	for _, override := range cfg.PaginationOverrides {
+		paginationOverrides = append(paginationOverrides, PaginationOverride{
+			ID:        override.ID,
+			ItemField: override.ItemField,
+		})
+	}
+
+	var commentOverrides []DocumentationOverride
+	for _, override := range cfg.CommentOverrides {
+		commentOverrides = append(commentOverrides, DocumentationOverride{
+			ID:      override.ID,
+			Match:   override.Match,
+			Replace: override.Replace,
+		})
+	}
+
+	var discovery *Discovery
+	if cfg.Discovery != nil {
+		var pollers []*Poller
+		for _, poller := range cfg.Discovery.Pollers {
+			pollers = append(pollers, &Poller{
+				Prefix:   poller.Prefix,
+				MethodID: poller.MethodID,
+			})
+		}
+		discovery = &Discovery{
+			OperationID: cfg.Discovery.OperationID,
+			Pollers:     pollers,
+		}
+	}
+
+	return &Config{
+		SpecificationFormat: cfg.General.SpecificationFormat,
+		SpecificationSource: cfg.General.SpecificationSource,
+		ServiceConfig:       cfg.General.ServiceConfig,
+		Source:              cfg.Source,
+		PaginationOverrides: paginationOverrides,
+		CommentOverrides:    commentOverrides,
+		Discovery:           discovery,
+	}
+}
+
 // CreateModel parses the service specification referenced in `config`,
 // cross-references the model, and applies any transformations or overrides
 // required by the configuration.
-func CreateModel(config *config.Config) (*api.API, error) {
+func CreateModel(cfg *Config) (*api.API, error) {
 	var err error
 	var model *api.API
-	switch config.General.SpecificationFormat {
+	switch cfg.SpecificationFormat {
 	case "disco":
-		model, err = ParseDisco(config)
+		model, err = ParseDisco(cfg)
 	case "openapi":
-		model, err = ParseOpenAPI(config)
+		model, err = ParseOpenAPI(cfg)
 	case "protobuf":
-		model, err = ParseProtobuf(config)
+		model, err = ParseProtobuf(cfg)
 	case "none":
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unknown parser %q", config.General.SpecificationFormat)
+		return nil, fmt.Errorf("unknown parser %q", cfg.SpecificationFormat)
 	}
 	if err != nil {
 		return nil, err
 	}
-	updateMethodPagination(config.PaginationOverrides, model)
+	updateMethodPagination(cfg.PaginationOverrides, model)
 	api.LabelRecursiveFields(model)
 	if err := api.CrossReference(model); err != nil {
 		return nil, err
 	}
-	if err := api.SkipModelElements(model, config.Source); err != nil {
+	if err := api.SkipModelElements(model, cfg.Source); err != nil {
 		return nil, err
 	}
-	if err := api.PatchDocumentation(model, config); err != nil {
+	var apiCommentOverrides []api.DocumentationOverride
+	for _, override := range cfg.CommentOverrides {
+		apiCommentOverrides = append(apiCommentOverrides, api.DocumentationOverride{
+			ID:      override.ID,
+			Match:   override.Match,
+			Replace: override.Replace,
+		})
+	}
+	if err := api.PatchDocumentation(model, apiCommentOverrides); err != nil {
 		return nil, err
 	}
 	// Verify all the services, messages and enums are in the same package.
 	if err := api.Validate(model); err != nil {
 		return nil, err
 	}
-	if name, ok := config.Source["name-override"]; ok {
+	if name, ok := cfg.Source["name-override"]; ok {
 		model.Name = name
 	}
-	if title, ok := config.Source["title-override"]; ok {
+	if title, ok := cfg.Source["title-override"]; ok {
 		model.Title = title
 	}
-	if description, ok := config.Source["description-override"]; ok {
+	if description, ok := cfg.Source["description-override"]; ok {
 		model.Description = description
 	}
 	return model, nil

--- a/internal/sidekick/parser/parser_test.go
+++ b/internal/sidekick/parser/parser_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
 const (
@@ -37,12 +36,10 @@ var (
 )
 
 func TestCreateModelDisco(t *testing.T) {
-	cfg := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "disco",
-			ServiceConfig:       secretManagerYamlFullPath,
-			SpecificationSource: discoSourceFile,
-		},
+	cfg := &Config{
+		SpecificationFormat: "disco",
+		ServiceConfig:       secretManagerYamlFullPath,
+		SpecificationSource: discoSourceFile,
 	}
 	got, err := CreateModel(cfg)
 	if err != nil {
@@ -73,12 +70,10 @@ func TestCreateModelDisco(t *testing.T) {
 }
 
 func TestCreateModelOpenAPI(t *testing.T) {
-	cfg := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "openapi",
-			ServiceConfig:       secretManagerYamlFullPath,
-			SpecificationSource: path.Join(testdataDir, "openapi/secretmanager_openapi_v1.json"),
-		},
+	cfg := &Config{
+		SpecificationFormat: "openapi",
+		ServiceConfig:       secretManagerYamlFullPath,
+		SpecificationSource: path.Join(testdataDir, "openapi/secretmanager_openapi_v1.json"),
 	}
 	model, err := CreateModel(cfg)
 	if err != nil {
@@ -93,12 +88,10 @@ func TestCreateModelOpenAPI(t *testing.T) {
 
 func TestCreateModelProtobuf(t *testing.T) {
 	requireProtoc(t)
-	cfg := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "protobuf",
-			ServiceConfig:       secretManagerYamlRelative,
-			SpecificationSource: "google/cloud/secretmanager/v1",
-		},
+	cfg := &Config{
+		SpecificationFormat: "protobuf",
+		ServiceConfig:       secretManagerYamlRelative,
+		SpecificationSource: "google/cloud/secretmanager/v1",
 		Source: map[string]string{
 			"googleapis-root": path.Join(testdataDir, "../../testdata/googleapis"),
 		},
@@ -116,12 +109,10 @@ func TestCreateModelProtobuf(t *testing.T) {
 
 func TestCreateModelOverrides(t *testing.T) {
 	requireProtoc(t)
-	cfg := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "protobuf",
-			ServiceConfig:       secretManagerYamlRelative,
-			SpecificationSource: "google/cloud/secretmanager/v1",
-		},
+	cfg := &Config{
+		SpecificationFormat: "protobuf",
+		ServiceConfig:       secretManagerYamlRelative,
+		SpecificationSource: "google/cloud/secretmanager/v1",
 		Source: map[string]string{
 			"googleapis-root":      path.Join(testdataDir, "../../testdata/googleapis"),
 			"name-override":        "Name Override",
@@ -151,12 +142,10 @@ func TestCreateModelOverrides(t *testing.T) {
 
 func TestCreateModelNone(t *testing.T) {
 	requireProtoc(t)
-	cfg := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "none",
-			ServiceConfig:       secretManagerYamlRelative,
-			SpecificationSource: "none",
-		},
+	cfg := &Config{
+		SpecificationFormat: "none",
+		ServiceConfig:       secretManagerYamlRelative,
+		SpecificationSource: "none",
 		Source: map[string]string{
 			"googleapis-root":      path.Join(testdataDir, "../../testdata/googleapis"),
 			"name-override":        "Name Override",
@@ -174,12 +163,10 @@ func TestCreateModelNone(t *testing.T) {
 }
 
 func TestCreateModelUnknown(t *testing.T) {
-	cfg := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "--unknown--",
-			ServiceConfig:       secretManagerYamlRelative,
-			SpecificationSource: "none",
-		},
+	cfg := &Config{
+		SpecificationFormat: "--unknown--",
+		ServiceConfig:       secretManagerYamlRelative,
+		SpecificationSource: "none",
 		Source: map[string]string{
 			"googleapis-root":      path.Join(testdataDir, "../../testdata/googleapis"),
 			"name-override":        "Name Override",
@@ -193,13 +180,11 @@ func TestCreateModelUnknown(t *testing.T) {
 }
 
 func TestCreateModelBadParse(t *testing.T) {
-	cfg := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "openapi",
-			ServiceConfig:       secretManagerYamlRelative,
-			// Note the mismatch between the format and the file contents.
-			SpecificationSource: discoSourceFile,
-		},
+	cfg := &Config{
+		SpecificationFormat: "openapi",
+		ServiceConfig:       secretManagerYamlRelative,
+		// Note the mismatch between the format and the file contents.
+		SpecificationSource: discoSourceFile,
 		Source: map[string]string{
 			"googleapis-root":      path.Join(testdataDir, "../../testdata/googleapis"),
 			"name-override":        "Name Override",

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -39,13 +39,13 @@ import (
 
 // ParseProtobuf reads Protobuf specifications and converts them into
 // the `api.API` model.
-func ParseProtobuf(cfg *config.Config) (*api.API, error) {
-	source := cfg.General.SpecificationSource
+func ParseProtobuf(cfg *Config) (*api.API, error) {
+	source := cfg.SpecificationSource
 	request, err := newCodeGeneratorRequest(source, cfg.Source)
 	if err != nil {
 		return nil, err
 	}
-	serviceConfig, err := loadServiceConfig(cfg)
+	serviceConfig, err := loadServiceConfig(cfg.ServiceConfig, cfg.Source)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -2058,7 +2058,7 @@ func TestProtobuf_ParseBadFiles(t *testing.T) {
 		cfg := &config.Config{
 			General: general,
 		}
-		if got, err := ParseProtobuf(cfg); err == nil {
+		if got, err := ParseProtobuf(NewConfig(cfg)); err == nil {
 			t.Fatalf("expected error with missing source file, got=%v", got)
 		}
 	}

--- a/internal/sidekick/parser/service_config.go
+++ b/internal/sidekick/parser/service_config.go
@@ -22,9 +22,9 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
-func loadServiceConfig(cfg *config.Config) (*serviceconfig.Service, error) {
-	if name := cfg.General.ServiceConfig; name != "" {
-		return serviceconfig.Read(findServiceConfigPath(name, cfg.Source))
+func loadServiceConfig(serviceConfigPath string, sourceOptions map[string]string) (*serviceconfig.Service, error) {
+	if serviceConfigPath != "" {
+		return serviceconfig.Read(findServiceConfigPath(serviceConfigPath, sourceOptions))
 	}
 	return nil, nil
 }

--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -91,7 +91,7 @@ func TestCodecError(t *testing.T) {
 			"--invalid--": "--invalid--",
 		},
 	}
-	model, err := parser.CreateModel(errorConfig)
+	model, err := parser.CreateModel(parser.NewConfig(errorConfig))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 			SpecificationSource: path.Join(testdataDir, "openapi/secretmanager_openapi_v1.json"),
 		},
 	}
-	model, err := parser.CreateModel(cfg)
+	model, err := parser.CreateModel(parser.NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestRustFromProtobuf(t *testing.T) {
 			"googleapis-root": path.Join(testdataDir, "../../testdata/googleapis"),
 		},
 	}
-	model, err := parser.CreateModel(cfg)
+	model, err := parser.CreateModel(parser.NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestRustClient(t *testing.T) {
 				"template-override": path.Join("templates", override),
 			},
 		}
-		model, err := parser.CreateModel(cfg)
+		model, err := parser.CreateModel(parser.NewConfig(cfg))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -236,7 +236,7 @@ func TestRustNosvc(t *testing.T) {
 			"template-override": path.Join("templates", "nosvc"),
 		},
 	}
-	model, err := parser.CreateModel(cfg)
+	model, err := parser.CreateModel(parser.NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestRustModuleRpc(t *testing.T) {
 			"template-override": "templates/mod",
 		},
 	}
-	model, err := parser.CreateModel(cfg)
+	model, err := parser.CreateModel(parser.NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestRustBootstrapWkt(t *testing.T) {
 			"module-path":       "crate",
 		},
 	}
-	model, err := parser.CreateModel(cfg)
+	model, err := parser.CreateModel(parser.NewConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/sidekick/refresh.go
+++ b/internal/sidekick/sidekick/refresh.go
@@ -60,7 +60,7 @@ func loadDir(rootConfig *config.Config, output string) (*api.API, *config.Config
 	if config.General.SpecificationSource == "" {
 		return nil, nil, fmt.Errorf("must provide general.specification-source")
 	}
-	model, err := parser.CreateModel(config)
+	model, err := parser.CreateModel(parser.NewConfig(config))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/surfer/gcloud/loader.go
+++ b/internal/surfer/gcloud/loader.go
@@ -19,17 +19,14 @@ import (
 	"os"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"gopkg.in/yaml.v3"
 )
 
 // createAPIModel parses the service specification and creates the API model.
 func createAPIModel(googleapisPath, includeList string) (*api.API, error) {
-	parserConfig := &config.Config{
-		General: config.GeneralConfig{
-			SpecificationFormat: "protobuf",
-		},
+	parserConfig := &parser.Config{
+		SpecificationFormat: "protobuf",
 		Source: map[string]string{
 			"local-root":   googleapisPath,
 			"include-list": includeList,


### PR DESCRIPTION
CreateModel previously depended on sidekick/config.Config, even though it only used a small subset of its fields.

This change introduces parser.Config, a minimal config scoped to parser needs, as a first step toward deprecating sidekick/config.Config.

For https://github.com/googleapis/librarian/issues/3662
