### PR TITLE
feat(internal/command): add -v flag

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -22,6 +22,12 @@ import (
 	"os/exec"
 )
 
+// Verbose controls whether commands are printed to stderr before execution.
+//
+// TODO(https://github.com/googleapis/librarian/issues/3687): pass in as
+// config.
+var Verbose bool
+
 // Run executes a program (with arguments) and captures any error output. It is a
 // convenience wrapper around RunWithEnv.
 func Run(ctx context.Context, command string, arg ...string) error {
@@ -38,6 +44,9 @@ func RunWithEnv(ctx context.Context, env map[string]string, command string, arg 
 		for k, v := range env {
 			cmd.Env = append(cmd.Env, k+"="+v)
 		}
+	}
+	if Verbose {
+		fmt.Fprintf(os.Stdout, "%s\n", cmd.String())
 	}
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%v: %v\n%s", cmd, err, output)

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/urfave/cli/v3"
 )
 
@@ -37,7 +38,17 @@ func Run(ctx context.Context, args ...string) error {
 		Name:      "librarian",
 		Usage:     "manage Google Cloud client libraries",
 		UsageText: "librarian [command]",
-		Version:   Version(),
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "verbose",
+				Aliases: []string{"v"},
+				Usage:   "enable verbose logging",
+			},
+		},
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			command.Verbose = cmd.Bool("verbose")
+			return ctx, nil
+		},
 		Commands: []*cli.Command{
 			addCommand(),
 			generateCommand(),

--- a/internal/librarian/verbose_test.go
+++ b/internal/librarian/verbose_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/command"
+)
+
+func TestVerboseFlag(t *testing.T) {
+	t.Cleanup(func() {
+		command.Verbose = false
+	})
+
+	for _, test := range []struct {
+		name        string
+		args        []string
+		wantVerbose bool
+	}{
+		{"without verbose flag", []string{"librarian", "version"}, false},
+		{"with -v flag", []string{"librarian", "-v", "version"}, true},
+		{"with --verbose flag", []string{"librarian", "--verbose", "version"}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command.Verbose = false
+			if err := Run(t.Context(), test.args...); err != nil {
+				t.Fatal(err)
+			}
+			if command.Verbose != test.wantVerbose {
+				t.Errorf("command.Verbose = %t, want %t", command.Verbose, test.wantVerbose)
+			}
+		})
+	}
+}


### PR DESCRIPTION
librarian now supports a -v flag. When -v is set, the command is printed to stdout.

Fixes https://github.com/googleapis/librarian/issues/3547