### PR TITLE
fix(internal/librarian): derive output for libraries when bumping

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -265,7 +265,7 @@ func TestAddCommand(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := libraryByName(gotCfg, testName)
+			got, err := findLibrary(gotCfg, testName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -356,7 +356,7 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 				t.Errorf("libraries count = %d, want 2", len(cfg.Libraries))
 			}
 
-			found, err := libraryByName(cfg, test.libraryName)
+			found, err := findLibrary(cfg, test.libraryName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -79,11 +79,11 @@ Examples:
 				Usage: "specific version to update to; not valid with --all",
 			},
 		},
-		Action: runBump,
+		Action: bumpAction,
 	}
 }
 
-func runBump(ctx context.Context, cmd *cli.Command) error {
+func bumpAction(ctx context.Context, cmd *cli.Command) error {
 	all := cmd.Bool("all")
 	libraryName := cmd.Args().First()
 	versionOverride := cmd.String("version")
@@ -100,6 +100,10 @@ func runBump(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return errors.Join(errConfigNotFound, err)
 	}
+	return runBump(ctx, cfg, all, libraryName, versionOverride)
+}
+
+func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride string) error {
 	gitExe := "git"
 	if cfg.Release != nil {
 		gitExe = command.GetExecutablePath(cfg.Release.Preinstalled, "git")
@@ -107,7 +111,6 @@ func runBump(ctx context.Context, cmd *cli.Command) error {
 	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
 		return err
 	}
-
 	if cfg.Release == nil {
 		return errReleaseConfigEmpty
 	}
@@ -116,33 +119,16 @@ func runBump(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	if cfg.Sources == nil || cfg.Sources.Googleapis == nil {
-		return errNoGoogleapiSourceInfo
-	}
-
-	googleapisDir, err := fetchSource(ctx, cfg.Sources.Googleapis, googleapisRepo)
-	if err != nil {
-		return err
-	}
-	var rustSources *rust.Sources
-	if cfg.Language == languageRust {
-		rustSources, err = fetchRustSources(ctx, cfg.Sources)
-		if err != nil {
-			return err
-		}
-		rustSources.Googleapis = googleapisDir
-	}
-
 	if all {
-		if err = bumpAll(ctx, cfg, lastTag, gitExe); err != nil {
+		if err := bumpAll(ctx, cfg, lastTag, gitExe); err != nil {
 			return err
 		}
 	} else {
-		libConfg, err := libraryByName(cfg, libraryName)
+		lib, err := findLibrary(cfg, libraryName)
 		if err != nil {
 			return err
 		}
-		if err = bumpLibrary(ctx, cfg, libConfg, lastTag, gitExe, versionOverride); err != nil {
+		if err := bumpLibrary(ctx, cfg, lib, lastTag, gitExe, versionOverride); err != nil {
 			return err
 		}
 	}
@@ -158,56 +144,46 @@ func bumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string) er
 	if err != nil {
 		return err
 	}
-	for _, library := range cfg.Libraries {
-		if shouldRelease(library, filesChanged) {
-			if err := bumpLibrary(ctx, cfg, library, lastTag, gitExe, ""); err != nil {
-				return err
-			}
+	for _, lib := range cfg.Libraries {
+		if lib.SkipPublish {
+			continue
+		}
+		output := libraryOutput(cfg.Language, lib, cfg.Default)
+		if !hasChangesIn(output, filesChanged) {
+			continue
+		}
+		if err := bumpLibrary(ctx, cfg, lib, lastTag, gitExe, ""); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func shouldRelease(library *config.Library, filesChanged []string) bool {
-	if library.SkipPublish {
-		return false
+func hasChangesIn(dir string, filesChanged []string) bool {
+	if !strings.HasSuffix(dir, "/") {
+		dir += "/"
 	}
-	pathWithTrailingSlash := library.Output
-	if !strings.HasSuffix(pathWithTrailingSlash, "/") {
-		pathWithTrailingSlash = pathWithTrailingSlash + "/"
-	}
-	for _, path := range filesChanged {
-		if strings.HasPrefix(path, pathWithTrailingSlash) {
+	for _, f := range filesChanged {
+		if strings.HasPrefix(f, dir) {
 			return true
 		}
 	}
 	return false
 }
 
-func bumpLibrary(ctx context.Context, cfg *config.Config, libConfig *config.Library, lastTag, gitExe, versionOverride string) error {
-	// If the language doesn't have bespoke versioning options, a default
-	// [semver.DeriveNextOptions] instance is returned.
+func bumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, lastTag, gitExe, versionOverride string) error {
 	opts := languageVersioningOptions[cfg.Language]
-	nextVersion, err := deriveNextVersion(ctx, gitExe, cfg, libConfig, opts, versionOverride)
+	version, err := deriveNextVersion(ctx, gitExe, cfg, lib, opts, versionOverride)
 	if err != nil {
 		return err
 	}
+	output := libraryOutput(cfg.Language, lib, cfg.Default)
 
 	switch cfg.Language {
 	case languageFake:
-		return fakeBumpLibrary(libConfig, nextVersion)
+		return fakeBumpLibrary(lib, version)
 	case languageRust:
-		release, err := rust.ManifestVersionNeedsBump(gitExe, lastTag, libConfig.Output+"/Cargo.toml")
-		if err != nil {
-			return err
-		}
-		if !release {
-			return nil
-		}
-		if _, err := rust.Bump(libConfig, nextVersion); err != nil {
-			return err
-		}
-		return nil
+		return rust.Bump(lib, output, version, gitExe, lastTag)
 	default:
 		return fmt.Errorf("%q does not support bump", cfg.Language)
 	}
@@ -228,8 +204,8 @@ func postBump(ctx context.Context, cfg *config.Config) error {
 	return nil
 }
 
-// libraryByName returns a library with the given name from the config.
-func libraryByName(c *config.Config, name string) (*config.Library, error) {
+// findLibrary returns a library with the given name from the config.
+func findLibrary(c *config.Config, name string) (*config.Library, error) {
 	if c.Libraries == nil {
 		return nil, fmt.Errorf("%w: %q", ErrLibraryNotFound, name)
 	}
@@ -282,7 +258,7 @@ func loadBranchLibraryVersion(ctx context.Context, gitExe, remote, branch, libNa
 	if err != nil {
 		return "", err
 	}
-	branchLibCfg, err := libraryByName(branchLibrarianCfg, libName)
+	branchLibCfg, err := findLibrary(branchLibrarianCfg, libName)
 	if err != nil {
 		return "", err
 	}
@@ -297,7 +273,7 @@ func loadBranchLibraryVersion(ctx context.Context, gitExe, remote, branch, libNa
 func findReleasedLibraries(cfgBefore, cfgAfter *config.Config) ([]string, error) {
 	results := []string{}
 	for _, candidate := range cfgAfter.Libraries {
-		candidateBefore, err := libraryByName(cfgBefore, candidate.Name)
+		candidateBefore, err := findLibrary(cfgBefore, candidate.Name)
 		if err != nil {
 			// Any error other than "not found" is effectively fatal.
 			if !errors.Is(err, ErrLibraryNotFound) {

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -88,6 +88,28 @@ func mergePackageDependencies(defaults, lib []*config.RustPackageDependency) []*
 	return result
 }
 
+// libraryOutput returns the output path for a library. If the library has an
+// explicit output path, it returns that. Otherwise, it computes the default
+// output path based on the channel path and default configuration.
+func libraryOutput(language string, lib *config.Library, defaults *config.Default) string {
+	if lib.Output != "" {
+		return lib.Output
+	}
+	if lib.Veneer {
+		// Veneers require explicit output, so return empty if not set.
+		return ""
+	}
+	channelPath := deriveChannelPath(language, lib.Name)
+	if len(lib.Channels) > 0 && lib.Channels[0].Path != "" {
+		channelPath = lib.Channels[0].Path
+	}
+	defaultOut := ""
+	if defaults != nil {
+		defaultOut = defaults.Output
+	}
+	return defaultOutput(language, channelPath, defaultOut)
+}
+
 // prepareLibrary applies language-specific derivations and fills defaults.
 // For Rust libraries without an explicit output path, it derives the output
 // from the first channel path.

--- a/internal/librarian/rust/bump_test.go
+++ b/internal/librarian/rust/bump_test.go
@@ -41,7 +41,7 @@ const (
 
 func TestBumpOne(t *testing.T) {
 	cfg := setupRelease(t)
-	if _, err := Bump(cfg.Libraries[0], storageReleased); err != nil {
+	if err := writeVersion(cfg.Libraries[0], cfg.Libraries[0].Output, storageReleased); err != nil {
 		t.Fatal(err)
 	}
 
@@ -114,14 +114,14 @@ func checkLibraryVersion(t *testing.T, library *config.Library, wantVersion stri
 }
 
 func TestNoCargoFile(t *testing.T) {
-	_, err := Bump(&config.Library{Version: "1.0.0", Output: "nonexistent/path"}, storageReleased)
+	err := writeVersion(&config.Library{Version: "1.0.0"}, "nonexistent/path", storageReleased)
 	if err == nil {
 		t.Error("expected error when Cargo.toml doesn't exist")
 	}
 }
 
 func TestMissingVersion(t *testing.T) {
-	_, err := Bump(&config.Library{}, "")
+	err := Bump(&config.Library{}, "", "", "", "")
 	if !errors.Is(err, errMissingVersion) {
 		t.Errorf("expected error %v, got %v", errMissingVersion, err)
 	}
@@ -165,10 +165,9 @@ func TestBumpLibraryNoVersion(t *testing.T) {
 			}
 
 			lib := &config.Library{
-				Name:   libName,
-				Output: libDir,
+				Name: libName,
 			}
-			if _, err := Bump(lib, test.wantVersion); err != nil {
+			if err := writeVersion(lib, libDir, test.wantVersion); err != nil {
 				t.Fatal(err)
 			}
 			checkLibraryVersion(t, lib, test.wantVersion)

--- a/internal/librarian/rust/update_manifest.go
+++ b/internal/librarian/rust/update_manifest.go
@@ -55,9 +55,9 @@ func updateCargoVersion(path, newVersion string) error {
 	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
 }
 
-// ManifestVersionNeedsBump checks if the manifest version needs to be bumped.
+// shouldBumpManifestVersion checks if the manifest version needs to be bumped.
 // It returns false if the version has already been updated since the last tag.
-func ManifestVersionNeedsBump(gitExe, lastTag, manifest string) (bool, error) {
+func shouldBumpManifestVersion(gitExe, lastTag, manifest string) (bool, error) {
 	delta := fmt.Sprintf("%s..HEAD", lastTag)
 	cmd := exec.Command(gitExe, "diff", delta, "--", manifest)
 	cmd.Dir = "."

--- a/internal/librarian/rust/update_manifest_test.go
+++ b/internal/librarian/rust/update_manifest_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
-func TestManifestVersionNeedsBumpSuccess(t *testing.T) {
+func TestShouldBumpManifestVersionSuccess(t *testing.T) {
 	const tag = "manifest-version-update-success"
 	testhelper.RequireCommand(t, "git")
 	testhelper.SetupForVersionBump(t, tag)
@@ -48,7 +48,7 @@ func TestManifestVersionNeedsBumpSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	needsBump, err := ManifestVersionNeedsBump("git", tag, name)
+	needsBump, err := shouldBumpManifestVersion("git", tag, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestManifestVersionNeedsBumpSuccess(t *testing.T) {
 	}
 }
 
-func TestManifestVersionNeedsBumpNewCrate(t *testing.T) {
+func TestShouldBumpManifestVersionNewCrate(t *testing.T) {
 	const tag = "manifest-version-update-new-crate"
 	testhelper.RequireCommand(t, "git")
 	testhelper.SetupForVersionBump(t, tag)
@@ -71,7 +71,7 @@ func TestManifestVersionNeedsBumpNewCrate(t *testing.T) {
 	}
 	name := path.Join("src", "new", "Cargo.toml")
 
-	needsBump, err := ManifestVersionNeedsBump("git", tag, name)
+	needsBump, err := shouldBumpManifestVersion("git", tag, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,12 +80,12 @@ func TestManifestVersionNeedsBumpNewCrate(t *testing.T) {
 	}
 }
 
-func TestManifestVersionNeedsBumpNoChange(t *testing.T) {
+func TestShouldBumpManifestVersionNoChange(t *testing.T) {
 	const tag = "manifest-version-update-no-change"
 	testhelper.RequireCommand(t, "git")
 	testhelper.SetupForVersionBump(t, tag)
 	name := path.Join("src", "storage", "Cargo.toml")
-	needsBump, err := ManifestVersionNeedsBump("git", tag, name)
+	needsBump, err := shouldBumpManifestVersion("git", tag, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,12 +94,12 @@ func TestManifestVersionNeedsBumpNoChange(t *testing.T) {
 	}
 }
 
-func TestManifestVersionNeedsBumpBadDiff(t *testing.T) {
+func TestShouldBumpManifestVersionBadDiff(t *testing.T) {
 	const tag = "manifest-version-update-success"
 	testhelper.RequireCommand(t, "git")
 	testhelper.SetupForVersionBump(t, tag)
 	name := path.Join("src", "storage", "Cargo.toml")
-	if updated, err := ManifestVersionNeedsBump("git", "not-a-valid-tag", name); err == nil {
+	if updated, err := shouldBumpManifestVersion("git", "not-a-valid-tag", name); err == nil {
 		t.Errorf("expected an error with an valid tag, got=%v", updated)
 	}
 }


### PR DESCRIPTION
When running librarian bump, libraries without an explicit output field in librarian.yaml failed with "exit status 128" because the output path was empty when passed to git.

The output path is now derived using the channel and defaults, before librarian bump is called.

Additionally, the librarian bump command logic and tests have been simplified to remove unnecessary code, such as fetching sources that were not used, and renaming functions to be clearer about what they do. 

Fixes https://github.com/googleapis/librarian/issues/3693