### PR TITLE
tests(internal/librarianops): skip TestGenerateCommand

### DIFF
--- a/internal/librarianops/librarianops_test.go
+++ b/internal/librarianops/librarianops_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestGenerateCommand(t *testing.T) {
+	t.Skip("flaky test: TODO(https://github.com/googleapis/librarian/issues/3698)")
 	repoDir := t.TempDir()
 	if err := command.Run(t.Context(), "git", "init", repoDir); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Skip TestGenerateCommand while we debug because it is currently flaky and fails with 403 errors.

For https://github.com/googleapis/librarian/issues/3698