### PR TITLE
refactor: rename Channel to API

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,9 +148,9 @@ type Library struct {
 	// Version is the library version.
 	Version string `yaml:"version,omitempty"`
 
-	// Channel specifies which googleapis Channel to generate from (for generated
+	// API specifies which googleapis API to generate from (for generated
 	// libraries).
-	Channels []*Channel `yaml:"channels,omitempty"`
+	APIs []*API `yaml:"channels,omitempty"`
 
 	// CopyrightYear is the copyright year for the library.
 	CopyrightYear string `yaml:"copyright_year,omitempty"`
@@ -207,8 +207,8 @@ type Library struct {
 	Rust *RustCrate `yaml:"rust,omitempty"`
 }
 
-// Channel describes a Channel to include in a library.
-type Channel struct {
+// API describes a API to include in a library.
+type API struct {
 	// Path specifies which googleapis Path to generate from (for generated
 	// libraries).
 	Path string `yaml:"path,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,14 +71,14 @@ func TestRead(t *testing.T) {
 			{
 				Name:    "google-cloud-secretmanager-v1",
 				Version: "1.2.3",
-				Channels: []*Channel{
+				APIs: []*API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
 			},
 			{
 				Name:    "google-cloud-storage-v2",
 				Version: "2.3.4",
-				Channels: []*Channel{
+				APIs: []*API{
 					{Path: "google/cloud/storage/v2"},
 				},
 				Rust: &RustCrate{

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -267,12 +267,12 @@ type PythonPackage struct {
 	// Example: ["warehouse-package-name=google-cloud-batch"]
 	OptArgs []string `yaml:"opt_args,omitempty"`
 
-	// OptArgsByChannel contains additional options passed to the generator,
+	// OptArgsByAPI contains additional options passed to the generator,
 	// where the options vary by channel. In each entry, the key is the channel
 	// (API path) and the value is the list of options to pass when generating
 	// that API channel.
 	// Example: {"google/cloud/secrets/v1beta": ["python-gapic-name=secretmanager"]}
-	OptArgsByChannel map[string][]string `yaml:"opt_args_by_channel,omitempty"`
+	OptArgsByAPI map[string][]string `yaml:"opt_args_by_api,omitempty"`
 }
 
 // DartPackage contains Dart-specific library configuration.

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -90,7 +90,7 @@ func addLibraryToLibrarianConfig(cfg *config.Config, name, output string, channe
 	}
 
 	for _, c := range channel {
-		lib.Channels = append(lib.Channels, &config.Channel{
+		lib.APIs = append(lib.APIs, &config.API{
 			Path: c,
 		})
 	}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -72,7 +72,7 @@ func TestAddLibrary(t *testing.T) {
 				{
 					Name:   "existinglib",
 					Output: "output",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{Path: "google/cloud/secretmanager/v1"},
 					},
 				},
@@ -81,7 +81,7 @@ func TestAddLibrary(t *testing.T) {
 			wantFinalLibraries: []*config.Library{
 				{
 					Name: "existinglib",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{Path: "google/cloud/secretmanager/v1"},
 					},
 				},
@@ -151,11 +151,11 @@ func TestAddCommand(t *testing.T) {
 
 	testName := "google-cloud-secret-manager"
 	for _, test := range []struct {
-		name         string
-		args         []string
-		wantErr      error
-		wantChannels []*config.Channel
-		wantOutput   string
+		name       string
+		args       []string
+		wantErr    error
+		wantAPIs   []*config.API
+		wantOutput string
 	}{
 		{
 			name:    "no args",
@@ -178,7 +178,7 @@ func TestAddCommand(t *testing.T) {
 				testName,
 				"google/cloud/secretmanager/v1",
 			},
-			wantChannels: []*config.Channel{
+			wantAPIs: []*config.API{
 				{
 					Path: "google/cloud/secretmanager/v1",
 				},
@@ -194,7 +194,7 @@ func TestAddCommand(t *testing.T) {
 				"google/cloud/secretmanager/v1beta2",
 				"google/cloud/secrets/v1beta1",
 			},
-			wantChannels: []*config.Channel{
+			wantAPIs: []*config.API{
 				{
 					Path: "google/cloud/secretmanager/v1",
 				},
@@ -219,7 +219,7 @@ func TestAddCommand(t *testing.T) {
 				"packages/google-cloud-secret-manager",
 			},
 			wantOutput: "packages/google-cloud-secret-manager",
-			wantChannels: []*config.Channel{
+			wantAPIs: []*config.API{
 				{
 					Path: "google/cloud/secretmanager/v1",
 				},
@@ -272,8 +272,8 @@ func TestAddCommand(t *testing.T) {
 			if test.wantOutput != "" && got.Output != test.wantOutput {
 				t.Errorf("output = %q, want %q", got.Output, test.wantOutput)
 			}
-			if test.wantChannels != nil {
-				if diff := cmp.Diff(test.wantChannels, got.Channels); diff != "" {
+			if test.wantAPIs != nil {
+				if diff := cmp.Diff(test.wantAPIs, got.APIs); diff != "" {
 					t.Errorf("channels mismatch (-want +got):\n%s", diff)
 				}
 			}
@@ -287,7 +287,7 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 		libraryName string
 		output      string
 		channels    []string
-		want        []*config.Channel
+		want        []*config.API
 	}{
 		{
 			name:        "library with no specification-source",
@@ -299,7 +299,7 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 			libraryName: "newlib",
 			output:      "output/newlib",
 			channels:    []string{"google/cloud/storage/v1"},
-			want: []*config.Channel{
+			want: []*config.API{
 				{
 					Path: "google/cloud/storage/v1",
 				},
@@ -314,7 +314,7 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 				"google/cloud/secretmanager/v1beta2",
 				"google/cloud/secrets/v1beta1",
 			},
-			want: []*config.Channel{
+			want: []*config.API{
 				{
 					Path: "google/cloud/secretmanager/v1",
 				},
@@ -366,7 +366,7 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 			if found.Version != "" {
 				t.Errorf("version = %q, want %q", found.Version, "")
 			}
-			if diff := cmp.Diff(test.want, found.Channels); diff != "" {
+			if diff := cmp.Diff(test.want, found.APIs); diff != "" {
 				t.Errorf("channels mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/librarian/dart/generate.go
+++ b/internal/librarian/dart/generate.go
@@ -29,7 +29,7 @@ import (
 
 // Generate generates a Dart client library.
 func Generate(ctx context.Context, library *config.Library, googleapisDir string) error {
-	sidekickConfig, err := toSidekickConfig(library, library.Channels[0], googleapisDir)
+	sidekickConfig, err := toSidekickConfig(library, library.APIs[0], googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func Format(ctx context.Context, library *config.Library) error {
 	return nil
 }
 
-func toSidekickConfig(library *config.Library, ch *config.Channel, googleapisDir string) (*sidekickconfig.Config, error) {
+func toSidekickConfig(library *config.Library, ch *config.API, googleapisDir string) (*sidekickconfig.Config, error) {
 	source := map[string]string{
 		"googleapis-root": googleapisDir,
 	}

--- a/internal/librarian/dart/generate_test.go
+++ b/internal/librarian/dart/generate_test.go
@@ -40,7 +40,7 @@ func TestGenerate(t *testing.T) {
 		Version:       "0.1.0",
 		Output:        outDir,
 		CopyrightYear: "2025",
-		Channels: []*config.Channel{
+		APIs: []*config.API{
 			{
 				Path: "google/cloud/secretmanager/v1",
 			},

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -163,10 +163,10 @@ func defaultOutput(language, channel, defaultOut string) string {
 	}
 }
 
-func deriveChannelPath(language, name string) string {
+func deriveAPIPath(language, name string) string {
 	switch language {
 	case languageRust:
-		return rust.DeriveChannelPath(name)
+		return rust.DeriveAPIPath(name)
 	default:
 		return strings.ReplaceAll(name, "-", "/")
 	}

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -92,17 +92,17 @@ func mergePackageDependencies(defaults, lib []*config.RustPackageDependency) []*
 // For Rust libraries without an explicit output path, it derives the output
 // from the first channel path.
 func prepareLibrary(language string, lib *config.Library, defaults *config.Default, fillInDefaults bool) (*config.Library, error) {
-	if len(lib.Channels) == 0 {
+	if len(lib.APIs) == 0 {
 		// If no channels are specified, create an empty channel first
-		lib.Channels = append(lib.Channels, &config.Channel{})
+		lib.APIs = append(lib.APIs, &config.API{})
 	}
 
 	// The googleapis path of a veneer library lives in language-specific configurations,
 	// so we only need to derive the path for non-veneer libraries.
 	if !lib.Veneer {
-		for _, ch := range lib.Channels {
+		for _, ch := range lib.APIs {
 			if ch.Path == "" {
-				ch.Path = deriveChannelPath(language, lib.Name)
+				ch.Path = deriveAPIPath(language, lib.Name)
 			}
 		}
 	}
@@ -110,7 +110,7 @@ func prepareLibrary(language string, lib *config.Library, defaults *config.Defau
 		if lib.Veneer {
 			return nil, fmt.Errorf("veneer %q requires an explicit output path", lib.Name)
 		}
-		lib.Output = defaultOutput(language, lib.Channels[0].Path, defaults.Output)
+		lib.Output = defaultOutput(language, lib.APIs[0].Path, defaults.Output)
 	}
 	if fillInDefaults {
 		return fillDefaults(lib, defaults), nil

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -249,49 +249,49 @@ func TestFillDefaults_Rust(t *testing.T) {
 
 func TestPrepareLibrary(t *testing.T) {
 	for _, test := range []struct {
-		name            string
-		language        string
-		output          string
-		veneer          bool
-		channels        []*config.Channel
-		wantOutput      string
-		wantErr         bool
-		wantChannelPath string
+		name        string
+		language    string
+		output      string
+		veneer      bool
+		channels    []*config.API
+		wantOutput  string
+		wantErr     bool
+		wantAPIPath string
 	}{
 		{
 			name:       "empty output derives path from channel",
 			language:   "rust",
-			channels:   []*config.Channel{{Path: "google/cloud/secretmanager/v1"}},
+			channels:   []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			wantOutput: "src/generated/cloud/secretmanager/v1",
 		},
 		{
 			name:       "explicit output keeps explicit path",
 			language:   "rust",
 			output:     "custom/output",
-			channels:   []*config.Channel{{Path: "google/cloud/secretmanager/v1"}},
+			channels:   []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			wantOutput: "custom/output",
 		},
 		{
 			name:       "empty output uses default for non-rust",
 			language:   "go",
-			channels:   []*config.Channel{{Path: "google/cloud/secretmanager/v1"}},
+			channels:   []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			wantOutput: "src/generated",
 		},
 		{
-			name:            "rust with no channels creates default and derives path",
-			language:        "rust",
-			channels:        nil,
-			wantOutput:      "src/generated/cloud/secretmanager/v1",
-			wantChannelPath: "google/cloud/secretmanager/v1",
+			name:        "rust with no channels creates default and derives path",
+			language:    "rust",
+			channels:    nil,
+			wantOutput:  "src/generated/cloud/secretmanager/v1",
+			wantAPIPath: "google/cloud/secretmanager/v1",
 		},
 		{
-			name:            "veneer rust with no channels does not derive path",
-			language:        "rust",
-			output:          "src/storage/test/v1",
-			veneer:          true,
-			channels:        nil,
-			wantOutput:      "src/storage/test/v1",
-			wantChannelPath: "",
+			name:        "veneer rust with no channels does not derive path",
+			language:    "rust",
+			output:      "src/storage/test/v1",
+			veneer:      true,
+			channels:    nil,
+			wantOutput:  "src/storage/test/v1",
+			wantAPIPath: "",
 		},
 		{
 			name:    "veneer without output returns error",
@@ -305,19 +305,19 @@ func TestPrepareLibrary(t *testing.T) {
 			wantOutput: "src/storage",
 		},
 		{
-			name:            "rust lib without service config",
-			language:        "rust",
-			channels:        []*config.Channel{{Path: "google/cloud/orgpolicy/v1"}},
-			wantOutput:      "src/generated/cloud/orgpolicy/v1",
-			wantChannelPath: "google/cloud/orgpolicy/v1",
+			name:        "rust lib without service config",
+			language:    "rust",
+			channels:    []*config.API{{Path: "google/cloud/orgpolicy/v1"}},
+			wantOutput:  "src/generated/cloud/orgpolicy/v1",
+			wantAPIPath: "google/cloud/orgpolicy/v1",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			lib := &config.Library{
-				Name:     "google-cloud-secretmanager-v1",
-				Output:   test.output,
-				Veneer:   test.veneer,
-				Channels: test.channels,
+				Name:   "google-cloud-secretmanager-v1",
+				Output: test.output,
+				Veneer: test.veneer,
+				APIs:   test.channels,
 			}
 			defaults := &config.Default{
 				Output: "src/generated",
@@ -335,10 +335,10 @@ func TestPrepareLibrary(t *testing.T) {
 			if got.Output != test.wantOutput {
 				t.Errorf("got output %q, want %q", got.Output, test.wantOutput)
 			}
-			if len(got.Channels) > 0 {
-				ch := got.Channels[0]
-				if test.wantChannelPath != "" && ch.Path != test.wantChannelPath {
-					t.Errorf("got channel path %q, want %q", ch.Path, test.wantChannelPath)
+			if len(got.APIs) > 0 {
+				ch := got.APIs[0]
+				if test.wantAPIPath != "" && ch.Path != test.wantAPIPath {
+					t.Errorf("got channel path %q, want %q", ch.Path, test.wantAPIPath)
 				}
 			}
 		})

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -59,14 +59,14 @@ func TestCreateProtocOptions(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
 		name     string
-		channel  *config.Channel
+		api      *config.API
 		library  *config.Library
 		expected []string
 		wantErr  bool
 	}{
 		{
 			name:    "basic case",
-			channel: &config.Channel{Path: "google/cloud/secretmanager/v1"},
+			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{},
 			expected: []string{
 				"--python_gapic_out=staging",
@@ -75,7 +75,7 @@ func TestCreateProtocOptions(t *testing.T) {
 		},
 		{
 			name:    "with transport",
-			channel: &config.Channel{Path: "google/cloud/secretmanager/v1"},
+			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{Transport: "grpc"},
 			expected: []string{
 				"--python_gapic_out=staging",
@@ -83,8 +83,8 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 		},
 		{
-			name:    "with python opts",
-			channel: &config.Channel{Path: "google/cloud/secretmanager/v1"},
+			name: "with python opts",
+			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{
 				Python: &config.PythonPackage{
 					OptArgs: []string{"opt1", "opt2"},
@@ -96,11 +96,11 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 		},
 		{
-			name:    "with python opts by channel",
-			channel: &config.Channel{Path: "google/cloud/secretmanager/v1"},
+			name: "with python opts by api",
+			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{
 				Python: &config.PythonPackage{
-					OptArgsByChannel: map[string][]string{
+					OptArgsByAPI: map[string][]string{
 						"google/cloud/secretmanager/v1": {"opt1", "opt2"},
 						"google/cloud/secretmanager/v2": {"opt3", "opt4"},
 					},
@@ -113,7 +113,7 @@ func TestCreateProtocOptions(t *testing.T) {
 		},
 		{
 			name:    "with version",
-			channel: &config.Channel{Path: "google/cloud/secretmanager/v1"},
+			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{Version: "1.2.3"},
 			expected: []string{
 				"--python_gapic_out=staging",
@@ -122,7 +122,7 @@ func TestCreateProtocOptions(t *testing.T) {
 		},
 		{
 			name: "with service config",
-			channel: &config.Channel{
+			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",
 			},
 			library: &config.Library{},
@@ -133,7 +133,7 @@ func TestCreateProtocOptions(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := createProtocOptions(test.channel, test.library, googleapisDir, "staging")
+			got, err := createProtocOptions(test.api, test.library, googleapisDir, "staging")
 			if (err != nil) != test.wantErr {
 				t.Fatalf("createProtocOptions() error = %v, wantErr %v", err, test.wantErr)
 			}
@@ -319,7 +319,7 @@ func TestRunPostProcessor(t *testing.T) {
 	}
 }
 
-func TestGenerateChannel(t *testing.T) {
+func TestGenerateAPI(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("slow test: Python GAPIC code generation")
@@ -328,9 +328,9 @@ func TestGenerateChannel(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "protoc-gen-python_gapic")
 	repoRoot := t.TempDir()
-	err := generateChannel(
+	err := generateAPI(
 		t.Context(),
-		&config.Channel{Path: "google/cloud/secretmanager/v1"},
+		&config.API{Path: "google/cloud/secretmanager/v1"},
 		&config.Library{Name: "secretmanager", Output: repoRoot},
 		googleapisDir,
 		repoRoot,
@@ -360,7 +360,7 @@ func TestGenerate(t *testing.T) {
 	library := &config.Library{
 		Name:   "secretmanager",
 		Output: outdir,
-		Channels: []*config.Channel{
+		APIs: []*config.API{
 			{
 				Path: "google/cloud/secretmanager/v1",
 			},

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -23,7 +23,7 @@ import (
 	sidekickconfig "github.com/googleapis/librarian/internal/sidekick/config"
 )
 
-func toSidekickConfig(library *config.Library, ch *config.Channel, sources *Sources) (*sidekickconfig.Config, error) {
+func toSidekickConfig(library *config.Library, ch *config.API, sources *Sources) (*sidekickconfig.Config, error) {
 	specFormat := "protobuf"
 	if library.SpecificationFormat != "" {
 		specFormat = library.SpecificationFormat

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -43,7 +43,7 @@ func TestToSidekickConfig(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		library *config.Library
-		channel *config.Channel
+		channel *config.API
 		want    *sidekickconfig.Config
 	}{
 		{
@@ -52,7 +52,7 @@ func TestToSidekickConfig(t *testing.T) {
 				Name: "google-cloud-storage",
 				Rust: &config.RustCrate{},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -80,7 +80,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -109,7 +109,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -150,7 +150,7 @@ func TestToSidekickConfig(t *testing.T) {
 					TemplateOverride:          "custom-template",
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -190,7 +190,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -228,7 +228,7 @@ func TestToSidekickConfig(t *testing.T) {
 					},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -261,7 +261,7 @@ func TestToSidekickConfig(t *testing.T) {
 					},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -313,7 +313,7 @@ func TestToSidekickConfig(t *testing.T) {
 					},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -356,7 +356,7 @@ func TestToSidekickConfig(t *testing.T) {
 					},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storage/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -389,7 +389,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis", "discovery"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/compute/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -417,7 +417,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/secretmanager/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -444,7 +444,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis", "discovery", "showcase"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/compute/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -469,7 +469,7 @@ func TestToSidekickConfig(t *testing.T) {
 			library: &config.Library{
 				Name: "google-cloud-apps-script-type-gmail",
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/apps/script/type/gmail",
 			},
 			want: &sidekickconfig.Config{
@@ -494,7 +494,7 @@ func TestToSidekickConfig(t *testing.T) {
 				Name:                "google-cloud-longrunning",
 				DescriptionOverride: "Defines types and an abstract service to handle long-running operations.",
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/longrunning",
 			},
 			want: &sidekickconfig.Config{
@@ -525,7 +525,7 @@ func TestToSidekickConfig(t *testing.T) {
 					},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/spanner/admin/database/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -552,7 +552,7 @@ func TestToSidekickConfig(t *testing.T) {
 					NameOverrides: ".google.cloud.storageinsights.v1.DatasetConfig.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.cloud.storageinsights.v1.DatasetConfig.cloud_storage_locations=CloudStorageLocationsOneOf",
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/storageinsights/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -597,7 +597,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis", "discovery"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/compute/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -641,7 +641,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"googleapis", "protobuf-src", "conformance"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "google/cloud/vision/v1",
 			},
 			want: &sidekickconfig.Config{
@@ -669,7 +669,7 @@ func TestToSidekickConfig(t *testing.T) {
 					Roots: []string{"showcase"},
 				},
 			},
-			channel: &config.Channel{
+			channel: &config.API{
 				Path: "schema/google/showcase/v1beta1",
 			},
 			want: &sidekickconfig.Config{

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -44,11 +44,11 @@ func Generate(ctx context.Context, library *config.Library, sources *Sources) er
 	if library.Veneer {
 		return generateVeneer(ctx, library, sources)
 	}
-	if len(library.Channels) != 1 {
+	if len(library.APIs) != 1 {
 		return fmt.Errorf("the Rust generator only supports a single channel per library")
 	}
 
-	sidekickConfig, err := toSidekickConfig(library, library.Channels[0], sources)
+	sidekickConfig, err := toSidekickConfig(library, library.APIs[0], sources)
 	if err != nil {
 		return err
 	}
@@ -161,9 +161,9 @@ func defaultLibraryName(channel string) string {
 	return strings.ReplaceAll(channel, "/", "-")
 }
 
-// DeriveChannelPath derives a channel path from a library name.
+// DeriveAPIPath derives a channel path from a library name.
 // For example: google-cloud-secretmanager-v1 -> google/cloud/secretmanager/v1.
-func DeriveChannelPath(name string) string {
+func DeriveAPIPath(name string) string {
 	return strings.ReplaceAll(name, "-", "/")
 }
 

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -236,7 +236,7 @@ func TestGenerate(t *testing.T) {
 				Output:        outDir,
 				ReleaseLevel:  "preview",
 				CopyrightYear: "2025",
-				Channels: []*config.Channel{
+				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
 					},
@@ -311,7 +311,7 @@ func TestDefaultLibraryName(t *testing.T) {
 	}
 }
 
-func TestDeriveChannelPath(t *testing.T) {
+func TestDeriveAPIPath(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		lib  string
@@ -329,7 +329,7 @@ func TestDeriveChannelPath(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := DeriveChannelPath(test.lib)
+			got := DeriveAPIPath(test.lib)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -80,7 +80,7 @@ func TestFormatConfig(t *testing.T) {
 			{
 				Name:    "google-cloud-storage-v1",
 				Version: "1.0.0",
-				Channels: []*config.Channel{
+				APIs: []*config.API{
 					{Path: "c"},
 					{Path: "a"},
 				},
@@ -126,7 +126,7 @@ func TestFormatConfig(t *testing.T) {
 	t.Run("sorts channels by path", func(t *testing.T) {
 		want := []string{"a", "c"}
 		var got []string
-		for _, ch := range storageLib.Channels {
+		for _, ch := range storageLib.APIs {
 			got = append(got, ch.Path)
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -218,7 +218,7 @@ func TestTidy_DerivableFields(t *testing.T) {
 				Libraries: []*config.Library{
 					{
 						Name: "google-cloud-accessapproval-v1",
-						Channels: []*config.Channel{
+						APIs: []*config.API{
 							{
 								Path: "google/cloud/accessapproval/v1",
 							},
@@ -237,7 +237,7 @@ func TestTidy_DerivableFields(t *testing.T) {
 				Libraries: []*config.Library{
 					{
 						Name: "google-cloud-aiplatform-v1-schema-predict-instance",
-						Channels: []*config.Channel{
+						APIs: []*config.API{
 							{
 								Path: "src/generated/cloud/aiplatform/schema/predict/instance",
 							},
@@ -256,7 +256,7 @@ func TestTidy_DerivableFields(t *testing.T) {
 				Libraries: []*config.Library{
 					{
 						Name: "google-cloud-orgpolicy-v1",
-						Channels: []*config.Channel{
+						APIs: []*config.API{
 							{
 								Path: "google/cloud/orgpolicy/v1",
 							},
@@ -284,11 +284,11 @@ func TestTidy_DerivableFields(t *testing.T) {
 				t.Fatalf("wrong number of libraries")
 			}
 			lib := cfg.Libraries[0]
-			if len(lib.Channels) != test.wantNumChnls {
+			if len(lib.APIs) != test.wantNumChnls {
 				t.Fatalf("wrong number of channels")
 			}
 			if test.wantNumChnls > 0 {
-				ch := lib.Channels[0]
+				ch := lib.APIs[0]
 				if ch.Path != test.wantPath {
 					t.Errorf("path should be %s, got %q", test.wantPath, ch.Path)
 				}
@@ -345,7 +345,7 @@ func TestTidy_DerivableOutput(t *testing.T) {
 			{
 				Name:   "google-cloud-secretmanager-v1",
 				Output: "generated/cloud/secretmanager/v1",
-				Channels: []*config.Channel{
+				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
 					},

--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -175,7 +175,7 @@ func buildLibraries(input *MigrationInput) []*config.Library {
 		library.Name = id
 		library.Version = libState.Version
 		if libState.APIs != nil {
-			library.Channels = toChannels(libState.APIs)
+			library.APIs = toAPIs(libState.APIs)
 		}
 		library.Keep = libState.PreserveRegex
 
@@ -229,10 +229,10 @@ func sliceToMap[T any](slice []*T, keyFunc func(t *T) string) map[string]*T {
 	return res
 }
 
-func toChannels(apis []*legacyconfig.API) []*config.Channel {
-	channels := make([]*config.Channel, 0, len(apis))
+func toAPIs(apis []*legacyconfig.API) []*config.API {
+	channels := make([]*config.API, 0, len(apis))
 	for _, api := range apis {
-		channels = append(channels, &config.Channel{
+		channels = append(channels, &config.API{
 			Path: api.Path,
 		})
 	}

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -185,7 +185,7 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 					{
 						Name:    "example-library",
 						Version: "1.0.0",
-						Channels: []*config.Channel{
+						APIs: []*config.API{
 							{
 								Path: "google/example/api/v1",
 							},
@@ -320,7 +320,7 @@ func TestBuildLibraries(t *testing.T) {
 			want: []*config.Library{
 				{
 					Name: "another-library",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/another/api/v1",
 						},
@@ -328,7 +328,7 @@ func TestBuildLibraries(t *testing.T) {
 				},
 				{
 					Name: "example-library",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/example/api/v1",
 						},
@@ -386,7 +386,7 @@ func TestBuildLibraries(t *testing.T) {
 			want: []*config.Library{
 				{
 					Name: "another-library",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/another/api/v1",
 						},
@@ -394,7 +394,7 @@ func TestBuildLibraries(t *testing.T) {
 				},
 				{
 					Name: "example-library",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/example/api/v1",
 						},

--- a/tool/cmd/migrate/main.go
+++ b/tool/cmd/migrate/main.go
@@ -329,7 +329,7 @@ func buildGAPIC(files []string, repoPath string) (map[string]*config.Library, er
 		lib.Output = relativePath
 
 		// Add channels
-		lib.Channels = append(lib.Channels, &config.Channel{
+		lib.APIs = append(lib.APIs, &config.API{
 			Path: apiPath,
 		})
 
@@ -664,8 +664,8 @@ func buildConfig(libraries map[string]*config.Library, defaults *config.Config) 
 	for _, lib := range libraries {
 		// Get the API path for this library
 		apiPath := ""
-		if len(lib.Channels) > 0 {
-			apiPath = lib.Channels[0].Path
+		if len(lib.APIs) > 0 {
+			apiPath = lib.APIs[0].Path
 		}
 
 		// Derive expected library name from API path
@@ -678,7 +678,7 @@ func buildConfig(libraries map[string]*config.Library, defaults *config.Config) 
 				len(lib.Rust.PackageDependencies) > 0 || len(lib.Rust.PaginationOverrides) > 0 ||
 				lib.Rust.NameOverrides != ""))
 		// Only include in libraries section if specific data needs to be retained
-		if !nameMatchesConvention || hasExtraConfig || len(lib.Channels) > 1 {
+		if !nameMatchesConvention || hasExtraConfig || len(lib.APIs) > 1 {
 			libCopy := *lib
 			libList = append(libList, &libCopy)
 		}

--- a/tool/cmd/migrate/main_test.go
+++ b/tool/cmd/migrate/main_test.go
@@ -177,7 +177,7 @@ func TestBuildGAPIC(t *testing.T) {
 			want: map[string]*config.Library{
 				"google-cloud-security-publicca-v1": {
 					Name: "google-cloud-security-publicca-v1",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/cloud/security/publicca/v1",
 						},
@@ -218,7 +218,7 @@ func TestBuildGAPIC(t *testing.T) {
 				},
 				"google-cloud-sql-v1": {
 					Name: "google-cloud-sql-v1",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/cloud/sql/v1",
 						},
@@ -294,7 +294,7 @@ func TestBuildGAPIC(t *testing.T) {
 			want: map[string]*config.Library{
 				"google-cloud-compute-v1": {
 					Name: "google-cloud-compute-v1",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/cloud/compute/v1",
 						},
@@ -706,7 +706,7 @@ func TestBuildConfig(t *testing.T) {
 			libraries: map[string]*config.Library{
 				"google-cloud-security-publicca-v1": {
 					Name: "google-cloud-security-publicca-v1",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/cloud/security/publicca/v1",
 						},
@@ -725,7 +725,7 @@ func TestBuildConfig(t *testing.T) {
 				},
 				"skipped": {
 					Name: "google-cloud-sql-v1",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/cloud/sql/v1",
 						},
@@ -738,7 +738,7 @@ func TestBuildConfig(t *testing.T) {
 				Libraries: []*config.Library{
 					{
 						Name: "google-cloud-security-publicca-v1",
-						Channels: []*config.Channel{
+						APIs: []*config.API{
 							{
 								Path: "google/cloud/security/publicca/v1",
 							},
@@ -764,7 +764,7 @@ func TestBuildConfig(t *testing.T) {
 			libraries: map[string]*config.Library{
 				"google-cloud-orgpolicy-v1": {
 					Name: "google-cloud-orgpolicy-v1",
-					Channels: []*config.Channel{
+					APIs: []*config.API{
 						{
 							Path: "google/cloud/orgpolicy/v1",
 						},
@@ -786,7 +786,7 @@ func TestBuildConfig(t *testing.T) {
 				Libraries: []*config.Library{
 					{
 						Name: "google-cloud-orgpolicy-v1",
-						Channels: []*config.Channel{
+						APIs: []*config.API{
 							{
 								Path: "google/cloud/orgpolicy/v1",
 							},


### PR DESCRIPTION
Rename Channel to API across the codebase.

channel will be renamed to api in a follow up PR, as will YAML changes.

For https://github.com/googleapis/librarian/issues/3689