### PR TITLE
fix(internal/librarian): separate cleaning from generation

### DIFF
--- a/internal/librarian/fake_test.go
+++ b/internal/librarian/fake_test.go
@@ -35,7 +35,7 @@ func TestGenerate(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	if _, err := generate(t.Context(), "fake", library, "", nil); err != nil {
+	if err := generate(t.Context(), "fake", library, "", nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -76,9 +76,9 @@ func TestGenerateCommand(t *testing.T) {
 			wantPostGenerate: true,
 		},
 		{
-			name: "skip generate",
-			args: []string{"librarian", "generate", lib3},
-			want: []string{},
+			name:    "skip generate",
+			args:    []string{"librarian", "generate", lib3},
+			wantErr: errSkipGenerate,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -194,9 +194,10 @@ func TestGenerateSkip(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name string
-		args []string
-		want []string
+		name    string
+		args    []string
+		wantErr error
+		want    []string
 	}{
 		{
 			name: "skip_generate with all flag",
@@ -204,8 +205,9 @@ func TestGenerateSkip(t *testing.T) {
 			want: []string{lib2},
 		},
 		{
-			name: "skip_generate with library name",
-			args: []string{"librarian", "generate", lib1},
+			name:    "skip_generate with library name",
+			args:    []string{"librarian", "generate", lib1},
+			wantErr: errSkipGenerate,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -229,7 +231,14 @@ libraries:
 			if err := os.WriteFile(filepath.Join(tempDir, librarianConfigPath), []byte(configContent), 0644); err != nil {
 				t.Fatal(err)
 			}
-			if err := Run(t.Context(), test.args...); err != nil {
+			err := Run(t.Context(), test.args...)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("want error %v, got %v", test.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
 				t.Fatal(err)
 			}
 			generated := make(map[string]bool)

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -110,21 +110,15 @@ func libraryOutput(language string, lib *config.Library, defaults *config.Defaul
 	return defaultOutput(language, apiPath, defaultOut)
 }
 
-// prepareLibrary applies language-specific derivations and fills defaults.
-// For Rust libraries without an explicit output path, it derives the output
-// from the first api path.
-func prepareLibrary(language string, lib *config.Library, defaults *config.Default, fillInDefaults bool) (*config.Library, error) {
+// applyDefaults applies language-specific derivations and fills defaults.
+func applyDefaults(language string, lib *config.Library, defaults *config.Default) (*config.Library, error) {
 	if len(lib.APIs) == 0 {
-		// If no apis are specified, create an empty api first
 		lib.APIs = append(lib.APIs, &config.API{})
 	}
-
-	// The googleapis path of a veneer library lives in language-specific configurations,
-	// so we only need to derive the path for non-veneer libraries.
 	if !lib.Veneer {
-		for _, ch := range lib.APIs {
-			if ch.Path == "" {
-				ch.Path = deriveAPIPath(language, lib.Name)
+		for _, api := range lib.APIs {
+			if api.Path == "" {
+				api.Path = deriveAPIPath(language, lib.Name)
 			}
 		}
 	}
@@ -134,9 +128,5 @@ func prepareLibrary(language string, lib *config.Library, defaults *config.Defau
 		}
 		lib.Output = defaultOutput(language, lib.APIs[0].Path, defaults.Output)
 	}
-	if fillInDefaults {
-		return fillDefaults(lib, defaults), nil
-	}
-
-	return lib, nil
+	return fillDefaults(lib, defaults), nil
 }

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -322,7 +322,7 @@ func TestPrepareLibrary(t *testing.T) {
 			defaults := &config.Default{
 				Output: "src/generated",
 			}
-			got, err := prepareLibrary(test.language, lib, defaults, true)
+			got, err := applyDefaults(test.language, lib, defaults)
 			if test.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")


### PR DESCRIPTION
When library output directories are nested, running cleanOutput and generate together in parallel can create a race condition where one library may delete files generated by another, leading to missing generated files.

This change separates cleaning and generation into distinct phases by deleting the generated output directories first, then running generate in parallel.

Additionally, routeGenerate, generateAll, and generateLibrary are merged into one function.

Fixes https://github.com/googleapis/librarian/issues/3718