### PR TITLE
feat(sidekick): generate features for `rustls` dep pruning

### DIFF
--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -48,9 +48,8 @@ default = [
 ]
 # Enabled by default. Use the default rustls crypto provider ([ring]) for TLS
 # and authentication. Applications with specific requirements for cryptography
-# (such as exclusively using the [aws-lc-rs], or [ring] crates) should disable
-# this default and install the default crypto provider in `rustls` to fit their
-# requirements.
+# (such as exclusively using the [aws-lc-rs]) should disable this default and
+# call `rustls::CryptoProvider::install_default()`.
 default-rustls-provider = ["gaxi/_default-rustls-provider"]
 {{#Codec.PerServiceFeatures}}
 {{#Codec.Services}}

--- a/internal/sidekick/rust/templates/common/README.md.mustache
+++ b/internal/sidekick/rust/templates/common/README.md.mustache
@@ -69,9 +69,9 @@ The main types to work with this crate are the clients:
 
 - `default-rustls-provider`: enabled by default. Use the default rustls crypto
   provider ([ring]) for TLS and authentication. Applications with specific
-  requirements for cryptography (such as exclusively using the [aws-lc-rs], or
-  [ring] crates) should disable this default and install the default crypto
-  provider in `rustls` to fit their requirements.
+  requirements for cryptography (such as exclusively using the [aws-lc-rs])
+  should disable this default and call
+  `rustls::CryptoProvider::install_default()`.
 {{#Codec.PerServiceFeatures}}
 - Each client can be enabled using its own feature. Use the client's name
   in `kebab-case` to enable the client.

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -69,9 +69,9 @@ limitations under the License.
 //!
 //! - `default-rustls-provider`: enabled by default. Use the default rustls crypto
 //!   provider ([ring]) for TLS and authentication. Applications with specific
-//!   requirements for cryptography (such as exclusively using the [aws-lc-rs], or
-//!   [ring] crates) should disable this default and install the default crypto
-//!   provider in `rustls` to fit their requirements.
+//!   requirements for cryptography (such as exclusively using the [aws-lc-rs])
+//!   should disable this default and call
+//!   `rustls::CryptoProvider::install_default()`.
 {{#Codec.PerServiceFeatures}}
 //! - Each client can be enabled using its own feature. Use the client's name
 //!   in `kebab-case` to enable the client.


### PR DESCRIPTION
The generated libraries need to prune the `rustls` dependencies, specifically the crypto provider. This changes the generated code to define compile-time features that either select a default `rustls` crypto provider, or define no default. In the latter case, the application must explicitly define the provider, which is typically what they want.

Part of the work for https://github.com/googleapis/google-cloud-rust/issues/4170


You can see the effect of these changes in https://github.com/googleapis/google-cloud-rust/pull/4366