### PR TITLE
chore(sidekick): default `rustls` provider changed

### DIFF
--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -46,10 +46,10 @@ default = [
     "{{{.}}}",
     {{/Codec.DefaultFeatures}}
 ]
-# Enabled by default. Use the default rustls crypto provider ([ring]) for TLS
-# and authentication. Applications with specific requirements for cryptography
-# (such as exclusively using the [aws-lc-rs]) should disable this default and
-# call `rustls::CryptoProvider::install_default()`.
+# Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
+# TLS and authentication. Applications with specific requirements for
+# cryptography (such as exclusively using the [ring] crate) should disable this
+# default and call `rustls::crypto::CryptoProvider::install_default()`.
 default-rustls-provider = ["gaxi/_default-rustls-provider"]
 {{#Codec.PerServiceFeatures}}
 {{#Codec.Services}}

--- a/internal/sidekick/rust/templates/common/README.md.mustache
+++ b/internal/sidekick/rust/templates/common/README.md.mustache
@@ -68,10 +68,10 @@ The main types to work with this crate are the clients:
 ## Features
 
 - `default-rustls-provider`: enabled by default. Use the default rustls crypto
-  provider ([ring]) for TLS and authentication. Applications with specific
-  requirements for cryptography (such as exclusively using the [aws-lc-rs])
+  provider ([aws-lc-rs]) for TLS and authentication. Applications with specific
+  requirements for cryptography (such as exclusively using the [ring] crate)
   should disable this default and call
-  `rustls::CryptoProvider::install_default()`.
+  `rustls::crypto::CryptoProvider::install_default()`.
 {{#Codec.PerServiceFeatures}}
 - Each client can be enabled using its own feature. Use the client's name
   in `kebab-case` to enable the client.

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -67,11 +67,11 @@ limitations under the License.
 //!
 //! # Features
 //!
-//! - `default-rustls-provider`: enabled by default. Use the default rustls crypto
-//!   provider ([ring]) for TLS and authentication. Applications with specific
-//!   requirements for cryptography (such as exclusively using the [aws-lc-rs])
-//!   should disable this default and call
-//!   `rustls::CryptoProvider::install_default()`.
+//! - `default-rustls-provider`: enabled by default. Use the default rustls
+//!   crypto provider ([aws-lc-rs]) for TLS and authentication. Applications
+//!   with specific requirements for cryptography (such as exclusively using the
+//!   [ring] crate) should disable this default and call
+//!   `rustls::crypto::CryptoProvider::install_default()`.
 {{#Codec.PerServiceFeatures}}
 //! - Each client can be enabled using its own feature. Use the client's name
 //!   in `kebab-case` to enable the client.


### PR DESCRIPTION
With the update to `reqwest` 0.13 we had to change the default `rustls` crypto provider from `ring` to `aws-lc-rs`. This changes the generated documentation to match.

Part of the work for https://github.com/googleapis/google-cloud-rust/issues/4367 