### PR TITLE
feat(internal/librarian): make formatLibrary a no-op for Python

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -285,6 +285,11 @@ func formatLibrary(ctx context.Context, language string, library *config.Library
 		return dart.Format(ctx, library)
 	case languageRust:
 		return rust.Format(ctx, library)
+	case languagePython:
+		// Python formatting is currently performed in the generate phase.
+		// TODO(https://github.com/googleapis/librarian/issues/3730): separate
+		// generation and formatting for Python.
+		return nil
 	}
 	return fmt.Errorf("language %q does not support formatting", language)
 }


### PR DESCRIPTION
Generation already includes formatting, so formatLibrary should currently just skip (rather than fail) when its input is a Python library.

Related to #3730