### PR TITLE
refactor(internal/config): rename channel to api

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,7 @@ type Library struct {
 
 	// API specifies which googleapis API to generate from (for generated
 	// libraries).
-	APIs []*API `yaml:"channels,omitempty"`
+	APIs []*API `yaml:"apis,omitempty"`
 
 	// CopyrightYear is the copyright year for the library.
 	CopyrightYear string `yaml:"copyright_year,omitempty"`

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -23,7 +23,7 @@ type GoModule struct {
 	ModulePathVersion           string   `yaml:"module_path_version,omitempty"`
 }
 
-// GoAPI represents configuration for a single API channel within a Go module.
+// GoAPI represents configuration for a single API api within a Go module.
 type GoAPI struct {
 	Path            string   `yaml:"path,omitempty"`
 	ClientDirectory string   `yaml:"client_directory,omitempty"`
@@ -263,14 +263,14 @@ type RustPoller struct {
 // PythonPackage contains Python-specific library configuration.
 type PythonPackage struct {
 	// OptArgs contains additional options passed to the generator, where
-	// the options are common to all channels.
+	// the options are common to all apis.
 	// Example: ["warehouse-package-name=google-cloud-batch"]
 	OptArgs []string `yaml:"opt_args,omitempty"`
 
 	// OptArgsByAPI contains additional options passed to the generator,
-	// where the options vary by channel. In each entry, the key is the channel
+	// where the options vary by api. In each entry, the key is the api
 	// (API path) and the value is the list of options to pass when generating
-	// that API channel.
+	// that API.
 	// Example: {"google/cloud/secrets/v1beta": ["python-gapic-name=secretmanager"]}
 	OptArgsByAPI map[string][]string `yaml:"opt_args_by_api,omitempty"`
 }

--- a/internal/config/testdata/librarian.yaml
+++ b/internal/config/testdata/librarian.yaml
@@ -46,13 +46,13 @@ default:
         force_used: true
 libraries:
   - name: google-cloud-secretmanager-v1
-    channels:
+    apis:
       - path: google/cloud/secretmanager/v1
     version: 1.2.3
   - name: google-cloud-storage-v2
     roots:
       - googleapis
-    channels:
+    apis:
       - path: google/cloud/storage/v2
     version: 2.3.4
     rust:

--- a/internal/config/testdata/rust/librarian.yaml
+++ b/internal/config/testdata/rust/librarian.yaml
@@ -46,11 +46,11 @@ default:
         force_used: true
 libraries:
   - name: google-cloud-secretmanager-v1
-    channels:
+    apis:
       - path: google/cloud/secretmanager/v1
     version: 1.2.3
   - name: google-cloud-storage-v2
-    channels:
+    apis:
       - path: google/cloud/storage/v2
     version: 2.3.4
     rust:

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -54,7 +54,7 @@ func addCommand() *cli.Command {
 	}
 }
 
-func runAdd(ctx context.Context, name string, channel ...string) error {
+func runAdd(ctx context.Context, name string, api ...string) error {
 	cfg, err := yaml.Read[config.Config](librarianConfigPath)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errConfigNotFound, err)
@@ -67,7 +67,7 @@ func runAdd(ctx context.Context, name string, channel ...string) error {
 		return fmt.Errorf("%w: %s", errLibraryAlreadyExists, name)
 	}
 
-	cfg = addLibraryToLibrarianConfig(cfg, name, channel...)
+	cfg = addLibraryToLibrarianConfig(cfg, name, api...)
 	if err := RunTidyOnConfig(ctx, cfg); err != nil {
 		return err
 	}

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -91,17 +91,17 @@ sources:
 libraries:
   - name: %s
     output: %s
-    channels:
+    apis:
       - path: google/cloud/speech/v1
       - path: grafeas/v1
   - name: %s
     output: %s
-    channels:
+    apis:
       - path: google/cloud/texttospeech/v1
   - name: %s
     output: %s
     skip_generate: true
-    channels:
+    apis:
       - path: google/cloud/speech/v1
 `, googleapisDir, lib1, lib1Output, lib2, lib2Output, lib3, lib3Output)
 			if err := os.WriteFile(filepath.Join(tempDir, librarianConfigPath), []byte(configContent), 0644); err != nil {
@@ -221,11 +221,11 @@ libraries:
   - name: %s
     output: %s
     skip_generate: true
-    channels:
+    apis:
       - path: google/cloud/speech/v1
   - name: %s
     output: %s
-    channels:
+    apis:
       - path: google/cloud/texttospeech/v1
 `, googleapisDir, lib1, lib1Output, lib2, lib2Output)
 			if err := os.WriteFile(filepath.Join(tempDir, librarianConfigPath), []byte(configContent), 0644); err != nil {
@@ -266,14 +266,14 @@ libraries:
 
 // createGoogleapisServiceConfigs creates a mock googleapis directory structure
 // with service config files for testing purposes.
-// The configs map keys are channel paths (e.g., "google/cloud/speech/v1")
+// The configs map keys are api paths (e.g., "google/cloud/speech/v1")
 // and values are the service config filenames (e.g., "speech_v1.yaml").
 func createGoogleapisServiceConfigs(t *testing.T, tempDir string, configs map[string]string) string {
 	t.Helper()
 	googleapisDir := filepath.Join(tempDir, "googleapis")
 
-	for channelPath, filename := range configs {
-		dir := filepath.Join(googleapisDir, channelPath)
+	for apiPath, filename := range configs {
+		dir := filepath.Join(googleapisDir, apiPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/librarianops/librarianops_test.go
+++ b/internal/librarianops/librarianops_test.go
@@ -56,7 +56,7 @@ libraries:
   - name: test-library
     version: 1.0.0
     output: output
-    channels:
+    apis:
       - path: google/cloud/secretmanager/v1
 `, googleapisDir)
 	if err := os.WriteFile(filepath.Join(repoDir, "librarian.yaml"), []byte(configContent), 0644); err != nil {


### PR DESCRIPTION
Rename channel to api in librarian.yaml and update all remaining references.

Fixes https://github.com/googleapis/librarian/issues/3689