### PR TITLE
fix(cmd/librarian): add error prefix

### DIFF
--- a/cmd/librarian/main.go
+++ b/cmd/librarian/main.go
@@ -26,6 +26,6 @@ import (
 func main() {
 	ctx := context.Background()
 	if err := librarian.Run(ctx, os.Args...); err != nil {
-		log.Fatalf("%v", err)
+		log.Fatalf("librarian: %v", err)
 	}
 }


### PR DESCRIPTION
Add a `librarian: ` prefix to all errors to disambiguate librarian errors from other tools and logs.