### PR TITLE
refactor(internal/librarian): use sample.Config in generate tests

### DIFF
--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sample"
+	"github.com/googleapis/librarian/internal/yaml"
 )
 
 func TestGenerateCommand(t *testing.T) {
@@ -84,27 +87,34 @@ func TestGenerateCommand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			t.Chdir(tempDir)
-			configContent := fmt.Sprintf(`language: fake
-sources:
-  googleapis:
-    dir: %s
-libraries:
-  - name: %s
-    output: %s
-    apis:
-      - path: google/cloud/speech/v1
-      - path: grafeas/v1
-  - name: %s
-    output: %s
-    apis:
-      - path: google/cloud/texttospeech/v1
-  - name: %s
-    output: %s
-    skip_generate: true
-    apis:
-      - path: google/cloud/speech/v1
-`, googleapisDir, lib1, lib1Output, lib2, lib2Output, lib3, lib3Output)
-			if err := os.WriteFile(filepath.Join(tempDir, librarianConfigPath), []byte(configContent), 0644); err != nil {
+			cfg := sample.Config()
+			cfg.Sources.Googleapis = &config.Source{Dir: googleapisDir}
+			cfg.Libraries = []*config.Library{
+				{
+					Name:   lib1,
+					Output: lib1Output,
+					APIs: []*config.API{
+						{Path: "google/cloud/speech/v1"},
+						{Path: "grafeas/v1"},
+					},
+				},
+				{
+					Name:   lib2,
+					Output: lib2Output,
+					APIs: []*config.API{
+						{Path: "google/cloud/texttospeech/v1"},
+					},
+				},
+				{
+					Name:         lib3,
+					Output:       lib3Output,
+					SkipGenerate: true,
+					APIs: []*config.API{
+						{Path: "google/cloud/speech/v1"},
+					},
+				},
+			}
+			if err := yaml.Write(filepath.Join(tempDir, librarianConfigPath), cfg); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
TestGenerateCommand now uses sample.Config(), yaml.Write(), and proper config structs instead of creating config content as a string literal.

This aligns with the pattern used in other tests like publish_test.go and bump_test.go.

For https://github.com/googleapis/librarian/issues/3777