### PR TITLE
refactor(internal/librarian): use sample.Config in add tests

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sample"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -94,18 +95,10 @@ func TestAddLibrary(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
 
-			cfg := &config.Config{
-				Language: languageFake,
-				Default: &config.Default{
-					Output: "output",
-				},
-				Libraries: test.initialLibraries,
-				Sources: &config.Sources{
-					Googleapis: &config.Source{
-						Dir: googleapisDir,
-					},
-				},
-			}
+			cfg := sample.Config()
+			cfg.Default.Output = "output"
+			cfg.Libraries = test.initialLibraries
+			cfg.Sources.Googleapis.Dir = googleapisDir
 			if err := yaml.Write(librarianConfigPath, cfg); err != nil {
 				t.Fatal(err)
 			}
@@ -203,17 +196,10 @@ func TestAddCommand(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
 
-			cfg := &config.Config{
-				Language: languageFake,
-				Default: &config.Default{
-					Output: "output",
-				},
-				Sources: &config.Sources{
-					Googleapis: &config.Source{
-						Dir: googleapisDir,
-					},
-				},
-			}
+			cfg := sample.Config()
+			cfg.Default.Output = "output"
+			cfg.Libraries = nil
+			cfg.Sources.Googleapis.Dir = googleapisDir
 			if err := yaml.Write(librarianConfigPath, cfg); err != nil {
 				t.Fatal(err)
 			}
@@ -291,13 +277,11 @@ func TestAddLibraryToLibrarianYaml(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
 
-			cfg := &config.Config{
-				Language: languageFake,
-				Libraries: []*config.Library{
-					{
-						Name:   "existinglib",
-						Output: "output/existinglib",
-					},
+			cfg := sample.Config()
+			cfg.Libraries = []*config.Library{
+				{
+					Name:   "existinglib",
+					Output: "output/existinglib",
 				},
 			}
 			if err := yaml.Write(librarianConfigPath, cfg); err != nil {


### PR DESCRIPTION
Tests in add_test.go now use sample.Config() as a based instead of constructing its own config.Config testdata, for consistency with other tests in this codebase.

For https://github.com/googleapis/librarian/issues/3777