### PR TITLE
fix(internal/librarian/dart): remove key prefix when building sidekick config

### DIFF
--- a/tool/cmd/migrate/main.go
+++ b/tool/cmd/migrate/main.go
@@ -181,7 +181,6 @@ func readRootSidekick(repoPath string) (*config.Config, error) {
 				Prefixes:                    prefix,
 				Protos:                      protos,
 				Packages:                    packages,
-				Version:                     version,
 			},
 		},
 	}

--- a/tool/cmd/migrate/main_test.go
+++ b/tool/cmd/migrate/main_test.go
@@ -87,7 +87,6 @@ func TestReadRootSidekick(t *testing.T) {
 							"proto:google.rpc":            "package:google_cloud_rpc/rpc.dart",
 							"proto:google.type":           "package:google_cloud_type/type.dart",
 						},
-						Version: "0.4.0",
 					},
 				},
 			},


### PR DESCRIPTION
Remove `prefix:` and `proto:` when building sidekick config. These prefix is already there in  `.sidekick.toml`.

For #3580 