### PR TITLE
feat(internal/serviceconfig): add FindGRPCServiceConfig

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -183,23 +183,14 @@ func createProtocOptions(ch *config.API, library *config.Library, googleapisDir,
 	}
 
 	// Add gRPC service config (retry/timeout settings)
-	// Auto-discover: look for *_grpc_service_config.json in the API directory
-	apiDir := filepath.Join(googleapisDir, ch.Path)
-	grpcConfigPath := ""
-	matches, err := filepath.Glob(filepath.Join(apiDir, "*_grpc_service_config.json"))
-	if err == nil && len(matches) > 0 {
-		if len(matches) > 1 {
-			return nil, fmt.Errorf("multiple grpc service config files found in %q", apiDir)
-		}
-		rel, err := filepath.Rel(googleapisDir, matches[0])
-		if err != nil {
-			return nil, fmt.Errorf("failed to compute relative path for %q: %w", matches[0], err)
-		}
-		grpcConfigPath = rel
+	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, ch.Path)
+	if err != nil {
+		return nil, err
 	}
 	if grpcConfigPath != "" {
 		opts = append(opts, fmt.Sprintf("retry-config=%s", grpcConfigPath))
 	}
+
 	api, err := serviceconfig.Find(googleapisDir, ch.Path)
 	if err != nil {
 		return nil, err

--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -176,3 +176,22 @@ func isServiceConfigFile(path string) (bool, error) {
 	}
 	return false, scanner.Err()
 }
+
+// FindGRPCServiceConfig searches for gRPC service config files in the given
+// API directory. It returns the path relative to googleapisDir for use with
+// protoc's retry-config option. Returns empty string if no config is found.
+// Returns an error if multiple matching files exist.
+func FindGRPCServiceConfig(googleapisDir, path string) (string, error) {
+	pattern := filepath.Join(googleapisDir, path, "*_grpc_service_config.json")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("multiple gRPC service config files found in %q", path)
+	}
+	return filepath.Rel(googleapisDir, matches[0])
+}


### PR DESCRIPTION
Add FindGRPCServiceConfig to discover gRPC service config files (*_grpc_service_config.json) in API directories, which are relied upon by various language generators, such as Python and Go.

Updates the Python generator to use this function.

For https://github.com/googleapis/librarian/issues/3617
For https://github.com/googleapis/librarian/issues/3627
