### PR TITLE
feat(internal/librarian/golang): add protoc command builder

### DIFF
--- a/internal/librarian/golang/protoc.go
+++ b/internal/librarian/golang/protoc.go
@@ -47,9 +47,6 @@ type protocConfig struct {
 	// HasGoGRPC indicates whether go_grpc_library is used.
 	HasGoGRPC bool
 
-	// HasLegacyGRPC indicates whether go_proto_library uses the legacy gRPC compiler.
-	HasLegacyGRPC bool
-
 	// Metadata enables generation of gapic_metadata.json (metadata).
 	Metadata bool
 
@@ -86,7 +83,7 @@ func buildProtocCommand(cfg *protocConfig) ([]string, error) {
 		"-I=" + cfg.GoogleapisDir,
 	}
 
-	if cfg.HasGoGRPC || cfg.HasLegacyGRPC {
+	if cfg.HasGoGRPC {
 		args = append(args,
 			"--go-grpc_out="+cfg.OutputDir,
 			"--go-grpc_opt=require_unimplemented_servers=false",

--- a/internal/librarian/golang/protoc_test.go
+++ b/internal/librarian/golang/protoc_test.go
@@ -78,19 +78,6 @@ func TestBuildProtocCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "with legacy grpc",
-			cfg: &protocConfig{
-				OutputDir:     "/output",
-				GoogleapisDir: testdataDir,
-				APIPath:       "google/cloud/secretmanager/v1",
-				HasLegacyGRPC: true,
-			},
-			wantContains: []string{
-				"--go-grpc_out=/output",
-				"--go-grpc_opt=require_unimplemented_servers=false",
-			},
-		},
-		{
 			name: "with service configs",
 			cfg: &protocConfig{
 				OutputDir:         "/output",


### PR DESCRIPTION
Add a protoc command builder that assembles the full set of arguments needed to generate Go code from proto files. 

For https://github.com/googleapis/librarian/issues/3617