### PR TITLE
refactor(internal/sidekick/rust): remove config package dependency

### DIFF
--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -68,7 +68,7 @@ func Generate(ctx context.Context, library *config.Library, sources *Sources) er
 			return err
 		}
 	}
-	if err := sidekickrust.Generate(ctx, model, library.Output, sidekickConfig); err != nil {
+	if err := sidekickrust.Generate(ctx, model, library.Output, sidekickConfig.General.SpecificationFormat, sidekickConfig.Codec); err != nil {
 		return err
 	}
 	if !exists {
@@ -110,7 +110,7 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *Sourc
 		}
 		switch sidekickConfig.General.Language {
 		case "rust":
-			err = sidekickrust.Generate(ctx, model, module.Output, sidekickConfig)
+			err = sidekickrust.Generate(ctx, model, module.Output, sidekickConfig.General.SpecificationFormat, sidekickConfig.Codec)
 		case "rust_storage":
 			return generateRustStorage(ctx, library, module.Output, sources)
 		case "rust+prost":
@@ -212,7 +212,7 @@ func generateRustStorage(ctx context.Context, library *config.Library, moduleOut
 		return fmt.Errorf("failed to create control model: %w", err)
 	}
 
-	return sidekickrust.GenerateStorage(ctx, moduleOutput, storageModel, storageConfig, controlModel, controlConfig)
+	return sidekickrust.GenerateStorage(ctx, moduleOutput, storageModel, storageConfig.General.SpecificationFormat, storageConfig.Codec, controlModel, controlConfig.General.SpecificationFormat, controlConfig.Codec)
 }
 
 func findModuleByOutput(library *config.Library, output string) *config.RustModule {

--- a/internal/sidekick/rust/generate.go
+++ b/internal/sidekick/rust/generate.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 	"github.com/googleapis/librarian/internal/sidekick/language"
 )
 
@@ -28,25 +27,25 @@ import (
 var templates embed.FS
 
 // Generate generates Rust code from the model.
-func Generate(ctx context.Context, model *api.API, outdir string, cfg *config.Config) error {
-	codec, err := newCodec(cfg.General.SpecificationFormat, cfg.Codec)
+func Generate(ctx context.Context, model *api.API, outdir, specFormat string, codec map[string]string) error {
+	c, err := newCodec(specFormat, codec)
 	if err != nil {
 		return err
 	}
-	annotations := annotateModel(model, codec)
+	annotations := annotateModel(model, c)
 	provider := templatesProvider()
-	generatedFiles := codec.generatedFiles(annotations.HasServices())
+	generatedFiles := c.generatedFiles(annotations.HasServices())
 	return language.GenerateFromModel(outdir, model, provider, generatedFiles)
 }
 
 // GenerateStorage generates Rust code for the storage service.
-func GenerateStorage(ctx context.Context, outdir string, storageModel *api.API, storageConfig *config.Config, controlModel *api.API, controlConfig *config.Config) error {
-	storageCodec, err := newCodec(storageConfig.General.SpecificationFormat, storageConfig.Codec)
+func GenerateStorage(ctx context.Context, outdir string, storageModel *api.API, storageSpecFormat string, storageCodecOpts map[string]string, controlModel *api.API, controlSpecFormat string, controlCodecOpts map[string]string) error {
+	storageCodec, err := newCodec(storageSpecFormat, storageCodecOpts)
 	if err != nil {
 		return err
 	}
 	annotateModel(storageModel, storageCodec)
-	controlCodec, err := newCodec(controlConfig.General.SpecificationFormat, controlConfig.Codec)
+	controlCodec, err := newCodec(controlSpecFormat, controlCodecOpts)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -99,14 +99,14 @@ func TestCodecError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, errorConfig); err == nil {
+	if err := Generate(t.Context(), model, outDir, errorConfig.General.SpecificationFormat, errorConfig.Codec); err == nil {
 		t.Errorf("expected an error with invalid Codec options")
 	}
 
-	if err := GenerateStorage(t.Context(), outDir, model, errorConfig, model, goodConfig); err == nil {
+	if err := GenerateStorage(t.Context(), outDir, model, errorConfig.General.SpecificationFormat, errorConfig.Codec, model, goodConfig.General.SpecificationFormat, goodConfig.Codec); err == nil {
 		t.Errorf("expected an error with invalid Codec options for storage")
 	}
-	if err := GenerateStorage(t.Context(), outDir, model, goodConfig, model, errorConfig); err == nil {
+	if err := GenerateStorage(t.Context(), outDir, model, goodConfig.General.SpecificationFormat, goodConfig.Codec, model, errorConfig.General.SpecificationFormat, errorConfig.Codec); err == nil {
 		t.Errorf("expected an error with invalid Codec options for control")
 	}
 }
@@ -126,7 +126,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg.General.SpecificationFormat, cfg.Codec); err != nil {
 		t.Fatal(err)
 	}
 	for _, expected := range expectedInCrate {
@@ -159,7 +159,7 @@ func TestRustFromDiscovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg.General.SpecificationFormat, cfg.Codec); err != nil {
 		t.Fatal(err)
 	}
 	for _, expected := range expectedInCrate {
@@ -194,7 +194,7 @@ func TestRustFromProtobuf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg.General.SpecificationFormat, cfg.Codec); err != nil {
 		t.Fatal(err)
 	}
 	for _, expected := range expectedInCrate {
@@ -233,7 +233,7 @@ func TestRustClient(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+		if err := Generate(t.Context(), model, outDir, cfg.General.SpecificationFormat, cfg.Codec); err != nil {
 			t.Fatal(err)
 		}
 		for _, expected := range expectedInClient {
@@ -278,7 +278,7 @@ func TestRustNosvc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg.General.SpecificationFormat, cfg.Codec); err != nil {
 		t.Fatal(err)
 	}
 	for _, expected := range expectedInNosvc {
@@ -316,7 +316,7 @@ func TestRustModuleRpc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, path.Join(outDir, "rpc"), cfg); err != nil {
+	if err := Generate(t.Context(), model, path.Join(outDir, "rpc"), cfg.General.SpecificationFormat, cfg.Codec); err != nil {
 		t.Fatal(err)
 	}
 
@@ -356,7 +356,7 @@ func TestRustBootstrapWkt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, path.Join(outDir, "wkt"), cfg); err != nil {
+	if err := Generate(t.Context(), model, path.Join(outDir, "wkt"), cfg.General.SpecificationFormat, cfg.Codec); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/sidekick/refresh.go
+++ b/internal/sidekick/sidekick/refresh.go
@@ -78,7 +78,7 @@ func refreshDir(ctx context.Context, rootConfig *config.Config, cmdLine *Command
 
 	switch config.General.Language {
 	case "rust":
-		return rust.Generate(ctx, model, output, config)
+		return rust.Generate(ctx, model, output, config.General.SpecificationFormat, config.Codec)
 	case "rust_storage":
 		// The StorageControl client depends on multiple specification sources.
 		// We load them both here manually, and pass them along to
@@ -91,7 +91,7 @@ func refreshDir(ctx context.Context, rootConfig *config.Config, cmdLine *Command
 		if err != nil {
 			return err
 		}
-		return rust.GenerateStorage(ctx, output, storageModel, storageConfig, controlModel, controlConfig)
+		return rust.GenerateStorage(ctx, output, storageModel, storageConfig.General.SpecificationFormat, storageConfig.Codec, controlModel, controlConfig.General.SpecificationFormat, controlConfig.Codec)
 	case "rust+prost":
 		return rust_prost.Generate(ctx, model, output, config)
 	case "dart":


### PR DESCRIPTION
The Generate and GenerateStorage functions now accept the specification format and codec options directly instead of a *config.Config struct.

This decouples the rust package from the sidekick config package, so that we can delete that package later on.