### PR TITLE
fix(internal/librarianops): set command.Verbose when -v flag is used

### DIFF
--- a/internal/librarianops/librarianops.go
+++ b/internal/librarianops/librarianops.go
@@ -98,7 +98,7 @@ For each repository, librarianops will:
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			all := cmd.Bool("all")
 			workDir := cmd.String("C")
-			verbose := cmd.Bool("v")
+			command.Verbose = cmd.Bool("v")
 			repoName := ""
 			if cmd.Args().Len() > 0 {
 				repoName = cmd.Args().Get(0)
@@ -112,7 +112,7 @@ For each repository, librarianops will:
 			if all && workDir != "" {
 				return fmt.Errorf("cannot use -C with --all")
 			}
-			return runGenerate(ctx, all, repoName, workDir, verbose)
+			return runGenerate(ctx, all, repoName, workDir, command.Verbose)
 		},
 	}
 }

--- a/internal/librarianops/librarianops_test.go
+++ b/internal/librarianops/librarianops_test.go
@@ -182,3 +182,33 @@ func TestUpdateLibrarianVersion(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestVerboseFlagSetsCommandVerbose(t *testing.T) {
+	origVerbose := command.Verbose
+	defer func() { command.Verbose = origVerbose }()
+
+	for _, test := range []struct {
+		name        string
+		args        []string
+		wantVerbose bool
+	}{
+		{
+			name:        "without -v flag",
+			args:        []string{"librarianops", "generate", "fake-repo"},
+			wantVerbose: false,
+		},
+		{
+			name:        "with -v flag",
+			args:        []string{"librarianops", "generate", "-v", "fake-repo"},
+			wantVerbose: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command.Verbose = false
+			Run(t.Context(), test.args...)
+			if command.Verbose != test.wantVerbose {
+				t.Errorf("command.Verbose = %v, want %v", command.Verbose, test.wantVerbose)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, the -v flag only passed the verbose setting to the librarian subprocess but did not set command.Verbose. This meant commands run by librarianops itself (git, gh, etc.) were not printed in verbose mode.

Using the -v flag now sets command.Verbose directly, enabling verbose output for all commands run by librarianops.

Fixes https://github.com/googleapis/librarian/issues/3786