### PR TITLE
feat(rust): implement `internal-builder` visibility option

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -79,6 +79,9 @@ type RustModule struct {
 	// IncludeList is a list of proto files to include (e.g., "date.proto,expr.proto").
 	IncludeList string `yaml:"include_list,omitempty"`
 
+	// InternalBuilder indicates whether generated builders should be internal to the crate.
+	InternalBuilder bool `yaml:"internal_builder,omitempty"`
+
 	// Language can be used to select a variation of the Rust generator.
 	// For example, `rust_storage` enables special handling for the storage client.
 	Language string `yaml:"language,omitempty"`

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -79,8 +79,8 @@ type RustModule struct {
 	// IncludeList is a list of proto files to include (e.g., "date.proto,expr.proto").
 	IncludeList string `yaml:"include_list,omitempty"`
 
-	// InternalBuilder indicates whether generated builders should be internal to the crate.
-	InternalBuilder bool `yaml:"internal_builder,omitempty"`
+	// InternalBuilders indicates whether generated builders should be internal to the crate.
+	InternalBuilders bool `yaml:"internal_builders,omitempty"`
 
 	// Language can be used to select a variation of the Rust generator.
 	// For example, `rust_storage` enables special handling for the storage client.

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -316,8 +316,8 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	if module.RootName != "" {
 		codec["root-name"] = module.RootName
 	}
-	if module.InternalBuilder {
-		codec["internal-builder"] = "true"
+	if module.InternalBuilders {
+		codec["internal-builders"] = "true"
 	}
 	return codec
 }

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -316,6 +316,9 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	if module.RootName != "" {
 		codec["root-name"] = module.RootName
 	}
+	if module.InternalBuilder {
+		codec["internal-builder"] = "true"
+	}
 	return codec
 }
 

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -78,6 +78,8 @@ type modelAnnotations struct {
 	// If true, the generated code includes detailed tracing attributes on HTTP
 	// requests.
 	DetailedTracingAttributes bool
+	// If true, the generated builders's visibility should be restricted to the crate.
+	InternalBuilder bool
 }
 
 // IsWktCrate returns true when bootstrapping the well-known types crate the templates add some
@@ -134,6 +136,8 @@ type serviceAnnotations struct {
 	// If true, the generated code includes detailed tracing attributes on HTTP
 	// requests.
 	DetailedTracingAttributes bool
+	// If true, the generated builders's visibility should be restricted to the crate.
+	InternalBuilder bool
 }
 
 // HasBindingSubstitutions returns true if the method has binding substitutions.
@@ -249,6 +253,7 @@ type methodAnnotation struct {
 	DetailedTracingAttributes bool
 	ResourceNameFields        []*resourceNameCandidateField
 	HasResourceNameFields     bool
+	InternalBuilder           bool
 }
 
 type pathInfoAnnotation struct {
@@ -673,6 +678,7 @@ func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 		GenerateSetterSamples:     codec.generateSetterSamples,
 		GenerateRpcSamples:        codec.generateRpcSamples,
 		DetailedTracingAttributes: codec.detailedTracingAttributes,
+		InternalBuilder:           codec.internalBuilder,
 	}
 
 	codec.addFeatureAnnotations(model, ann)
@@ -932,6 +938,7 @@ func (c *codec) annotateService(s *api.Service) {
 		ExtendGrpcTransport:       c.extendGrpcTransport,
 		Incomplete:                slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !c.generateMethod(m) }),
 		DetailedTracingAttributes: c.detailedTracingAttributes,
+		InternalBuilder:           c.internalBuilder,
 	}
 	s.Codec = ann
 }
@@ -1025,6 +1032,7 @@ func (c *codec) annotateMethod(m *api.Method) {
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		ResourceNameFields:        resourceNameFields,
 		HasResourceNameFields:     len(resourceNameFields) > 0,
+		InternalBuilder:           c.internalBuilder,
 	}
 	if annotation.Name == "clone" {
 		// Some methods look too similar to standard Rust traits. Clippy makes

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -79,13 +79,21 @@ type modelAnnotations struct {
 	// requests.
 	DetailedTracingAttributes bool
 	// If true, the generated builders's visibility should be restricted to the crate.
-	InternalBuilder bool
+	InternalBuilders bool
 }
 
 // IsWktCrate returns true when bootstrapping the well-known types crate the templates add some
 // ad-hoc code.
 func (m *modelAnnotations) IsWktCrate() bool {
 	return m.PackageName == "google-cloud-wkt"
+}
+
+// BuilderVisibility returns the visibility for client and request builders.
+func (m *modelAnnotations) BuilderVisibility() string {
+	if m.InternalBuilders {
+		return "pub(crate)"
+	}
+	return "pub"
 }
 
 // HasServices returns true if there are any services in the model.
@@ -137,7 +145,15 @@ type serviceAnnotations struct {
 	// requests.
 	DetailedTracingAttributes bool
 	// If true, the generated builders's visibility should be restricted to the crate.
-	InternalBuilder bool
+	InternalBuilders bool
+}
+
+// BuilderVisibility returns the visibility for client and request builders.
+func (s *serviceAnnotations) BuilderVisibility() string {
+	if s.InternalBuilders {
+		return "pub(crate)"
+	}
+	return "pub"
 }
 
 // HasBindingSubstitutions returns true if the method has binding substitutions.
@@ -253,7 +269,15 @@ type methodAnnotation struct {
 	DetailedTracingAttributes bool
 	ResourceNameFields        []*resourceNameCandidateField
 	HasResourceNameFields     bool
-	InternalBuilder           bool
+	InternalBuilders          bool
+}
+
+// BuilderVisibility returns the visibility for client and request builders.
+func (m *methodAnnotation) BuilderVisibility() string {
+	if m.InternalBuilders {
+		return "pub(crate)"
+	}
+	return "pub"
 }
 
 type pathInfoAnnotation struct {
@@ -678,7 +702,7 @@ func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 		GenerateSetterSamples:     codec.generateSetterSamples,
 		GenerateRpcSamples:        codec.generateRpcSamples,
 		DetailedTracingAttributes: codec.detailedTracingAttributes,
-		InternalBuilder:           codec.internalBuilder,
+		InternalBuilders:          codec.internalBuilders,
 	}
 
 	codec.addFeatureAnnotations(model, ann)
@@ -938,7 +962,7 @@ func (c *codec) annotateService(s *api.Service) {
 		ExtendGrpcTransport:       c.extendGrpcTransport,
 		Incomplete:                slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !c.generateMethod(m) }),
 		DetailedTracingAttributes: c.detailedTracingAttributes,
-		InternalBuilder:           c.internalBuilder,
+		InternalBuilders:          c.internalBuilders,
 	}
 	s.Codec = ann
 }
@@ -1032,7 +1056,7 @@ func (c *codec) annotateMethod(m *api.Method) {
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		ResourceNameFields:        resourceNameFields,
 		HasResourceNameFields:     len(resourceNameFields) > 0,
-		InternalBuilder:           c.internalBuilder,
+		InternalBuilders:          c.internalBuilders,
 	}
 	if annotation.Name == "clone" {
 		// Some methods look too similar to standard Rust traits. Clippy makes

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -157,6 +157,32 @@ func TestAnnotateMethodAPIVersion(t *testing.T) {
 	}
 }
 
+func TestAnnotateMethodInternalBuilder(t *testing.T) {
+	model := annotateMethodModel(t)
+	err := api.CrossReference(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	codec, err := newCodec("protobuf", map[string]string{
+		"internal-builder": "true",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = annotateModel(model, codec)
+
+	methodID := ".test.v1.ResourceService.Delete"
+	gotMethod, ok := model.State.MethodByID[methodID]
+	if !ok {
+		t.Fatalf("missing method %s", methodID)
+	}
+	got := gotMethod.Codec.(*methodAnnotation)
+	if !got.InternalBuilder {
+		t.Errorf("expected InternalBuilder to be true for method %s", methodID)
+	}
+}
+
 func annotateMethodModel(t *testing.T) *api.API {
 	t.Helper()
 	request := &api.Message{

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -157,7 +157,7 @@ func TestAnnotateMethodAPIVersion(t *testing.T) {
 	}
 }
 
-func TestAnnotateMethodInternalBuilder(t *testing.T) {
+func TestAnnotateMethodInternalBuilders(t *testing.T) {
 	model := annotateMethodModel(t)
 	err := api.CrossReference(model)
 	if err != nil {
@@ -165,7 +165,7 @@ func TestAnnotateMethodInternalBuilder(t *testing.T) {
 	}
 
 	codec, err := newCodec("protobuf", map[string]string{
-		"internal-builder": "true",
+		"internal-builders": "true",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -178,8 +178,11 @@ func TestAnnotateMethodInternalBuilder(t *testing.T) {
 		t.Fatalf("missing method %s", methodID)
 	}
 	got := gotMethod.Codec.(*methodAnnotation)
-	if !got.InternalBuilder {
-		t.Errorf("expected InternalBuilder to be true for method %s", methodID)
+	if !got.InternalBuilders {
+		t.Errorf("expected InternalBuilders to be true for method %s", methodID)
+	}
+	if got.BuilderVisibility() != "pub(crate)" {
+		t.Errorf("mismatch in BuilderVisibility, want=pub(crate), got=%s", got.BuilderVisibility())
 	}
 }
 

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -136,26 +136,30 @@ func TestClippyWarnings(t *testing.T) {
 	}
 }
 
-func TestInternalBuilderAnnotation(t *testing.T) {
+func TestInternalBuildersAnnotation(t *testing.T) {
 	for _, test := range []struct {
-		Options map[string]string
-		Want    bool
+		Options        map[string]string
+		Want           bool
+		WantVisibility string
 	}{
 		{
-			Options: map[string]string{},
-			Want:    false,
+			Options:        map[string]string{},
+			Want:           false,
+			WantVisibility: "pub",
 		},
 		{
 			Options: map[string]string{
-				"internal-builder": "true",
+				"internal-builders": "true",
 			},
-			Want: true,
+			Want:           true,
+			WantVisibility: "pub(crate)",
 		},
 		{
 			Options: map[string]string{
-				"internal-builder": "false",
+				"internal-builders": "false",
 			},
-			Want: false,
+			Want:           false,
+			WantVisibility: "pub",
 		},
 	} {
 		model := newTestAnnotateModelAPI()
@@ -164,12 +168,18 @@ func TestInternalBuilderAnnotation(t *testing.T) {
 			t.Fatal(err)
 		}
 		got := annotateModel(model, codec)
-		if got.InternalBuilder != test.Want {
-			t.Errorf("mismatch in InternalBuilder, want=%v, got=%v", test.Want, got.InternalBuilder)
+		if got.InternalBuilders != test.Want {
+			t.Errorf("mismatch in InternalBuilders, want=%v, got=%v", test.Want, got.InternalBuilders)
 		}
 		svcAnn := model.Services[0].Codec.(*serviceAnnotations)
-		if svcAnn.InternalBuilder != test.Want {
-			t.Errorf("mismatch in service InternalBuilder, want=%v, got=%v", test.Want, svcAnn.InternalBuilder)
+		if svcAnn.InternalBuilders != test.Want {
+			t.Errorf("mismatch in service InternalBuilders, want=%v, got=%v", test.Want, svcAnn.InternalBuilders)
+		}
+		if got.BuilderVisibility() != test.WantVisibility {
+			t.Errorf("mismatch in BuilderVisibility, want=%s, got=%s", test.WantVisibility, got.BuilderVisibility())
+		}
+		if svcAnn.BuilderVisibility() != test.WantVisibility {
+			t.Errorf("mismatch in service BuilderVisibility, want=%s, got=%s", test.WantVisibility, svcAnn.BuilderVisibility())
 		}
 	}
 }

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -136,6 +136,44 @@ func TestClippyWarnings(t *testing.T) {
 	}
 }
 
+func TestInternalBuilderAnnotation(t *testing.T) {
+	for _, test := range []struct {
+		Options map[string]string
+		Want    bool
+	}{
+		{
+			Options: map[string]string{},
+			Want:    false,
+		},
+		{
+			Options: map[string]string{
+				"internal-builder": "true",
+			},
+			Want: true,
+		},
+		{
+			Options: map[string]string{
+				"internal-builder": "false",
+			},
+			Want: false,
+		},
+	} {
+		model := newTestAnnotateModelAPI()
+		codec, err := newCodec("protobuf", test.Options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := annotateModel(model, codec)
+		if got.InternalBuilder != test.Want {
+			t.Errorf("mismatch in InternalBuilder, want=%v, got=%v", test.Want, got.InternalBuilder)
+		}
+		svcAnn := model.Services[0].Codec.(*serviceAnnotations)
+		if svcAnn.InternalBuilder != test.Want {
+			t.Errorf("mismatch in service InternalBuilder, want=%v, got=%v", test.Want, svcAnn.InternalBuilder)
+		}
+	}
+}
+
 func newTestAnnotateModelAPI() *api.API {
 	service0 := &api.Service{
 		Name: "Service0",

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -172,6 +172,12 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `generate-rpc-samples` value %q to boolean: %w", definition, err)
 			}
 			codec.generateRpcSamples = value
+		case key == "internal-builder":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `internal-builder` value %q to boolean: %w", definition, err)
+			}
+			codec.internalBuilder = value
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -318,6 +324,8 @@ type codec struct {
 	generateSetterSamples bool
 	// If true, the generator will produce reference documentation samples for functions that correspond to RPCs.
 	generateRpcSamples bool
+	// If true, the generator will set the internal builder's visibility to public (crate).
+	internalBuilder bool
 }
 
 type systemParameter struct {

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -172,12 +172,12 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `generate-rpc-samples` value %q to boolean: %w", definition, err)
 			}
 			codec.generateRpcSamples = value
-		case key == "internal-builder":
+		case key == "internal-builders":
 			value, err := strconv.ParseBool(definition)
 			if err != nil {
-				return nil, fmt.Errorf("cannot convert `internal-builder` value %q to boolean: %w", definition, err)
+				return nil, fmt.Errorf("cannot convert `internal-builders` value %q to boolean: %w", definition, err)
 			}
-			codec.internalBuilder = value
+			codec.internalBuilders = value
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -325,7 +325,7 @@ type codec struct {
 	// If true, the generator will produce reference documentation samples for functions that correspond to RPCs.
 	generateRpcSamples bool
 	// If true, the generator will set the internal builder's visibility to public (crate).
-	internalBuilder bool
+	internalBuilders bool
 }
 
 type systemParameter struct {

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -317,10 +317,10 @@ func TestParseOptions(t *testing.T) {
 		{
 			Format: "protobuf",
 			Options: map[string]string{
-				"internal-builder": "true",
+				"internal-builders": "true",
 			},
 			Update: func(c *codec) {
-				c.internalBuilder = true
+				c.internalBuilders = true
 			},
 		},
 	} {
@@ -359,7 +359,7 @@ func TestParseOptionsErrors(t *testing.T) {
 		{Options: map[string]string{"routing-required": ""}},
 		{Options: map[string]string{"generate-setter-samples": ""}},
 		{Options: map[string]string{"generate-rpc-samples": ""}},
-		{Options: map[string]string{"internal-builder": ""}},
+		{Options: map[string]string{"internal-builders": ""}},
 		{Options: map[string]string{"--invalid--": ""}},
 	} {
 		if got, err := newCodec("disco", test.Options); err == nil {

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -314,6 +314,15 @@ func TestParseOptions(t *testing.T) {
 				c.generateRpcSamples = true
 			},
 		},
+		{
+			Format: "protobuf",
+			Options: map[string]string{
+				"internal-builder": "true",
+			},
+			Update: func(c *codec) {
+				c.internalBuilder = true
+			},
+		},
 	} {
 		want, err := newCodec(test.Format, map[string]string{})
 		if err != nil {
@@ -350,6 +359,7 @@ func TestParseOptionsErrors(t *testing.T) {
 		{Options: map[string]string{"routing-required": ""}},
 		{Options: map[string]string{"generate-setter-samples": ""}},
 		{Options: map[string]string{"generate-rpc-samples": ""}},
+		{Options: map[string]string{"internal-builder": ""}},
 		{Options: map[string]string{"--invalid--": ""}},
 	} {
 		if got, err := newCodec("disco", test.Options); err == nil {

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -27,8 +27,8 @@ pub mod {{Codec.ModuleName}} {
     use crate::Result;
     {{^Codec.HasVeneer}}
 
-    {{^Model.Codec.InternalBuilder}}
     /// A builder for [{{Codec.Name}}][crate::client::{{Codec.Name}}].
+    {{^Codec.InternalBuilders}}
     ///
     /// ```
     /// # async fn sample() -> gax::client_builder::Result<()> {
@@ -41,8 +41,8 @@ pub mod {{Codec.ModuleName}} {
     ///     .build().await?;
     /// # Ok(()) }
     /// ```
-    {{/Model.Codec.InternalBuilder}}
-    {{#Model.Codec.InternalBuilder}}pub(crate){{/Model.Codec.InternalBuilder}}{{^Model.Codec.InternalBuilder}}pub{{/Model.Codec.InternalBuilder}} type ClientBuilder =
+    {{/Codec.InternalBuilders}}
+    {{Codec.BuilderVisibility}} type ClientBuilder =
         gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
 
     pub(crate) mod client {
@@ -79,7 +79,7 @@ pub mod {{Codec.ModuleName}} {
 
     {{#Codec.Methods}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}] calls.
-    {{^Model.Codec.InternalBuilder}}
+    {{^Codec.InternalBuilders}}
     ///
     /// # Example
     /// ```
@@ -114,9 +114,9 @@ pub mod {{Codec.ModuleName}} {
     ///   // ... details omitted ...
     /// }
     /// ```
-    {{/Model.Codec.InternalBuilder}}
+    {{/Codec.InternalBuilders}}
     #[derive(Clone, Debug)]
-    {{#Model.Codec.InternalBuilder}}pub(crate){{/Model.Codec.InternalBuilder}}{{^Model.Codec.InternalBuilder}}pub{{/Model.Codec.InternalBuilder}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
+    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -27,6 +27,7 @@ pub mod {{Codec.ModuleName}} {
     use crate::Result;
     {{^Codec.HasVeneer}}
 
+    {{^Model.Codec.InternalBuilder}}
     /// A builder for [{{Codec.Name}}][crate::client::{{Codec.Name}}].
     ///
     /// ```
@@ -40,7 +41,8 @@ pub mod {{Codec.ModuleName}} {
     ///     .build().await?;
     /// # Ok(()) }
     /// ```
-    pub type ClientBuilder =
+    {{/Model.Codec.InternalBuilder}}
+    {{#Model.Codec.InternalBuilder}}pub(crate){{/Model.Codec.InternalBuilder}}{{^Model.Codec.InternalBuilder}}pub{{/Model.Codec.InternalBuilder}} type ClientBuilder =
         gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
 
     pub(crate) mod client {
@@ -77,6 +79,7 @@ pub mod {{Codec.ModuleName}} {
 
     {{#Codec.Methods}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}] calls.
+    {{^Model.Codec.InternalBuilder}}
     ///
     /// # Example
     /// ```
@@ -111,8 +114,9 @@ pub mod {{Codec.ModuleName}} {
     ///   // ... details omitted ...
     /// }
     /// ```
+    {{/Model.Codec.InternalBuilder}}
     #[derive(Clone, Debug)]
-    pub struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
+    {{#Model.Codec.InternalBuilder}}pub(crate){{/Model.Codec.InternalBuilder}}{{^Model.Codec.InternalBuilder}}pub{{/Model.Codec.InternalBuilder}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {

--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -28,6 +28,7 @@ limitations under the License.
 /// Implements a client for the {{Codec.APITitle}}.
 {{^Codec.HasVeneer}}
 ///
+{{^Codec.InternalBuilder}}
 /// # Example
 /// ```
 /// # async fn sample() -> gax::client_builder::Result<()> {
@@ -36,6 +37,7 @@ limitations under the License.
 /// // use `client` to make requests to the {{Codec.APITitle}}.
 /// # Ok(()) }
 /// ```
+{{/Codec.InternalBuilder}}
 ///
 /// # Service Description
 ///
@@ -91,6 +93,7 @@ pub struct {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     {{^Codec.HasVeneer}}
+    {{^Codec.InternalBuilder}}
     /// Returns a builder for [{{Codec.Name}}].
     ///
     /// ```
@@ -99,7 +102,8 @@ impl {{Codec.Name}} {
     /// let client = {{Codec.Name}}::builder().build().await?;
     /// # Ok(()) }
     /// ```
-    pub fn builder() -> super::builder::{{Codec.ModuleName}}::ClientBuilder {
+    {{/Codec.InternalBuilder}}
+    {{#Codec.InternalBuilder}}pub(crate){{/Codec.InternalBuilder}}{{^Codec.InternalBuilder}}pub{{/Codec.InternalBuilder}} fn builder() -> super::builder::{{Codec.ModuleName}}::ClientBuilder {
         gax::client_builder::internal::new_builder(super::builder::{{Codec.ModuleName}}::client::Factory)
     }
     {{/Codec.HasVeneer}}
@@ -135,7 +139,7 @@ impl {{Codec.Name}} {
     {{#Codec.Methods}}
 
     {{> /templates/common/client_method_preamble}}
-    pub fn {{Codec.Name}}(&self) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
+    {{#Codec.InternalBuilder}}pub(crate){{/Codec.InternalBuilder}}{{^Codec.InternalBuilder}}pub{{/Codec.InternalBuilder}} fn {{Codec.Name}}(&self) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
     {
         super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}::new(self.inner.clone())
     }

--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -28,7 +28,7 @@ limitations under the License.
 /// Implements a client for the {{Codec.APITitle}}.
 {{^Codec.HasVeneer}}
 ///
-{{^Codec.InternalBuilder}}
+{{^Model.Codec.InternalBuilders}}
 /// # Example
 /// ```
 /// # async fn sample() -> gax::client_builder::Result<()> {
@@ -37,7 +37,7 @@ limitations under the License.
 /// // use `client` to make requests to the {{Codec.APITitle}}.
 /// # Ok(()) }
 /// ```
-{{/Codec.InternalBuilder}}
+{{/Model.Codec.InternalBuilders}}
 ///
 /// # Service Description
 ///
@@ -93,8 +93,8 @@ pub struct {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     {{^Codec.HasVeneer}}
-    {{^Codec.InternalBuilder}}
     /// Returns a builder for [{{Codec.Name}}].
+    {{^Model.Codec.InternalBuilders}}
     ///
     /// ```
     /// # async fn sample() -> gax::client_builder::Result<()> {
@@ -102,8 +102,8 @@ impl {{Codec.Name}} {
     /// let client = {{Codec.Name}}::builder().build().await?;
     /// # Ok(()) }
     /// ```
-    {{/Codec.InternalBuilder}}
-    {{#Codec.InternalBuilder}}pub(crate){{/Codec.InternalBuilder}}{{^Codec.InternalBuilder}}pub{{/Codec.InternalBuilder}} fn builder() -> super::builder::{{Codec.ModuleName}}::ClientBuilder {
+    {{/Model.Codec.InternalBuilders}}
+    {{Codec.BuilderVisibility}} fn builder() -> super::builder::{{Codec.ModuleName}}::ClientBuilder {
         gax::client_builder::internal::new_builder(super::builder::{{Codec.ModuleName}}::client::Factory)
     }
     {{/Codec.HasVeneer}}
@@ -139,7 +139,7 @@ impl {{Codec.Name}} {
     {{#Codec.Methods}}
 
     {{> /templates/common/client_method_preamble}}
-    {{#Codec.InternalBuilder}}pub(crate){{/Codec.InternalBuilder}}{{^Codec.InternalBuilder}}pub{{/Codec.InternalBuilder}} fn {{Codec.Name}}(&self) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
+    {{Codec.BuilderVisibility}} fn {{Codec.Name}}(&self) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
     {
         super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}::new(self.inner.clone())
     }


### PR DESCRIPTION
Implement a new config option `internal_builder` for Rust modules. 
When set to true, this option restricts the visibility of generated request builders and client constructors from `pub` to `pub(crate)`, and remove the doctests which would fail as the builders are no longer `pub`.
By making these internal builders internal to the crate, we prevent them from leaking into the public API while still allowing them to be used by the veneer.
Fix #3784