### PR TITLE
fix: pass `not-for-publication` from librarian config to sidekick config

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -299,9 +299,6 @@ type DartPackage struct {
 	// NameOverride overrides the package name
 	NameOverride string `yaml:"name_override,omitempty"`
 
-	// NotForPublication indicates whether this package should not be published.
-	NotForPublication string `yaml:"not_for_publication,omitempty"`
-
 	// Packages maps Dart package names to version constraints.
 	// Keys are in the format "package:googleapis_auth" and values are version strings like "^2.0.0".
 	Packages map[string]string `yaml:"packages,omitempty"`

--- a/internal/librarian/dart/generate.go
+++ b/internal/librarian/dart/generate.go
@@ -92,6 +92,9 @@ func buildCodec(library *config.Library) map[string]string {
 	if library.Version != "" {
 		codec["version"] = library.Version
 	}
+	if library.SkipPublish {
+		codec["not-for-publication"] = "true"
+	}
 	if library.Dart == nil {
 		return codec
 	}
@@ -114,9 +117,6 @@ func buildCodec(library *config.Library) map[string]string {
 	}
 	if dart.LibraryPathOverride != "" {
 		codec["library-path-override"] = dart.LibraryPathOverride
-	}
-	if dart.NotForPublication != "" {
-		codec["not-for-publication"] = dart.NotForPublication
 	}
 	if dart.PartFile != "" {
 		codec["part-file"] = dart.PartFile

--- a/internal/librarian/dart/generate_test.go
+++ b/internal/librarian/dart/generate_test.go
@@ -182,9 +182,7 @@ func TestBuildCodec(t *testing.T) {
 		{
 			name: "not for publication",
 			library: &config.Library{
-				Dart: &config.DartPackage{
-					NotForPublication: "true",
-				},
+				SkipPublish: true,
 			},
 			want: map[string]string{
 				"not-for-publication": "true",
@@ -284,6 +282,7 @@ func TestBuildCodec(t *testing.T) {
 			library: &config.Library{
 				CopyrightYear: "2025",
 				Version:       "1.0.0",
+				SkipPublish:   true,
 				Dart: &config.DartPackage{
 					APIKeysEnvironmentVariables: "GOOGLE_API_KEY",
 					Dependencies:                "http: ^1.3.0",
@@ -291,7 +290,6 @@ func TestBuildCodec(t *testing.T) {
 					ExtraImports:                "package:googleapis_auth/auth.dart",
 					IssueTrackerURL:             "https://github.com/googleapis/google-cloud-dart/issues",
 					LibraryPathOverride:         "lib/custom.dart",
-					NotForPublication:           "false",
 					PartFile:                    "part 'src/common.dart';",
 					ReadmeAfterTitleText:        "**Note:** This package is experimental.",
 					ReadmeQuickstartText:        "Run `dart pub add` to install.",
@@ -316,7 +314,7 @@ func TestBuildCodec(t *testing.T) {
 				"extra-imports":                  "package:googleapis_auth/auth.dart",
 				"issue-tracker-url":              "https://github.com/googleapis/google-cloud-dart/issues",
 				"library-path-override":          "lib/custom.dart",
-				"not-for-publication":            "false",
+				"not-for-publication":            "true",
 				"part-file":                      "part 'src/common.dart';",
 				"readme-after-title-text":        "**Note:** This package is experimental.",
 				"readme-quickstart-text":         "Run `dart pub add` to install.",
@@ -445,6 +443,7 @@ func TestToSidekickConfig(t *testing.T) {
 		{
 			name: "with dart package",
 			library: &config.Library{
+				SkipPublish: true,
 				Dart: &config.DartPackage{
 					APIKeysEnvironmentVariables: "GOOGLE_API_KEY",
 					Dependencies:                "dep-1,dep-2",
@@ -452,7 +451,6 @@ func TestToSidekickConfig(t *testing.T) {
 					ExtraImports:                "extra-imports",
 					IssueTrackerURL:             "https://tracker/issues",
 					LibraryPathOverride:         "library-path-override",
-					NotForPublication:           "false",
 					PartFile:                    "part-file",
 					ReadmeAfterTitleText:        "readme-after-title-text",
 					ReadmeQuickstartText:        "readme-quickstart-text",
@@ -491,7 +489,7 @@ func TestToSidekickConfig(t *testing.T) {
 					"extra-imports":                  "extra-imports",
 					"issue-tracker-url":              "https://tracker/issues",
 					"library-path-override":          "library-path-override",
-					"not-for-publication":            "false",
+					"not-for-publication":            "true",
 					"package:googleapis_auth":        "^2.0.0",
 					"part-file":                      "part-file",
 					"prefix:google.logging.type":     "logging_type",


### PR DESCRIPTION
Pass `not-for-publication` from librarian config to sidekick config.

For #3580