### PR TITLE
doc: fix script to preserve list and line break

### DIFF
--- a/cmd/config_doc_generate.go
+++ b/cmd/config_doc_generate.go
@@ -337,6 +337,30 @@ func (d *docData) formatType(typeName string) string {
 	return res
 }
 
+// cleanDoc collapses standard word-wrapping into single spaces but preserves
+// paragraph breaks and list items by using <br> tags, which are required
+// for multi-line content within Markdown table cells.
 func cleanDoc(doc string) string {
-	return strings.Join(strings.Fields(doc), " ")
+	lines := strings.Split(strings.TrimSpace(doc), "\n")
+	var out strings.Builder
+	for i, line := range lines {
+		cleanedLine := strings.Join(strings.Fields(line), " ")
+		if cleanedLine == "" {
+			// Convert empty lines to <br> to preserve paragraph breaks.
+			out.WriteString("<br>")
+			continue
+		}
+		if i > 0 {
+			prevLineCleaned := strings.Join(strings.Fields(lines[i-1]), " ")
+			// Use <br> if the current line is a list item or if it follows a blank line.
+			// Otherwise, use a space to collapse wrapped text into a single paragraph.
+			if prevLineCleaned == "" || strings.HasPrefix(cleanedLine, "-") || strings.HasPrefix(cleanedLine, "*") {
+				out.WriteString("<br>")
+			} else {
+				out.WriteString(" ")
+			}
+		}
+		out.WriteString(cleanedLine)
+	}
+	return out.String()
 }

--- a/cmd/config_doc_generate_test.go
+++ b/cmd/config_doc_generate_test.go
@@ -221,6 +221,26 @@ func TestCleanDoc(t *testing.T) {
 			doc:  " This  is   a    comment. ",
 			want: "This is a comment.",
 		},
+		{
+			name: "doc with paragraph break",
+			doc:  "First paragraph.\n\nSecond paragraph.",
+			want: "First paragraph.<br><br>Second paragraph.",
+		},
+		{
+			name: "doc with list items",
+			doc:  "Supported languages:\n- Python\n- Rust\n- Dart",
+			want: "Supported languages:<br>- Python<br>- Rust<br>- Dart",
+		},
+		{
+			name: "doc with list items and asterisk",
+			doc:  "Reasons:\n* Reason 1\n* Reason 2",
+			want: "Reasons:<br>* Reason 1<br>* Reason 2",
+		},
+		{
+			name: "mixed paragraphs and lists",
+			doc:  "Header.\n\n- Item 1\n- Item 2\n\nFooter.",
+			want: "Header.<br><br>- Item 1<br>- Item 2<br><br>Footer.",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := cleanDoc(test.doc)

--- a/doc/api-allowlist-schema.md
+++ b/doc/api-allowlist-schema.md
@@ -8,7 +8,7 @@ This document describes the schema for the API Allowlist.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `Path` | string | Path is the proto directory path in github.com/googleapis/googleapis. If ServiceConfig is empty, the service config is assumed to live at this path. |
-| `Languages` | list of string | Languages restricts which languages can generate client libraries for this API. Empty means all languages can use this API. Restrictions exist for several reasons: - Newer languages (Rust, Dart) skip older beta versions when stable versions exist - Python has historical legacy APIs not available to other languages - Some APIs (like DIREGAPIC protos) are only used by specific languages |
+| `Languages` | list of string | Languages restricts which languages can generate client libraries for this API. Empty means all languages can use this API.<br><br>Restrictions exist for several reasons:<br>- Newer languages (Rust, Dart) skip older beta versions when stable versions exist<br>- Python has historical legacy APIs not available to other languages<br>- Some APIs (like DIREGAPIC protos) are only used by specific languages |
 | `Discovery` | string | Discovery is the file path to a discovery document in github.com/googleapis/discovery-artifact-manager. Used by sidekick languages (Rust, Dart) as an alternative to proto files. |
 | `OpenAPI` | string | OpenAPI is the file path to an OpenAPI spec, currently in internal/testdata. This is not an official spec yet and exists only for Rust to validate OpenAPI support. |
 | `ServiceConfig` | string | ServiceConfig is the service config file path override. If empty, the service config is discovered in the directory specified by Path. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -9,7 +9,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `language` | string | Language is the language for this workspace (go, python, rust). |
 | `version` | string | Version is the librarian tool version to use. |
-| `repo` | string | Repo is the repository name, such as "googleapis/google-cloud-python". TODO(https://github.com/googleapis/librarian/issues/3003): Remove this field when .repo-metadata.json generation is removed. |
+| `repo` | string | Repo is the repository name, such as "googleapis/google-cloud-python".<br><br>TODO(https://github.com/googleapis/librarian/issues/3003): Remove this field when .repo-metadata.json generation is removed. |
 | `sources` | [Sources](#sources-configuration) (optional) | Sources references external source repositories. |
 | `release` | [Release](#release-configuration) (optional) | Release holds the configuration parameter for publishing and release subcommands. |
 | `default` | [Default](#default-configuration) (optional) | Default contains default settings for all libraries. They apply to all libraries unless overridden. |
@@ -22,7 +22,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `branch` | string | Branch sets the name of the release branch, typically `main` |
 | `ignored_changes` | list of string | IgnoredChanges defines globs that are ignored in change analysis. |
-| `preinstalled` | map[string]string | Preinstalled tools defines the list of tools that must be preinstalled. This is indexed by the well-known name of the tool vs. its path, e.g. [preinstalled] cargo = /usr/bin/cargo |
+| `preinstalled` | map[string]string | Preinstalled tools defines the list of tools that must be preinstalled.<br><br>This is indexed by the well-known name of the tool vs. its path, e.g. [preinstalled] cargo = /usr/bin/cargo |
 | `remote` | string | Remote sets the name of the source-of-truth remote for releases, typically `upstream`. |
 | `roots_pem` | string | An alternative location for the `roots.pem` file. If empty it has no effect. |
 | `tools` | map[string][]Tool | Tools defines the list of tools to install, indexed by installer. |


### PR DESCRIPTION
When generating config docs from comments, the line breaks and lists should be preserved for readability.

This is a followup to #3835.