### PR TITLE
refactor(internal/librarianops): simplify generate command interface

### DIFF
--- a/internal/librarianops/generate_test.go
+++ b/internal/librarianops/generate_test.go
@@ -69,7 +69,15 @@ func TestGenerateCommand(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			args := []string{"librarianops", "generate", "-C", repoDir, "fake-repo"}
+			// Rename temp dir to fake-repo so basename matches expected repo
+			// name.
+			fakeRepoDir := filepath.Join(filepath.Dir(repoDir), "fake-repo")
+			if err := os.Rename(repoDir, fakeRepoDir); err != nil {
+				t.Fatal(err)
+			}
+			repoDir = fakeRepoDir
+
+			args := []string{"librarianops", "generate", "-C", repoDir}
 			if test.verbose {
 				args = append(args, "-v")
 				command.Verbose = true
@@ -126,20 +134,16 @@ func TestGenerateCommand_Errors(t *testing.T) {
 		args []string
 	}{
 		{
-			name: "both repo and all flag",
-			args: []string{"librarianops", "generate", "--all", "fake-repo"},
-		},
-		{
-			name: "neither repo nor all flag",
+			name: "no repo argument",
 			args: []string{"librarianops", "generate"},
-		},
-		{
-			name: "all flag with C flag",
-			args: []string{"librarianops", "generate", "--all", "-C", "/tmp/foo"},
 		},
 		{
 			name: "unsupported repo",
 			args: []string{"librarianops", "generate", "unsupported-repo"},
+		},
+		{
+			name: "unsupported repo via C flag",
+			args: []string{"librarianops", "generate", "-C", "/tmp/unsupported-repo"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarianops/librarianops.go
+++ b/internal/librarianops/librarianops.go
@@ -23,11 +23,8 @@ import (
 )
 
 const (
-	branchPrefix = "librarianops-generateall-"
-	commitTitle  = "chore: run librarian update and generate --all"
-
-	repoFake = "fake-repo" // used for testing
 	repoRust = "google-cloud-rust"
+	repoFake = "fake-repo" // used for testing
 )
 
 var supportedRepositories = map[string]bool{


### PR DESCRIPTION
Remove the --all flag and simplify the -C flag behavior. The repo name is now inferred from filepath.Base(dir) when using -C, eliminating the need to specify it separately.

The new interface is:

    librarianops generate <repo>
    librarianops generate -C <dir>

The --all flag is removed, since the expectation is that we would only ever process on repo at at time locally, or can run:

    librarian generate google-cloud-rust && librarian generate google-cloud-go && ...

Also move generate-specific code to generate.go and generate_test.go.