### PR TITLE
fix: TestBuildGoLibraries to sort result by name before comparison

### DIFF
--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/legacylibrarian/legacyconfig"
 )
@@ -372,7 +373,9 @@ func TestBuildGoLibraries(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := buildGoLibraries(test.input)
-			if diff := cmp.Diff(test.want, got); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmpopts.SortSlices(func(a, b *config.Library) bool {
+				return a.Name < b.Name
+			})); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Test was flaky due to order of libraries in the result. Sorting from this code was recently removed and moved to a higher level function ([here](https://github.com/googleapis/librarian/pull/3831/files)). Fix by ignoring ordering diff in test comparison.

Fix #3859
Fix #3862