### PR TITLE
test(sidekick/rust): prepare for strict package mappings

### DIFF
--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -49,6 +49,8 @@ func TestGenerateVeneer(t *testing.T) {
 					{Name: "wkt", Package: "google-cloud-wkt", Source: "google.protobuf"},
 					{Name: "iam_v1", Package: "google-cloud-iam-v1", Source: "google.iam.v1"},
 					{Name: "location", Package: "google-cloud-location", Source: "google.cloud.location"},
+					{Name: "google-cloud-api", Package: "google-cloud-api", Source: "google.api"},
+					{Name: "google-cloud-type", Package: "google-cloud-type", Source: "google.type"},
 				},
 			},
 			Modules: []*config.RustModule{
@@ -248,6 +250,8 @@ func TestGenerate(t *testing.T) {
 							{Name: "wkt", Package: "google-cloud-wkt", Source: "google.protobuf"},
 							{Name: "iam_v1", Package: "google-cloud-iam-v1", Source: "google.iam.v1"},
 							{Name: "location", Package: "google-cloud-location", Source: "google.cloud.location"},
+							{Name: "google-cloud-api", Package: "google-cloud-api", Source: "google.api"},
+							{Name: "google-cloud-type", Package: "google-cloud-type", Source: "google.type"},
 						},
 					},
 				},

--- a/internal/sidekick/rust/annotate_map_test.go
+++ b/internal/sidekick/rust/annotate_map_test.go
@@ -155,10 +155,7 @@ func TestMapValueAnnotations(t *testing.T) {
 		model := api.NewTestAPI([]*api.Message{message, mapMessage}, []*api.Enum{}, []*api.Service{})
 		api.CrossReference(model)
 		api.LabelRecursiveFields(model)
-		codec, err := newCodec(test.spec, map[string]string{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		codec := newTestCodec(t, test.spec, "test", map[string]string{})
 		annotateModel(model, codec)
 
 		got := field.Codec.(*fieldAnnotations).SerdeAs
@@ -207,10 +204,7 @@ func TestMapAnnotationsSameSame(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{message, mapMessage}, []*api.Enum{}, []*api.Service{})
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
-	codec, err := newCodec("protobuf", map[string]string{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	codec := newTestCodec(t, "protobuf", "test", map[string]string{})
 	annotateModel(model, codec)
 
 	got := field.Codec.(*fieldAnnotations).SerdeAs

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -28,12 +28,9 @@ func TestAnnotateMethodNames(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	codec, err := newCodec("protobuf", map[string]string{
+	codec := newTestCodec(t, "protobuf", "", map[string]string{
 		"include-grpc-only-methods": "true",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	_ = annotateModel(model, codec)
 
 	for _, test := range []struct {
@@ -98,7 +95,7 @@ func TestAnnotateDiscoveryAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	codec, err := newCodec("protobuf", map[string]string{
+	codec := newTestCodec(t, "protobuf", "", map[string]string{
 		"include-grpc-only-methods": "true",
 	})
 	if err != nil {
@@ -141,10 +138,7 @@ func TestAnnotateMethodAPIVersion(t *testing.T) {
 	}
 	gotMethod.APIVersion = "v1_20260205"
 
-	codec, err := newCodec("disco", map[string]string{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	codec := newTestCodec(t, "disco", "", map[string]string{})
 	_ = annotateModel(model, codec)
 
 	got := gotMethod.Codec.(*methodAnnotation)
@@ -164,12 +158,9 @@ func TestAnnotateMethodInternalBuilders(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	codec, err := newCodec("protobuf", map[string]string{
+	codec := newTestCodec(t, "protobuf", "", map[string]string{
 		"internal-builders": "true",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	_ = annotateModel(model, codec)
 
 	methodID := ".test.v1.ResourceService.Delete"

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -54,10 +54,7 @@ func TestDefaultFeatures(t *testing.T) {
 		},
 	} {
 		model := newTestAnnotateModelAPI()
-		codec, err := newCodec("protobuf", test.Options)
-		if err != nil {
-			t.Fatal(err)
-		}
+		codec := newTestCodec(t, "protobuf", "", test.Options)
 		got := annotateModel(model, codec)
 		t.Logf("Options=%v", test.Options)
 		if diff := cmp.Diff(test.Want, got.DefaultFeatures); diff != "" {
@@ -89,10 +86,7 @@ func TestRustdocWarnings(t *testing.T) {
 		},
 	} {
 		model := newTestAnnotateModelAPI()
-		codec, err := newCodec("protobuf", test.Options)
-		if err != nil {
-			t.Fatal(err)
-		}
+		codec := newTestCodec(t, "protobuf", "", test.Options)
 		got := annotateModel(model, codec)
 		t.Logf("Options=%v", test.Options)
 		if diff := cmp.Diff(test.Want, got.DisabledRustdocWarnings); diff != "" {
@@ -124,10 +118,7 @@ func TestClippyWarnings(t *testing.T) {
 		},
 	} {
 		model := newTestAnnotateModelAPI()
-		codec, err := newCodec("protobuf", test.Options)
-		if err != nil {
-			t.Fatal(err)
-		}
+		codec := newTestCodec(t, "protobuf", "", test.Options)
 		got := annotateModel(model, codec)
 		t.Logf("Options=%v", test.Options)
 		if diff := cmp.Diff(test.Want, got.DisabledClippyWarnings); diff != "" {
@@ -163,10 +154,7 @@ func TestInternalBuildersAnnotation(t *testing.T) {
 		},
 	} {
 		model := newTestAnnotateModelAPI()
-		codec, err := newCodec("protobuf", test.Options)
-		if err != nil {
-			t.Fatal(err)
-		}
+		codec := newTestCodec(t, "protobuf", "", test.Options)
 		got := annotateModel(model, codec)
 		if got.InternalBuilders != test.Want {
 			t.Errorf("mismatch in InternalBuilders, want=%v, got=%v", test.Want, got.InternalBuilders)

--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -84,6 +84,9 @@ func TestCodecError(t *testing.T) {
 			ServiceConfig:       path.Join(testdataDir, "../../testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
 			SpecificationSource: path.Join(testdataDir, "openapi/secretmanager_openapi_v1.json"),
 		},
+		Codec: map[string]string{
+			"package:wkt": "source=google.protobuf,package=google-cloud-wkt",
+		},
 	}
 	errorConfig := &config.Config{
 		General: config.GeneralConfig{
@@ -121,6 +124,9 @@ func TestRustFromOpenAPI(t *testing.T) {
 			ServiceConfig:       path.Join(testdataDir, "../../testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
 			SpecificationSource: path.Join(testdataDir, "openapi/secretmanager_openapi_v1.json"),
 		},
+		Codec: map[string]string{
+			"package:wkt": "source=google.protobuf,package=google-cloud-wkt",
+		},
 	}
 	model, err := parser.CreateModel(cfg)
 	if err != nil {
@@ -152,6 +158,7 @@ func TestRustFromDiscovery(t *testing.T) {
 			SpecificationSource: path.Join(testdataDir, "disco/compute.v1.json"),
 		},
 		Codec: map[string]string{
+			"package:wkt":          "source=google.protobuf,package=google-cloud-wkt",
 			"per-service-features": "true",
 		},
 	}
@@ -189,6 +196,13 @@ func TestRustFromProtobuf(t *testing.T) {
 		Source: map[string]string{
 			"googleapis-root": path.Join(testdataDir, "../../testdata/googleapis"),
 		},
+		Codec: map[string]string{
+			"package:wkt":                   "source=google.protobuf,package=google-cloud-wkt",
+			"package:google-cloud-api":      "source=google.api,package=google-cloud-api",
+			"package:google-cloud-location": "source=google.cloud.location,package=google-cloud-location",
+			"package:google-cloud-iam-v1":   "source=google.iam.v1,package=google-cloud-iam-v1",
+			"package:google-cloud-type":     "source=google.type,package=google-cloud-type",
+		},
 	}
 	model, err := parser.CreateModel(cfg)
 	if err != nil {
@@ -225,8 +239,13 @@ func TestRustClient(t *testing.T) {
 				"googleapis-root": path.Join(testdataDir, "../../testdata/googleapis"),
 			},
 			Codec: map[string]string{
-				"copyright-year":    "2025",
-				"template-override": path.Join("templates", override),
+				"copyright-year":                "2025",
+				"template-override":             path.Join("templates", override),
+				"package:wkt":                   "source=google.protobuf,package=google-cloud-wkt",
+				"package:google-cloud-api":      "source=google.api,package=google-cloud-api",
+				"package:google-cloud-location": "source=google.cloud.location,package=google-cloud-location",
+				"package:google-cloud-iam-v1":   "source=google.iam.v1,package=google-cloud-iam-v1",
+				"package:google-cloud-type":     "source=google.type,package=google-cloud-type",
 			},
 		}
 		model, err := parser.CreateModel(cfg)
@@ -270,8 +289,13 @@ func TestRustNosvc(t *testing.T) {
 			"googleapis-root": path.Join(testdataDir, "../../testdata/googleapis"),
 		},
 		Codec: map[string]string{
-			"copyright-year":    "2025",
-			"template-override": path.Join("templates", "nosvc"),
+			"copyright-year":                "2025",
+			"template-override":             path.Join("templates", "nosvc"),
+			"package:wkt":                   "source=google.protobuf,package=google-cloud-wkt",
+			"package:google-cloud-api":      "source=google.api,package=google-cloud-api",
+			"package:google-cloud-location": "source=google.cloud.location,package=google-cloud-location",
+			"package:google-cloud-iam-v1":   "source=google.iam.v1,package=google-cloud-iam-v1",
+			"package:google-cloud-type":     "source=google.type,package=google-cloud-type",
 		},
 	}
 	model, err := parser.CreateModel(cfg)
@@ -310,6 +334,7 @@ func TestRustModuleRpc(t *testing.T) {
 		Codec: map[string]string{
 			"copyright-year":    "2025",
 			"template-override": "templates/mod",
+			"package:wkt":       "source=google.protobuf,package=google-cloud-wkt",
 		},
 	}
 	model, err := parser.CreateModel(cfg)


### PR DESCRIPTION
The Rust codec is about to get more strict w.r.t. package names. Prepare all the test for it.

Towards #3857 