### PR TITLE
fix(internal/librarian): remove default specification_format in tidy

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -76,6 +76,9 @@ func tidyLibrary(cfg *config.Config, lib *config.Library) error {
 	if len(lib.Roots) == 1 && lib.Roots[0] == "googleapis" {
 		lib.Roots = nil
 	}
+	if lib.SpecificationFormat == "protobuf" {
+		lib.SpecificationFormat = ""
+	}
 	// Only remove derivable API paths when there's exactly one API.
 	// When there are multiple APIs, preserve all of them.
 	if len(lib.APIs) == 1 && isDerivableAPIPath(cfg.Language, lib.Name, lib.APIs[0].Path) {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -211,11 +211,12 @@ func TestTidy_DerivableFields(t *testing.T) {
 		},
 	}
 	for _, test := range []struct {
-		name         string
-		config       *config.Config
-		wantPath     string
-		wantNumLibs  int
-		wantNumChnls int
+		name                    string
+		config                  *config.Config
+		wantPath                string
+		wantNumLibs             int
+		wantNumChnls            int
+		wantSpecificationFormat string
 	}{
 		{
 			name: "derivable fields removed",
@@ -223,7 +224,8 @@ func TestTidy_DerivableFields(t *testing.T) {
 				Sources: googleapisSource,
 				Libraries: []*config.Library{
 					{
-						Name: "google-cloud-accessapproval-v1",
+						Name:                "google-cloud-accessapproval-v1",
+						SpecificationFormat: "protobuf",
 						APIs: []*config.API{
 							{
 								Path: "google/cloud/accessapproval/v1",
@@ -232,9 +234,10 @@ func TestTidy_DerivableFields(t *testing.T) {
 					},
 				},
 			},
-			wantPath:     "",
-			wantNumLibs:  1,
-			wantNumChnls: 0,
+			wantPath:                "",
+			wantNumLibs:             1,
+			wantNumChnls:            0,
+			wantSpecificationFormat: "",
 		},
 		{
 			name: "non-derivable path not removed",
@@ -298,6 +301,9 @@ func TestTidy_DerivableFields(t *testing.T) {
 				if ch.Path != test.wantPath {
 					t.Errorf("path should be %s, got %q", test.wantPath, ch.Path)
 				}
+			}
+			if lib.SpecificationFormat != test.wantSpecificationFormat {
+				t.Errorf("specification_format = %q, want %q", lib.SpecificationFormat, test.wantSpecificationFormat)
 			}
 		})
 	}


### PR DESCRIPTION
The tidy command now removes `specification_format: protobuf` from librarian.yaml since "protobuf" is the default value.