### PR TITLE
feat(internal/librarian/dart): add DefaultOutput function

### DIFF
--- a/internal/librarian/dart/generate.go
+++ b/internal/librarian/dart/generate.go
@@ -18,6 +18,7 @@ package dart
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
@@ -48,4 +49,9 @@ func Format(ctx context.Context, library *config.Library) error {
 		return err
 	}
 	return nil
+}
+
+// DefaultOutput returns the default output directory for a Dart library.
+func DefaultOutput(name, defaultOutput string) string {
+	return filepath.Join(defaultOutput, name)
 }

--- a/internal/librarian/dart/generate_test.go
+++ b/internal/librarian/dart/generate_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/source"
 	"github.com/googleapis/librarian/internal/testhelper"
@@ -109,5 +110,40 @@ func TestFormat(t *testing.T) {
 	}
 	if err := Format(t.Context(), library); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDefaultOutput(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		libName       string
+		defaultOutput string
+		want          string
+	}{
+		{
+			name:          "simple case",
+			libName:       "google-cloud-secretmanager-v1",
+			defaultOutput: "packages/",
+			want:          "packages/google-cloud-secretmanager-v1",
+		},
+		{
+			name:          "empty default output",
+			libName:       "my-lib",
+			defaultOutput: "",
+			want:          "my-lib",
+		},
+		{
+			name:          "empty lib name",
+			libName:       "",
+			defaultOutput: "packages/",
+			want:          "packages",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultOutput(test.libName, test.defaultOutput)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -159,6 +159,8 @@ func postGenerate(ctx context.Context, language string) error {
 
 func defaultOutput(language, name, api, defaultOut string) string {
 	switch language {
+	case languageDart:
+		return dart.DefaultOutput(name, defaultOut)
 	case languageRust:
 		return rust.DefaultOutput(api, defaultOut)
 	case languagePython:

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -295,6 +295,57 @@ func createGoogleapisServiceConfigs(t *testing.T, tempDir string, configs map[st
 	return googleapisDir
 }
 
+func TestDefaultOutput(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		language   string
+		libName    string
+		api        string
+		defaultOut string
+		want       string
+	}{
+		{
+			name:       "dart",
+			language:   "dart",
+			libName:    "google-cloud-secretmanager-v1",
+			api:        "google/cloud/secretmanager/v1",
+			defaultOut: "packages",
+			want:       "packages/google-cloud-secretmanager-v1",
+		},
+		{
+			name:       "rust",
+			language:   "rust",
+			libName:    "google-cloud-secretmanager-v1",
+			api:        "google/cloud/secretmanager/v1",
+			defaultOut: "generated",
+			want:       "generated/cloud/secretmanager/v1",
+		},
+		{
+			name:       "python",
+			language:   "python",
+			libName:    "google-cloud-secretmanager-v1",
+			api:        "google/cloud/secretmanager/v1",
+			defaultOut: "packages",
+			want:       "packages/google-cloud-secretmanager-v1",
+		},
+		{
+			name:       "unknown language",
+			language:   "unknown",
+			libName:    "google-cloud-secretmanager-v1",
+			api:        "google/cloud/secretmanager/v1",
+			defaultOut: "output",
+			want:       "output",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := defaultOutput(test.language, test.libName, test.api, test.defaultOut)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCleanOutput(t *testing.T) {
 	for _, test := range []struct {
 		name    string


### PR DESCRIPTION
DefaultOutput is added, which computes the default output directory for a Dart library by joining the default output path with the library name.