### PR TITLE
chore(migrate): use type inference when making maps

### DIFF
--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -162,13 +162,13 @@ func fetchGoogleapis(ctx context.Context) (*config.Source, error) {
 
 func buildGoLibraries(input *MigrationInput) []*config.Library {
 	var libraries []*config.Library
-	idToLibraryState := sliceToMap[legacyconfig.LibraryState](
+	idToLibraryState := sliceToMap(
 		input.librarianState.Libraries,
 		func(lib *legacyconfig.LibraryState) string {
 			return lib.ID
 		})
 
-	idToLibraryConfig := sliceToMap[legacyconfig.LibraryConfig](
+	idToLibraryConfig := sliceToMap(
 		input.librarianConfig.Libraries,
 		func(lib *legacyconfig.LibraryConfig) string {
 			return lib.LibraryID
@@ -176,7 +176,7 @@ func buildGoLibraries(input *MigrationInput) []*config.Library {
 
 	idToGoModule := make(map[string]*RepoConfigModule)
 	if input.repoConfig != nil {
-		idToGoModule = sliceToMap[RepoConfigModule](
+		idToGoModule = sliceToMap(
 			input.repoConfig.Modules,
 			func(mod *RepoConfigModule) string {
 				return mod.Name


### PR DESCRIPTION
Uses type inference in buildGoLibraries to simplify code and removing distracting code suggestion messages from VS Code.