### PR TITLE
chore: bump go version to latest

### DIFF
--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -37,7 +37,7 @@
 FROM marketplace.gcr.io/google/debian12@sha256:326ccf35aa72f7cc8cbd25b69e819a81c5fd9ed675c6c9ffb51f3214a64f23cf AS build
 
 ARG TARGETARCH
-ENV GO_VERSION=1.25.6
+ENV GO_VERSION=1.25.7
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/librarian
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cloud.google.com/go/artifactregistry v1.19.0


### PR DESCRIPTION
This was reported by vulncheck.

Fixes: #3931