### PR TITLE
fix: add logic and cmd to update Transports in api.go

### DIFF
--- a/tool/cmd/importconfigs/main.go
+++ b/tool/cmd/importconfigs/main.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// import configs is a tool to import configs from googleapis into api.go
+// intended to be a temp tool during migration
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+func main() {
+	ctx := context.Background()
+	cmd := &cli.Command{
+		Name:      "import-configs",
+		Usage:     "commands for import configs",
+		UsageText: "import-configs [command]",
+		Commands: []*cli.Command{
+			updateTransportsCommand(),
+		},
+	}
+	if err := cmd.Run(ctx, os.Args); err != nil {
+		log.Fatalf("import-configs: %v", err)
+	}
+}

--- a/tool/cmd/importconfigs/update_transports.go
+++ b/tool/cmd/importconfigs/update_transports.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package importconfig provides commands for importing configurations.
-package importconfig
+package main
 
 import (
 	"context"

--- a/tool/cmd/importconfigs/update_transports_test.go
+++ b/tool/cmd/importconfigs/update_transports_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package importconfig
+package main
 
 import (
 	"os"


### PR DESCRIPTION
Add logic and command to loop through API list in api.go and update transport info based BUILD.bazel from googleapis.
This is intended to be used during migration, so for simplicity passing path to googleapis dir to command (we assume transport info does not change other than new libs).

To test run this command:
`go run ./tool/cmd/importconfigs update-transports --googleapis path/to/local/googleapis/dir`

For clarity, will add the changes to api.go in a separate followup pr.

For #3775