### PR TITLE
test: reuse already defined openAPIFile in test

### DIFF
--- a/internal/sidekick/parser/parser_test.go
+++ b/internal/sidekick/parser/parser_test.go
@@ -78,7 +78,7 @@ func TestCreateModelOpenAPI(t *testing.T) {
 		General: config.GeneralConfig{
 			SpecificationFormat: "openapi",
 			ServiceConfig:       secretManagerYamlFullPath,
-			SpecificationSource: path.Join(mainTestdataDir, "secretmanager_openapi_v1.json"),
+			SpecificationSource: openAPIFile,
 		},
 	}
 	model, err := CreateModel(cfg)


### PR DESCRIPTION
reuse already defined openAPIFile var in test to reduce duplication. 

Followup to https://github.com/googleapis/librarian/pull/3943#discussion_r2775766444