### PR TITLE
chore: add cloud-sdk-rust-team as owner for sidekick files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 * @googleapis/cloud-sdk-librarian-team
 
 # Locations for all sidekick code.
-/*/sidekick/ @googleapis/cloud-sdk-sidekick-team
+/*/sidekick/ @googleapis/cloud-sdk-sidekick-team @googleapis/cloud-sdk-rust-team
 
 # Locations for all surfer code.
 /*/surfer/ @googleapis/cloud-sdk-surfer-team


### PR DESCRIPTION
Add googleapis/cloud-sdk-rust-team to lines with googleapis/cloud-sdk-sidekick-team, because rust-cloud-sdk (old team) is a subteams of cloud-sdk-sidekick-team. We don't intend to make cloud-sdk-rust-team a subteam.


b/481376531