### PR TITLE
fix(sidekick/rust): `bytes` serialization

### DIFF
--- a/internal/sidekick/parser/parser.go
+++ b/internal/sidekick/parser/parser.go
@@ -51,13 +51,9 @@ func NewModelConfigFromSidekickConfig(cfg *config.Config) ModelConfig {
 	if cfg == nil {
 		return ModelConfig{}
 	}
-	specFormat := cfg.General.SpecificationFormat
-	if specFormat == "disco" {
-		specFormat = "discovery"
-	}
 	return ModelConfig{
 		Language:            cfg.General.Language,
-		SpecificationFormat: specFormat,
+		SpecificationFormat: cfg.General.SpecificationFormat,
 		SpecificationSource: cfg.General.SpecificationSource,
 		ServiceConfig:       cfg.General.ServiceConfig,
 		Source:              cfg.Source,

--- a/internal/sidekick/rust/annotate_field_test.go
+++ b/internal/sidekick/rust/annotate_field_test.go
@@ -630,7 +630,7 @@ func TestBytesAnnotations(t *testing.T) {
 	}{
 		{"protobuf", "::bytes::Bytes", "serde_with::base64::Base64"},
 		{"openapi", "::bytes::Bytes", "serde_with::base64::Base64"},
-		{"disco", "::bytes::Bytes", "serde_with::base64::Base64<serde_with::base64::UrlSafe>"},
+		{"discovery", "::bytes::Bytes", "serde_with::base64::Base64<serde_with::base64::UrlSafe>"},
 	} {
 		singular_field := &api.Field{
 			Name:     "singular_field",

--- a/internal/sidekick/rust/annotate_map_test.go
+++ b/internal/sidekick/rust/annotate_map_test.go
@@ -102,11 +102,11 @@ func TestMapValueAnnotations(t *testing.T) {
 		wantSerdeAs string
 	}{
 		{"protobuf", api.STRING_TYPE, "unused", "serde_with::Same"},
-		{"disco", api.STRING_TYPE, "unused", "serde_with::Same"},
+		{"discovery", api.STRING_TYPE, "unused", "serde_with::Same"},
 		{"protobuf", api.BYTES_TYPE, "unused", "serde_with::base64::Base64"},
-		{"disco", api.BYTES_TYPE, "unused", "serde_with::base64::Base64<serde_with::base64::UrlSafe>"},
+		{"discovery", api.BYTES_TYPE, "unused", "serde_with::base64::Base64<serde_with::base64::UrlSafe>"},
 		{"protobuf", api.MESSAGE_TYPE, ".google.protobuf.BytesValue", "serde_with::base64::Base64"},
-		{"disco", api.MESSAGE_TYPE, ".google.protobuf.BytesValue", "serde_with::base64::Base64<serde_with::base64::UrlSafe>"},
+		{"discovery", api.MESSAGE_TYPE, ".google.protobuf.BytesValue", "serde_with::base64::Base64<serde_with::base64::UrlSafe>"},
 
 		{"protobuf", api.BOOL_TYPE, "unused", "serde_with::Same"},
 		{"protobuf", api.INT32_TYPE, "unused", "wkt::internal::I32"},

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -144,7 +144,7 @@ func TestAnnotateMethodAPIVersion(t *testing.T) {
 	}
 	gotMethod.APIVersion = "v1_20260205"
 
-	codec := newTestCodec(t, "disco", "", map[string]string{})
+	codec := newTestCodec(t, "discovery", "", map[string]string{})
 	_, err = annotateModel(model, codec)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -75,7 +75,7 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 		releaseLevel:            "preview",
 		systemParameters:        sysParams,
 		serializeEnumsAsStrings: specificationFormat != "protobuf",
-		bytesUseUrlSafeAlphabet: specificationFormat == "disco",
+		bytesUseUrlSafeAlphabet: specificationFormat == "discovery",
 	}
 
 	for key, definition := range options {

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -66,7 +66,7 @@ func TestParseOptions(t *testing.T) {
 			},
 		},
 		{
-			Format:  "disco",
+			Format:  "discovery",
 			Options: map[string]string{},
 			Update: func(c *codec) {
 				c.systemParameters = []systemParameter{


### PR DESCRIPTION
The discovery-based clients use custom serialization for `bytes`.

Fixes #3973 