### PR TITLE
chore(internal/serviceconfig): rewrite API allowlist as YAML file

### DIFF
--- a/doc/api-allowlist-schema.md
+++ b/doc/api-allowlist-schema.md
@@ -4,16 +4,16 @@ This document describes the schema for the API Allowlist.
 
 ## API Configuration
 
-[Link to code](../internal/serviceconfig/api.go#L53)
+[Link to code](../internal/serviceconfig/api.go#L50)
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `Path` | string | Path is the proto directory path in github.com/googleapis/googleapis. If ServiceConfig is empty, the service config is assumed to live at this path. |
-| `Languages` | list of string | Languages restricts which languages can generate client libraries for this API. Empty means all languages can use this API.<br><br>Restrictions exist for several reasons:<br>- Newer languages (Rust, Dart) skip older beta versions when stable versions exist<br>- Python has historical legacy APIs not available to other languages<br>- Some APIs (like DIREGAPIC protos) are only used by specific languages |
-| `Discovery` | string | Discovery is the file path to a discovery document in github.com/googleapis/discovery-artifact-manager. Used by sidekick languages (Rust, Dart) as an alternative to proto files. |
-| `OpenAPI` | string | OpenAPI is the file path to an OpenAPI spec, currently in internal/testdata. This is not an official spec yet and exists only for Rust to validate OpenAPI support. |
-| `ServiceConfig` | string | ServiceConfig is the service config file path override. If empty, the service config is discovered in the directory specified by Path. |
-| `Title` | string | Title overrides the API title from the service config. |
-| `NewIssueURI` | string | NewIssueURI overrides the new issue URI from the service config's publishing section. |
-| `DocumentationURI` | string | DocumentationURI overrides the product documentation URI from the service config's publishing section. |
-| `APIShortName` | string | APIShortName overrides the API short name from the service config's publishing section. |
-| `Transports` | map[string]Transport | Transports defines the supported transports per language. Map key is the language name (e.g., "python", "rust"). Optional. If omitted, all languages use GRPCRest by default. |
+| `path` | string | Path is the proto directory path in github.com/googleapis/googleapis. If ServiceConfig is empty, the service config is assumed to live at this path. |
+| `languages` | list of string | Languages restricts which languages can generate client libraries for this API. Empty means all languages can use this API.<br><br>Restrictions exist for several reasons:<br>- Newer languages (Rust, Dart) skip older beta versions when stable versions exist<br>- Python has historical legacy APIs not available to other languages<br>- Some APIs (like DIREGAPIC protos) are only used by specific languages |
+| `discovery` | string | Discovery is the file path to a discovery document in github.com/googleapis/discovery-artifact-manager. Used by sidekick languages (Rust, Dart) as an alternative to proto files. |
+| `open_api` | string | OpenAPI is the file path to an OpenAPI spec, currently in internal/testdata. This is not an official spec yet and exists only for Rust to validate OpenAPI support. |
+| `service_config` | string | ServiceConfig is the service config file path override. If empty, the service config is discovered in the directory specified by Path. |
+| `title` | string | Title overrides the API title from the service config. |
+| `new_issue_uri` | string | NewIssueURI overrides the new issue URI from the service config's publishing section. |
+| `documentation_uri` | string | DocumentationURI overrides the product documentation URI from the service config's publishing section. |
+| `api_short_name` | string | APIShortName overrides the API short name from the service config's publishing section. |
+| `transports` | map[string]Transport | Transports defines the supported transports per language. Map key is the language name (e.g., "python", "rust"). Optional. If omitted, all languages use GRPCRest by default. |

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -16,6 +16,13 @@
 
 package serviceconfig
 
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/yaml"
+)
+
 const (
 	// LangDart is the language identifier for Dart.
 	LangDart = "dart"
@@ -25,16 +32,6 @@ const (
 	LangPython = "python"
 	// LangRust is the language identifier for Rust.
 	LangRust = "rust"
-
-	titleAppsScriptTypes           = "Google Apps Script Types"
-	titleAccessContextManagerTypes = "Access Context Manager Types"
-	titleCloudTraceAPI             = "Cloud Trace API"
-	titleFirestoreAPI              = "Cloud Firestore API"
-	titleGKEHubTypes               = "GKE Hub Types"
-	titleLoggingTypes              = "Logging types"
-
-	serviceConfigAIPlatformSchema  = "google/cloud/aiplatform/v1/schema/aiplatform_v1.yaml"
-	serviceConfigAIPlatformV1Beta1 = "google/cloud/aiplatform/v1beta1/aiplatform_v1beta1.yaml"
 )
 
 // Transport defines the supported transport protocol.
@@ -53,7 +50,7 @@ const (
 type API struct {
 	// Path is the proto directory path in github.com/googleapis/googleapis.
 	// If ServiceConfig is empty, the service config is assumed to live at this path.
-	Path string
+	Path string `yaml:"path,omitempty"`
 
 	// Languages restricts which languages can generate client libraries for this API.
 	// Empty means all languages can use this API.
@@ -62,40 +59,40 @@ type API struct {
 	//   - Newer languages (Rust, Dart) skip older beta versions when stable versions exist
 	//   - Python has historical legacy APIs not available to other languages
 	//   - Some APIs (like DIREGAPIC protos) are only used by specific languages
-	Languages []string
+	Languages []string `yaml:"languages,omitempty"`
 
 	// Discovery is the file path to a discovery document in
 	// github.com/googleapis/discovery-artifact-manager.
 	// Used by sidekick languages (Rust, Dart) as an alternative to proto files.
-	Discovery string
+	Discovery string `yaml:"discovery,omitempty"`
 
 	// OpenAPI is the file path to an OpenAPI spec, currently in internal/testdata.
 	// This is not an official spec yet and exists only for Rust to validate OpenAPI support.
-	OpenAPI string
+	OpenAPI string `yaml:"open_api,omitempty"`
 
 	// ServiceConfig is the service config file path override.
 	// If empty, the service config is discovered in the directory specified by Path.
-	ServiceConfig string
+	ServiceConfig string `yaml:"service_config,omitempty"`
 
 	// Title overrides the API title from the service config.
-	Title string
+	Title string `yaml:"title,omitempty"`
 
 	// NewIssueURI overrides the new issue URI from the service config's
 	// publishing section.
-	NewIssueURI string
+	NewIssueURI string `yaml:"new_issue_uri,omitempty"`
 
 	// DocumentationURI overrides the product documentation URI from the service
 	// config's publishing section.
-	DocumentationURI string
+	DocumentationURI string `yaml:"documentation_uri,omitempty"`
 
 	// APIShortName overrides the API short name from the service config's
 	// publishing section.
-	APIShortName string
+	APIShortName string `yaml:"api_short_name,omitempty"`
 
 	// Transports defines the supported transports per language.
 	// Map key is the language name (e.g., "python", "rust").
 	// Optional. If omitted, all languages use GRPCRest by default.
-	Transports map[string]Transport
+	Transports map[string]Transport `yaml:"transports,omitempty"`
 }
 
 // Transport gets transport for a given language.
@@ -109,416 +106,19 @@ func (api *API) Transport(language string) string {
 	return string(GRPCRest)
 }
 
-// APIs defines API paths that require explicit configurations.
-// APIs not in this list are implicitly allowed if
-// they start with "google/cloud/".
-var APIs = []API{
-	{Path: "google/ads/admanager/v1", Languages: []string{LangPython}},
-	{Path: "google/ads/datamanager/v1", Languages: []string{LangPython}},
-	{Path: "google/ai/generativelanguage/v1", Languages: []string{LangPython}},
-	{Path: "google/ai/generativelanguage/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/ai/generativelanguage/v1beta", Languages: []string{LangPython, LangDart}},
-	{Path: "google/ai/generativelanguage/v1beta2", Languages: []string{LangPython}},
-	{Path: "google/ai/generativelanguage/v1beta3", Languages: []string{LangPython}},
-	{Path: "google/analytics/admin/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/analytics/admin/v1beta", Languages: []string{LangPython}},
-	{Path: "google/analytics/data/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/analytics/data/v1beta", Languages: []string{LangPython}},
-	{Path: "google/api"},
-	{Path: "google/api/apikeys/v2"},
-	{Path: "google/api/cloudquotas/v1"},
-	{Path: "google/api/cloudquotas/v1beta", Languages: []string{LangPython}},
-	{Path: "google/api/servicecontrol/v1"},
-	{Path: "google/api/servicecontrol/v2"},
-	{Path: "google/api/servicemanagement/v1"},
-	{Path: "google/api/serviceusage/v1"},
-	{Path: "google/appengine/logging/v1", Languages: []string{LangPython}},
-	{Path: "google/appengine/v1"},
-	{Path: "google/apps/card/v1", Languages: []string{LangPython}},
-	{Path: "google/apps/events/subscriptions/v1", Languages: []string{LangPython}},
-	{Path: "google/apps/events/subscriptions/v1beta", Languages: []string{LangPython}},
-	{Path: "google/apps/meet/v2", Languages: []string{LangPython}},
-	{Path: "google/apps/meet/v2beta", Languages: []string{LangPython}},
-	{Path: "google/apps/script/type", Title: titleAppsScriptTypes},
-	{Path: "google/apps/script/type/calendar", Title: titleAppsScriptTypes},
-	{Path: "google/apps/script/type/docs", Title: titleAppsScriptTypes},
-	{Path: "google/apps/script/type/drive", Title: titleAppsScriptTypes},
-	{Path: "google/apps/script/type/gmail", Title: titleAppsScriptTypes},
-	{Path: "google/apps/script/type/sheets", Title: titleAppsScriptTypes},
-	{Path: "google/apps/script/type/slides", Title: titleAppsScriptTypes},
-	{Path: "google/area120/tables/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/bigtable/admin/v2"},
-	{Path: "google/chat/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/accessapproval/v1"},
-	{Path: "google/cloud/advisorynotifications/v1"},
-	{Path: "google/cloud/aiplatform/v1", Transports: map[string]Transport{LangGo: GRPC}},
-	{Path: "google/cloud/aiplatform/v1/schema/predict/instance", ServiceConfig: serviceConfigAIPlatformSchema},
-	{Path: "google/cloud/aiplatform/v1/schema/predict/params", ServiceConfig: serviceConfigAIPlatformSchema},
-	{Path: "google/cloud/aiplatform/v1/schema/predict/prediction", ServiceConfig: serviceConfigAIPlatformSchema},
-	{Path: "google/cloud/aiplatform/v1/schema/trainingjob/definition", ServiceConfig: serviceConfigAIPlatformSchema},
-	{Path: "google/cloud/aiplatform/v1beta1", ServiceConfig: serviceConfigAIPlatformV1Beta1, Languages: []string{LangPython, LangDart}},
-	{Path: "google/cloud/alloydb/connectors/v1"},
-	{Path: "google/cloud/alloydb/connectors/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/alloydb/connectors/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/alloydb/v1"},
-	{Path: "google/cloud/alloydb/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/alloydb/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/apigateway/v1"},
-	{Path: "google/cloud/apigeeconnect/v1"},
-	{Path: "google/cloud/apigeeregistry/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/apihub/v1"},
-	{Path: "google/cloud/apiregistry/v1"},
-	{Path: "google/cloud/apiregistry/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/apphub/v1"},
-	{Path: "google/cloud/asset/v1"},
-	{Path: "google/cloud/asset/v1p1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/asset/v1p2beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/asset/v1p5beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/assuredworkloads/v1"},
-	{Path: "google/cloud/assuredworkloads/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/audit", Languages: []string{LangPython}},
-	{Path: "google/cloud/auditmanager/v1"},
-	{Path: "google/cloud/automl/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/automl/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/backupdr/v1"},
-	{Path: "google/cloud/baremetalsolution/v2"},
-	{Path: "google/cloud/batch/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/batch/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/beyondcorp/appconnections/v1"},
-	{Path: "google/cloud/beyondcorp/appconnectors/v1"},
-	{Path: "google/cloud/beyondcorp/appgateways/v1"},
-	{Path: "google/cloud/beyondcorp/clientconnectorservices/v1"},
-	{Path: "google/cloud/beyondcorp/clientgateways/v1"},
-	{Path: "google/cloud/biglake/v1"},
-	{Path: "google/cloud/bigquery/analyticshub/v1"},
-	{Path: "google/cloud/bigquery/biglake/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/biglake/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/connection/v1"},
-	{Path: "google/cloud/bigquery/dataexchange/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/datapolicies/v1"},
-	{Path: "google/cloud/bigquery/datapolicies/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/datapolicies/v2"},
-	{Path: "google/cloud/bigquery/datapolicies/v2beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/datatransfer/v1"},
-	{Path: "google/cloud/bigquery/logging/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/migration/v2"},
-	{Path: "google/cloud/bigquery/migration/v2alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/reservation/v1"},
-	{Path: "google/cloud/bigquery/storage/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/storage/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/storage/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/storage/v1beta2", Languages: []string{LangPython}},
-	{Path: "google/cloud/bigquery/v2"},
-	{Path: "google/cloud/billing/budgets/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/billing/budgets/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/billing/v1"},
-	{Path: "google/cloud/binaryauthorization/v1"},
-	{Path: "google/cloud/binaryauthorization/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/capacityplanner/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/certificatemanager/v1"},
-	{Path: "google/cloud/channel/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/chronicle/v1"},
-	{Path: "google/cloud/cloudcontrolspartner/v1"},
-	{Path: "google/cloud/cloudcontrolspartner/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/clouddms/v1"},
-	{Path: "google/cloud/cloudsecuritycompliance/v1"},
-	{Path: "google/cloud/commerce/consumer/procurement/v1"},
-	{Path: "google/cloud/commerce/consumer/procurement/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/common"},
-	{Path: "google/cloud/compute/v1", Discovery: "discoveries/compute.v1.json"},
-	{Path: "google/cloud/compute/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/confidentialcomputing/v1"},
-	{Path: "google/cloud/config/v1"},
-	{Path: "google/cloud/configdelivery/v1"},
-	{Path: "google/cloud/configdelivery/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/configdelivery/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/connectors/v1"},
-	{Path: "google/cloud/contactcenterinsights/v1"},
-	{Path: "google/cloud/contentwarehouse/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/databasecenter/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/datacatalog/lineage/v1"},
-	{Path: "google/cloud/datacatalog/v1"},
-	{Path: "google/cloud/datacatalog/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/dataform/v1"},
-	{Path: "google/cloud/dataform/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/datafusion/v1"},
-	{Path: "google/cloud/datalabeling/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/dataplex/v1"},
-	{Path: "google/cloud/dataproc/v1"},
-	{Path: "google/cloud/dataqna/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/datastream/v1"},
-	{Path: "google/cloud/datastream/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/deploy/v1"},
-	{Path: "google/cloud/developerconnect/v1"},
-	{Path: "google/cloud/devicestreaming/v1"},
-	{Path: "google/cloud/dialogflow/cx/v3"},
-	{Path: "google/cloud/dialogflow/cx/v3beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/dialogflow/v2"},
-	{Path: "google/cloud/dialogflow/v2beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/discoveryengine/v1"},
-	{Path: "google/cloud/discoveryengine/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/discoveryengine/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/dns/v1", Discovery: "discoveries/dns.v1.json"},
-	{Path: "google/cloud/documentai/v1"},
-	{Path: "google/cloud/documentai/v1beta3", Languages: []string{LangPython}},
-	{Path: "google/cloud/domains/v1"},
-	{Path: "google/cloud/domains/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/edgecontainer/v1"},
-	{Path: "google/cloud/edgenetwork/v1"},
-	{Path: "google/cloud/enterpriseknowledgegraph/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/essentialcontacts/v1"},
-	{Path: "google/cloud/eventarc/publishing/v1"},
-	{Path: "google/cloud/eventarc/v1"},
-	{Path: "google/cloud/filestore/v1"},
-	{Path: "google/cloud/financialservices/v1"},
-	{Path: "google/cloud/functions/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/functions/v2"},
-	{Path: "google/cloud/gdchardwaremanagement/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/geminidataanalytics/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/geminidataanalytics/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/gkebackup/v1"},
-	{Path: "google/cloud/gkeconnect/gateway/v1"},
-	{Path: "google/cloud/gkeconnect/gateway/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/gkehub/v1"},
-	{Path: "google/cloud/gkehub/v1/configmanagement", Title: titleGKEHubTypes},
-	{Path: "google/cloud/gkehub/v1/multiclusteringress", Title: titleGKEHubTypes},
-	{Path: "google/cloud/gkehub/v1/rbacrolebindingactuation", Title: titleGKEHubTypes},
-	{Path: "google/cloud/gkehub/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/gkemulticloud/v1"},
-	{Path: "google/cloud/gkerecommender/v1"},
-	{Path: "google/cloud/gsuiteaddons/v1"},
-	{Path: "google/cloud/hypercomputecluster/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/iap/v1"},
-	{Path: "google/cloud/ids/v1"},
-	{Path: "google/cloud/kms/inventory/v1"},
-	{Path: "google/cloud/kms/v1"},
-	{Path: "google/cloud/language/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/language/v1beta2", Languages: []string{LangPython}},
-	{Path: "google/cloud/language/v2"},
-	{Path: "google/cloud/licensemanager/v1"},
-	{Path: "google/cloud/lifesciences/v2beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/location"},
-	{Path: "google/cloud/locationfinder/v1"},
-	{Path: "google/cloud/lustre/v1"},
-	{Path: "google/cloud/maintenance/api/v1"},
-	{Path: "google/cloud/maintenance/api/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/managedidentities/v1"},
-	{Path: "google/cloud/managedkafka/schemaregistry/v1"},
-	{Path: "google/cloud/managedkafka/v1"},
-	{Path: "google/cloud/mediatranslation/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/memcache/v1"},
-	{Path: "google/cloud/memcache/v1beta2", Languages: []string{LangPython}},
-	{Path: "google/cloud/memorystore/v1"},
-	{Path: "google/cloud/memorystore/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/metastore/v1"},
-	{Path: "google/cloud/metastore/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/metastore/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/migrationcenter/v1"},
-	{Path: "google/cloud/modelarmor/v1"},
-	{Path: "google/cloud/modelarmor/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/netapp/v1"},
-	{Path: "google/cloud/networkconnectivity/v1"},
-	{Path: "google/cloud/networkconnectivity/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/networkmanagement/v1"},
-	{Path: "google/cloud/networksecurity/v1"},
-	{Path: "google/cloud/networksecurity/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/networksecurity/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/networkservices/v1"},
-	{Path: "google/cloud/notebooks/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/notebooks/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/notebooks/v2"},
-	{Path: "google/cloud/optimization/v1"},
-	{Path: "google/cloud/oracledatabase/v1"},
-	{Path: "google/cloud/orchestration/airflow/service/v1"},
-	{Path: "google/cloud/orchestration/airflow/service/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/orgpolicy/v1", Title: "Organization Policy Types"},
-	{Path: "google/cloud/orgpolicy/v2"},
-	{Path: "google/cloud/osconfig/v1"},
-	{Path: "google/cloud/osconfig/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/oslogin/common", Title: "Cloud OS Login Common Types"},
-	{Path: "google/cloud/oslogin/v1"},
-	{Path: "google/cloud/parallelstore/v1"},
-	{Path: "google/cloud/parallelstore/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/parametermanager/v1"},
-	{Path: "google/cloud/phishingprotection/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/policysimulator/v1"},
-	{Path: "google/cloud/policytroubleshooter/iam/v3"},
-	{Path: "google/cloud/policytroubleshooter/v1"},
-	{Path: "google/cloud/privatecatalog/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/privilegedaccessmanager/v1"},
-	{Path: "google/cloud/rapidmigrationassessment/v1"},
-	{Path: "google/cloud/recaptchaenterprise/v1"},
-	{Path: "google/cloud/recommendationengine/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/recommender/logging/v1"},
-	{Path: "google/cloud/recommender/v1"},
-	{Path: "google/cloud/recommender/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/redis/cluster/v1"},
-	{Path: "google/cloud/redis/cluster/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/redis/v1"},
-	{Path: "google/cloud/redis/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/resourcemanager/v3"},
-	{Path: "google/cloud/retail/v2"},
-	{Path: "google/cloud/retail/v2alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/retail/v2beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/run/v2"},
-	{Path: "google/cloud/saasplatform/saasservicemgmt/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/scheduler/v1"},
-	{Path: "google/cloud/scheduler/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/secretmanager/v1", OpenAPI: "testdata/secretmanager_openapi_v1.json"},
-	{Path: "google/cloud/secretmanager/v1beta2", Languages: []string{LangPython}},
-	{Path: "google/cloud/secrets/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/securesourcemanager/v1"},
-	{Path: "google/cloud/security/privateca/v1"},
-	{Path: "google/cloud/security/privateca/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/security/publicca/v1"},
-	{Path: "google/cloud/security/publicca/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/securitycenter/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/securitycenter/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/securitycenter/v1p1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/securitycenter/v2"},
-	{Path: "google/cloud/securitycentermanagement/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/securityposture/v1"},
-	{Path: "google/cloud/servicedirectory/v1"},
-	{Path: "google/cloud/servicedirectory/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/servicehealth/v1"},
-	{Path: "google/cloud/shell/v1"},
-	{Path: "google/cloud/speech/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/speech/v1p1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/speech/v2"},
-	{Path: "google/cloud/sql/v1"},
-	{Path: "google/cloud/storagebatchoperations/v1"},
-	{Path: "google/cloud/storageinsights/v1"},
-	{Path: "google/cloud/support/v2"},
-	{Path: "google/cloud/support/v2beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/talent/v4"},
-	{Path: "google/cloud/talent/v4beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/tasks/v2"},
-	{Path: "google/cloud/tasks/v2beta2", Languages: []string{LangPython}},
-	{Path: "google/cloud/tasks/v2beta3", Languages: []string{LangPython}},
-	{Path: "google/cloud/telcoautomation/v1"},
-	{Path: "google/cloud/telcoautomation/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/texttospeech/v1"},
-	{Path: "google/cloud/texttospeech/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/timeseriesinsights/v1"},
-	{Path: "google/cloud/tpu/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/tpu/v2"},
-	{Path: "google/cloud/tpu/v2alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/translate/v3"},
-	{Path: "google/cloud/translate/v3beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/vectorsearch/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/video/livestream/v1"},
-	{Path: "google/cloud/video/stitcher/v1"},
-	{Path: "google/cloud/video/transcoder/v1"},
-	{Path: "google/cloud/videointelligence/v1"},
-	{Path: "google/cloud/videointelligence/v1beta2", Languages: []string{LangPython}},
-	{Path: "google/cloud/videointelligence/v1p1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/videointelligence/v1p2beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/videointelligence/v1p3beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/vision/v1"},
-	{Path: "google/cloud/vision/v1p1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/vision/v1p2beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/vision/v1p3beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/vision/v1p4beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/visionai/v1", Languages: []string{LangPython}},
-	{Path: "google/cloud/visionai/v1alpha1", Languages: []string{LangPython}},
-	{Path: "google/cloud/vmmigration/v1"},
-	{Path: "google/cloud/vmwareengine/v1"},
-	{Path: "google/cloud/vpcaccess/v1"},
-	{Path: "google/cloud/webrisk/v1"},
-	{Path: "google/cloud/webrisk/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/cloud/websecurityscanner/v1"},
-	{Path: "google/cloud/websecurityscanner/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/cloud/websecurityscanner/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/workflows/executions/v1"},
-	{Path: "google/cloud/workflows/executions/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/workflows/v1"},
-	{Path: "google/cloud/workflows/v1beta", Languages: []string{LangPython}},
-	{Path: "google/cloud/workstations/v1"},
-	{Path: "google/cloud/workstations/v1beta", Languages: []string{LangPython}},
-	{Path: "google/container/v1"},
-	{Path: "google/container/v1beta1", Languages: []string{LangPython}},
-	{Path: "google/dataflow/v1beta3", Languages: []string{LangPython}},
-	{Path: "google/datastore/admin/v1"},
-	{Path: "google/devtools/artifactregistry/v1"},
-	{Path: "google/devtools/artifactregistry/v1beta2", Languages: []string{LangPython}},
-	{Path: "google/devtools/cloudbuild/v1"},
-	{Path: "google/devtools/cloudbuild/v2"},
-	{Path: "google/devtools/cloudprofiler/v2"},
-	{Path: "google/devtools/cloudtrace/v1", Title: titleCloudTraceAPI},
-	{Path: "google/devtools/cloudtrace/v2", Title: titleCloudTraceAPI},
-	{Path: "google/devtools/containeranalysis/v1"},
-	{Path: "google/devtools/source/v1", Languages: []string{LangPython}},
-	{Path: "google/firestore/admin/v1"},
-	{Path: "google/firestore/v1", Title: titleFirestoreAPI},
-	{Path: "google/geo/type", Languages: []string{LangPython}},
-	{Path: "google/iam/admin/v1"},
-	{Path: "google/iam/credentials/v1"},
-	{Path: "google/iam/v1"},
-	{Path: "google/iam/v1/logging", Languages: []string{LangPython}},
-	{Path: "google/iam/v2"},
-	{Path: "google/iam/v2beta", Languages: []string{LangPython}},
-	{Path: "google/iam/v3"},
-	{Path: "google/iam/v3beta", Languages: []string{LangPython}},
-	{Path: "google/identity/accesscontextmanager/type", Title: titleAccessContextManagerTypes},
-	{Path: "google/identity/accesscontextmanager/v1"},
-	{Path: "google/logging/type", Title: titleLoggingTypes},
-	{Path: "google/logging/v2"},
-	{Path: "google/longrunning"},
-	{Path: "google/maps/addressvalidation/v1", Languages: []string{LangPython}},
-	{Path: "google/maps/areainsights/v1", Languages: []string{LangPython}},
-	{Path: "google/maps/fleetengine/delivery/v1", Languages: []string{LangPython}},
-	{Path: "google/maps/fleetengine/v1", Languages: []string{LangPython}},
-	{Path: "google/maps/mapsplatformdatasets/v1", Languages: []string{LangPython}},
-	{Path: "google/maps/places/v1", Languages: []string{LangPython}},
-	{Path: "google/maps/routeoptimization/v1", Languages: []string{LangPython}},
-	{Path: "google/maps/routing/v2", Languages: []string{LangPython}},
-	{Path: "google/maps/solar/v1", Languages: []string{LangPython}},
-	{Path: "google/marketingplatform/admin/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/monitoring/dashboard/v1"},
-	{Path: "google/monitoring/metricsscope/v1"},
-	{Path: "google/monitoring/v3"},
-	{Path: "google/privacy/dlp/v2"},
-	{Path: "google/protobuf", Languages: []string{LangRust, LangDart}},
-	{Path: "google/pubsub/v1"},
-	{Path: "google/rpc"},
-	{Path: "google/rpc/context", Title: "RPC Audit and Logging Attributes"},
-	{Path: "google/shopping/css/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/accounts/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/accounts/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/conversions/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/conversions/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/datasources/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/datasources/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/inventories/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/inventories/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/issueresolution/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/issueresolution/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/lfp/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/lfp/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/notifications/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/notifications/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/ordertracking/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/ordertracking/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/products/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/products/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/productstudio/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/promotions/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/promotions/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/quota/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/quota/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/reports/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/reports/v1alpha", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/reports/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/reviews/v1", Languages: []string{LangPython}},
-	{Path: "google/shopping/merchant/reviews/v1beta", Languages: []string{LangPython}},
-	{Path: "google/shopping/type", Languages: []string{LangPython}},
-	{Path: "google/spanner/admin/database/v1"},
-	{Path: "google/spanner/admin/instance/v1"},
-	{Path: "google/storage/control/v2"},
-	{Path: "google/storage/v2"},
-	{Path: "google/storagetransfer/v1"},
-	{Path: "google/type"},
-	{Path: "grafeas/v1"},
-	{Path: "schema/google/showcase/v1beta1", ServiceConfig: "schema/google/showcase/v1beta1/showcase_v1beta1.yaml"},
-	{Path: "src/google/protobuf", Languages: []string{LangDart}},
+var (
+	//go:embed apis.yaml
+	apiYaml []byte
+	// APIs defines API paths that require explicit configurations.
+	// APIs not in this list are implicitly allowed if
+	// they start with "google/cloud/".
+	APIs = unmarshalAPIsOrPanic()
+)
+
+func unmarshalAPIsOrPanic() []API {
+	apis, err := yaml.Unmarshal[[]API](apiYaml)
+	if err != nil {
+		panic(fmt.Sprintf("failed to unmarshal api.yaml: %v", err))
+	}
+	return *apis
 }

--- a/internal/serviceconfig/apis.yaml
+++ b/internal/serviceconfig/apis.yaml
@@ -1,0 +1,838 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+- path: google/ads/admanager/v1
+  languages:
+    - python
+- path: google/ads/datamanager/v1
+  languages:
+    - python
+- path: google/ai/generativelanguage/v1
+  languages:
+    - python
+- path: google/ai/generativelanguage/v1alpha
+  languages:
+    - python
+- path: google/ai/generativelanguage/v1beta
+  languages:
+    - python
+- path: google/ai/generativelanguage/v1beta2
+  languages:
+    - python
+- path: google/ai/generativelanguage/v1beta3
+  languages:
+    - python
+- path: google/analytics/admin/v1alpha
+  languages:
+    - python
+- path: google/analytics/admin/v1beta
+  languages:
+    - python
+- path: google/analytics/data/v1alpha
+  languages:
+    - python
+- path: google/analytics/data/v1beta
+  languages:
+    - python
+- path: google/api
+- path: google/api/apikeys/v2
+- path: google/api/cloudquotas/v1
+- path: google/api/cloudquotas/v1beta
+  languages:
+    - python
+- path: google/api/servicecontrol/v1
+- path: google/api/servicecontrol/v2
+- path: google/api/servicemanagement/v1
+- path: google/api/serviceusage/v1
+- path: google/appengine/logging/v1
+  languages:
+    - python
+- path: google/appengine/v1
+- path: google/apps/card/v1
+  languages:
+    - python
+- path: google/apps/events/subscriptions/v1
+  languages:
+    - python
+- path: google/apps/events/subscriptions/v1beta
+  languages:
+    - python
+- path: google/apps/meet/v2
+  languages:
+    - python
+- path: google/apps/meet/v2beta
+  languages:
+    - python
+- path: google/apps/script/type
+  title: Google Apps Script Types
+- path: google/apps/script/type/calendar
+  title: Google Apps Script Types
+- path: google/apps/script/type/docs
+  title: Google Apps Script Types
+- path: google/apps/script/type/drive
+  title: Google Apps Script Types
+- path: google/apps/script/type/gmail
+  title: Google Apps Script Types
+- path: google/apps/script/type/sheets
+  title: Google Apps Script Types
+- path: google/apps/script/type/slides
+  title: Google Apps Script Types
+- path: google/area120/tables/v1alpha1
+  languages:
+    - python
+- path: google/bigtable/admin/v2
+- path: google/chat/v1
+  languages:
+    - python
+- path: google/cloud/accessapproval/v1
+- path: google/cloud/advisorynotifications/v1
+- path: google/cloud/aiplatform/v1
+  transports:
+    go: grpc
+- path: google/cloud/aiplatform/v1/schema/predict/instance
+  service_config: google/cloud/aiplatform/v1/schema/aiplatform_v1.yaml
+- path: google/cloud/aiplatform/v1/schema/predict/params
+  service_config: google/cloud/aiplatform/v1/schema/aiplatform_v1.yaml
+- path: google/cloud/aiplatform/v1/schema/predict/prediction
+  service_config: google/cloud/aiplatform/v1/schema/aiplatform_v1.yaml
+- path: google/cloud/aiplatform/v1/schema/trainingjob/definition
+  service_config: google/cloud/aiplatform/v1/schema/aiplatform_v1.yaml
+- path: google/cloud/aiplatform/v1beta1
+  languages:
+    - python
+  service_config: google/cloud/aiplatform/v1beta1/aiplatform_v1beta1.yaml
+- path: google/cloud/alloydb/connectors/v1
+- path: google/cloud/alloydb/connectors/v1alpha
+  languages:
+    - python
+- path: google/cloud/alloydb/connectors/v1beta
+  languages:
+    - python
+- path: google/cloud/alloydb/v1
+- path: google/cloud/alloydb/v1alpha
+  languages:
+    - python
+- path: google/cloud/alloydb/v1beta
+  languages:
+    - python
+- path: google/cloud/apigateway/v1
+- path: google/cloud/apigeeconnect/v1
+- path: google/cloud/apigeeregistry/v1
+  languages:
+    - python
+- path: google/cloud/apihub/v1
+- path: google/cloud/apiregistry/v1
+- path: google/cloud/apiregistry/v1beta
+  languages:
+    - python
+- path: google/cloud/apphub/v1
+- path: google/cloud/asset/v1
+- path: google/cloud/asset/v1p1beta1
+  languages:
+    - python
+- path: google/cloud/asset/v1p2beta1
+  languages:
+    - python
+- path: google/cloud/asset/v1p5beta1
+  languages:
+    - python
+- path: google/cloud/assuredworkloads/v1
+- path: google/cloud/assuredworkloads/v1beta1
+  languages:
+    - python
+- path: google/cloud/audit
+  languages:
+    - python
+- path: google/cloud/auditmanager/v1
+- path: google/cloud/automl/v1
+  languages:
+    - python
+- path: google/cloud/automl/v1beta1
+  languages:
+    - python
+- path: google/cloud/backupdr/v1
+- path: google/cloud/baremetalsolution/v2
+- path: google/cloud/batch/v1
+  languages:
+    - python
+- path: google/cloud/batch/v1alpha
+  languages:
+    - python
+- path: google/cloud/beyondcorp/appconnections/v1
+- path: google/cloud/beyondcorp/appconnectors/v1
+- path: google/cloud/beyondcorp/appgateways/v1
+- path: google/cloud/beyondcorp/clientconnectorservices/v1
+- path: google/cloud/beyondcorp/clientgateways/v1
+- path: google/cloud/biglake/v1
+- path: google/cloud/bigquery/analyticshub/v1
+- path: google/cloud/bigquery/biglake/v1
+  languages:
+    - python
+- path: google/cloud/bigquery/biglake/v1alpha1
+  languages:
+    - python
+- path: google/cloud/bigquery/connection/v1
+- path: google/cloud/bigquery/dataexchange/v1beta1
+  languages:
+    - python
+- path: google/cloud/bigquery/datapolicies/v1
+- path: google/cloud/bigquery/datapolicies/v1beta1
+  languages:
+    - python
+- path: google/cloud/bigquery/datapolicies/v2
+- path: google/cloud/bigquery/datapolicies/v2beta1
+  languages:
+    - python
+- path: google/cloud/bigquery/datatransfer/v1
+- path: google/cloud/bigquery/logging/v1
+  languages:
+    - python
+- path: google/cloud/bigquery/migration/v2
+- path: google/cloud/bigquery/migration/v2alpha
+  languages:
+    - python
+- path: google/cloud/bigquery/reservation/v1
+- path: google/cloud/bigquery/storage/v1
+  languages:
+    - python
+- path: google/cloud/bigquery/storage/v1alpha
+  languages:
+    - python
+- path: google/cloud/bigquery/storage/v1beta
+  languages:
+    - python
+- path: google/cloud/bigquery/storage/v1beta2
+  languages:
+    - python
+- path: google/cloud/bigquery/v2
+- path: google/cloud/billing/budgets/v1
+  languages:
+    - python
+- path: google/cloud/billing/budgets/v1beta1
+  languages:
+    - python
+- path: google/cloud/billing/v1
+- path: google/cloud/binaryauthorization/v1
+- path: google/cloud/binaryauthorization/v1beta1
+  languages:
+    - python
+- path: google/cloud/capacityplanner/v1beta
+  languages:
+    - python
+- path: google/cloud/certificatemanager/v1
+- path: google/cloud/channel/v1
+  languages:
+    - python
+- path: google/cloud/chronicle/v1
+- path: google/cloud/cloudcontrolspartner/v1
+- path: google/cloud/cloudcontrolspartner/v1beta
+  languages:
+    - python
+- path: google/cloud/clouddms/v1
+- path: google/cloud/cloudsecuritycompliance/v1
+- path: google/cloud/commerce/consumer/procurement/v1
+- path: google/cloud/commerce/consumer/procurement/v1alpha1
+  languages:
+    - python
+- path: google/cloud/common
+  languages:
+    - python
+- path: google/cloud/compute/v1
+  discovery: discoveries/compute.v1.json
+- path: google/cloud/compute/v1beta
+  languages:
+    - python
+- path: google/cloud/confidentialcomputing/v1
+- path: google/cloud/config/v1
+- path: google/cloud/configdelivery/v1
+- path: google/cloud/configdelivery/v1alpha
+  languages:
+    - python
+- path: google/cloud/configdelivery/v1beta
+  languages:
+    - python
+- path: google/cloud/connectors/v1
+- path: google/cloud/contactcenterinsights/v1
+- path: google/cloud/contentwarehouse/v1
+  languages:
+    - python
+- path: google/cloud/databasecenter/v1beta
+  languages:
+    - python
+- path: google/cloud/datacatalog/lineage/v1
+- path: google/cloud/datacatalog/v1
+- path: google/cloud/datacatalog/v1beta1
+  languages:
+    - python
+- path: google/cloud/dataform/v1
+- path: google/cloud/dataform/v1beta1
+  languages:
+    - python
+- path: google/cloud/datafusion/v1
+- path: google/cloud/datalabeling/v1beta1
+  languages:
+    - python
+- path: google/cloud/dataplex/v1
+- path: google/cloud/dataproc/v1
+- path: google/cloud/dataqna/v1alpha
+  languages:
+    - python
+- path: google/cloud/datastream/v1
+- path: google/cloud/datastream/v1alpha1
+  languages:
+    - python
+- path: google/cloud/deploy/v1
+- path: google/cloud/developerconnect/v1
+- path: google/cloud/devicestreaming/v1
+- path: google/cloud/dialogflow/cx/v3
+- path: google/cloud/dialogflow/cx/v3beta1
+  languages:
+    - python
+- path: google/cloud/dialogflow/v2
+- path: google/cloud/dialogflow/v2beta1
+  languages:
+    - python
+- path: google/cloud/discoveryengine/v1
+- path: google/cloud/discoveryengine/v1alpha
+  languages:
+    - python
+- path: google/cloud/discoveryengine/v1beta
+  languages:
+    - python
+- path: google/cloud/dns/v1
+  discovery: discoveries/dns.v1.json
+- path: google/cloud/documentai/v1
+- path: google/cloud/documentai/v1beta3
+  languages:
+    - python
+- path: google/cloud/domains/v1
+- path: google/cloud/domains/v1beta1
+  languages:
+    - python
+- path: google/cloud/edgecontainer/v1
+- path: google/cloud/edgenetwork/v1
+- path: google/cloud/enterpriseknowledgegraph/v1
+  languages:
+    - python
+- path: google/cloud/essentialcontacts/v1
+- path: google/cloud/eventarc/publishing/v1
+- path: google/cloud/eventarc/v1
+- path: google/cloud/filestore/v1
+- path: google/cloud/financialservices/v1
+- path: google/cloud/functions/v1
+  languages:
+    - python
+- path: google/cloud/functions/v2
+- path: google/cloud/gdchardwaremanagement/v1alpha
+  languages:
+    - python
+- path: google/cloud/geminidataanalytics/v1alpha
+  languages:
+    - python
+- path: google/cloud/geminidataanalytics/v1beta
+  languages:
+    - python
+- path: google/cloud/gkebackup/v1
+- path: google/cloud/gkeconnect/gateway/v1
+- path: google/cloud/gkeconnect/gateway/v1beta1
+  languages:
+    - python
+- path: google/cloud/gkehub/v1
+- path: google/cloud/gkehub/v1/configmanagement
+  title: GKE Hub Types
+- path: google/cloud/gkehub/v1/multiclusteringress
+  title: GKE Hub Types
+- path: google/cloud/gkehub/v1/rbacrolebindingactuation
+  title: GKE Hub Types
+- path: google/cloud/gkehub/v1beta1
+  languages:
+    - python
+- path: google/cloud/gkemulticloud/v1
+- path: google/cloud/gkerecommender/v1
+- path: google/cloud/gsuiteaddons/v1
+- path: google/cloud/hypercomputecluster/v1beta
+  languages:
+    - python
+- path: google/cloud/iap/v1
+- path: google/cloud/ids/v1
+- path: google/cloud/kms/inventory/v1
+- path: google/cloud/kms/v1
+- path: google/cloud/language/v1
+  languages:
+    - python
+- path: google/cloud/language/v1beta2
+  languages:
+    - python
+- path: google/cloud/language/v2
+- path: google/cloud/licensemanager/v1
+- path: google/cloud/lifesciences/v2beta
+  languages:
+    - python
+- path: google/cloud/location
+- path: google/cloud/locationfinder/v1
+- path: google/cloud/lustre/v1
+- path: google/cloud/maintenance/api/v1
+- path: google/cloud/maintenance/api/v1beta
+  languages:
+    - python
+- path: google/cloud/managedidentities/v1
+- path: google/cloud/managedkafka/schemaregistry/v1
+- path: google/cloud/managedkafka/v1
+- path: google/cloud/mediatranslation/v1beta1
+  languages:
+    - python
+- path: google/cloud/memcache/v1
+- path: google/cloud/memcache/v1beta2
+  languages:
+    - python
+- path: google/cloud/memorystore/v1
+- path: google/cloud/memorystore/v1beta
+  languages:
+    - python
+- path: google/cloud/metastore/v1
+- path: google/cloud/metastore/v1alpha
+  languages:
+    - python
+- path: google/cloud/metastore/v1beta
+  languages:
+    - python
+- path: google/cloud/migrationcenter/v1
+- path: google/cloud/modelarmor/v1
+- path: google/cloud/modelarmor/v1beta
+  languages:
+    - python
+- path: google/cloud/netapp/v1
+- path: google/cloud/networkconnectivity/v1
+- path: google/cloud/networkconnectivity/v1alpha1
+  languages:
+    - python
+- path: google/cloud/networkmanagement/v1
+- path: google/cloud/networksecurity/v1
+- path: google/cloud/networksecurity/v1alpha1
+  languages:
+    - python
+- path: google/cloud/networksecurity/v1beta1
+  languages:
+    - python
+- path: google/cloud/networkservices/v1
+- path: google/cloud/notebooks/v1
+  languages:
+    - python
+- path: google/cloud/notebooks/v1beta1
+  languages:
+    - python
+- path: google/cloud/notebooks/v2
+- path: google/cloud/optimization/v1
+- path: google/cloud/oracledatabase/v1
+- path: google/cloud/orchestration/airflow/service/v1
+- path: google/cloud/orchestration/airflow/service/v1beta1
+  languages:
+    - python
+- path: google/cloud/orgpolicy/v1
+  title: Organization Policy Types
+- path: google/cloud/orgpolicy/v2
+- path: google/cloud/osconfig/v1
+- path: google/cloud/osconfig/v1alpha
+  languages:
+    - python
+- path: google/cloud/oslogin/common
+  title: Cloud OS Login Common Types
+- path: google/cloud/oslogin/v1
+- path: google/cloud/parallelstore/v1
+- path: google/cloud/parallelstore/v1beta
+  languages:
+    - python
+- path: google/cloud/parametermanager/v1
+- path: google/cloud/phishingprotection/v1beta1
+  languages:
+    - python
+- path: google/cloud/policysimulator/v1
+- path: google/cloud/policytroubleshooter/iam/v3
+- path: google/cloud/policytroubleshooter/v1
+- path: google/cloud/privatecatalog/v1beta1
+  languages:
+    - python
+- path: google/cloud/privilegedaccessmanager/v1
+- path: google/cloud/rapidmigrationassessment/v1
+- path: google/cloud/recaptchaenterprise/v1
+- path: google/cloud/recommendationengine/v1beta1
+  languages:
+    - python
+- path: google/cloud/recommender/logging/v1
+- path: google/cloud/recommender/v1
+- path: google/cloud/recommender/v1beta1
+  languages:
+    - python
+- path: google/cloud/redis/cluster/v1
+- path: google/cloud/redis/cluster/v1beta1
+  languages:
+    - python
+- path: google/cloud/redis/v1
+- path: google/cloud/redis/v1beta1
+  languages:
+    - python
+- path: google/cloud/resourcemanager/v3
+- path: google/cloud/retail/v2
+- path: google/cloud/retail/v2alpha
+  languages:
+    - python
+- path: google/cloud/retail/v2beta
+  languages:
+    - python
+- path: google/cloud/run/v2
+- path: google/cloud/saasplatform/saasservicemgmt/v1beta1
+  languages:
+    - python
+- path: google/cloud/scheduler/v1
+- path: google/cloud/scheduler/v1beta1
+  languages:
+    - python
+- path: google/cloud/secretmanager/v1
+  open_api: testdata/secretmanager_openapi_v1.json
+- path: google/cloud/secretmanager/v1beta2
+  languages:
+    - python
+- path: google/cloud/secrets/v1beta1
+  languages:
+    - python
+- path: google/cloud/securesourcemanager/v1
+- path: google/cloud/security/privateca/v1
+- path: google/cloud/security/privateca/v1beta1
+  languages:
+    - python
+- path: google/cloud/security/publicca/v1
+- path: google/cloud/security/publicca/v1beta1
+  languages:
+    - python
+- path: google/cloud/securitycenter/v1
+  languages:
+    - python
+- path: google/cloud/securitycenter/v1beta1
+  languages:
+    - python
+- path: google/cloud/securitycenter/v1p1beta1
+  languages:
+    - python
+- path: google/cloud/securitycenter/v2
+- path: google/cloud/securitycentermanagement/v1
+  languages:
+    - python
+- path: google/cloud/securityposture/v1
+- path: google/cloud/servicedirectory/v1
+- path: google/cloud/servicedirectory/v1beta1
+  languages:
+    - python
+- path: google/cloud/servicehealth/v1
+- path: google/cloud/shell/v1
+- path: google/cloud/speech/v1
+  languages:
+    - python
+- path: google/cloud/speech/v1p1beta1
+  languages:
+    - python
+- path: google/cloud/speech/v2
+- path: google/cloud/sql/v1
+- path: google/cloud/storagebatchoperations/v1
+- path: google/cloud/storageinsights/v1
+- path: google/cloud/support/v2
+- path: google/cloud/support/v2beta
+  languages:
+    - python
+- path: google/cloud/talent/v4
+- path: google/cloud/talent/v4beta1
+  languages:
+    - python
+- path: google/cloud/tasks/v2
+- path: google/cloud/tasks/v2beta2
+  languages:
+    - python
+- path: google/cloud/tasks/v2beta3
+  languages:
+    - python
+- path: google/cloud/telcoautomation/v1
+- path: google/cloud/telcoautomation/v1alpha1
+  languages:
+    - python
+- path: google/cloud/texttospeech/v1
+- path: google/cloud/texttospeech/v1beta1
+  languages:
+    - python
+- path: google/cloud/timeseriesinsights/v1
+- path: google/cloud/tpu/v1
+  languages:
+    - python
+- path: google/cloud/tpu/v2
+- path: google/cloud/tpu/v2alpha1
+  languages:
+    - python
+- path: google/cloud/translate/v3
+- path: google/cloud/translate/v3beta1
+  languages:
+    - python
+- path: google/cloud/vectorsearch/v1beta
+  languages:
+    - python
+- path: google/cloud/video/livestream/v1
+- path: google/cloud/video/stitcher/v1
+- path: google/cloud/video/transcoder/v1
+- path: google/cloud/videointelligence/v1
+- path: google/cloud/videointelligence/v1beta2
+  languages:
+    - python
+- path: google/cloud/videointelligence/v1p1beta1
+  languages:
+    - python
+- path: google/cloud/videointelligence/v1p2beta1
+  languages:
+    - python
+- path: google/cloud/videointelligence/v1p3beta1
+  languages:
+    - python
+- path: google/cloud/vision/v1
+- path: google/cloud/vision/v1p1beta1
+  languages:
+    - python
+- path: google/cloud/vision/v1p2beta1
+  languages:
+    - python
+- path: google/cloud/vision/v1p3beta1
+  languages:
+    - python
+- path: google/cloud/vision/v1p4beta1
+  languages:
+    - python
+- path: google/cloud/visionai/v1
+  languages:
+    - python
+- path: google/cloud/visionai/v1alpha1
+  languages:
+    - python
+- path: google/cloud/vmmigration/v1
+- path: google/cloud/vmwareengine/v1
+- path: google/cloud/vpcaccess/v1
+- path: google/cloud/webrisk/v1
+- path: google/cloud/webrisk/v1beta1
+  languages:
+    - python
+- path: google/cloud/websecurityscanner/v1
+- path: google/cloud/websecurityscanner/v1alpha
+  languages:
+    - python
+- path: google/cloud/websecurityscanner/v1beta
+  languages:
+    - python
+- path: google/cloud/workflows/executions/v1
+- path: google/cloud/workflows/executions/v1beta
+  languages:
+    - python
+- path: google/cloud/workflows/v1
+- path: google/cloud/workflows/v1beta
+  languages:
+    - python
+- path: google/cloud/workstations/v1
+- path: google/cloud/workstations/v1beta
+  languages:
+    - python
+- path: google/container/v1
+- path: google/container/v1beta1
+  languages:
+    - python
+- path: google/dataflow/v1beta3
+  languages:
+    - python
+- path: google/datastore/admin/v1
+- path: google/devtools/artifactregistry/v1
+- path: google/devtools/artifactregistry/v1beta2
+  languages:
+    - python
+- path: google/devtools/cloudbuild/v1
+- path: google/devtools/cloudbuild/v2
+- path: google/devtools/cloudprofiler/v2
+- path: google/devtools/cloudtrace/v1
+  title: Cloud Trace API
+- path: google/devtools/cloudtrace/v2
+  title: Cloud Trace API
+- path: google/devtools/containeranalysis/v1
+- path: google/devtools/source/v1
+  languages:
+    - python
+- path: google/firestore/admin/v1
+- path: google/firestore/v1
+  title: Cloud Firestore API
+- path: google/geo/type
+  languages:
+    - python
+- path: google/iam/admin/v1
+- path: google/iam/credentials/v1
+- path: google/iam/v1
+- path: google/iam/v1/logging
+  languages:
+    - python
+- path: google/iam/v2
+- path: google/iam/v2beta
+  languages:
+    - python
+- path: google/iam/v3
+- path: google/iam/v3beta
+  languages:
+    - python
+- path: google/identity/accesscontextmanager/type
+  title: Access Context Manager Types
+- path: google/identity/accesscontextmanager/v1
+- path: google/logging/type
+  title: Logging types
+- path: google/logging/v2
+- path: google/longrunning
+- path: google/maps/addressvalidation/v1
+  languages:
+    - python
+- path: google/maps/areainsights/v1
+  languages:
+    - python
+- path: google/maps/fleetengine/delivery/v1
+  languages:
+    - python
+- path: google/maps/fleetengine/v1
+  languages:
+    - python
+- path: google/maps/mapsplatformdatasets/v1
+  languages:
+    - python
+- path: google/maps/places/v1
+  languages:
+    - python
+- path: google/maps/routeoptimization/v1
+  languages:
+    - python
+- path: google/maps/routing/v2
+  languages:
+    - python
+- path: google/maps/solar/v1
+  languages:
+    - python
+- path: google/marketingplatform/admin/v1alpha
+  languages:
+    - python
+- path: google/monitoring/dashboard/v1
+- path: google/monitoring/metricsscope/v1
+- path: google/monitoring/v3
+- path: google/privacy/dlp/v2
+- path: google/protobuf
+  languages:
+    - rust
+- path: google/pubsub/v1
+- path: google/rpc
+- path: google/rpc/context
+  title: RPC Audit and Logging Attributes
+- path: google/shopping/css/v1
+  languages:
+    - python
+- path: google/shopping/merchant/accounts/v1
+  languages:
+    - python
+- path: google/shopping/merchant/accounts/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/conversions/v1
+  languages:
+    - python
+- path: google/shopping/merchant/conversions/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/datasources/v1
+  languages:
+    - python
+- path: google/shopping/merchant/datasources/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/inventories/v1
+  languages:
+    - python
+- path: google/shopping/merchant/inventories/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/issueresolution/v1
+  languages:
+    - python
+- path: google/shopping/merchant/issueresolution/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/lfp/v1
+  languages:
+    - python
+- path: google/shopping/merchant/lfp/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/notifications/v1
+  languages:
+    - python
+- path: google/shopping/merchant/notifications/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/ordertracking/v1
+  languages:
+    - python
+- path: google/shopping/merchant/ordertracking/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/products/v1
+  languages:
+    - python
+- path: google/shopping/merchant/products/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/productstudio/v1alpha
+  languages:
+    - python
+- path: google/shopping/merchant/promotions/v1
+  languages:
+    - python
+- path: google/shopping/merchant/promotions/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/quota/v1
+  languages:
+    - python
+- path: google/shopping/merchant/quota/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/reports/v1
+  languages:
+    - python
+- path: google/shopping/merchant/reports/v1alpha
+  languages:
+    - python
+- path: google/shopping/merchant/reports/v1beta
+  languages:
+    - python
+- path: google/shopping/merchant/reviews/v1
+  languages:
+    - python
+- path: google/shopping/merchant/reviews/v1beta
+  languages:
+    - python
+- path: google/shopping/type
+  languages:
+    - python
+- path: google/spanner/admin/database/v1
+- path: google/spanner/admin/instance/v1
+- path: google/storage/control/v2
+- path: google/storage/v2
+- path: google/storagetransfer/v1
+- path: google/type
+- path: grafeas/v1
+- path: schema/google/showcase/v1beta1
+  service_config: schema/google/showcase/v1beta1/showcase_v1beta1.yaml
+- path: src/google/protobuf
+  languages:
+    - dart


### PR DESCRIPTION
Adds an api.yaml file with the equivalent content to APIs, and embeds it within librarian. It is unmarshaled when librarian is run.

After #3975 is merged, we'll want to add more data to the allowlist, for all the APIs without publishing entries in the service config. That will be:

- Painful in terms of adding all the values
- Painful in terms of an ever-increasing amount of data in source code