### PR TITLE
chore(internal/git): use consistent parameter name and ordering

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -36,8 +36,8 @@ var (
 )
 
 // AssertGitStatusClean returns an error if the git working directory has uncommitted changes.
-func AssertGitStatusClean(ctx context.Context, git string) error {
-	output, err := command.Output(ctx, git, "status", "--porcelain")
+func AssertGitStatusClean(ctx context.Context, gitExe string) error {
+	output, err := command.Output(ctx, gitExe, "status", "--porcelain")
 	if err != nil {
 		return fmt.Errorf("failed to check git status: %w", err)
 	}
@@ -78,10 +78,10 @@ func GetCommitHash(ctx context.Context, gitExe, revision string) (string, error)
 }
 
 // FilesChangedSince returns the files changed since the given git ref.
-func FilesChangedSince(ctx context.Context, ref, gitExe string, ignoredChanges []string) ([]string, error) {
+func FilesChangedSince(ctx context.Context, gitExe, ref string, ignoredChanges []string) ([]string, error) {
 	output, err := command.Output(ctx, gitExe, "diff", "--name-only", ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get files changed since tag %s: %w", ref, err)
+		return nil, fmt.Errorf("failed to get files changed since ref %s: %w", ref, err)
 	}
 	return filesFilter(ignoredChanges, strings.Split(output, "\n")), nil
 }
@@ -168,8 +168,8 @@ func FindCommitsForPath(ctx context.Context, gitExe, path string) ([]string, err
 // branch, this will leave the repository with a detached head. If revision is the
 // name of a valid path, that file is checked out instead. (Git does not provide a
 // way of differentiation between these.)
-func Checkout(ctx context.Context, git, revision string) error {
-	_, err := command.Output(ctx, git, "checkout", revision)
+func Checkout(ctx context.Context, gitExe, revision string) error {
+	_, err := command.Output(ctx, gitExe, "checkout", revision)
 	if err != nil {
 		return fmt.Errorf("failed to checkout revision %s: %w", revision, err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -118,7 +118,7 @@ func TestFilesChangedSuccess(t *testing.T) {
 	remoteDir := testhelper.SetupRepoWithChange(t, wantTag)
 	testhelper.CloneRepository(t, remoteDir)
 
-	got, err := FilesChangedSince(t.Context(), wantTag, command.GetExecutablePath(nil, "git"), nil)
+	got, err := FilesChangedSince(t.Context(), command.GetExecutablePath(nil, "git"), wantTag, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestFilesBadRef(t *testing.T) {
 	const wantTag = "release-2002-03-04"
 	remoteDir := testhelper.SetupRepoWithChange(t, wantTag)
 	testhelper.CloneRepository(t, remoteDir)
-	if got, err := FilesChangedSince(t.Context(), "--invalid--", command.GetExecutablePath(nil, "git"), nil); err == nil {
+	if got, err := FilesChangedSince(t.Context(), command.GetExecutablePath(nil, "git"), "--invalid--", nil); err == nil {
 		t.Errorf("expected an error with invalid tag, got=%v", got)
 	}
 }

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -139,7 +139,7 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 }
 
 func bumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string) error {
-	filesChanged, err := git.FilesChangedSince(ctx, lastTag, gitExe, cfg.Release.IgnoredChanges)
+	filesChanged, err := git.FilesChangedSince(ctx, gitExe, lastTag, cfg.Release.IgnoredChanges)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -33,15 +33,15 @@ func Publish(ctx context.Context, config *config.Release, dryRun, dryRunKeepGoin
 	if err := preFlight(ctx, config.Preinstalled, config.Remote, config.Tools["cargo"]); err != nil {
 		return err
 	}
-	gitPath := command.GetExecutablePath(config.Preinstalled, "git")
-	lastTag, err := git.GetLastTag(ctx, gitPath, config.Remote, config.Branch)
+	gitExe := command.GetExecutablePath(config.Preinstalled, "git")
+	lastTag, err := git.GetLastTag(ctx, gitExe, config.Remote, config.Branch)
 	if err != nil {
 		return err
 	}
-	if err := git.MatchesBranchPoint(ctx, gitPath, config.Remote, config.Branch); err != nil {
+	if err := git.MatchesBranchPoint(ctx, gitExe, config.Remote, config.Branch); err != nil {
 		return err
 	}
-	files, err := git.FilesChangedSince(ctx, lastTag, gitPath, config.IgnoredChanges)
+	files, err := git.FilesChangedSince(ctx, gitExe, lastTag, config.IgnoredChanges)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ensures that we always use `gitExe` as the name of the parameter (and argument, at least in the cases I checked), and that it's always the second parameter in git functions.