### PR TITLE
fix(internal/legacylibrarian): use 'release:failed' label upon failure

### DIFF
--- a/internal/legacylibrarian/legacylibrarian/mocks_test.go
+++ b/internal/legacylibrarian/legacylibrarian/mocks_test.go
@@ -60,6 +60,7 @@ type mockGitHubClient struct {
 	releaseNames            []string
 	librarianState          *legacyconfig.LibrarianState
 	librarianConfig         *legacyconfig.LibrarianConfig
+	replacedLabels          []string
 }
 
 func (m *mockGitHubClient) GetRawContent(ctx context.Context, path, ref string) ([]byte, error) {
@@ -94,6 +95,7 @@ func (m *mockGitHubClient) GetLabels(ctx context.Context, number int) ([]string,
 
 func (m *mockGitHubClient) ReplaceLabels(ctx context.Context, number int, labels []string) error {
 	m.replaceLabelsCalls++
+	m.replacedLabels = labels
 	return m.replaceLabelsErr
 }
 


### PR DESCRIPTION
When a release fails to process we don't want to indefinitely retry processing that pull request. We will instead now mark it as failed so future searches from our automation don't find the pull request. In these cases a bug will be opened from a production notification in Google Cloud which will require an engineer to investigate the failure.

Internal Bug: b/481308012