### PR TITLE
fix(rust): help parse list items

### DIFF
--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -15,7 +15,6 @@
 package rust
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"log/slog"
@@ -846,13 +845,8 @@ func isMultiLineListItem(lines []string, index int) bool {
 //
 // [setext headers]: https://spec.commonmark.org/0.20/#setext-header
 func fixSetextHeadings(input string) string {
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	var lines []string
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-
 	var result []string
+	lines := strings.Split(input, "\n")
 	i := 0
 	for i < len(lines) {
 		if isMultiLineListItem(lines, i) {

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -1672,7 +1672,7 @@ func TestFormatDocCommentsSetextHeadings(t *testing.T) {
 			}
 			got := strings.Join(comments, "\n")
 			if diff := cmp.Diff(testCase.want, got); diff != "" {
-				t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #4019 

See the associated changes in: https://github.com/googleapis/google-cloud-rust/pull/4668

Our formatting struggles on lone dashes. Hilariously, sometimes they are taken to be a [setext header](https://spec.commonmark.org/0.20/#setext-header).

I tried for hours to disable the setext parser in `goldmark`, but that approach was not feasible.

I also considered documentation overrides for offending documentation. I decided on this approach because it may avoid some problems in the future.