### PR TITLE
fix(sidekick/rust): Really really remove EOF newline in template

### DIFF
--- a/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
@@ -16,6 +16,7 @@ limitations under the License.
 Terminate each line in a comment so
 (a) we can read this code as each case is in a separate line,and
 (b) the newline is suppressed in the output to get tighter code.
+Use no newline at the end of file so the partials are all merged into a single line.
 }}{{#AIPStandardGetInfo}}{{!
 }}.set_{{ResourceNameRequestField.Codec.SetterName}}(resource_name){{!
 }}{{/AIPStandardGetInfo}}{{!
@@ -29,6 +30,3 @@ Terminate each line in a comment so
 }}.set_{{ParentRequestField.Codec.SetterName}}(parent){{!
 }}{{/AIPStandardListInfo}}{{!
 }}{{^IsAIPStandard}}/* set fields */{{/IsAIPStandard}}
-{{!
-Use no newline at the end of file so the the partials are all merged into a single line.
-}}


### PR DESCRIPTION
In https://github.com/googleapis/librarian/pull/4027 I inadvertently added a newline after the template part when I was trying to remove the newline after the template part.