### PR TITLE
fix(.github/workflows): assign failure issues to commit author

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           ISSUE_TITLE="all: tests failed at HEAD"
           BODY="Tests failed at HEAD of the \`main\` branch. Please review Workflow Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for detail."
-          ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" -R $GH_REPO)
+          ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${{ github.actor }} -R $GH_REPO)
           ISSUE_NUM=${ISSUE_LINK##*/}
           gh issue comment $ISSUE_NUM --body "@googleapis/cloud-sdk-librarian-team A critical issue has been created, please respond immediately."
         env:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: Create an issue for push event to main
         run: |
-          ISSUE_TITLE="rust: google-cloud-rust fails with librarian at HEAD"
+          ISSUE_TITLE="google-cloud-rust: librarian generate fails when run at HEAD"
           BODY="The Rust CI failed on the \`main\` branch.
 
           Running \`librarian generate --all\` on the [google-cloud-rust](https://github.com/googleapis/google-cloud-rust) repository using \`librarian\` at HEAD failed.
@@ -91,7 +91,7 @@ jobs:
             gh issue comment "$EXISTING_ISSUE" --repo $GH_REPO --body "The build failed again. Workflow Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             echo "Creating new issue."
-            ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" -R $GH_REPO)
+            ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${{ github.actor }} -R $GH_REPO)
             ISSUE_NUM=${ISSUE_LINK##*/}
             gh issue comment $ISSUE_NUM --body "@googleapis/cloud-sdk-librarian-team A critical issue has been created, please respond immediately."
           fi


### PR DESCRIPTION
Auto-created issues for CI failures are now assigned to the person who pushed the failing commit using github.actor so that the issue is triaged to someone as a starting point.

Also update the rust.yaml issue title to be more descriptive.