### PR TITLE
chore: update CODEOWNERS to replace cloud-sdk-sidekick-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,10 @@
 * @googleapis/cloud-sdk-librarian-team
 
 # Locations for all sidekick code.
-/*/sidekick/ @googleapis/cloud-sdk-librarian-team @googleapis/cloud-sdk-dart-team @googleapis/cloud-sdk-rust-team
-/*/sidekick/dart @googleapis/cloud-sdk-dart-team
+/*/sidekick/ @googleapis/cloud-sdk-dart-team @googleapis/cloud-sdk-rust-team
+/*/sidekick/dart/ @googleapis/cloud-sdk-dart-team
+/*/sidekick/rust/ @googleapis/cloud-sdk-rust-team
+/*/sidekick/rust_prost/ @googleapis/cloud-sdk-rust-team
 
 # Locations for all surfer code.
 /*/surfer/ @googleapis/cloud-sdk-surfer-team


### PR DESCRIPTION
For https://github.com/googleapis/librarian/issues/4033 and https://github.com/googleapis/librarian/issues/4032. The sidekick team has only 3 members. The Sidekick project is maintained by the Librarian team. Let's remove the Sidekick team.

- cloud-sdk-dart-team to co-own the sidekick path.
- cloud-sdk-dart-team to own `sidekick/dart` path.
- cloud-sdk-rust-team to own `rust` and `rust_prost` under sidekick folder.