### PR TITLE
Revert "chore(tool/cmd/migrate): update Go library keep list"

### DIFF
--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -245,7 +245,7 @@ func buildGoLibraries(input *MigrationInput) ([]*config.Library, error) {
 		}
 		library.Keep = libState.PreserveRegex
 		if libraryNames[id] {
-			library.Keep = append(library.Keep, filepath.Join(id, "aliasshim", "aliasshim.go"))
+			library.Keep = append(library.Keep, "aliasshim/aliasshim.go")
 		}
 		slices.Sort(library.Keep)
 

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -463,7 +463,7 @@ func TestBuildGoLibraries(t *testing.T) {
 			want: []*config.Library{
 				{
 					Name: "accessapproval",
-					Keep: []string{"accessapproval/aliasshim/aliasshim.go"},
+					Keep: []string{"aliasshim/aliasshim.go"},
 				},
 			},
 		},


### PR DESCRIPTION
Now we use library name as implicit library output, we need to restore the keep list.

The keep list is relative to library output, not repo root.

Reverts googleapis/librarian#4038