### PR TITLE
fix(internal/legacylibrarian): allow parsing commits with no space

### DIFF
--- a/internal/legacylibrarian/legacygitrepo/conventional_commits.go
+++ b/internal/legacylibrarian/legacygitrepo/conventional_commits.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	commitRegex = regexp.MustCompile(`^(?P<type>\w+)(?:\((?P<scope>.*)\))?(?P<breaking>!)?:\s(?P<description>.*)`)
+	commitRegex = regexp.MustCompile(`^(?P<type>\w+)(?:\((?P<scope>.*)\))?(?P<breaking>!)?:\s?(?P<description>.*)`)
 	// footerRegex defines the format for a conventional commit footer.
 	// A footer key consists of letters and hyphens, or is the "BREAKING CHANGE"
 	// literal. The key is followed by ":" and then the value.

--- a/internal/legacylibrarian/legacygitrepo/conventional_commits_test.go
+++ b/internal/legacylibrarian/legacygitrepo/conventional_commits_test.go
@@ -49,6 +49,21 @@ func TestParseCommits(t *testing.T) {
 			},
 		},
 		{
+			name:    "simple_commit_with_no_space_separator",
+			message: "feat:add new feature",
+			want: []*ConventionalCommit{
+				{
+					Type:       "feat",
+					Subject:    "add new feature",
+					LibraryID:  "example-id",
+					IsNested:   false,
+					Footers:    make(map[string]string),
+					CommitHash: sha.String(),
+					When:       now,
+				},
+			},
+		},
+		{
 			name:    "simple_commit_with_scope",
 			message: "feat(scope): add new feature",
 			want: []*ConventionalCommit{


### PR DESCRIPTION
A recent commit in googleapis had no space after the conventional commit sperator. We need to be able to parse a commit like this.

Fixes: #4060