### PR TITLE
feat(python): support proto-only APIs

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -103,7 +103,7 @@ This document describes the schema for the librarian.yaml.
 
 ## DartPackage Configuration
 
-[Link to code](../internal/config/language.go#L284)
+[Link to code](../internal/config/language.go#L288)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `api_keys_environment_variables` | string | APIKeysEnvironmentVariables is a comma-separated list of environment variable names that can contain API keys (e.g., "GOOGLE_API_KEY,GEMINI_API_KEY"). |
@@ -152,6 +152,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `opt_args` | list of string | OptArgs contains additional options passed to the generator, where the options are common to all apis. Example: ["warehouse-package-name=google-cloud-batch"] |
 | `opt_args_by_api` | map[string][]string | OptArgsByAPI contains additional options passed to the generator, where the options vary by api. In each entry, the key is the api (API path) and the value is the list of options to pass when generating that API. Example: {"google/cloud/secrets/v1beta": ["python-gapic-name=secretmanager"]} |
+| `proto_only_apis` | list of string | ProtoOnlyAPIs contains the list of API paths which are proto-only, so should use regular protoc Python generation instead of GAPIC. |
 
 ## RustCrate Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -278,6 +278,10 @@ type PythonPackage struct {
 	// that API.
 	// Example: {"google/cloud/secrets/v1beta": ["python-gapic-name=secretmanager"]}
 	OptArgsByAPI map[string][]string `yaml:"opt_args_by_api,omitempty"`
+
+	// ProtoOnlyAPIs contains the list of API paths which are proto-only, so
+	// should use regular protoc Python generation instead of GAPIC.
+	ProtoOnlyAPIs []string `yaml:"proto_only_apis,omitempty"`
 }
 
 // DartPackage contains Dart-specific library configuration.

--- a/tool/cmd/migrate/python_test.go
+++ b/tool/cmd/migrate/python_test.go
@@ -108,6 +108,14 @@ func TestBuildPythonLibraries(t *testing.T) {
 			},
 			want: []*config.Library{
 				{
+					Name:         "google-cloud-audit-log",
+					APIs:         []*config.API{{Path: "google/cloud/audit"}},
+					ReleaseLevel: "preview",
+					Python: &config.PythonPackage{
+						ProtoOnlyAPIs: []string{"google/cloud/audit"},
+					},
+				},
+				{
 					Name:         "google-cloud-workstations",
 					ReleaseLevel: "preview",
 					APIs:         []*config.API{{Path: "google/cloud/workstations/v1"}},


### PR DESCRIPTION
Adds handling for "proto-only" APIs (by which we mean APIs without a GAPIC library configured). These APIs:

- Use the python and pyi protoc plugins, not gapic
- Generate to a slightly different staging directory
- Copy the .proto files as well as the generated code

This change configures these APIs during migration.

Fixes #3204.