### PR TITLE
chore(tool/cmd/migrate): keep `go.mod` and `go.sum`

### DIFF
--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -161,7 +161,7 @@ func buildConfigFromLibrarian(ctx context.Context, input *MigrationInput) (*conf
 		cfg.Default.ReleaseLevel = "stable"
 		cfg.Default.Transport = "grpc+rest"
 	} else {
-		cfg.Default.Keep = []string{"CHANGES.md"}
+		cfg.Default.Keep = []string{"CHANGES.md", "go.mod", "go.sum"}
 		cfg.Default.Output = "."
 		cfg.Default.ReleaseLevel = "ga"
 		cfg.Libraries, err = buildGoLibraries(input)

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -116,7 +116,7 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 					},
 				},
 				Default: &config.Default{
-					Keep:         []string{"CHANGES.md"},
+					Keep:         []string{"CHANGES.md", "go.mod", "go.sum"},
 					Output:       ".",
 					ReleaseLevel: "ga",
 					TagFormat:    defaultTagFormat,
@@ -235,7 +235,7 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 					},
 				},
 				Default: &config.Default{
-					Keep:         []string{"CHANGES.md"},
+					Keep:         []string{"CHANGES.md", "go.mod", "go.sum"},
 					Output:       ".",
 					ReleaseLevel: "ga",
 					TagFormat:    defaultTagFormat,


### PR DESCRIPTION
We need to keep `go.mod` and `go.sum` for each Go library because generating them from scratch will likely update the dependency, which should be in a separate process.

This is similar to what Legacy librarian does.

For #3618