### PR TITLE
refactor(internal/serviceconfig): remove redundant func

### DIFF
--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -100,7 +100,7 @@ func FromLibrary(library *config.Library, language, repo, googleapisDir, default
 
 // FromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
 func FromAPI(api *serviceconfig.API, library *config.Library, language, repo, defaultVersion, outputDir string) error {
-	clientDocURL := buildClientDocURL(language, extractNameFromAPIID(api.ServiceName))
+	clientDocURL := buildClientDocURL(language, api.ShortName)
 	apiDescription := api.Description
 	if library.DescriptionOverride != "" {
 		apiDescription = library.DescriptionOverride
@@ -164,11 +164,4 @@ func cleanTitle(title string) string {
 	title = strings.TrimSpace(title)
 	title = strings.TrimSuffix(title, " API")
 	return strings.TrimSpace(title)
-}
-
-// extractNameFromAPIID extracts the service name from the API ID.
-// Example: "secretmanager.googleapis.com" -> "secretmanager".
-func extractNameFromAPIID(apiID string) string {
-	name, _, _ := strings.Cut(apiID, ".")
-	return name
 }

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -178,25 +178,6 @@ func TestCleanTitle(t *testing.T) {
 	}
 }
 
-func TestExtractNameFromAPIID(t *testing.T) {
-	for _, test := range []struct {
-		name  string
-		apiID string
-		want  string
-	}{
-		{"standard", "secretmanager.googleapis.com", "secretmanager"},
-		{"no domain", "secretmanager", "secretmanager"},
-		{"empty", "", ""},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := extractNameFromAPIID(test.apiID)
-			if got != test.want {
-				t.Errorf("got %q, want %q", got, test.want)
-			}
-		})
-	}
-}
-
 func TestExtractBaseProductURL(t *testing.T) {
 	for _, test := range []struct {
 		name   string


### PR DESCRIPTION
Remove `extractNameFromAPIID` since the result is already been populated to short name.

Fixes #4083