### PR TITLE
doc: remove link to code from config docs

### DIFF
--- a/cmd/config_doc_generate.go
+++ b/cmd/config_doc_generate.go
@@ -59,8 +59,7 @@ This document describes the schema for the {{.Title}}.
 {{range .Structs}}
 ## {{.Title}}
 
-{{if .SourceLink}}[Link to code]({{.SourceLink}})
-{{end}}{{if .Doc}}{{.Doc}}
+{{if .Doc}}{{.Doc}}
 {{end}}| Field | Type | Description |
 | :--- | :--- | :--- |
 {{range .Fields}}| {{.Name}} | {{.Type}} | {{.Description}} |
@@ -72,10 +71,9 @@ type pageData struct {
 }
 
 type structData struct {
-	Title      string
-	SourceLink string
-	Doc        string
-	Fields     []fieldData
+	Title  string
+	Doc    string
+	Fields []fieldData
 }
 
 type fieldData struct {
@@ -231,7 +229,7 @@ func (d *docData) generate(output io.Writer) error {
 	}
 	// Collect all struct data first
 	for _, k := range append(d.configKeys, d.otherKeys...) {
-		sd, err := d.collectStructData(k, d.sources[k])
+		sd, err := d.collectStructData(k)
 		if err != nil {
 			return err
 		}
@@ -241,16 +239,15 @@ func (d *docData) generate(output io.Writer) error {
 }
 
 // collectStructData prepares the metadata for a single Go struct.
-func (d *docData) collectStructData(name string, sourceLink string) (structData, error) {
+func (d *docData) collectStructData(name string) (structData, error) {
 	st := d.structs[name]
 	title := name + titleSuffix
 	if name == d.rootStruct {
 		title = d.rootHeading + titleSuffix
 	}
 	structData := structData{
-		Title:      title,
-		SourceLink: sourceLink,
-		Doc:        d.docs[name],
+		Title: title,
+		Doc:   d.docs[name],
 	}
 	for _, field := range st.Fields.List {
 		if len(field.Names) == 0 {

--- a/cmd/config_doc_generate_test.go
+++ b/cmd/config_doc_generate_test.go
@@ -313,8 +313,4 @@ type Alpha struct {
 	if !(configIdx < secondIdx && secondIdx < alphaIdx && alphaIdx < otherIdx) {
 		t.Errorf("incorrect order: root_config=%d, second=%d, alpha=%d, other=%d", configIdx, secondIdx, alphaIdx, otherIdx)
 	}
-
-	if !strings.Contains(got, "[Link to code](../config.go#L4)") {
-		t.Error("output missing expected source link for Config")
-	}
 }

--- a/doc/api-allowlist-schema.md
+++ b/doc/api-allowlist-schema.md
@@ -4,7 +4,6 @@ This document describes the schema for the API Allowlist.
 
 ## API Configuration
 
-[Link to code](../internal/serviceconfig/api.go#L66)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `Description` | string | Description provides the information for describing an API. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -4,7 +4,6 @@ This document describes the schema for the librarian.yaml.
 
 ## Root Configuration
 
-[Link to code](../internal/config/config.go#L22)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `language` | string | Language is the language for this workspace (go, python, rust). |
@@ -17,7 +16,6 @@ This document describes the schema for the librarian.yaml.
 
 ## Release Configuration
 
-[Link to code](../internal/config/config.go#L50)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `branch` | string | Branch sets the name of the release branch, typically `main` |
@@ -29,7 +27,6 @@ This document describes the schema for the librarian.yaml.
 
 ## Tool Configuration
 
-[Link to code](../internal/config/config.go#L76)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `name` | string | Name is the name of the tool e.g. nox. |
@@ -37,7 +34,6 @@ This document describes the schema for the librarian.yaml.
 
 ## Sources Configuration
 
-[Link to code](../internal/config/config.go#L85)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `conformance` | [Source](#source-configuration) (optional) | Conformance is the path to the `conformance-tests` repository, used as include directory for `protoc`. |
@@ -48,7 +44,6 @@ This document describes the schema for the librarian.yaml.
 
 ## Source Configuration
 
-[Link to code](../internal/config/config.go#L103)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `branch` | string | Branch is the source's git branch to pull updates from. Unset should be interpreted as the repository default branch. |
@@ -59,7 +54,6 @@ This document describes the schema for the librarian.yaml.
 
 ## Default Configuration
 
-[Link to code](../internal/config/config.go#L124)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `keep` | list of string | Keep lists files and directories to preserve during regeneration. |
@@ -72,7 +66,6 @@ This document describes the schema for the librarian.yaml.
 
 ## Library Configuration
 
-[Link to code](../internal/config/config.go#L150)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `name` | string | Name is the library name, such as "secretmanager" or "storage". |
@@ -96,14 +89,12 @@ This document describes the schema for the librarian.yaml.
 
 ## API Configuration
 
-[Link to code](../internal/config/config.go#L219)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `path` | string | Path specifies which googleapis Path to generate from (for generated libraries). |
 
 ## DartPackage Configuration
 
-[Link to code](../internal/config/language.go#L301)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `api_keys_environment_variables` | string | APIKeysEnvironmentVariables is a comma-separated list of environment variable names that can contain API keys (e.g., "GOOGLE_API_KEY,GEMINI_API_KEY"). |
@@ -126,7 +117,6 @@ This document describes the schema for the librarian.yaml.
 
 ## GoAPI Configuration
 
-[Link to code](../internal/config/language.go#L30)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `client_directory` | string | ClientDirectory is the directory where the client is generated, relative to Library.Output. |
@@ -139,7 +129,6 @@ This document describes the schema for the librarian.yaml.
 
 ## GoModule Configuration
 
-[Link to code](../internal/config/language.go#L20)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `delete_generation_output_paths` | list of string | DeleteGenerationOutputPaths is a list of paths to delete before generation. |
@@ -148,7 +137,6 @@ This document describes the schema for the librarian.yaml.
 
 ## PythonPackage Configuration
 
-[Link to code](../internal/config/language.go#L282)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `opt_args` | list of string | OptArgs contains additional options passed to the generator, where the options are common to all apis. Example: ["warehouse-package-name=google-cloud-batch"] |
@@ -157,7 +145,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustCrate Configuration
 
-[Link to code](../internal/config/language.go#L148)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | (embedded) | [RustDefault](#rustdefault-configuration) |  |
@@ -184,7 +171,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustDefault Configuration
 
-[Link to code](../internal/config/language.go#L50)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `package_dependencies` | list of [RustPackageDependency](#rustpackagedependency-configuration) (optional) | PackageDependencies is a list of default package dependencies. These are inherited by all libraries. If a library defines its own package_dependencies, the library-specific ones take precedence over these defaults for dependencies with the same name. |
@@ -194,7 +180,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustDiscovery Configuration
 
-[Link to code](../internal/config/language.go#L264)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `operation_id` | string | OperationID is the ID of the LRO operation type (e.g., ".google.cloud.compute.v1.Operation"). |
@@ -202,7 +187,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustDocumentationOverride Configuration
 
-[Link to code](../internal/config/language.go#L243)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `id` | string | ID is the fully qualified element ID (e.g., .google.cloud.dialogflow.v2.Message.field). |
@@ -211,7 +195,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustModule Configuration
 
-[Link to code](../internal/config/language.go#L70)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `disabled_rustdoc_warnings` | yaml.StringSlice | DisabledRustdocWarnings specifies rustdoc lints to disable. An empty slice explicitly enables all warnings. |
@@ -240,7 +223,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustPackageDependency Configuration
 
-[Link to code](../internal/config/language.go#L215)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `name` | string | Name is the dependency name. It is listed first so it appears at the top of each dependency entry in YAML. |
@@ -253,7 +235,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustPaginationOverride Configuration
 
-[Link to code](../internal/config/language.go#L255)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `id` | string | ID is the fully qualified method ID (e.g., .google.cloud.sql.v1.Service.Method). |
@@ -261,7 +242,6 @@ This document describes the schema for the librarian.yaml.
 
 ## RustPoller Configuration
 
-[Link to code](../internal/config/language.go#L273)
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `prefix` | string | Prefix is an acceptable prefix for the URL path (e.g., "compute/v1/projects/{project}/zones/{zone}"). |


### PR DESCRIPTION
Removes logic to generate "[Link to code]" links in config docs. It causes more friction than being helpful right now, as both config are frequently edited and causing merging conflicts. We can bring it back later if it becomes helpful.