### PR TITLE
refactor(internal/sidekick): migrate pagination logic and overrides to sidekick/api

### DIFF
--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -80,9 +80,9 @@ func libraryToModelConfig(library *config.Library, ch *config.API, sources *sour
 			}
 		}
 		if len(library.Rust.PaginationOverrides) > 0 {
-			modelCfg.PaginationOverrides = make([]sidekickconfig.PaginationOverride, len(library.Rust.PaginationOverrides))
+			modelCfg.PaginationOverrides = make([]api.PaginationOverride, len(library.Rust.PaginationOverrides))
 			for i, override := range library.Rust.PaginationOverrides {
-				modelCfg.PaginationOverrides[i] = sidekickconfig.PaginationOverride{
+				modelCfg.PaginationOverrides[i] = api.PaginationOverride{
 					ID:        override.ID,
 					ItemField: override.ItemField,
 				}
@@ -270,9 +270,9 @@ func moduleToModelConfig(library *config.Library, module *config.RustModule, sou
 		}
 	}
 	if len(library.Rust.PaginationOverrides) > 0 {
-		modelCfg.PaginationOverrides = make([]sidekickconfig.PaginationOverride, len(library.Rust.PaginationOverrides))
+		modelCfg.PaginationOverrides = make([]api.PaginationOverride, len(library.Rust.PaginationOverrides))
 		for i, override := range library.Rust.PaginationOverrides {
-			modelCfg.PaginationOverrides[i] = sidekickconfig.PaginationOverride{
+			modelCfg.PaginationOverrides[i] = api.PaginationOverride{
 				ID:        override.ID,
 				ItemField: override.ItemField,
 			}

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -288,7 +288,7 @@ func TestLibraryToModelConfig(t *testing.T) {
 				Override: api.ModelOverride{
 					Title: "Secret Manager API",
 				},
-				PaginationOverrides: []sidekickconfig.PaginationOverride{
+				PaginationOverrides: []api.PaginationOverride{
 					{
 						ID:        ".google.cloud.secretmanager.v1.Secret.ListSecrets",
 						ItemField: "secrets",
@@ -815,7 +815,7 @@ func TestModuleToModelConfig(t *testing.T) {
 					"googleapis-root": absPath(t, googleapisRoot),
 					"roots":           "googleapis",
 				},
-				PaginationOverrides: []sidekickconfig.PaginationOverride{
+				PaginationOverrides: []api.PaginationOverride{
 					{
 						ID:        ".google.cloud.example.v1.Example.ListExamples",
 						ItemField: "examples",
@@ -850,7 +850,7 @@ func TestModuleToModelConfig(t *testing.T) {
 					"googleapis-root": absPath(t, googleapisRoot),
 					"roots":           "googleapis",
 				},
-				PaginationOverrides: []sidekickconfig.PaginationOverride{
+				PaginationOverrides: []api.PaginationOverride{
 					{
 						ID:        ".google.cloud.example.v1.Example.ListExamples",
 						ItemField: "examples",

--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -1213,14 +1213,6 @@ func (m *Message) HasFields() bool {
 	return len(m.Fields) != 0
 }
 
-// PaginationInfo contains information related to pagination aka [AIP-4233](https://google.aip.dev/client-libraries/4233).
-type PaginationInfo struct {
-	// The field that gives us the next page token.
-	NextPageToken *Field
-	// PageableItem is the field to be paginated over.
-	PageableItem *Field
-}
-
 // Enum defines a message used in request/response handling.
 type Enum struct {
 	// Documentation for the message.

--- a/internal/sidekick/api/pagination.go
+++ b/internal/sidekick/api/pagination.go
@@ -12,13 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package parser
+package api
 
 import (
 	"slices"
-
-	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
 const (
@@ -28,9 +25,25 @@ const (
 	nextPageToken = "nextPageToken"
 )
 
-// updateMethodPagination marks all methods that conform to
+// PaginationOverride describes overrides for pagination config of a method.
+type PaginationOverride struct {
+	// The method ID.
+	ID string
+	// The name of the field used for `items`.
+	ItemField string
+}
+
+// PaginationInfo contains information related to pagination aka [AIP-4233](https://google.aip.dev/client-libraries/4233).
+type PaginationInfo struct {
+	// The field that gives us the next page token.
+	NextPageToken *Field
+	// PageableItem is the field to be paginated over.
+	PageableItem *Field
+}
+
+// UpdateMethodPagination marks all methods that conform to
 // [AIP-4233](https://google.aip.dev/client-libraries/4233) as pageable.
-func updateMethodPagination(overrides []config.PaginationOverride, a *api.API) {
+func UpdateMethodPagination(overrides []PaginationOverride, a *API) {
 	for _, m := range a.State.MethodByID {
 		reqMsg := a.State.MessageByID[m.InputTypeID]
 		pageTokenField := paginationRequestInfo(reqMsg)
@@ -48,7 +61,7 @@ func updateMethodPagination(overrides []config.PaginationOverride, a *api.API) {
 	}
 }
 
-func paginationRequestInfo(request *api.Message) *api.Field {
+func paginationRequestInfo(request *Message) *Field {
 	if request == nil {
 		return nil
 	}
@@ -58,7 +71,7 @@ func paginationRequestInfo(request *api.Message) *api.Field {
 	return paginationRequestToken(request)
 }
 
-func paginationRequestPageSize(request *api.Message) *api.Field {
+func paginationRequestPageSize(request *Message) *Field {
 	for _, field := range request.Fields {
 		// Some legacy services (e.g. sqladmin.googleapis.com)
 		// predate AIP-4233 and use `maxResults` instead of
@@ -73,30 +86,30 @@ func paginationRequestPageSize(request *api.Message) *api.Field {
 	return nil
 }
 
-func isPaginationPageSizeType(field *api.Field) bool {
-	return field.Typez == api.INT32_TYPE || field.Typez == api.UINT32_TYPE
+func isPaginationPageSizeType(field *Field) bool {
+	return field.Typez == INT32_TYPE || field.Typez == UINT32_TYPE
 }
 
-func isPaginationMaxResultsType(field *api.Field) bool {
+func isPaginationMaxResultsType(field *Field) bool {
 	// Legacy maxResults types can be int32/uint32, and protobuf wrappers Int32Value/UInt32Value.
 	if isPaginationPageSizeType(field) {
 		return true
 	}
-	return field.Typez == api.MESSAGE_TYPE &&
+	return field.Typez == MESSAGE_TYPE &&
 		(field.TypezID == ".google.protobuf.Int32Value" ||
 			field.TypezID == ".google.protobuf.UInt32Value")
 }
 
-func paginationRequestToken(request *api.Message) *api.Field {
+func paginationRequestToken(request *Message) *Field {
 	for _, field := range request.Fields {
-		if field.JSONName == pageToken && field.Typez == api.STRING_TYPE {
+		if field.JSONName == pageToken && field.Typez == STRING_TYPE {
 			return field
 		}
 	}
 	return nil
 }
 
-func paginationResponseInfo(overrides []config.PaginationOverride, methodID string, response *api.Message) *api.PaginationInfo {
+func paginationResponseInfo(overrides []PaginationOverride, methodID string, response *Message) *PaginationInfo {
 	if response == nil {
 		return nil
 	}
@@ -105,38 +118,38 @@ func paginationResponseInfo(overrides []config.PaginationOverride, methodID stri
 	if pageableItem == nil || nextPageToken == nil {
 		return nil
 	}
-	return &api.PaginationInfo{
+	return &PaginationInfo{
 		PageableItem:  pageableItem,
 		NextPageToken: nextPageToken,
 	}
 }
 
-func paginationResponseItem(overrides []config.PaginationOverride, methodID string, response *api.Message) *api.Field {
-	idx := slices.IndexFunc(overrides, func(o config.PaginationOverride) bool { return o.ID == methodID })
+func paginationResponseItem(overrides []PaginationOverride, methodID string, response *Message) *Field {
+	idx := slices.IndexFunc(overrides, func(o PaginationOverride) bool { return o.ID == methodID })
 	if idx != -1 {
 		overrideName := overrides[idx].ItemField
-		fieldIdx := slices.IndexFunc(response.Fields, func(f *api.Field) bool { return f.Name == overrideName })
+		fieldIdx := slices.IndexFunc(response.Fields, func(f *Field) bool { return f.Name == overrideName })
 		if fieldIdx == -1 {
 			return nil
 		}
 		return response.Fields[fieldIdx]
 	}
 
-	var mapItems *api.Field
+	var mapItems *Field
 	for _, field := range response.Fields {
 		if field.Map && mapItems == nil {
 			mapItems = field
 		}
-		if field.Repeated && field.Typez == api.MESSAGE_TYPE {
+		if field.Repeated && field.Typez == MESSAGE_TYPE {
 			return field
 		}
 	}
 	return mapItems
 }
 
-func paginationResponseNextPageToken(response *api.Message) *api.Field {
+func paginationResponseNextPageToken(response *Message) *Field {
 	for _, field := range response.Fields {
-		if field.JSONName == nextPageToken && field.Typez == api.STRING_TYPE {
+		if field.JSONName == nextPageToken && field.Typez == STRING_TYPE {
 			return field
 		}
 	}

--- a/internal/sidekick/api/pagination_test.go
+++ b/internal/sidekick/api/pagination_test.go
@@ -12,82 +12,80 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package parser
+package api
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/config"
 )
 
 func TestPageSimple(t *testing.T) {
-	resource := &api.Message{
+	resource := &Message{
 		Name: "Resource",
 		ID:   ".package.Resource",
 	}
-	request := &api.Message{
+	request := &Message{
 		Name: "Request",
 		ID:   ".package.Request",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "parent",
 				JSONName: "parent",
 				ID:       ".package.Request.parent",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_token",
 				JSONName: "pageToken",
 				ID:       ".package.Request.pageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_size",
 				JSONName: "pageSize",
 				ID:       ".package.Request.pageSize",
-				Typez:    api.INT32_TYPE,
+				Typez:    INT32_TYPE,
 			},
 		},
 	}
-	response := &api.Message{
+	response := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "next_page_token",
 				JSONName: "nextPageToken",
 				ID:       ".package.Request.nextPageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "items",
 				JSONName: "items",
 				ID:       ".package.Request.items",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				TypezID:  ".package.Resource",
 				Repeated: true,
 			},
 		},
 	}
-	method := &api.Method{
+	method := &Method{
 		Name:         "List",
 		ID:           ".package.Service.List",
 		InputTypeID:  ".package.Request",
 		OutputTypeID: ".package.Response",
 	}
-	service := &api.Service{
+	service := &Service{
 		Name:    "Service",
 		ID:      ".package.Service",
-		Methods: []*api.Method{method},
+		Methods: []*Method{method},
 	}
-	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(nil, model)
+	model := NewTestAPI([]*Message{request, response, resource}, []*Enum{}, []*Service{service})
+	UpdateMethodPagination(nil, model)
 	if method.Pagination != request.Fields[1] {
 		t.Errorf("mismatch, want=%v, got=%v", request.Fields[1], method.Pagination)
 	}
-	want := &api.PaginationInfo{
+	want := &PaginationInfo{
 		NextPageToken: response.Fields[0],
 		PageableItem:  response.Fields[1],
 	}
@@ -97,49 +95,49 @@ func TestPageSimple(t *testing.T) {
 }
 
 func TestPageWithOverride(t *testing.T) {
-	resource := &api.Message{
+	resource := &Message{
 		Name: "Resource",
 		ID:   ".package.Resource",
 	}
-	request := &api.Message{
+	request := &Message{
 		Name: "Request",
 		ID:   ".package.Request",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "parent",
 				JSONName: "parent",
 				ID:       ".package.Request.parent",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_token",
 				JSONName: "pageToken",
 				ID:       ".package.Request.pageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_size",
 				JSONName: "pageSize",
 				ID:       ".package.Request.pageSize",
-				Typez:    api.INT32_TYPE,
+				Typez:    INT32_TYPE,
 			},
 		},
 	}
-	response := &api.Message{
+	response := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "next_page_token",
 				JSONName: "nextPageToken",
 				ID:       ".package.Request.nextPageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "warnings",
 				JSONName: "warnings",
 				ID:       ".package.Request.warnings",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				TypezID:  ".package.Warning",
 				Repeated: true,
 			},
@@ -147,32 +145,32 @@ func TestPageWithOverride(t *testing.T) {
 				Name:     "items",
 				JSONName: "items",
 				ID:       ".package.Request.items",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				TypezID:  ".package.Resource",
 				Repeated: true,
 			},
 		},
 	}
-	method := &api.Method{
+	method := &Method{
 		Name:         "List",
 		ID:           ".package.Service.List",
 		InputTypeID:  ".package.Request",
 		OutputTypeID: ".package.Response",
 	}
-	service := &api.Service{
+	service := &Service{
 		Name:    "Service",
 		ID:      ".package.Service",
-		Methods: []*api.Method{method},
+		Methods: []*Method{method},
 	}
-	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	overrides := []config.PaginationOverride{
+	model := NewTestAPI([]*Message{request, response, resource}, []*Enum{}, []*Service{service})
+	overrides := []PaginationOverride{
 		{ID: ".package.Service.List", ItemField: "items"},
 	}
-	updateMethodPagination(overrides, model)
+	UpdateMethodPagination(overrides, model)
 	if method.Pagination != request.Fields[1] {
 		t.Errorf("mismatch, want=%v, got=%v", request.Fields[1], method.Pagination)
 	}
-	want := &api.PaginationInfo{
+	want := &PaginationInfo{
 		NextPageToken: response.Fields[0],
 		PageableItem:  response.Fields[2],
 	}
@@ -182,222 +180,222 @@ func TestPageWithOverride(t *testing.T) {
 }
 
 func TestPageMissingInputType(t *testing.T) {
-	resource := &api.Message{
+	resource := &Message{
 		Name: "Resource",
 		ID:   ".package.Resource",
 	}
-	response := &api.Message{
+	response := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "next_page_token",
 				JSONName: "nextPageToken",
 				ID:       ".package.Request.nextPageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "items",
 				JSONName: "items",
 				ID:       ".package.Request.items",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				TypezID:  ".package.Resource",
 				Repeated: true,
 			},
 		},
 	}
-	method := &api.Method{
+	method := &Method{
 		Name:         "List",
 		ID:           ".package.Service.List",
 		InputTypeID:  ".package.Request",
 		OutputTypeID: ".package.Response",
 	}
-	service := &api.Service{
+	service := &Service{
 		Name:    "Service",
 		ID:      ".package.Service",
-		Methods: []*api.Method{method},
+		Methods: []*Method{method},
 	}
-	model := api.NewTestAPI([]*api.Message{response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(nil, model)
+	model := NewTestAPI([]*Message{response, resource}, []*Enum{}, []*Service{service})
+	UpdateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
 }
 
 func TestPageMissingOutputType(t *testing.T) {
-	resource := &api.Message{
+	resource := &Message{
 		Name: "Resource",
 		ID:   ".package.Resource",
 	}
-	request := &api.Message{
+	request := &Message{
 		Name: "Request",
 		ID:   ".package.Request",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "parent",
 				JSONName: "parent",
 				ID:       ".package.Request.parent",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_token",
 				JSONName: "pageToken",
 				ID:       ".package.Request.pageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_size",
 				JSONName: "pageSize",
 				ID:       ".package.Request.pageSize",
-				Typez:    api.INT32_TYPE,
+				Typez:    INT32_TYPE,
 			},
 		},
 	}
-	method := &api.Method{
+	method := &Method{
 		Name:         "List",
 		ID:           ".package.Service.List",
 		InputTypeID:  ".package.Request",
 		OutputTypeID: ".package.Response",
 	}
-	service := &api.Service{
+	service := &Service{
 		Name:    "Service",
 		ID:      ".package.Service",
-		Methods: []*api.Method{method},
+		Methods: []*Method{method},
 	}
-	model := api.NewTestAPI([]*api.Message{request, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(nil, model)
+	model := NewTestAPI([]*Message{request, resource}, []*Enum{}, []*Service{service})
+	UpdateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
 }
 
 func TestPageBadRequest(t *testing.T) {
-	resource := &api.Message{
+	resource := &Message{
 		Name: "Resource",
 		ID:   ".package.Resource",
 	}
-	request := &api.Message{
+	request := &Message{
 		Name:   "Request",
 		ID:     ".package.Request",
-		Fields: []*api.Field{},
+		Fields: []*Field{},
 	}
-	response := &api.Message{
+	response := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "next_page_token",
 				JSONName: "nextPageToken",
 				ID:       ".package.Request.nextPageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "items",
 				JSONName: "items",
 				ID:       ".package.Request.items",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				TypezID:  ".package.Resource",
 				Repeated: true,
 			},
 		},
 	}
-	method := &api.Method{
+	method := &Method{
 		Name:         "List",
 		ID:           ".package.Service.List",
 		InputTypeID:  ".package.Request",
 		OutputTypeID: ".package.Response",
 	}
-	service := &api.Service{
+	service := &Service{
 		Name:    "Service",
 		ID:      ".package.Service",
-		Methods: []*api.Method{method},
+		Methods: []*Method{method},
 	}
-	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(nil, model)
+	model := NewTestAPI([]*Message{request, response, resource}, []*Enum{}, []*Service{service})
+	UpdateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
 }
 
 func TestPageBadResponse(t *testing.T) {
-	resource := &api.Message{
+	resource := &Message{
 		Name: "Resource",
 		ID:   ".package.Resource",
 	}
-	request := &api.Message{
+	request := &Message{
 		Name:   "Request",
 		ID:     ".package.Request",
-		Fields: []*api.Field{},
+		Fields: []*Field{},
 	}
-	response := &api.Message{
+	response := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "parent",
 				JSONName: "parent",
 				ID:       ".package.Request.parent",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_token",
 				JSONName: "pageToken",
 				ID:       ".package.Request.pageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 			{
 				Name:     "page_size",
 				JSONName: "pageSize",
 				ID:       ".package.Request.pageSize",
-				Typez:    api.INT32_TYPE,
+				Typez:    INT32_TYPE,
 			},
 		},
 	}
-	method := &api.Method{
+	method := &Method{
 		Name:         "List",
 		ID:           ".package.Service.List",
 		InputTypeID:  ".package.Request",
 		OutputTypeID: ".package.Response",
 	}
-	service := &api.Service{
+	service := &Service{
 		Name:    "Service",
 		ID:      ".package.Service",
-		Methods: []*api.Method{method},
+		Methods: []*Method{method},
 	}
-	model := api.NewTestAPI([]*api.Message{request, response, resource}, []*api.Enum{}, []*api.Service{service})
-	updateMethodPagination(nil, model)
+	model := NewTestAPI([]*Message{request, response, resource}, []*Enum{}, []*Service{service})
+	UpdateMethodPagination(nil, model)
 	if method.Pagination != nil {
 		t.Errorf("mismatch, want=nil, got=%v", method.Pagination)
 	}
 }
 
 func TestPaginationRequestInfoErrors(t *testing.T) {
-	badSize := &api.Message{
+	badSize := &Message{
 		Name: "Request",
 		ID:   ".package.Request",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "page_token",
 				JSONName: "pageToken",
 				ID:       ".package.Request.pageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 		},
 	}
-	badToken := &api.Message{
+	badToken := &Message{
 		Name: "Request",
 		ID:   ".package.Request",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "page_size",
 				JSONName: "pageSize",
 				ID:       ".package.Request.pageSize",
-				Typez:    api.INT32_TYPE,
+				Typez:    INT32_TYPE,
 			},
 		},
 	}
 
-	for _, input := range []*api.Message{nil, badSize, badToken} {
+	for _, input := range []*Message{nil, badSize, badToken} {
 		if got := paginationRequestInfo(input); got != nil {
 			t.Errorf("expected paginationRequestInfo(...) == nil, got=%v, input=%v", got, input)
 		}
@@ -407,20 +405,20 @@ func TestPaginationRequestInfoErrors(t *testing.T) {
 func TestPaginationRequestPageSizeSuccess(t *testing.T) {
 	for _, test := range []struct {
 		Name    string
-		Typez   api.Typez
+		Typez   Typez
 		TypezID string
 	}{
-		{"pageSize", api.INT32_TYPE, ""},
-		{"pageSize", api.UINT32_TYPE, ""},
-		{"maxResults", api.INT32_TYPE, ""},
-		{"maxResults", api.UINT32_TYPE, ""},
-		{"maxResults", api.MESSAGE_TYPE, ".google.protobuf.Int32Value"},
-		{"maxResults", api.MESSAGE_TYPE, ".google.protobuf.UInt32Value"},
+		{"pageSize", INT32_TYPE, ""},
+		{"pageSize", UINT32_TYPE, ""},
+		{"maxResults", INT32_TYPE, ""},
+		{"maxResults", UINT32_TYPE, ""},
+		{"maxResults", MESSAGE_TYPE, ".google.protobuf.Int32Value"},
+		{"maxResults", MESSAGE_TYPE, ".google.protobuf.UInt32Value"},
 	} {
-		response := &api.Message{
+		response := &Message{
 			Name: "Response",
 			ID:   ".package.Response",
-			Fields: []*api.Field{
+			Fields: []*Field{
 				{
 					Name:     test.Name,
 					JSONName: test.Name,
@@ -439,27 +437,27 @@ func TestPaginationRequestPageSizeSuccess(t *testing.T) {
 func TestPaginationRequestPageSizeNotMatching(t *testing.T) {
 	for _, test := range []struct {
 		Name    string
-		Typez   api.Typez
+		Typez   Typez
 		TypezID string
 	}{
-		{"badName", api.INT32_TYPE, ""},
-		{"badName", api.UINT32_TYPE, ""},
-		{"badName", api.INT32_TYPE, ""},
-		{"badName", api.UINT32_TYPE, ""},
-		{"badName", api.MESSAGE_TYPE, ".google.protobuf.Int32Value"},
-		{"badName", api.MESSAGE_TYPE, ".google.protobuf.UInt32Value"},
+		{"badName", INT32_TYPE, ""},
+		{"badName", UINT32_TYPE, ""},
+		{"badName", INT32_TYPE, ""},
+		{"badName", UINT32_TYPE, ""},
+		{"badName", MESSAGE_TYPE, ".google.protobuf.Int32Value"},
+		{"badName", MESSAGE_TYPE, ".google.protobuf.UInt32Value"},
 
-		{"pageSize", api.INT64_TYPE, ""},
-		{"pageSize", api.UINT64_TYPE, ""},
-		{"maxResults", api.INT64_TYPE, ""},
-		{"maxResults", api.UINT64_TYPE, ""},
-		{"maxResults", api.MESSAGE_TYPE, ".google.protobuf.Int64Value"},
-		{"maxResults", api.MESSAGE_TYPE, ".google.protobuf.UInt64Value"},
+		{"pageSize", INT64_TYPE, ""},
+		{"pageSize", UINT64_TYPE, ""},
+		{"maxResults", INT64_TYPE, ""},
+		{"maxResults", UINT64_TYPE, ""},
+		{"maxResults", MESSAGE_TYPE, ".google.protobuf.Int64Value"},
+		{"maxResults", MESSAGE_TYPE, ".google.protobuf.UInt64Value"},
 	} {
-		response := &api.Message{
+		response := &Message{
 			Name: "Response",
 			ID:   ".package.Response",
-			Fields: []*api.Field{
+			Fields: []*Field{
 				{
 					Name:     test.Name,
 					JSONName: test.Name,
@@ -478,15 +476,15 @@ func TestPaginationRequestPageSizeNotMatching(t *testing.T) {
 func TestPaginationRequestToken(t *testing.T) {
 	for _, test := range []struct {
 		Name  string
-		Typez api.Typez
+		Typez Typez
 	}{
-		{"badName", api.STRING_TYPE},
-		{"nextPageToken", api.INT32_TYPE},
+		{"badName", STRING_TYPE},
+		{"nextPageToken", INT32_TYPE},
 	} {
-		response := &api.Message{
+		response := &Message{
 			Name: "Response",
 			ID:   ".package.Response",
-			Fields: []*api.Field{
+			Fields: []*Field{
 				{
 					Name:     test.Name,
 					JSONName: test.Name,
@@ -502,34 +500,34 @@ func TestPaginationRequestToken(t *testing.T) {
 }
 
 func TestPaginationResponseErrors(t *testing.T) {
-	badToken := &api.Message{
+	badToken := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "items",
 				JSONName: "items",
 				ID:       ".package.Request.items",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				TypezID:  ".package.Resource",
 				Repeated: true,
 			},
 		},
 	}
-	badItems := &api.Message{
+	badItems := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "next_page_token",
 				JSONName: "nextPageToken",
 				ID:       ".package.Request.nextPageToken",
-				Typez:    api.STRING_TYPE,
+				Typez:    STRING_TYPE,
 			},
 		},
 	}
 
-	for _, input := range []*api.Message{badToken, badItems, nil} {
+	for _, input := range []*Message{badToken, badItems, nil} {
 		if got := paginationResponseInfo(nil, ".package.Service.List", input); got != nil {
 			t.Errorf("expected paginationResponseInfo(...) == nil, got=%v, input=%v", got, input)
 		}
@@ -540,16 +538,16 @@ func TestPaginationResponseItemMatching(t *testing.T) {
 	for _, test := range []struct {
 		Repeated bool
 		Map      bool
-		Typez    api.Typez
+		Typez    Typez
 		Name     string
 	}{
-		{false, true, api.MESSAGE_TYPE, "items"},
-		{true, false, api.MESSAGE_TYPE, "items"},
+		{false, true, MESSAGE_TYPE, "items"},
+		{true, false, MESSAGE_TYPE, "items"},
 	} {
-		response := &api.Message{
+		response := &Message{
 			Name: "Response",
 			ID:   ".package.Response",
-			Fields: []*api.Field{
+			Fields: []*Field{
 				{
 					Name:     test.Name,
 					JSONName: test.Name,
@@ -574,21 +572,21 @@ func TestPaginationResponseItemMatchingMany(t *testing.T) {
 		{true, false},
 		{false, true},
 	} {
-		response := &api.Message{
+		response := &Message{
 			Name: "Response",
 			ID:   ".package.Response",
-			Fields: []*api.Field{
+			Fields: []*Field{
 				{
 					Name:     "first",
 					JSONName: "first",
-					Typez:    api.MESSAGE_TYPE,
+					Typez:    MESSAGE_TYPE,
 					Repeated: test.Repeated,
 					Map:      test.Map,
 				},
 				{
 					Name:     "second",
 					JSONName: "second",
-					Typez:    api.MESSAGE_TYPE,
+					Typez:    MESSAGE_TYPE,
 					Repeated: test.Repeated,
 					Map:      test.Map,
 				},
@@ -602,20 +600,20 @@ func TestPaginationResponseItemMatchingMany(t *testing.T) {
 }
 
 func TestPaginationResponseItemMatchingPreferRepeatedOverMap(t *testing.T) {
-	response := &api.Message{
+	response := &Message{
 		Name: "Response",
 		ID:   ".package.Response",
-		Fields: []*api.Field{
+		Fields: []*Field{
 			{
 				Name:     "map",
 				JSONName: "map",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				Map:      true,
 			},
 			{
 				Name:     "repeated",
 				JSONName: "repeated",
-				Typez:    api.MESSAGE_TYPE,
+				Typez:    MESSAGE_TYPE,
 				Repeated: true,
 			},
 		},
@@ -627,24 +625,24 @@ func TestPaginationResponseItemMatchingPreferRepeatedOverMap(t *testing.T) {
 }
 
 func TestPaginationResponseItemNotMatching(t *testing.T) {
-	overrides := []config.PaginationOverride{
+	overrides := []PaginationOverride{
 		{ID: ".package.Service.List", ItemField: "--invalid--"},
 	}
 	for _, test := range []struct {
 		Name      string
 		Repeated  bool
-		Typez     api.Typez
-		Overrides []config.PaginationOverride
+		Typez     Typez
+		Overrides []PaginationOverride
 	}{
-		{"badRepeated", false, api.MESSAGE_TYPE, nil},
-		{"badType", true, api.STRING_TYPE, nil},
-		{"bothBad", false, api.ENUM_TYPE, nil},
-		{"badOverride", true, api.MESSAGE_TYPE, overrides},
+		{"badRepeated", false, MESSAGE_TYPE, nil},
+		{"badType", true, STRING_TYPE, nil},
+		{"bothBad", false, ENUM_TYPE, nil},
+		{"badOverride", true, MESSAGE_TYPE, overrides},
 	} {
-		response := &api.Message{
+		response := &Message{
 			Name: "Response",
 			ID:   ".package.Response",
-			Fields: []*api.Field{
+			Fields: []*Field{
 				{
 					Name:     test.Name,
 					JSONName: test.Name,
@@ -663,15 +661,15 @@ func TestPaginationResponseItemNotMatching(t *testing.T) {
 func TestPaginationResponseNextPageToken(t *testing.T) {
 	for _, test := range []struct {
 		Name  string
-		Typez api.Typez
+		Typez Typez
 	}{
-		{"badName", api.STRING_TYPE},
-		{"nextPageToken", api.INT32_TYPE},
+		{"badName", STRING_TYPE},
+		{"nextPageToken", INT32_TYPE},
 	} {
-		response := &api.Message{
+		response := &Message{
 			Name: "Response",
 			ID:   ".package.Response",
-			Fields: []*api.Field{
+			Fields: []*Field{
 				{
 					Name:     test.Name,
 					JSONName: test.Name,

--- a/internal/sidekick/config/config.go
+++ b/internal/sidekick/config/config.go
@@ -28,17 +28,8 @@ type DocumentationOverride struct {
 	Replace string `toml:"replace"`
 }
 
-// PaginationOverride describes overrides for pagination config of a method.
-type PaginationOverride struct {
-	// The method ID.
-	ID string `toml:"id"`
-	// The name of the field used for `items`.
-	ItemField string `toml:"item-field"`
-}
-
 // Config is the main configuration struct.
 type Config struct {
-	Discovery           *Discovery              `toml:"discovery,omitempty"`
-	CommentOverrides    []DocumentationOverride `toml:"documentation-overrides,omitempty"`
-	PaginationOverrides []PaginationOverride    `toml:"pagination-overrides,omitempty"`
+	Discovery        *Discovery              `toml:"discovery,omitempty"`
+	CommentOverrides []DocumentationOverride `toml:"documentation-overrides,omitempty"`
 }

--- a/internal/sidekick/parser/disco_test.go
+++ b/internal/sidekick/parser/disco_test.go
@@ -107,7 +107,7 @@ func TestDisco_ParsePagination(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	updateMethodPagination(nil, model)
+	api.UpdateMethodPagination(nil, model)
 	wantID := "..zones.list"
 	got, ok := model.State.MethodByID[wantID]
 	if !ok {
@@ -134,7 +134,7 @@ func TestDisco_ParsePaginationAggregate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	updateMethodPagination(nil, model)
+	api.UpdateMethodPagination(nil, model)
 	wantID := "..machineTypes.aggregatedList"
 	got, ok := model.State.MethodByID[wantID]
 	if !ok {

--- a/internal/sidekick/parser/openapi_test.go
+++ b/internal/sidekick/parser/openapi_test.go
@@ -537,7 +537,7 @@ func openapiSecretManagerAPI(t *testing.T) *api.API {
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
-	updateMethodPagination(nil, test)
+	api.UpdateMethodPagination(nil, test)
 	return test
 }
 
@@ -948,7 +948,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
-	updateMethodPagination(nil, test)
+	api.UpdateMethodPagination(nil, test)
 
 	service, ok := test.State.ServiceByID["..Service"]
 	if !ok {

--- a/internal/sidekick/parser/parser.go
+++ b/internal/sidekick/parser/parser.go
@@ -45,7 +45,7 @@ type ModelConfig struct {
 
 	// Documentation/pagination overrides
 	CommentOverrides    []config.DocumentationOverride
-	PaginationOverrides []config.PaginationOverride
+	PaginationOverrides []api.PaginationOverride
 
 	// Discovery poller configurations
 	Discovery *config.Discovery
@@ -75,7 +75,7 @@ func CreateModel(cfg *ModelConfig) (*api.API, error) {
 	if err != nil {
 		return nil, err
 	}
-	updateMethodPagination(cfg.PaginationOverrides, model)
+	api.UpdateMethodPagination(cfg.PaginationOverrides, model)
 	api.LabelRecursiveFields(model)
 	if err := api.CrossReference(model); err != nil {
 		return nil, err

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -1133,7 +1133,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to make API for Protobuf %v", err)
 	}
-	updateMethodPagination(nil, test)
+	api.UpdateMethodPagination(nil, test)
 	service, ok := test.State.ServiceByID[".test.TestService"]
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")


### PR DESCRIPTION
Move UpdateMethodPagination from parser to api and migrate PaginationOverride from config to api. This consolidates pagination-related logic and configuration in the api package.

Part of #4041 