### PR TITLE
refactor(sidekick): rename ResourceNameHeuristic to TargetResource

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -929,9 +929,9 @@ type PathBinding struct {
 	PathTemplate *PathTemplate
 	// Query parameter fields.
 	QueryParameters map[string]bool
-	// ResourceNameHeuristic contains the results of the resource name identification heuristic, if any.
+	// TargetResource contains the results of the resource name identification.
 	// This helps identify which resource this path is likely targeting.
-	ResourceNameHeuristic *ResourceNameHeuristic
+	TargetResource *TargetResource
 	// Language specific annotations.
 	Codec any
 }
@@ -1518,9 +1518,9 @@ func (f *Field) IsResourceReference() bool {
 	return f.ResourceReference != nil
 }
 
-// ResourceNameHeuristic contains the results of the resource name identification heuristic.
+// TargetResource contains the results of the resource name identification.
 // It provides the sequences of fields used by language-specific generators to inject tracing attributes.
-type ResourceNameHeuristic struct {
+type TargetResource struct {
 	// FieldPaths is a list of field name sequences that, when joined, form a resource name.
 	// For example, [["project"], ["zone"], ["instance"]] identifies a multi-part resource.
 	FieldPaths [][]string

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -235,7 +235,7 @@ func TestPathTemplateBuilder(t *testing.T) {
 }
 
 func TestPathBindingHeuristic(t *testing.T) {
-	heuristic := &ResourceNameHeuristic{
+	heuristic := &TargetResource{
 		FieldPaths: [][]string{{"project"}, {"zone"}, {"instance"}},
 		PathTemplate: NewPathTemplate().
 			WithLiteral("projects").WithVariableNamed("project").
@@ -243,16 +243,16 @@ func TestPathBindingHeuristic(t *testing.T) {
 			WithLiteral("instances").WithVariableNamed("instance"),
 	}
 	binding := &PathBinding{
-		Verb:                  "GET",
-		ResourceNameHeuristic: heuristic,
+		Verb:           "GET",
+		TargetResource: heuristic,
 	}
 
 	if binding.Verb != "GET" {
 		t.Errorf("expected GET, got %s", binding.Verb)
 	}
 
-	if binding.ResourceNameHeuristic.FieldPaths[0][0] != "project" {
-		t.Errorf("expected project, got %s", binding.ResourceNameHeuristic.FieldPaths[0][0])
+	if binding.TargetResource.FieldPaths[0][0] != "project" {
+		t.Errorf("expected project, got %s", binding.TargetResource.FieldPaths[0][0])
 	}
 }
 


### PR DESCRIPTION
Originally, the plan was to only implement the heuristic for resource name identification. 
However, in order to make it language agnostic (aka keeping the logic in the `model`, not just Rust specific), this field should be the container for the identified target resource of a `PathBinding`, regardless of whether it was identified via annotations or heuristically.