### PR TITLE
feat(sidekick): add resource name heuristic foundation

### DIFF
--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -49,21 +49,10 @@ func isBaseVocabulary(segment string) bool {
 	return baseVocabulary[segment]
 }
 
-// singularExceptions is a set of common segments that end in 's' but are not collections.
-var singularExceptions = map[string]bool{
-	"address":  true,
-	"status":   true,
-	"ingress":  true,
-	"egress":   true,
-	"access":   true,
-	"analysis": true,
-}
-
 // isCollectionIdentifier returns true if the segment is likely a collection ID.
 // It checks in the following order:
 // 1. Base vocabulary (projects, locations, etc.)
-// 2. Known resource plurals (from the API model)
-// 3. Fallback heuristic: ends in 's', len > 2, and not in the exception list.
+// 2. Known resource plurals (from the API model).
 func isCollectionIdentifier(segment string, knownPlurals map[string]bool) bool {
 	if isBaseVocabulary(segment) {
 		return true
@@ -71,8 +60,5 @@ func isCollectionIdentifier(segment string, knownPlurals map[string]bool) bool {
 	if knownPlurals != nil && knownPlurals[segment] {
 		return true
 	}
-	if singularExceptions[segment] {
-		return false
-	}
-	return len(segment) > 2 && strings.HasSuffix(segment, "s")
+	return false
 }

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -105,12 +105,12 @@ func TestIsCollectionIdentifier(t *testing.T) {
 		{"billingAccounts", nil, true},
 
 		// Standard plural heuristic
-		{"instances", nil, true},
-		{"disks", nil, true},
-		{"clusters", nil, true},
-		{"backups", nil, true},
-		{"vms", nil, true},
-		{"ips", nil, true},
+		{"instances", map[string]bool{"instances": true}, true},
+		{"disks", map[string]bool{"disks": true}, true},
+		{"clusters", map[string]bool{"clusters": true}, true},
+		{"backups", map[string]bool{"backups": true}, true},
+		{"vms", map[string]bool{"vms": true}, true},
+		{"ips", map[string]bool{"ips": true}, true},
 
 		// Ignored / Invalid
 		{"v1", nil, false},       // Version


### PR DESCRIPTION
Introduce helpers to build necessary vocabulary required for heuristic resource identification. 
This is the first part of the heuristic logic. Later PRs will work on integrating the matching logic.

For #4100 