### PR TITLE
feat(docuploader): add CreateArchive function

### DIFF
--- a/internal/docuploader/archive.go
+++ b/internal/docuploader/archive.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docuploader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/command"
+)
+
+var (
+	errTarFailure          = errors.New("tar reported failure")
+	errTarUnexpectedOutput = errors.New("tar reported success but provided unexpected output")
+)
+
+// CreateArchive creates a documentation archive suitable for uploading for
+// staging. It is expected that the metadata has already been written in
+// sourceDir as docs.metadata.json. This is equivalent to running
+// `tar czf {targetFile} -C {sourceDir} --xform s:./:: .`
+// (The "--xform" part is to avoid ./ being included in all paths in the
+// archive.)
+func CreateArchive(ctx context.Context, tarExe, sourceDir, targetFile string) error {
+	output, err := command.Output(ctx, tarExe, "czf", targetFile, "-C", sourceDir, "--xform", "s:./::", ".")
+	if err != nil {
+		return fmt.Errorf("failed to create archive %s: %w, %w", targetFile, errTarFailure, err)
+	}
+	if len(output) > 0 {
+		return fmt.Errorf("failed to create archive %s with output %s: %w", targetFile, output, errTarUnexpectedOutput)
+	}
+	return nil
+}

--- a/internal/docuploader/archive_test.go
+++ b/internal/docuploader/archive_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docuploader
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+func TestCreateArchive(t *testing.T) {
+	testhelper.RequireCommand(t, "tar")
+	dir := t.TempDir()
+	paths := []string{
+		"other.txt",
+		"otherdir/a.txt",
+		"docs/a.txt",
+		"docs/readme.txt",
+		"docs/subdir/a.txt",
+	}
+	for _, path := range paths {
+		fullPath := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+		slog.Info("Created file", "file", fullPath)
+	}
+
+	sourceDir := filepath.Join(dir, "docs")
+	targetFile := filepath.Join(dir, "target.tar.gz")
+
+	if err := CreateArchive(t.Context(), "tar", sourceDir, targetFile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use tar again to find out what's in the archive...
+	output, err := command.Output(t.Context(), "tar", "tzf", targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotFiles := strings.Split(strings.TrimSpace(output), "\n")
+	slices.Sort(gotFiles)
+	wantFiles := []string{
+		"./",
+		"a.txt",
+		"readme.txt",
+		"subdir/",
+		"subdir/a.txt",
+	}
+	if diff := cmp.Diff(wantFiles, gotFiles); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCreateArchive_Error(t *testing.T) {
+	testhelper.RequireCommand(t, "tar")
+	testhelper.RequireCommand(t, "echo")
+	dir := t.TempDir()
+	t.Parallel()
+
+	for _, test := range []struct {
+		name       string
+		tarExe     string
+		sourceDir  string
+		targetFile string
+		wantErr    error
+	}{
+		{
+			name:       "tar error",
+			tarExe:     "tar",
+			sourceDir:  dir,
+			targetFile: "/",
+			wantErr:    errTarFailure,
+		},
+		{
+			name:       "tar success but with unexpected output",
+			tarExe:     "echo",
+			sourceDir:  dir,
+			targetFile: "/",
+			wantErr:    errTarUnexpectedOutput,
+		}} {
+		t.Run(test.name, func(t *testing.T) {
+			gotErr := CreateArchive(t.Context(), test.tarExe, test.sourceDir, test.targetFile)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("CreateArchive(%q, %q, %q) error = %v, wantErr %v", test.tarExe, test.sourceDir, test.targetFile, gotErr, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/docuploader/metadata.go
+++ b/internal/docuploader/metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/docuploader/metadata_test.go
+++ b/internal/docuploader/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This just calls tar to create an archive. (This is simpler than writing the code directly in go, and we expect to have tar present.)

Towards #3980