### PR TITLE
refactor(librarianops): isolate github logic to shared file

### DIFF
--- a/internal/librarianops/generate.go
+++ b/internal/librarianops/generate.go
@@ -163,9 +163,9 @@ func createGithubDetails(repoName string) GithubDetails {
 	body := fmt.Sprintf(`
 Update %s to the latest commit and regenerate all client libraries.`, sources)
 	return GithubDetails{
-		prTitle:    title,
-		prBody:     body,
-		branchName: branchPrefix,
+		PrTitle:    title,
+		PrBody:     body,
+		BranchName: generateBranchName(branchPrefix, time.Now()),
 	}
 }
 

--- a/internal/librarianops/github_utils.go
+++ b/internal/librarianops/github_utils.go
@@ -24,10 +24,10 @@ import (
 
 // uploadToGithub creates a branch, commits changes, pushes the changes, and creates a PR with the given details.
 func uploadToGithub(ctx context.Context, githubDetails GithubDetails) error {
-	if err := createBranch(ctx, githubDetails.branchName); err != nil {
+	if err := createBranch(ctx, githubDetails.BranchName); err != nil {
 		return err
 	}
-	if err := commitChanges(ctx, githubDetails.prTitle); err != nil {
+	if err := commitChanges(ctx, githubDetails.PrTitle); err != nil {
 		return err
 	}
 	if err := pushChanges(ctx); err != nil {
@@ -64,11 +64,11 @@ func pushChanges(ctx context.Context) error {
 
 // GithubDetails contains the details for the github changes to be made.
 type GithubDetails struct {
-	prTitle    string
-	prBody     string
-	branchName string
+	PrTitle    string
+	PrBody     string
+	BranchName string
 }
 
 func createPR(ctx context.Context, githubDetails GithubDetails) error {
-	return command.Run(ctx, "gh", "pr", "create", "--title", githubDetails.prTitle, "--body", githubDetails.prBody)
+	return command.Run(ctx, "gh", "pr", "create", "--title", githubDetails.PrTitle, "--body", githubDetails.PrBody)
 }

--- a/internal/librarianops/github_utils_test.go
+++ b/internal/librarianops/github_utils_test.go
@@ -39,9 +39,9 @@ func TestUploadToGithub(t *testing.T) {
 		{
 			name: "standard success",
 			details: GithubDetails{
-				prTitle:    wantTitle,
-				prBody:     wantBody,
-				branchName: wantBranch,
+				PrTitle:    wantTitle,
+				PrBody:     wantBody,
+				BranchName: wantBranch,
 			},
 			wantCmds: [][]string{
 				{"git", "checkout", "-b", wantBranch},
@@ -55,11 +55,11 @@ func TestUploadToGithub(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mocker := &command.MockCommander{
 				MockResults: map[string]command.MockResult{
-					command.FormatCmd("git", "checkout", "-b", tc.details.branchName):                                   {},
+					command.FormatCmd("git", "checkout", "-b", tc.details.BranchName):                                   {},
 					command.FormatCmd("git", "add", "."):                                                                {},
-					command.FormatCmd("git", "commit", "-m", tc.details.prTitle):                                        {},
+					command.FormatCmd("git", "commit", "-m", tc.details.PrTitle):                                        {},
 					command.FormatCmd("git", "push", "-u", "origin", "HEAD"):                                            {},
-					command.FormatCmd("gh", "pr", "create", "--title", tc.details.prTitle, "--body", tc.details.prBody): {},
+					command.FormatCmd("gh", "pr", "create", "--title", tc.details.PrTitle, "--body", tc.details.PrBody): {},
 				},
 			}
 			ctx := mocker.InjectContext(t.Context())
@@ -134,7 +134,7 @@ func TestUploadToGithub_Error(t *testing.T) {
 			mocker := &command.MockCommander{MockResults: tc.mockResults}
 			ctx := mocker.InjectContext(t.Context())
 
-			err := uploadToGithub(ctx, GithubDetails{prTitle: title, branchName: branch})
+			err := uploadToGithub(ctx, GithubDetails{PrTitle: title, BranchName: branch})
 
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -356,7 +356,7 @@ func TestCreatePR(t *testing.T) {
 	}{
 		{
 			name:    "minimal pr",
-			details: GithubDetails{prTitle: "T", prBody: "B"},
+			details: GithubDetails{PrTitle: "T", PrBody: "B"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -367,7 +367,7 @@ func TestCreatePR(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			want := [][]string{{"gh", "pr", "create", "--title", tc.details.prTitle, "--body", tc.details.prBody}}
+			want := [][]string{{"gh", "pr", "create", "--title", tc.details.PrTitle, "--body", tc.details.PrBody}}
 			if diff := cmp.Diff(want, mocker.GotCommands); diff != "" {
 				t.Errorf("command mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
refactor: isolate github logic to shared file

Moves GitHub-specific logic from generate.go to a new github_utils.go file. This refactor generalizes the functions to make them reusable across the codebase.

Also created a high-level helper for uploading changes, function will be used in next PR by upgrade command. Generate command will be refactored to use that function.