### PR TITLE
feat(sidekick): expand heuristic vocabulary by learning from standard methods

### DIFF
--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -83,7 +83,7 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 				continue
 			}
 			for _, binding := range method.PathInfo.Bindings {
-				extractLiteralsFromPath(binding.PathTemplate, vocab)
+				vocab = extractLiteralsFromPath(binding.PathTemplate, vocab)
 			}
 		}
 	}
@@ -92,9 +92,9 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 
 // extractLiteralsFromPath parses a path template and adds any string literals
 // (both top-level and nested inside variables) to the provided vocabulary set.
-func extractLiteralsFromPath(tmpl *PathTemplate, vocab map[string]bool) {
+func extractLiteralsFromPath(tmpl *PathTemplate, vocab map[string]bool) map[string]bool {
 	if tmpl == nil {
-		return
+		return vocab
 	}
 	for _, seg := range tmpl.Segments {
 		// Add regular literals (e.g. /projects/...)
@@ -110,4 +110,5 @@ func extractLiteralsFromPath(tmpl *PathTemplate, vocab map[string]bool) {
 			}
 		}
 	}
+	return vocab
 }

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -63,16 +63,6 @@ func isCollectionIdentifier(segment string, vocabulary map[string]bool) bool {
 	return false
 }
 
-// isStandardMethod returns true if the method name indicates a standard
-// RESTful operation as per AIP guidelines.
-func isStandardMethod(name string) bool {
-	return strings.HasPrefix(name, "Get") ||
-		strings.HasPrefix(name, "List") ||
-		strings.HasPrefix(name, "Create") ||
-		strings.HasPrefix(name, "Update") ||
-		strings.HasPrefix(name, "Delete")
-}
-
 // BuildHeuristicVocabulary collects known resource target names from the model.
 // It learns from both explicit ResourceDefinitions and by analyzing the
 // HTTP path templates of standard methods.
@@ -89,7 +79,7 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 	// 2. Discover from standard method paths
 	for _, service := range model.Services {
 		for _, method := range service.Methods {
-			if !isStandardMethod(method.Name) || method.PathInfo == nil {
+			if !method.IsAIPStandard() || method.PathInfo == nil {
 				continue
 			}
 			for _, binding := range method.PathInfo.Bindings {

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -174,6 +174,22 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 					Methods: []*Method{
 						{
 							Name: "ListWidgets",
+							InputType: &Message{
+								Name: "ListWidgetsRequest",
+								Fields: []*Field{
+									{Name: "parent", ResourceReference: &ResourceReference{Type: "*"}},
+								},
+							},
+							OutputType: &Message{
+								Name: "ListWidgetsResponse",
+								Pagination: &PaginationInfo{
+									PageableItem: &Field{
+										MessageType: &Message{
+											Resource: &Resource{Type: "example.com/Widget"},
+										},
+									},
+								},
+							},
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
@@ -220,6 +236,16 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 					Methods: []*Method{
 						{
 							Name: "GetItem",
+							InputType: &Message{
+								Name: "GetItemRequest",
+								Fields: []*Field{
+									{Name: "name", ResourceReference: &ResourceReference{Type: "*"}},
+								},
+							},
+							OutputType: &Message{
+								Name:     "Item",
+								Resource: &Resource{Type: "example.com/Item", Singular: "item"},
+							},
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
@@ -242,6 +268,16 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 					Methods: []*Method{
 						{
 							Name: "GetInstance",
+							InputType: &Message{
+								Name: "GetInstanceRequest",
+								Fields: []*Field{
+									{Name: "name", ResourceReference: &ResourceReference{Type: "*"}},
+								},
+							},
+							OutputType: &Message{
+								Name:     "Instance",
+								Resource: &Resource{Type: "example.com/Instance", Singular: "instance"},
+							},
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
@@ -269,6 +305,14 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 			model := &API{
 				ResourceDefinitions: test.resources,
 				Services:            test.services,
+				State: &APIState{
+					ResourceByType: make(map[string]*Resource),
+				},
+			}
+			for _, svc := range model.Services {
+				for _, m := range svc.Methods {
+					m.Model = model
+				}
 			}
 			got := BuildHeuristicVocabulary(model)
 			if diff := cmp.Diff(test.want, got); diff != "" {

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -145,10 +145,11 @@ func TestIsCollectionIdentifier(t *testing.T) {
 	}
 }
 
-func TestBuildKnownPlurals(t *testing.T) {
+func TestBuildHeuristicVocabulary(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		resources []*Resource
+		services  []*Service
 		want      map[string]bool
 	}{
 		{
@@ -167,6 +168,99 @@ func TestBuildKnownPlurals(t *testing.T) {
 			want: map[string]bool{"items": true, "elements": true},
 		},
 		{
+			name: "from standard method path",
+			services: []*Service{
+				{
+					Methods: []*Method{
+						{
+							Name: "ListWidgets",
+							PathInfo: &PathInfo{
+								Bindings: []*PathBinding{
+									{
+										PathTemplate: NewPathTemplate().
+											WithLiteral("users").WithVariableNamed("user").
+											WithLiteral("widgets").WithVariableNamed("widget"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]bool{"users": true, "widgets": true},
+		},
+		{
+			name: "ignores non-standard method path",
+			services: []*Service{
+				{
+					Methods: []*Method{
+						{
+							Name: "ProcessData", // Not standard
+							PathInfo: &PathInfo{
+								Bindings: []*PathBinding{
+									{
+										PathTemplate: NewPathTemplate().
+											WithLiteral("internal").WithVariableNamed("id"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "combined resources and paths",
+			resources: []*Resource{
+				{Plural: "items"},
+			},
+			services: []*Service{
+				{
+					Methods: []*Method{
+						{
+							Name: "GetItem",
+							PathInfo: &PathInfo{
+								Bindings: []*PathBinding{
+									{
+										PathTemplate: NewPathTemplate().
+											WithLiteral("users").WithVariableNamed("user").
+											WithLiteral("items").WithVariableNamed("item"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]bool{"items": true, "users": true},
+		},
+		{
+			name: "from nested variable template (e.g. {name=projects/*/instances/*})",
+			services: []*Service{
+				{
+					Methods: []*Method{
+						{
+							Name: "GetInstance",
+							PathInfo: &PathInfo{
+								Bindings: []*PathBinding{
+									{
+										PathTemplate: NewPathTemplate().
+											WithLiteral("v1").
+											WithVariable(&PathVariable{
+												FieldPath: []string{"name"},
+												Segments:  []string{"projects", SingleSegmentWildcard, "instances", MultiSegmentWildcard},
+											}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]bool{"v1": true, "projects": true, "instances": true},
+		},
+		{
 			name: "empty model",
 			want: map[string]bool{},
 		},
@@ -174,10 +268,11 @@ func TestBuildKnownPlurals(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			model := &API{
 				ResourceDefinitions: test.resources,
+				Services:            test.services,
 			}
-			got := BuildKnownPlurals(model)
+			got := BuildHeuristicVocabulary(model)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("BuildKnownPlurals() mismatch (-want +got):\n%s", diff)
+				t.Errorf("BuildHeuristicVocabulary() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Implement the **Learning Phase** for the resource name heuristic. 

Previously, the heuristic vocabulary was built around `model.ResourceDefinitions`. If an API completely lacks `google.api.resource` annotations, the heuristic would not identify any collections, failing back to the base vocabulary (`projects`, `locations`, etc).

Now we can dynamically discover valid resource target names purely by analyzing the standard HTTP paths of an API.

Fixes #4162 