### PR TITLE
chore: add python to allow-list for google/devtools/clouderrorreporting/v1beta1

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1287,6 +1287,7 @@
 - path: google/devtools/clouderrorreporting/v1beta1
   languages:
     - go
+    - python
 - path: google/devtools/cloudprofiler/v2
 - path: google/devtools/cloudtrace/v1
   title: Cloud Trace API


### PR DESCRIPTION
While anything under google/cloud is implicitly allow-listed, anything else needs to be in sdk.yaml.