### PR TITLE
feat(python): add overrides for repo metadata fields

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -155,6 +155,8 @@ This document describes the schema for the librarian.yaml.
 | `opt_args` | list of string | OptArgs contains additional options passed to the generator, where the options are common to all apis. Example: ["warehouse-package-name=google-cloud-batch"] |
 | `opt_args_by_api` | map[string][]string | OptArgsByAPI contains additional options passed to the generator, where the options vary by api. In each entry, the key is the api (API path) and the value is the list of options to pass when generating that API. Example: {"google/cloud/secrets/v1beta": ["python-gapic-name=secretmanager"]} |
 | `proto_only_apis` | list of string | ProtoOnlyAPIs contains the list of API paths which are proto-only, so should use regular protoc Python generation instead of GAPIC. |
+| `name_pretty_override` | string | NamePrettyOverride allows the "name_pretty" field in .repo-metadata.json to be overridden, to reduce diffs while migrating. TODO(https://github.com/googleapis/librarian/issues/4175): remove this field. |
+| `product_documentation_override` | string | ProductDocumentationOverride allows the "product_documentation" field in .repo-metadata.json to be overridden, to reduce diffs while migrating. TODO(https://github.com/googleapis/librarian/issues/4175): remove this field. |
 
 ## RustCrate Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -311,6 +311,18 @@ type PythonPackage struct {
 	// ProtoOnlyAPIs contains the list of API paths which are proto-only, so
 	// should use regular protoc Python generation instead of GAPIC.
 	ProtoOnlyAPIs []string `yaml:"proto_only_apis,omitempty"`
+
+	// NamePrettyOverride allows the "name_pretty" field in .repo-metadata.json
+	// to be overridden, to reduce diffs while migrating.
+	// TODO(https://github.com/googleapis/librarian/issues/4175): remove this
+	// field.
+	NamePrettyOverride string `yaml:"name_pretty_override,omitempty"`
+
+	// ProductDocumentationOverride allows the "product_documentation" field in
+	// .repo-metadata.json to be overridden, to reduce diffs while migrating.
+	// TODO(https://github.com/googleapis/librarian/issues/4175): remove this
+	// field.
+	ProductDocumentationOverride string `yaml:"product_documentation_override,omitempty"`
 }
 
 // PythonDefault contains Python-specific default configuration.

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -194,6 +194,8 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 							},
 						},
 						Python: &config.PythonPackage{
+							ProductDocumentationOverride: "https://cloud.google.com/secret-manager/",
+							NamePrettyOverride:           "Secret Manager",
 							OptArgsByAPI: map[string][]string{
 								"google/cloud/secretmanager/v1": {"warehouse-package-name=google-cloud-secret-manager"},
 							},

--- a/tool/cmd/migrate/python_test.go
+++ b/tool/cmd/migrate/python_test.go
@@ -59,6 +59,8 @@ func TestBuildPythonLibraries(t *testing.T) {
 						"docs/CHANGELOG.md",
 					},
 					Python: &config.PythonPackage{
+						NamePrettyOverride:           "Secret Manager",
+						ProductDocumentationOverride: "https://cloud.google.com/secret-manager/",
 						OptArgsByAPI: map[string][]string{
 							"google/cloud/secretmanager/v1": {"warehouse-package-name=google-cloud-secret-manager"},
 						},
@@ -112,7 +114,9 @@ func TestBuildPythonLibraries(t *testing.T) {
 					APIs:         []*config.API{{Path: "google/cloud/audit"}},
 					ReleaseLevel: "preview",
 					Python: &config.PythonPackage{
-						ProtoOnlyAPIs: []string{"google/cloud/audit"},
+						NamePrettyOverride:           "Audit Log API",
+						ProductDocumentationOverride: "https://cloud.google.com/logging/docs/audit",
+						ProtoOnlyAPIs:                []string{"google/cloud/audit"},
 					},
 				},
 				{
@@ -148,6 +152,8 @@ func TestBuildPythonLibraries(t *testing.T) {
 					},
 					DescriptionOverride: "The Cloud Billing Budget API stores Cloud Billing budgets, which define a budget plan and the rules to execute as spend is tracked against that plan.",
 					Python: &config.PythonPackage{
+						NamePrettyOverride:           "Cloud Billing Budget",
+						ProductDocumentationOverride: "https://cloud.google.com/billing/docs/how-to/budget-api-overview",
 						OptArgsByAPI: map[string][]string{
 							"google/cloud/billing/budgets/v1":      {"transport=grpc+rest"},
 							"google/cloud/billing/budgets/v1beta1": {"transport=grpc"},
@@ -180,6 +186,8 @@ func TestBuildPythonLibraries(t *testing.T) {
 					},
 					DescriptionOverride: "Manage BigQuery connections to external data sources.",
 					Python: &config.PythonPackage{
+						NamePrettyOverride:           "BigQuery Connection",
+						ProductDocumentationOverride: "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
 						OptArgsByAPI: map[string][]string{
 							"google/cloud/bigquery/connection/v1": {
 								"python-gapic-namespace=google.cloud",

--- a/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-workstations/.repo-metadata.json
+++ b/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-workstations/.repo-metadata.json
@@ -9,8 +9,8 @@
   "language": "python",
   "library_type": "GAPIC_AUTO",
   "name": "workstations",
-  "name_pretty": "Cloud Workstations",
-  "product_documentation": "https://cloud.google.com/workstations/",
+  "name_pretty": "",
+  "product_documentation": "",
   "release_level": "preview",
   "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
Allows the Python-specific configuration for a library to override fields in repo metadata, expected to be on a temporary basis. Both name_pretty and product_documentation in .repo-metadata.json can affect other files - particularly generated documentation - as the post-processor reads the JSON file.

While we're preparing for migration, we'd like to minimize the diffs between the results of current generation and librarian generation as much as possible. After migration has been completed, we should see whether the override values in the configuration are worth keeping (in which case they should probably be propagated to sdk.yaml) or can be discarded. In either case, the override fields themselves should be removed. This is tracked in #4175.

This change:
- Adds the fields
- Sets them during migration
- Uses them during generation