### PR TITLE
feat(sidekick): construct resource name template

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -1531,4 +1531,8 @@ type TargetResource struct {
 	// FieldPaths is a list of field name sequences that, when joined, form a resource name.
 	// For example, [["project"], ["zone"], ["instance"]] identifies a multi-part resource.
 	FieldPaths [][]string
+
+	// Template is the canonical HTTP path template for the resource.
+	// Example: "//compute.googleapis.com/projects/{project}/locations/{location}"
+	Template string
 }


### PR DESCRIPTION
Implement the generation phase for resource naming, enabling downstream language generators to receive a canonical resource name `Template` alongside `FieldPaths`.

Note:
* `FieldPaths`: used to fetch the variable values from the user's request object.
* `Template`: used to arrange variable values into the final URL. 

This PR handles both two key tasks:
1. Construct the full resource path
2. Handle exploded vs full name variables (this actually did not require special handling).

Fixes #4172 
Fixes #4173 