### PR TITLE
cleanup(rust): remove duplicate error check

### DIFF
--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -102,9 +102,6 @@ func TestAnnotateDiscoveryAnnotations(t *testing.T) {
 	codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{
 		"include-grpc-only-methods": "true",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	_, err = annotateModel(model, codec)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Clean up a minor syntax issue where an `err` variable was being checked twice.