### PR TITLE
fix(sidekick): correct heuristic template indexing

### DIFF
--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -83,6 +83,7 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 	}
 
 	var fieldPaths [][]string
+	var firstIndex = -1
 	var lastIndex int
 	segments := binding.PathTemplate.Segments
 
@@ -108,6 +109,9 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 		if err != nil {
 			return nil, err
 		}
+		if firstIndex == -1 {
+			firstIndex = i - 1
+		}
 		fieldPaths = append(fieldPaths, fieldPath)
 		lastIndex = i + 1
 	}
@@ -116,7 +120,7 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 		return nil, nil
 	}
 
-	template, err := constructTemplate(method, segments[:lastIndex])
+	template, err := constructTemplate(method, segments[firstIndex:lastIndex])
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -211,6 +211,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 			name:      "heuristic: compute instance",
 			serviceID: ".google.cloud.compute.v1.Instances", // eligible
 			path: NewPathTemplate().
+				WithLiteral("compute").WithLiteral("v1").
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("zones").WithVariableNamed("zone").
 				WithLiteral("instances").WithVariableNamed("instance"),


### PR DESCRIPTION
When generating the `Template` for resource names, the parser was incorrectly capturing preceding elements in the HTTP URL (e.g., `/v1`). 

Adding `firstIndex` tracking allows the parser to identify when the valid `collection/id` chain begin.

The next PRs will add the necessary blocks in `transport.rs.mustache`. The generated Rust snippets should look like something below:
```
#[cfg(google_cloud_unstable_resource_name)]
let options = if let Some(resource_name) = (|| {
    Some(format!(
        "//compute.googleapis.com/projects/{}/zones/{}/acceleratorTypes/{}",
        Some(&req)
            .map(|m| &m.project)
            .map(|s| s.as_str())
            .filter(|s| !s.is_empty())?,
        Some(&req)
            .map(|m| &m.zone)
            .map(|s| s.as_str())
            .filter(|s| !s.is_empty())?,
        Some(&req)
            .map(|m| &m.accelerator_type)
            .map(|s| s.as_str())
            .filter(|s| !s.is_empty())?,
    ))
})() {
    use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
    options.insert_extension(ResourceName(resource_name))
} else {
    options
};
```
Staged at: https://github.com/googleapis/google-cloud-rust/pull/4826

For #4018 