### PR TITLE
refactor(sidekick): Simplify sample info representation

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -312,18 +312,20 @@ type Method struct {
 	IsStreaming bool
 	// IsAIPStandard is true if the method is one of the AIP standard methods.
 	IsAIPStandard bool
-	// AIPStandardGetInfo contains information relevant to get operations.
-	AIPStandardGetInfo *AIPStandardGetInfo
-	// AIPStandardDeleteInfo contains information relevant to delete operations.
-	AIPStandardDeleteInfo *AIPStandardDeleteInfo
-	// AIPStandardUndeleteInfo contains information relevant to undelete operations.
-	AIPStandardUndeleteInfo *AIPStandardUndeleteInfo
-	// AIPStandardCreateInfo contains information relevant to create operations.
-	AIPStandardCreateInfo *AIPStandardCreateInfo
-	// AIPStandardUpdateInfo contains information relevant to update operations.
-	AIPStandardUpdateInfo *AIPStandardUpdateInfo
-	// AIPStandardListInfo contains information relevant to list operations.
-	AIPStandardListInfo *AIPStandardListInfo
+	// IsAIPStandardGet is true if the method is an AIP standard get method.
+	IsAIPStandardGet bool
+	// IsAIPStandardDelete is true if the method is an AIP standard delete method.
+	IsAIPStandardDelete bool
+	// IsAIPStandardUndelete is true if the method is an AIP standard undelete method.
+	IsAIPStandardUndelete bool
+	// IsAIPStandardCreate is true if the method is an AIP standard create method.
+	IsAIPStandardCreate bool
+	// IsAIPStandardUpdate is true if the method is an AIP standard update method.
+	IsAIPStandardUpdate bool
+	// IsAIPStandardList is true if the method is an AIP standard list method.
+	IsAIPStandardList bool
+	// AIPStandardSampleInfo contains sample generation information for AIP standard methods.
+	AIPStandardSampleInfo *AIPStandardSampleInfo
 	// Codec contains language specific annotations.
 	Codec any
 }
@@ -412,60 +414,34 @@ func (m *Method) HasAutoPopulatedFields() bool {
 	return len(m.AutoPopulated) != 0
 }
 
-// AIPStandardGetInfo contains information relevant to get operations
-// that are like those defined by AIP-131.
-type AIPStandardGetInfo struct {
-	// ResourceNameRequestField is the field in the method input that contains the resource name
-	// of the resource that the get operation should fetch.
-	ResourceNameRequestField *Field
+// AIPStandardSampleInfo contains information for generating samples for AIP standard methods.
+type AIPStandardSampleInfo struct {
+	// SampleFunctionParameters is a list of string argument names that the generated sample function requires.
+	SampleFunctionParameters []string
+	// InitFieldsFromParameter contains fields that should be initialized from a sample function parameter.
+	InitFieldsFromParameter []*SampleParameterInit
+	// InitFieldsFromStringLiteral contains fields that should be initialized with a string literal.
+	InitFieldsFromStringLiteral []*Field
+	// InitFieldsFromMessage contains fields that should be initialized with a new message instance.
+	InitFieldsFromMessage []*SampleMessageInit
+	// UpdateMaskField is the update mask field, if any, that needs to be initialized.
+	UpdateMaskField *Field
 }
 
-// AIPStandardDeleteInfo contains information relevant to delete operations
-// that are like those defined by AIP-135.
-type AIPStandardDeleteInfo struct {
-	// ResourceNameRequestField is the field in the method input that contains the resource name
-	// of the resource that the delete operation should delete.
-	ResourceNameRequestField *Field
+// SampleParameterInit describes a field that should be initialized from a parameter.
+type SampleParameterInit struct {
+	// Field is the field to be initialized.
+	Field *Field
+	// ParameterName is the name of the parameter to use.
+	ParameterName string
 }
 
-// AIPStandardUndeleteInfo contains information relevant to an undelete operation
-// as implied by AIP-135.
-type AIPStandardUndeleteInfo struct {
-	// ResourceNameRequestField is the field in the method input that contains the resource name
-	// of the resource that the undelete operation should restore.
-	ResourceNameRequestField *Field
-}
-
-// AIPStandardCreateInfo contains information relevant to create operations
-// that are like those defined by AIP-133.
-type AIPStandardCreateInfo struct {
-	// ParentRequestField is the field in the method input that contains the parent resource name
-	// where the resource is to be created.
-	ParentRequestField *Field
-	// ResourceIDRequestField is the field in the method input that contains the resource ID
-	// for the resource to be created. This field is optional in the AIP.
-	ResourceIDRequestField *Field
-	// ResourceRequestField is the field in the method input that contains the resource
-	// to be created.
-	ResourceRequestField *Field
-}
-
-// AIPStandardUpdateInfo contains information relevant to update operations
-// that are like those defined by AIP-134.
-type AIPStandardUpdateInfo struct {
-	// ResourceRequestField is the field in the method input that contains the resource
-	// to be updated.
-	ResourceRequestField *Field
-	// UpdateMaskRequestField is the field in the method input that contains the update mask.
-	UpdateMaskRequestField *Field
-}
-
-// AIPStandardListInfo contains information relevant to list operations
-// that are like those defined by AIP-132.
-type AIPStandardListInfo struct {
-	// ParentRequestField is the field in the method input that contains the parent resource name
-	// of the resources that the list operation should fetch.
-	ParentRequestField *Field
+// SampleMessageInit describes a field that should be initialized with a message.
+type SampleMessageInit struct {
+	// Field is the field to be initialized.
+	Field *Field
+	// ParameterName is the name of the parameter to set as the "name" field of the message, if any.
+	ParameterName string
 }
 
 const (

--- a/internal/sidekick/api/skip_test.go
+++ b/internal/sidekick/api/skip_test.go
@@ -301,6 +301,30 @@ func TestIncludeNestedMessages(t *testing.T) {
 	}
 }
 
+var methodIgnoreFields = []string{
+	"Model",
+	"Service",
+	"SourceService",
+	"InputType",
+	"OutputType",
+	"InputTypeID",
+	"OutputTypeID",
+	"IsSimple",
+	"IsLRO",
+	"LongRunningResponseType",
+	"LongRunningReturnsEmpty",
+	"IsList",
+	"IsStreaming",
+	"IsAIPStandard",
+	"IsAIPStandardGet",
+	"IsAIPStandardDelete",
+	"IsAIPStandardUndelete",
+	"IsAIPStandardCreate",
+	"IsAIPStandardUpdate",
+	"IsAIPStandardList",
+	"AIPStandardSampleInfo",
+}
+
 func TestIncludeMethods(t *testing.T) {
 	m := &Message{
 		Name: "Empty",
@@ -362,7 +386,7 @@ func TestIncludeMethods(t *testing.T) {
 			ID:   ".test.Service1.Method2",
 		},
 	}
-	if diff := cmp.Diff(wantMethods, s1.Methods, cmpopts.IgnoreFields(Method{}, "Model", "Service", "SourceService", "InputType", "OutputType", "InputTypeID", "OutputTypeID", "IsSimple", "IsLRO", "LongRunningResponseType", "LongRunningReturnsEmpty", "IsList", "IsStreaming", "IsAIPStandard", "AIPStandardGetInfo", "AIPStandardDeleteInfo", "AIPStandardUndeleteInfo", "AIPStandardCreateInfo", "AIPStandardUpdateInfo", "AIPStandardListInfo")); diff != "" {
+	if diff := cmp.Diff(wantMethods, s1.Methods, cmpopts.IgnoreFields(Method{}, methodIgnoreFields...)); diff != "" {
 		t.Errorf("mismatch in methods (-want, +got)\n:%s", diff)
 	}
 }

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -790,7 +790,7 @@ func TestAIPStandardGetInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardGetInfo
+		want   *AIPStandardSampleInfo
 	}{
 		{
 			name: "valid get operation with wildcard resource reference",
@@ -800,8 +800,11 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				OutputType: output,
 				Model:      f.model,
 			},
-			want: &AIPStandardGetInfo{
-				ResourceNameRequestField: f.wildcardResourceField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.wildcardResourceField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -812,8 +815,11 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				OutputType: output,
 				Model:      f.model,
 			},
-			want: &AIPStandardGetInfo{
-				ResourceNameRequestField: f.resourceNameField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -826,8 +832,11 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardGetInfo{
-				ResourceNameRequestField: f.resourceNameNoSingularField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameNoSingularField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -942,9 +951,9 @@ func TestAIPStandardGetInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardGetInfo
+			got := tc.method.AIPStandardSampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardGetInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -956,7 +965,7 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardDeleteInfo
+		want   *AIPStandardSampleInfo
 	}{
 		{
 			name: "valid simple delete with wildcard resource reference",
@@ -966,8 +975,11 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardDeleteInfo{
-				ResourceNameRequestField: f.wildcardResourceField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.wildcardResourceField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -978,8 +990,11 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardDeleteInfo{
-				ResourceNameRequestField: f.resourceNameField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -990,8 +1005,11 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardDeleteInfo{
-				ResourceNameRequestField: f.resourceNameNoSingularField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameNoSingularField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1002,8 +1020,11 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				OperationInfo: &OperationInfo{},
 				Model:         f.model,
 			},
-			want: &AIPStandardDeleteInfo{
-				ResourceNameRequestField: f.resourceNameField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1014,8 +1035,11 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardDeleteInfo{
-				ResourceNameRequestField: f.resourceOtherNameField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceOtherNameField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1070,9 +1094,9 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardDeleteInfo
+			got := tc.method.AIPStandardSampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardDeleteInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1084,7 +1108,7 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardUndeleteInfo
+		want   *AIPStandardSampleInfo
 	}{
 		{
 			name: "valid simple undelete with wildcard resource reference",
@@ -1096,8 +1120,11 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardUndeleteInfo{
-				ResourceNameRequestField: f.wildcardResourceField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.wildcardResourceField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1110,8 +1137,11 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardUndeleteInfo{
-				ResourceNameRequestField: f.resourceNameField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1124,8 +1154,11 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardUndeleteInfo{
-				ResourceNameRequestField: f.resourceNameNoSingularField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameNoSingularField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1136,8 +1169,11 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				OperationInfo: &OperationInfo{},
 				Model:         f.model,
 			},
-			want: &AIPStandardUndeleteInfo{
-				ResourceNameRequestField: f.resourceNameField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceNameField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1150,8 +1186,11 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardUndeleteInfo{
-				ResourceNameRequestField: f.resourceOtherNameField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"resource_name"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: f.resourceOtherNameField, ParameterName: "resource_name"},
+				},
 			},
 		},
 		{
@@ -1206,9 +1245,9 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardUndeleteInfo
+			got := tc.method.AIPStandardSampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardUndeleteInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1239,7 +1278,7 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardCreateInfo
+		want   *AIPStandardSampleInfo
 	}{
 		{
 			name: "valid create operation",
@@ -1256,10 +1295,15 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardCreateInfo{
-				ParentRequestField:     parentField,
-				ResourceIDRequestField: idField,
-				ResourceRequestField:   resourceField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"parent"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: parentField, ParameterName: "parent"},
+				},
+				InitFieldsFromStringLiteral: []*Field{idField},
+				InitFieldsFromMessage: []*SampleMessageInit{
+					{Field: resourceField},
+				},
 			},
 		},
 		{
@@ -1276,9 +1320,14 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardCreateInfo{
-				ParentRequestField:   parentField,
-				ResourceRequestField: resourceField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"parent"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: parentField, ParameterName: "parent"},
+				},
+				InitFieldsFromMessage: []*SampleMessageInit{
+					{Field: resourceField},
+				},
 			},
 		},
 		{
@@ -1302,9 +1351,9 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardCreateInfo
+			got := tc.method.AIPStandardSampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardCreateInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1330,7 +1379,7 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardUpdateInfo
+		want   *AIPStandardSampleInfo
 	}{
 		{
 			name: "valid update operation",
@@ -1346,9 +1395,12 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardUpdateInfo{
-				ResourceRequestField:   resourceField,
-				UpdateMaskRequestField: updateMaskField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"name"},
+				InitFieldsFromMessage: []*SampleMessageInit{
+					{Field: resourceField, ParameterName: "name"},
+				},
+				UpdateMaskField: updateMaskField,
 			},
 		},
 		{
@@ -1364,8 +1416,11 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardUpdateInfo{
-				ResourceRequestField: resourceField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"name"},
+				InitFieldsFromMessage: []*SampleMessageInit{
+					{Field: resourceField, ParameterName: "name"},
+				},
 			},
 		},
 		{
@@ -1418,9 +1473,9 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardUpdateInfo
+			got := tc.method.AIPStandardSampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardUpdateInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1456,7 +1511,7 @@ func TestAIPStandardListInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardListInfo
+		want   *AIPStandardSampleInfo
 	}{
 		{
 			name: "valid list operation with parent field match by child_type",
@@ -1466,8 +1521,11 @@ func TestAIPStandardListInfo(t *testing.T) {
 				OutputType: listOutput,
 				Model:      f.model,
 			},
-			want: &AIPStandardListInfo{
-				ParentRequestField: parentField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"parent"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: parentField, ParameterName: "parent"},
+				},
 			},
 		},
 		{
@@ -1478,8 +1536,11 @@ func TestAIPStandardListInfo(t *testing.T) {
 				OutputType: listOutput,
 				Model:      f.model,
 			},
-			want: &AIPStandardListInfo{
-				ParentRequestField: otherParentField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"parent"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: otherParentField, ParameterName: "parent"},
+				},
 			},
 		},
 		{
@@ -1490,8 +1551,11 @@ func TestAIPStandardListInfo(t *testing.T) {
 				OutputType: listOutput,
 				Model:      f.model,
 			},
-			want: &AIPStandardListInfo{
-				ParentRequestField: plainParentField,
+			want: &AIPStandardSampleInfo{
+				SampleFunctionParameters: []string{"parent"},
+				InitFieldsFromParameter: []*SampleParameterInit{
+					{Field: plainParentField, ParameterName: "parent"},
+				},
 			},
 		},
 		{
@@ -1549,9 +1613,9 @@ func TestAIPStandardListInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardListInfo
+			got := tc.method.AIPStandardSampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardListInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
@@ -13,32 +13,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{#AIPStandardGetInfo}}
-///         .set_{{ResourceNameRequestField.Codec.SetterName}}(resource_name)
-{{/AIPStandardGetInfo}}
-{{#AIPStandardDeleteInfo}}
-///         .set_{{ResourceNameRequestField.Codec.SetterName}}(resource_name)
-{{/AIPStandardDeleteInfo}}
-{{#AIPStandardUndeleteInfo}}
-///         .set_{{ResourceNameRequestField.Codec.SetterName}}(resource_name)
-{{/AIPStandardUndeleteInfo}}
-{{#AIPStandardCreateInfo}}
-///         .set_{{ParentRequestField.Codec.SetterName}}(parent){{#ResourceIDRequestField}}.set_{{Codec.SetterName}}("{{Codec.SetterName}}_value"){{/ResourceIDRequestField}}
-///         .set_{{ResourceRequestField.Codec.SetterName}}(
-///             {{ResourceRequestField.MessageType.Codec.Name}}::new()/* set fields */
+{{#IsAIPStandard}}
+{{#AIPStandardSampleInfo}}
+{{#InitFieldsFromParameter}}
+///         .set_{{Field.Codec.SetterName}}({{ParameterName}})
+{{/InitFieldsFromParameter}}
+{{#InitFieldsFromStringLiteral}}
+///         .set_{{Codec.SetterName}}("{{Codec.SetterName}}_value")
+{{/InitFieldsFromStringLiteral}}
+{{#InitFieldsFromMessage}}
+///         .set_{{Field.Codec.SetterName}}(
+///             {{Field.MessageType.Codec.Name}}::new(){{#ParameterName}}.set_name({{ParameterName}}){{/ParameterName}}/* set fields */
 ///         )
-{{/AIPStandardCreateInfo}}
-{{#AIPStandardUpdateInfo}}
-///         .set_{{ResourceRequestField.Codec.SetterName}}(
-///             {{ResourceRequestField.MessageType.Codec.Name}}::new().set_name(name)/* set fields */
-///         )
-{{#UpdateMaskRequestField}}
+{{/InitFieldsFromMessage}}
+{{#UpdateMaskField}}
 ///         .set_{{Codec.SetterName}}(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
-{{/UpdateMaskRequestField}}
-{{/AIPStandardUpdateInfo}}
-{{#AIPStandardListInfo}}
-///         .set_{{ParentRequestField.Codec.SetterName}}(parent)
-{{/AIPStandardListInfo}}
+{{/UpdateMaskField}}
+{{/AIPStandardSampleInfo}}
+{{/IsAIPStandard}}
 {{^IsAIPStandard}}
 ///         /* set fields */
 {{/IsAIPStandard}}

--- a/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
@@ -25,16 +25,17 @@ limitations under the License.
 {{#IsList}}
 /// use google_cloud_gax::paginator::ItemPaginator as _;
 {{/IsList}}
-{{#AIPStandardCreateInfo}}
-/// use {{Service.Model.Codec.PackageNamespace}}::model::{{ResourceRequestField.MessageType.Codec.Name}};
-{{/AIPStandardCreateInfo}}
-{{#AIPStandardUpdateInfo}}
-{{#UpdateMaskRequestField}}
+{{#IsAIPStandard}}
+{{#AIPStandardSampleInfo}}
+{{#UpdateMaskField}}
 /// # extern crate wkt as google_cloud_wkt;
 /// use google_cloud_wkt::FieldMask;
-{{/UpdateMaskRequestField}}
-/// use {{Service.Model.Codec.PackageNamespace}}::model::{{ResourceRequestField.MessageType.Codec.Name}};
-{{/AIPStandardUpdateInfo}}
+{{/UpdateMaskField}}
+{{#InitFieldsFromMessage}}
+/// use {{Service.Model.Codec.PackageNamespace}}::model::{{Field.MessageType.Codec.Name}};
+{{/InitFieldsFromMessage}}
+{{/AIPStandardSampleInfo}}
+{{/IsAIPStandard}}
 /// use {{Service.Model.Codec.PackageNamespace}}::Result;
 /// async fn sample(
 {{> /templates/common/client_method_samples/parameters}}

--- a/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
@@ -13,24 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{#AIPStandardGetInfo}}
-///    client: &{{Service.Codec.Name}}, resource_name: &str
-{{/AIPStandardGetInfo}}
-{{#AIPStandardDeleteInfo}}
-///    client: &{{Service.Codec.Name}}, resource_name: &str
-{{/AIPStandardDeleteInfo}}
-{{#AIPStandardUndeleteInfo}}
-///    client: &{{Service.Codec.Name}}, resource_name: &str
-{{/AIPStandardUndeleteInfo}}
-{{#AIPStandardCreateInfo}}
-///    client: &{{Service.Codec.Name}}, parent: &str
-{{/AIPStandardCreateInfo}}
-{{#AIPStandardUpdateInfo}}
-///    client: &{{Service.Codec.Name}}, name: &str
-{{/AIPStandardUpdateInfo}}
-{{#AIPStandardListInfo}}
-///    client: &{{Service.Codec.Name}}, parent: &str
-{{/AIPStandardListInfo}}
+{{#IsAIPStandard}}
+{{#AIPStandardSampleInfo}}
+///    client: &{{Service.Codec.Name}}{{#SampleFunctionParameters}}, {{.}}: &str{{/SampleFunctionParameters}}
+{{/AIPStandardSampleInfo}}
+{{/IsAIPStandard}}
 {{^IsAIPStandard}}
 ///    client: &{{Service.Codec.Name}}
 {{/IsAIPStandard}}

--- a/internal/surfer/gcloud/utils/method.go
+++ b/internal/surfer/gcloud/utils/method.go
@@ -67,7 +67,7 @@ func IsCreate(m *api.Method) bool {
 // IsGet determines if the method is a standard Get method (AIP-131).
 func IsGet(m *api.Method) bool {
 	// Use sidekick's robust AIP check if available.
-	if m.AIPStandardGetInfo != nil {
+	if m.IsAIPStandardGet {
 		return true
 	}
 	// Fallback heuristic
@@ -105,7 +105,7 @@ func IsUpdate(m *api.Method) bool {
 // IsDelete determines if the method is a standard Delete method (AIP-135).
 func IsDelete(m *api.Method) bool {
 	// Use sidekick's robust AIP check if available.
-	if m.AIPStandardDeleteInfo != nil {
+	if m.IsAIPStandardDelete {
 		return true
 	}
 	// Fallback heuristic


### PR DESCRIPTION
This will help with:
- showing resource name formatting in samples. We can pass the resource name segments as parameters and initialize the resoure name field by combining them in the right format.
- generating samples with initialized requests. The templates don't need to know about any specific fields, only about different types of fields.