### PR TITLE
fix(internal/librarian/golang): fix error assertion in TestClean_Error

### DIFF
--- a/internal/librarian/golang/clean_test.go
+++ b/internal/librarian/golang/clean_test.go
@@ -162,8 +162,7 @@ func TestClean_Error(t *testing.T) {
 
 			err := Clean(lib)
 			if err == nil {
-				t.Error(err)
-				return
+				t.Fatal("expected error")
 			}
 			if diff := cmp.Diff(test.wantErrMsg, err.Error()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
TestClean_Error uses `t.Error(err)` and then returns when err is nil, which just logs nil. Replace with t.Fatal("expected error") when the expected error is not returned.