### PR TITLE
fix(internal/librarian/python): fix comment typo for deriveGAPICGenerationInfo

### DIFF
--- a/internal/librarian/python/clean.go
+++ b/internal/librarian/python/clean.go
@@ -193,8 +193,8 @@ func deleteUnlessKept(lib *config.Library, path string) error {
 	return nil
 }
 
-// deriveGAPICGenerationInfo derives an apiInfo for  a single API within a library, using
-// the API path and the options from the configuration.
+// deriveGAPICGenerationInfo derives a gapicGenerationInfo for a single API within a library,
+// using the API path and the options from the configuration.
 func deriveGAPICGenerationInfo(api *config.API, lib *config.Library) (*gapicGenerationInfo, error) {
 	splitPath := strings.Split(api.Path, "/")
 	if len(splitPath) < 2 {


### PR DESCRIPTION
The comment for deriveGAPICGenerationInfo incorrectly says "apiInfo" instead of "gapicGenerationInfo", and has a double space. Fix the type name and spacing to match the actual return type.