### PR TITLE
fix(internal/git): move %w to end of error format string

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -135,7 +135,7 @@ func ShowFileAtRevision(ctx context.Context, gitExe, revision, path string) (str
 	revisionAndPath := fmt.Sprintf("%s:%s", revision, path)
 	output, err := command.Output(ctx, gitExe, "show", revisionAndPath)
 	if err != nil {
-return "", fmt.Errorf("%s: %w", revisionAndPath, errors.Join(errGitShow, err))
+		return "", fmt.Errorf("%s: %w", revisionAndPath, errors.Join(errGitShow, err))
 	}
 	return strings.TrimSuffix(output, "\n"), nil
 }


### PR DESCRIPTION
The wrapped error should appear at the end of the fmt.Errorf format string, following Go conventions.

Fixes https://github.com/googleapis/librarian/issues/3732