### PR TITLE
fix(internal/librarian): use consistent usage text for commands

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -41,7 +41,7 @@ func addCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "add",
 		Usage:     "add a new client library to librarian.yaml",
-		UsageText: "librarian add <apis...> [flags]",
+		UsageText: "librarian add <apis...>",
 		Action: func(ctx context.Context, c *cli.Command) error {
 			apis := c.Args().Slice()
 			if len(apis) == 0 {

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -59,7 +59,7 @@ func bumpCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "bump",
 		Usage:     "update versions and prepare release artifacts",
-		UsageText: "librarian bump [library] [--all] [--version=<version>]",
+		UsageText: "librarian bump <library | --all> [flags]",
 		Description: `bump updates version numbers and prepares the files needed for a new release.
 
 If a library name is given, only that library is updated. The --all flag updates every

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -47,7 +47,7 @@ func generateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "generate",
 		Usage:     "generate a client library",
-		UsageText: "librarian generate [library] [--all]",
+		UsageText: "librarian generate <library | --all> [flags]",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "all",


### PR DESCRIPTION
UsageText is updated for the add, generate, and bump commands to follow consistent conventions.

For https://github.com/googleapis/librarian/issues/3631