### PR TITLE
feat(tool/cmd/migrate): parse enabled generator features from legacy librarian repo config

### DIFF
--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -594,7 +594,7 @@ func TestBuildGoLibraries(t *testing.T) {
 			},
 		},
 		{
-			name: "parse enable generator features from repo config",
+			name: "parse enable generator features from api level",
 			input: &MigrationInput{
 				librarianState: &legacyconfig.LibrarianState{
 					Libraries: []*legacyconfig.LibraryState{
@@ -645,6 +645,76 @@ func TestBuildGoLibraries(t *testing.T) {
 									"feature-3",
 								},
 								Path: "google/cloud/secretmanager/v1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "parse enable generator features from library level",
+			input: &MigrationInput{
+				librarianState: &legacyconfig.LibrarianState{
+					Libraries: []*legacyconfig.LibraryState{
+						{
+							ID: "secretmanager",
+							APIs: []*legacyconfig.API{
+								{
+									Path: "google/cloud/secretmanager/v1",
+								},
+								{
+									Path: "google/cloud/secretmanager/v1beta1",
+								},
+							},
+						},
+					},
+				},
+				librarianConfig: &legacyconfig.LibrarianConfig{},
+				repoConfig: &RepoConfig{
+					Modules: []*RepoConfigModule{
+						{
+							Name: "secretmanager",
+							EnabledGeneratorFeatures: []string{
+								"feature-1",
+								"feature-2",
+							},
+							APIs: []*RepoConfigAPI{
+								{
+									Path: "google/cloud/secretmanager/v1beta1",
+								},
+							},
+						},
+					},
+				},
+				repoPath:      "testdata/google-cloud-go",
+				googleapisDir: "testdata/googleapis",
+			},
+			want: []*config.Library{
+				{
+					Name: "secretmanager",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+						{Path: "google/cloud/secretmanager/v1beta1"},
+					},
+					Go: &config.GoModule{
+						GoAPIs: []*config.GoAPI{
+							{
+								// This API is created because the enabled
+								// generator features are not empty.
+								EnabledGeneratorFeatures: []string{
+									"feature-1",
+									"feature-2",
+								},
+								Path: "google/cloud/secretmanager/v1",
+							},
+							{
+								// Enabled generator features merge into
+								// this API.
+								EnabledGeneratorFeatures: []string{
+									"feature-1",
+									"feature-2",
+								},
+								Path: "google/cloud/secretmanager/v1beta1",
 							},
 						},
 					},


### PR DESCRIPTION
Parse enabled generator features from legacy librarian repo config (`.librarian/generator-input/repo-config.yaml`)

For #3618