### PR TITLE
feat(sidekick): add end-with-s fallback for collection identification heuristic

### DIFF
--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -292,12 +292,25 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 			want:   nil,
 		},
 		{
-			name:      "heuristic: skips non-collection literal (e.g. users)",
+			name:      "heuristic: fallback matches literal ending in 's' (e.g. users)",
 			serviceID: ".google.cloud.compute.v1.Instances",
 			path: NewPathTemplate().
-				WithLiteral("users").WithVariableNamed("user"), // "users" not in base vocab or known plurals
+				WithLiteral("users").WithVariableNamed("user"), // matches fallback heuristic
 			fields: []*Field{
 				{Name: "user", Typez: STRING_TYPE},
+			},
+			want: &TargetResource{
+				FieldPaths: [][]string{{"user"}},
+				Template:   "//test-api.googleapis.com/users/{user}",
+			},
+		},
+		{
+			name:      "heuristic: skips non-collection literal without 's'",
+			serviceID: ".google.cloud.compute.v1.Instances",
+			path: NewPathTemplate().
+				WithLiteral("metadata").WithVariableNamed("data"), // does not match fallback
+			fields: []*Field{
+				{Name: "data", Typez: STRING_TYPE},
 			},
 			want: nil,
 		},

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -42,14 +42,15 @@ var baseVocabulary = map[string]bool{
 	"folders":         true,
 	"organizations":   true,
 	"billingAccounts": true,
+}
 
-	// Legacy Discovery
-	"zones":         true,
-	"regions":       true,
-	"networks":      true,
-	"instances":     true,
-	"machineTypes":  true,
-	"subnetworks":   true,
+var singularExceptions = map[string]bool{
+	"address":  true,
+	"status":   true,
+	"ingress":  true,
+	"egress":   true,
+	"access":   true,
+	"analysis": true,
 }
 
 // isBaseVocabulary checks if a segment is part of the common resource vocabulary.
@@ -61,6 +62,7 @@ func isBaseVocabulary(segment string) bool {
 // It checks in the following order:
 // 1. Base vocabulary (projects, locations, etc.)
 // 2. Known resource plurals (from the API model).
+// 3. Fallback: if the segment ends in 's' and is not in the singular exceptions list.
 func isCollectionIdentifier(segment string, vocabulary map[string]bool) bool {
 	if isBaseVocabulary(segment) {
 		return true
@@ -68,10 +70,9 @@ func isCollectionIdentifier(segment string, vocabulary map[string]bool) bool {
 	if vocabulary != nil && vocabulary[segment] {
 		return true
 	}
-	// // Fallback: if the segment ends in 's' and stripping it matches the variable name exactly.
-	// if len(segment) > 1 && strings.HasSuffix(segment, "s") {
-	// 	return true
-	// }
+	if len(segment) > 2 && strings.HasSuffix(segment, "s") && !singularExceptions[segment] {
+		return true
+	}
 	return false
 }
 

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -42,6 +42,14 @@ var baseVocabulary = map[string]bool{
 	"folders":         true,
 	"organizations":   true,
 	"billingAccounts": true,
+
+	// Legacy Discovery
+	"zones":         true,
+	"regions":       true,
+	"networks":      true,
+	"instances":     true,
+	"machineTypes":  true,
+	"subnetworks":   true,
 }
 
 // isBaseVocabulary checks if a segment is part of the common resource vocabulary.
@@ -60,6 +68,10 @@ func isCollectionIdentifier(segment string, vocabulary map[string]bool) bool {
 	if vocabulary != nil && vocabulary[segment] {
 		return true
 	}
+	// // Fallback: if the segment ends in 's' and stripping it matches the variable name exactly.
+	// if len(segment) > 1 && strings.HasSuffix(segment, "s") {
+	// 	return true
+	// }
 	return false
 }
 


### PR DESCRIPTION
Our resource naming heuristic relies on [`BuildHeuristicVocabulary`](https://github.com/googleapis/librarian/blob/aba326871186a08c3de9c8ae645e60f758bcd2fe/internal/sidekick/api/resource_name_heuristic.go#L69) to identify valid collections. This function expects AIP-standard APIs and parses path bindings on standard methods (`Get`, `List`, etc.).

Unfortunately, this approach seems to fall apart for `google-cloud-compute-v1`, which is a Discovery API and does not satisfy AIP-compliant requirements for `BuildHeuristicVocabulary` to work.

The "end-with-s" fallback helps us get by, and `singularExceptions` consists of words that should not be considered plural. We can add more exceptions later should they come up.

For #4018