### PR TITLE
refactor(sidekick): Generalize method sample information

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -324,8 +324,9 @@ type Method struct {
 	IsAIPStandardUpdate bool
 	// IsAIPStandardList is true if the method is an AIP standard list method.
 	IsAIPStandardList bool
-	// AIPStandardSampleInfo contains sample generation information for AIP standard methods.
-	AIPStandardSampleInfo *AIPStandardSampleInfo
+	// SampleInfo may contain sample generation information for this method,
+	// usually if it is an AIP conforming metho.
+	SampleInfo *SampleInfo
 	// Codec contains language specific annotations.
 	Codec any
 }
@@ -414,34 +415,17 @@ func (m *Method) HasAutoPopulatedFields() bool {
 	return len(m.AutoPopulated) != 0
 }
 
-// AIPStandardSampleInfo contains information for generating samples for AIP standard methods.
-type AIPStandardSampleInfo struct {
-	// SampleFunctionParameters is a list of string argument names that the generated sample function requires.
-	SampleFunctionParameters []string
-	// InitFieldsFromParameter contains fields that should be initialized from a sample function parameter.
-	InitFieldsFromParameter []*SampleParameterInit
-	// InitFieldsFromStringLiteral contains fields that should be initialized with a string literal.
-	InitFieldsFromStringLiteral []*Field
-	// InitFieldsFromMessage contains fields that should be initialized with a new message instance.
-	InitFieldsFromMessage []*SampleMessageInit
-	// UpdateMaskField is the update mask field, if any, that needs to be initialized.
+// SampleInfo contains sample generation information for a single method,
+// usually if it is an AIP conforming method.
+type SampleInfo struct {
+	// ResourceNameField is the field containing the resource name or parent resource name.
+	ResourceNameField *Field
+	// ResourceIDField is the field containing the resource ID, usually present in Create methods.
+	ResourceIDField *Field
+	// MessageField is the field containing the message body to be created or updated.
+	MessageField *Field
+	// UpdateMaskField is the field containing the update mask, present in Update methods.
 	UpdateMaskField *Field
-}
-
-// SampleParameterInit describes a field that should be initialized from a parameter.
-type SampleParameterInit struct {
-	// Field is the field to be initialized.
-	Field *Field
-	// ParameterName is the name of the parameter to use.
-	ParameterName string
-}
-
-// SampleMessageInit describes a field that should be initialized with a message.
-type SampleMessageInit struct {
-	// Field is the field to be initialized.
-	Field *Field
-	// ParameterName is the name of the parameter to set as the "name" field of the message, if any.
-	ParameterName string
 }
 
 const (

--- a/internal/sidekick/api/skip_test.go
+++ b/internal/sidekick/api/skip_test.go
@@ -322,7 +322,7 @@ var methodIgnoreFields = []string{
 	"IsAIPStandardCreate",
 	"IsAIPStandardUpdate",
 	"IsAIPStandardList",
-	"AIPStandardSampleInfo",
+	"SampleInfo",
 }
 
 func TestIncludeMethods(t *testing.T) {

--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -230,24 +230,24 @@ func enrichMethodSamples(m *Method) {
 
 	m.IsStreaming = m.ClientSideStreaming || m.ServerSideStreaming
 
-	if m.AIPStandardSampleInfo = aipStandardGetInfo(m); m.AIPStandardSampleInfo != nil {
+	if m.SampleInfo = aipStandardGetInfo(m); m.SampleInfo != nil {
 		m.IsAIPStandardGet = true
-	} else if m.AIPStandardSampleInfo = aipStandardDeleteInfo(m); m.AIPStandardSampleInfo != nil {
+	} else if m.SampleInfo = aipStandardDeleteInfo(m); m.SampleInfo != nil {
 		m.IsAIPStandardDelete = true
-	} else if m.AIPStandardSampleInfo = aipStandardUndeleteInfo(m); m.AIPStandardSampleInfo != nil {
+	} else if m.SampleInfo = aipStandardUndeleteInfo(m); m.SampleInfo != nil {
 		m.IsAIPStandardUndelete = true
-	} else if m.AIPStandardSampleInfo = aipStandardCreateInfo(m); m.AIPStandardSampleInfo != nil {
+	} else if m.SampleInfo = aipStandardCreateInfo(m); m.SampleInfo != nil {
 		m.IsAIPStandardCreate = true
-	} else if m.AIPStandardSampleInfo = aipStandardUpdateInfo(m); m.AIPStandardSampleInfo != nil {
+	} else if m.SampleInfo = aipStandardUpdateInfo(m); m.SampleInfo != nil {
 		m.IsAIPStandardUpdate = true
-	} else if m.AIPStandardSampleInfo = aipStandardListInfo(m); m.AIPStandardSampleInfo != nil {
+	} else if m.SampleInfo = aipStandardListInfo(m); m.SampleInfo != nil {
 		m.IsAIPStandardList = true
 	}
 
-	m.IsAIPStandard = m.AIPStandardSampleInfo != nil
+	m.IsAIPStandard = m.SampleInfo != nil
 }
 
-func aipStandardGetInfo(m *Method) *AIPStandardSampleInfo {
+func aipStandardGetInfo(m *Method) *SampleInfo {
 	if !m.IsSimple || m.InputType == nil || m.ReturnsEmpty {
 		return nil
 	}
@@ -280,15 +280,12 @@ func aipStandardGetInfo(m *Method) *AIPStandardSampleInfo {
 		return nil
 	}
 
-	return &AIPStandardSampleInfo{
-		SampleFunctionParameters: []string{"resource_name"},
-		InitFieldsFromParameter: []*SampleParameterInit{
-			{Field: resourceField, ParameterName: "resource_name"},
-		},
+	return &SampleInfo{
+		ResourceNameField: resourceField,
 	}
 }
 
-func aipStandardDeleteInfo(m *Method) *AIPStandardSampleInfo {
+func aipStandardDeleteInfo(m *Method) *SampleInfo {
 	if !m.IsSimple && m.OperationInfo == nil {
 		return nil
 	}
@@ -312,15 +309,12 @@ func aipStandardDeleteInfo(m *Method) *AIPStandardSampleInfo {
 		return nil
 	}
 
-	return &AIPStandardSampleInfo{
-		SampleFunctionParameters: []string{"resource_name"},
-		InitFieldsFromParameter: []*SampleParameterInit{
-			{Field: resourceField, ParameterName: "resource_name"},
-		},
+	return &SampleInfo{
+		ResourceNameField: resourceField,
 	}
 }
 
-func aipStandardUndeleteInfo(m *Method) *AIPStandardSampleInfo {
+func aipStandardUndeleteInfo(m *Method) *SampleInfo {
 	if !m.IsSimple && m.OperationInfo == nil {
 		return nil
 	}
@@ -344,15 +338,12 @@ func aipStandardUndeleteInfo(m *Method) *AIPStandardSampleInfo {
 		return nil
 	}
 
-	return &AIPStandardSampleInfo{
-		SampleFunctionParameters: []string{"resource_name"},
-		InitFieldsFromParameter: []*SampleParameterInit{
-			{Field: resourceField, ParameterName: "resource_name"},
-		},
+	return &SampleInfo{
+		ResourceNameField: resourceField,
 	}
 }
 
-func aipStandardCreateInfo(m *Method) *AIPStandardSampleInfo {
+func aipStandardCreateInfo(m *Method) *SampleInfo {
 	if (!m.IsSimple && !m.IsLRO) || m.InputType == nil || m.ReturnsEmpty {
 		return nil
 	}
@@ -391,22 +382,17 @@ func aipStandardCreateInfo(m *Method) *AIPStandardSampleInfo {
 
 	resourceIDField := findResourceIDField(m.InputType, maybeSingular)
 
-	info := &AIPStandardSampleInfo{
-		SampleFunctionParameters: []string{"parent"},
-		InitFieldsFromParameter: []*SampleParameterInit{
-			{Field: parentField, ParameterName: "parent"},
-		},
-		InitFieldsFromMessage: []*SampleMessageInit{
-			{Field: resourceField},
-		},
+	info := &SampleInfo{
+		ResourceNameField: parentField,
+		MessageField:      resourceField,
 	}
 	if resourceIDField != nil {
-		info.InitFieldsFromStringLiteral = []*Field{resourceIDField}
+		info.ResourceIDField = resourceIDField
 	}
 	return info
 }
 
-func aipStandardUpdateInfo(m *Method) *AIPStandardSampleInfo {
+func aipStandardUpdateInfo(m *Method) *SampleInfo {
 	if (!m.IsSimple && !m.IsLRO) || m.InputType == nil || m.ReturnsEmpty {
 		return nil
 	}
@@ -443,16 +429,13 @@ func aipStandardUpdateInfo(m *Method) *AIPStandardSampleInfo {
 		}
 	}
 
-	return &AIPStandardSampleInfo{
-		SampleFunctionParameters: []string{"name"},
-		InitFieldsFromMessage: []*SampleMessageInit{
-			{Field: resourceField, ParameterName: "name"},
-		},
+	return &SampleInfo{
+		MessageField:    resourceField,
 		UpdateMaskField: updateMaskField,
 	}
 }
 
-func aipStandardListInfo(m *Method) *AIPStandardSampleInfo {
+func aipStandardListInfo(m *Method) *SampleInfo {
 	if !m.IsList || m.InputType == nil {
 		return nil
 	}
@@ -482,11 +465,8 @@ func aipStandardListInfo(m *Method) *AIPStandardSampleInfo {
 		return nil
 	}
 
-	return &AIPStandardSampleInfo{
-		SampleFunctionParameters: []string{"parent"},
-		InitFieldsFromParameter: []*SampleParameterInit{
-			{Field: parentField, ParameterName: "parent"},
-		},
+	return &SampleInfo{
+		ResourceNameField: parentField,
 	}
 }
 

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -790,7 +790,7 @@ func TestAIPStandardGetInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardSampleInfo
+		want   *SampleInfo
 	}{
 		{
 			name: "valid get operation with wildcard resource reference",
@@ -800,11 +800,8 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				OutputType: output,
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.wildcardResourceField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.wildcardResourceField,
 			},
 		},
 		{
@@ -815,11 +812,8 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				OutputType: output,
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameField,
 			},
 		},
 		{
@@ -832,11 +826,8 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameNoSingularField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameNoSingularField,
 			},
 		},
 		{
@@ -951,9 +942,9 @@ func TestAIPStandardGetInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardSampleInfo
+			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -965,7 +956,7 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardSampleInfo
+		want   *SampleInfo
 	}{
 		{
 			name: "valid simple delete with wildcard resource reference",
@@ -975,11 +966,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.wildcardResourceField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.wildcardResourceField,
 			},
 		},
 		{
@@ -990,11 +978,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameField,
 			},
 		},
 		{
@@ -1005,11 +990,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameNoSingularField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameNoSingularField,
 			},
 		},
 		{
@@ -1020,11 +1002,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				OperationInfo: &OperationInfo{},
 				Model:         f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameField,
 			},
 		},
 		{
@@ -1035,11 +1014,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				ReturnsEmpty: true,
 				Model:        f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceOtherNameField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceOtherNameField,
 			},
 		},
 		{
@@ -1094,9 +1070,9 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardSampleInfo
+			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1108,7 +1084,7 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardSampleInfo
+		want   *SampleInfo
 	}{
 		{
 			name: "valid simple undelete with wildcard resource reference",
@@ -1120,11 +1096,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.wildcardResourceField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.wildcardResourceField,
 			},
 		},
 		{
@@ -1137,11 +1110,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameField,
 			},
 		},
 		{
@@ -1154,11 +1124,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameNoSingularField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameNoSingularField,
 			},
 		},
 		{
@@ -1169,11 +1136,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				OperationInfo: &OperationInfo{},
 				Model:         f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceNameField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceNameField,
 			},
 		},
 		{
@@ -1186,11 +1150,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				},
 				Model: f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"resource_name"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: f.resourceOtherNameField, ParameterName: "resource_name"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: f.resourceOtherNameField,
 			},
 		},
 		{
@@ -1245,9 +1206,9 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardSampleInfo
+			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1278,7 +1239,7 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardSampleInfo
+		want   *SampleInfo
 	}{
 		{
 			name: "valid create operation",
@@ -1295,15 +1256,10 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"parent"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: parentField, ParameterName: "parent"},
-				},
-				InitFieldsFromStringLiteral: []*Field{idField},
-				InitFieldsFromMessage: []*SampleMessageInit{
-					{Field: resourceField},
-				},
+			want: &SampleInfo{
+				ResourceNameField: parentField,
+				ResourceIDField:   idField,
+				MessageField:      resourceField,
 			},
 		},
 		{
@@ -1320,14 +1276,9 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"parent"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: parentField, ParameterName: "parent"},
-				},
-				InitFieldsFromMessage: []*SampleMessageInit{
-					{Field: resourceField},
-				},
+			want: &SampleInfo{
+				ResourceNameField: parentField,
+				MessageField:      resourceField,
 			},
 		},
 		{
@@ -1351,9 +1302,9 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardSampleInfo
+			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1379,7 +1330,7 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardSampleInfo
+		want   *SampleInfo
 	}{
 		{
 			name: "valid update operation",
@@ -1395,11 +1346,8 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"name"},
-				InitFieldsFromMessage: []*SampleMessageInit{
-					{Field: resourceField, ParameterName: "name"},
-				},
+			want: &SampleInfo{
+				MessageField:    resourceField,
 				UpdateMaskField: updateMaskField,
 			},
 		},
@@ -1416,11 +1364,8 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 				OutputType: &Message{Resource: f.resource},
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"name"},
-				InitFieldsFromMessage: []*SampleMessageInit{
-					{Field: resourceField, ParameterName: "name"},
-				},
+			want: &SampleInfo{
+				MessageField: resourceField,
 			},
 		},
 		{
@@ -1473,9 +1418,9 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardSampleInfo
+			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1511,7 +1456,7 @@ func TestAIPStandardListInfo(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method *Method
-		want   *AIPStandardSampleInfo
+		want   *SampleInfo
 	}{
 		{
 			name: "valid list operation with parent field match by child_type",
@@ -1521,11 +1466,8 @@ func TestAIPStandardListInfo(t *testing.T) {
 				OutputType: listOutput,
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"parent"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: parentField, ParameterName: "parent"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: parentField,
 			},
 		},
 		{
@@ -1536,11 +1478,8 @@ func TestAIPStandardListInfo(t *testing.T) {
 				OutputType: listOutput,
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"parent"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: otherParentField, ParameterName: "parent"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: otherParentField,
 			},
 		},
 		{
@@ -1551,11 +1490,8 @@ func TestAIPStandardListInfo(t *testing.T) {
 				OutputType: listOutput,
 				Model:      f.model,
 			},
-			want: &AIPStandardSampleInfo{
-				SampleFunctionParameters: []string{"parent"},
-				InitFieldsFromParameter: []*SampleParameterInit{
-					{Field: plainParentField, ParameterName: "parent"},
-				},
+			want: &SampleInfo{
+				ResourceNameField: plainParentField,
 			},
 		},
 		{
@@ -1613,9 +1549,9 @@ func TestAIPStandardListInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			enrichMethodSamples(tc.method)
-			got := tc.method.AIPStandardSampleInfo
+			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("AIPStandardSampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
@@ -14,22 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 {{#IsAIPStandard}}
-{{#AIPStandardSampleInfo}}
-{{#InitFieldsFromParameter}}
-///         .set_{{Field.Codec.SetterName}}({{ParameterName}})
-{{/InitFieldsFromParameter}}
-{{#InitFieldsFromStringLiteral}}
+{{#SampleInfo}}
+{{#ResourceNameField}}
+///         .set_{{Codec.SetterName}}({{Codec.SetterName}})
+{{/ResourceNameField}}
+{{#ResourceIDField}}
 ///         .set_{{Codec.SetterName}}("{{Codec.SetterName}}_value")
-{{/InitFieldsFromStringLiteral}}
-{{#InitFieldsFromMessage}}
-///         .set_{{Field.Codec.SetterName}}(
-///             {{Field.MessageType.Codec.Name}}::new(){{#ParameterName}}.set_name({{ParameterName}}){{/ParameterName}}/* set fields */
+{{/ResourceIDField}}
+{{#MessageField}}
+///         .set_{{Codec.SetterName}}(
+///             {{MessageType.Codec.Name}}::new(){{#IsAIPStandardUpdate}}.set_name(name){{/IsAIPStandardUpdate}}/* set fields */
 ///         )
-{{/InitFieldsFromMessage}}
+{{/MessageField}}
 {{#UpdateMaskField}}
 ///         .set_{{Codec.SetterName}}(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
 {{/UpdateMaskField}}
-{{/AIPStandardSampleInfo}}
+{{/SampleInfo}}
 {{/IsAIPStandard}}
 {{^IsAIPStandard}}
 ///         /* set fields */

--- a/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
@@ -26,15 +26,15 @@ limitations under the License.
 /// use google_cloud_gax::paginator::ItemPaginator as _;
 {{/IsList}}
 {{#IsAIPStandard}}
-{{#AIPStandardSampleInfo}}
+{{#SampleInfo}}
 {{#UpdateMaskField}}
 /// # extern crate wkt as google_cloud_wkt;
 /// use google_cloud_wkt::FieldMask;
 {{/UpdateMaskField}}
-{{#InitFieldsFromMessage}}
-/// use {{Service.Model.Codec.PackageNamespace}}::model::{{Field.MessageType.Codec.Name}};
-{{/InitFieldsFromMessage}}
-{{/AIPStandardSampleInfo}}
+{{#MessageField}}
+/// use {{Service.Model.Codec.PackageNamespace}}::model::{{MessageType.Codec.Name}};
+{{/MessageField}}
+{{/SampleInfo}}
 {{/IsAIPStandard}}
 /// use {{Service.Model.Codec.PackageNamespace}}::Result;
 /// async fn sample(

--- a/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 {{#IsAIPStandard}}
-{{#AIPStandardSampleInfo}}
-///    client: &{{Service.Codec.Name}}{{#SampleFunctionParameters}}, {{.}}: &str{{/SampleFunctionParameters}}
-{{/AIPStandardSampleInfo}}
+{{#SampleInfo}}
+///    client: &{{Service.Codec.Name}}{{#ResourceNameField}}, {{Codec.SetterName}}: &str{{/ResourceNameField}}{{#IsAIPStandardUpdate}}, name: &str{{/IsAIPStandardUpdate}}
+{{/SampleInfo}}
 {{/IsAIPStandard}}
 {{^IsAIPStandard}}
 ///    client: &{{Service.Codec.Name}}


### PR DESCRIPTION
With the last sample model simplification, some of the specifics of how Rust generates samples were sipping into the model. The samples model is now language neutral, presenting only semantic information.