### PR TITLE
feat(repometadata): handle APIs with no service config

### DIFF
--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -36,8 +36,7 @@ const (
 )
 
 var (
-	errNoAPIs          = errors.New("library has no APIs from which to get metadata")
-	errNoServiceConfig = errors.New("library has no service config from which to get metadata")
+	errNoAPIs = errors.New("library has no APIs from which to get metadata")
 )
 
 // RepoMetadata represents the .repo-metadata.json file structure.
@@ -121,9 +120,6 @@ func FromLibrary(config *config.Config, library *config.Library, googleapisDir s
 	api, err := serviceconfig.Find(googleapisDir, firstAPIPath, config.Language)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find API for path %s: %w", firstAPIPath, err)
-	}
-	if api.ServiceConfig == "" {
-		return nil, fmt.Errorf("failed to generate metadata for %s: %w", library.Name, errNoServiceConfig)
 	}
 	return fromAPI(config, api, library), nil
 }

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -74,6 +74,20 @@ func TestFromLibrary(t *testing.T) {
 				APIDescription:       "Stores, manages, and secures access to application secrets.",
 			},
 		},
+		{
+			name: "no service config",
+			library: &config.Library{
+				Name:         "google-longrunning",
+				ReleaseLevel: "stable",
+				APIs:         []*config.API{{Path: "google/longrunning"}},
+			},
+			want: &RepoMetadata{
+				ReleaseLevel:     "stable",
+				Language:         "python",
+				Repo:             "googleapis/google-cloud-python",
+				DistributionName: "google-longrunning",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
@@ -121,15 +135,6 @@ func TestFromLibrary_Error(t *testing.T) {
 				APIs:         []*config.API{{Path: "android/notallowed/v1"}},
 			},
 			// Error returned by serviceconfig.Find isn't easily distinguished
-		},
-		{
-			name: "no service config",
-			library: &config.Library{
-				Name:         "google-longrunning",
-				ReleaseLevel: "stable",
-				APIs:         []*config.API{{Path: "google/longrunning"}},
-			},
-			wantErr: errNoServiceConfig,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Removes a check to see whether there's a service config. We never access the service config directly within repometadata.FromAPI, so it's fine for it to be absent. We may well have very little information to put in the RepoMetadata returned by functions, but that's okay.