### PR TITLE
feat(python): handle fully-handwritten libraries

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -17,7 +17,6 @@ package python
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -36,8 +35,6 @@ const (
 	googleapisDevDocumentationTemplate  = "https://googleapis.dev/python/%s/latest"
 )
 
-var errNoApis = errors.New("no apis configured for library")
-
 // GenerateLibraries generates all the given libraries in sequence.
 func GenerateLibraries(ctx context.Context, config *config.Config, libraries []*config.Library, googleapisDir string) error {
 	for _, library := range libraries {
@@ -50,8 +47,9 @@ func GenerateLibraries(ctx context.Context, config *config.Config, libraries []*
 
 // generate generates a Python client library.
 func generate(ctx context.Context, config *config.Config, library *config.Library, googleapisDir string) error {
+	// If the library has no APIs, there's nothing to do.
 	if len(library.APIs) == 0 {
-		return fmt.Errorf("error generating %s: %w", library.Name, errNoApis)
+		return nil
 	}
 
 	// Convert library.Output to absolute path since protoc runs from a

--- a/tool/cmd/migrate/python.go
+++ b/tool/cmd/migrate/python.go
@@ -87,8 +87,11 @@ func buildPythonLibraries(input *MigrationInput, googleapisDir string) ([]*confi
 			Version: libState.Version,
 			Python:  &config.PythonPackage{},
 		}
-		if libState.APIs != nil {
+		if len(libState.APIs) > 0 {
 			library.APIs = toAPIs(libState.APIs)
+		} else {
+			library.Output = filepath.Join("packages", library.Name)
+			library.Veneer = true
 		}
 		// Convert "preserve" regexes into "keep" paths, sorted for ease
 		// of testing.

--- a/tool/cmd/migrate/python_test.go
+++ b/tool/cmd/migrate/python_test.go
@@ -201,6 +201,28 @@ func TestBuildPythonLibraries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "veneer",
+			input: &MigrationInput{
+				repoPath: "testdata/google-cloud-python",
+				librarianState: &legacyconfig.LibrarianState{
+					Libraries: []*legacyconfig.LibraryState{
+						{
+							ID: "google-api-core",
+						},
+					},
+				},
+				librarianConfig: &legacyconfig.LibrarianConfig{},
+			},
+			want: []*config.Library{
+				{
+					Name:   "google-api-core",
+					Veneer: true,
+					Output: "packages/google-api-core",
+					Python: &config.PythonPackage{NamePrettyOverride: "Google API client core library"},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := buildPythonLibraries(test.input, "testdata/googleapis")

--- a/tool/cmd/migrate/testdata/google-cloud-python/packages/google-api-core/.repo-metadata.json
+++ b/tool/cmd/migrate/testdata/google-cloud-python/packages/google-api-core/.repo-metadata.json
@@ -1,0 +1,12 @@
+{
+    "name": "google-api-core",
+    "name_pretty": "Google API client core library",
+    "client_documentation": "https://googleapis.dev/python/google-api-core/latest",
+    "release_level": "stable",
+    "language": "python",
+    "library_type": "CORE",
+    "repo": "googleapis/google-cloud-python",
+    "distribution_name": "google-api-core",
+    "default_version": "",
+    "codeowner_team": "@googleapis/cloud-sdk-python-team"
+}


### PR DESCRIPTION
Changes generation to ignore libraries with no APIs, and changes migration to explicitly say they're veneers, and set the output directory.

Later we *may* want to generate .repo-metadata.json files for fully-handwritten libraries, but for now we really don't need to (and that doesn't work). It's tempting to put the check into the language-agnostic code, but it's possible that some languages *will* want to generate some files even when there are no APIs.