### PR TITLE
fix(java): add header to generated proto- and grpc- modules

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -154,12 +153,28 @@ func postProcess(ctx context.Context, outdir, libraryName, version, googleapisDi
 	return nil
 }
 
-var headerRegex = regexp.MustCompile(`\* Copyright \d{4} Google LLC`)
-
 // addMissingHeaders prepends the license header to all Java files in the given directory
 // if they don't already have one.
 func addMissingHeaders(dir string) error {
 	year := time.Now().Year()
+	licenseText := buildLicenseText(year)
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.Type().IsRegular() || filepath.Ext(path) != ".java" {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if license.HasHeader(content) {
+			return nil
+		}
+		return os.WriteFile(path, append([]byte(licenseText), content...), 0644)
+	})
+}
+
+// buildLicenseText constructs the complete license header text for the given year.
+func buildLicenseText(year int) string {
 	lines := license.Header(strconv.Itoa(year))
 	var b strings.Builder
 	b.WriteString("/*\n")
@@ -169,21 +184,7 @@ func addMissingHeaders(dir string) error {
 		b.WriteString("\n")
 	}
 	b.WriteString(" */\n")
-	licenseText := b.String()
-
-	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-		if err != nil || !d.Type().IsRegular() || filepath.Ext(path) != ".java" {
-			return err
-		}
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		if headerRegex.Match(content) {
-			return nil
-		}
-		return os.WriteFile(path, append([]byte(licenseText), content...), 0644)
-	})
+	return b.String()
 }
 
 func createProtocOptions(api *config.API, library *config.Library, googleapisDir, protoDir, grpcDir, gapicDir string) ([]string, error) {

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -467,22 +467,27 @@ func TestCollectJavaFiles(t *testing.T) {
 
 func TestAddMissingHeaders(t *testing.T) {
 	for _, test := range []struct {
-		name       string
-		filename   string
-		content    string
-		wantHeader bool
+		name         string
+		filename     string
+		content      string
+		wantModified bool
 	}{
 		{
-			name:       "file without header",
-			filename:   "NoHeader.java",
-			content:    "package com.example;\npublic class NoHeader {}",
-			wantHeader: true,
+			name:         "file without header",
+			filename:     "NoHeader.java",
+			content:      "package com.example;",
+			wantModified: true,
 		},
 		{
-			name:       "file with existing header",
-			filename:   "WithHeader.java",
-			content:    "/*\n * Copyright 2024 Google LLC\n */\npackage com.example;\npublic class WithHeader {}",
-			wantHeader: true,
+			name:     "file with full header",
+			filename: "WithHeader.java",
+			content:  "/* Licensed under the Apache License, Version 2.0 (the \"License\") */\npackage com.example;",
+		},
+		{
+			name:         "file with partial header",
+			filename:     "PartialHeader.java",
+			content:      "/* Copyright 2024 Google LLC */\npackage com.example;",
+			wantModified: true,
 		},
 		{
 			name:     "non-java file",
@@ -494,22 +499,21 @@ func TestAddMissingHeaders(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			path := filepath.Join(tmpDir, test.filename)
-			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+			originalContent := []byte(test.content)
+			if err := os.WriteFile(path, originalContent, 0644); err != nil {
 				t.Fatal(err)
 			}
 			if err := addMissingHeaders(tmpDir); err != nil {
 				t.Fatal(err)
 			}
-			got, err := os.ReadFile(path)
+
+			newContent, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}
-			hasHeader := strings.HasPrefix(string(got), "/*\n * Copyright")
-			if hasHeader != test.wantHeader {
-				t.Errorf("header presence = %v, want %v", hasHeader, test.wantHeader)
-			}
-			if !strings.Contains(string(got), test.content) {
-				t.Error("original content not preserved")
+			wasModified := !bytes.Equal(originalContent, newContent)
+			if wasModified != test.wantModified {
+				t.Errorf("modification status = %v, want %v", wasModified, test.wantModified)
 			}
 		})
 	}

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -15,7 +15,16 @@
 // Package license provides functions for generating license header text.
 package license
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
+
+// HasHeader returns true if the content contains the Apache 2.0 license header.
+// It checks for the presence of a specific, static line from the license text.
+func HasHeader(content []byte) bool {
+	return bytes.Contains(content, []byte("Licensed under the Apache License, Version 2.0"))
+}
 
 // Header returns the license header with the given year.
 func Header(year string) []string {

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -17,6 +17,8 @@ package license
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestLicense(t *testing.T) {
@@ -27,5 +29,39 @@ func TestLicense(t *testing.T) {
 	}
 	if !strings.Contains(got[0], want) {
 		t.Errorf("bad start line for Header(), got=%q, want=%q", got[0], want)
+	}
+}
+
+func TestHasHeader(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "full header",
+			content: `/*\n * Copyright 2024 Google LLC\n *\n * Licensed under the Apache License, Version 2.0 (the "License");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n *     https://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an "AS IS" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */\npackage com.example;`,
+			want:    true,
+		},
+		{
+			name:    "partial header (only copyright)",
+			content: `/*\n * Copyright 2024 Google LLC\n */\npackage com.example;`,
+		},
+		{
+			name:    "no header",
+			content: `package com.example;\npublic class NoHeader {}`,
+		},
+		{
+			name:    "empty file",
+			content: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := HasHeader([]byte(test.content))
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("HasHeader() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Adds header to generated proto- and grpc- modules when not present.
Similar logic to synthtool [here](https://github.com/googleapis/sdk-platform-java/blob/4206e6ed7546d6b8330dcb8dc29179e59677ccd3/hermetic_build/library_generation/owlbot/synthtool/languages/java.py#L97), except not dealing with resource name classes malformed license headers.

Fix #4129