### PR TITLE
refactor(internal/surfer/gcloud): deduplicate help text rule lookup

### DIFF
--- a/internal/surfer/gcloud/builder.go
+++ b/internal/surfer/gcloud/builder.go
@@ -595,7 +595,7 @@ func findFieldHelpTextRule(field *api.Field, overrides *Config) *HelpTextRule {
 // the given selector. The rules function extracts the relevant rule slice from
 // each API's HelpTextRules.
 func findHelpTextRuleBySelector(selector string, overrides *Config, rules func(*HelpTextRules) []*HelpTextRule) *HelpTextRule {
-	if overrides.APIs == nil {
+    if overrides == nil || overrides.APIs == nil {
 		return nil
 	}
 	for _, api := range overrides.APIs {


### PR DESCRIPTION
findHelpTextRule and findFieldHelpTextRule had identical iteration logic, and the only difference is in how they derive the selector.

Move the shared logic to a findHelpTextRuleBySelector helper function, with findHelpTextRule and findFieldHelpTextRule as thin wrappers.