### PR TITLE
refactor(internal/surfer/gcloud): compute resource once in NewCommand

### DIFF
--- a/internal/surfer/gcloud/generate.go
+++ b/internal/surfer/gcloud/generate.go
@@ -96,7 +96,7 @@ func generateService(service *api.Service, overrides *Config, model *api.API, ou
 		// For each method, we determine the plural name of the resource it operates on.
 		// This plural name (e.g., "instances") will serve as our collection ID.
 		// Example: For the `CreateInstance` method, this will return "instances".
-		collectionID := getPluralResourceNameForMethod(method, model)
+		collectionID := pluralResourceName(getResourceForMethod(method, model))
 
 		// If a collection ID is found, we add the method to our map.
 		if collectionID != "" {
@@ -135,7 +135,7 @@ func generateResourceCommands(collectionID string, methods []*api.Method, baseDi
 		return fmt.Errorf("failed to create resource directory for %q: %w", collectionID, err)
 	}
 
-	singular := getSingularResourceNameForMethod(methods[0], model)
+	singular := singularResourceName(getResourceForMethod(methods[0], model))
 
 	// We determine the short service name from the default host to use as a fallback title.
 	shortServiceName, _, _ := strings.Cut(service.DefaultHost, ".")

--- a/internal/surfer/gcloud/resource.go
+++ b/internal/surfer/gcloud/resource.go
@@ -196,38 +196,34 @@ func getResourceForMethod(method *api.Method, model *api.API) *api.Resource {
 	return nil
 }
 
-// getPluralResourceNameForMethod determines the plural name of a resource. It follows a clear
-// hierarchy of truth: first, the explicit `plural` field in the resource
-// definition, and second, inference from the resource pattern.
-func getPluralResourceNameForMethod(method *api.Method, model *api.API) string {
-	resource := getResourceForMethod(method, model)
-	if resource != nil {
-		// The `plural` field in the `(google.api.resource)` annotation is the
-		// most authoritative source.
-		if resource.Plural != "" {
-			return resource.Plural
-		}
-		// If the `plural` field is not present, we fall back to inferring the
-		// plural name from the resource's pattern string, as per AIP-122.
-		if len(resource.Patterns) > 0 {
-			return getPluralFromSegments(resource.Patterns[0])
-		}
+// singularResourceName determines the singular name from a resource definition.
+// It follows a clear hierarchy of truth: first, the explicit `singular` field
+// in the resource definition, and second, inference from the resource pattern.
+func singularResourceName(resource *api.Resource) string {
+	if resource == nil {
+		return ""
+	}
+	if resource.Singular != "" {
+		return resource.Singular
+	}
+	if len(resource.Patterns) > 0 {
+		return getSingularFromSegments(resource.Patterns[0])
 	}
 	return ""
 }
 
-// getSingularResourceNameForMethod determines the singular name of a resource. It follows a clear
-// hierarchy of truth: first, the explicit `singular` field in the resource
-// definition, and second, inference from the resource pattern.
-func getSingularResourceNameForMethod(method *api.Method, model *api.API) string {
-	resource := getResourceForMethod(method, model)
-	if resource != nil {
-		if resource.Singular != "" {
-			return resource.Singular
-		}
-		if len(resource.Patterns) > 0 {
-			return getSingularFromSegments(resource.Patterns[0])
-		}
+// pluralResourceName determines the plural name from a resource definition.
+// It follows a clear hierarchy of truth: first, the explicit `plural` field
+// in the resource definition, and second, inference from the resource pattern.
+func pluralResourceName(resource *api.Resource) string {
+	if resource == nil {
+		return ""
+	}
+	if resource.Plural != "" {
+		return resource.Plural
+	}
+	if len(resource.Patterns) > 0 {
+		return getPluralFromSegments(resource.Patterns[0])
 	}
 	return ""
 }

--- a/internal/surfer/gcloud/resource_test.go
+++ b/internal/surfer/gcloud/resource_test.go
@@ -617,7 +617,7 @@ func TestGetPluralResourceNameForMethod(t *testing.T) {
 			model := &api.API{
 				ResourceDefinitions: test.resourceDefs,
 			}
-			got := getPluralResourceNameForMethod(test.method, model)
+			got := pluralResourceName(getResourceForMethod(test.method, model))
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -708,7 +708,7 @@ func TestGetSingularResourceNameForMethod(t *testing.T) {
 			model := &api.API{
 				ResourceDefinitions: test.resourceDefs,
 			}
-			got := getSingularResourceNameForMethod(test.method, model)
+			got := singularResourceName(getResourceForMethod(test.method, model))
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
getResourceForMethod was called multiple times for the same method during a single NewCommand invocation. This change computes it once and passes the result down.