### PR TITLE
fix(surfer/gcloud): fix cmp.Diff format string in config_test.go

### DIFF
--- a/internal/surfer/gcloud/config_test.go
+++ b/internal/surfer/gcloud/config_test.go
@@ -50,6 +50,6 @@ func TestReadGcloudConfig(t *testing.T) {
 	}
 	want := fmt.Sprintf("service_name: %s\n%s", cfg.ServiceName, strings.Join(lines[index:], "\n"))
 	if diff := cmp.Diff(want, string(got)); diff != "" {
-		t.Errorf("mismatch(-want, +got)\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
The format string uses `"mismatch(-want, +got)\n%s"` which differs from the project convention `"mismatch (-want +got):\n%s"`. Fix for consistency.