### PR TITLE
fix(surfer/gcloud): simplify TestReadGcloudConfig

### DIFF
--- a/internal/surfer/gcloud/config_test.go
+++ b/internal/surfer/gcloud/config_test.go
@@ -36,7 +36,7 @@ func TestReadGcloudConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := cmp.Diff(cfg, roundTripped, cmpopts.EquateEmpty()); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
The test manually skips comment lines with a magic offset to round-trip YAML through string comparison, which is fragile. Replace with a struct-level round-trip: read, marshal, unmarshal, compare structs.