### PR TITLE
doc(style): add local copies of Go wiki style guides

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -9,9 +9,9 @@ When reviewing or generating code, apply the following checks and references:
   [`doc/howwewritego.md`](../doc/howwewritego.md), which defines the project’s
   architectural patterns, design decisions, and testing requirements.
 - **Verify testing quality:** Add or update tests as needed, following the
-  guidance in [Go Test Comments](https://go.dev/wiki/TestComments).
+  guidance in [Go Test Comments](../doc/styleguide/go-test-comments.md).
 - **Enforce idiomatic Go:** Flag patterns that conflict with the recommendations
-  in [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+  in [Go Code Review Comments](../doc/styleguide/go-code-review-comments.md).
 - **Write clear Markdown:** Follow the
   [Google Markdown Style Guide](../doc/styleguide/markdown-style-guide.md).
 - **Write proper commit messages:** Follow the conventions in

--- a/doc/howwewritego.md
+++ b/doc/howwewritego.md
@@ -22,7 +22,7 @@ For guidance, refer to the following resources:
 
 - [Effective Go](https://go.dev/doc/effective_go): The canonical guide to
   writing idiomatic Go code.
-- [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments): Common
+- [Go Code Review Comments](styleguide/go-code-review-comments.md): Common
   feedback and best practices used in Go code reviews.
 - [Google's Go Style Guide](https://google.github.io/styleguide/go/decisions):
   Google’s guidance on Go style and design decisions.
@@ -182,7 +182,7 @@ inputs versus which functions only read them.
 
 When writing tests, we follow the patterns below to ensure consistency,
 readability, and ease of debugging. See
-[Go Test Comments](https://go.dev/wiki/TestComments) for conventions around
+[Go Test Comments](styleguide/go-test-comments.md) for conventions around
 writing test code.
 
 ### Use `t.Context()`

--- a/doc/styleguide/README.md
+++ b/doc/styleguide/README.md
@@ -1,0 +1,2 @@
+This folder contains local copies of external style guides so that Gemini can
+read them directly instead of fetching them from the web.

--- a/doc/styleguide/go-code-review-comments.md
+++ b/doc/styleguide/go-code-review-comments.md
@@ -1,0 +1,722 @@
+# Go Code Review Comments
+
+_This document was copied from https://go.dev/wiki/CodeReviewComments for use by
+Gemini._
+
+---
+
+This page collects common comments made during reviews of Go code, so that a
+single detailed explanation can be referred to by shorthands. This is a laundry
+list of common style issues, not a comprehensive style guide.
+
+You can view this as a supplement to
+[Effective Go](https://go.dev/doc/effective_go).
+
+Additional comments related to testing can be found at
+[Go Test Comments](go-test-comments.md).
+
+**Please
+[discuss changes](https://go.dev/issue/new?title=wiki%3A+CodeReviewComments+change&body=&labels=Documentation)
+before editing this page**, even _minor_ ones. Many people have opinions and
+this is not the place for edit wars.
+
+## Gofmt
+
+Run [gofmt](https://pkg.go.dev/cmd/gofmt/) on your code to automatically fix
+the majority of mechanical style issues. Almost all Go code in the wild uses
+`gofmt`. The rest of this document addresses non-mechanical style points.
+
+An alternative is to use
+[goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports), a superset of
+`gofmt` which additionally adds (and removes) import lines as necessary.
+
+## Comment Sentences
+
+See
+[https://go.dev/doc/effective_go#commentary](https://go.dev/doc/effective_go#commentary).
+Comments documenting declarations should be full sentences, even if that seems a
+little redundant. This approach makes them format well when extracted into godoc
+documentation. Comments should begin with the name of the thing being described
+and end in a period:
+
+```go
+// Request represents a request to run a command.
+type Request struct { ...
+
+// Encode writes the JSON encoding of req to w.
+func Encode(w io.Writer, req *Request) { ...
+```
+
+and so on.
+
+## Contexts
+
+Values of the context.Context type carry security credentials, tracing
+information, deadlines, and cancellation signals across API and process
+boundaries. Go programs pass Contexts explicitly along the entire function call
+chain from incoming RPCs and HTTP requests to outgoing requests.
+
+Most functions that use a Context should accept it as their first parameter:
+
+```go
+func F(ctx context.Context, /* other arguments */) {}
+```
+
+A function that is never request-specific may use context.Background(), but err
+on the side of passing a Context even if you think you don't need to. The
+default case is to pass a Context; only use context.Background() directly if you
+have a good reason why the alternative is a mistake.
+
+Don't add a Context member to a struct type; instead add a ctx parameter to each
+method on that type that needs to pass it along. The one exception is for
+methods whose signature must match an interface in the standard library or in a
+third party library.
+
+Don't create custom Context types or use interfaces other than Context in
+function signatures.
+
+If you have application data to pass around, put it in a parameter, in the
+receiver, in globals, or, if it truly belongs there, in a Context value.
+
+Contexts are immutable, so it's fine to pass the same ctx to multiple calls that
+share the same deadline, cancellation signal, credentials, parent trace, etc.
+
+## Copying
+
+To avoid unexpected aliasing, be careful when copying a struct from another
+package. For example, the bytes.Buffer type contains a `[]byte` slice. If you
+copy a `Buffer`, the slice in the copy may alias the array in the original,
+causing subsequent method calls to have surprising effects.
+
+In general, do not copy a value of type `T` if its methods are associated with
+the pointer type, `*T`.
+
+## Crypto Rand
+
+Do not use package
+[`math/rand`](https://pkg.go.dev/math/rand) or
+[`math/rand/v2`](https://pkg.go.dev/math/rand/v2) to generate keys, even
+throwaway ones. Seeded with
+[`Time.Nanoseconds()`](https://pkg.go.dev/time#Time.Nanosecond), there are just
+a few bits of entropy. Instead, use
+[`crypto/rand.Reader`](https://pkg.go.dev/crypto/rand#pkg-variables). If you
+need text, use
+[`crypto/rand.Text`](https://pkg.go.dev/crypto/rand#Text), or alternatively,
+encode random bytes with
+[`encoding/hex`](https://pkg.go.dev/encoding/hex) or
+[`encoding/base64`](https://pkg.go.dev/encoding/base64).
+
+```go
+import (
+    "crypto/rand"
+    "fmt"
+)
+
+func Key() string {
+  return rand.Text()
+}
+```
+
+## Declaring Empty Slices
+
+When declaring an empty slice, prefer
+
+```go
+var t []string
+```
+
+over
+
+```go
+t := []string{}
+```
+
+The former declares a nil slice value, while the latter is non-nil but
+zero-length. They are functionally equivalent--their `len` and `cap` are both
+zero--but the nil slice is the preferred style.
+
+Note that there are limited circumstances where a non-nil but zero-length slice
+is preferred, such as when encoding JSON objects (a `nil` slice encodes to
+`null`, while `[]string{}` encodes to the JSON array `[]`).
+
+When designing interfaces, avoid making a distinction between a nil slice and a
+non-nil, zero-length slice, as this can lead to subtle programming errors.
+
+For more discussion about nil in Go see Francesc Campoy's talk
+[Understanding Nil](https://www.youtube.com/watch?v=ynoY2xz-F8s).
+
+## Doc Comments
+
+All top-level, exported names should have doc comments, as should non-trivial
+unexported type or function declarations. See
+[https://go.dev/doc/effective_go#commentary](https://go.dev/doc/effective_go#commentary)
+for more information about commentary conventions.
+
+## Don't Panic
+
+See
+[https://go.dev/doc/effective_go#errors](https://go.dev/doc/effective_go#errors).
+Don't use panic for normal error handling. Use error and multiple return values.
+
+## Error Strings
+
+Error strings should not be capitalized (unless beginning with proper nouns or
+acronyms) or end with punctuation, since they are usually printed following
+other context. That is, use `fmt.Errorf("something bad")` not
+`fmt.Errorf("Something bad")`, so that
+`log.Printf("Reading %s: %v", filename, err)` formats without a spurious
+capital letter mid-message. This does not apply to logging, which is implicitly
+line-oriented and not combined inside other messages.
+
+## Examples
+
+When adding a new package, include examples of intended usage: a runnable
+Example, or a simple test demonstrating a complete call sequence.
+
+Read more about
+[testable Example() functions](https://go.dev/blog/examples).
+
+## Goroutine Lifetimes
+
+When you spawn goroutines, make it clear when - or whether - they exit.
+
+Goroutines can leak by blocking on channel sends or receives: the garbage
+collector will not terminate a goroutine even if the channels it is blocked on
+are unreachable.
+
+Even when goroutines do not leak, leaving them in-flight when they are no longer
+needed can cause other subtle and hard-to-diagnose problems. Sends on closed
+channels panic. Modifying still-in-use inputs "after the result isn't needed"
+can still lead to data races. And leaving goroutines in-flight for arbitrarily
+long can lead to unpredictable memory usage.
+
+Try to keep concurrent code simple enough that goroutine lifetimes are obvious.
+If that just isn't feasible, document when and why the goroutines exit.
+
+## Handle Errors
+
+See
+[https://go.dev/doc/effective_go#errors](https://go.dev/doc/effective_go#errors).
+Do not discard errors using `_` variables. If a function returns an error, check
+it to make sure the function succeeded. Handle the error, return it, or, in
+truly exceptional situations, panic.
+
+## Imports
+
+Avoid renaming imports except to avoid a name collision; good package names
+should not require renaming. In the event of collision, prefer to rename the
+most local or project-specific import.
+
+Imports are organized in groups, with blank lines between them. The standard
+library packages are always in the first group.
+
+```go
+package main
+
+import (
+    "fmt"
+    "hash/adler32"
+    "os"
+
+    "github.com/foo/bar"
+    "rsc.io/goversion/version"
+)
+```
+
+[goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) will do this
+for you.
+
+## Import Blank
+
+Packages that are imported only for their side effects (using the syntax
+`import _ "pkg"`) should only be imported in the main package of a program, or
+in tests that require them.
+
+## Import Dot
+
+The import . form can be useful in tests that, due to circular dependencies,
+cannot be made part of the package being tested:
+
+```go
+package foo_test
+
+import (
+    "bar/testutil" // also imports "foo"
+    . "foo"
+)
+```
+
+In this case, the test file cannot be in package foo because it uses
+bar/testutil, which imports foo. So we use the 'import .' form to let the file
+pretend to be part of package foo even though it is not. Except for this one
+case, do not use import . in your programs. It makes the programs much harder to
+read because it is unclear whether a name like Quux is a top-level identifier in
+the current package or in an imported package.
+
+## In-Band Errors
+
+In C and similar languages, it's common for functions to return values like -1
+or null to signal errors or missing results:
+
+```go
+// Lookup returns the value for key or "" if there is no mapping for key.
+func Lookup(key string) string
+
+// Failing to check for an in-band error value can lead to bugs:
+Parse(Lookup(key))  // returns "parse failure for value" instead of "no value for key"
+```
+
+Go's support for multiple return values provides a better solution. Instead of
+requiring clients to check for an in-band error value, a function should return
+an additional value to indicate whether its other return values are valid. This
+return value may be an error, or a boolean when no explanation is needed. It
+should be the final return value.
+
+```go
+// Lookup returns the value for key or ok=false if there is no mapping for key.
+func Lookup(key string) (value string, ok bool)
+```
+
+This prevents the caller from using the result incorrectly:
+
+```go
+Parse(Lookup(key))  // compile-time error
+```
+
+And encourages more robust and readable code:
+
+```go
+value, ok := Lookup(key)
+if !ok {
+    return fmt.Errorf("no value for %q", key)
+}
+return Parse(value)
+```
+
+This rule applies to exported functions but is also useful for unexported
+functions.
+
+Return values like nil, "", 0, and -1 are fine when they are valid results for a
+function, that is, when the caller need not handle them differently from other
+values.
+
+Some standard library functions, like those in package "strings", return
+in-band error values. This greatly simplifies string-manipulation code at the
+cost of requiring more diligence from the programmer. In general, Go code should
+return additional values for errors.
+
+## Indent Error Flow
+
+Try to keep the normal code path at a minimal indentation, and indent the error
+handling, dealing with it first. This improves the readability of the code by
+permitting visually scanning the normal path quickly. For instance, don't write:
+
+```go
+if err != nil {
+    // error handling
+} else {
+    // normal code
+}
+```
+
+Instead, write:
+
+```go
+if err != nil {
+    // error handling
+    return // or continue, etc.
+}
+// normal code
+```
+
+If the `if` statement has an initialization statement, such as:
+
+```go
+if x, err := f(); err != nil {
+    // error handling
+    return
+} else {
+    // use x
+}
+```
+
+then this may require moving the short variable declaration to its own line:
+
+```go
+x, err := f()
+if err != nil {
+    // error handling
+    return
+}
+// use x
+```
+
+## Initialisms
+
+Words in names that are initialisms or acronyms (e.g. "URL" or "NATO") have a
+consistent case. For example, "URL" should appear as "URL" or "url" (as in
+"urlPony", or "URLPony"), never as "Url". As an example: ServeHTTP not
+ServeHttp. For identifiers with multiple initialized "words", use for example
+"xmlHTTPRequest" or "XMLHTTPRequest".
+
+This rule also applies to "ID" when it is short for "identifier" (which is
+pretty much all cases when it's not the "id" as in "ego", "superego"), so write
+"appID" instead of "appId".
+
+Code generated by the protocol buffer compiler is exempt from this rule.
+Human-written code is held to a higher standard than machine-written code.
+
+## Interfaces
+
+Go interfaces generally belong in the package that uses values of the interface
+type, not the package that implements those values. The implementing package
+should return concrete (usually pointer or struct) types: that way, new methods
+can be added to implementations without requiring extensive refactoring.
+
+Do not define interfaces on the implementor side of an API "for mocking";
+instead, design the API so that it can be tested using the public API of the
+real implementation.
+
+Do not define interfaces before they are used: without a realistic example of
+usage, it is too difficult to see whether an interface is even necessary, let
+alone what methods it ought to contain.
+
+```go
+package consumer  // consumer.go
+
+type Thinger interface { Thing() bool }
+
+func Foo(t Thinger) string { ... }
+```
+
+```go
+package consumer // consumer_test.go
+
+type fakeThinger struct{ ... }
+func (t fakeThinger) Thing() bool { ... }
+...
+if Foo(fakeThinger{...}) == "x" { ... }
+```
+
+```go
+// DO NOT DO IT!!!
+package producer
+
+type Thinger interface { Thing() bool }
+
+type defaultThinger struct{ ... }
+func (t defaultThinger) Thing() bool { ... }
+
+func NewThinger() Thinger { return defaultThinger{ ... } }
+```
+
+Instead return a concrete type and let the consumer mock the producer
+implementation.
+
+```go
+package producer
+
+type Thinger struct{ ... }
+func (t Thinger) Thing() bool { ... }
+
+func NewThinger() Thinger { return Thinger{ ... } }
+```
+
+## Line Length
+
+There is no rigid line length limit in Go code, but avoid uncomfortably long
+lines. Similarly, don't add line breaks to keep lines short when they are more
+readable long--for example, if they are repetitive.
+
+Most of the time when people wrap lines "unnaturally" (in the middle of function
+calls or function declarations, more or less, say, though some exceptions are
+around), the wrapping would be unnecessary if they had a reasonable number of
+parameters and reasonably short variable names. Long lines seem to go with long
+names, and getting rid of the long names helps a lot.
+
+In other words, break lines because of the semantics of what you're writing (as
+a general rule) and not because of the length of the line. If you find that this
+produces lines that are too long, then change the names or the semantics and
+you'll probably get a good result.
+
+This is, actually, exactly the same advice about how long a function should be.
+There's no rule "never have a function more than N lines long", but there is
+definitely such a thing as too long of a function, and of too repetitive tiny
+functions, and the solution is to change where the function boundaries are, not
+to start counting lines.
+
+## Mixed Caps
+
+See
+[https://go.dev/doc/effective_go#mixed-caps](https://go.dev/doc/effective_go#mixed-caps).
+This applies even when it breaks conventions in other languages. For example an
+unexported constant is `maxLength` not `MaxLength` or `MAX_LENGTH`.
+
+Also see [Initialisms](#initialisms).
+
+## Named Result Parameters
+
+Consider what it will look like in godoc. Named result parameters like:
+
+```go
+func (n *Node) Parent1() (node *Node) {}
+func (n *Node) Parent2() (node *Node, err error) {}
+```
+
+will be repetitive in godoc; better to use:
+
+```go
+func (n *Node) Parent1() *Node {}
+func (n *Node) Parent2() (*Node, error) {}
+```
+
+On the other hand, if a function returns two or three parameters of the same
+type, or if the meaning of a result isn't clear from context, adding names may
+be useful in some contexts. Don't name result parameters just to avoid declaring
+a var inside the function; that trades off a minor implementation brevity at the
+cost of unnecessary API verbosity.
+
+```go
+func (f *Foo) Location() (float64, float64, error)
+```
+
+is less clear than:
+
+```go
+// Location returns f's latitude and longitude.
+// Negative values mean south and west, respectively.
+func (f *Foo) Location() (lat, long float64, err error)
+```
+
+Naked returns are okay if the function is a handful of lines. Once it's a medium
+sized function, be explicit with your return values. Corollary: it's not worth
+it to name result parameters just because it enables you to use naked returns.
+Clarity of docs is always more important than saving a line or two in your
+function.
+
+Finally, in some cases you need to name a result parameter in order to change it
+in a deferred closure. That is always OK.
+
+## Naked Returns
+
+A `return` statement without arguments returns the named return values. This is
+known as a "naked" return.
+
+```go
+func split(sum int) (x, y int) {
+    x = sum * 4 / 9
+    y = sum - x
+    return
+}
+```
+
+See [Named Result Parameters](#named-result-parameters).
+
+## Package Comments
+
+Package comments, like all comments to be presented by godoc, must appear
+adjacent to the package clause, with no blank line.
+
+```go
+// Package math provides basic constants and mathematical functions.
+package math
+```
+
+```go
+/*
+Package template implements data-driven templates for generating textual
+output such as HTML.
+....
+*/
+package template
+```
+
+For "package main" comments, other styles of comment are fine after the binary
+name (and it may be capitalized if it comes first), For example, for a
+`package main` in the directory `seedgen` you could write:
+
+```go
+// Binary seedgen ...
+package main
+```
+
+or
+
+```go
+// Command seedgen ...
+package main
+```
+
+or
+
+```go
+// Program seedgen ...
+package main
+```
+
+or
+
+```go
+// The seedgen command ...
+package main
+```
+
+or
+
+```go
+// The seedgen program ...
+package main
+```
+
+or
+
+```go
+// Seedgen ..
+package main
+```
+
+These are examples, and sensible variants of these are acceptable.
+
+Note that starting the sentence with a lower-case word is not among the
+acceptable options for package comments, as these are publicly-visible and
+should be written in proper English, including capitalizing the first word of
+the sentence. When the binary name is the first word, capitalizing it is
+required even though it does not strictly match the spelling of the command-line
+invocation.
+
+See
+[https://go.dev/doc/effective_go#commentary](https://go.dev/doc/effective_go#commentary)
+for more information about commentary conventions.
+
+## Package Names
+
+All references to names in your package will be done using the package name, so
+you can omit that name from the identifiers. For example, if you are in package
+chubby, you don't need type ChubbyFile, which clients will write as
+`chubby.ChubbyFile`. Instead, name the type `File`, which clients will write as
+`chubby.File`. Avoid meaningless package names like util, common, misc, api,
+types, and interfaces. See
+[https://go.dev/doc/effective_go#package-names](https://go.dev/doc/effective_go#package-names)
+and [https://go.dev/blog/package-names](https://go.dev/blog/package-names) for
+more.
+
+## Pass Values
+
+Don't pass pointers as function arguments just to save a few bytes. If a
+function refers to its argument `x` only as `*x` throughout, then the argument
+shouldn't be a pointer. Common instances of this include passing a pointer to a
+string (`*string`) or a pointer to an interface value (`*io.Reader`). In both
+cases the value itself is a fixed size and can be passed directly. This advice
+does not apply to large structs, or even small structs that might grow.
+
+## Receiver Names
+
+The name of a method's receiver should be a reflection of its identity; often a
+one or two letter abbreviation of its type suffices (such as "c" or "cl" for
+"Client"). Don't use generic names such as "me", "this" or "self", identifiers
+typical of object-oriented languages that gives the method a special meaning. In
+Go, the receiver of a method is just another parameter and therefore, should be
+named accordingly. The name need not be as descriptive as that of a method
+argument, as its role is obvious and serves no documentary purpose. It can be
+very short as it will appear on almost every line of every method of the type;
+familiarity admits brevity. Be consistent, too: if you call the receiver "c" in
+one method, don't call it "cl" in another.
+
+## Receiver Type
+
+Choosing whether to use a value or pointer receiver on methods can be difficult,
+especially to new Go programmers. If in doubt, use a pointer, but there are
+times when a value receiver makes sense, usually for reasons of efficiency, such
+as for small unchanging structs or values of basic type. Some useful guidelines:
+
+- If the receiver is a map, func or chan, don't use a pointer to them. If the
+  receiver is a slice and the method doesn't reslice or reallocate the slice,
+  don't use a pointer to it.
+- If the method needs to mutate the receiver, the receiver must be a pointer.
+- If the receiver is a struct that contains a sync.Mutex or similar
+  synchronizing field, the receiver must be a pointer to avoid copying.
+- If the receiver is a large struct or array, a pointer receiver is more
+  efficient. How large is large? Assume it's equivalent to passing all its
+  elements as arguments to the method. If that feels too large, it's also too
+  large for the receiver.
+- Can function or methods, either concurrently or when called from this method,
+  be mutating the receiver? A value type creates a copy of the receiver when the
+  method is invoked, so outside updates will not be applied to this receiver. If
+  changes must be visible in the original receiver, the receiver must be a
+  pointer.
+- If the receiver is a struct, array or slice and any of its elements is a
+  pointer to something that might be mutating, prefer a pointer receiver, as it
+  will make the intention clearer to the reader.
+- If the receiver is a small array or struct that is naturally a value type (for
+  instance, something like the time.Time type), with no mutable fields and no
+  pointers, or is just a simple basic type such as int or string, a value
+  receiver makes sense. A value receiver can reduce the amount of garbage that
+  can be generated; if a value is passed to a value method, an on-stack copy can
+  be used instead of allocating on the heap. (The compiler tries to be smart
+  about avoiding this allocation, but it can't always succeed.) Don't choose a
+  value receiver type for this reason without profiling first.
+- Don't mix receiver types. Choose either pointers or struct types for all
+  available methods.
+- Finally, when in doubt, use a pointer receiver.
+
+## Synchronous Functions
+
+Prefer synchronous functions - functions which return their results directly or
+finish any callbacks or channel ops before returning - over asynchronous ones.
+
+Synchronous functions keep goroutines localized within a call, making it easier
+to reason about their lifetimes and avoid leaks and data races. They're also
+easier to test: the caller can pass an input and check the output without the
+need for polling or synchronization.
+
+If callers need more concurrency, they can add it easily by calling the function
+from a separate goroutine. But it is quite difficult - sometimes impossible - to
+remove unnecessary concurrency at the caller side.
+
+## Useful Test Failures
+
+Tests should fail with helpful messages saying what was wrong, with what inputs,
+what was actually got, and what was expected. It may be tempting to write a bunch
+of assertFoo helpers, but be sure your helpers produce useful error messages.
+Assume that the person debugging your failing test is not you, and is not your
+team. A typical Go test fails like:
+
+```go
+if got != tt.want {
+    t.Errorf("Foo(%q) = %d; want %d", tt.in, got, tt.want) // or Fatalf, if test can't test anything more past this point
+}
+```
+
+Note that the order here is actual != expected, and the message uses that order
+too. Some test frameworks encourage writing these backwards: 0 != x, "expected
+0, got x", and so on. Go does not.
+
+If that seems like a lot of typing, you may want to write a
+[table-driven test](https://go.dev/wiki/TableDrivenTests).
+
+Another common technique to disambiguate failing tests when using a test helper
+with different input is to wrap each caller with a different TestFoo function,
+so the test fails with that name:
+
+```go
+func TestSingleValue(t *testing.T) { testHelper(t, []int{80}) }
+func TestNoValues(t *testing.T)    { testHelper(t, []int{}) }
+```
+
+In any case, the onus is on you to fail with a helpful message to whoever's
+debugging your code in the future.
+
+## Variable Names
+
+Variable names in Go should be short rather than long. This is especially true
+for local variables with limited scope. Prefer `c` to `lineCount`. Prefer `i`
+to `sliceIndex`.
+
+The basic rule: the further from its declaration that a name is used, the more
+descriptive the name must be. For a method receiver, one or two letters is
+sufficient. Common variables such as loop indices and readers can be a single
+letter (`i`, `r`). More unusual things and global variables need more
+descriptive names.
+
+See also the longer discussion in the
+[Google Go Style Guide](https://google.github.io/styleguide/go/decisions#variable-names).

--- a/doc/styleguide/go-test-comments.md
+++ b/doc/styleguide/go-test-comments.md
@@ -1,0 +1,285 @@
+# Go Test Comments
+
+_This document was copied from https://go.dev/wiki/TestComments for use by
+Gemini._
+
+---
+
+This page is a supplement to
+[Go Code Review Comments](go-code-review-comments.md), but is targeted
+specifically to test code.
+
+**Please
+[discuss changes](https://go.dev/issue/new?title=wiki%3A+TestComments+change&body=&labels=Documentation)
+before editing this page**, even _minor_ ones. Many people have opinions and
+this is not the place for edit wars.
+
+## Assert Libraries
+
+Avoid the use of 'assert' libraries to help your tests. Go developers arriving
+from xUnit frameworks often want to write code like:
+
+```go
+assert.IsNotNil(t, "obj", obj)
+assert.StringEq(t, "obj.Type", obj.Type, "blogPost")
+assert.IntEq(t, "obj.Comments", obj.Comments, 2)
+assert.StringNotEq(t, "obj.Body", obj.Body, "")
+```
+
+but this either stops the test early (if assert calls `t.Fatalf` or `panic`) or
+omits interesting information about what the test got right. It also forces the
+assert package to create a whole new sub-language instead of reusing the existing
+programming language (Go itself). Go has good support for printing structures,
+so a better way to write this code is:
+
+```go
+if obj == nil || obj.Type != "blogPost" || obj.Comments != 2 || obj.Body == "" {
+    t.Errorf("AddPost() = %+v", obj)
+}
+```
+
+Assert libraries make it too easy to write imprecise tests and inevitably end up
+duplicating features already in the language, like expression evaluation,
+comparisons, sometimes even more. Strive to write tests that are precise both
+about what went wrong and what went right, and make use of Go itself instead of
+creating a mini-language inside Go.
+
+## Choose Human-Readable Subtest Names
+
+When you use `t.Run` to create a subtest, the first argument is used as a
+descriptive name for the test. To ensure that test results are legible to humans
+reading the logs, choose subtest names that will remain useful and readable
+after escaping. (The test runner replaces spaces with underscores, and it
+escapes non-printing characters).
+
+To [identify the inputs](#identify-the-input), use `t.Log` in the body of the
+subtest or include them in the test's failure messages, where they won't be
+escaped by the test runner.
+
+## Compare Stable Results
+
+Avoid comparing results that may inherently depend on output stability of some
+external package that you do not control. Instead, the test should compare on
+semantically relevant information that is stable and resistant to changes in
+your dependencies. For functionality that returns a formatted string or
+serialized bytes, it is generally not safe to assume that the output is stable.
+
+For example,
+[`json.Marshal`](https://pkg.go.dev/encoding/json/#Marshal) makes no guarantee
+about the exact bytes that it may emit. It has the freedom to change (and has
+changed in the past) the output. Tests that perform string equality on the exact
+JSON string may break if the `json` package changes how it serializes the bytes.
+Instead, a more robust test would parse the contents of the JSON string and
+ensure that it is semantically equivalent to some expected data structure.
+
+## Compare Full Structures
+
+If your function returns a struct, don't write test code that performs an
+individual comparison for each field of the struct. Instead, construct the
+struct that you're expecting your function to return, and compare in one shot
+using [diffs](#print-diffs) or
+[deep comparisons](#equality-comparison-and-diffs). The same rule applies to
+arrays and maps.
+
+If your struct needs to be compared for approximate equality or some other kind
+of semantic equality, or it contains fields that cannot be compared for equality
+(e.g. if one of the fields is an `io.Reader`), tweaking a
+[`cmp.Diff`](https://pkg.go.dev/github.com/google/go-cmp/cmp#Diff) or
+[`cmp.Equal`](https://pkg.go.dev/github.com/google/go-cmp/cmp#Equal)
+comparison with
+[cmpopts](https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts) options
+such as
+[`cmpopts.IgnoreInterfaces`](https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts#IgnoreInterfaces)
+may meet your needs
+([example](https://go.dev/play/p/vrCUNVfxsvF)); otherwise, this technique just
+won't work, so do whatever works.
+
+If your function returns multiple return values, you don't need to wrap those in
+a struct before comparing them. Just compare the return values individually and
+print them.
+
+## Equality Comparison and Diffs
+
+The `==` operator evaluates equality using the
+[language-defined comparisons](https://go.dev/ref/spec#Comparison_operators).
+Values it can compare include numeric, string, and pointer values and structs
+with fields of those values. In particular, it determines two pointers to be
+equal only if they point to the same variable.
+
+Use the [cmp](https://pkg.go.dev/github.com/google/go-cmp/cmp) package. Use
+[`cmp.Equal`](https://pkg.go.dev/github.com/google/go-cmp/cmp#Equal) for
+equality comparison and
+[`cmp.Diff`](https://pkg.go.dev/github.com/google/go-cmp/cmp#Diff) to obtain a
+human-readable diff between objects.
+
+Although the `cmp` package is not part of the Go standard library, it is
+maintained by the Go team and should produce stable results across Go version
+updates. It is user-configurable and should serve most comparison needs.
+
+You will find older code using the standard `reflect.DeepEqual` function to
+compare complex structures. Prefer `cmp` for new code, and consider updating
+older code to use `cmp` where practical. `reflect.DeepEqual` is sensitive to
+changes in unexported fields and other implementation details.
+
+NOTE: The `cmp` package can also be used with protocol buffer messages, by
+including the `cmp.Comparer(proto.Equal)` option when comparing protocol buffer
+messages.
+
+## Got before Want
+
+Test outputs should output the actual value that the function returned before
+printing the value that was expected. A usual format for printing test outputs
+is "`YourFunc(%v) = %v, want %v`".
+
+For diffs, directionality is less apparent, and thus it is important to include
+a key to aid in interpreting the failure. See [Print Diffs](#print-diffs).
+
+Whichever order you use in your failure messages, you should explicitly indicate
+the ordering as a part of the failure message, because existing code is
+inconsistent about the ordering.
+
+## Identify the Function
+
+In most tests, failure messages should include the name of the function that
+failed, even though it seems obvious from the name of the test function.
+
+Prefer:
+
+```go
+t.Errorf("YourFunc(%v) = %v, want %v", in, got, want)
+```
+
+and not:
+
+```go
+t.Errorf("got %v, want %v", got, want)
+```
+
+## Identify the Input
+
+In most tests, your test failure messages should include the function inputs if
+they are short. If the relevant properties of the inputs are not obvious (for
+example, because the inputs are large or opaque), you should name your test
+cases with a description of what's being tested, and print the description as
+part of your error message.
+
+Do not use the index of the test in the test table as a substitute for naming
+your tests or printing the inputs. Nobody wants to go through your test table
+and count the entries in order to figure out which test case is failing.
+
+## Keep Going
+
+Even after your test cases encounter a failure, they should keep going for as
+long as possible in order to print out all of the failed checks in a single run.
+This way, someone who's fixing the failing test doesn't have to play
+whac-a-mole, fixing one bug and then re-running the test to find the next bug.
+
+On a practical level, prefer calling `t.Error` over `t.Fatal`. When comparing
+several different properties of a function's output, use `t.Error` for each of
+those comparisons.
+
+`t.Fatal` is usually only appropriate when some piece of test setup fails,
+without which you cannot run the test at all. In a table-driven test, `t.Fatal`
+is appropriate for failures that set up the whole test function before the test
+loop. Failures that affect a single entry in the test table, which make it
+impossible to continue with that entry, should be reported as follows:
+
+- If you're not using `t.Run` subtests, you should use `t.Error` followed by a
+  `continue` statement to move on to the next table entry.
+- If you're using subtests (and you're inside a call to `t.Run`), then `t.Fatal`
+  ends the current subtest and allows your test case to progress to the next
+  subtest, so use `t.Fatal`.
+
+## Mark Test Helpers
+
+A test helper is a function that performs a setup or teardown task, such as
+constructing an input message, that does not depend on the code under test.
+
+If you pass a `*testing.T`, call
+[`t.Helper`](https://pkg.go.dev/testing#T.Helper) to attribute failures in the
+test helper to the line where the helper is called.
+
+```go
+func TestSomeFunction(t *testing.T) {
+  golden := readFile(t, "testdata/golden.txt")
+  // ...
+}
+
+func readFile(t *testing.T, filename string) string {
+  t.Helper()
+
+  contents, err := ioutil.ReadFile(filename)
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  return string(contents)
+}
+```
+
+Do not use this pattern when it obscures the connection between a test failure
+and the conditions that led to it. Specifically, `t.Helper` should not be used
+to implement assert libraries.
+
+## Print Diffs
+
+If your function returns large output then it can be hard for someone reading
+the failure message to find the differences when your test fails. Instead of
+printing both the returned value and the wanted value, make a diff.
+
+Add some text to your failure message explaining the direction of the diff.
+
+Something like "`diff -want +got`" is good when you're using the `cmp` package
+(if you pass `(want, got)` to the function), because the `-` and `+` that you
+add to your format string will match the `+` and `-` that actually appear at the
+beginning of the diff lines.
+
+The diff will span multiple lines, so you should print a newline before you
+print the diff.
+
+## Table-Driven Tests vs Multiple Test Functions
+
+[Table-driven](https://go.dev/wiki/TableDrivenTests) tests should be used
+whenever many different test cases can be tested using similar testing logic, for
+example when testing whether the actual output of a function is equal to the
+expected output, or when testing whether the outputs of a function always
+conform to the same set of invariants.
+
+When some test cases need to be checked using different logic from other test
+cases, it is more appropriate to write multiple test functions. The logic of
+your test code can get difficult to understand when every entry in a table has
+to be subjected to multiple kinds of conditional logic to do the right kind of
+output check for the right kind of input. If they have different logic but
+identical setup, a sequence of subtests within a single test function might also
+make sense.
+
+You can combine table-driven tests with multiple test functions. For example, if
+you're testing that a function's non-error output exactly matches the expected
+output, and you're also testing that the function returns some non-nil error
+when it gets invalid input, then the clearest unit tests can be achieved by
+writing two separate table-driven test functions -- one for normal non-error
+outputs, and one for error outputs.
+
+## Test Error Semantics
+
+When a unit test performs string comparisons or uses `reflect.DeepEqual` to
+check that particular kinds of errors are returned for particular inputs, you
+may find that your tests are fragile if you have to reword any of those error
+messages in the future. Since this has the potential to turn your unit test into
+a
+[change detector](https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html),
+don't use string comparison to check what type of error your function returns.
+
+It's OK to use string comparisons to check that error messages coming from the
+package under test satisfy some property, for example, that it includes the
+parameter name.
+
+If you care about testing the exact type of error that your functions return,
+you should separate the error string intended for human eyes from the structure
+that is exposed for programmatic use. In this case, you should avoid using
+`fmt.Errorf`, which tends to destroy semantic error information.
+
+Many people who write APIs don't care exactly what kinds of errors their API
+returns for different inputs. If your API is like this, then it is sufficient to
+create error messages using `fmt.Errorf`, and then in the unit test, test only
+whether the error was non-nil when you expected an error.


### PR DESCRIPTION
Local copies of Go Code Review Comments and Go Test Comments are added to doc/styleguide so that Gemini can reference them directly instead of fetching from go.dev/wiki.

References in doc/howwewritego.md and .gemini/styleguide.md are updated to point to the local copies.