### PR TITLE
fix(codecov): add package-level coverage targets

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,18 @@ coverage:
         target: 80% # The target coverage percentage for the project
         threshold: 0% # Allow 0% drop from the target; any drop below target will fail
         if_ci_failed: error # Set the CI status to 'error' if coverage conditions are not met
+      sidekick:
+        target: 80%
+        threshold: 0%
+        if_ci_failed: error
+        paths:
+          - internal/sidekick/**
+      surfer:
+        target: 80%
+        threshold: 0%
+        if_ci_failed: error
+        paths:
+          - internal/surfer/**
     patch: off
 ignore:
   # test packages do not need code coverage
@@ -30,4 +42,3 @@ ignore:
   - internal/legacylibrarian/legacycontainer/java/pom
   - internal/legacylibrarian/legacycontainer/java/release
   - internal/legacylibrarian/legacyimages
-  - internal/surfer/gcloud


### PR DESCRIPTION
Coverage status checks are added for internal/surfer and internal/sidekick. The internal/surfer/gcloud package is removed from the ignore list now that it has >80% test coverage.