### PR TITLE
ci(all): enforce 5-minute timeout on presubmit CI jobs

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -19,6 +19,8 @@ permissions:
 jobs:
   go-generate:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -37,6 +39,8 @@ jobs:
           fi
   legacylibrarian:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -51,6 +55,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   test:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -19,6 +19,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -435,3 +435,11 @@ We only update dependencies for security vulnerabilities, bug fixes, or to add
 feature support. Security vulnerabilities are identified using Dependabot and
 govulncheck. Dependency updates for bug fixes or new features must be associated
 with an issue in this repository.
+
+### Presubmit Time Limit
+
+Presubmit jobs are expected to take less than 5 minutes. This keeps the feedback
+loop fast for contributors and reviewers. Tests that take longer than 5 minutes
+should run as postsubmit jobs (triggered only on push to main) instead. See the
+[Rust workflow's `integration` job](https://github.com/googleapis/librarian/blob/2e22539c6dbab1a786d51054136e28a7218d9d7e/.github/workflows/rust.yaml#L72)
+for an example.


### PR DESCRIPTION
Create a policy that all presubmit workflow jobs have a timeout of 5 minutes to keep the feedback loop fast. Tests that need more time should run as postsubmit jobs instead.

The policy is documented in CONTRIBUTING.md and the timeout is set in .github/workflow files.