### PR TITLE
feat(python): preserve "API" as a suffix in .repo-metadata.json

### DIFF
--- a/tool/cmd/migrate/python.go
+++ b/tool/cmd/migrate/python.go
@@ -310,7 +310,7 @@ func applyRepoMetadata(metadataPath, googleapisDir string, library *config.Libra
 		if err != nil {
 			return nil, err
 		}
-		defaultTitle = apiInfo.Title
+		defaultTitle = strings.TrimSuffix(strings.TrimSpace(apiInfo.Title), " API")
 		defaultDocumentationURI = apiInfo.DocumentationURI
 		defaultDefaultVersion = filepath.Base(library.APIs[0].Path)
 	}

--- a/tool/cmd/migrate/python_test.go
+++ b/tool/cmd/migrate/python_test.go
@@ -154,7 +154,7 @@ func TestBuildPythonLibraries(t *testing.T) {
 					DescriptionOverride: "The Cloud Billing Budget API stores Cloud Billing budgets, which define a budget plan and the rules to execute as spend is tracked against that plan.",
 					Python: &config.PythonPackage{
 						DefaultVersion:               "v1beta",
-						NamePrettyOverride:           "Cloud Billing Budget",
+						NamePrettyOverride:           "Cloud Billing Budget API",
 						ProductDocumentationOverride: "https://cloud.google.com/billing/docs/how-to/budget-api-overview",
 						OptArgsByAPI: map[string][]string{
 							"google/cloud/billing/budgets/v1":      {"transport=grpc+rest"},
@@ -188,7 +188,6 @@ func TestBuildPythonLibraries(t *testing.T) {
 					},
 					DescriptionOverride: "Manage BigQuery connections to external data sources.",
 					Python: &config.PythonPackage{
-						NamePrettyOverride:           "BigQuery Connection",
 						ProductDocumentationOverride: "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
 						OptArgsByAPI: map[string][]string{
 							"google/cloud/bigquery/connection/v1": {

--- a/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-billing-budgets/.repo-metadata.json
+++ b/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-billing-budgets/.repo-metadata.json
@@ -9,7 +9,7 @@
   "language": "python",
   "library_type": "GAPIC_AUTO",
   "name": "google-cloud-billing-budgets",
-  "name_pretty": "Cloud Billing Budget",
+  "name_pretty": "Cloud Billing Budget API",
   "product_documentation": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",
   "release_level": "stable",
   "repo": "googleapis/google-cloud-python",


### PR DESCRIPTION
As part of migration, we already detect when the name_pretty in the existing metadata isn't the same as what we would generate. This change makes that detection better by mimicking the API suffix removal from the API title, which is normally performed in repometadata.FromAPI.

The overrides here are intended to be temporary to make migration as simple as possible; #4175 is already tracking their later removal.