### PR TITLE
refactor(internal/librarian/rust): in publish extract semverchecks to its own function

### DIFF
--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -128,7 +128,7 @@ func runSemverChecks(ctx context.Context, semverData semverData) error {
 	return nil
 }
 
-// runSemverChecks iterates through manifests and runs semver checks for each.
+// semverCheck runs semver checks for a specific crate.
 func semverCheck(ctx context.Context, semverData semverData, name string, manifest string) error {
 	if git.IsNewFile(ctx, semverData.gitPath, semverData.lastTag, manifest) {
 		// If the manifest is new, we can skip semver checks, since there is no previous version to compare against.


### PR DESCRIPTION
Initial refactor for https://github.com/googleapis/librarian/issues/3537.

Refactor semver-related fields into a `semverData` struct to reduce function signature bloat and separated the core semver execution loop into dedicated `runSemverChecks` and `semverCheck` helper functions, removing nested logic from `publishCrates` so we can easily implement multithreading for the checks.

