### PR TITLE
feat(sidekick/rust): decouple resource name template generation from HTTP path

### DIFF
--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -19,6 +19,7 @@ import (
 	"cmp"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -1618,33 +1619,16 @@ func (c *codec) annotateResourceNameGeneration(m *api.Method, annotation *method
 	return nil
 }
 
+var templateVarRegex = regexp.MustCompile(`\{[^{}]*\}`)
+
 // formatResourceNameTemplateFromPath constructs the Rust format string directly from the
-// parsed PathTemplate.
+// resolved TargetResource.Template.
 func formatResourceNameTemplateFromPath(m *api.Method, b *api.PathBinding) (string, error) {
-	// Determine the service host (mirroring logic in api/resource_identification.go)
-	host := m.Model.Name + ".googleapis.com"
-	if m.Service != nil && m.Service.DefaultHost != "" {
-		host = m.Service.DefaultHost
+	if b.TargetResource == nil || b.TargetResource.Template == "" {
+		return "", fmt.Errorf("missing target resource template for method %s", m.ID)
 	}
 
-	var sb strings.Builder
-	sb.WriteString("//")
-	sb.WriteString(host)
-
-	// We assume simple path templates where variables correspond to arguments.
-	if b.PathTemplate == nil {
-		return "", fmt.Errorf("missing path template for method %s", m.ID)
-	}
-
-	for _, seg := range b.PathTemplate.Segments {
-		sb.WriteByte('/')
-		if seg.Literal != nil {
-			sb.WriteString(*seg.Literal)
-		} else if seg.Variable != nil {
-			sb.WriteString("{}")
-		}
-	}
-	return sb.String(), nil
+	return templateVarRegex.ReplaceAllString(b.TargetResource.Template, "{}"), nil
 }
 
 // isIdempotent returns "true" if the method is idempotent by default, and "false", if not.

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -437,8 +437,8 @@ func TestFormatResourceNameTemplateFromPath(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("formatResourceNameTemplateFromPath() error = %v, wantErr %v", err, tc.wantErr)
 			}
-			if got != tc.want {
-				t.Errorf("formatResourceNameTemplateFromPath() got = %v, want %v", got, tc.want)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -362,3 +362,84 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatResourceNameTemplateFromPath(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		method  *api.Method
+		binding *api.PathBinding
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Basic",
+			method: &api.Method{
+				Model: &api.API{Name: "test"},
+				Service: &api.Service{
+					DefaultHost: "test.googleapis.com",
+				},
+			},
+			binding: &api.PathBinding{
+				TargetResource: &api.TargetResource{
+					Template: "//test.googleapis.com/projects/{project}/zones/{zone}",
+				},
+			},
+			want: "//test.googleapis.com/projects/{}/zones/{}",
+		},
+		{
+			name: "With Extended Field Path",
+			method: &api.Method{
+				Model:   &api.API{Name: "test"},
+				Service: &api.Service{},
+			},
+			binding: &api.PathBinding{
+				TargetResource: &api.TargetResource{
+					Template: "//test.googleapis.com/items/{item.id}",
+				},
+			},
+			want: "//test.googleapis.com/items/{}",
+		},
+		{
+			name: "Discovery API Compute V1 Example",
+			method: &api.Method{
+				Model: &api.API{Name: "compute"},
+				Service: &api.Service{
+					DefaultHost: "compute.googleapis.com",
+				},
+			},
+			binding: &api.PathBinding{
+				PathTemplate: api.NewPathTemplate().
+					WithLiteral("compute").
+					WithLiteral("v1").
+					WithLiteral("projects").
+					WithVariableNamed("project").
+					WithLiteral("zones").
+					WithVariableNamed("zone"),
+				TargetResource: &api.TargetResource{
+					// Notice that constructTemplate already stripped out "compute/v1"
+					Template: "//compute.googleapis.com/projects/{project}/zones/{zone}",
+				},
+			},
+			want: "//compute.googleapis.com/projects/{}/zones/{}",
+		},
+		{
+			name: "Missing TargetResource",
+			method: &api.Method{
+				ID:    "test.method",
+				Model: &api.API{Name: "test"},
+			},
+			binding: &api.PathBinding{},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatResourceNameTemplateFromPath(tc.method, tc.binding)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("formatResourceNameTemplateFromPath() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("formatResourceNameTemplateFromPath() got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Update the Rust code generator to construct resource name templates using `TargetResource.Template`.

A previous PR attempted to dynamically construct the resource name directly from the method's existing `PathBinding.PathTemplate`, which looks really neat. However, this approach breaks specifically for `compute-v1`, a Discovery API, with the HTTP path templates containing prefixes such as the service name and API version (e.g., `compute/v1/projects/{project}/zones/{zone}`.

This change ensures that non-resource elements are trimmed off.

For #4183