### PR TITLE
chore(internal/serviceconfig): add `google/datastore/v1` to allowlist

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -990,9 +990,6 @@
     nodejs: grpc+rest
     php: grpc+rest
     python: grpc+rest
-- languages:
-    - go
-  path: google/datastore/v1
 - documentation_uri: https://cloud.google.com/datastream/
   languages:
     - go
@@ -2264,6 +2261,9 @@
     - python
     - rust
   path: google/datastore/admin/v1
+- languages:
+    - go
+  path: google/datastore/v1
 - documentation_uri: https://cloud.google.com/artifact-registry
   languages:
     - go


### PR DESCRIPTION
Add `google/datastore/v1` to allowlist.

For #3617 