### PR TITLE
refactor(sidekick): adopt heuristic vocabulary for resource identification

### DIFF
--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -101,10 +101,27 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 					firstIndex := i - 1
 					for firstIndex >= 2 {
 						if tmpl.Segments[firstIndex-1].Variable != nil && tmpl.Segments[firstIndex-2].Literal != nil {
+							// Stop matching if the preceding segment isn't a known collection.
+							if !vocabulary[*tmpl.Segments[firstIndex-2].Literal] {
+								break
+							}
 							firstIndex -= 2
 						} else {
 							break
 						}
+					}
+
+					// Verify the chain connects properly to the root of the path.
+					// If earlier variables exist, this chain is just a trailing partial match and should be ignored.
+					disconnected := false
+					for k := 0; k < firstIndex; k++ {
+						if tmpl.Segments[k].Variable != nil {
+							disconnected = true
+							break
+						}
+					}
+					if disconnected {
+						continue
 					}
 
 					var fieldPaths [][]string

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -128,7 +128,7 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 					}, nil
 				}
 			}
-			return nil, nil
+			// continue scanning backward if not in vocabulary
 		}
 	}
 	return nil, nil

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -81,53 +81,57 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 		return nil, nil
 	}
 
-	var fieldPaths [][]string
-	var firstIndex = -1
-	var lastIndex int
-	segments := binding.PathTemplate.Segments
-
-	// Iterate starting from the second segment, looking for (literal, variable) pairs.
-	for i := 1; i < len(segments); i++ {
-		curr := segments[i]
-		prev := segments[i-1]
-
-		if curr.Variable == nil || prev.Literal == nil {
-			continue
-		}
-
-		// Check if the preceding literal is a valid collection identifier.
-		if !isCollectionIdentifier(*prev.Literal, vocabulary) {
-			// Once a path segment breaks the chain of valid (collection, ID) pairs,
-			// the resource identifier stops.
-			break
-		}
-
-		fieldPath := curr.Variable.FieldPath
-		// Verify the field exists in the input message.
-		_, err := findField(method.InputType, fieldPath)
-		if err != nil {
-			return nil, err
-		}
-		if firstIndex == -1 {
-			firstIndex = i - 1
-		}
-		fieldPaths = append(fieldPaths, fieldPath)
-		lastIndex = i + 1
-	}
-
-	if len(fieldPaths) == 0 {
+	tmpl := binding.PathTemplate
+	if tmpl == nil {
 		return nil, nil
 	}
 
-	template, err := constructTemplate(method, segments[firstIndex:lastIndex])
-	if err != nil {
-		return nil, err
-	}
+	// Iterate backwards over segments
+	for i := len(tmpl.Segments) - 1; i >= 0; i-- {
+		seg := tmpl.Segments[i]
+		if seg.Variable != nil {
+			if i > 0 && tmpl.Segments[i-1].Literal != nil {
+				token := *tmpl.Segments[i-1].Literal
+				if vocabulary[token] {
+					if method.InputType == nil {
+						return nil, fmt.Errorf("consistency error: method %q has no InputType", method.Name)
+					}
 
-	return &TargetResource{
-		FieldPaths: fieldPaths,
-		Template:   template,
-	}, nil
+					// Walk backwards to find the start of the (literal, variable) chain
+					firstIndex := i - 1
+					for firstIndex >= 2 {
+						if tmpl.Segments[firstIndex-1].Variable != nil && tmpl.Segments[firstIndex-2].Literal != nil {
+							firstIndex -= 2
+						} else {
+							break
+						}
+					}
+
+					var fieldPaths [][]string
+					targetSegments := tmpl.Segments[firstIndex : i+1]
+					for _, s := range targetSegments {
+						if s.Variable != nil {
+							_, err := findField(method.InputType, s.Variable.FieldPath)
+							if err != nil {
+								return nil, err
+							}
+							fieldPaths = append(fieldPaths, s.Variable.FieldPath)
+						}
+					}
+					template, err := constructTemplate(method, targetSegments)
+					if err != nil {
+						return nil, err
+					}
+					return &TargetResource{
+						FieldPaths: fieldPaths,
+						Template:   template,
+					}, nil
+				}
+			}
+			return nil, nil
+		}
+	}
+	return nil, nil
 }
 
 func identifyExplicitTarget(method *Method, binding *PathBinding) (*TargetResource, error) {

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -89,64 +89,65 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 	// Iterate backwards over segments
 	for i := len(tmpl.Segments) - 1; i >= 0; i-- {
 		seg := tmpl.Segments[i]
-		if seg.Variable != nil {
-			if i > 0 && tmpl.Segments[i-1].Literal != nil {
-				token := *tmpl.Segments[i-1].Literal
-				if vocabulary[token] {
-					if method.InputType == nil {
-						return nil, fmt.Errorf("consistency error: method %q has no InputType", method.Name)
-					}
-
-					// Walk backwards to find the start of the (literal, variable) chain
-					firstIndex := i - 1
-					for firstIndex >= 2 {
-						if tmpl.Segments[firstIndex-1].Variable != nil && tmpl.Segments[firstIndex-2].Literal != nil {
-							// Stop matching if the preceding segment isn't a known collection.
-							if !vocabulary[*tmpl.Segments[firstIndex-2].Literal] {
-								break
-							}
-							firstIndex -= 2
-						} else {
-							break
-						}
-					}
-
-					// Verify the chain connects properly to the root of the path.
-					// If earlier variables exist, this chain is just a trailing partial match and should be ignored.
-					disconnected := false
-					for k := 0; k < firstIndex; k++ {
-						if tmpl.Segments[k].Variable != nil {
-							disconnected = true
-							break
-						}
-					}
-					if disconnected {
-						continue
-					}
-
-					var fieldPaths [][]string
-					targetSegments := tmpl.Segments[firstIndex : i+1]
-					for _, s := range targetSegments {
-						if s.Variable != nil {
-							_, err := findField(method.InputType, s.Variable.FieldPath)
-							if err != nil {
-								return nil, err
-							}
-							fieldPaths = append(fieldPaths, s.Variable.FieldPath)
-						}
-					}
-					template, err := constructTemplate(method, targetSegments)
-					if err != nil {
-						return nil, err
-					}
-					return &TargetResource{
-						FieldPaths: fieldPaths,
-						Template:   template,
-					}, nil
-				}
-			}
-			// continue scanning backward if not in vocabulary
+		if seg.Variable == nil || i == 0 || tmpl.Segments[i-1].Literal == nil {
+			continue
 		}
+
+		token := *tmpl.Segments[i-1].Literal
+		if !vocabulary[token] {
+			continue // continue scanning backward if not in vocabulary
+		}
+
+		if method.InputType == nil {
+			return nil, fmt.Errorf("consistency error: method %q has no InputType", method.Name)
+		}
+
+		// Walk backwards to find the start of the (literal, variable) chain
+		firstIndex := i - 1
+		for firstIndex >= 2 {
+			if tmpl.Segments[firstIndex-1].Variable != nil && tmpl.Segments[firstIndex-2].Literal != nil {
+				// Stop matching if the preceding segment isn't a known collection.
+				if !vocabulary[*tmpl.Segments[firstIndex-2].Literal] {
+					break
+				}
+				firstIndex -= 2
+			} else {
+				break
+			}
+		}
+
+		// Verify the chain connects properly to the root of the path.
+		// If earlier variables exist, this chain is just a trailing partial match and should be ignored.
+		disconnected := false
+		for k := 0; k < firstIndex; k++ {
+			if tmpl.Segments[k].Variable != nil {
+				disconnected = true
+				break
+			}
+		}
+		if disconnected {
+			continue
+		}
+
+		var fieldPaths [][]string
+		targetSegments := tmpl.Segments[firstIndex : i+1]
+		for _, s := range targetSegments {
+			if s.Variable != nil {
+				_, err := findField(method.InputType, s.Variable.FieldPath)
+				if err != nil {
+					return nil, err
+				}
+				fieldPaths = append(fieldPaths, s.Variable.FieldPath)
+			}
+		}
+		template, err := constructTemplate(method, targetSegments)
+		if err != nil {
+			return nil, err
+		}
+		return &TargetResource{
+			FieldPaths: fieldPaths,
+			Template:   template,
+		}, nil
 	}
 	return nil, nil
 }

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -287,6 +287,30 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		},
 
 		{
+			name:      "heuristic: stops at unknown segment",
+			serviceID: ".google.cloud.compute.v1.Instances",
+			path: NewPathTemplate().
+				WithLiteral("projects").WithVariableNamed("project").
+				WithLiteral("unknown").WithVariableNamed("other").
+				WithLiteral("instances").WithVariableNamed("instance"),
+			fields: []*Field{
+				{Name: "project", Typez: STRING_TYPE},
+				{Name: "other", Typez: STRING_TYPE},
+				{Name: "instance", Typez: STRING_TYPE},
+			},
+			getPaths: []*PathTemplate{
+				NewPathTemplate().
+					WithLiteral("projects").WithVariableNamed("project").
+					WithLiteral("zones").WithVariableNamed("zone").
+					WithLiteral("instances").WithVariableNamed("instance"),
+			},
+			want: &TargetResource{
+				FieldPaths: [][]string{{"project"}},
+				Template:   ParseTemplateForTest("//test-api.googleapis.com/projects/{project}"),
+			},
+		},
+
+		{
 			name:      "heuristic: skips if input field missing",
 			serviceID: ".google.cloud.compute.v1.Instances",
 			path: NewPathTemplate().

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -204,14 +204,30 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		serviceID string
 		path      *PathTemplate
 		fields    []*Field
+		getPaths  []*PathTemplate // Path templates for Get/List methods to build vocabulary
 		resources []*Resource
 		want      *TargetResource
 	}{
+
 		{
-			name:      "heuristic: compute instance",
+			name:      "heuristic: standard infrastructure tokens",
 			serviceID: ".google.cloud.compute.v1.Instances", // eligible
 			path: NewPathTemplate().
-				WithLiteral("compute").WithLiteral("v1").
+				WithLiteral("projects").WithVariableNamed("project").
+				WithLiteral("locations").WithVariableNamed("location"),
+			fields: []*Field{
+				{Name: "project", Typez: STRING_TYPE},
+				{Name: "location", Typez: STRING_TYPE},
+			},
+			want: &TargetResource{
+				FieldPaths: [][]string{{"project"}, {"location"}},
+				Template:   ParseTemplateForTest("//test-api.googleapis.com/projects/{project}/locations/{location}"),
+			},
+		},
+		{
+			name:      "heuristic: learns custom tokens from GET methods",
+			serviceID: ".google.cloud.compute.v1.Instances", // eligible
+			path: NewPathTemplate().
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("zones").WithVariableNamed("zone").
 				WithLiteral("instances").WithVariableNamed("instance"),
@@ -220,15 +236,18 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "zone", Typez: STRING_TYPE},
 				{Name: "instance", Typez: STRING_TYPE},
 			},
-			resources: []*Resource{
-				{Plural: "zones", Type: "compute.googleapis.com/Zone"},
-				{Plural: "instances", Type: "compute.googleapis.com/Instance"},
+			getPaths: []*PathTemplate{
+				NewPathTemplate().
+					WithLiteral("projects").WithVariableNamed("project").
+					WithLiteral("zones").WithVariableNamed("zone").
+					WithLiteral("instances").WithVariableNamed("instance"),
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"project"}, {"zone"}, {"instance"}},
 				Template:   ParseTemplateForTest("//test-api.googleapis.com/projects/{project}/zones/{zone}/instances/{instance}"),
 			},
 		},
+
 		{
 			name:      "heuristic: not eligible service",
 			serviceID: "any.service", // not eligible
@@ -240,49 +259,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 			resources: nil,
 			want:      nil,
 		},
-		{
-			name:      "heuristic: stops at unknown segment",
-			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("unknown").WithVariableNamed("other").
-				WithLiteral("instances").WithVariableNamed("instance"),
-			fields: []*Field{
-				{Name: "project", Typez: STRING_TYPE},
-				{Name: "other", Typez: STRING_TYPE},
-				{Name: "instance", Typez: STRING_TYPE},
-			},
-			resources: []*Resource{
-				{Plural: "instances", Type: "compute.googleapis.com/Instance"},
-			},
-			want: &TargetResource{
-				FieldPaths: [][]string{{"project"}},
-				Template:   ParseTemplateForTest("//test-api.googleapis.com/projects/{project}"),
-			},
-		},
-		{
-			name:      "heuristic: stops at trailing action",
-			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("zones").WithVariableNamed("zone").
-				WithLiteral("instances").WithVariableNamed("instance").
-				WithLiteral("start").WithVariableNamed("action_id"), // "start" is not a collection
-			fields: []*Field{
-				{Name: "project", Typez: STRING_TYPE},
-				{Name: "zone", Typez: STRING_TYPE},
-				{Name: "instance", Typez: STRING_TYPE},
-				{Name: "action_id", Typez: STRING_TYPE},
-			},
-			resources: []*Resource{
-				{Plural: "zones", Type: "compute.googleapis.com/Zone"},
-				{Plural: "instances", Type: "compute.googleapis.com/Instance"},
-			},
-			want: &TargetResource{
-				FieldPaths: [][]string{{"project"}, {"zone"}, {"instance"}},
-				Template:   ParseTemplateForTest("//test-api.googleapis.com/projects/{project}/zones/{zone}/instances/{instance}"),
-			},
-		},
+
 		{
 			name:      "heuristic: skips if input field missing",
 			serviceID: ".google.cloud.compute.v1.Instances",
@@ -291,19 +268,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 			fields: []*Field{}, // No fields
 			want:   nil,
 		},
-		{
-			name:      "heuristic: fallback matches literal ending in 's' (e.g. users)",
-			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
-				WithLiteral("users").WithVariableNamed("user"), // matches fallback heuristic
-			fields: []*Field{
-				{Name: "user", Typez: STRING_TYPE},
-			},
-			want: &TargetResource{
-				FieldPaths: [][]string{{"user"}},
-				Template:   ParseTemplateForTest("//test-api.googleapis.com/users/{user}"),
-			},
-		},
+
 		{
 			name:      "heuristic: skips non-collection literal without 's'",
 			serviceID: ".google.cloud.compute.v1.Instances",
@@ -314,26 +279,24 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 			},
 			want: nil,
 		},
-		{
-			name:      "heuristic: non-string field is still identified (if valid)",
-			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
-				WithLiteral("instances").WithVariableNamed("instance_id"),
-			fields: []*Field{
-				{Name: "instance_id", Typez: INT64_TYPE}, // Unlikely but good test case
-			},
-			resources: []*Resource{
-				{Plural: "instances"},
-			},
-			want: &TargetResource{
-				FieldPaths: [][]string{{"instance_id"}},
-				Template:   ParseTemplateForTest("//test-api.googleapis.com/instances/{instance_id}"),
-			},
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model, binding := setupTestModel(test.serviceID, test.path, test.fields)
-			model.ResourceDefinitions = test.resources
+			if test.resources != nil {
+				model.ResourceDefinitions = test.resources
+			}
+
+			// Add Get methods to populate vocabulary
+			for _, p := range test.getPaths {
+				m := &Method{
+					Name:          "GetSomething",
+					IsAIPStandard: true,
+					PathInfo: &PathInfo{
+						Bindings: []*PathBinding{{PathTemplate: p}},
+					},
+				}
+				model.Services[0].Methods = append(model.Services[0].Methods, m)
+			}
 			IdentifyTargetResources(model)
 
 			got := binding.TargetResource

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -261,6 +261,32 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		},
 
 		{
+			name:      "heuristic: stops at trailing action",
+			serviceID: ".google.cloud.compute.v1.Instances",
+			path: NewPathTemplate().
+				WithLiteral("projects").WithVariableNamed("project").
+				WithLiteral("zones").WithVariableNamed("zone").
+				WithLiteral("instances").WithVariableNamed("instance").
+				WithLiteral("start").WithVariableNamed("action_id"), // "start" is not a collection
+			fields: []*Field{
+				{Name: "project", Typez: STRING_TYPE},
+				{Name: "zone", Typez: STRING_TYPE},
+				{Name: "instance", Typez: STRING_TYPE},
+				{Name: "action_id", Typez: STRING_TYPE},
+			},
+			getPaths: []*PathTemplate{
+				NewPathTemplate().
+					WithLiteral("projects").WithVariableNamed("project").
+					WithLiteral("zones").WithVariableNamed("zone").
+					WithLiteral("instances").WithVariableNamed("instance"),
+			},
+			want: &TargetResource{
+				FieldPaths: [][]string{{"project"}, {"zone"}, {"instance"}},
+				Template:   ParseTemplateForTest("//test-api.googleapis.com/projects/{project}/zones/{zone}/instances/{instance}"),
+			},
+		},
+
+		{
 			name:      "heuristic: skips if input field missing",
 			serviceID: ".google.cloud.compute.v1.Instances",
 			path: NewPathTemplate().

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -110,7 +110,6 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 						token := *tmpl.Segments[i-1].Literal
 						tokens[token] = true
 					}
-					break
 				}
 			}
 		}

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -117,17 +117,3 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 	}
 	return tokens
 }
-
-// isCollectionIdentifier checks if a segment is a valid collection identifier.
-// It checks in the following order:
-// 1. Existing vocabulary (contains base tokens and tokens learned from API paths).
-// 2. Fallback heuristic: checks if the segment ends with 's'.
-func isCollectionIdentifier(segment string, vocabulary map[string]bool) bool {
-	if vocabulary != nil && vocabulary[segment] {
-		return true
-	}
-	if strings.HasSuffix(segment, "s") {
-		return true
-	}
-	return false
-}

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -124,6 +124,7 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 				"folders":         true,
 				"organizations":   true,
 				"billingAccounts": true,
+				"users":           true,
 				"widgets":         true,
 			},
 		},


### PR DESCRIPTION
Update the logic of `identifyHeuristicTarget` to use the dynamically built `vocabulary` in the previous steps.

Fixes #4321 