### PR TITLE
fix(internal/config): fix the typo

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -38,9 +38,9 @@ type GoAPI struct {
 	// EnabledGeneratorFeatures provides a mechanism for enabling generator features
 	// at the API level.
 	EnabledGeneratorFeatures []string `yaml:"enabled_generator_features,omitempty"`
-	// DIREGARPIC indicates whether generation uses DIREGAPIC (Discovery REST GAPICs).
+	// DIREGAPIC indicates whether generation uses DIREGAPIC (Discovery REST GAPICs).
 	// This is typically false. Used for the GCE (compute) client.
-	DIREGARPIC bool `yaml:"diregapic,omitempty"`
+	DIREGAPIC bool `yaml:"diregapic,omitempty"`
 	// ImportPath is the Go import path for the API.
 	ImportPath string `yaml:"import_path,omitempty"`
 	// NestedProtos is a list of nested proto files.

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -198,7 +198,7 @@ func buildGAPICOpts(apiPath string, library *config.Library, goAPI *config.GoAPI
 	if goAPI == nil || !goAPI.NoRESTNumericEnums {
 		opts = append(opts, "rest-numeric-enums")
 	}
-	if goAPI != nil && goAPI.DIREGARPIC {
+	if goAPI != nil && goAPI.DIREGAPIC {
 		opts = append(opts, "diregapic")
 	}
 	if goAPI != nil && goAPI.EnabledGeneratorFeatures != nil {

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -922,7 +922,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 			goAPI: &config.GoAPI{
 				ClientPackage:      "compute",
 				ImportPath:         "compute/apiv1",
-				DIREGARPIC:         true,
+				DIREGAPIC:          true,
 				NoRESTNumericEnums: true,
 				Path:               "google/cloud/compute/v1",
 			},

--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -296,7 +296,7 @@ func buildGoLibraries(input *MigrationInput) ([]*config.Library, error) {
 			}
 			goAPI.ClientPackage = info.ClientPackageName
 			goAPI.ProtoOnly = info.DisableGAPIC
-			goAPI.DIREGARPIC = info.HasDiregapic
+			goAPI.DIREGAPIC = info.HasDiregapic
 			goAPI.ImportPath = info.ImportPath
 			goAPI.NoMetadata = info.NoMetadata
 			goAPI.NoRESTNumericEnums = info.NoRESTNumericEnums

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -788,7 +788,7 @@ func TestBuildGoLibraries(t *testing.T) {
 					Go: &config.GoModule{
 						GoAPIs: []*config.GoAPI{
 							{
-								DIREGARPIC:         true,
+								DIREGAPIC:          true,
 								NoRESTNumericEnums: true,
 								Path:               "google/cloud/compute/v1",
 							},


### PR DESCRIPTION
Fix the typo in Go config, introduced by https://github.com/googleapis/librarian/pull/4329.