### PR TITLE
fix(sidekick): ignore API version strings when building heuristic vocabulary

### DIFF
--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -108,6 +108,10 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 				if seg.Variable != nil {
 					if i > 0 && tmpl.Segments[i-1].Literal != nil {
 						token := *tmpl.Segments[i-1].Literal
+						// Do not add API version strings (e.g., v1, v1beta1) to the vocabulary
+						if len(token) >= 2 && token[0] == 'v' && token[1] >= '0' && token[1] <= '9' {
+							continue
+						}
 						tokens[token] = true
 					}
 					break

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -213,7 +213,6 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 				"folders":         true,
 				"organizations":   true,
 				"billingAccounts": true,
-				"v1":              true,
 			},
 		},
 		{


### PR DESCRIPTION
When `BuildHeuristicVocabulary` dynamically learns collection names from method paths, it parses standard paths and assumes the string literal preceding a variable is a collection name. However, for APIs with flat paths like `/dns/v1/{resource}:setIamPolicy`, it incorrectly identified the API version v1 as a collection name since it immediately precedes a variable.

This adds an explicit exclusion string check to aggressively filter out known API version prefixes (e.g. v1, v2, v1beta1, v1p1beta1).

Fixes #4336 