### PR TITLE
feat(sidekick/rust): extract variables in rust template

### DIFF
--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -397,6 +397,11 @@ func (s *bindingSubstitution) TemplateAsString() string {
 	return strings.Join(s.Template, "/")
 }
 
+// VariableName returns the variable name to be used in the templates.
+func (s *bindingSubstitution) VariableName() string {
+	return fmt.Sprintf("var_%s", strings.ReplaceAll(s.FieldName, ".", "_"))
+}
+
 type pathBindingAnnotation struct {
 	// The path format string for this binding
 	//
@@ -1252,7 +1257,7 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method) (*bindingSubsti
 	}
 	var rustNames []string
 	for _, n := range v.FieldPath {
-		rustNames = append(rustNames, toSnake(n))
+		rustNames = append(rustNames, toSnakeNoMangling(n))
 	}
 	binding := &bindingSubstitution{
 		FieldAccessor: fieldAccessor,

--- a/internal/sidekick/rust/annotate_test.go
+++ b/internal/sidekick/rust/annotate_test.go
@@ -1483,7 +1483,7 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 		{"machine", "machine", "Some(&req).map(|m| &m.machine).map(|s| s.as_str())"},
 		{"machineType", "machine_type", "Some(&req).map(|m| &m.machine_type).map(|s| s.as_str())"},
 		{"machine_type", "machine_type", "Some(&req).map(|m| &m.machine_type).map(|s| s.as_str())"},
-		{"type", "r#type", "Some(&req).map(|m| &m.r#type).map(|s| s.as_str())"},
+		{"type", "type", "Some(&req).map(|m| &m.r#type).map(|s| s.as_str())"},
 	} {
 		field := &api.Field{
 			Name:     test.FieldName,

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -104,10 +104,13 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{#PathInfo.Bindings}}
         .or_else(|| {
             {{#Codec.HasVariablePath}}
+            {{#Codec.Substitutions}}
+            let {{VariableName}} = try_match({{{FieldAccessor}}}, {{{TemplateAsArray}}})?;
+            {{/Codec.Substitutions}}
             let path = format!(
                 "{{Codec.PathFmt}}",
                 {{#Codec.Substitutions}}
-                try_match({{{FieldAccessor}}}, {{{TemplateAsArray}}})?,
+                {{VariableName}},
                 {{/Codec.Substitutions}}
             );
             {{/Codec.HasVariablePath}}


### PR DESCRIPTION
Extract segment substitutions into variable bindings before string formatting, making the variables reusable for both `path` and `_resource_name`.

For #4183 