### PR TITLE
feat(sidekick/rust): decouple option extraction and support resource names

### DIFF
--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -1632,17 +1632,7 @@ func (c *codec) annotateResourceNameGeneration(m *api.Method, annotation *method
 						return err
 					}
 					bAnn.ResourceNameTemplate = tmpl
-
-					var args []string
-					for _, path := range b.TargetResource.FieldPaths {
-						var rustNames []string
-						for _, p := range path {
-							rustNames = append(rustNames, toSnakeNoMangling(p))
-						}
-						varName := fmt.Sprintf("var_%s", strings.Join(rustNames, "_"))
-						args = append(args, varName)
-					}
-					bAnn.ResourceNameArgs = args
+					bAnn.ResourceNameArgs = formatResourceNameArgs(b.TargetResource.FieldPaths)
 
 					if annotation.ResourceNameTemplate == "" {
 						annotation.ResourceNameTemplate = bAnn.ResourceNameTemplate
@@ -1678,6 +1668,20 @@ func formatResourceNameTemplateFromPath(m *api.Method, b *api.PathBinding) (stri
 		}
 	}
 	return sb.String(), nil
+}
+
+// formatResourceNameArgs creates the corresponding Rust template variables for the resource name.
+func formatResourceNameArgs(fieldPaths [][]string) []string {
+	var args []string
+	for _, path := range fieldPaths {
+		var rustNames []string
+		for _, p := range path {
+			rustNames = append(rustNames, toSnakeNoMangling(p))
+		}
+		varName := fmt.Sprintf("var_%s", strings.Join(rustNames, "_"))
+		args = append(args, varName)
+	}
+	return args
 }
 
 // isIdempotent returns "true" if the method is idempotent by default, and "false", if not.

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -1613,19 +1613,6 @@ func (c *codec) annotateResourceNameGeneration(m *api.Method, annotation *method
 	if m.PathInfo != nil {
 		for _, b := range m.PathInfo.Bindings {
 			if b.TargetResource != nil {
-				tmpl, err := formatResourceNameTemplateFromPath(m, b)
-				if err != nil {
-					return err
-				}
-				annotation.ResourceNameTemplate = tmpl
-				for _, path := range b.TargetResource.FieldPaths {
-					var rustNames []string
-					for _, p := range path {
-						rustNames = append(rustNames, toSnakeNoMangling(p))
-					}
-					varName := fmt.Sprintf("var_%s", strings.Join(rustNames, "_"))
-					annotation.ResourceNameArgs = append(annotation.ResourceNameArgs, varName)
-				}
 				annotation.HasResourceNameGeneration = true
 				break
 			}
@@ -1633,10 +1620,37 @@ func (c *codec) annotateResourceNameGeneration(m *api.Method, annotation *method
 
 		if annotation.HasResourceNameGeneration {
 			for _, b := range m.PathInfo.Bindings {
-				if bAnn, ok := b.Codec.(*pathBindingAnnotation); ok {
-					bAnn.HasResourceNameGeneration = true
-					bAnn.ResourceNameTemplate = annotation.ResourceNameTemplate
-					bAnn.ResourceNameArgs = annotation.ResourceNameArgs
+				bAnn, ok := b.Codec.(*pathBindingAnnotation)
+				if !ok {
+					continue
+				}
+				bAnn.HasResourceNameGeneration = true
+
+				if b.TargetResource != nil {
+					tmpl, err := formatResourceNameTemplateFromPath(m, b)
+					if err != nil {
+						return err
+					}
+					bAnn.ResourceNameTemplate = tmpl
+
+					var args []string
+					for _, path := range b.TargetResource.FieldPaths {
+						var rustNames []string
+						for _, p := range path {
+							rustNames = append(rustNames, toSnakeNoMangling(p))
+						}
+						varName := fmt.Sprintf("var_%s", strings.Join(rustNames, "_"))
+						args = append(args, varName)
+					}
+					bAnn.ResourceNameArgs = args
+
+					if annotation.ResourceNameTemplate == "" {
+						annotation.ResourceNameTemplate = bAnn.ResourceNameTemplate
+						annotation.ResourceNameArgs = bAnn.ResourceNameArgs
+					}
+				} else {
+					bAnn.ResourceNameTemplate = ""
+					bAnn.ResourceNameArgs = nil
 				}
 			}
 		}

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -416,6 +416,11 @@ type pathBindingAnnotation struct {
 
 	// The codec is configured to generated detailed tracing attributes.
 	DetailedTracingAttributes bool
+
+	// Resource name generation fields, propagated from method scope.
+	HasResourceNameGeneration bool
+	ResourceNameTemplate      string
+	ResourceNameArgs          []string
 }
 
 // QueryParamsCanFail returns true if we serialize certain query parameters, which can fail. The code we generate
@@ -1614,15 +1619,25 @@ func (c *codec) annotateResourceNameGeneration(m *api.Method, annotation *method
 				}
 				annotation.ResourceNameTemplate = tmpl
 				for _, path := range b.TargetResource.FieldPaths {
-					accSegments, err := makeAccessors(path, m)
-					if err != nil {
-						return err
+					var rustNames []string
+					for _, p := range path {
+						rustNames = append(rustNames, toSnakeNoMangling(p))
 					}
-					fullAcc := "Some(&req)" + strings.Join(accSegments, "") + ".unwrap_or(\"\")"
-					annotation.ResourceNameArgs = append(annotation.ResourceNameArgs, fullAcc)
+					varName := fmt.Sprintf("var_%s", strings.Join(rustNames, "_"))
+					annotation.ResourceNameArgs = append(annotation.ResourceNameArgs, varName)
 				}
 				annotation.HasResourceNameGeneration = true
 				break
+			}
+		}
+
+		if annotation.HasResourceNameGeneration {
+			for _, b := range m.PathInfo.Bindings {
+				if bAnn, ok := b.Codec.(*pathBindingAnnotation); ok {
+					bAnn.HasResourceNameGeneration = true
+					bAnn.ResourceNameTemplate = annotation.ResourceNameTemplate
+					bAnn.ResourceNameArgs = annotation.ResourceNameArgs
+				}
 			}
 		}
 	}

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -1624,6 +1624,7 @@ func (c *codec) annotateResourceNameGeneration(m *api.Method, annotation *method
 				if !ok {
 					continue
 				}
+				// To make sure the Rust code for each binding returns the same type, we set HasResourceNameGeneration = true for all bindings to cue each binding to produce the same typed result (even if this specific binding does not have a TargetResource.)
 				bAnn.HasResourceNameGeneration = true
 
 				if b.TargetResource != nil {

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -328,9 +328,9 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 			want: &methodAnnotation{
 				ResourceNameTemplate: "//Test.googleapis.com/projects/{}/zones/{}/types/{}",
 				ResourceNameArgs: []string{
-					"Some(&req).map(|m| &m.project).map(|s| s.as_str()).unwrap_or(\"\")",
-					"Some(&req).map(|m| &m.zone).map(|s| s.as_str()).unwrap_or(\"\")",
-					"Some(&req).map(|m| &m.r#type).map(|s| s.as_str()).unwrap_or(\"\")",
+					"var_project",
+					"var_zone",
+					"var_type",
 				},
 				HasResourceNameGeneration: true,
 			},

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -197,6 +197,9 @@ func annotateMethodModel(t *testing.T) *api.API {
 			{Name: "project", ID: ".test.v1.Request.project", Typez: api.STRING_TYPE},
 			{Name: "zone", ID: ".test.v1.Request.zone", Typez: api.STRING_TYPE},
 			{Name: "type", ID: ".test.v1.Request.type", Typez: api.STRING_TYPE},
+			{Name: "name", ID: ".test.v1.Request.name", Typez: api.STRING_TYPE},
+			{Name: "location", ID: ".test.v1.Request.location", Typez: api.STRING_TYPE},
+			{Name: "cluster", ID: ".test.v1.Request.cluster", Typez: api.STRING_TYPE},
 		},
 	}
 	response := &api.Message{
@@ -311,6 +314,40 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 		{"type"},
 	})
 
+	// Setup: Inject multiple bindings for the "Self" method
+	mSelf := model.State.MethodByID[".test.v1.ResourceService.Self"]
+	mSelf.PathInfo.Bindings = []*api.PathBinding{
+		{
+			Verb: "GET",
+			PathTemplate: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("name"),
+			TargetResource: &api.TargetResource{
+				Template:   api.ParseTemplateForTest("//Test.googleapis.com/projects/{project}/locations/{location}/clusters/{cluster}"),
+				FieldPaths: [][]string{{"name"}},
+			},
+		},
+		{
+			Verb: "GET",
+			PathTemplate: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithLiteral("projects").
+				WithVariableNamed("project").
+				WithLiteral("locations").
+				WithVariableNamed("location").
+				WithLiteral("clusters").
+				WithVariableNamed("cluster"),
+			TargetResource: &api.TargetResource{
+				Template:   api.ParseTemplateForTest("//Test.googleapis.com/projects/{project}/locations/{location}/clusters/{cluster}"),
+				FieldPaths: [][]string{{"project"}, {"location"}, {"cluster"}},
+			},
+		},
+		{
+			Verb:         "GET",
+			PathTemplate: api.NewPathTemplate(),
+		},
+	}
+
 	codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{})
 	_, err = annotateModel(model, codec)
 	if err != nil {
@@ -318,9 +355,10 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		id   string
-		want *methodAnnotation
+		name         string
+		id           string
+		want         *methodAnnotation
+		wantBindings []*pathBindingAnnotation
 	}{
 		{
 			name: "WithTargetResource",
@@ -342,6 +380,34 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 				HasResourceNameGeneration: false,
 			},
 		},
+		{
+			name: "MultipleBindings",
+			id:   ".test.v1.ResourceService.Self",
+			want: &methodAnnotation{
+				ResourceNameTemplate: "//Test.googleapis.com/projects/{}/locations/{}/clusters/{}",
+				ResourceNameArgs: []string{
+					"var_name",
+				},
+				HasResourceNameGeneration: true,
+			},
+			wantBindings: []*pathBindingAnnotation{
+				{
+					HasResourceNameGeneration: true,
+					ResourceNameTemplate:      "//Test.googleapis.com/projects/{}/locations/{}/clusters/{}",
+					ResourceNameArgs:          []string{"var_name"},
+				},
+				{
+					HasResourceNameGeneration: true,
+					ResourceNameTemplate:      "//Test.googleapis.com/projects/{}/locations/{}/clusters/{}",
+					ResourceNameArgs:          []string{"var_project", "var_location", "var_cluster"},
+				},
+				{
+					HasResourceNameGeneration: true,
+					ResourceNameTemplate:      "",
+					ResourceNameArgs:          nil,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -358,6 +424,15 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 				"RoutingRequired", "DetailedTracingAttributes", "ResourceNameFields",
 				"HasResourceNameFields", "InternalBuilders")); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)
+			}
+
+			if tc.wantBindings != nil {
+				for i, wantBinding := range tc.wantBindings {
+					gotBinding := m.PathInfo.Bindings[i].Codec.(*pathBindingAnnotation)
+					if diff := cmp.Diff(wantBinding, gotBinding, cmpopts.IgnoreFields(pathBindingAnnotation{}, "DetailedTracingAttributes", "PathFmt", "QueryParams", "Substitutions")); diff != "" {
+						t.Errorf("binding %d mismatch (-want, +got):\n%s", i, diff)
+					}
+				}
 			}
 		})
 	}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -95,12 +95,22 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             true,
         );
         {{/HasAutoPopulatedFields}}
+        {{#Codec.HasResourceNameGeneration}}
+        {{#Codec.DetailedTracingAttributes}}
+        let (builder, method, _path_template, _resource_name) = None
+        {{/Codec.DetailedTracingAttributes}}
+        {{^Codec.DetailedTracingAttributes}}
+        let (builder, method, _resource_name) = None
+        {{/Codec.DetailedTracingAttributes}}
+        {{/Codec.HasResourceNameGeneration}}
+        {{^Codec.HasResourceNameGeneration}}
         {{#Codec.DetailedTracingAttributes}}
         let (builder, method, _path_template) = None
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         let (builder, method) = None
         {{/Codec.DetailedTracingAttributes}}
+        {{/Codec.HasResourceNameGeneration}}
         {{#PathInfo.Bindings}}
         .or_else(|| {
             {{#Codec.HasVariablePath}}
@@ -121,6 +131,15 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             let path_template = "{{Codec.PathTemplate}}";
             {{/Codec.DetailedTracingAttributes}}
 
+            {{#Codec.HasResourceNameGeneration}}
+            let _resource_name = format!(
+                "{{{Codec.ResourceNameTemplate}}}",
+                {{#Codec.ResourceNameArgs}}
+                {{{.}}},
+                {{/Codec.ResourceNameArgs}}
+            );
+            {{/Codec.HasResourceNameGeneration}}
+
             let builder = self.inner.builder(Method::{{Verb}}, path);
             {{#Codec.QueryParamsCanFail}}
             let builder = (|| {
@@ -136,12 +155,22 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{/Codec.QueryParams}}
             let builder = Ok(builder);
             {{/Codec.QueryParamsCanFail}}
+            {{#Codec.HasResourceNameGeneration}}
+            {{#Codec.DetailedTracingAttributes}}
+            Some(builder.map(|b| (b, Method::{{Verb}}, path_template, _resource_name)))
+            {{/Codec.DetailedTracingAttributes}}
+            {{^Codec.DetailedTracingAttributes}}
+            Some(builder.map(|b| (b, Method::{{Verb}}, _resource_name)))
+            {{/Codec.DetailedTracingAttributes}}
+            {{/Codec.HasResourceNameGeneration}}
+            {{^Codec.HasResourceNameGeneration}}
             {{#Codec.DetailedTracingAttributes}}
             Some(builder.map(|b| (b, Method::{{Verb}}, path_template)))
             {{/Codec.DetailedTracingAttributes}}
             {{^Codec.DetailedTracingAttributes}}
             Some(builder.map(|b| (b, Method::{{Verb}})))
             {{/Codec.DetailedTracingAttributes}}
+            {{/Codec.HasResourceNameGeneration}}
         })
         {{/PathInfo.Bindings}}
         .ok_or_else(|| {
@@ -178,6 +207,12 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             options.insert_extension(PathTemplate(_path_template))
         };
         {{/Codec.DetailedTracingAttributes}}
+        {{#Codec.HasResourceNameGeneration}}
+        let options = {
+            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
+            options.insert_extension(ResourceName(_resource_name))
+        };
+        {{/Codec.HasResourceNameGeneration}}
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             {{! TODO(#4156) - return idempotency from the above closure }}


### PR DESCRIPTION
Inject resource name generation into the Rust generator.

Fixes #4183 