### PR TITLE
feat(sidekick/rust): add ResourceName flag

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -220,6 +220,7 @@ This document describes the schema for the librarian.yaml.
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `post_process_protos` | string | Indicates whether to post-process protos. |
 | `detailed_tracing_attributes` | bool | Indicates whether to include detailed tracing attributes. |
+| `resource_name` | bool | Indicates whether to apply heuristics to identify and generate resource names. |
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |
 | `pagination_overrides` | list of [RustPaginationOverride](#rustpaginationoverride-configuration) | Contains overrides for pagination configuration. |
 | `name_overrides` | string | Contains codec-level overrides for type and service names. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -241,6 +241,9 @@ type RustCrate struct {
 	// DetailedTracingAttributes indicates whether to include detailed tracing attributes.
 	DetailedTracingAttributes bool `yaml:"detailed_tracing_attributes,omitempty"`
 
+	// ResourceName indicates whether to apply heuristics to identify and generate resource names.
+	ResourceName bool `yaml:"resource_name,omitempty"`
+
 	// DocumentationOverrides contains overrides for element documentation.
 	DocumentationOverrides []RustDocumentationOverride `yaml:"documentation_overrides,omitempty"`
 

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -62,6 +62,7 @@ func libraryToModelConfig(library *config.Library, ch *config.API, sources *side
 			Description: library.DescriptionOverride,
 			Title:       svcConfig.Title,
 		},
+		ResourceName: library.Rust != nil && library.Rust.ResourceName,
 	}
 
 	if library.Rust != nil {
@@ -261,6 +262,7 @@ func moduleToModelConfig(library *config.Library, module *config.RustModule, sou
 			IncludedIDs: module.IncludedIds,
 			SkippedIDs:  module.SkippedIds,
 		},
+		ResourceName: library.Rust != nil && library.Rust.ResourceName,
 	}
 	if len(module.DocumentationOverrides) > 0 {
 		modelCfg.CommentOverrides = make([]api.DocumentationOverride, len(module.DocumentationOverrides))

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -25,9 +25,9 @@ import (
 // This is done in two passes:
 //  1. Explicit Identification: Matches google.api.resource_reference annotations
 //     with fields present in the PathTemplate.
-//  2. Heuristic Identification: For allow-listed services, uses path segment
-//     patterns to identify resources when annotations are missing.
-func IdentifyTargetResources(model *API) error {
+//  2. Heuristic Identification: If enableHeuristics is true and the service is
+//     allow-listed, uses path segment patterns to identify resources when annotations are missing.
+func IdentifyTargetResources(model *API, enableHeuristics bool) error {
 	// Build the set of known resource names for the heuristic.
 	vocabulary := BuildHeuristicVocabulary(model)
 
@@ -37,7 +37,7 @@ func IdentifyTargetResources(model *API) error {
 				continue
 			}
 			for _, binding := range method.PathInfo.Bindings {
-				if err := identifyTargetResourceForBinding(method, binding, vocabulary); err != nil {
+				if err := identifyTargetResourceForBinding(method, binding, vocabulary, enableHeuristics); err != nil {
 					return err
 				}
 			}
@@ -47,7 +47,7 @@ func IdentifyTargetResources(model *API) error {
 }
 
 // identifyTargetResourceForBinding processes a single path binding to identify its target resource.
-func identifyTargetResourceForBinding(method *Method, binding *PathBinding, vocabulary map[string]bool) error {
+func identifyTargetResourceForBinding(method *Method, binding *PathBinding, vocabulary map[string]bool, enableHeuristics bool) error {
 	if binding.PathTemplate == nil {
 		return nil
 	}
@@ -65,13 +65,15 @@ func identifyTargetResourceForBinding(method *Method, binding *PathBinding, voca
 
 	// Priority 2: Heuristic Identification
 	// Uses path segment patterns to guess the resource.
-	target, err = identifyHeuristicTarget(method, binding, vocabulary)
-	if err != nil {
-		return err
-	}
-	if target != nil {
-		binding.TargetResource = target
-		return nil
+	if enableHeuristics {
+		target, err = identifyHeuristicTarget(method, binding, vocabulary)
+		if err != nil {
+			return err
+		}
+		if target != nil {
+			binding.TargetResource = target
+			return nil
+		}
 	}
 	return nil
 }

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -140,7 +140,7 @@ func TestIdentifyTargetResources(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model, binding := setupTestModel(test.serviceID, test.path, test.fields)
-			IdentifyTargetResources(model)
+			IdentifyTargetResources(model, true)
 
 			got := binding.TargetResource
 			if diff := cmp.Diff(test.want, got); diff != "" {
@@ -188,7 +188,7 @@ func TestIdentifyTargetResources_NoMatch(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model, binding := setupTestModel(test.serviceID, test.path, test.fields)
-			IdentifyTargetResources(model)
+			IdentifyTargetResources(model, true)
 
 			got := binding.TargetResource
 			if got != nil {
@@ -378,12 +378,34 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				}
 				model.Services[0].Methods = append(model.Services[0].Methods, m)
 			}
-			IdentifyTargetResources(model)
+			IdentifyTargetResources(model, true)
 
 			got := binding.TargetResource
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestIdentifyTargetResources_HeuristicsDisabled(t *testing.T) {
+	// A setup that would normally match the heuristics
+	serviceID := ".google.cloud.compute.v1.Instances"
+	path := NewPathTemplate().
+		WithLiteral("projects").WithVariableNamed("project").
+		WithLiteral("locations").WithVariableNamed("location")
+	fields := []*Field{
+		{Name: "project", Typez: STRING_TYPE},
+		{Name: "location", Typez: STRING_TYPE},
+	}
+
+	model, binding := setupTestModel(serviceID, path, fields)
+
+	// Explicitly disable heuristics
+	IdentifyTargetResources(model, false)
+
+	// Since heuristics are disabled, it should not find the target resource
+	if binding.TargetResource != nil {
+		t.Errorf("IdentifyTargetResources(model, false) populated TargetResource %v, want nil", binding.TargetResource)
 	}
 }

--- a/internal/sidekick/parser/parser.go
+++ b/internal/sidekick/parser/parser.go
@@ -50,6 +50,9 @@ type ModelConfig struct {
 	// Discovery poller configurations
 	Discovery *api.Discovery
 
+	// Resource heuristic enablement
+	ResourceName bool
+
 	// Model overrides
 	Override api.ModelOverride
 }
@@ -80,7 +83,7 @@ func CreateModel(cfg *ModelConfig) (*api.API, error) {
 	if err := api.CrossReference(model); err != nil {
 		return nil, err
 	}
-	if err := api.IdentifyTargetResources(model); err != nil {
+	if err := api.IdentifyTargetResources(model, cfg.ResourceName); err != nil {
 		return nil, err
 	}
 	if err := api.SkipModelElements(model, cfg.Override); err != nil {


### PR DESCRIPTION
Introduce the `ResourceName` boolean flag into the configuration and plumb it down to `IdentifyTargetResources`.