### PR TITLE
fix(java): exclude additional protos from copied output

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -143,7 +143,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	return nil
 }
 
-func runProtoc(ctx context.Context, args []string) error {
+var runProtoc = func(ctx context.Context, args []string) error {
 	return command.Run(ctx, "protoc", args...)
 }
 

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,6 +283,43 @@ func TestGenerateAPI(t *testing.T) {
 	restructuredPath := filepath.Join(outdir, "google-cloud-secretmanager", "src", "main", "java")
 	if _, err := os.Stat(restructuredPath); err != nil {
 		t.Errorf("expected restructured path %s to exist: %v", restructuredPath, err)
+	}
+}
+
+func TestGenerateAPI_NoTools(t *testing.T) {
+	// Temporarily mock runProtoc to avoid external tool requirements.
+	oldRunProtoc := runProtoc
+	defer func() { runProtoc = oldRunProtoc }()
+	// Capture all calls to runProtoc to verify arguments without executing the command.
+	var calls [][]string
+	runProtoc = func(ctx context.Context, args []string) error {
+		calls = append(calls, args)
+		return nil
+	}
+	outdir := t.TempDir()
+	api := &config.API{Path: "google/cloud/secretmanager/v1"}
+	library := &config.Library{Name: "secretmanager", Output: outdir}
+
+	err := generateAPI(t.Context(), api, library, googleapisDir, outdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that runProtoc was called 3 times: proto, grpc, and gapic.
+	if len(calls) != 3 {
+		t.Errorf("expected 3 calls to runProtoc, got %d", len(calls))
+	}
+	// Basic validation of GAPIC generation arguments (the 3rd call).
+	gapicArgs := calls[2]
+	foundGapicOut := false
+	for _, arg := range gapicArgs {
+		if strings.HasPrefix(arg, "--java_gapic_out=") {
+			foundGapicOut = true
+			break
+		}
+	}
+	if !foundGapicOut {
+		t.Errorf("expected --java_gapic_out in gapicArgs, but not found: %v", gapicArgs)
 	}
 }
 


### PR DESCRIPTION
This change modifies Librarian to execute protoc independently for Java Proto, gRPC, and GAPIC generation phases. This separation allows additional protos to be excluded from the Java Proto and gRPC phases. Previously all protos, including additional protos like location.proto are used for all three phases, resulting in additional gRPC classes in output.

For #4062