### PR TITLE
fix(internal/librarian/java): keep pom.xml during clean

### DIFF
--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -83,8 +83,8 @@ func cleanPath(targetPath, root string, keepSet map[string]bool) error {
 		if keepSet[rel] || itTestRegexp.MatchString(filepath.ToSlash(rel)) {
 			return nil
 		}
-		// Bypass clirr-ignored-differences.xml files as they are generated once and manually maintained.
-		if d.Name() == "clirr-ignored-differences.xml" {
+		// Bypass clirr-ignored-differences.xml and pom.xml files as they are generated once and manually maintained.
+		if d.Name() == "clirr-ignored-differences.xml" || d.Name() == "pom.xml" {
 			return nil
 		}
 		return os.Remove(path)

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -48,6 +48,7 @@ func TestClean(t *testing.T) {
 	files := []string{
 		filepath.Join(tmpDir, libraryName, "src", "Main.java"),
 		filepath.Join(tmpDir, libraryName, "src", "test", "java", "com", "google", "cloud", "secretmanager", "v1", "it", "ITSecretManagerTest.java"),
+		filepath.Join(tmpDir, libraryName, "pom.xml"),
 		filepath.Join(tmpDir, "kept-file.txt"),
 		filepath.Join(tmpDir, "kept-dir", "file.txt"),
 	}
@@ -85,6 +86,7 @@ func TestClean(t *testing.T) {
 	keptPaths := []string{
 		filepath.Join(tmpDir, "kept-file.txt"),
 		filepath.Join(tmpDir, "kept-dir", "file.txt"),
+		filepath.Join(tmpDir, libraryName, "pom.xml"),
 		filepath.Join(tmpDir, libraryName, "src", "test", "java", "com", "google", "cloud", "secretmanager", "v1", "it", "ITSecretManagerTest.java"),
 	}
 	for _, p := range keptPaths {


### PR DESCRIPTION
Modified the Java clean process to bypass pom.xml files, ensuring they are not removed if they already exist in the output directory. This matches the hermetic_build behavior on re-generation, except for surgical changes when new major version added.

For https://github.com/googleapis/librarian/issues/4127