### PR TITLE
chore(internal/serviceconfig): add networkconnectivity v1beta

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1464,7 +1464,8 @@
     php: grpc+rest
     python: grpc
     ruby: grpc
-- languages:
+- documentation_uri: https://cloud.google.com/network-connectivity/
+  languages:
     - go
     - python
   path: google/cloud/networkconnectivity/v1beta


### PR DESCRIPTION
Add `google/cloud/networkconnectivity/v1beta` to allowlist.

Though cloud API are allowed by default, the transport is not the default value.