### PR TITLE
chore(internal/serviceconfig): add pubsublite v1

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1649,6 +1649,14 @@
     - go
     - python
     - rust
+  path: google/cloud/pubsublite/v1
+  transports:
+    go: grpc
+    python: grpc
+- languages:
+    - go
+    - python
+    - rust
   path: google/cloud/rapidmigrationassessment/v1
   transports:
     go: grpc+rest


### PR DESCRIPTION
Add `google/cloud/pubsublite/v1` to allowlist.

Though cloud API are allowed by default, the transport is not the default value.