### PR TITLE
feat(internal/serviceconfig): add Rust to google/cloud/securitycentermanagement/v1 in sdk.yaml

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1820,6 +1820,7 @@
 - languages:
     - go
     - python
+    - rust
   path: google/cloud/securitycentermanagement/v1
 - languages:
     - go


### PR DESCRIPTION
Add rust to securitycentermanagement/v1 for https://github.com/googleapis/google-cloud-rust/issues/4728