### PR TITLE
refactor(surfer/gcloud): simplify test setup with helpers

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -254,6 +254,12 @@ func (f *Field) WithResourceReference(refType string) *Field {
 	return f
 }
 
+// WithChildTypeReference sets the child type resource reference on a field.
+func (f *Field) WithChildTypeReference(childType string) *Field {
+	f.ResourceReference = &ResourceReference{ChildType: childType}
+	return f
+}
+
 // NewTestResource creates a resource with defaults.
 func NewTestResource(typez string) *Resource {
 	return &Resource{

--- a/internal/surfer/gcloud/method_test.go
+++ b/internal/surfer/gcloud/method_test.go
@@ -30,8 +30,8 @@ func TestIsCreate(t *testing.T) {
 	}{
 		{"Name Prefix", &api.Method{Name: "CreateInstance"}, true},
 		{"Name Mismatch", &api.Method{Name: "GetInstance"}, false},
-		{"Verb Match", &api.Method{Name: "CreateInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "POST"}}}}, true},
-		{"Verb Mismatch", &api.Method{Name: "CreateInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, false},
+		{"Verb Match", api.NewTestMethod("CreateInstance").WithVerb("POST"), true},
+		{"Verb Mismatch", api.NewTestMethod("CreateInstance").WithVerb("GET"), false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -51,8 +51,8 @@ func TestIsGet(t *testing.T) {
 	}{
 		{"Name Prefix", &api.Method{Name: "GetInstance"}, true},
 		{"Name Mismatch", &api.Method{Name: "CreateInstance"}, false},
-		{"Verb Match", &api.Method{Name: "GetInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, true},
-		{"Verb Mismatch", &api.Method{Name: "GetInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "POST"}}}}, false},
+		{"Verb Match", api.NewTestMethod("GetInstance").WithVerb("GET"), true},
+		{"Verb Mismatch", api.NewTestMethod("GetInstance").WithVerb("POST"), false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -72,8 +72,8 @@ func TestIsList(t *testing.T) {
 	}{
 		{"Name Prefix", &api.Method{Name: "ListInstances"}, true},
 		{"Name Mismatch", &api.Method{Name: "GetInstance"}, false},
-		{"Verb Match", &api.Method{Name: "ListInstances", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, true},
-		{"Verb Mismatch", &api.Method{Name: "ListInstances", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "POST"}}}}, false},
+		{"Verb Match", api.NewTestMethod("ListInstances").WithVerb("GET"), true},
+		{"Verb Mismatch", api.NewTestMethod("ListInstances").WithVerb("POST"), false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -93,9 +93,9 @@ func TestIsUpdate(t *testing.T) {
 	}{
 		{"Name Prefix", &api.Method{Name: "UpdateInstance"}, true},
 		{"Name Mismatch", &api.Method{Name: "GetInstance"}, false},
-		{"Verb Match PATCH", &api.Method{Name: "UpdateInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "PATCH"}}}}, true},
-		{"Verb Match PUT", &api.Method{Name: "UpdateInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "PUT"}}}}, true},
-		{"Verb Mismatch", &api.Method{Name: "UpdateInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, false},
+		{"Verb Match PATCH", api.NewTestMethod("UpdateInstance").WithVerb("PATCH"), true},
+		{"Verb Match PUT", api.NewTestMethod("UpdateInstance").WithVerb("PUT"), true},
+		{"Verb Mismatch", api.NewTestMethod("UpdateInstance").WithVerb("GET"), false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -115,8 +115,8 @@ func TestIsDelete(t *testing.T) {
 	}{
 		{"Name Prefix", &api.Method{Name: "DeleteInstance"}, true},
 		{"Name Mismatch", &api.Method{Name: "GetInstance"}, false},
-		{"Verb Match", &api.Method{Name: "DeleteInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "DELETE"}}}}, true},
-		{"Verb Mismatch", &api.Method{Name: "DeleteInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, false},
+		{"Verb Match", api.NewTestMethod("DeleteInstance").WithVerb("DELETE"), true},
+		{"Verb Mismatch", api.NewTestMethod("DeleteInstance").WithVerb("GET"), false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -138,18 +138,7 @@ func TestGetCommandName(t *testing.T) {
 		{"Standard Create", &api.Method{Name: "CreateInstance"}, "create"},
 		{"Standard List", &api.Method{Name: "ListInstances"}, "list"},
 		{"Standard Get", &api.Method{Name: "GetInstance"}, "describe"},
-		{"Custom Verb in Path", &api.Method{
-			Name: "ExportData",
-			PathInfo: &api.PathInfo{
-				Bindings: []*api.PathBinding{
-					{
-						PathTemplate: &api.PathTemplate{
-							Verb: &v,
-						},
-					},
-				},
-			},
-		}, "export_data"},
+		{"Custom Verb in Path", api.NewTestMethod("ExportData").WithPathTemplate(&api.PathTemplate{Verb: &v}), "export_data"},
 		{"Fallback to Name", &api.Method{Name: "ExportData"}, "export_data"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -244,20 +233,14 @@ func TestIsResourceMethod(t *testing.T) {
 		method *api.Method
 		want   bool
 	}{
-		{"Standard Get", &api.Method{Name: "GetInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, true},
-		{"Standard List", &api.Method{Name: "ListInstances", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, false},
-		{"Custom Resource", &api.Method{
-			Name: "CustomInstance",
-			PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{
-				PathTemplate: &api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithVariable(api.NewPathVariable("instance"))}},
-			}}},
-		}, true},
-		{"Custom Collection", &api.Method{
-			Name: "CustomCollection",
-			PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{
-				PathTemplate: &api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithLiteral("instances")}},
-			}}},
-		}, false},
+		{"Standard Get", api.NewTestMethod("GetInstance").WithVerb("GET"), true},
+		{"Standard List", api.NewTestMethod("ListInstances").WithVerb("GET"), false},
+		{"Custom Resource", api.NewTestMethod("CustomInstance").WithPathTemplate(
+			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithVariable(api.NewPathVariable("instance"))}},
+		), true},
+		{"Custom Collection", api.NewTestMethod("CustomCollection").WithPathTemplate(
+			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithLiteral("instances")}},
+		), false},
 		{"Nil PathInfo", &api.Method{Name: "CustomMethod", PathInfo: nil}, false},
 		{"Empty Bindings", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{}}}, false},
 		{"Nil PathTemplate", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{PathTemplate: nil}}}}, false},
@@ -278,20 +261,14 @@ func TestIsCollectionMethod(t *testing.T) {
 		method *api.Method
 		want   bool
 	}{
-		{"Standard Get", &api.Method{Name: "GetInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, false},
-		{"Standard List", &api.Method{Name: "ListInstances", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, true},
-		{"Custom Resource", &api.Method{
-			Name: "CustomInstance",
-			PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{
-				PathTemplate: &api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithVariable(api.NewPathVariable("instance"))}},
-			}}},
-		}, false},
-		{"Custom Collection", &api.Method{
-			Name: "CustomCollection",
-			PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{
-				PathTemplate: &api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithLiteral("instances")}},
-			}}},
-		}, true},
+		{"Standard Get", api.NewTestMethod("GetInstance").WithVerb("GET"), false},
+		{"Standard List", api.NewTestMethod("ListInstances").WithVerb("GET"), true},
+		{"Custom Resource", api.NewTestMethod("CustomInstance").WithPathTemplate(
+			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithVariable(api.NewPathVariable("instance"))}},
+		), false},
+		{"Custom Collection", api.NewTestMethod("CustomCollection").WithPathTemplate(
+			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithLiteral("instances")}},
+		), true},
 		{"Nil PathInfo", &api.Method{Name: "CustomMethod", PathInfo: nil}, false},
 		{"Empty Bindings", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{}}}, false},
 		{"Nil PathTemplate", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{PathTemplate: nil}}}}, false},
@@ -312,12 +289,12 @@ func TestIsStandardMethod(t *testing.T) {
 		method *api.Method
 		want   bool
 	}{
-		{"Get", &api.Method{Name: "GetInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, true},
-		{"List", &api.Method{Name: "ListInstances", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "GET"}}}}, true},
-		{"Create", &api.Method{Name: "CreateInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "POST"}}}}, true},
-		{"Update", &api.Method{Name: "UpdateInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "PATCH"}}}}, true},
-		{"Delete", &api.Method{Name: "DeleteInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "DELETE"}}}}, true},
-		{"Custom", &api.Method{Name: "ExportInstance", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{Verb: "POST"}}}}, false},
+		{"Get", api.NewTestMethod("GetInstance").WithVerb("GET"), true},
+		{"List", api.NewTestMethod("ListInstances").WithVerb("GET"), true},
+		{"Create", api.NewTestMethod("CreateInstance").WithVerb("POST"), true},
+		{"Update", api.NewTestMethod("UpdateInstance").WithVerb("PATCH"), true},
+		{"Delete", api.NewTestMethod("DeleteInstance").WithVerb("DELETE"), true},
+		{"Custom", api.NewTestMethod("ExportInstance").WithVerb("POST"), false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/surfer/gcloud/resource_test.go
+++ b/internal/surfer/gcloud/resource_test.go
@@ -15,6 +15,7 @@
 package gcloud
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,24 +29,14 @@ func TestGetPluralFromSegments(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "Standard",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("location").WithMatch()),
-				*api.NewPathSegment().WithLiteral("instances"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("instance").WithMatch()),
-			},
-			want: "instances",
+			name:     "Standard",
+			segments: parseResourcePattern("projects/{project}/locations/{location}/instances/{instance}"),
+			want:     "instances",
 		},
 		{
-			name: "Short",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("shelves"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("shelf").WithMatch()),
-			},
-			want: "shelves",
+			name:     "Short",
+			segments: parseResourcePattern("shelves/{shelf}"),
+			want:     "shelves",
 		},
 		{
 			name: "No Variable End",
@@ -79,29 +70,14 @@ func TestGetParentFromSegments(t *testing.T) {
 		want     []api.PathSegment
 	}{
 		{
-			name: "Standard",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("location").WithMatch()),
-				*api.NewPathSegment().WithLiteral("instances"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("instance").WithMatch()),
-			},
-			want: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("location").WithMatch()),
-			},
+			name:     "Standard",
+			segments: parseResourcePattern("projects/{project}/locations/{location}/instances/{instance}"),
+			want:     parseResourcePattern("projects/{project}/locations/{location}"),
 		},
 		{
-			name: "Root",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-			},
-			want: []api.PathSegment{},
+			name:     "Root",
+			segments: parseResourcePattern("projects/{project}"),
+			want:     []api.PathSegment{},
 		},
 		{
 			name: "Too Short",
@@ -142,24 +118,14 @@ func TestGetSingularFromSegments(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "Standard",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("location").WithMatch()),
-				*api.NewPathSegment().WithLiteral("instances"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("instance").WithMatch()),
-			},
-			want: "instance",
+			name:     "Standard",
+			segments: parseResourcePattern("projects/{project}/locations/{location}/instances/{instance}"),
+			want:     "instance",
 		},
 		{
-			name: "Short",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("shelves"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("shelf").WithMatch()),
-			},
-			want: "shelf",
+			name:     "Short",
+			segments: parseResourcePattern("shelves/{shelf}"),
+			want:     "shelf",
 		},
 		{
 			name: "No Variable End",
@@ -193,55 +159,29 @@ func TestGetCollectionPathFromSegments(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "Standard",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("location").WithMatch()),
-				*api.NewPathSegment().WithLiteral("instances"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("instance").WithMatch()),
-			},
-			want: "projects.locations.instances",
+			name:     "Standard",
+			segments: parseResourcePattern("projects/{project}/locations/{location}/instances/{instance}"),
+			want:     "projects.locations.instances",
 		},
 		{
-			name: "Short",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("shelves"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("shelf").WithMatch()),
-			},
-			want: "shelves",
+			name:     "Short",
+			segments: parseResourcePattern("shelves/{shelf}"),
+			want:     "shelves",
 		},
 		{
-			name: "Root",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-			},
-			want: "projects",
+			name:     "Root",
+			segments: parseResourcePattern("projects/{project}"),
+			want:     "projects",
 		},
 		{
-			name: "Mixed",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("organizations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("organization").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("location").WithMatch()),
-				*api.NewPathSegment().WithLiteral("clusters"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("cluster").WithMatch()),
-			},
-			want: "organizations.locations.clusters",
+			name:     "Mixed",
+			segments: parseResourcePattern("organizations/{organization}/locations/{location}/clusters/{cluster}"),
+			want:     "organizations.locations.clusters",
 		},
 		{
-			name: "Global",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("global"),
-				*api.NewPathSegment().WithLiteral("networks"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("network").WithMatch()),
-			},
-			want: "projects.networks",
+			name:     "Global",
+			segments: parseResourcePattern("projects/{project}/global/networks/{network}"),
+			want:     "projects.networks",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -261,17 +201,9 @@ func TestExtractPathFromSegments(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "Standard Regional",
-			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("v1"),
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("location").WithMatch()),
-				*api.NewPathSegment().WithLiteral("instances"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("instance").WithMatch()),
-			},
-			want: "projects.locations.instances",
+			name:     "Standard Regional",
+			segments: parseResourcePattern("v1/projects/{project}/locations/{location}/instances/{instance}"),
+			want:     "projects.locations.instances",
 		},
 		{
 			name: "Complex Variable",
@@ -446,12 +378,7 @@ func TestGetResourceForMethod(t *testing.T) {
 				Name: "GetInstance",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "name",
-							ResourceReference: &api.ResourceReference{
-								Type: "example.googleapis.com/Instance",
-							},
-						},
+						api.NewTestField("name").WithResourceReference("example.googleapis.com/Instance"),
 					},
 				},
 			},
@@ -464,12 +391,7 @@ func TestGetResourceForMethod(t *testing.T) {
 				Name: "ListInstances",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "parent",
-							ResourceReference: &api.ResourceReference{
-								ChildType: "example.googleapis.com/Instance",
-							},
-						},
+						api.NewTestField("parent").WithChildTypeReference("example.googleapis.com/Instance"),
 					},
 				},
 			},
@@ -502,12 +424,7 @@ func TestGetResourceForMethod(t *testing.T) {
 				Name: "GetOther",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "name",
-							ResourceReference: &api.ResourceReference{
-								Type: "example.googleapis.com/Other",
-							},
-						},
+						api.NewTestField("name").WithResourceReference("example.googleapis.com/Other"),
 					},
 				},
 			},
@@ -538,10 +455,7 @@ func TestGetPluralResourceNameForMethod(t *testing.T) {
 	instanceResource := &api.Resource{
 		Type: "example.googleapis.com/Instance",
 		Patterns: []api.ResourcePattern{
-			{
-				*api.NewPathSegment().WithLiteral("instances"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("instance").WithMatch()),
-			},
+			parseResourcePattern("instances/{instance}"),
 		},
 	}
 
@@ -557,12 +471,7 @@ func TestGetPluralResourceNameForMethod(t *testing.T) {
 				Name: "ListInstances",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "parent",
-							ResourceReference: &api.ResourceReference{
-								ChildType: "example.googleapis.com/Instance",
-							},
-						},
+						api.NewTestField("parent").WithChildTypeReference("example.googleapis.com/Instance"),
 					},
 				},
 			},
@@ -575,12 +484,7 @@ func TestGetPluralResourceNameForMethod(t *testing.T) {
 				Name: "ListBooks",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "parent",
-							ResourceReference: &api.ResourceReference{
-								ChildType: "example.googleapis.com/Book",
-							},
-						},
+						api.NewTestField("parent").WithChildTypeReference("example.googleapis.com/Book"),
 					},
 				},
 			},
@@ -599,12 +503,7 @@ func TestGetPluralResourceNameForMethod(t *testing.T) {
 				Name: "ListUnknown",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "parent",
-							ResourceReference: &api.ResourceReference{
-								ChildType: "example.googleapis.com/Unknown",
-							},
-						},
+						api.NewTestField("parent").WithChildTypeReference("example.googleapis.com/Unknown"),
 					},
 				},
 			},
@@ -629,10 +528,7 @@ func TestGetSingularResourceNameForMethod(t *testing.T) {
 	instanceResource := &api.Resource{
 		Type: "example.googleapis.com/Instance",
 		Patterns: []api.ResourcePattern{
-			{
-				*api.NewPathSegment().WithLiteral("instances"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("instance").WithMatch()),
-			},
+			parseResourcePattern("instances/{instance}"),
 		},
 	}
 
@@ -648,12 +544,7 @@ func TestGetSingularResourceNameForMethod(t *testing.T) {
 				Name: "ListInstances",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "parent",
-							ResourceReference: &api.ResourceReference{
-								ChildType: "example.googleapis.com/Instance",
-							},
-						},
+						api.NewTestField("parent").WithChildTypeReference("example.googleapis.com/Instance"),
 					},
 				},
 			},
@@ -666,12 +557,7 @@ func TestGetSingularResourceNameForMethod(t *testing.T) {
 				Name: "ListBooks",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "parent",
-							ResourceReference: &api.ResourceReference{
-								ChildType: "example.googleapis.com/Book",
-							},
-						},
+						api.NewTestField("parent").WithChildTypeReference("example.googleapis.com/Book"),
 					},
 				},
 			},
@@ -690,12 +576,7 @@ func TestGetSingularResourceNameForMethod(t *testing.T) {
 				Name: "ListUnknown",
 				InputType: &api.Message{
 					Fields: []*api.Field{
-						{
-							Name: "parent",
-							ResourceReference: &api.ResourceReference{
-								ChildType: "example.googleapis.com/Unknown",
-							},
-						},
+						api.NewTestField("parent").WithChildTypeReference("example.googleapis.com/Unknown"),
 					},
 				},
 			},
@@ -734,4 +615,21 @@ func TestGetResourceNameFromType(t *testing.T) {
 			}
 		})
 	}
+}
+
+// parseResourcePattern converts a resource pattern string into a
+// []api.PathSegment slice for testing. It handles AIP resource patterns
+// (e.g., "projects/{project}/locations/{location}"). Variables
+// automatically get a single-segment wildcard match.
+func parseResourcePattern(pattern string) []api.PathSegment {
+	var segments []api.PathSegment
+	for part := range strings.SplitSeq(pattern, "/") {
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			name := part[1 : len(part)-1]
+			segments = append(segments, *api.NewPathSegment().WithVariable(api.NewPathVariable(name).WithMatch()))
+		} else {
+			segments = append(segments, *api.NewPathSegment().WithLiteral(part))
+		}
+	}
+	return segments
 }


### PR DESCRIPTION
Add test helpers to reduce verbose API object construction in tests. 

A parseResourcePattern helper is added to convert pattern strings like "projects/{project}/locations/{location}" into PathSegment slices.

A WithChildTypeReference method on Field sets ResourceReference.ChildType.

Tests in method_test.go now use NewTestMethod().WithVerb() instead of inline struct literals.

Fixes https://github.com/googleapis/librarian/issues/3666