### PR TITLE
fix(surfer/gcloud): remove redundant case transformation

### DIFF
--- a/internal/surfer/gcloud/builder.go
+++ b/internal/surfer/gcloud/builder.go
@@ -245,7 +245,7 @@ func newPrimaryResourceParam(field *api.Field, method *api.Method, model *api.AP
 		segments = getParentFromSegments(segments)
 	}
 
-	resourceName := strcase.ToSnake(strings.TrimSuffix(field.Name, "_id"))
+	resourceName := strings.TrimSuffix(field.Name, "_id")
 	if field.Name == "name" || isList(method) {
 		resourceName = getSingularFromSegments(segments)
 	}

--- a/internal/surfer/gcloud/resource.go
+++ b/internal/surfer/gcloud/resource.go
@@ -100,8 +100,8 @@ func isPrimaryResource(field *api.Field, method *api.Method) bool {
 		resource, err := getResourceFromMethod(method)
 		if err == nil {
 			name := getResourceNameFromType(resource.Type)
-			// TODO(https://github.com/googleapis/librarian/issues/3361): Verify that this case transformation
-			// is consistent with gcloud conventions and doesn't introduce traceability issues.
+			// Convert CamelCase resource name (e.g., "Instance") to snake_case
+			// to match the proto field naming convention (e.g., "instance_id").
 			if name != "" && field.Name == strcase.ToSnake(name)+"_id" {
 				return true
 			}


### PR DESCRIPTION
Remove a redundant strcase.ToSnake call in newPrimaryResourceParam where the input is already snake_case after trimming the "_id" suffix.

Replace the TODO in isPrimaryResource with a comment explaining why the ToSnake conversion is correct there (CamelCase resource type name needs conversion to match proto field naming convention).

Fixes https://github.com/googleapis/librarian/issues/3361