### PR TITLE
fix(internal/yaml): remove extra blank line after license header in Write

### DIFF
--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -92,7 +92,6 @@ func Write(path string, v any) error {
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
-	b.WriteString("\n")
 	header := b.String()
 
 	data = append([]byte(header), data...)

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -91,7 +91,6 @@ const copyright = `# Copyright %s Google LLC
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 `
 
 func TestWrite(t *testing.T) {


### PR DESCRIPTION
yaml.Write added an extra newline between the license header and the YAML content. This caused yamlfmt to flag the output as incorrectly formatted, since the blank line is not expected between the header comment and the document body.