### PR TITLE
fix(python): fix Python generation broken by #4340

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -195,7 +195,7 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 	case config.LanguageDart:
 		return dart.GenerateLibraries(ctx, libraries, src)
 	case config.LanguagePython:
-		return python.GenerateLibraries(ctx, cfg, libraries, src)
+		return python.GenerateLibraries(ctx, cfg, libraries, googleapisDir)
 	case config.LanguageGo:
 		return golang.GenerateLibraries(ctx, libraries, googleapisDir)
 	case config.LanguageJava:

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -28,7 +28,6 @@ import (
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/repometadata"
 	"github.com/googleapis/librarian/internal/serviceconfig"
-	sidekickconfig "github.com/googleapis/librarian/internal/sidekick/config"
 )
 
 const (
@@ -37,9 +36,9 @@ const (
 )
 
 // GenerateLibraries generates all the given libraries in sequence.
-func GenerateLibraries(ctx context.Context, config *config.Config, libraries []*config.Library, sources *sidekickconfig.Sources) error {
+func GenerateLibraries(ctx context.Context, config *config.Config, libraries []*config.Library, googleapisDir string) error {
 	for _, library := range libraries {
-		if err := generate(ctx, config, library, sources); err != nil {
+		if err := generate(ctx, config, library, googleapisDir); err != nil {
 			return err
 		}
 	}
@@ -47,7 +46,7 @@ func GenerateLibraries(ctx context.Context, config *config.Config, libraries []*
 }
 
 // generate generates a Python client library.
-func generate(ctx context.Context, config *config.Config, library *config.Library, sources *sidekickconfig.Sources) error {
+func generate(ctx context.Context, config *config.Config, library *config.Library, googleapisDir string) error {
 	// If the library has no APIs, there's nothing to do.
 	if len(library.APIs) == 0 {
 		return nil
@@ -70,7 +69,7 @@ func generate(ctx context.Context, config *config.Config, library *config.Librar
 	// and pass it down.
 	repoRoot := filepath.Dir(filepath.Dir(outdir))
 	for _, api := range library.APIs {
-		if err := generateAPI(ctx, api, library, sources.Googleapis, repoRoot); err != nil {
+		if err := generateAPI(ctx, api, library, googleapisDir, repoRoot); err != nil {
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
@@ -78,7 +77,7 @@ func generate(ctx context.Context, config *config.Config, library *config.Librar
 	// Construct the repo metadata in memory, then write it to disk. This has
 	// to be before post-processing, as the data in .repo-metadata.json is used
 	// by the post-processor, primarily for documentation.
-	repoMetadata, err := createRepoMetadata(config, library, sources)
+	repoMetadata, err := createRepoMetadata(config, library, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -107,16 +106,20 @@ func generate(ctx context.Context, config *config.Config, library *config.Librar
 
 // createRepoMetadata creates (in memory, not on disk) a RepoMetadata suitable
 // for the given library.
-func createRepoMetadata(cfg *config.Config, library *config.Library, sources *sidekickconfig.Sources) (*repometadata.RepoMetadata, error) {
+func createRepoMetadata(cfg *config.Config, library *config.Library, googleapisDir string) (*repometadata.RepoMetadata, error) {
 	// Just to avoid lots of checks for library.Python being nil.
 	packageOptions := library.Python
 	if packageOptions == nil {
 		packageOptions = &config.PythonPackage{}
 	}
-	repoMetadata, err := repometadata.FromLibrary(cfg, library, sources)
+	// TODO(https://github.com/googleapis/librarian/issues/4428): once
+	// repometadata exposes a FromLibrary function or similar that we can use,
+	// we should call that again, so that repometadata.FromAPI can be hidden.
+	api, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, cfg.Language)
 	if err != nil {
 		return nil, err
 	}
+	repoMetadata := repometadata.FromAPI(cfg, api, library)
 	if packageOptions.MetadataNameOverride != "" {
 		repoMetadata.Name = packageOptions.MetadataNameOverride
 	} else {

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/repometadata"
-	sidekickconfig "github.com/googleapis/librarian/internal/sidekick/config"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
@@ -609,8 +608,7 @@ func TestGenerateLibraries(t *testing.T) {
 	for _, library := range libraries {
 		library.Output = filepath.Join(repoRoot, "packages", library.Name)
 	}
-	sources := &sidekickconfig.Sources{Googleapis: googleapisDir}
-	if err := GenerateLibraries(t.Context(), cfg, libraries, sources); err != nil {
+	if err := GenerateLibraries(t.Context(), cfg, libraries, googleapisDir); err != nil {
 		t.Fatal(err)
 	}
 	for _, library := range libraries {
@@ -651,8 +649,7 @@ func TestGenerateLibraries_Error(t *testing.T) {
 			},
 		},
 	}
-	sources := &sidekickconfig.Sources{Googleapis: googleapisDir}
-	gotErr := GenerateLibraries(t.Context(), cfg, libraries, sources)
+	gotErr := GenerateLibraries(t.Context(), cfg, libraries, googleapisDir)
 	wantErr := os.ErrPermission
 	if !errors.Is(gotErr, wantErr) {
 		t.Errorf("GenerateLibraries error = %v, wantErr %v", gotErr, wantErr)
@@ -673,9 +670,7 @@ func TestGenerate_NoAPIs(t *testing.T) {
 		Name:   "no-apis",
 		Output: filepath.Join(repoRoot, "packages", "will-not-be-created"),
 	}
-
-	sources := &sidekickconfig.Sources{Googleapis: googleapisDir}
-	if err := generate(t.Context(), cfg, library, sources); err != nil {
+	if err := generate(t.Context(), cfg, library, googleapisDir); err != nil {
 		t.Fatal(err)
 	}
 	// Validate that we haven't got as far as creating the output directory.
@@ -727,9 +722,7 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 	}
-
-	sources := &sidekickconfig.Sources{Googleapis: googleapisDir}
-	if err := generate(t.Context(), cfg, library, sources); err != nil {
+	if err := generate(t.Context(), cfg, library, googleapisDir); err != nil {
 		t.Fatal(err)
 	}
 	gotMetadata, err := repometadata.Read(outdir)
@@ -937,8 +930,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 				Language: config.LanguagePython,
 				Repo:     "googleapis/google-cloud-python",
 			}
-			sources := &sidekickconfig.Sources{Googleapis: googleapisDir}
-			got, err := createRepoMetadata(cfg, test.library, sources)
+			got, err := createRepoMetadata(cfg, test.library, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -961,8 +953,7 @@ func TestCreateRepoMetadata_Error(t *testing.T) {
 	}
 	// We don't check what the error is here; there's only one place it can
 	// come, and it's not an error we create ourselves.
-	sources := &sidekickconfig.Sources{Googleapis: googleapisDir}
-	_, err := createRepoMetadata(cfg, library, sources)
+	_, err := createRepoMetadata(cfg, library, googleapisDir)
 	if err == nil {
 		t.Error("expected error, got nil")
 	}

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -126,11 +126,11 @@ func FromLibrary(config *config.Config, library *config.Library, sources *sideki
 	if err != nil {
 		return nil, fmt.Errorf("failed to find API for path %s: %w", firstAPIPath, err)
 	}
-	return fromAPI(config, api, library), nil
+	return FromAPI(config, api, library), nil
 }
 
-// fromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
-func fromAPI(config *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
+// FromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
+func FromAPI(config *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
 	apiDescription := api.Description
 	if library.DescriptionOverride != "" {
 		apiDescription = library.DescriptionOverride


### PR DESCRIPTION
Reverts to using googleapisDir for Python generation, instead of a sidekickconfig.Sources that is only populated for Rust and Dart.

In order to avoid breaking the Rust and Dart code, this inlines a small amount of repometadata.FromLibrary and calls repometadata.FromAPI (which was previously private to the package, but is now exposed).

Fixes #4427.