### PR TITLE
chore(github/workflows): install protoc and taplo in librarian tests

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -62,6 +62,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
+      - uses: ./.github/actions/install-protoc
+      - uses: ./.github/actions/install-taplo
       - name: Run tests
         run: |
           go test -race -coverprofile=coverage.out -covermode=atomic \


### PR DESCRIPTION
Added protoc and taplo in librarian CI tests, needed to really test things. 
For now specifically needed in generate.

For https://github.com/googleapis/librarian/issues/4438