### PR TITLE
fix(tool/cmd/migrate): resolve duplicate API paths and regex failures

### DIFF
--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -215,7 +215,7 @@ func parseOwlBotAPIPaths(owlBot *owlBotYAML, googleapisDir, pkgName string) ([]*
 		return nil, fmt.Errorf("cannot parse API path from .OwlBot.yaml source: %q", source)
 	}
 	basePath := matches[1]
-	if basePath == "" && len(matches) > 2 {
+	if basePath == "" {
 		basePath = matches[2]
 	}
 
@@ -235,10 +235,13 @@ func parseOwlBotAPIPaths(owlBot *owlBotYAML, googleapisDir, pkgName string) ([]*
 		apiDir := filepath.Dir(path)
 		apiPath, err := filepath.Rel(googleapisDir, apiDir)
 		if err != nil {
-			return nil
+			return fmt.Errorf("getting relative path for %s: %w", apiDir, err)
 		}
 		info, err := parseBazelNodejsInfo(googleapisDir, apiPath)
-		if err != nil || info == nil {
+		if err != nil {
+			return fmt.Errorf("parsing bazel info for %s: %w", apiPath, err)
+		}
+		if info == nil {
 			return nil
 		}
 		// Match the npm package name.


### PR DESCRIPTION
The regular expression used to parse base API paths from .OwlBot.yaml source patterns is updated to support a wider variety of directory structures. Previously, the regex assumed the presence of parentheses used for version matching (e.g. (v1|v1beta1)), causing failures when migrating APIs with specific unversioned directory paths like grafeas-nodejs.

The parseOwlBotAPIPaths function has been rewritten to recursively walk the matched base path and inspect the nodejs_gapic_library rules in the BUILD.bazel files. It now explicitly matches the Bazel rule's package_name property to the Node.js library's package.json name, ensuring packages sharing the same base path (like google-cloud-monitoring and google-monitoring-dashboard) are assigned the correct API paths.

Additionally, runNodejsMigration now wraps errors returned by librarian.RunTidyOnConfig to surface the exact cause of any librarian tidy failed errors.