### PR TITLE
fix(sidekick/rust): skip version prefix from generated resource names

### DIFF
--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -245,6 +245,9 @@ func constructTemplate(method *Method, segments []PathSegment) ([]PathSegment, e
 	for _, seg := range segments {
 		if seg.Literal != nil {
 			l := *seg.Literal
+			if isVersionString(l) {
+				continue
+			}
 			result = append(result, PathSegment{Literal: &l})
 		} else if seg.Variable != nil {
 			result = append(result, PathSegment{Variable: &PathVariable{

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -134,7 +134,7 @@ func TestIdentifyTargetResources(t *testing.T) {
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"name"}},
-				Template:   ParseTemplateForTest("//test-api.googleapis.com/v1/{name}"),
+				Template:   ParseTemplateForTest("//test-api.googleapis.com/{name}"),
 			},
 		},
 	} {


### PR DESCRIPTION
Use the existing `isVersionString()` check to exclude API version prefix path elements from being appended to the heuristic `resource_name`.

Fixes #4471 