### PR TITLE
chore(migrate): remove veneer field from python migration

### DIFF
--- a/tool/cmd/migrate/python.go
+++ b/tool/cmd/migrate/python.go
@@ -92,9 +92,6 @@ func buildPythonLibraries(input *MigrationInput, googleapisDir string) ([]*confi
 		}
 		if len(libState.APIs) > 0 {
 			library.APIs = toAPIs(libState.APIs)
-		} else {
-			library.Output = filepath.Join("packages", library.Name)
-			library.Veneer = true
 		}
 		// Convert "preserve" regexes into "keep" paths, sorted for ease
 		// of testing.

--- a/tool/cmd/migrate/python_test.go
+++ b/tool/cmd/migrate/python_test.go
@@ -214,7 +214,7 @@ func TestBuildPythonLibraries(t *testing.T) {
 			},
 		},
 		{
-			name: "veneer",
+			name: "no APIs",
 			input: &MigrationInput{
 				repoPath: "testdata/google-cloud-python",
 				librarianState: &legacyconfig.LibrarianState{
@@ -228,9 +228,7 @@ func TestBuildPythonLibraries(t *testing.T) {
 			},
 			want: []*config.Library{
 				{
-					Name:   "google-api-core",
-					Veneer: true,
-					Output: "packages/google-api-core",
+					Name: "google-api-core",
 					Python: &config.PythonPackage{
 						PythonDefault: config.PythonDefault{
 							LibraryType: "CORE",


### PR DESCRIPTION
Now that API paths aren't inferred for Python, we can treat all libraries the same way: the output path is always inferred, and we don't need to special-case "there are no APIs listed because we don't need to generate anything".