### PR TITLE
chore(migrate): provide the correct tag format for python

### DIFF
--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -142,6 +142,7 @@ func buildConfigFromLibrarian(ctx context.Context, input *MigrationInput) (*conf
 		}
 		cfg.Default.Output = "packages"
 		cfg.Default.ReleaseLevel = "stable"
+		cfg.Default.TagFormat = pythonTagFormat
 	} else {
 		input.googleapisDir = src.Dir
 		cfg.Default.Output = "."

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -141,7 +141,7 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 				Default: &config.Default{
 					Output:       "packages",
 					ReleaseLevel: "stable",
-					TagFormat:    defaultTagFormat,
+					TagFormat:    pythonTagFormat,
 					Python: &config.PythonDefault{
 						CommonGAPICPaths: pythonDefaultCommonGAPICPaths,
 						LibraryType:      pythonDefaultLibraryType,
@@ -180,7 +180,7 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 				Default: &config.Default{
 					Output:       "packages",
 					ReleaseLevel: "stable",
-					TagFormat:    defaultTagFormat,
+					TagFormat:    pythonTagFormat,
 					Python: &config.PythonDefault{
 						CommonGAPICPaths: pythonDefaultCommonGAPICPaths,
 						LibraryType:      pythonDefaultLibraryType,

--- a/tool/cmd/migrate/python.go
+++ b/tool/cmd/migrate/python.go
@@ -60,7 +60,10 @@ var pythonDefaultCommonGAPICPaths = []string{
 	"docs/summary_overview.md",
 }
 
-const pythonDefaultLibraryType = repometadata.GAPICAutoLibraryType
+const (
+	pythonDefaultLibraryType = repometadata.GAPICAutoLibraryType
+	pythonTagFormat          = "{name}: v{version}"
+)
 
 // pythonGapicInfo contains information about the py_gapic_library target
 // from BUILD.bazel.


### PR DESCRIPTION
This changes the migrated librarian configuration for Python to use tag names that follow the pattern in
https://github.com/googleapis/google-cloud-python