### PR TITLE
fix(sidekick): crop trailing literals from resource names

### DIFF
--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -166,7 +166,7 @@ func identifyExplicitTarget(method *Method, binding *PathBinding) (*TargetResour
 		return nil, fmt.Errorf("consistency error: method %q has no InputType", method.Name)
 	}
 
-	var lastVarIndex int = -1
+	var lastVarIndex = -1
 	// Collect field paths corresponding to variable segments in the path template
 	for i, segment := range binding.PathTemplate.Segments {
 		if segment.Variable == nil {

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -166,8 +166,9 @@ func identifyExplicitTarget(method *Method, binding *PathBinding) (*TargetResour
 		return nil, fmt.Errorf("consistency error: method %q has no InputType", method.Name)
 	}
 
+	var lastVarIndex int = -1
 	// Collect field paths corresponding to variable segments in the path template
-	for _, segment := range binding.PathTemplate.Segments {
+	for i, segment := range binding.PathTemplate.Segments {
 		if segment.Variable == nil {
 			continue
 		}
@@ -184,12 +185,13 @@ func identifyExplicitTarget(method *Method, binding *PathBinding) (*TargetResour
 			return nil, nil
 		}
 		fieldPaths = append(fieldPaths, fieldPath)
+		lastVarIndex = i
 	}
 
 	if len(fieldPaths) == 0 {
 		return nil, nil
 	}
-	template, err := constructTemplate(method, binding.PathTemplate.Segments)
+	template, err := constructTemplate(method, binding.PathTemplate.Segments[:lastVarIndex+1])
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -137,6 +137,25 @@ func TestIdentifyTargetResources(t *testing.T) {
 				Template:   ParseTemplateForTest("//test-api.googleapis.com/{name}"),
 			},
 		},
+		{
+			name:      "explicit: crop trailing literals (API Keys keyString case)",
+			serviceID: "apikeys.googleapis.com",
+			path: NewPathTemplate().
+				WithLiteral("v2").
+				WithVariable(NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch().WithLiteral("keys").WithMatch()).
+				WithLiteral("keyString"),
+			fields: []*Field{
+				{
+					Name:              "name",
+					Typez:             STRING_TYPE,
+					ResourceReference: &ResourceReference{Type: "apikeys.googleapis.com/Key"},
+				},
+			},
+			want: &TargetResource{
+				FieldPaths: [][]string{{"name"}},
+				Template:   ParseTemplateForTest("//test-api.googleapis.com/{name}"),
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model, binding := setupTestModel(test.serviceID, test.path, test.fields)


### PR DESCRIPTION
Drop the remaining trailing literal segments.

Fixes #4489 