### PR TITLE
fix(librarian): check for output directory existence before cleaning

### DIFF
--- a/internal/librarian/fake.go
+++ b/internal/librarian/fake.go
@@ -95,3 +95,9 @@ func fakeCreateSkeleton(library *config.Library) error {
 func fakeDefaultLibraryName(api string) string {
 	return strings.ReplaceAll(api, "/", "-")
 }
+
+func fakeClean(library *config.Library) error {
+	// We always generate a README.md file, so it's fine to delete that.
+	// This function shouldn't be called if the output directory doesn't exist.
+	return os.Remove(filepath.Join(library.Output, "README.md"))
+}

--- a/internal/librarian/fake_test.go
+++ b/internal/librarian/fake_test.go
@@ -15,6 +15,7 @@
 package librarian
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,5 +51,52 @@ func TestGenerate(t *testing.T) {
 	want := "# test-library\n\nGenerated library\n"
 	if diff := cmp.Diff(want, string(content)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCleanLibraries(t *testing.T) {
+	const (
+		libraryName = "test-library"
+		outputDir   = "output"
+	)
+	library := &config.Library{
+		Name:   libraryName,
+		Output: outputDir,
+	}
+	cfg := &config.Config{
+		Language: config.LanguageFake,
+	}
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	if err := generateLibraries(t.Context(), cfg, []*config.Library{library}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cleanLibraries(cfg.Language, []*config.Library{library}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := os.Stat(filepath.Join(library.Output, "README.md"))
+	wantErr := os.ErrNotExist
+	if !errors.Is(err, wantErr) {
+		t.Errorf("after cleaning, checking for README.md error = %v, wantErr %v", err, wantErr)
+	}
+}
+
+func TestFakeClean_Error(t *testing.T) {
+	const (
+		libraryName = "test-library"
+		outputDir   = "output"
+	)
+	library := &config.Library{
+		Name:   libraryName,
+		Output: outputDir,
+	}
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	err := fakeClean(library)
+	wantErr := os.ErrNotExist
+	if !errors.Is(err, wantErr) {
+		t.Errorf("fakeClean(), error = %v, wantErr %v", err, wantErr)
 	}
 }

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -117,13 +118,18 @@ func runGenerate(ctx context.Context, cfg *config.Config, all bool, libraryName 
 // delegating to language-specific code to clean each library.
 func cleanLibraries(language string, libraries []*config.Library) error {
 	for _, library := range libraries {
+		if _, err := os.Stat(library.Output); os.IsNotExist(err) {
+			continue
+		}
 		switch language {
 		case config.LanguageDart:
 			if err := checkAndClean(library.Output, library.Keep); err != nil {
 				return err
 			}
 		case config.LanguageFake:
-			// No cleaning needed.
+			if err := fakeClean(library); err != nil {
+				return err
+			}
 		case config.LanguageGo:
 			if err := golang.Clean(library); err != nil {
 				return err


### PR DESCRIPTION
Changes cleanLibraries to skip the cleaning of any library whose output directory doesn't exist, which will happen the first time a library is generated. Language-specific code should be able to assume that the output directory exists. The fake language implementation of clean effectively validates this expectation by unconditionally deleting README.md.