### PR TITLE
fix(librarian): `generate` for new libraries

### DIFF
--- a/internal/librarian/clean.go
+++ b/internal/librarian/clean.go
@@ -27,7 +27,7 @@ import (
 // in keep does not exist.
 func checkAndClean(dir string, keep []string) error {
 	keepSet, err := check(dir, keep)
-	if err != nil {
+	if err != nil || keepSet == nil {
 		return err
 	}
 	return clean(dir, keepSet)

--- a/internal/librarian/clean_test.go
+++ b/internal/librarian/clean_test.go
@@ -117,3 +117,13 @@ func TestCleanOutput(t *testing.T) {
 		})
 	}
 }
+
+// checkAndClean() needs to work when adding a library. In that case the
+// destination does not exist.
+func TestCheckAndCleanMissingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist")
+	if err := checkAndClean(path, []string{}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Before this change `generate` did not work for new libraries. The code attempts to clean the non-existing directory, and `filepath.Walkdir()` returns an immediate error.