### PR TITLE
fix(internal/librarian/rust): remove wrong argument in semverCheck

### DIFF
--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -165,7 +165,7 @@ func semverCheck(ctx context.Context, semverData semverData, name string, manife
 		// If the manifest is new, we can skip semver checks, since there is no previous version to compare against.
 		return nil
 	}
-	err := command.Run(ctx, semverData.cargoPath, "semver-checks", "--frozen", "--all-features", "-p", name)
+	err := command.Run(ctx, semverData.cargoPath, "semver-checks", "--all-features", "-p", name)
 	if err != nil && semverData.dryRunKeepGoing {
 		slog.Warn("semver check failed, but continuing due to --keep-going", "crate", name, "error", err)
 		return nil


### PR DESCRIPTION
The `--frozen` argument was incorrectly added to `semverCheck` in I wrongly added it in https://github.com/googleapis/librarian/commit/60b64baccb223381382c11bcab62f6b459a12a1b without validation, and the flag does not actually exist.

See https://crates.io/crates/cargo-semver-checks#what-features-does-cargo-semver-checks-enable-in-the-tested-crates for details.
