### PR TITLE
fix(tool/cmd/migrate): add hardcoded repo name to config

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -221,6 +221,7 @@ func buildConfig(gen *GenerationConfig, googleapisDir string) *config.Config {
 			Googleapis: &config.Source{Dir: googleapisDir},
 		},
 		Libraries: libs,
+		Repo:      "googleapis/google-cloud-java",
 	}
 }
 

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -94,6 +94,7 @@ func TestBuildConfig(t *testing.T) {
 			},
 			want: &config.Config{
 				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
 				Default:  &config.Default{},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
@@ -124,6 +125,7 @@ func TestBuildConfig(t *testing.T) {
 			},
 			want: &config.Config{
 				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
 				Default:  &config.Default{},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
@@ -160,6 +162,7 @@ func TestBuildConfig(t *testing.T) {
 			},
 			want: &config.Config{
 				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
 				Default:  &config.Default{},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
@@ -221,6 +224,7 @@ func TestBuildConfig(t *testing.T) {
 			},
 			want: &config.Config{
 				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
 				Default:  &config.Default{},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},


### PR DESCRIPTION
Add hardcoded repo name to the migrated librarian config.

For #4306