### PR TITLE
fix(sidekick/rust): remove trailing whitespace from generic templates

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -122,7 +122,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{^Codec.HasVariablePath}}
             let path = "{{Codec.PathFmt}}".to_string();
             {{/Codec.HasVariablePath}}
-            
+
             {{#Codec.DetailedTracingAttributes}}
             let path_template = "{{Codec.PathTemplate}}";
             {{/Codec.DetailedTracingAttributes}}


### PR DESCRIPTION
Fixes #4549.