### PR TITLE
feat(librarian): add --legacylibrarian-pr-body flag to bump command

### DIFF
--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -86,9 +86,10 @@ DESCRIPTION:
 
 OPTIONS:
 
-	--all             update all libraries in the workspace
-	--version string  specific version to update to; not valid with --all
-	--help, -h        show help
+	--all                             update all libraries in the workspace
+	--version string                  specific version to update to; not valid with --all
+	--legacylibrarian-pr-body string  a file to create with text to put in the body of the PR
+	--help, -h                        show help
 
 GLOBAL OPTIONS:
 

--- a/internal/legacylibrarian/legacylibrarian/tag_and_release.go
+++ b/internal/legacylibrarian/legacylibrarian/tag_and_release.go
@@ -227,10 +227,11 @@ func (r *tagRunner) processPullRequest(ctx context.Context, p *legacygithub.Pull
 		tagFormat := legacyconfig.DetermineTagFormat(release.Library, libraryState, librarianConfig)
 		tagName := legacyconfig.FormatTag(tagFormat, release.Library, release.Version)
 		releaseName := fmt.Sprintf("%s: v%s", release.Library, release.Version)
-		if _, err := r.ghClient.CreateRelease(ctx, tagName, releaseName, release.Body, commitSha); err != nil {
-			return fmt.Errorf("failed to create release: %w", err)
+		if len(release.Body) > 0 {
+			if _, err := r.ghClient.CreateRelease(ctx, tagName, releaseName, release.Body, commitSha); err != nil {
+				return fmt.Errorf("failed to create release: %w", err)
+			}
 		}
-
 	}
 	return r.replaceReleasePendingLabel(ctx, p, releaseDoneLabel)
 }

--- a/internal/legacylibrarian/legacylibrarian/tag_test.go
+++ b/internal/legacylibrarian/legacylibrarian/tag_test.go
@@ -429,6 +429,16 @@ Libraries: a,b,c
 				},
 			},
 		},
+		{
+			name: "contentless releases",
+			body: `
+<details><summary>google-cloud-functions: v2.3.4</summary></details>
+<details><summary>google-cloud-storage: v1.2.3</summary></details>`,
+			want: []libraryRelease{
+				{Library: "google-cloud-functions", Version: "2.3.4"},
+				{Library: "google-cloud-storage", Version: "1.2.3"},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := parsePullRequestBody(test.body)
@@ -446,6 +456,16 @@ func TestProcessPullRequest(t *testing.T) {
 	branch := "main"
 	prWithRelease := &legacygithub.PullRequest{
 		Body:           &prBody,
+		Number:         &prNumber,
+		MergeCommitSHA: &mergeCommitSHA,
+		Labels:         []*gh.Label{{Name: gh.Ptr(releasePendingLabel)}},
+		Base: &gh.PullRequestBranch{
+			Ref: &branch,
+		},
+	}
+	bodyWithoutReleaseNotes := `<details><summary>google-cloud-storage: v1.2.3</summary></details>`
+	prWithoutReleaseNotes := &legacygithub.PullRequest{
+		Body:           &bodyWithoutReleaseNotes,
 		Number:         &prNumber,
 		MergeCommitSHA: &mergeCommitSHA,
 		Labels:         []*gh.Label{{Name: gh.Ptr(releasePendingLabel)}},
@@ -496,11 +516,22 @@ func TestProcessPullRequest(t *testing.T) {
 			wantReleaseNames:       []string{"google-cloud-storage: v1.2.3"},
 		},
 		{
+			name: "tag but no GitHub release",
+			pr:   prWithoutReleaseNotes,
+			ghClient: &mockGitHubClient{
+				librarianState: state,
+			},
+			wantCreateReleaseCalls: 0,
+			wantReplaceLabelsCalls: 1,
+			wantCreateTagCalls:     1,
+		},
+		{
 			name: "no release details",
 			pr:   prWithoutRelease,
 			ghClient: &mockGitHubClient{
 				librarianState: state,
-			}},
+			},
+		},
 		{
 			name: "library not found",
 			pr:   prWithRelease,

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -81,7 +81,7 @@ Examples:
 				Name:  "version",
 				Usage: "specific version to update to; not valid with --all",
 			},
-			// TODO(FIXME:issue number if we go ahead with this): remove this
+			// TODO(https://github.com/googleapis/librarian/issues/4575): remove this
 			// when we migrate fully from legacylibrarian.
 			&cli.StringFlag{
 				Name:  "legacylibrarian-pr-body",

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -80,6 +81,12 @@ Examples:
 				Name:  "version",
 				Usage: "specific version to update to; not valid with --all",
 			},
+			// TODO(FIXME:issue number if we go ahead with this): remove this
+			// when we migrate fully from legacylibrarian.
+			&cli.StringFlag{
+				Name:  "legacylibrarian-pr-body",
+				Usage: "a file to create with text to put in the body of the PR",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			all := cmd.Bool("all")
@@ -98,14 +105,14 @@ Examples:
 			if err != nil {
 				return err
 			}
-			return runBump(ctx, cfg, all, libraryName, versionOverride)
+			return runBump(ctx, cfg, all, libraryName, versionOverride, cmd.String("legacylibrarian-pr-body"))
 		},
 	}
 }
 
 // runBump performs the actual work of the bump command, after all the command
 // lines arguments have been validated and the configuration loaded.
-func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride string) error {
+func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride, legacylibrarianPRBodyFile string) error {
 	if cfg.Release == nil {
 		return errReleaseConfigEmpty
 	}
@@ -135,6 +142,13 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 
 	if err := postBump(ctx, cfg); err != nil {
 		return err
+	}
+
+	if legacylibrarianPRBodyFile != "" {
+		legacylibraryPRBody := createLegacylibrarianPRBody(librariesToBump)
+		if err := os.WriteFile(legacylibrarianPRBodyFile, []byte(legacylibraryPRBody), 0644); err != nil {
+			return fmt.Errorf("error writing %s: %w", legacylibrarianPRBodyFile, err)
+		}
 	}
 	return RunTidyOnConfig(ctx, cfg)
 }
@@ -448,4 +462,15 @@ func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.
 	default:
 		return fmt.Errorf("%q should not be using legacyRustBumpLibrary", cfg.Language)
 	}
+}
+
+// createLegacylibrarianPRBody returns a string suitable to use as the body of
+// a pull request that bumps the given libraries, such that it can be processed
+// by legacylibrarian.
+func createLegacylibrarianPRBody(bumpedLibraries []*config.Library) string {
+	var lines []string
+	for _, lib := range bumpedLibraries {
+		lines = append(lines, fmt.Sprintf("<details><summary>%s: v%s</summary></details>", lib.Name, lib.Version))
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -48,6 +48,8 @@ func TestBumpCommand(t *testing.T) {
 		name         string
 		args         []string
 		withChanges  []string
+		prBodyFile   string
+		wantPRBody   string
 		wantVersions map[string]string
 	}{
 		{
@@ -144,6 +146,34 @@ func TestBumpCommandDeriveOutput(t *testing.T) {
 	}
 }
 
+func TestBumpCommandLegacylibrarianPRBodyFile(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+	cfg := sample.Config()
+	opts := testhelper.SetupOptions{
+		Clone:       cfg.Release.Branch,
+		Config:      cfg,
+		Tags:        []string{sample.InitialLib1Tag, sample.InitialLib2Tag},
+		WithChanges: []string{filepath.Join(sample.Lib1Output, "src", "lib.rs")},
+	}
+	testhelper.Setup(t, opts)
+
+	if err := Run(t.Context(), "librarian", "bump", "--all", "--legacylibrarian-pr-body=pr.txt"); err != nil {
+		t.Fatal(err)
+	}
+	prBody, err := os.ReadFile("pr.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prBodyText := string(prBody)
+	// Exact format is tested in TestCreateLegacylibrarianPRBody
+	if !strings.Contains(prBodyText, sample.Lib1Name) {
+		t.Errorf("expected PR body to contain %s; got %s", sample.Lib1Name, prBodyText)
+	}
+	if !strings.Contains(prBodyText, sample.NextVersion) {
+		t.Errorf("expected PR body to contain %s; got %s", sample.NextVersion, prBodyText)
+	}
+}
+
 func TestBumpCommand_Error(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 
@@ -191,6 +221,12 @@ func TestBumpCommand_Error(t *testing.T) {
 				return c
 			}(),
 			wantErr: errReleaseConfigEmpty,
+		},
+		{
+			name:    "bad pr file",
+			args:    []string{"librarian", "bump", sample.Lib1Name, "--legacylibrarian-pr-body=missing-directory/pr.txt"},
+			cfg:     sample.Config(),
+			wantErr: os.ErrNotExist,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -266,7 +302,6 @@ func TestFindLibrary(t *testing.T) {
 
 func TestRunBump_Error(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "git")
 
 	tests := []struct {
 		name            string
@@ -296,9 +331,9 @@ func TestRunBump_Error(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			gotErr := runBump(t.Context(), cfg, false, test.libraryName, test.versionOverride)
+			gotErr := runBump(t.Context(), cfg, false, test.libraryName, test.versionOverride, "")
 			if !errors.Is(gotErr, test.wantErr) {
-				t.Errorf("bumpLibrary() error = %v, wantErr %v", gotErr, test.wantErr)
+				t.Errorf("runBump() error = %v, wantErr %v", gotErr, test.wantErr)
 			}
 		})
 	}
@@ -1338,6 +1373,18 @@ func TestLibraryChanged(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestCreateLegacylibrarianPRBody(t *testing.T) {
+	libraries := []*config.Library{
+		{Name: "functions", Version: "2.3.4"},
+		{Name: "storage", Version: "1.2.3"},
+	}
+	want := "<details><summary>functions: v2.3.4</summary></details>\n<details><summary>storage: v1.2.3</summary></details>"
+	got := createLegacylibrarianPRBody(libraries)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
This is a temporary flag so that while we're using librarian bump to perform the actual version bump, the operator can specify the name of a file, and librarian will write the content of the PR to create into that file. (This could potentially be used by librarianops as well as by human operators.) The flag will be removed when legacylibrarian is turned down.

Additionally, tweaks legacylibrarian's tag-and-release command to skip creating a GitHub release if the release body would be empty.