### PR TITLE
fix(librarian/nodejs): include version in staging directory path

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -64,7 +64,8 @@ func generateLibrary(ctx context.Context, library *config.Library, googleapisDir
 }
 
 func generateAPI(ctx context.Context, api *config.API, library *config.Library, googleapisDir, repoRoot string) error {
-	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name)
+	version := filepath.Base(api.Path)
+	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, version)
 	if err := os.MkdirAll(stagingDir, 0755); err != nil {
 		return err
 	}

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -15,6 +15,7 @@
 package nodejs
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -369,9 +370,49 @@ func TestGenerateAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", "google-cloud-secretmanager")
+	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", "google-cloud-secretmanager", "v1")
 	if _, err := os.Stat(stagingDir); err != nil {
 		t.Errorf("expected staging directory to exist: %v", err)
+	}
+}
+
+func TestGenerateAPI_MultipleVersions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test: Node.js GAPIC code generation")
+	}
+
+	testhelper.RequireCommand(t, "gapic-generator-typescript")
+	absGoogleapisDir, err := filepath.Abs(googleapisDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := t.TempDir()
+	library := &config.Library{
+		Name: "google-cloud-secretmanager",
+		APIs: []*config.API{
+			{Path: "google/cloud/secretmanager/v1"},
+			{Path: "google/cloud/secretmanager/v1beta1"},
+		},
+	}
+	outDir := filepath.Join(repoRoot, "packages", library.Name)
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	library.Output = outDir
+
+	for _, api := range library.APIs {
+		err = generateAPI(t.Context(), api, library, absGoogleapisDir, repoRoot)
+		if err != nil {
+			t.Fatalf("failed to generate api %q: %v", api.Path, err)
+		}
+	}
+	for _, api := range library.APIs {
+		version := filepath.Base(api.Path)
+		stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, version)
+		if _, err := os.Stat(stagingDir); err != nil {
+			t.Errorf("expected staging directory for %s to exist: %v", version, err)
+		}
 	}
 }
 
@@ -386,26 +427,28 @@ func TestRunPostProcessor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create staging structure matching gapic-generator-typescript output.
-	stagingBase := filepath.Join(repoRoot, "owl-bot-staging", library.Name, "v1")
-	srcDir := filepath.Join(stagingBase, "src", "v1")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(srcDir, "index.ts"),
-		[]byte("export {SecretManagerServiceClient} from './secret_manager_service_client';\n"),
-		0644,
-	); err != nil {
-		t.Fatal(err)
-	}
-	protoDir := filepath.Join(stagingBase, "protos", "google", "cloud", "secretmanager", "v1")
-	if err := os.MkdirAll(protoDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	protoContent := "syntax = \"proto3\";\npackage google.cloud.secretmanager.v1;\n"
-	if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(protoContent), 0644); err != nil {
-		t.Fatal(err)
+	// Create staging structure matching gapic-generator-typescript output for multiple versions.
+	for _, v := range []string{"v1", "v1beta1"} {
+		stagingBase := filepath.Join(repoRoot, "owl-bot-staging", library.Name, v)
+		srcDir := filepath.Join(stagingBase, "src", v)
+		if err := os.MkdirAll(srcDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(srcDir, "index.ts"),
+			[]byte("export {SecretManagerServiceClient} from './secret_manager_service_client';\n"),
+			0644,
+		); err != nil {
+			t.Fatal(err)
+		}
+		protoDir := filepath.Join(stagingBase, "protos", "google", "cloud", "secretmanager", v)
+		if err := os.MkdirAll(protoDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		protoContent := fmt.Sprintf("syntax = \"proto3\";\npackage google.cloud.secretmanager.%s;\n", v)
+		if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(protoContent), 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if err := runPostProcessor(t.Context(), library, repoRoot, outDir); err != nil {


### PR DESCRIPTION
The Node.js library generation now includes the API version in the owl-bot-staging directory structure. This change enables the post-processor to correctly combine multiple API versions into a single library.

Previously, all API versions for a library were staged in the same flat directory, which caused issues when multiple versions needed to be processed. The staging directory now follows the pattern `owl-bot-staging/<library-name>/<version>`.

For https://github.com/googleapis/librarian/issues/4404