### PR TITLE
feat(tool/cmd/migrate): extract copyright year from existing files

### DIFF
--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -139,6 +139,11 @@ func buildNodejsLibraries(repoPath, googleapisDir string) ([]*config.Library, er
 			library.APIs = apis
 		}
 
+		// Extract copyright year from existing generated source files.
+		if year := extractCopyrightYear(pkgDir); year != "" {
+			library.CopyrightYear = year
+		}
+
 		// Check if the npm package name needs to be set explicitly.
 		derivedName := deriveNpmPackageName(libraryName)
 		if pkgJSON.Name != derivedName {
@@ -298,6 +303,21 @@ func ensureNodejsPackage(l *config.Library) *config.NodejsPackage {
 		l.Nodejs = &config.NodejsPackage{}
 	}
 	return l.Nodejs
+}
+
+// copyrightYearRegex matches "Copyright YYYY Google" in a file header.
+var copyrightYearRegex = regexp.MustCompile(`Copyright (\d{4}) Google`)
+
+// extractCopyrightYear reads the copyright year from src/index.ts.
+func extractCopyrightYear(pkgDir string) string {
+	data, err := os.ReadFile(filepath.Join(pkgDir, "src", "index.ts"))
+	if err != nil {
+		return ""
+	}
+	if m := copyrightYearRegex.FindSubmatch(data); len(m) > 1 {
+		return string(m[1])
+	}
+	return ""
 }
 
 // deriveNpmPackageName derives the expected npm package name from a library

--- a/tool/cmd/migrate/nodejs_test.go
+++ b/tool/cmd/migrate/nodejs_test.go
@@ -29,8 +29,9 @@ func TestBuildNodejsLibraries(t *testing.T) {
 	}
 	want := []*config.Library{
 		{
-			Name:    "google-cloud-secretmanager",
-			Version: "6.1.0",
+			Name:          "google-cloud-secretmanager",
+			Version:       "6.1.0",
+			CopyrightYear: "2019",
 			APIs: []*config.API{
 				{Path: "google/cloud/secretmanager/v1"},
 			},

--- a/tool/cmd/migrate/testdata/google-cloud-node/packages/google-cloud-secretmanager/src/index.ts
+++ b/tool/cmd/migrate/testdata/google-cloud-node/packages/google-cloud-secretmanager/src/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export {SecretManagerServiceClient} from './v1';


### PR DESCRIPTION
Read the copyright year from src/index.ts in each package and set it as copyright_year in the library config. This preserves the original copyright year when libraries are regenerated, since the generator always uses the current year.

For https://github.com/googleapis/librarian/issues/4413