### PR TITLE
feat(internal/librarian): parallelize library formatting

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -224,7 +224,7 @@ func formatLibraries(ctx context.Context, language string, libraries []*config.L
 			return nil
 		case config.LanguageRust:
 			// Rust formatting cannot be parallelized because it shares the
-		// Cargo.toml workspace file across libraries.
+			// Cargo.toml workspace file across libraries.
 			if err := rust.Format(ctx, library); err != nil {
 				return err
 			}


### PR DESCRIPTION
Library formatting is now run concurrently for languages where each library formats independently (Go, Node.js, Dart). Languages that share state across libraries, such as Rust which uses a shared Cargo.toml workspace file, remain sequential.