### PR TITLE
test(librarian/rust): add tests for buildModuleCodec

### DIFF
--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -1067,6 +1067,251 @@ func TestFormatPackageDependency(t *testing.T) {
 	}
 }
 
+func TestBuildModuleCodec(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		module  *config.RustModule
+		want    map[string]string
+	}{
+		{
+			name:    "minimal module",
+			library: &config.Library{},
+			module:  &config.RustModule{},
+			want:    map[string]string{},
+		},
+		{
+			name:    "with GenerateSetterSamples and GenerateRpcSamples",
+			library: &config.Library{},
+			module: &config.RustModule{
+				GenerateSetterSamples: "true",
+				GenerateRpcSamples:    "true",
+			},
+			want: map[string]string{
+				"generate-setter-samples": "true",
+				"generate-rpc-samples":    "true",
+			},
+		},
+		{
+			name:    "with HasVeneer",
+			library: &config.Library{},
+			module: &config.RustModule{
+				HasVeneer: true,
+			},
+			want: map[string]string{
+				"has-veneer": "true",
+			},
+		},
+		{
+			name:    "with IncludeGrpcOnlyMethods",
+			library: &config.Library{},
+			module: &config.RustModule{
+				IncludeGrpcOnlyMethods: true,
+			},
+			want: map[string]string{
+				"include-grpc-only-methods": "true",
+			},
+		},
+		{
+			name:    "with DetailedTracingAttributes set at module level",
+			library: &config.Library{},
+			module: &config.RustModule{
+				DetailedTracingAttributes: ptr(true),
+			},
+			want: map[string]string{
+				"detailed-tracing-attributes": "true",
+			},
+		},
+		{
+			name: "with DetailedTracingAttributes inherited from library level",
+			library: &config.Library{
+				Rust: &config.RustCrate{
+					RustDefault: config.RustDefault{
+						DetailedTracingAttributes: ptr(true),
+					},
+				},
+			},
+			module: &config.RustModule{},
+			want: map[string]string{
+				"detailed-tracing-attributes": "true",
+			},
+		},
+		{
+			name: "with DetailedTracingAttributes false overriding library level true",
+			library: &config.Library{
+				Rust: &config.RustCrate{
+					RustDefault: config.RustDefault{
+						DetailedTracingAttributes: ptr(true),
+					},
+				},
+			},
+			module: &config.RustModule{
+				DetailedTracingAttributes: ptr(false),
+			},
+			want: map[string]string{},
+		},
+		{
+			name:    "with ModulePath",
+			library: &config.Library{},
+			module: &config.RustModule{
+				ModulePath: "crate::generated::gapic::model",
+			},
+			want: map[string]string{
+				"module-path": "crate::generated::gapic::model",
+			},
+		},
+		{
+			name:    "with NameOverrides",
+			library: &config.Library{},
+			module: &config.RustModule{
+				NameOverrides: "foo=bar,baz=qux",
+			},
+			want: map[string]string{
+				"name-overrides": "foo=bar,baz=qux",
+			},
+		},
+		{
+			name:    "with PostProcessProtos",
+			library: &config.Library{},
+			module: &config.RustModule{
+				PostProcessProtos: "some-post-process",
+			},
+			want: map[string]string{
+				"post-process-protos": "some-post-process",
+			},
+		},
+		{
+			name:    "with RoutingRequired",
+			library: &config.Library{},
+			module: &config.RustModule{
+				RoutingRequired: true,
+			},
+			want: map[string]string{
+				"routing-required": "true",
+			},
+		},
+		{
+			name:    "with ExtendGrpcTransport",
+			library: &config.Library{},
+			module: &config.RustModule{
+				ExtendGrpcTransport: true,
+			},
+			want: map[string]string{
+				"extend-grpc-transport": "true",
+			},
+		},
+		{
+			name:    "with Template prepends templates/",
+			library: &config.Library{},
+			module: &config.RustModule{
+				Template: "prost",
+			},
+			want: map[string]string{
+				"template-override": "templates/prost",
+			},
+		},
+		{
+			name: "with DisabledRustdocWarnings overrides library level",
+			library: &config.Library{
+				Rust: &config.RustCrate{
+					RustDefault: config.RustDefault{
+						DisabledRustdocWarnings: []string{"lib-warning1"},
+					},
+				},
+			},
+			module: &config.RustModule{
+				DisabledRustdocWarnings: []string{"mod-warning1", "mod-warning2"},
+			},
+			want: map[string]string{
+				"disabled-rustdoc-warnings": "mod-warning1,mod-warning2",
+			},
+		},
+		{
+			name:    "with RootName",
+			library: &config.Library{},
+			module: &config.RustModule{
+				RootName: "custom-root",
+			},
+			want: map[string]string{
+				"root-name": "custom-root",
+			},
+		},
+		{
+			name:    "with InternalBuilders",
+			library: &config.Library{},
+			module: &config.RustModule{
+				InternalBuilders: true,
+			},
+			want: map[string]string{
+				"internal-builders": "true",
+			},
+		},
+		{
+			name: "all fields set",
+			library: &config.Library{
+				Name:          "google-cloud-example",
+				CopyrightYear: "2024",
+				Rust: &config.RustCrate{
+					DisabledClippyWarnings: []string{"clippy1"},
+					RustDefault: config.RustDefault{
+						DisabledRustdocWarnings: []string{"lib-warning"},
+						PackageDependencies: []*config.RustPackageDependency{
+							{
+								Name:    "dep1",
+								Package: "pkg1",
+							},
+						},
+						DetailedTracingAttributes: ptr(false),
+					},
+				},
+			},
+			module: &config.RustModule{
+				GenerateSetterSamples:     "true",
+				GenerateRpcSamples:        "false",
+				HasVeneer:                 true,
+				IncludeGrpcOnlyMethods:    true,
+				DetailedTracingAttributes: ptr(true),
+				ModulePath:                "crate::model",
+				NameOverrides:             "a=b",
+				PostProcessProtos:         "post",
+				RoutingRequired:           true,
+				ExtendGrpcTransport:       true,
+				Template:                  "grpc-client",
+				DisabledRustdocWarnings:   []string{"w1", "w2"},
+				RootName:                  "my-root",
+				InternalBuilders:          true,
+			},
+			want: map[string]string{
+				"package-name-override":       "google-cloud-example",
+				"copyright-year":              "2024",
+				"disabled-rustdoc-warnings":   "w1,w2",
+				"disabled-clippy-warnings":    "clippy1",
+				"package:dep1":                "package=pkg1",
+				"generate-setter-samples":     "true",
+				"generate-rpc-samples":        "false",
+				"has-veneer":                  "true",
+				"include-grpc-only-methods":   "true",
+				"detailed-tracing-attributes": "true",
+				"module-path":                 "crate::model",
+				"name-overrides":              "a=b",
+				"post-process-protos":         "post",
+				"routing-required":            "true",
+				"extend-grpc-transport":       "true",
+				"template-override":           "templates/grpc-client",
+				"root-name":                   "my-root",
+				"internal-builders":           "true",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildModuleCodec(test.library, test.module)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestBuildCodec(t *testing.T) {
 	for _, test := range []struct {
 		name    string


### PR DESCRIPTION
Add tests covering all branches in buildModuleCodec, including each codec field and DetailedTracingAttributes override logic.

Fixes https://github.com/googleapis/librarian/issues/4238