### PR TITLE
test(librarian/dart): improve test coverage for toModelConfig

### DIFF
--- a/internal/librarian/dart/codec.go
+++ b/internal/librarian/dart/codec.go
@@ -40,6 +40,7 @@ func toModelConfig(library *config.Library, ch *config.API, sources *sidekickcon
 	root := sources.Googleapis
 	if ch.Path == "schema/google/showcase/v1beta1" {
 		root = sources.Showcase
+		src.ActiveRoots = append(src.ActiveRoots, "showcase")
 	}
 	svcConfig, err := serviceconfig.Find(root, ch.Path, config.LanguageDart)
 	if err != nil {

--- a/internal/librarian/dart/codec_test.go
+++ b/internal/librarian/dart/codec_test.go
@@ -497,7 +497,7 @@ func TestToModelConfig(t *testing.T) {
 						Googleapis: googleapisDir,
 						Showcase:   showcaseDir,
 					},
-					ActiveRoots: []string{"googleapis"},
+					ActiveRoots: []string{"googleapis", "showcase"},
 				},
 				Codec: map[string]string{},
 				Override: api.ModelOverride{


### PR DESCRIPTION
New test cases are added to cover previously untested code paths: explicit protobuf specification format, Dart include list propagation, the showcase API path using sources.Showcase as root, and custom active roots passed through library.Roots.

Fixes https://github.com/googleapis/librarian/issues/4233