### PR TITLE
fix(migrate): allow migration to run on arbitrary directories

### DIFF
--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -103,7 +103,7 @@ NAME:
 
 USAGE:
 
-	librarian tidy [path]
+	librarian tidy
 
 OPTIONS:
 

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -66,7 +66,7 @@ func runAdd(ctx context.Context, cfg *config.Config, apis ...string) error {
 	if err != nil {
 		return err
 	}
-	return RunTidyOnConfig(ctx, cfg)
+	return RunTidyOnConfig(ctx, ".", cfg)
 }
 
 func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (*config.Config, error) {

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -150,7 +150,7 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 			return fmt.Errorf("error writing %s: %w", legacylibrarianPRBodyFile, err)
 		}
 	}
-	return RunTidyOnConfig(ctx, cfg)
+	return RunTidyOnConfig(ctx, ".", cfg)
 }
 
 // findLibrariesToBump determines which versions should be bumped based on
@@ -415,7 +415,7 @@ func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryNa
 	if err := postBump(ctx, cfg); err != nil {
 		return err
 	}
-	return RunTidyOnConfig(ctx, cfg)
+	return RunTidyOnConfig(ctx, ".", cfg)
 }
 
 // legacyRustBumpAll applies the legacy (but still in use) "bump all" approach

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -37,19 +38,20 @@ func tidyCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "tidy",
 		Usage:     "format and validate librarian.yaml",
-		UsageText: "librarian tidy [path]",
+		UsageText: "librarian tidy",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			cfg, err := yaml.Read[config.Config](librarianConfigPath)
 			if err != nil {
 				return err
 			}
-			return RunTidyOnConfig(ctx, cfg)
+			return RunTidyOnConfig(ctx, ".", cfg)
 		},
 	}
 }
 
-// RunTidyOnConfig formats and validates the provided librarian configuration and writes it to disk.
-func RunTidyOnConfig(ctx context.Context, cfg *config.Config) error {
+// RunTidyOnConfig formats and validates the provided librarian configuration
+// and writes it to disk, relative to the specified repository root directory.
+func RunTidyOnConfig(ctx context.Context, repoDir string, cfg *config.Config) error {
 	if err := validateLibraries(cfg); err != nil {
 		return err
 	}
@@ -58,7 +60,7 @@ func RunTidyOnConfig(ctx context.Context, cfg *config.Config) error {
 		return errNoGoogleapiSourceInfo
 	}
 	cfg.Libraries = tidyLibraries(cfg)
-	return yaml.Write(librarianConfigPath, formatConfig(cfg))
+	return yaml.Write(filepath.Join(repoDir, librarianConfigPath), formatConfig(cfg))
 }
 
 func tidyLibraries(cfg *config.Config) []*config.Library {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -300,11 +300,10 @@ func TestTidy_DerivableFields(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			t.Chdir(tempDir)
-			if err := RunTidyOnConfig(t.Context(), test.config); err != nil {
+			if err := RunTidyOnConfig(t.Context(), tempDir, test.config); err != nil {
 				t.Fatal(err)
 			}
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -329,7 +328,8 @@ func TestTidy_DerivableFields(t *testing.T) {
 	}
 }
 
-func TestTidyDuplicateError(t *testing.T) {
+func TestTidy_DuplicateError(t *testing.T) {
+	tempDir := t.TempDir()
 	cfg := &config.Config{
 		Language: config.LanguageRust,
 		Sources: &config.Sources{
@@ -350,7 +350,7 @@ func TestTidyDuplicateError(t *testing.T) {
 		},
 	}
 
-	err := RunTidyOnConfig(t.Context(), cfg)
+	err := RunTidyOnConfig(t.Context(), tempDir, cfg)
 	if err == nil {
 		t.Fatal("expected error for duplicate library")
 	}
@@ -361,7 +361,6 @@ func TestTidyDuplicateError(t *testing.T) {
 
 func TestTidy_DerivableOutput(t *testing.T) {
 	tempDir := t.TempDir()
-	t.Chdir(tempDir)
 	cfg := &config.Config{
 		Language: config.LanguageRust,
 		Default: &config.Default{
@@ -386,10 +385,10 @@ func TestTidy_DerivableOutput(t *testing.T) {
 			},
 		},
 	}
-	if err := RunTidyOnConfig(t.Context(), cfg); err != nil {
+	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	got, err := yaml.Read[config.Config](librarianConfigPath)
+	got, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -403,7 +402,6 @@ func TestTidy_DerivableOutput(t *testing.T) {
 
 func TestTidy_DerivableAPIPath(t *testing.T) {
 	tempDir := t.TempDir()
-	t.Chdir(tempDir)
 	cfg := &config.Config{
 		Language: config.LanguageDart,
 		Default: &config.Default{
@@ -427,10 +425,10 @@ func TestTidy_DerivableAPIPath(t *testing.T) {
 			},
 		},
 	}
-	if err := RunTidyOnConfig(t.Context(), cfg); err != nil {
+	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	got, err := yaml.Read[config.Config](librarianConfigPath)
+	got, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,7 +442,6 @@ func TestTidy_DerivableAPIPath(t *testing.T) {
 
 func TestTidy_DerivableRoots(t *testing.T) {
 	tempDir := t.TempDir()
-	t.Chdir(tempDir)
 	cfg := &config.Config{
 		Language: config.LanguageRust,
 		Default: &config.Default{
@@ -468,10 +465,10 @@ func TestTidy_DerivableRoots(t *testing.T) {
 			},
 		},
 	}
-	if err := RunTidyOnConfig(t.Context(), cfg); err != nil {
+	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	got, err := yaml.Read[config.Config](librarianConfigPath)
+	got, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -559,11 +556,10 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			t.Chdir(tempDir)
 
-			RunTidyOnConfig(t.Context(), test.cfg)
+			RunTidyOnConfig(t.Context(), tempDir, test.cfg)
 
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -579,7 +575,8 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 	}
 }
 
-func TestTidyMissingGoogleApisSource(t *testing.T) {
+func TestTidy_MissingGoogleApisSource(t *testing.T) {
+	tempDir := t.TempDir()
 	cfg := &config.Config{
 		Language: config.LanguageRust,
 		Libraries: []*config.Library{
@@ -593,7 +590,7 @@ func TestTidyMissingGoogleApisSource(t *testing.T) {
 			},
 		},
 	}
-	err := RunTidyOnConfig(t.Context(), cfg)
+	err := RunTidyOnConfig(t.Context(), tempDir, cfg)
 	if err == nil {
 		t.Fatalf("expected error, got %v", nil)
 	}
@@ -604,7 +601,6 @@ func TestTidyMissingGoogleApisSource(t *testing.T) {
 
 func TestTidy_VeneerSkipGenerate(t *testing.T) {
 	tempDir := t.TempDir()
-	t.Chdir(tempDir)
 	cfg := &config.Config{
 		Language: config.LanguageRust,
 		Sources: &config.Sources{
@@ -622,10 +618,10 @@ func TestTidy_VeneerSkipGenerate(t *testing.T) {
 			},
 		},
 	}
-	if err := RunTidyOnConfig(t.Context(), cfg); err != nil {
+	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	cfg, err := yaml.Read[config.Config](librarianConfigPath)
+	cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tool/cmd/migrate/dotnet.go
+++ b/tool/cmd/migrate/dotnet.go
@@ -67,7 +67,7 @@ func runDotnetMigration(ctx context.Context, repoPath string) error {
 	// The directory name in Googleapis is present for migration code to look
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""
-	if err := librarian.RunTidyOnConfig(ctx, cfg); err != nil {
+	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
 		return errTidyFailed
 	}
 	log.Printf("Successfully migrated %d .NET libraries", len(cfg.Libraries))

--- a/tool/cmd/migrate/dotnet_test.go
+++ b/tool/cmd/migrate/dotnet_test.go
@@ -349,7 +349,6 @@ func TestRunDotnetMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Chdir(t.TempDir())
 
 	fetchSource = func(ctx context.Context) (*config.Source, error) {
 		return &config.Source{
@@ -374,13 +373,16 @@ func TestRunDotnetMigration(t *testing.T) {
 		},
 		{
 			name:     "missing_file",
-			repoPath: "testdata/run/non-existent",
+			repoPath: "testdata/run/no-config",
 			wantErr:  os.ErrNotExist,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			repoPath := filepath.Join(wd, test.repoPath)
-			err := runDotnetMigration(t.Context(), repoPath)
+			dir := t.TempDir()
+			if err := os.CopyFS(dir, os.DirFS(test.repoPath)); err != nil {
+				t.Fatal(err)
+			}
+			err := runDotnetMigration(t.Context(), dir)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -147,7 +147,7 @@ func runJavaMigration(ctx context.Context, repoPath string) error {
 	// The directory name in Googleapis is present for migration code to look
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""
-	if err := librarian.RunTidyOnConfig(ctx, cfg); err != nil {
+	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
 		return errTidyFailed
 	}
 	log.Printf("Successfully migrated %d Java libraries", len(cfg.Libraries))

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -49,26 +49,18 @@ func TestRunJavaMigration(t *testing.T) {
 		},
 		{
 			name:     "no_generation_config",
-			repoPath: "testdata/run/non-existent",
+			repoPath: "testdata/run/no-config",
 			wantErr:  os.ErrNotExist,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			outputPath := "librarian.yaml"
-			t.Cleanup(func() {
-				if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
-					t.Fatalf("cleanup: %v", err)
-				}
-			})
-			err := runJavaMigration(t.Context(), test.repoPath)
-			if test.wantErr != nil {
-				if !errors.Is(err, test.wantErr) {
-					t.Fatalf("expected error %v, got %v", test.wantErr, err)
-				}
-				return
-			}
-			if err != nil {
+			dir := t.TempDir()
+			if err := os.CopyFS(dir, os.DirFS(test.repoPath)); err != nil {
 				t.Fatal(err)
+			}
+			err := runJavaMigration(t.Context(), dir)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}
 		})
 	}

--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -97,7 +97,7 @@ func runLibrarianMigration(ctx context.Context, language string, repoPath string
 
 	// If we already have a config, we just replace the libraries which are new.
 	// (Everything else about the existing configuration is maintained.)
-	existingConfig, err := yaml.Read[config.Config]("librarian.yaml")
+	existingConfig, err := yaml.Read[config.Config](filepath.Join(repoPath, "librarian.yaml"))
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to load existing librarian.yaml: %w", err)
 	}
@@ -106,7 +106,7 @@ func runLibrarianMigration(ctx context.Context, language string, repoPath string
 		cfg = existingConfig
 	}
 
-	if err := librarian.RunTidyOnConfig(ctx, cfg); err != nil {
+	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
 		return errTidyFailed
 	}
 	return nil

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -84,13 +84,10 @@ func TestRunMigrateLibrarian(t *testing.T) {
 			if err := os.CopyFS(dir, os.DirFS(test.repoPath)); err != nil {
 				t.Fatal(err)
 			}
-			// TODO(https://github.com/googleapis/librarian/issues/4569): remove
-			// this chdir when we change within the prod code.
-			t.Chdir(dir)
 			if err := runLibrarianMigration(t.Context(), "python", dir, test.librariesToMigrate); err != nil {
 				t.Fatal(err)
 			}
-			gotConfig, err := yaml.Read[config.Config]("librarian.yaml")
+			gotConfig, err := yaml.Read[config.Config](filepath.Join(dir, "librarian.yaml"))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -93,7 +93,7 @@ func runNodejsMigration(ctx context.Context, repoPath string) error {
 	}
 	cfg.Sources.Googleapis.Dir = ""
 
-	if err := librarian.RunTidyOnConfig(ctx, cfg); err != nil {
+	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
 		return fmt.Errorf("librarian tidy failed: %w", err)
 	}
 	return nil

--- a/tool/cmd/migrate/testdata/run/no-config/README.txt
+++ b/tool/cmd/migrate/testdata/run/no-config/README.txt
@@ -1,0 +1,2 @@
+This file exists to make sure that the parent directory exists.
+The directory deliberately contains no configuration of any kind, however.


### PR DESCRIPTION
Removes the (inconsistently applied) assumption that "migrate" is always run on the current directory. This requires a small change to production librarian code such that RunTidyOnConfig can be run on arbitrary directories; however, librarian itself still assumes the current directory is the repository root.

Fixes #4569