### PR TITLE
fix(internal/librarian/golang): do not move files for libs without APIs

### DIFF
--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -57,7 +57,7 @@ func Generate(ctx context.Context, library *config.Library, googleapisDir string
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
-	if err := buildLibraryDirectory(library, outdir); err != nil {
+	if err := moveGeneratedFiles(library, outdir); err != nil {
 		return err
 	}
 	moduleRoot := filepath.Join(outdir, library.Name)
@@ -180,10 +180,10 @@ func buildGAPICImportPath(goAPI *config.GoAPI) string {
 		goAPI.ImportPath, goAPI.ClientPackage)
 }
 
-// buildLibraryDirectory restructures the generated files into the final module layout by moving the
+// moveGeneratedFiles restructures the generated files into the final module layout by moving the
 // generated package into the library directory, fixing version paths, and removing any paths configured
 // for deletion.
-func buildLibraryDirectory(library *config.Library, outDir string) error {
+func moveGeneratedFiles(library *config.Library, outDir string) error {
 	if len(library.APIs) == 0 {
 		return nil
 	}


### PR DESCRIPTION
The generation logic for Go libraries previously assumed that APIs were always present, attempting to move generated files from a temporary directory even when no APIs were configured.

This led to errors when generating or restructuring libraries without APIs.

This change extracts the directory restructuring logic into a new `buildLibraryDirectory` function. It also adds an early return if the library has no APIs configured, ensuring that the process does not attempt to access or move non-existent files.

Librarian CI should fail since https://github.com/googleapis/librarian/commit/202b637f4bb90c3e8e57be62cbf518278b1f47eb.

We didn't add unit test because this [test](https://github.com/googleapis/librarian/blob/202b637f4bb90c3e8e57be62cbf518278b1f47eb/internal/librarian/golang/generate_test.go#L321) would fail without this change.

We didn't catch this in the CI because CI didn't install Go dependencies, will raise a follow PR to resolve this.