### PR TITLE
chore(sidekick/rust): use LazyLock instead of lazy_static

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -137,16 +137,15 @@ const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}/";
 pub(crate) mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
-    lazy_static::lazy_static! {
-        pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
-            let ac = gaxi::api_header::XGoogApiClient{
-                name:          NAME,
-                version:       VERSION,
-                library_type:  gaxi::api_header::GAPIC,
+    pub(crate) static X_GOOG_API_CLIENT_HEADER: std::sync::LazyLock<String> =
+        std::sync::LazyLock::new(|| {
+            let ac = gaxi::api_header::XGoogApiClient {
+                name: NAME,
+                version: VERSION,
+                library_type: gaxi::api_header::GAPIC,
             };
             ac.rest_header_value()
-        };
-    }
+        });
 }
 
 // Define some shortcuts for imported crates.

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -122,16 +122,16 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
 pub(crate) mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
-    lazy_static::lazy_static! {
-        pub(crate) static ref INSTRUMENTATION_CLIENT_INFO: gaxi::options::InstrumentationClientInfo = {
-            let mut info = gaxi::options::InstrumentationClientInfo::default();
-            info.service_name = "{{Name}}";
-            info.client_version = VERSION;
-            info.client_artifact = NAME;
-            info.default_host = "{{Codec.DefaultHostShort}}";
-            info
-        };
-    }
+    pub(crate) static INSTRUMENTATION_CLIENT_INFO: std::sync::LazyLock<
+        gaxi::options::InstrumentationClientInfo,
+    > = std::sync::LazyLock::new(|| {
+        let mut info = gaxi::options::InstrumentationClientInfo::default();
+        info.service_name = "{{Name}}";
+        info.client_version = VERSION;
+        info.client_artifact = NAME;
+        info.default_host = "{{Codec.DefaultHostShort}}";
+        info
+    });
 }
 {{/Codec.DetailedTracingAttributes}}
 {{/Codec.HasServices}}

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -40,16 +40,15 @@ const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}";
 mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
-    lazy_static::lazy_static! {
-        pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
-            let ac = gaxi::api_header::XGoogApiClient{
-                name:          NAME,
-                version:       VERSION,
-                library_type:  gaxi::api_header::GAPIC,
+    pub(crate) static X_GOOG_API_CLIENT_HEADER: std::sync::LazyLock<String> =
+        std::sync::LazyLock::new(|| {
+            let ac = gaxi::api_header::XGoogApiClient {
+                name: NAME,
+                version: VERSION,
+                library_type: gaxi::api_header::GAPIC,
             };
             ac.grpc_header_value()
-        };
-    }
+        });
 }
 
 {{/Codec.HasServices}}


### PR DESCRIPTION
This allows removing an external rust dependency and instead relies on the standard library.