### PR TITLE
chore(internal/config): update gapic-showcase dependency

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,8 +39,8 @@ func TestRustRead(t *testing.T) {
 				SHA256: "81e6057ffd85154af5268c2c3c8f2408745ca0f7fa03d43c68f4847f31eb5f98",
 			},
 			Showcase: &Source{
-				Commit: "3f4e3f4f5e2f4c6e8b6f4e2f4c6e8b6f4e2f4c6e",
-				SHA256: "d41d8cd98f00b204e9800998ecf8427e",
+				Commit: "846ec3b86067d1480b43c3b869e89aacc15dfd7d",
+				SHA256: "c43e9c0e3f4ad9aa541f73b06b5e067915277eb36cbeb9e8a3882f8677d5eec4",
 			},
 			ProtobufSrc: &Source{
 				Commit:  "4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b",

--- a/internal/config/testdata/librarian.yaml
+++ b/internal/config/testdata/librarian.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,30 +13,27 @@
 # limitations under the License.
 language: rust
 sources:
+  conformance:
+    commit: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+    sha256: f572d396fae9206628714fb2ce00f72e94f2258f
   discovery:
     commit: b27c80574e918a7e2a36eb21864d1d2e45b8c032
     sha256: 67c8d3792f0ebf5f0582dce675c379d0f486604eb0143814c79e788954aa1212
   googleapis:
     commit: 9fcfbea0aa5b50fa22e190faceb073d74504172b
     sha256: 81e6057ffd85154af5268c2c3c8f2408745ca0f7fa03d43c68f4847f31eb5f98
-  showcase:
-    commit: 3f4e3f4f5e2f4c6e8b6f4e2f4c6e8b6f4e2f4c6e
-    sha256: d41d8cd98f00b204e9800998ecf8427e
   protobuf:
     commit: 4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     subpath: src
-  conformance:
-    commit: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
-    sha256: f572d396fae9206628714fb2ce00f72e94f2258f
+  showcase:
+    commit: 846ec3b86067d1480b43c3b869e89aacc15dfd7d
+    sha256: c43e9c0e3f4ad9aa541f73b06b5e067915277eb36cbeb9e8a3882f8677d5eec4
 default:
   output: src/generated/
   release_level: stable
   tag_format: '{name}/v{version}'
   rust:
-    disabled_rustdoc_warnings:
-      - redundant_explicit_links
-      - broken_intra_doc_links
     package_dependencies:
       - name: bytes
         package: bytes
@@ -44,17 +41,20 @@ default:
       - name: serde
         package: serde
         force_used: true
+    disabled_rustdoc_warnings:
+      - redundant_explicit_links
+      - broken_intra_doc_links
 libraries:
   - name: google-cloud-secretmanager-v1
+    version: 1.2.3
     apis:
       - path: google/cloud/secretmanager/v1
-    version: 1.2.3
   - name: google-cloud-storage-v2
-    roots:
-      - googleapis
+    version: 2.3.4
     apis:
       - path: google/cloud/storage/v2
-    version: 2.3.4
+    roots:
+      - googleapis
     rust:
       disabled_rustdoc_warnings:
         - rustdoc::bare_urls
@@ -70,15 +70,15 @@ libraries:
     veneer: true
     rust:
       modules:
-        - source: google/storage/v2
-          service_config: google/storage/v2/storage_v2.yaml
-          output: src/storage/src/generated/gapic
-          template: grpc-client
-          has_veneer: true
-          routing_required: true
+        - has_veneer: true
           included_ids:
             - .google.storage.v2.Storage.GetBucket
             - .google.storage.v2.Storage.ListBuckets
-        - source: google/storage/v2
-          output: src/storage/src/generated/protos/storage
+          output: src/storage/src/generated/gapic
+          routing_required: true
+          service_config: google/storage/v2/storage_v2.yaml
+          api_path: ""
+          template: grpc-client
+        - output: src/storage/src/generated/protos/storage
+          api_path: ""
           template: prost

--- a/internal/config/testdata/rust/librarian.yaml
+++ b/internal/config/testdata/rust/librarian.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,30 +13,27 @@
 # limitations under the License.
 language: rust
 sources:
+  conformance:
+    commit: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+    sha256: f572d396fae9206628714fb2ce00f72e94f2258f
   discovery:
     commit: b27c80574e918a7e2a36eb21864d1d2e45b8c032
     sha256: 67c8d3792f0ebf5f0582dce675c379d0f486604eb0143814c79e788954aa1212
   googleapis:
     commit: 9fcfbea0aa5b50fa22e190faceb073d74504172b
     sha256: 81e6057ffd85154af5268c2c3c8f2408745ca0f7fa03d43c68f4847f31eb5f98
-  showcase:
-    commit: 3f4e3f4f5e2f4c6e8b6f4e2f4c6e8b6f4e2f4c6e
-    sha256: d41d8cd98f00b204e9800998ecf8427e
   protobuf:
     commit: 4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     subpath: src
-  conformance:
-    commit: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
-    sha256: f572d396fae9206628714fb2ce00f72e94f2258f
+  showcase:
+    commit: 846ec3b86067d1480b43c3b869e89aacc15dfd7d
+    sha256: c43e9c0e3f4ad9aa541f73b06b5e067915277eb36cbeb9e8a3882f8677d5eec4
 default:
   output: src/generated/
   release_level: stable
   tag_format: '{name}/v{version}'
   rust:
-    disabled_rustdoc_warnings:
-      - redundant_explicit_links
-      - broken_intra_doc_links
     package_dependencies:
       - name: bytes
         package: bytes
@@ -44,15 +41,18 @@ default:
       - name: serde
         package: serde
         force_used: true
+    disabled_rustdoc_warnings:
+      - redundant_explicit_links
+      - broken_intra_doc_links
 libraries:
   - name: google-cloud-secretmanager-v1
+    version: 1.2.3
     apis:
       - path: google/cloud/secretmanager/v1
-    version: 1.2.3
   - name: google-cloud-storage-v2
+    version: 2.3.4
     apis:
       - path: google/cloud/storage/v2
-    version: 2.3.4
     roots:
       - googleapis
     rust:
@@ -63,15 +63,15 @@ libraries:
     veneer: true
     rust:
       modules:
-        - api_path: google/storage/v2
-          service_config: google/storage/v2/storage_v2.yaml
-          output: src/storage/src/generated/gapic
-          template: grpc-client
-          has_veneer: true
-          routing_required: true
+        - has_veneer: true
           included_ids:
             - .google.storage.v2.Storage.GetBucket
             - .google.storage.v2.Storage.ListBuckets
-        - api_path: google/storage/v2
-          output: src/storage/src/generated/protos/storage
+          output: src/storage/src/generated/gapic
+          routing_required: true
+          service_config: google/storage/v2/storage_v2.yaml
+          api_path: google/storage/v2
+          template: grpc-client
+        - output: src/storage/src/generated/protos/storage
+          api_path: google/storage/v2
           template: prost


### PR DESCRIPTION
Update `gapic-showcase` source in the test configurations to the latest commit, pulling in the recent fixes for T4 spans and logs.