### PR TITLE
fid(tool/cmd/migrate): rm hardcoded google-cloud-jar-parent as not used

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -196,12 +196,6 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			Version:      v,
 			SkipGenerate: true,
 		})
-		// Hardcode jar-parent as it follows the same version.
-		libs = append(libs, &config.Library{
-			Name:         "google-cloud-jar-parent",
-			Version:      v,
-			SkipGenerate: true,
-		})
 	}
 	for _, l := range gen.Libraries {
 		name := l.LibraryName

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -297,11 +297,6 @@ func TestBuildConfig(t *testing.T) {
 						SkipGenerate: true,
 					},
 					{
-						Name:         "google-cloud-jar-parent",
-						Version:      "1.79.0",
-						SkipGenerate: true,
-					},
-					{
 						Name:    "accessapproval",
 						Output:  "java-accessapproval",
 						Version: "2.86.0",


### PR DESCRIPTION
Originally intend to use for repo level pom generation, not needed anymore.