### PR TITLE
feat(migrate): populate the version in librarian.yaml

### DIFF
--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -160,6 +160,7 @@ func buildConfigFromLibrarian(ctx context.Context, input *MigrationInput) (*conf
 	cfg := &config.Config{
 		Language: input.lang,
 		Repo:     repo,
+		Version:  librarian.Version(),
 		Sources: &config.Sources{
 			Googleapis: src,
 		},

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -379,6 +379,12 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			// The tests don't specify a version; ensure there is one, but
+			// then clear the field for further comparisons.
+			if got.Version == "" {
+				t.Errorf("expected non-empty version; was empty")
+			}
+			got.Version = ""
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
The version field in librarian.yaml is set from the librarian.Version() function.

We *should* run migrate using a tagged version, in which case the version will be set appropriately. When run using a local build, the version won't be suitable for use in librarianops, and will have to be modified manually - but will still be okay for local testing of migration.

Note that incremental migration only changes libraries, so after the initial migration, the version is fixed.