### PR TITLE
fix(.github/workflows): increase max session turns

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -43,7 +43,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 25
+                "maxSessionTurns": 100
               },
               "mcpServers": {
                 "github": {

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -44,7 +44,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 25
+                "maxSessionTurns": 100
               },
               "mcpServers": {
                 "github": {


### PR DESCRIPTION
Increase maxSessionTurns to 100 when using `@gemini-cli`. At the moment it is very easy to quickly hit the limit.