### PR TITLE
fix(.github/workflows): remove unexpected inputs from gemini-cli workflows

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           workflow_name: 'gemini-invoke'
-          github_pr_number: '${{ github.event.pull_request.number }}'
-          github_issue_number: '${{ github.event.issue.number }}'
           settings: |-
             {
               "model": {

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           workflow_name: 'gemini-plan-execute'
-          github_pr_number: '${{ github.event.pull_request.number }}'
-          github_issue_number: '${{ github.event.issue.number }}'
           settings: |-
             {
               "model": {


### PR DESCRIPTION
The github_pr_number and github_issue_number inputs are removed from the with section of the google-github-actions/run-gemini-cli@v0 action in .github/workflows/gemini-invoke.yml and
.github/workflows/gemini-plan-execute.yml.

These inputs are not supported by the action and were causing "Unexpected input(s)" warnings during workflow runs.

Fixes https://github.com/googleapis/librarian/issues/4668