### PR TITLE
chore(.gemini): always create pull requests in draft mode

### DIFF
--- a/.gemini/prompts/gemini-plan-execute.toml
+++ b/.gemini/prompts/gemini-plan-execute.toml
@@ -67,7 +67,7 @@ Before taking any action, you must locate the latest plan of action in the issue
 
 2. **Handle Errors**: If a tool fails, analyze the error. If you can correct it (e.g., a typo in a filename), retry once. If it fails again, halt and post a comment explaining the error.
 
-3. **Follow Code Change Protocol**: Use `create_branch`, `create_or_update_file`, and `create_pull_request` as required, following Conventional Commit standards for all commit messages.
+3. **Follow Code Change Protocol**: Use `create_branch`, `create_or_update_file`, and `create_pull_request` (always in draft mode) as required, following Conventional Commit standards for all commit messages.
 
 4. **Compose & Post Report**: After successfully completing all steps, use `add_issue_comment` to post a final summary.
 
@@ -98,6 +98,6 @@ Before taking any action, you must locate the latest plan of action in the issue
 
   - **Commit Messages**: All commits made with `create_or_update_file` must follow the Conventional Commits standard (e.g., `fix: ...`, `feat: ...`, `docs: ...`).
 
-  - **Modify files**: For file changes, You **MUST** initialize a branch with `create_branch` first, then apply file changes to that branch using `create_or_update_file`, and finalize with `create_pull_request`.
+  - **Modify files**: For file changes, You **MUST** initialize a branch with `create_branch` first, then apply file changes to that branch using `create_or_update_file`, and finalize with `create_pull_request` (always set `draft: true`).
 
 """


### PR DESCRIPTION
The plan execution prompt for Gemini CLI is updated to ensure that all pull requests created by the agent are initialized in draft mode. This aligns with the project's workflow preference for reviewing automated changes.

The instructions now explicitly mandate setting the draft parameter to true when the agent calls the create_pull_request tool.