### PR TITLE
feat(internal/librarian): tidy to cleanup release level if same as default

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -95,6 +95,9 @@ func tidyLibrary(cfg *config.Config, lib *config.Library) *config.Library {
 	lib.APIs = slices.DeleteFunc(lib.APIs, func(ch *config.API) bool {
 		return ch.Path == ""
 	})
+	if cfg.Default != nil && lib.ReleaseLevel != "" && lib.ReleaseLevel == cfg.Default.ReleaseLevel {
+		lib.ReleaseLevel = ""
+	}
 	return tidyLanguageConfig(lib, cfg.Language)
 }
 

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -217,6 +217,7 @@ func TestTidy_DerivableFields(t *testing.T) {
 		wantNumLibs             int
 		wantNumAPIs             int
 		wantSpecificationFormat string
+		wantReleaseLevel        string
 	}{
 		{
 			name: "derivable fields removed",
@@ -297,6 +298,23 @@ func TestTidy_DerivableFields(t *testing.T) {
 			wantNumLibs: 1,
 			wantNumAPIs: 1,
 		},
+		{
+			name: "release level removed if same as default",
+			config: &config.Config{
+				Default: &config.Default{
+					ReleaseLevel: "preview",
+				},
+				Sources: googleapisSource,
+				Libraries: []*config.Library{
+					{
+						Name:         "google-cloud-secretmanager-v1",
+						ReleaseLevel: "preview",
+					},
+				},
+			},
+			wantNumLibs:      1,
+			wantReleaseLevel: "",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -323,6 +341,9 @@ func TestTidy_DerivableFields(t *testing.T) {
 			}
 			if lib.SpecificationFormat != test.wantSpecificationFormat {
 				t.Errorf("specification_format = %q, want %q", lib.SpecificationFormat, test.wantSpecificationFormat)
+			}
+			if lib.ReleaseLevel != test.wantReleaseLevel {
+				t.Errorf("release_level = %q, want %q", lib.ReleaseLevel, test.wantReleaseLevel)
 			}
 		})
 	}


### PR DESCRIPTION
Remove redundant release level per library if same as default when running tidy.