### PR TITLE
feat(tool/cmd/migrate): java migrate adds default release level to librarian.yaml

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -272,7 +272,9 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 	}
 	return &config.Config{
 		Language: "java",
-		Default:  &config.Default{},
+		Default: &config.Default{
+			ReleaseLevel: "preview",
+		},
 		Sources: &config.Sources{
 			Googleapis: src,
 		},

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -91,7 +91,9 @@ func TestBuildConfig(t *testing.T) {
 			want: &config.Config{
 				Language: "java",
 				Repo:     "googleapis/google-cloud-java",
-				Default:  &config.Default{},
+				Default: &config.Default{
+					ReleaseLevel: "preview",
+				},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
 				},
@@ -122,7 +124,9 @@ func TestBuildConfig(t *testing.T) {
 			want: &config.Config{
 				Language: "java",
 				Repo:     "googleapis/google-cloud-java",
-				Default:  &config.Default{},
+				Default: &config.Default{
+					ReleaseLevel: "preview",
+				},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
 				},
@@ -159,7 +163,9 @@ func TestBuildConfig(t *testing.T) {
 			want: &config.Config{
 				Language: "java",
 				Repo:     "googleapis/google-cloud-java",
-				Default:  &config.Default{},
+				Default: &config.Default{
+					ReleaseLevel: "preview",
+				},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
 				},
@@ -221,7 +227,9 @@ func TestBuildConfig(t *testing.T) {
 			want: &config.Config{
 				Language: "java",
 				Repo:     "googleapis/google-cloud-java",
-				Default:  &config.Default{},
+				Default: &config.Default{
+					ReleaseLevel: "preview",
+				},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
 				},
@@ -286,7 +294,9 @@ func TestBuildConfig(t *testing.T) {
 			want: &config.Config{
 				Language: "java",
 				Repo:     "googleapis/google-cloud-java",
-				Default:  &config.Default{},
+				Default: &config.Default{
+					ReleaseLevel: "preview",
+				},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
 				},


### PR DESCRIPTION
Java migrate sets default release level to preview. This is same as Java's current behavior, see [code](https://github.com/googleapis/sdk-platform-java/blob/67a2ecb689c267bb7afa0685ed030216da223c4a/hermetic_build/common/model/generation_config.py#L141).

