### PR TITLE
chore(internal/librarian/golang): update readme template

### DIFF
--- a/internal/librarian/golang/template/_README.md.txt
+++ b/internal/librarian/golang/template/_README.md.txt
@@ -19,6 +19,21 @@ However, a `v1+` module may have breaking changes in two scenarios:
 * Packages with `alpha` or `beta` in the import path
 * The GoDoc has an explicit stability disclaimer (for example, for an experimental feature).
 
+### Which package to use?
+
+Generated client library surfaces can be found in packages whose import path
+ends in `.../apivXXX`. The `XXX` could be something like `1` or `2` in the case
+of a stable service backend or may be like `1beta2` or `2beta` in the case of a
+more experimental service backend. Because of this fact, a given module can have
+multiple clients for different service backends. In these cases it is generally
+recommended to use clients with stable service backends, with import suffixes like
+`apiv1`, unless you need to use features that are only present in a beta backend
+or there is not yet a stable backend available.
+
+## Google Cloud Samples
+
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=go).
+
 ## Go Version Support
 
 See the [Go Versions Supported](https://github.com/googleapis/google-cloud-go#go-versions-supported)


### PR DESCRIPTION
Restore README.md template.

We plan to generate README.md and merge the changes before migration, so it is worth to restore the template.

Revert #4587

For #3618