### PR TITLE
fix(.github/workflows): enable mcp_github_create_issue

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -56,6 +56,7 @@ jobs:
                   ],
                   "includeTools": [
                     "add_issue_comment",
+                    "create_issue",
                     "issue_read",
                     "list_issues",
                     "search_issues",

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -57,6 +57,7 @@ jobs:
                   ],
                   "includeTools": [
                     "add_issue_comment",
+                    "create_issue",
                     "issue_read",
                     "list_issues",
                     "search_issues",


### PR DESCRIPTION
Enable the `mcp_github_create_issue` tool by adding `create_issue`  to the `includeTools` array for the GitHub MCP server in both the `gemini-invoke.yml` and `gemini-plan-execute.yml` workflows. 

This allows `@gemini-cli` to create GitHub issues with an approved plan.

Fixes #4690