### PR TITLE
fix(.github/workflows): create ~/.gemini before running Gemini CLI

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: 'Checkout Code'
         uses: 'actions/checkout@v6'
+      - name: 'Create Gemini config directory'
+        run: 'mkdir -p ~/.gemini'
       - name: 'Run Gemini CLI'
         id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@v0'

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: 'Checkout Code'
         uses: 'actions/checkout@v6'
+      - name: 'Create Gemini config directory'
+        run: 'mkdir -p ~/.gemini'
       - name: 'Run Gemini CLI'
         id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@v0'


### PR DESCRIPTION
The Gemini CLI expects ~/.gemini/ to exist when saving its project registry. On a fresh GitHub Actions runner this directory is missing, causing an ENOENT error on rename of projects.json.tmp. The error text is written to stderr, which also triggers a "stderr was not valid JSON" warning because the action expects structured JSON there.

Adding mkdir -p ~/.gemini before the action runs prevents both problems.