### PR TITLE
fix(python): populate language in .repo-metadata for handwritten libr…

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -118,6 +118,7 @@ func createRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		repoMetadata = &repometadata.RepoMetadata{
 			Name:             library.Name,
 			DistributionName: library.Name,
+			Language:         cfg.Language,
 			Repo:             cfg.Repo,
 			ReleaseLevel:     library.ReleaseLevel,
 		}

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -1146,6 +1146,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 				Name:                "google-auth",
 				DistributionName:    "google-auth",
 				ClientDocumentation: "https://googleapis.dev/python/google-auth/latest",
+				Language:            config.LanguagePython,
 				LibraryType:         "AUTH",
 				Repo:                "googleapis/google-cloud-python",
 				ReleaseLevel:        "stable",


### PR DESCRIPTION
…aries

Uses the Librarian configuration's language value (which should always be "python" in this code) to populate the .repo-metadata.json language field for handwritten libraries. For generated libraries this is populated by repometadata.FromAPI.