### PR TITLE
chore(migrate): hard-code an extra keep list for Python firestore library

### DIFF
--- a/tool/cmd/migrate/python.go
+++ b/tool/cmd/migrate/python.go
@@ -102,6 +102,26 @@ func buildPythonLibraries(input *MigrationInput, googleapisDir string) ([]*confi
 		if err != nil {
 			return nil, err
 		}
+		if library.Name == "google-cloud-firestore" {
+			// Hard-coded list of additional files to keep for
+			// Firestore; it's not worth writing tricky logic to
+			// detect these.
+			firestoreDocs := []string{
+				"docs/firestore_admin_v1/admin_client.rst",
+				"docs/firestore_v1/aggregation.rst",
+				"docs/firestore_v1/batch.rst",
+				"docs/firestore_v1/bulk_writer.rst",
+				"docs/firestore_v1/client.rst",
+				"docs/firestore_v1/collection.rst",
+				"docs/firestore_v1/document.rst",
+				"docs/firestore_v1/field_path.rst",
+				"docs/firestore_v1/query.rst",
+				"docs/firestore_v1/transaction.rst",
+				"docs/firestore_v1/transforms.rst",
+				"docs/firestore_v1/types.rst",
+			}
+			keep = append(keep, firestoreDocs...)
+		}
 		slices.Sort(keep)
 		library.Keep = keep
 

--- a/tool/cmd/migrate/python_test.go
+++ b/tool/cmd/migrate/python_test.go
@@ -268,6 +268,58 @@ func TestBuildPythonLibraries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "firestore (extra keep paths)",
+			input: &MigrationInput{
+				repoPath: "testdata/google-cloud-python",
+				librarianState: &legacyconfig.LibrarianState{
+					Libraries: []*legacyconfig.LibraryState{
+						{
+							ID:          "google-cloud-firestore",
+							SourceRoots: []string{"packages/google-cloud-firestore"},
+							PreserveRegex: []string{
+								"^packages/google-cloud-firestore/CHANGELOG.md",
+								"^packages/google-cloud-firestore/docs/CHANGELOG.md",
+							},
+						},
+					},
+				},
+				librarianConfig: &legacyconfig.LibrarianConfig{},
+			},
+			want: []*config.Library{
+				{
+					Name: "google-cloud-firestore",
+					Keep: []string{
+						"CHANGELOG.md",
+						"docs/CHANGELOG.md",
+						"docs/firestore_admin_v1/admin_client.rst",
+						"docs/firestore_v1/aggregation.rst",
+						"docs/firestore_v1/batch.rst",
+						"docs/firestore_v1/bulk_writer.rst",
+						"docs/firestore_v1/client.rst",
+						"docs/firestore_v1/collection.rst",
+						"docs/firestore_v1/document.rst",
+						"docs/firestore_v1/field_path.rst",
+						"docs/firestore_v1/query.rst",
+						"docs/firestore_v1/transaction.rst",
+						"docs/firestore_v1/transforms.rst",
+						"docs/firestore_v1/types.rst",
+					},
+					Python: &config.PythonPackage{
+						PythonDefault: config.PythonDefault{
+							LibraryType: "GAPIC_COMBO",
+						},
+						NamePrettyOverride:           "Cloud Firestore API",
+						ProductDocumentationOverride: "https://cloud.google.com/firestore",
+						APIShortnameOverride:         "firestore",
+						APIIDOverride:                "firestore.googleapis.com",
+						IssueTrackerOverride:         "https://issuetracker.google.com/savedsearches/5337669",
+						MetadataNameOverride:         "firestore",
+						DefaultVersion:               "v1",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := buildPythonLibraries(test.input, "testdata/googleapis")

--- a/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-firestore/.repo-metadata.json
+++ b/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-firestore/.repo-metadata.json
@@ -1,0 +1,17 @@
+{
+    "name": "firestore",
+    "name_pretty": "Cloud Firestore API",
+    "product_documentation": "https://cloud.google.com/firestore",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/firestore/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/5337669",
+    "release_level": "stable",
+    "language": "python",
+    "library_type": "GAPIC_COMBO",
+    "repo": "googleapis/google-cloud-python",
+    "distribution_name": "google-cloud-firestore",
+    "api_id": "firestore.googleapis.com",
+    "requires_billing": true,
+    "default_version": "v1",
+    "codeowner_team": "@googleapis/api-firestore @googleapis/api-firestore-partners",
+    "api_shortname": "firestore"
+}

--- a/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-firestore/CHANGELOG.md
+++ b/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-firestore/CHANGELOG.md
@@ -1,0 +1,1 @@
+Empty changelog

--- a/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-firestore/docs/CHANGELOG.md
+++ b/tool/cmd/migrate/testdata/google-cloud-python/packages/google-cloud-firestore/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+Empty changelog


### PR DESCRIPTION
The legacylibrarian configuration for the Python google-cloud-firestore library relies on selective remove regexes for docs, which aren't used in the migration tool. Instead, based on the results of testing migration, this adds a keep list for handwritten files which would otherwise be deleted by the librarian logic.