### PR TITLE
cleanup(sidekick/rust): unused dev dependency

### DIFF
--- a/internal/librarian/rust/testdata/Cargo.toml
+++ b/internal/librarian/rust/testdata/Cargo.toml
@@ -22,5 +22,4 @@ serde = "1"
 serde_json = "1"
 serde_with = "3"
 time = "0.3"
-tokio-test = "0.4"
 wkt = { version = "1", package = "google-cloud-wkt" }

--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -67,6 +67,3 @@ all-features = true
 {{#Codec.RequiredPackages}}
 {{{.}}}
 {{/Codec.RequiredPackages}}
-
-[dev-dependencies]
-tokio-test.workspace = true


### PR DESCRIPTION
We no longer use `tokio-test` as a dev dependency for the generated libraries.