### PR TITLE
refactor(internal/librarian/golang): rename clientPathFromLibraryRoot` to `clientPathFromRepoRoot`

### DIFF
--- a/internal/librarian/golang/bump.go
+++ b/internal/librarian/golang/bump.go
@@ -45,7 +45,7 @@ func Bump(library *config.Library, output, version string) error {
 		if goAPI == nil {
 			return fmt.Errorf("could not find Go API associated with %s: %w", api.Path, errGoAPINotFound)
 		}
-		snippetDir := snippetDirectory(output, clientPathFromLibraryRoot(library, goAPI))
+		snippetDir := snippetDirectory(output, clientPathFromRepoRoot(library, goAPI))
 		if _, err := os.Stat(snippetDir); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				// A client may not have snippets, e.g., proto-only clients,

--- a/internal/librarian/golang/clean.go
+++ b/internal/librarian/golang/clean.go
@@ -129,7 +129,7 @@ func cleanClientDirectory(library *config.Library, libraryDir string, keepSet ma
 		if goAPI == nil {
 			return fmt.Errorf("could not find Go API associated with %s: %w", api.Path, errGoAPINotFound)
 		}
-		relClientPath := clientPathFromLibraryRoot(library, goAPI)
+		relClientPath := clientPathFromRepoRoot(library, goAPI)
 		clientPath := filepath.Join(library.Output, relClientPath)
 		if err := cleanGeneratedClientFiles(clientPath, libraryDir, keepSet); err != nil {
 			return err

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -320,7 +320,7 @@ func updateSnippetMetadata(library *config.Library, output string) error {
 		if goAPI.ProtoOnly {
 			continue
 		}
-		baseDir := snippetDirectory(output, clientPathFromLibraryRoot(library, goAPI))
+		baseDir := snippetDirectory(output, clientPathFromRepoRoot(library, goAPI))
 		if _, err := os.Stat(baseDir); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return nil

--- a/internal/librarian/golang/module.go
+++ b/internal/librarian/golang/module.go
@@ -135,9 +135,9 @@ func defaultImportPathAndClientPkg(apiPath string) (string, string) {
 	return fmt.Sprintf("%s/api%s", importPath, version), pkg
 }
 
-// clientPathFromLibraryRoot returns the relative path from the module root to the client directory.
+// clientPathFromRepoRoot returns the relative path from the repo root to the client directory.
 // It strips any module path version from the import path to get the correct filesystem path.
-func clientPathFromLibraryRoot(library *config.Library, goAPI *config.GoAPI) string {
+func clientPathFromRepoRoot(library *config.Library, goAPI *config.GoAPI) string {
 	importPath := goAPI.ImportPath
 	if library.Go != nil && library.Go.ModulePathVersion != "" {
 		modulePathVersion := filepath.Join(string(filepath.Separator), library.Go.ModulePathVersion)

--- a/internal/librarian/golang/module_test.go
+++ b/internal/librarian/golang/module_test.go
@@ -337,7 +337,7 @@ func TestDefaultImportPathAndClientPkg(t *testing.T) {
 	}
 }
 
-func TestClientPathFromLibraryRoot(t *testing.T) {
+func TestClientPathFromRepoRoot(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		library *config.Library
@@ -416,7 +416,7 @@ func TestClientPathFromLibraryRoot(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := clientPathFromLibraryRoot(test.library, test.goAPI)
+			got := clientPathFromRepoRoot(test.library, test.goAPI)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/golang/repometadata.go
+++ b/internal/librarian/golang/repometadata.go
@@ -45,7 +45,7 @@ func generateRepoMetadata(api *serviceconfig.API, library *config.Library) error
 		LibraryType:         repometadata.GAPICAutoLibraryType,
 		ReleaseLevel:        level,
 	}
-	return metadata.Write(filepath.Join(library.Output, clientPathFromLibraryRoot(library, goAPI)))
+	return metadata.Write(filepath.Join(library.Output, clientPathFromRepoRoot(library, goAPI)))
 }
 
 // clientDocURL builds the client documentation URL for Go SDK.

--- a/internal/librarian/golang/version.go
+++ b/internal/librarian/golang/version.go
@@ -69,7 +69,7 @@ func generateClientVersionFile(library *config.Library, apiPath string) (err err
 		// Therefore, version.go does not need to be generated.
 		return nil
 	}
-	dir := filepath.Join(library.Output, clientPathFromLibraryRoot(library, goAPI))
+	dir := filepath.Join(library.Output, clientPathFromRepoRoot(library, goAPI))
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}


### PR DESCRIPTION
The function `clientPathFromLibraryRoot` is renamed to `clientPathFromRepoRoot` to more accurately describe its behavior.

This is a preparation PR for #4577.

For #4506