### PR TITLE
doc: clarify package config contains only data types

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,7 +29,7 @@ Before submitting changes, run the full test suite:
 - `go.mod`: **NO NEW DEPENDENCIES.** Use only what is already available.
 - `cmd/`: Main entrypoint to CLI commands.
 - `internal/command`: Use `command.Run` for execution. `os/exec` is permitted for other tasks.
-- `internal/config`: Structs here have a 1:1 correlation with `librarian.yaml`.
+- `internal/config`: **Pure data types only.** Structs and constants here are a direct 1:1 mapping with `librarian.yaml`. Do not add functions or methods to this package.
 - `internal/testhelper`: **ALWAYS** check here for existing utilities before creating new test tools.
 - `internal/yaml`: **ALWAYS** use this package instead of `gopkg.in/yaml.v3`.
 

--- a/doc/howwewritego.md
+++ b/doc/howwewritego.md
@@ -398,6 +398,15 @@ func parseReleaseLevel(path string) string {
 For progress output, `internal/command` provides a `Verbose` flag. When enabled
 by an application (e.g., via `-v`), all executed commands are printed.
 
+## Package-Specific Rules
+
+### `internal/config`
+
+The `internal/config` package is a direct 1:1 mapping with `librarian.yaml`. It
+contains only struct types and constants that mirror the YAML schema. Do not add
+functions or methods to this package. Any logic that operates on configuration
+values belongs in the package that uses them, not in `internal/config` itself.
+
 ## Need Help? Just Ask!
 
 This guide will continue to evolve. If something feels unclear or is missing,


### PR DESCRIPTION
The internal/config package is a direct 1:1 mapping with librarian.yaml and should contain only struct types and constants. This updates GEMINI.md and doc/howwewritego.md to make this rule explicit.