### PR TITLE
refactor(internal/surfer): encapsulate provider logic into new package

### DIFF
--- a/internal/surfer/gcloud/argument_builder.go
+++ b/internal/surfer/gcloud/argument_builder.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/surfer/gcloud/provider"
 	"github.com/iancoleman/strcase"
 )
 
@@ -26,7 +27,7 @@ import (
 // arguments for a gcloud command.
 type argumentBuilder struct {
 	method    *api.Method
-	overrides *Config
+	overrides *provider.Config
 	model     *api.API
 	service   *api.Service
 	field     *api.Field
@@ -34,7 +35,7 @@ type argumentBuilder struct {
 }
 
 // newArgumentBuilder constructs a new argumentBuilder.
-func newArgumentBuilder(method *api.Method, overrides *Config, model *api.API, service *api.Service, field *api.Field, apiField string) *argumentBuilder {
+func newArgumentBuilder(method *api.Method, overrides *provider.Config, model *api.API, service *api.Service, field *api.Field, apiField string) *argumentBuilder {
 	return &argumentBuilder{
 		method:    method,
 		overrides: overrides,
@@ -71,7 +72,7 @@ func (b *argumentBuilder) build() (Argument, error) {
 	} else if b.field.EnumType != nil {
 		arg.Choices = b.choices()
 	} else {
-		arg.Type = getGcloudType(b.field.Typez)
+		arg.Type = provider.GetGcloudType(b.field.Typez)
 	}
 
 	return arg, nil
@@ -82,11 +83,11 @@ func (b *argumentBuilder) repeated() bool {
 }
 
 func (b *argumentBuilder) clearable() bool {
-	return isUpdate(b.method) && b.repeated()
+	return provider.IsUpdate(b.method) && b.repeated()
 }
 
 func (b *argumentBuilder) helpText() string {
-	if rule := findFieldHelpTextRule(b.field, b.overrides); rule != nil {
+	if rule := provider.FindFieldHelpTextRule(b.overrides, b.field.ID); rule != nil {
 		return rule.HelpText.Brief
 	}
 	// TODO(https://github.com/googleapis/librarian/issues/3033): improve default help text inference
@@ -115,7 +116,7 @@ func (b *argumentBuilder) mapSpec() []ArgSpec {
 // BuildPrimaryResource creates the main positional resource argument for a command.
 // This is the argument that represents the resource being acted upon (e.g., the instance name).
 func (b *argumentBuilder) buildPrimaryResource() Argument {
-	resource := getResourceForMethod(b.method, b.model)
+	resource := provider.GetResourceForMethod(b.method, b.model)
 	var segments []api.PathSegment
 	// TODO(https://github.com/googleapis/librarian/issues/3415): Support multiple resource patterns and multitype resources.
 	if resource != nil && len(resource.Patterns) > 0 {
@@ -123,44 +124,44 @@ func (b *argumentBuilder) buildPrimaryResource() Argument {
 	}
 
 	// For List methods, the primary resource is the parent of the method's resource.
-	if isList(b.method) {
-		segments = getParentFromSegments(segments)
+	if provider.IsList(b.method) {
+		segments = provider.GetParentFromSegments(segments)
 	}
 
 	resourceName := strings.TrimSuffix(b.field.Name, "_id")
-	if b.field.Name == "name" || isList(b.method) {
-		resourceName = getSingularFromSegments(segments)
+	if b.field.Name == "name" || provider.IsList(b.method) {
+		resourceName = provider.GetSingularFromSegments(segments)
 	}
 
 	var helpText string
 	switch {
-	case isCreate(b.method):
+	case provider.IsCreate(b.method):
 		helpText = fmt.Sprintf("The %s to create.", resourceName)
-	case isList(b.method):
-		helpText = fmt.Sprintf("The project and location for which to retrieve %s information.", getPluralFromSegments(segments))
+	case provider.IsList(b.method):
+		helpText = fmt.Sprintf("The project and location for which to retrieve %s information.", provider.GetPluralFromSegments(segments))
 	default:
 		helpText = fmt.Sprintf("The %s to operate on.", resourceName)
 	}
 
-	collectionPath := getCollectionPathFromSegments(segments)
+	collectionPath := provider.GetCollectionPathFromSegments(segments)
 	hostParts := strings.Split(b.service.DefaultHost, ".")
 	shortServiceName := hostParts[0]
 
 	param := Argument{
 		HelpText:          helpText,
-		IsPositional:      !isList(b.method),
+		IsPositional:      !provider.IsList(b.method),
 		IsPrimaryResource: true,
 		Required:          true,
 		ResourceSpec: &ResourceSpec{
 			Name:                  resourceName,
-			PluralName:            getPluralFromSegments(segments),
+			PluralName:            provider.GetPluralFromSegments(segments),
 			Collection:            fmt.Sprintf("%s.%s", shortServiceName, collectionPath),
 			DisableAutoCompleters: false,
 			Attributes:            newAttributesFromSegments(segments),
 		},
 	}
 
-	if isCreate(b.method) {
+	if provider.IsCreate(b.method) {
 		param.RequestIDField = strcase.ToLowerCamel(b.field.Name)
 	}
 
@@ -180,14 +181,14 @@ func (b *argumentBuilder) resourceReferenceSpec() (*ResourceSpec, error) {
 
 			pluralName := def.Plural
 			if pluralName == "" {
-				pluralName = getPluralFromSegments(segments)
+				pluralName = provider.GetPluralFromSegments(segments)
 			}
 
-			name := getSingularFromSegments(segments)
+			name := provider.GetSingularFromSegments(segments)
 
 			hostParts := strings.Split(b.service.DefaultHost, ".")
 			shortServiceName := hostParts[0]
-			baseCollectionPath := getCollectionPathFromSegments(segments)
+			baseCollectionPath := provider.GetCollectionPathFromSegments(segments)
 			fullCollectionPath := fmt.Sprintf("%s.%s", shortServiceName, baseCollectionPath)
 
 			return &ResourceSpec{

--- a/internal/surfer/gcloud/argument_builder_test.go
+++ b/internal/surfer/gcloud/argument_builder_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/surfer/gcloud/provider"
 )
 
 func TestNewArguments(t *testing.T) {
@@ -53,7 +54,7 @@ func TestNewArguments(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := newCommandBuilder(test.method, &Config{}, model, service).newArguments()
+			got, err := newCommandBuilder(test.method, &provider.Config{}, model, service).newArguments()
 			if err != nil {
 				t.Fatalf("newArguments() unexpected error = %v", err)
 			}
@@ -89,7 +90,7 @@ func TestNewArguments_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := newCommandBuilder(test.method, &Config{}, model, service).newArguments()
+			_, err := newCommandBuilder(test.method, &provider.Config{}, model, service).newArguments()
 			if err == nil {
 				t.Fatalf("newArguments() expected error, got nil")
 			}
@@ -118,7 +119,7 @@ func TestNewArgument(t *testing.T) {
 		field     *api.Field
 		apiField  string
 		method    *api.Method
-		overrides *Config
+		overrides *provider.Config
 		want      Argument
 	}{
 		{
@@ -164,12 +165,12 @@ func TestNewArgument(t *testing.T) {
 				f.ID = "test.foo"
 				return f
 			}(),
-			overrides: &Config{
-				APIs: []API{
+			overrides: &provider.Config{
+				APIs: []provider.API{
 					{
-						HelpText: &HelpTextRules{
-							FieldRules: []*HelpTextRule{
-								{Selector: "test.foo", HelpText: &HelpTextElement{Brief: "Override Foo"}},
+						HelpText: &provider.HelpTextRules{
+							FieldRules: []*provider.HelpTextRule{
+								{Selector: "test.foo", HelpText: &provider.HelpTextElement{Brief: "Override Foo"}},
 							},
 						},
 					},
@@ -189,7 +190,7 @@ func TestNewArgument(t *testing.T) {
 			t.Parallel()
 			overrides := test.overrides
 			if overrides == nil {
-				overrides = &Config{}
+				overrides = &provider.Config{}
 			}
 			got, err := newArgumentBuilder(test.method, overrides, model, service, test.field, test.apiField).build()
 			if err != nil {
@@ -528,7 +529,7 @@ func TestArgumentsFromField(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			args, err := newCommandBuilder(createMethod, &Config{}, model, service).argumentsFromField(test.field, test.prefix)
+			args, err := newCommandBuilder(createMethod, &provider.Config{}, model, service).argumentsFromField(test.field, test.prefix)
 			if err != nil {
 				t.Fatalf("argumentsFromField() unexpected error = %v", err)
 			}
@@ -571,7 +572,7 @@ func TestArgumentsFromField_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := newCommandBuilder(createMethod, &Config{}, model, service).argumentsFromField(test.field, test.prefix)
+			_, err := newCommandBuilder(createMethod, &provider.Config{}, model, service).argumentsFromField(test.field, test.prefix)
 			if err == nil {
 				t.Fatalf("argumentsFromField() expected error, got nil")
 			}

--- a/internal/surfer/gcloud/command_builder.go
+++ b/internal/surfer/gcloud/command_builder.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/surfer/gcloud/provider"
 	"github.com/iancoleman/strcase"
 )
 
@@ -27,13 +28,13 @@ import (
 // definition from an API method.
 type commandBuilder struct {
 	method    *api.Method
-	overrides *Config
+	overrides *provider.Config
 	model     *api.API
 	service   *api.Service
 }
 
 // newCommandBuilder constructs a new commandBuilder for a specific method execution.
-func newCommandBuilder(method *api.Method, overrides *Config, model *api.API, service *api.Service) *commandBuilder {
+func newCommandBuilder(method *api.Method, overrides *provider.Config, model *api.API, service *api.Service) *commandBuilder {
 	return &commandBuilder{
 		method:    method,
 		overrides: overrides,
@@ -57,19 +58,19 @@ func (b *commandBuilder) build() (*Command, error) {
 		Hidden:           b.hidden(),
 		HelpText:         b.helpText(),
 		ReleaseTracks:    b.releaseTracks(),
-		APIVersion:       apiVersion(b.overrides),
+		APIVersion:       provider.APIVersion(b.overrides),
 		Collection:       b.collectionPath(false),
 		Method:           b.requestMethod(),
 		Arguments:        args,
 		ResponseIDField:  b.responseIDField(),
 		OutputFormat:     b.outputFormat(),
-		ReadModifyUpdate: isUpdate(b.method),
+		ReadModifyUpdate: provider.IsUpdate(b.method),
 		Async:            b.async(),
 	}, nil
 }
 
 func (b *commandBuilder) responseIDField() string {
-	if isList(b.method) {
+	if provider.IsList(b.method) {
 		// List commands should have an id_field to enable the --uri flag.
 		return "name"
 	}
@@ -78,11 +79,11 @@ func (b *commandBuilder) responseIDField() string {
 
 // outputFormat generates the string output format for List commands.
 func (b *commandBuilder) outputFormat() string {
-	if !isList(b.method) {
+	if !provider.IsList(b.method) {
 		return ""
 	}
 
-	resourceMsg := findResourceMessage(b.method.OutputType)
+	resourceMsg := provider.FindResourceMessage(b.method.OutputType)
 	if resourceMsg == nil {
 		return ""
 	}
@@ -102,7 +103,7 @@ func (b *commandBuilder) async() *Async {
 
 	// Extract the resource result if the LRO response type matches the
 	// method's resource type.
-	resource := getResourceForMethod(b.method, b.model)
+	resource := provider.GetResourceForMethod(b.method, b.model)
 	if resource == nil {
 		return async
 	}
@@ -116,7 +117,7 @@ func (b *commandBuilder) async() *Async {
 		responseTypeName = responseTypeID[idx+1:]
 	}
 
-	singular := getSingularResourceNameForMethod(b.method, b.model)
+	singular := provider.GetSingularResourceNameForMethod(b.method, b.model)
 	if strings.EqualFold(responseTypeName, singular) || strings.HasSuffix(resource.Type, "/"+responseTypeName) {
 		async.ExtractResourceResult = true
 	}
@@ -133,7 +134,7 @@ func (b *commandBuilder) hidden() bool {
 }
 
 func (b *commandBuilder) helpText() HelpText {
-	rule := findHelpTextRule(b.method, b.overrides)
+	rule := provider.FindHelpTextRule(b.overrides, strings.TrimPrefix(b.method.ID, "."))
 	if rule != nil {
 		return HelpText{
 			Brief:       rule.HelpText.Brief,
@@ -147,7 +148,7 @@ func (b *commandBuilder) helpText() HelpText {
 func (b *commandBuilder) releaseTracks() []string {
 	// Infer default release track from proto package.
 	// TODO(https://github.com/googleapis/librarian/issues/3289): Allow gcloud config to overwrite the track for this command.
-	inferredTrack := inferTrackFromPackage(b.method.Service.Package)
+	inferredTrack := provider.InferTrackFromPackage(b.method.Service.Package)
 	return []string{strings.ToUpper(inferredTrack)}
 }
 
@@ -157,8 +158,8 @@ func (b *commandBuilder) requestMethod() string {
 	// MUST match the custom verb defined in the HTTP binding (e.g., ":exportData" -> "exportData").
 	if b.method.PathInfo != nil && len(b.method.PathInfo.Bindings) > 0 && b.method.PathInfo.Bindings[0].PathTemplate.Verb != nil {
 		return *b.method.PathInfo.Bindings[0].PathTemplate.Verb
-	} else if !isStandardMethod(b.method) {
-		commandName, _ := getCommandName(b.method)
+	} else if !provider.IsStandardMethod(b.method) {
+		commandName, _ := provider.GetCommandName(b.method)
 		// GetCommandName returns snake_case (e.g. "export_data"), but request.method expects camelCase (e.g. "exportData").
 		return strcase.ToLowerCamel(commandName)
 	}
@@ -197,7 +198,7 @@ func (b *commandBuilder) argumentsFromField(field *api.Field, prefix string) ([]
 	// Primary resource args are checked first because fields like "parent"
 	// and "name" are primary resources in certain method types (e.g., List
 	// and Get/Delete/Update respectively) and must not be ignored.
-	if isPrimaryResource(field, b.method) {
+	if provider.IsPrimaryResource(field, b.method) {
 		arg := newArgumentBuilder(b.method, b.overrides, b.model, b.service, field, prefix).buildPrimaryResource()
 		return []Argument{arg}, nil
 	}
@@ -242,7 +243,7 @@ func (b *commandBuilder) collectionPath(isAsync bool) []string {
 			continue
 		}
 
-		basePath := extractPathFromSegments(binding.PathTemplate.Segments)
+		basePath := provider.ExtractPathFromSegments(binding.PathTemplate.Segments)
 
 		if basePath == "" {
 			continue
@@ -276,7 +277,7 @@ func tableFormat(message *api.Message) string {
 
 	for _, f := range message.Fields {
 		// Sanitize field name to prevent DSL injection.
-		if !isSafeName(f.JSONName) {
+		if !provider.IsSafeName(f.JSONName) {
 			continue
 		}
 
@@ -317,56 +318,12 @@ func tableFormat(message *api.Message) string {
 	return fmt.Sprintf("table(\n%s)", sb.String())
 }
 
-// findHelpTextRule finds the help text rule from the config that applies to the current method.
-func findHelpTextRule(method *api.Method, overrides *Config) *HelpTextRule {
-	if overrides.APIs == nil {
-		return nil
-	}
-	for _, api := range overrides.APIs {
-		if api.HelpText == nil {
-			continue
-		}
-		for _, rule := range api.HelpText.MethodRules {
-			if rule.Selector == strings.TrimPrefix(method.ID, ".") {
-				return rule
-			}
-		}
-	}
-	return nil
-}
-
-// findFieldHelpTextRule finds the help text rule from the config that applies to the current field.
-func findFieldHelpTextRule(field *api.Field, overrides *Config) *HelpTextRule {
-	if overrides.APIs == nil {
-		return nil
-	}
-	for _, api := range overrides.APIs {
-		if api.HelpText == nil {
-			continue
-		}
-		for _, rule := range api.HelpText.FieldRules {
-			if rule.Selector == field.ID {
-				return rule
-			}
-		}
-	}
-	return nil
-}
-
-// apiVersion extracts the API version from the configuration.
-func apiVersion(overrides *Config) string {
-	if len(overrides.APIs) > 0 {
-		return overrides.APIs[0].APIVersion
-	}
-	return ""
-}
-
 // isIgnored determines if a field should be excluded from the generated command arguments.
 func isIgnored(field *api.Field, method *api.Method) bool {
 	if field.Name == "parent" || field.Name == "name" || field.Name == "update_mask" {
 		return true
 	}
-	if isList(method) {
+	if provider.IsList(method) {
 		switch field.Name {
 		case "page_size", "page_token", "filter", "order_by":
 			return true
@@ -375,7 +332,7 @@ func isIgnored(field *api.Field, method *api.Method) bool {
 	if slices.Contains(field.Behavior, api.FIELD_BEHAVIOR_OUTPUT_ONLY) {
 		return true
 	}
-	if isUpdate(method) && slices.Contains(field.Behavior, api.FIELD_BEHAVIOR_IMMUTABLE) {
+	if provider.IsUpdate(method) && slices.Contains(field.Behavior, api.FIELD_BEHAVIOR_IMMUTABLE) {
 		return true
 	}
 	return false

--- a/internal/surfer/gcloud/command_builder_test.go
+++ b/internal/surfer/gcloud/command_builder_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/surfer/gcloud/provider"
 )
 
 func TestOutputFormat(t *testing.T) {
@@ -119,7 +120,7 @@ func TestRequestMethod(t *testing.T) {
 			service.DefaultHost = "test.googleapis.com"
 			test.method.Service = service
 
-			got := newCommandBuilder(test.method, &Config{}, nil, service).requestMethod()
+			got := newCommandBuilder(test.method, &provider.Config{}, nil, service).requestMethod()
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("requestMethod() mismatch (-want +got):\n%s", diff)
 			}
@@ -312,142 +313,11 @@ func TestCollectionPath(t *testing.T) {
 	}
 }
 
-func TestFindHelpTextRule(t *testing.T) {
-	method := api.NewTestMethod("CreateInstance")
-	method.ID = "google.cloud.test.v1.Service.CreateInstance"
-
-	for _, test := range []struct {
-		name      string
-		overrides *Config
-		want      *HelpTextRule
-	}{
-		{
-			name:      "No APIs in config",
-			overrides: &Config{},
-			want:      nil,
-		},
-		{
-			name: "Matching rule found",
-			overrides: &Config{
-				APIs: []API{
-					{
-						HelpText: &HelpTextRules{
-							MethodRules: []*HelpTextRule{
-								{
-									Selector: "google.cloud.test.v1.Service.CreateInstance",
-									HelpText: &HelpTextElement{
-										Brief: "Override Brief",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &HelpTextRule{
-				Selector: "google.cloud.test.v1.Service.CreateInstance",
-				HelpText: &HelpTextElement{
-					Brief: "Override Brief",
-				},
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			got := findHelpTextRule(method, test.overrides)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("findHelpTextRule() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestFindFieldHelpTextRule(t *testing.T) {
-	field := api.NewTestField("instance_id")
-	field.ID = ".google.cloud.test.v1.Request.instance_id"
-
-	for _, test := range []struct {
-		name      string
-		overrides *Config
-		want      *HelpTextRule
-	}{
-		{
-			name:      "No APIs in config",
-			overrides: &Config{},
-			want:      nil,
-		},
-		{
-			name: "Matching rule found",
-			overrides: &Config{
-				APIs: []API{
-					{
-						HelpText: &HelpTextRules{
-							FieldRules: []*HelpTextRule{
-								{
-									Selector: ".google.cloud.test.v1.Request.instance_id",
-									HelpText: &HelpTextElement{
-										Brief: "Override Field Brief",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &HelpTextRule{
-				Selector: ".google.cloud.test.v1.Request.instance_id",
-				HelpText: &HelpTextElement{
-					Brief: "Override Field Brief",
-				},
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			got := findFieldHelpTextRule(field, test.overrides)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("findFieldHelpTextRule() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestAPIVersion(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		overrides *Config
-		want      string
-	}{
-		{
-			name:      "No APIs in config",
-			overrides: &Config{},
-			want:      "",
-		},
-		{
-			name: "API version found",
-			overrides: &Config{
-				APIs: []API{
-					{APIVersion: "v2beta1"},
-				},
-			},
-			want: "v2beta1",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			got := apiVersion(test.overrides)
-			if got != test.want {
-				t.Errorf("apiVersion() = %v, want %v", got, test.want)
-			}
-		})
-	}
-}
-
 func TestNewCommand(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		method    *api.Method
-		overrides *Config
+		overrides *provider.Config
 		want      *Command
 	}{
 		{
@@ -472,8 +342,8 @@ func TestNewCommand(t *testing.T) {
 				m.OutputType.Pagination = &api.PaginationInfo{PageableItem: m.OutputType.Fields[0]}
 				return m
 			}(),
-			overrides: &Config{
-				APIs: []API{
+			overrides: &provider.Config{
+				APIs: []provider.API{
 					{RootIsHidden: false},
 				},
 			},
@@ -502,15 +372,15 @@ func TestNewCommand(t *testing.T) {
 				m.ID = "google.cloud.test.v1.Service.UpdateThing"
 				return m
 			}(),
-			overrides: &Config{
-				APIs: []API{
+			overrides: &provider.Config{
+				APIs: []provider.API{
 					{
 						RootIsHidden: true,
-						HelpText: &HelpTextRules{
-							MethodRules: []*HelpTextRule{
+						HelpText: &provider.HelpTextRules{
+							MethodRules: []*provider.HelpTextRule{
 								{
 									Selector: "google.cloud.test.v1.Service.UpdateThing",
-									HelpText: &HelpTextElement{Brief: "Updated Brief"},
+									HelpText: &provider.HelpTextElement{Brief: "Updated Brief"},
 								},
 							},
 						},
@@ -538,7 +408,7 @@ func TestNewCommand(t *testing.T) {
 				m.OperationInfo = &api.OperationInfo{ResponseTypeID: "Thing", MetadataTypeID: "Metadata"}
 				return m
 			}(),
-			overrides: &Config{},
+			overrides: &provider.Config{},
 			want: &Command{
 				Hidden: true,
 				Async: &Async{

--- a/internal/surfer/gcloud/generate.go
+++ b/internal/surfer/gcloud/generate.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package gcloud provides functionality for generating gcloud commands.
 package gcloud
 
 import (
@@ -22,17 +23,18 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/surfer/gcloud/provider"
 	"github.com/iancoleman/strcase"
 )
 
 // Generate generates gcloud commands for a service.
 func Generate(_ context.Context, googleapis, gcloudconfig, output, includeList string) error {
-	overrides, err := readGcloudConfig(gcloudconfig)
+	overrides, err := provider.ReadGcloudConfig(gcloudconfig)
 	if err != nil {
 		return err
 	}
 
-	model, err := createAPIModel(googleapis, includeList)
+	model, err := provider.CreateAPIModel(googleapis, includeList)
 	if err != nil {
 		return err
 	}
@@ -50,7 +52,7 @@ func Generate(_ context.Context, googleapis, gcloudconfig, output, includeList s
 	return nil
 }
 
-func generateService(service *api.Service, overrides *Config, model *api.API, output string) error {
+func generateService(service *api.Service, overrides *provider.Config, model *api.API, output string) error {
 	shortServiceName, _, found := strings.Cut(service.DefaultHost, ".")
 	if !found {
 		return fmt.Errorf("failed to determine short service name for service %q: default_host is empty", service.Name)
@@ -62,9 +64,9 @@ func generateService(service *api.Service, overrides *Config, model *api.API, ou
 		return fmt.Errorf("failed to create surface directory for %q: %w", shortServiceName, err)
 	}
 
-	track := strings.ToUpper(inferTrackFromPackage(service.Package))
+	track := strings.ToUpper(provider.InferTrackFromPackage(service.Package))
 	data := CommandGroup{
-		ServiceTitle:    getServiceTitle(model, shortServiceName),
+		ServiceTitle:    provider.GetServiceTitle(model, shortServiceName),
 		ClassNamePrefix: strcase.ToCamel(shortServiceName),
 		Tracks:          []string{track},
 	}
@@ -78,7 +80,7 @@ func generateService(service *api.Service, overrides *Config, model *api.API, ou
 	methodsByResource := make(map[string][]*api.Method)
 
 	for _, method := range service.Methods {
-		collectionID := getPluralResourceNameForMethod(method, model)
+		collectionID := provider.GetPluralResourceNameForMethod(method, model)
 
 		if collectionID != "" {
 			methodsByResource[collectionID] = append(methodsByResource[collectionID], method)
@@ -99,7 +101,7 @@ func generateService(service *api.Service, overrides *Config, model *api.API, ou
 //
 // For a given collectionID like "instances", this function will create a directory
 // `instances/` and populate it with `create.yaml`, `delete.yaml`, etc.
-func generateResourceCommands(collectionID string, methods []*api.Method, baseDir string, overrides *Config, model *api.API, service *api.Service) error {
+func generateResourceCommands(collectionID string, methods []*api.Method, baseDir string, overrides *provider.Config, model *api.API, service *api.Service) error {
 	if len(methods) == 0 {
 		return nil
 	}
@@ -110,13 +112,13 @@ func generateResourceCommands(collectionID string, methods []*api.Method, baseDi
 		return fmt.Errorf("failed to create resource directory for %q: %w", collectionID, err)
 	}
 
-	singular := getSingularResourceNameForMethod(methods[0], model)
+	singular := provider.GetSingularResourceNameForMethod(methods[0], model)
 
 	shortServiceName, _, _ := strings.Cut(service.DefaultHost, ".")
 
-	track := strings.ToUpper(inferTrackFromPackage(service.Package))
+	track := strings.ToUpper(provider.InferTrackFromPackage(service.Package))
 	data := CommandGroup{
-		ServiceTitle:     getServiceTitle(model, shortServiceName),
+		ServiceTitle:     provider.GetServiceTitle(model, shortServiceName),
 		ResourceSingular: singular,
 		ClassNamePrefix:  strcase.ToCamel(collectionID),
 		Tracks:           []string{track},
@@ -133,7 +135,7 @@ func generateResourceCommands(collectionID string, methods []*api.Method, baseDi
 	}
 
 	for _, method := range methods {
-		verb, err := getCommandName(method)
+		verb, err := provider.GetCommandName(method)
 		if err != nil {
 			// Continue to the next method if we can't determine a command name,
 			// logging the issue might be useful here in the future.

--- a/internal/surfer/gcloud/generate_test.go
+++ b/internal/surfer/gcloud/generate_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/surfer/gcloud/provider"
 )
 
 func TestGenerateService(t *testing.T) {
@@ -68,7 +69,7 @@ func TestGenerateService(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			err := generateService(test.service, &Config{}, test.model, tmpDir)
+			err := generateService(test.service, &provider.Config{}, test.model, tmpDir)
 			if (err != nil) != test.wantErr {
 				t.Errorf("generateService() error = %v, wantErr %v", err, test.wantErr)
 			}
@@ -94,7 +95,7 @@ func TestGenerateResourceCommands(t *testing.T) {
 				}},
 			},
 		},
-	}, tmpDir, &Config{}, &api.API{Title: "Parallelstore API"}, &api.Service{DefaultHost: "parallelstore.googleapis.com"})
+	}, tmpDir, &provider.Config{}, &api.API{Title: "Parallelstore API"}, &api.Service{DefaultHost: "parallelstore.googleapis.com"})
 
 	if err != nil {
 		t.Fatalf("generateResourceCommands() error = %v", err)

--- a/internal/surfer/gcloud/provider/config.go
+++ b/internal/surfer/gcloud/provider/config.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package gcloud generates gcloud command YAML files.
-package gcloud
+// Package provider contains configuration types and helpers for surfer tools.
+package provider
 
 // Config represents the top-level schema of a gcloud config YAML file.
 type Config struct {
@@ -218,4 +218,48 @@ type ResourcePattern struct {
 	// APIVersion is the API version associated with this resource pattern
 	// (e.g., "v1").
 	APIVersion string `yaml:"api_version,omitempty"`
+}
+
+// FindHelpTextRule finds the help text rule from the config that applies to the given method ID.
+func FindHelpTextRule(c *Config, methodID string) *HelpTextRule {
+	if c.APIs == nil {
+		return nil
+	}
+	for _, api := range c.APIs {
+		if api.HelpText == nil {
+			continue
+		}
+		for _, rule := range api.HelpText.MethodRules {
+			if rule.Selector == methodID {
+				return rule
+			}
+		}
+	}
+	return nil
+}
+
+// FindFieldHelpTextRule finds the help text rule from the config that applies to the given field ID.
+func FindFieldHelpTextRule(c *Config, fieldID string) *HelpTextRule {
+	if c.APIs == nil {
+		return nil
+	}
+	for _, api := range c.APIs {
+		if api.HelpText == nil {
+			continue
+		}
+		for _, rule := range api.HelpText.FieldRules {
+			if rule.Selector == fieldID {
+				return rule
+			}
+		}
+	}
+	return nil
+}
+
+// APIVersion extracts the API version from the configuration.
+func APIVersion(c *Config) string {
+	if len(c.APIs) > 0 {
+		return c.APIs[0].APIVersion
+	}
+	return ""
 }

--- a/internal/surfer/gcloud/provider/config_test.go
+++ b/internal/surfer/gcloud/provider/config_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFindHelpTextRule(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		overrides *Config
+		methodID  string
+		want      *HelpTextRule
+	}{
+		{
+			name:      "No APIs in config",
+			overrides: &Config{},
+			methodID:  "google.cloud.test.v1.Service.CreateInstance",
+			want:      nil,
+		},
+		{
+			name: "Matching rule found",
+			overrides: &Config{
+				APIs: []API{
+					{
+						HelpText: &HelpTextRules{
+							MethodRules: []*HelpTextRule{
+								{
+									Selector: "google.cloud.test.v1.Service.CreateInstance",
+									HelpText: &HelpTextElement{
+										Brief: "Override Brief",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			methodID: "google.cloud.test.v1.Service.CreateInstance",
+			want: &HelpTextRule{
+				Selector: "google.cloud.test.v1.Service.CreateInstance",
+				HelpText: &HelpTextElement{
+					Brief: "Override Brief",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := FindHelpTextRule(test.overrides, test.methodID)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("FindHelpTextRule() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindFieldHelpTextRule(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		overrides *Config
+		fieldID   string
+		want      *HelpTextRule
+	}{
+		{
+			name:      "No APIs in config",
+			overrides: &Config{},
+			fieldID:   ".google.cloud.test.v1.Request.instance_id",
+			want:      nil,
+		},
+		{
+			name: "Matching rule found",
+			overrides: &Config{
+				APIs: []API{
+					{
+						HelpText: &HelpTextRules{
+							FieldRules: []*HelpTextRule{
+								{
+									Selector: ".google.cloud.test.v1.Request.instance_id",
+									HelpText: &HelpTextElement{
+										Brief: "Override Field Brief",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			fieldID: ".google.cloud.test.v1.Request.instance_id",
+			want: &HelpTextRule{
+				Selector: ".google.cloud.test.v1.Request.instance_id",
+				HelpText: &HelpTextElement{
+					Brief: "Override Field Brief",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := FindFieldHelpTextRule(test.overrides, test.fieldID)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("FindFieldHelpTextRule() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAPIVersion(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		overrides *Config
+		want      string
+	}{
+		{
+			name:      "No APIs in config",
+			overrides: &Config{},
+			want:      "",
+		},
+		{
+			name: "API version found",
+			overrides: &Config{
+				APIs: []API{
+					{APIVersion: "v2beta1"},
+				},
+			},
+			want: "v2beta1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := APIVersion(test.overrides)
+			if got != test.want {
+				t.Errorf("APIVersion() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/surfer/gcloud/provider/field.go
+++ b/internal/surfer/gcloud/provider/field.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"fmt"
@@ -20,8 +20,8 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
-// getGcloudType maps an API field type to the corresponding gcloud argparse type.
-func getGcloudType(t api.Typez) string {
+// GetGcloudType maps an API field type to the corresponding gcloud argparse type.
+func GetGcloudType(t api.Typez) string {
 	switch t {
 	case api.DOUBLE_TYPE, api.FLOAT_TYPE:
 		return "float"
@@ -42,9 +42,9 @@ func getGcloudType(t api.Typez) string {
 	}
 }
 
-// isSafeName checks if a name contains only safe characters (alphanumeric, underscores, dots).
+// IsSafeName checks if a name contains only safe characters (alphanumeric, underscores, dots).
 // This prevents injection vulnerabilities when generating code or templates.
-func isSafeName(name string) bool {
+func IsSafeName(name string) bool {
 	for _, r := range name {
 		switch {
 		case r >= 'a' && r <= 'z':

--- a/internal/surfer/gcloud/provider/field_test.go
+++ b/internal/surfer/gcloud/provider/field_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"testing"
@@ -40,9 +40,9 @@ func TestGetGcloudType(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := getGcloudType(test.typez)
+			got := GetGcloudType(test.typez)
 			if got != test.want {
-				t.Errorf("getGcloudType(%v) = %q, want %q", test.typez, got, test.want)
+				t.Errorf("GetGcloudType(%v) = %q, want %q", test.typez, got, test.want)
 			}
 		})
 	}
@@ -64,9 +64,9 @@ func TestIsSafeName(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isSafeName(test.name)
+			got := IsSafeName(test.name)
 			if got != test.want {
-				t.Errorf("isSafeName(%q) = %v, want %v", test.name, got, test.want)
+				t.Errorf("IsSafeName(%q) = %v, want %v", test.name, got, test.want)
 			}
 		})
 	}
@@ -76,8 +76,8 @@ func TestGetGcloudType_Panic(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
-			t.Errorf("getGcloudType() did not panic for unsupported type")
+			t.Errorf("GetGcloudType() did not panic for unsupported type")
 		}
 	}()
-	getGcloudType(api.Typez(999))
+	GetGcloudType(api.Typez(999))
 }

--- a/internal/surfer/gcloud/provider/loader.go
+++ b/internal/surfer/gcloud/provider/loader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"fmt"
@@ -22,11 +22,11 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
-	"gopkg.in/yaml.v3"
+	"github.com/googleapis/librarian/internal/yaml"
 )
 
-// createAPIModel parses the service specification and creates the API model.
-func createAPIModel(googleapisPath, includeList string) (*api.API, error) {
+// CreateAPIModel parses the service specification and creates the API model.
+func CreateAPIModel(googleapisPath, includeList string) (*api.API, error) {
 	parserConfig := &parser.ModelConfig{
 		SpecificationFormat: libconfig.SpecProtobuf,
 		Source: &sources.SourceConfig{
@@ -53,16 +53,16 @@ func createAPIModel(googleapisPath, includeList string) (*api.API, error) {
 	return model, nil
 }
 
-// readGcloudConfig loads the gcloud configuration from a gcloud.yaml file.
-func readGcloudConfig(path string) (*Config, error) {
+// ReadGcloudConfig loads the gcloud configuration from a gcloud.yaml file.
+func ReadGcloudConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read gcloud config file: %w", err)
 	}
 
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	cfg, err := yaml.Unmarshal[Config](data)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse gcloud config YAML: %w", err)
 	}
-	return &cfg, nil
+	return cfg, nil
 }

--- a/internal/surfer/gcloud/provider/loader_test.go
+++ b/internal/surfer/gcloud/provider/loader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"os"
@@ -24,7 +24,7 @@ import (
 )
 
 func TestReadGcloudConfig(t *testing.T) {
-	files, err := filepath.Glob("testdata/*/gcloud.yaml")
+	files, err := filepath.Glob("../testdata/*/gcloud.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestReadGcloudConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			cfg, err := yaml.Unmarshal[*Config](data)
+			cfg, err := yaml.Unmarshal[Config](data)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -46,7 +46,7 @@ func TestReadGcloudConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			roundTripped, err := yaml.Unmarshal[*Config](marshaled)
+			roundTripped, err := yaml.Unmarshal[Config](marshaled)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/surfer/gcloud/provider/method.go
+++ b/internal/surfer/gcloud/provider/method.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"fmt"
@@ -22,22 +22,22 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// getCommandName maps an API method to a standard gcloud command name (in snake_case).
+// GetCommandName maps an API method to a standard gcloud command name (in snake_case).
 // This name is typically used for the command's file name.
-func getCommandName(method *api.Method) (string, error) {
+func GetCommandName(method *api.Method) (string, error) {
 	if method == nil {
 		return "", fmt.Errorf("method cannot be nil")
 	}
 	switch {
-	case isGet(method):
+	case IsGet(method):
 		return "describe", nil
-	case isList(method):
+	case IsList(method):
 		return "list", nil
-	case isCreate(method):
+	case IsCreate(method):
 		return "create", nil
-	case isUpdate(method):
+	case IsUpdate(method):
 		return "update", nil
-	case isDelete(method):
+	case IsDelete(method):
 		return "delete", nil
 	default:
 		// For custom methods (AIP-136), we try to extract the custom verb from the HTTP path.
@@ -53,19 +53,19 @@ func getCommandName(method *api.Method) (string, error) {
 	}
 }
 
-// isCreate determines if the method is a standard Create method (AIP-133).
-func isCreate(m *api.Method) bool {
+// IsCreate determines if the method is a standard Create method (AIP-133).
+func IsCreate(m *api.Method) bool {
 	if !strings.HasPrefix(m.Name, "Create") {
 		return false
 	}
-	if verb := getHTTPVerb(m); verb != "" {
+	if verb := GetHTTPVerb(m); verb != "" {
 		return verb == "POST"
 	}
 	return true
 }
 
-// isGet determines if the method is a standard Get method (AIP-131).
-func isGet(m *api.Method) bool {
+// IsGet determines if the method is a standard Get method (AIP-131).
+func IsGet(m *api.Method) bool {
 	// Use sidekick's robust AIP check if available.
 	if m.IsAIPStandardGet {
 		return true
@@ -74,36 +74,36 @@ func isGet(m *api.Method) bool {
 	if !strings.HasPrefix(m.Name, "Get") {
 		return false
 	}
-	if verb := getHTTPVerb(m); verb != "" {
+	if verb := GetHTTPVerb(m); verb != "" {
 		return verb == "GET"
 	}
 	return true
 }
 
-// isList determines if the method is a standard List method (AIP-132).
-func isList(m *api.Method) bool {
+// IsList determines if the method is a standard List method (AIP-132).
+func IsList(m *api.Method) bool {
 	if !strings.HasPrefix(m.Name, "List") {
 		return false
 	}
-	if verb := getHTTPVerb(m); verb != "" {
+	if verb := GetHTTPVerb(m); verb != "" {
 		return verb == "GET"
 	}
 	return true
 }
 
-// isUpdate determines if the method is a standard Update method (AIP-134).
-func isUpdate(m *api.Method) bool {
+// IsUpdate determines if the method is a standard Update method (AIP-134).
+func IsUpdate(m *api.Method) bool {
 	if !strings.HasPrefix(m.Name, "Update") {
 		return false
 	}
-	if verb := getHTTPVerb(m); verb != "" {
+	if verb := GetHTTPVerb(m); verb != "" {
 		return verb == "PATCH" || verb == "PUT"
 	}
 	return true
 }
 
-// isDelete determines if the method is a standard Delete method (AIP-135).
-func isDelete(m *api.Method) bool {
+// IsDelete determines if the method is a standard Delete method (AIP-135).
+func IsDelete(m *api.Method) bool {
 	// Use sidekick's robust AIP check if available.
 	if m.IsAIPStandardDelete {
 		return true
@@ -112,34 +112,34 @@ func isDelete(m *api.Method) bool {
 	if !strings.HasPrefix(m.Name, "Delete") {
 		return false
 	}
-	if verb := getHTTPVerb(m); verb != "" {
+	if verb := GetHTTPVerb(m); verb != "" {
 		return verb == "DELETE"
 	}
 	return true
 }
 
-// isStandardMethod determines if the method is one of the standard AIP methods
+// IsStandardMethod determines if the method is one of the standard AIP methods
 // (Get, List, Create, Update, Delete).
-func isStandardMethod(m *api.Method) bool {
-	return isGet(m) || isList(m) || isCreate(m) || isUpdate(m) || isDelete(m)
+func IsStandardMethod(m *api.Method) bool {
+	return IsGet(m) || IsList(m) || IsCreate(m) || IsUpdate(m) || IsDelete(m)
 }
 
-// getHTTPVerb returns the HTTP verb from the primary binding, or an empty string if not available.
-func getHTTPVerb(m *api.Method) string {
+// GetHTTPVerb returns the HTTP verb from the primary binding, or an empty string if not available.
+func GetHTTPVerb(m *api.Method) string {
 	if m.PathInfo != nil && len(m.PathInfo.Bindings) > 0 {
 		return m.PathInfo.Bindings[0].Verb
 	}
 	return ""
 }
 
-// isResourceMethod determines if the method operates on a specific resource instance.
+// IsResourceMethod determines if the method operates on a specific resource instance.
 // This includes standard Get, Update, Delete methods, and custom methods where the
 // HTTP path ends with a variable segment (e.g. `.../instances/{instance}`).
-func isResourceMethod(m *api.Method) bool {
+func IsResourceMethod(m *api.Method) bool {
 	switch {
-	case isGet(m), isUpdate(m), isDelete(m):
+	case IsGet(m), IsUpdate(m), IsDelete(m):
 		return true
-	case isCreate(m), isList(m):
+	case IsCreate(m), IsList(m):
 		return false
 	default:
 		// Fallback for custom methods
@@ -156,14 +156,14 @@ func isResourceMethod(m *api.Method) bool {
 	}
 }
 
-// isCollectionMethod determines if the method operates on a collection of resources.
+// IsCollectionMethod determines if the method operates on a collection of resources.
 // This includes standard List and Create methods, and custom methods where the
 // HTTP path ends with a literal segment (e.g. `.../instances`).
-func isCollectionMethod(m *api.Method) bool {
+func IsCollectionMethod(m *api.Method) bool {
 	switch {
-	case isList(m), isCreate(m):
+	case IsList(m), IsCreate(m):
 		return true
-	case isGet(m), isUpdate(m), isDelete(m):
+	case IsGet(m), IsUpdate(m), IsDelete(m):
 		return false
 	default:
 		// Fallback for custom methods
@@ -180,9 +180,9 @@ func isCollectionMethod(m *api.Method) bool {
 	}
 }
 
-// findResourceMessage identifies the primary resource message within a List response.
+// FindResourceMessage identifies the primary resource message within a List response.
 // Per AIP-132, this is usually the repeated field in the response message.
-func findResourceMessage(outputType *api.Message) *api.Message {
+func FindResourceMessage(outputType *api.Message) *api.Message {
 	if outputType == nil {
 		return nil
 	}

--- a/internal/surfer/gcloud/provider/method_test.go
+++ b/internal/surfer/gcloud/provider/method_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"errors"
@@ -35,7 +35,7 @@ func TestIsCreate(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isCreate(test.method)
+			got := IsCreate(test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -56,7 +56,7 @@ func TestIsGet(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isGet(test.method)
+			got := IsGet(test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -77,7 +77,7 @@ func TestIsList(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isList(test.method)
+			got := IsList(test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -99,7 +99,7 @@ func TestIsUpdate(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isUpdate(test.method)
+			got := IsUpdate(test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -120,7 +120,7 @@ func TestIsDelete(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isDelete(test.method)
+			got := IsDelete(test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -143,7 +143,7 @@ func TestGetCommandName(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := getCommandName(test.method)
+			got, err := GetCommandName(test.method)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -190,7 +190,7 @@ func TestFindResourceMessage(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := findResourceMessage(test.outputType)
+			got := FindResourceMessage(test.outputType)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -212,16 +212,16 @@ func TestGetCommandName_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, gotErr := getCommandName(test.method)
+			_, gotErr := GetCommandName(test.method)
 			if test.wantErr != nil {
 				if gotErr == nil {
-					t.Fatalf("getCommandName() returned nil error, want %v", test.wantErr)
+					t.Fatalf("GetCommandName() returned nil error, want %v", test.wantErr)
 				}
 				if gotErr.Error() != test.wantErr.Error() {
-					t.Errorf("getCommandName() error = %q, want %q", gotErr.Error(), test.wantErr.Error())
+					t.Errorf("GetCommandName() error = %q, want %q", gotErr.Error(), test.wantErr.Error())
 				}
 			} else if gotErr != nil {
-				t.Errorf("getCommandName() returned error %v, want nil", gotErr)
+				t.Errorf("GetCommandName() returned error %v, want nil", gotErr)
 			}
 		})
 	}
@@ -248,7 +248,7 @@ func TestIsResourceMethod(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			if got := isResourceMethod(test.method); got != test.want {
+			if got := IsResourceMethod(test.method); got != test.want {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(test.want, got))
 			}
 		})
@@ -276,7 +276,7 @@ func TestIsCollectionMethod(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			if got := isCollectionMethod(test.method); got != test.want {
+			if got := IsCollectionMethod(test.method); got != test.want {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(test.want, got))
 			}
 		})
@@ -298,7 +298,7 @@ func TestIsStandardMethod(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isStandardMethod(test.method)
+			got := IsStandardMethod(test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/surfer/gcloud/provider/resource.go
+++ b/internal/surfer/gcloud/provider/resource.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"fmt"
@@ -22,10 +22,10 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// getPluralFromSegments infers the plural name of a resource from its structured path segments.
+// GetPluralFromSegments infers the plural name of a resource from its structured path segments.
 // Per AIP-122, the plural is the literal segment before the final variable segment.
 // Example: `.../instances/{instance}` -> "instances".
-func getPluralFromSegments(segments []api.PathSegment) string {
+func GetPluralFromSegments(segments []api.PathSegment) string {
 	if len(segments) < 2 {
 		return ""
 	}
@@ -41,11 +41,11 @@ func getPluralFromSegments(segments []api.PathSegment) string {
 	return *secondLastSegment.Literal
 }
 
-// getParentFromSegments extracts the pattern segments for the parent resource.
+// GetParentFromSegments extracts the pattern segments for the parent resource.
 // It assumes the standard resource pattern structure where the last two segments
 // are the literal plural noun and the variable singular noun of the child resource.
 // Example: `projects/.../locations/{location}/instances/{instance}` -> `projects/.../locations/{location}`.
-func getParentFromSegments(segments []api.PathSegment) []api.PathSegment {
+func GetParentFromSegments(segments []api.PathSegment) []api.PathSegment {
 	if len(segments) < 2 {
 		return nil
 	}
@@ -57,11 +57,11 @@ func getParentFromSegments(segments []api.PathSegment) []api.PathSegment {
 	return nil
 }
 
-// getSingularFromSegments infers the singular name of a resource from its structured path segments.
+// GetSingularFromSegments infers the singular name of a resource from its structured path segments.
 // According to AIP-123, the last segment of a resource pattern MUST be a variable representing
 // the resource ID, and its name MUST be the singular form of the resource noun.
 // Example: `.../instances/{instance}` -> "instance".
-func getSingularFromSegments(segments []api.PathSegment) string {
+func GetSingularFromSegments(segments []api.PathSegment) string {
 	if len(segments) == 0 {
 		return ""
 	}
@@ -73,11 +73,11 @@ func getSingularFromSegments(segments []api.PathSegment) string {
 	return last.Variable.FieldPath[len(last.Variable.FieldPath)-1]
 }
 
-// getCollectionPathFromSegments constructs the base gcloud collection path from a
+// GetCollectionPathFromSegments constructs the base gcloud collection path from a
 // structured resource pattern, according to AIP-122 conventions.
 // It joins the literal collection identifiers with dots.
 // Example: `projects/{project}/locations/{location}/instances/{instance}` -> `projects.locations.instances`.
-func getCollectionPathFromSegments(segments []api.PathSegment) string {
+func GetCollectionPathFromSegments(segments []api.PathSegment) string {
 	var collectionParts []string
 	for i := 0; i < len(segments)-1; i++ {
 		// A collection identifier is a literal segment followed by a variable segment.
@@ -89,17 +89,17 @@ func getCollectionPathFromSegments(segments []api.PathSegment) string {
 	return strings.Join(collectionParts, ".")
 }
 
-// isPrimaryResource determines if a field represents the primary resource of a method.
-func isPrimaryResource(field *api.Field, method *api.Method) bool {
+// IsPrimaryResource determines if a field represents the primary resource of a method.
+func IsPrimaryResource(field *api.Field, method *api.Method) bool {
 	if method.InputType == nil {
 		return false
 	}
 	// For `Create` methods, the primary resource is identified by a field named
 	// in the format "{resource}_id" (e.g., "instance_id").
-	if isCreate(method) {
-		resource, err := getResourceFromMethod(method)
+	if IsCreate(method) {
+		resource, err := GetResourceFromMethod(method)
 		if err == nil {
-			name := getResourceNameFromType(resource.Type)
+			name := GetResourceNameFromType(resource.Type)
 			// Convert CamelCase resource name (e.g., "Instance") to snake_case
 			// to match the proto field naming convention (e.g., "instance_id").
 			if name != "" && field.Name == strcase.ToSnake(name)+"_id" {
@@ -112,29 +112,29 @@ func isPrimaryResource(field *api.Field, method *api.Method) bool {
 	// the primary resource scope is identified by the "parent" field.
 	// Note: Create is collection-based but uses the new resource ID (e.g. "instance_id")
 	// as the primary positional argument, so "parent" is not the primary resource arg.
-	if isCollectionMethod(method) && !isCreate(method) && field.Name == "parent" {
+	if IsCollectionMethod(method) && !IsCreate(method) && field.Name == "parent" {
 		return true
 	}
 
 	// For resource-based methods (Get, Delete, Update, and custom resource methods),
 	// the primary resource is identified by the "name" field.
-	if isResourceMethod(method) && field.Name == "name" {
+	if IsResourceMethod(method) && field.Name == "name" {
 		return true
 	}
 
 	return false
 }
 
-// getResourceNameFromType extracts the singular resource name from a resource type string.
+// GetResourceNameFromType extracts the singular resource name from a resource type string.
 // According to AIP-123, the format of a resource type is {Service Name}/{Type}, where
 // {Type} is the singular form of the resource noun.
-func getResourceNameFromType(typeStr string) string {
+func GetResourceNameFromType(typeStr string) string {
 	parts := strings.Split(typeStr, "/")
 	return parts[len(parts)-1]
 }
 
-// getResourceFromMethod extracts the resource definition from a method's input message if it exists.
-func getResourceFromMethod(method *api.Method) (*api.Resource, error) {
+// GetResourceFromMethod extracts the resource definition from a method's input message if it exists.
+func GetResourceFromMethod(method *api.Method) (*api.Resource, error) {
 	for _, f := range method.InputType.Fields {
 		if f.MessageType != nil && f.MessageType.Resource != nil {
 			return f.MessageType.Resource, nil
@@ -143,16 +143,16 @@ func getResourceFromMethod(method *api.Method) (*api.Resource, error) {
 	return nil, fmt.Errorf("resource message not found in input type for method %q", method.Name)
 }
 
-// getResourceForMethod finds the `api.Resource` definition associated with a method.
+// GetResourceForMethod finds the `api.Resource` definition associated with a method.
 // This is a crucial function for linking a method to the resource it operates on.
-func getResourceForMethod(method *api.Method, model *api.API) *api.Resource {
+func GetResourceForMethod(method *api.Method, model *api.API) *api.Resource {
 	if method.InputType == nil {
 		return nil
 	}
 
 	// Strategy 1: For Create (AIP-133) and Update (AIP-134), the request message
 	// usually contains a field that *is* the resource message.
-	if resource, err := getResourceFromMethod(method); err == nil {
+	if resource, err := GetResourceFromMethod(method); err == nil {
 		return resource
 	}
 
@@ -196,11 +196,11 @@ func getResourceForMethod(method *api.Method, model *api.API) *api.Resource {
 	return nil
 }
 
-// getPluralResourceNameForMethod determines the plural name of a resource. It follows a clear
+// GetPluralResourceNameForMethod determines the plural name of a resource. It follows a clear
 // hierarchy of truth: first, the explicit `plural` field in the resource
 // definition, and second, inference from the resource pattern.
-func getPluralResourceNameForMethod(method *api.Method, model *api.API) string {
-	resource := getResourceForMethod(method, model)
+func GetPluralResourceNameForMethod(method *api.Method, model *api.API) string {
+	resource := GetResourceForMethod(method, model)
 	if resource != nil {
 		// The `plural` field in the `(google.api.resource)` annotation is the
 		// most authoritative source.
@@ -210,34 +210,34 @@ func getPluralResourceNameForMethod(method *api.Method, model *api.API) string {
 		// If the `plural` field is not present, we fall back to inferring the
 		// plural name from the resource's pattern string, as per AIP-122.
 		if len(resource.Patterns) > 0 {
-			return getPluralFromSegments(resource.Patterns[0])
+			return GetPluralFromSegments(resource.Patterns[0])
 		}
 	}
 	return ""
 }
 
-// getSingularResourceNameForMethod determines the singular name of a resource. It follows a clear
+// GetSingularResourceNameForMethod determines the singular name of a resource. It follows a clear
 // hierarchy of truth: first, the explicit `singular` field in the resource
 // definition, and second, inference from the resource pattern.
-func getSingularResourceNameForMethod(method *api.Method, model *api.API) string {
-	resource := getResourceForMethod(method, model)
+func GetSingularResourceNameForMethod(method *api.Method, model *api.API) string {
+	resource := GetResourceForMethod(method, model)
 	if resource != nil {
 		if resource.Singular != "" {
 			return resource.Singular
 		}
 		if len(resource.Patterns) > 0 {
-			return getSingularFromSegments(resource.Patterns[0])
+			return GetSingularFromSegments(resource.Patterns[0])
 		}
 	}
 	return ""
 }
 
-// extractPathFromSegments extracts the dot-separated collection path from path segments.
+// ExtractPathFromSegments extracts the dot-separated collection path from path segments.
 // It handles:
 // 1. Skipping API version prefixes (e.g., v1).
 // 2. Extracting internal structure from complex variables (e.g., {name=projects/*/locations/*}).
 // 3. Including all literal segments (e.g., instances in .../instances).
-func extractPathFromSegments(segments []api.PathSegment) string {
+func ExtractPathFromSegments(segments []api.PathSegment) string {
 	var parts []string
 	for i, seg := range segments {
 		if seg.Literal != nil {
@@ -248,7 +248,7 @@ func extractPathFromSegments(segments []api.PathSegment) string {
 			}
 			parts = append(parts, val)
 		} else if seg.Variable != nil && len(seg.Variable.Segments) > 1 {
-			internal := extractCollectionFromStrings(seg.Variable.Segments)
+			internal := ExtractCollectionFromStrings(seg.Variable.Segments)
 			if internal != "" {
 				parts = append(parts, internal)
 			}
@@ -257,9 +257,9 @@ func extractPathFromSegments(segments []api.PathSegment) string {
 	return strings.Join(parts, ".")
 }
 
-// extractCollectionFromStrings constructs a collection path from a list of string segments
+// ExtractCollectionFromStrings constructs a collection path from a list of string segments
 // (literals and wildcards), following AIP-122 conventions (literal followed by variable/wildcard).
-func extractCollectionFromStrings(parts []string) string {
+func ExtractCollectionFromStrings(parts []string) string {
 	var sb strings.Builder
 	var prev string
 

--- a/internal/surfer/gcloud/provider/resource_test.go
+++ b/internal/surfer/gcloud/provider/resource_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"strings"
@@ -55,7 +55,7 @@ func TestGetPluralFromSegments(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := getPluralFromSegments(test.segments)
+			got := GetPluralFromSegments(test.segments)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -103,7 +103,7 @@ func TestGetParentFromSegments(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := getParentFromSegments(test.segments)
+			got := GetParentFromSegments(test.segments)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -144,7 +144,7 @@ func TestGetSingularFromSegments(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := getSingularFromSegments(test.segments)
+			got := GetSingularFromSegments(test.segments)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -186,7 +186,7 @@ func TestGetCollectionPathFromSegments(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := getCollectionPathFromSegments(test.segments)
+			got := GetCollectionPathFromSegments(test.segments)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -233,7 +233,7 @@ func TestExtractPathFromSegments(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := extractPathFromSegments(test.segments)
+			got := ExtractPathFromSegments(test.segments)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -335,7 +335,7 @@ func TestIsPrimaryResource(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := isPrimaryResource(test.field, test.method)
+			got := IsPrimaryResource(test.field, test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -443,7 +443,7 @@ func TestGetResourceForMethod(t *testing.T) {
 				ResourceDefinitions: test.resourceDefs,
 				Messages:            test.messages,
 			}
-			got := getResourceForMethod(test.method, model)
+			got := GetResourceForMethod(test.method, model)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -516,7 +516,7 @@ func TestGetPluralResourceNameForMethod(t *testing.T) {
 			model := &api.API{
 				ResourceDefinitions: test.resourceDefs,
 			}
-			got := getPluralResourceNameForMethod(test.method, model)
+			got := GetPluralResourceNameForMethod(test.method, model)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -589,7 +589,7 @@ func TestGetSingularResourceNameForMethod(t *testing.T) {
 			model := &api.API{
 				ResourceDefinitions: test.resourceDefs,
 			}
-			got := getSingularResourceNameForMethod(test.method, model)
+			got := GetSingularResourceNameForMethod(test.method, model)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -609,7 +609,7 @@ func TestGetResourceNameFromType(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := getResourceNameFromType(test.typeStr)
+			got := GetResourceNameFromType(test.typeStr)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/surfer/gcloud/provider/service_info.go
+++ b/internal/surfer/gcloud/provider/service_info.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"strings"
@@ -21,10 +21,10 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// inferTrackFromPackage infers the release track from the proto package name.
+// InferTrackFromPackage infers the release track from the proto package name.
 // as mandated per AIP-185
 // e.g. "google.cloud.parallelstore.v1beta" -> "beta".
-func inferTrackFromPackage(pkg string) string {
+func InferTrackFromPackage(pkg string) string {
 	parts := strings.Split(pkg, ".")
 	version := parts[len(parts)-1]
 
@@ -42,9 +42,9 @@ func inferTrackFromPackage(pkg string) string {
 	return "ga"
 }
 
-// getServiceTitle returns the service title for documentation.
+// GetServiceTitle returns the service title for documentation.
 // It tries to use the API title, falling back to a CamelCase version of the short service name.
-func getServiceTitle(model *api.API, shortServiceName string) string {
+func GetServiceTitle(model *api.API, shortServiceName string) string {
 	if t := strings.TrimSuffix(model.Title, " API"); t != "" {
 		return t
 	}

--- a/internal/surfer/gcloud/provider/service_info_test.go
+++ b/internal/surfer/gcloud/provider/service_info_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package provider
 
 import (
 	"testing"
@@ -36,7 +36,7 @@ func TestInferTrackFromPackage(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := inferTrackFromPackage(test.pkg)
+			got := InferTrackFromPackage(test.pkg)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -86,7 +86,7 @@ func TestGetServiceTitle(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := getServiceTitle(test.model, test.shortServiceName)
+			got := GetServiceTitle(test.model, test.shortServiceName)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
The core gcloud configuration, field, loader, method, resource, and service information logic has been extracted from the  package into a new, dedicated  package. This separates generic surfer API rules and configuration definitions from the gcloud-specific command and argument builder implementations.

`provider` should slowly decrease in size as sidekick improves and the gcloud config decreases in size. This abstracts away the current current sources of data so that they can be updated over time.

Fix: #4714