### PR TITLE
fix(.github/workflows): exclude java and nodejs from main workflow

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Run tests
         run: |
           go test -race -coverprofile=coverage.out -covermode=atomic \
-            $(go list ./... | grep -v -E 'internal/librarian/(java|nodejs|python|rust|dart)|internal/sidekick|internal/legacylibrarian')
+            $(go list ./... | grep -v -E 'internal/librarian/(dart|java|nodejs|python|rust)|internal/sidekick|internal/legacylibrarian')
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
The java and nodejs packages each have dedicated CI workflows that install the required external tools (gapic-generator-typescript, eslint, protoc plugins, etc.). The main librarian.yaml workflow should not run tests to avoid duplicate tests runs.

This adds java and nodejs to the exclusion list, matching how python, rust, and dart are already excluded.

For https://github.com/googleapis/librarian/issues/4663
For https://github.com/googleapis/librarian/issues/4664