### PR TITLE
refactor(internal/librarian): inline postGenerate into generateLibraries

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -246,7 +246,6 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 	return nil
 }
 
-
 func defaultOutput(language string, name, api, defaultOut string) string {
 	switch language {
 	case config.LanguageDart:


### PR DESCRIPTION
The postGenerate function was a separate dispatch step that ran repo-level actions after all libraries were generated. This inlines each language's post-generate call into its own case block within generateLibraries, eliminating the extra function and switch statement.