### PR TITLE
refactor(internal/config): remove rust_storage language enum

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -341,7 +341,7 @@ This document describes the schema for the librarian.yaml.
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_list` | string | Is a list of proto files to include (e.g., "date.proto,expr.proto"). |
 | `internal_builders` | bool | Indicates whether generated builders should be internal to the crate. |
-| `language` | string | Can be used to select a variation of the Rust generator. For example, `rust_storage` enables special handling for the storage client. |
+| `language` | string | Can be used to select a variation of the Rust generator. |
 | `module_path` | string | Is the Rust module path for converters (e.g., "crate::generated::gapic::model"). |
 | `module_roots` | map[string]string |  |
 | `name_overrides` | string | Contains codec-level overrides for type and service names. |
@@ -354,7 +354,7 @@ This document describes the schema for the librarian.yaml.
 | `skipped_ids` | list of string | Is a list of proto IDs to skip in generation. |
 | `specification_format` | string | Overrides the library-level specification format. |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
-| `template` | string | Specifies which generator template to use. Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod". |
+| `template` | string | Specifies which generator template to use. Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod", "storage". |
 
 ## RustPackageDependency Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -45,8 +45,6 @@ const (
 	LanguageRuby = "ruby"
 	// LanguageRust is the language identifier for Rust.
 	LanguageRust = "rust"
-	// LanguageRustStorage is a variation of the Rust generator for storage.
-	LanguageRustStorage = "rust_storage"
 )
 
 // GoModule represents the Go-specific configuration for a library.
@@ -151,7 +149,6 @@ type RustModule struct {
 	InternalBuilders bool `yaml:"internal_builders,omitempty"`
 
 	// Language can be used to select a variation of the Rust generator.
-	// For example, `rust_storage` enables special handling for the storage client.
 	Language string `yaml:"language,omitempty"`
 
 	// ModulePath is the Rust module path for converters
@@ -194,7 +191,7 @@ type RustModule struct {
 	APIPath string `yaml:"api_path"`
 
 	// Template specifies which generator template to use.
-	// Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod".
+	// Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod", "storage".
 	Template string `yaml:"template"`
 }
 

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -713,13 +713,13 @@ func TestModuleToModelConfig(t *testing.T) {
 				Rust: &config.RustCrate{
 					Modules: []*config.RustModule{
 						{
-							Language: config.LanguageRustStorage,
+							Language: "custom",
 						},
 					},
 				},
 			},
 			want: &parser.ModelConfig{
-				Language:            config.LanguageRustStorage,
+				Language:            "custom",
 				SpecificationFormat: config.SpecProtobuf,
 				Source: &sources.SourceConfig{
 					ActiveRoots: []string{"googleapis"},

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -124,6 +124,9 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *sourc
 		return nil
 	}
 	for _, module := range library.Rust.Modules {
+		if module.Template == "storage" {
+			return generateRustStorage(ctx, library, module.Output, sources)
+		}
 		modelConfig, err := moduleToModelConfig(library, module, sources)
 		if err != nil {
 			return fmt.Errorf("moduleToModelConfig %q: %w", module.Output, err)
@@ -132,17 +135,10 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *sourc
 		if err != nil {
 			return fmt.Errorf("CreateModel %q: %w", module.Output, err)
 		}
-		switch modelConfig.Language {
-		case config.LanguageRust:
-			if module.Template == "prost" {
-				err = rust_prost.Generate(ctx, model, module.Output, modelConfig)
-			} else {
-				err = sidekickrust.Generate(ctx, model, module.Output, modelConfig)
-			}
-		case config.LanguageRustStorage:
-			return generateRustStorage(ctx, library, module.Output, sources)
-		default:
-			err = fmt.Errorf("language %q not supported", modelConfig.Language)
+		if module.Template == "prost" {
+			err = rust_prost.Generate(ctx, model, module.Output, modelConfig)
+		} else {
+			err = sidekickrust.Generate(ctx, model, module.Output, modelConfig)
 		}
 		if err != nil {
 			return fmt.Errorf("module %q: %w", module.Output, err)

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -579,7 +579,7 @@ func TestFindModuleByOutput(t *testing.T) {
 							Output:   "target-output",
 						},
 						{
-							Language: config.LanguageRustStorage,
+							Template: "storage",
 							Output:   "other-output",
 						},
 					},

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -157,10 +157,6 @@ func tidyLanguageConfig(lib *config.Library, language string) *config.Library {
 
 // isEmptyRustModule returns true if the module is a placeholder that can be removed.
 func isEmptyRustModule(module *config.RustModule) bool {
-	if module.Language == config.LanguageRustStorage {
-		// The Rust storage module has hardcoded API paths and templates, so it is never empty.
-		return false
-	}
 	return module.APIPath == "" && module.Template == ""
 }
 

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -587,7 +587,7 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 							Modules: []*config.RustModule{
 								{
 									Output:   "src/storage/src/generated/protos/storage",
-									Language: config.LanguageRustStorage,
+									Template: "storage",
 								},
 							},
 						},


### PR DESCRIPTION
The rust_storage language enum was a hack used for special handling of the storage client. It is not a real language, so the language enum should contain only actual languages.

The storage generation is now triggered by template: "storage" on the Rust module, which is consistent with how other generation variations like "prost" are already handled via the template field. The isEmptyRustModule function no longer needs a special case because a module with template: "storage" is not considered empty.

Fixes https://github.com/googleapis/librarian/issues/4291