### PR TITLE
fix(internal/librarian/nodejs): remove .OwlBot.yaml from output

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -210,7 +210,7 @@ func runPostProcessor(ctx context.Context, library *config.Library, googleapisDi
 
 	// Remove .OwlBot.yaml produced by the generator. Librarian replaces
 	// OwlBot so this file is no longer needed.
-	if err := os.Remove(filepath.Join(outDir, ".OwlBot.yaml")); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(filepath.Join(outDir, ".OwlBot.yaml")); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to remove .OwlBot.yaml: %w", err)
 	}
 

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -438,7 +438,7 @@ func TestRunPostProcessor_RemovesOwlBotYaml(t *testing.T) {
 	if err := runPostProcessor(t.Context(), library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(outDir, ".OwlBot.yaml")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(outDir, ".OwlBot.yaml")); !errors.Is(err, os.ErrNotExist) {
 		t.Error("expected .OwlBot.yaml to be removed after post-processing")
 	}
 }


### PR DESCRIPTION
The gapic-generator-typescript produces a .OwlBot.yaml file as part of its output. Since librarian replaces OwlBot, this file is no longer needed. The file is now deleted from the output directory after combine-library runs in runPostProcessor.

Fixes https://github.com/googleapis/librarian/issues/4457