### PR TITLE
chore(python): always specify default_version and require it

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -17,6 +17,7 @@ package python
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,6 +35,8 @@ const (
 	cloudGoogleComDocumentationTemplate = "https://cloud.google.com/python/docs/reference/%s/latest"
 	googleapisDevDocumentationTemplate  = "https://googleapis.dev/python/%s/latest"
 )
+
+var errNoDefaultVersion = errors.New("default version must be specified for every library with generated APIs")
 
 // Generate generates a Python client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, googleapisDir string) error {
@@ -118,9 +121,18 @@ func createRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		if err != nil {
 			return nil, err
 		}
-		// Use the version of the first-listed API path as the default version,
-		// unless it's overridden later.
-		repoMetadata.DefaultVersion = filepath.Base(library.APIs[0].Path)
+		// Require the DefaultVersion field, even if we could have inferred
+		// it. The default version affects the final code, and changes to it
+		// should be explicit - if adding a new version of an API changes the
+		// inferred default version, that would cause compatibility issues. This
+		// in itself is far from ideal; keeping the default version is "safe"
+		// but toilsome operationally.
+		// TODO(https://github.com/googleapis/librarian/issues/4772): design away
+		// from default versions.
+		if packageOptions.DefaultVersion == "" {
+			return nil, fmt.Errorf("error creating metadata for %s: %w", library.Name, errNoDefaultVersion)
+		}
+		repoMetadata.DefaultVersion = packageOptions.DefaultVersion
 	} else {
 		// Handwritten library: populate from scratch (and then apply overrides
 		// as normal).
@@ -130,15 +142,16 @@ func createRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 			Language:         cfg.Language,
 			Repo:             cfg.Repo,
 			ReleaseLevel:     library.ReleaseLevel,
+			// Allow even handwritten libraries to specify a default value in
+			// the package options if they want to. This would be unusual, but
+			// if it's specified, we should honor it.
+			DefaultVersion: packageOptions.DefaultVersion,
 		}
 	}
 	if packageOptions.MetadataNameOverride != "" {
 		repoMetadata.Name = packageOptions.MetadataNameOverride
 	} else {
 		repoMetadata.Name = library.Name
-	}
-	if packageOptions.DefaultVersion != "" {
-		repoMetadata.DefaultVersion = packageOptions.DefaultVersion
 	}
 	repoMetadata.LibraryType = packageOptions.LibraryType
 	repoMetadata.ClientDocumentation = BuildClientDocumentationURI(library.Name, repoMetadata.Name)

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -731,6 +731,7 @@ func TestGenerate_Multiple(t *testing.T) {
 					Path: "google/cloud/secretmanager/v1",
 				},
 			},
+			Python: &config.PythonPackage{DefaultVersion: "v1"},
 		},
 		{
 			Name: "configdelivery",
@@ -739,6 +740,7 @@ func TestGenerate_Multiple(t *testing.T) {
 					Path: "google/cloud/configdelivery/v1",
 				},
 			},
+			Python: &config.PythonPackage{DefaultVersion: "v1"},
 		},
 	}
 	for _, library := range libraries {
@@ -798,6 +800,7 @@ func TestGenerate_Error(t *testing.T) {
 				APIs: []*config.API{
 					{Path: "bogus/"},
 				},
+				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 		},
 		{
@@ -808,6 +811,7 @@ func TestGenerate_Error(t *testing.T) {
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
+				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 			setup: func(t *testing.T, lib *config.Library) {
 				if err := os.MkdirAll(lib.Output, 0755); err != nil {
@@ -828,6 +832,7 @@ func TestGenerate_Error(t *testing.T) {
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
+				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 			setup: func(t *testing.T, lib *config.Library) {
 				postProcessorScript := filepath.Join(".librarian", "generator-input", "client-post-processing", "bad.yaml")
@@ -844,6 +849,7 @@ func TestGenerate_Error(t *testing.T) {
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
+				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 			setup: func(t *testing.T, lib *config.Library) {
 				if err := os.MkdirAll(filepath.Join(lib.Output, "docs", "README.rst"), 0755); err != nil {
@@ -940,6 +946,7 @@ func TestGenerate(t *testing.T) {
 						LibraryType: "GAPIC_AUTO",
 					},
 					SkipReadmeCopy: test.skipReadmeCopy,
+					DefaultVersion: "v1",
 				},
 			}
 			if err := Generate(t.Context(), cfg, library, googleapisDir); err != nil {
@@ -1019,6 +1026,7 @@ func TestGenerate_APIOrder(t *testing.T) {
 			{Path: "google/cloud/workflows/executions/v1"},
 		},
 		Python: &config.PythonPackage{
+			DefaultVersion: "v1",
 			PythonDefault: config.PythonDefault{
 				LibraryType: "GAPIC_AUTO",
 			},
@@ -1083,6 +1091,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 				// In normal operation this is populated from the top-level
 				// default.
 				Python: &config.PythonPackage{
+					DefaultVersion: "v1",
 					PythonDefault: config.PythonDefault{
 						LibraryType: "GAPIC_AUTO",
 					},
@@ -1116,6 +1125,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 					},
 				},
 				Python: &config.PythonPackage{
+					DefaultVersion: "v2",
 					PythonDefault: config.PythonDefault{
 						LibraryType: "GAPIC_AUTO",
 					},
@@ -1180,39 +1190,6 @@ func TestCreateRepoMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "default version",
-			library: &config.Library{
-				Name:         "google-cloud-secret-manager",
-				ReleaseLevel: "stable",
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-					},
-				},
-				Python: &config.PythonPackage{
-					PythonDefault: config.PythonDefault{
-						LibraryType: "GAPIC_AUTO",
-					},
-				},
-			},
-			want: &repometadata.RepoMetadata{
-				Name:                 "google-cloud-secret-manager",
-				NamePretty:           "Secret Manager",
-				ProductDocumentation: "https://cloud.google.com/secret-manager/",
-				IssueTracker:         "https://issuetracker.google.com/issues/new?component=784854&template=1380926",
-				ReleaseLevel:         "stable",
-				Language:             config.LanguagePython,
-				Repo:                 "googleapis/google-cloud-python",
-				DistributionName:     "google-cloud-secret-manager",
-				APIID:                "secretmanager.googleapis.com",
-				APIShortname:         "secretmanager",
-				APIDescription:       "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
-				LibraryType:          "GAPIC_AUTO",
-				ClientDocumentation:  "https://cloud.google.com/python/docs/reference/google-cloud-secret-manager/latest",
-				DefaultVersion:       "v1",
-			},
-		},
-		{
 			name: "handwritten library",
 			library: &config.Library{
 				Name:         "google-auth",
@@ -1225,6 +1202,29 @@ func TestCreateRepoMetadata(t *testing.T) {
 			},
 			want: &repometadata.RepoMetadata{
 				Name:                "google-auth",
+				DistributionName:    "google-auth",
+				ClientDocumentation: "https://googleapis.dev/python/google-auth/latest",
+				Language:            config.LanguagePython,
+				LibraryType:         "AUTH",
+				Repo:                "googleapis/google-cloud-python",
+				ReleaseLevel:        "stable",
+			},
+		},
+		{
+			name: "handwritten library with default version",
+			library: &config.Library{
+				Name:         "google-auth",
+				ReleaseLevel: "stable",
+				Python: &config.PythonPackage{
+					DefaultVersion: "oauth2",
+					PythonDefault: config.PythonDefault{
+						LibraryType: "AUTH",
+					},
+				},
+			},
+			want: &repometadata.RepoMetadata{
+				Name:                "google-auth",
+				DefaultVersion:      "oauth2",
 				DistributionName:    "google-auth",
 				ClientDocumentation: "https://googleapis.dev/python/google-auth/latest",
 				Language:            config.LanguagePython,
@@ -1251,21 +1251,46 @@ func TestCreateRepoMetadata(t *testing.T) {
 }
 
 func TestCreateRepoMetadata_Error(t *testing.T) {
-	cfg := &config.Config{
-		Language: config.LanguagePython,
-		Repo:     "googleapis/google-cloud-python",
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		wantErr error
+	}{
+		{
+			name: "invalid API path",
+			library: &config.Library{
+				Name:         "android-library",
+				ReleaseLevel: "stable",
+				APIs:         []*config.API{{Path: "android/notallowed/v1"}},
+				Python:       &config.PythonPackage{DefaultVersion: "v1"},
+			},
+		},
+		{
+			name: "generated library with no default version",
+			library: &config.Library{
+				Name:         "google-cloud-secret-manager",
+				ReleaseLevel: "stable",
+				APIs:         []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+			wantErr: errNoDefaultVersion,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Language: config.LanguagePython,
+				Repo:     "googleapis/google-cloud-python",
+			}
+			_, gotErr := createRepoMetadata(cfg, test.library, googleapisDir)
+			// For errors we can't specify
+			if gotErr == nil {
+				t.Fatal("expected error; got nil")
+			}
+			if test.wantErr != nil && !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("stageProtoFiles error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
 	}
-	library := &config.Library{
-		Name:         "google-cloud-secret-manager",
-		ReleaseLevel: "stable",
-		APIs:         []*config.API{{Path: "android/notallowed/v1"}},
-	}
-	// We don't check what the error is here; there's only one place it can
-	// come, and it's not an error we create ourselves.
-	_, err := createRepoMetadata(cfg, library, googleapisDir)
-	if err == nil {
-		t.Error("expected error, got nil")
-	}
+
 }
 
 func requireSynthtool(t *testing.T) {

--- a/tool/cmd/migrate/legacylibrarian_test.go
+++ b/tool/cmd/migrate/legacylibrarian_test.go
@@ -264,6 +264,7 @@ func TestBuildConfigFromLibrarian(t *testing.T) {
 							},
 						},
 						Python: &config.PythonPackage{
+							DefaultVersion:               "v1",
 							MetadataNameOverride:         "secretmanager",
 							ProductDocumentationOverride: "https://cloud.google.com/secret-manager/",
 							NamePrettyOverride:           "Secret Manager",

--- a/tool/cmd/migrate/python.go
+++ b/tool/cmd/migrate/python.go
@@ -317,7 +317,6 @@ func filterPathsByRegex(paths []string, regexps []*regexp.Regexp) []string {
 func applyRepoMetadata(metadataPath, googleapisDir string, library *config.Library) (*config.Library, error) {
 	defaultTitle := ""
 	defaultDocumentationURI := ""
-	defaultDefaultVersion := ""
 	defaultIssueTracker := ""
 	defaultAPIShortname := ""
 	defaultAPIID := ""
@@ -331,7 +330,6 @@ func applyRepoMetadata(metadataPath, googleapisDir string, library *config.Libra
 		}
 		defaultTitle = strings.TrimSuffix(strings.TrimSpace(apiInfo.Title), " API")
 		defaultDocumentationURI = apiInfo.DocumentationURI
-		defaultDefaultVersion = filepath.Base(library.APIs[0].Path)
 		defaultIssueTracker = apiInfo.NewIssueURI
 		defaultAPIShortname = apiInfo.ShortName
 		defaultAPIID = apiInfo.ServiceName
@@ -365,9 +363,6 @@ func applyRepoMetadata(metadataPath, googleapisDir string, library *config.Libra
 	if repoMetadata.Name != library.Name {
 		library.Python.MetadataNameOverride = repoMetadata.Name
 	}
-	if repoMetadata.DefaultVersion != defaultDefaultVersion {
-		library.Python.DefaultVersion = repoMetadata.DefaultVersion
-	}
 	if repoMetadata.LibraryType != pythonDefaultLibraryType {
 		library.Python.LibraryType = repoMetadata.LibraryType
 	}
@@ -383,6 +378,15 @@ func applyRepoMetadata(metadataPath, googleapisDir string, library *config.Libra
 	if repoMetadata.APIID != defaultAPIID {
 		library.Python.APIIDOverride = repoMetadata.APIID
 	}
+	// Always populate the DefaultVersion field, even if we could have inferred
+	// it. The default version affects the final code, and changes to it should
+	// be explicit - if adding a new version of an API changes the inferred
+	// default version, that would cause compatibility issues. This in itself is
+	// far from ideal; keeping the default version is "safe" but toilsome
+	// operationally.
+	// TODO(https://github.com/googleapis/librarian/issues/4772): design away
+	// from default versions.
+	library.Python.DefaultVersion = repoMetadata.DefaultVersion
 
 	return library, nil
 }

--- a/tool/cmd/migrate/python_test.go
+++ b/tool/cmd/migrate/python_test.go
@@ -64,6 +64,7 @@ func TestBuildPythonLibraries(t *testing.T) {
 						APIShortnameOverride:         "secretmanager",
 						APIIDOverride:                "secretmanager.googleapis.com",
 						ProductDocumentationOverride: "https://cloud.google.com/secret-manager/",
+						DefaultVersion:               "v1",
 						OptArgsByAPI: map[string][]string{
 							"google/cloud/secretmanager/v1": {"warehouse-package-name=google-cloud-secret-manager"},
 						},
@@ -91,6 +92,7 @@ func TestBuildPythonLibraries(t *testing.T) {
 					ReleaseLevel: "preview",
 					APIs:         []*config.API{{Path: "google/cloud/workstations/v1"}},
 					Python: &config.PythonPackage{
+						DefaultVersion:       "v1",
 						IssueTrackerOverride: "https://github.com/googleapis/google-cloud-python/issues",
 					},
 				},
@@ -135,6 +137,7 @@ func TestBuildPythonLibraries(t *testing.T) {
 					ReleaseLevel: "preview",
 					APIs:         []*config.API{{Path: "google/cloud/workstations/v1"}},
 					Python: &config.PythonPackage{
+						DefaultVersion:       "v1",
 						IssueTrackerOverride: "https://github.com/googleapis/google-cloud-python/issues",
 					},
 				},
@@ -209,6 +212,7 @@ func TestBuildPythonLibraries(t *testing.T) {
 								"rest-numeric-enums=False",
 							},
 						},
+						DefaultVersion: "v1",
 					},
 				},
 			},


### PR DESCRIPTION
When migrating libraries, always take the default_version value from the existing .repo-metadata.json file, even if we could infer it.

Even though the default_version can be inferred correctly in many cases at any given snapshot, inferring it at generation time means that the addition of a new API version may well change the inferred value when we don't want it to (because it would be a breaking change). Leaving the default version explicit for now allows us to be conservative and avoid breaking users, at the cost of a little toil when onboarding a new library.

The longer-term problem is captured in #4772 (referenced in both librarian and migrate). Ideally I'd like us to move away from default versions even existing, rather than just doing a better job of inferring them.