### PR TITLE
feat(internal/librarian/nodejs): copy generated samples from staging

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -371,7 +371,10 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 func copySamplesFromStaging(stagingDir, outDir string) error {
 	versions, err := os.ReadDir(stagingDir)
 	if err != nil {
-		return nil // staging dir may not exist
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // staging dir may not exist
+		}
+		return err
 	}
 	for _, v := range versions {
 		if !v.IsDir() {
@@ -379,10 +382,16 @@ func copySamplesFromStaging(stagingDir, outDir string) error {
 		}
 		samplesDir := filepath.Join(stagingDir, v.Name(), "samples")
 		if _, err := os.Stat(samplesDir); err != nil {
-			continue
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return err
 		}
 		if err := filepath.WalkDir(samplesDir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
 				return nil
 			}
 			rel, err := filepath.Rel(samplesDir, path)

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -759,25 +759,26 @@ func TestCopySamplesFromStaging(t *testing.T) {
 	stagingDir := t.TempDir()
 	outDir := t.TempDir()
 
-	// Create v1 with a sample .js file and a snippet_metadata_ file.
-	v1SamplesDir := filepath.Join(stagingDir, "v1", "samples", "generated", "v1")
-	if err := os.MkdirAll(v1SamplesDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(v1SamplesDir, "sample.js"), []byte("console.log('v1');"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(v1SamplesDir, "snippet_metadata_google.cloud.test.v1.json"), []byte(`{"snippets":[]}`), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create v1beta1 with a snippet_metadata_ file.
-	v1beta1SamplesDir := filepath.Join(stagingDir, "v1beta1", "samples", "generated", "v1beta1")
-	if err := os.MkdirAll(v1beta1SamplesDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(v1beta1SamplesDir, "snippet_metadata_google.cloud.test.v1beta1.json"), []byte(`{"snippets":["beta"]}`), 0644); err != nil {
-		t.Fatal(err)
+	for _, v := range []struct {
+		version         string
+		sampleContent   string
+		metadataContent string
+	}{
+		{version: "v1", sampleContent: "console.log('v1');", metadataContent: `{"snippets":[]}`},
+		{version: "v1beta1", metadataContent: `{"snippets":["beta"]}`},
+	} {
+		samplesDir := filepath.Join(stagingDir, v.version, "samples", "generated", v.version)
+		if err := os.MkdirAll(samplesDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if v.sampleContent != "" {
+			if err := os.WriteFile(filepath.Join(samplesDir, "sample.js"), []byte(v.sampleContent), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(samplesDir, "snippet_metadata_google.cloud.test."+v.version+".json"), []byte(v.metadataContent), 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if err := copySamplesFromStaging(stagingDir, outDir); err != nil {


### PR DESCRIPTION
The gapic-generator-typescript writes sample snippets and snippet metadata JSON files to `owl-bot-staging/<lib>/<version>/samples/`, but combine-library only moves src/ and protos/ into the output directory. The generated samples were left behind in staging and deleted during cleanup.

A new copySamplesFromStaging function walks the version directories in staging, copies all sample files into `<outDir>/samples/`, and renames snippet_metadata_ prefixed files to use the snippet_metadata. convention that existing packages follow.

Fixes https://github.com/googleapis/librarian/issues/4752