### PR TITLE
fix(internal/librarian/nodejs): preserve all keep files during combine-library

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -172,20 +172,23 @@ func runPostProcessor(ctx context.Context, library *config.Library, googleapisDi
 	// Librarian CLI tool).
 
 	// combine-library wipes the destination directory before writing generated
-	// files (src/, protos/). Save the non-generated files it would delete, then
-	// restore them afterward.
-	preserveFiles := []string{"librarian.js", ".readme-partials.yaml", "README.md"}
+	// files (src/, protos/). Save the keep files it would delete, then restore
+	// them afterward.
 	backupDir, err := os.MkdirTemp("", "librarian-backup-*")
 	if err != nil {
 		return fmt.Errorf("failed to create backup dir: %w", err)
 	}
 	defer os.RemoveAll(backupDir)
-	for _, name := range preserveFiles {
+	for _, name := range library.Keep {
 		src := filepath.Join(outDir, name)
 		if _, err := os.Stat(src); err != nil {
 			continue // file doesn't exist, nothing to save
 		}
-		if err := os.Rename(src, filepath.Join(backupDir, name)); err != nil {
+		dst := filepath.Join(backupDir, name)
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return fmt.Errorf("failed to create backup subdir for %s: %w", name, err)
+		}
+		if err := os.Rename(src, dst); err != nil {
 			return fmt.Errorf("failed to save %s: %w", name, err)
 		}
 	}
@@ -199,13 +202,17 @@ func runPostProcessor(ctx context.Context, library *config.Library, googleapisDi
 		return fmt.Errorf("combine-library: %w", err)
 	}
 
-	// Restore non-generated files.
-	for _, name := range preserveFiles {
+	// Restore keep files.
+	for _, name := range library.Keep {
 		src := filepath.Join(backupDir, name)
 		if _, err := os.Stat(src); err != nil {
 			continue
 		}
-		if err := os.Rename(src, filepath.Join(outDir, name)); err != nil {
+		dst := filepath.Join(outDir, name)
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return fmt.Errorf("failed to create output subdir for %s: %w", name, err)
+		}
+		if err := os.Rename(src, dst); err != nil {
 			return fmt.Errorf("failed to restore %s: %w", name, err)
 		}
 	}

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -451,7 +451,10 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 	testhelper.RequireCommand(t, "npx")
 
 	repoRoot := t.TempDir()
-	library := &config.Library{Name: "google-cloud-secretmanager"}
+	library := &config.Library{
+		Name: "google-cloud-secretmanager",
+		Keep: []string{"librarian.js", ".readme-partials.yaml", "README.md"},
+	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		t.Fatal(err)
@@ -561,7 +564,10 @@ func TestRunPostProcessor_PreservesFiles(t *testing.T) {
 	testhelper.RequireCommand(t, "compileProtos")
 
 	repoRoot := t.TempDir()
-	library := &config.Library{Name: "google-cloud-test"}
+	library := &config.Library{
+		Name: "google-cloud-test",
+		Keep: []string{"README.md", ".readme-partials.yaml", "system-test/.eslintrc.yml"},
+	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		t.Fatal(err)
@@ -575,6 +581,14 @@ func TestRunPostProcessor_PreservesFiles(t *testing.T) {
 	}
 	partialsContent := "introduction: ''\nbody: ''"
 	if err := os.WriteFile(filepath.Join(outDir, ".readme-partials.yaml"), []byte(partialsContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	eslintContent := "extends: eslint:recommended"
+	eslintDir := filepath.Join(outDir, "system-test")
+	if err := os.MkdirAll(eslintDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(eslintDir, ".eslintrc.yml"), []byte(eslintContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -591,6 +605,13 @@ func TestRunPostProcessor_PreservesFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(outDir, ".readme-partials.yaml")); err != nil {
 		t.Errorf("expected .readme-partials.yaml to be preserved: %v", err)
+	}
+	gotEslint, err := os.ReadFile(filepath.Join(outDir, "system-test", ".eslintrc.yml"))
+	if err != nil {
+		t.Fatalf("expected system-test/.eslintrc.yml to be preserved: %v", err)
+	}
+	if string(gotEslint) != eslintContent {
+		t.Errorf("system-test/.eslintrc.yml content = %q, want %q", string(gotEslint), eslintContent)
 	}
 }
 


### PR DESCRIPTION
runPostProcessor now iterates over library.Keep instead of the previous hardcoded slice. It also creates subdirectories in both the backup and output paths so that keep files in nested directories (e.g. system-test/.eslintrc.yml) are handled correctly.

Fixes https://github.com/googleapis/librarian/issues/4741