### PR TITLE
fix(internal/librarian/rust): check sdk.yaml to determine veneer

### DIFF
--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/repometadata"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	sidekickrust "github.com/googleapis/librarian/internal/sidekick/rust"
 	"github.com/googleapis/librarian/internal/sidekick/rust_prost"
@@ -32,13 +33,26 @@ import (
 )
 
 // IsVeneer reports whether the library has handwritten code wrapping generated
-// code. A library is a veneer when it has Rust module configuration, or when
-// it has no APIs and an explicit output path.
+// code.
+//
+// A library is a veneer when it has Rust module configuration. A library with
+// no APIs and an explicit output is a veneer if its derived API path is not
+// listed in sdk.yaml; libraries whose derived path appears in sdk.yaml are
+// generated libraries whose APIs have not been populated yet (e.g.
+// google-cloud-oslogin-common), not veneers.
 func IsVeneer(lib *config.Library) bool {
 	if lib.Rust != nil && len(lib.Rust.Modules) > 0 {
 		return true
 	}
-	return len(lib.APIs) == 0 && lib.Output != ""
+	if len(lib.APIs) == 0 && lib.Output != "" {
+		// If the derived API path is in sdk.yaml, this is a generated
+		// library whose APIs have not been populated yet, not a veneer.
+		if serviceconfig.HasAPIPath(DeriveAPIPath(lib.Name), config.LanguageRust) {
+			return false
+		}
+		return true
+	}
+	return false
 }
 
 // Generate generates a Rust client library.

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -129,6 +129,14 @@ func TestIsVeneer(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "nosvc library without rust modules",
+			lib: &config.Library{
+				Name:   "google-cloud-oslogin-common",
+				Output: "src/generated/cloud/oslogin/common",
+			},
+			want: false,
+		},
+		{
 			name: "output with api",
 			lib: &config.Library{
 				Name: "google-cloud-api",
@@ -138,6 +146,14 @@ func TestIsVeneer(t *testing.T) {
 				Output: "src/generated/api/types",
 			},
 			want: false,
+		},
+		{
+			name: "handwritten library not in sdk.yaml",
+			lib: &config.Library{
+				Name:   "google-cloud-auth",
+				Output: "src/auth",
+			},
+			want: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -19,6 +19,8 @@ package serviceconfig
 import (
 	_ "embed"
 	"fmt"
+	"slices"
+	"sync"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/yaml"
@@ -142,6 +144,27 @@ var (
 	//    the file as per repository conventions.
 	APIs = unmarshalAPIsOrPanic()
 )
+
+var (
+	apisByPath     map[string]*API
+	apisByPathOnce sync.Once
+)
+
+// HasAPIPath reports whether path matches the Path field of any API in
+// sdk.yaml that is available for the given language.
+func HasAPIPath(path, language string) bool {
+	apisByPathOnce.Do(func() {
+		apisByPath = make(map[string]*API, len(APIs))
+		for i := range APIs {
+			apisByPath[APIs[i].Path] = &APIs[i]
+		}
+	})
+	api, ok := apisByPath[path]
+	if !ok {
+		return false
+	}
+	return len(api.Languages) == 0 || slices.Contains(api.Languages, language)
+}
 
 func unmarshalAPIsOrPanic() []API {
 	apis, err := yaml.Unmarshal[[]API](sdkYaml)

--- a/internal/serviceconfig/api_test.go
+++ b/internal/serviceconfig/api_test.go
@@ -41,6 +41,27 @@ func TestAPIsAlphabeticalOrder(t *testing.T) {
 	}
 }
 
+func TestHasAPIPath(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		path     string
+		language string
+		want     bool
+	}{
+		{"matching path and language", "google/api", config.LanguageRust, true},
+		{"matching path but not language", "google/ads/admanager/v1", config.LanguageRust, false},
+		{"unknown path", "google/does/not/exist/v1", config.LanguageRust, false},
+		{"empty path", "", config.LanguageRust, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := HasAPIPath(test.path, test.language)
+			if got != test.want {
+				t.Errorf("HasAPIPath(%q, %q) = %v, want %v", test.path, test.language, got, test.want)
+			}
+		})
+	}
+}
+
 func TestGetTransport(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
IsVeneer previously treated any library with no APIs and an explicit output path as a veneer. This incorrectly classified nosvc libraries like google-cloud-oslogin-common, which have a known API path in sdk.yaml but no APIs populated yet at the time IsVeneer is called. When treated as a veneer, generateVeneer found no modules and silently produced no output.

IsVeneer now derives the API path from the library name and checks sdk.yaml. If the path is listed, the library is a generated library whose APIs have not been populated yet, not a veneer. Handwritten libraries like google-cloud-auth, whose derived path is not in sdk.yaml, continue to be classified as veneers.

Fixes https://github.com/googleapis/librarian/issues/4786