### PR TITLE
fix(internal/librarian/nodejs): run npm install before formatting

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -465,10 +465,17 @@ func copySamplesFromStaging(stagingDir, outDir string) error {
 	return nil
 }
 
-// Format runs gts (npm run fix) on the library directory.
+// Format runs npm install to restore dependencies, then runs eslint --fix on
+// the library directory.
 func Format(ctx context.Context, library *config.Library) error {
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+
+	// Run npm install to restore node_modules, which may have been removed
+	// by combine-library.
+	if err := command.RunInDir(ctx, library.Output, "npm", "install"); err != nil {
+		return fmt.Errorf("npm install failed: %w", err)
 	}
 
 	// ESLint exit codes:

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -537,9 +537,13 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 
 func TestFormat(t *testing.T) {
 	testhelper.RequireCommand(t, "eslint")
+	testhelper.RequireCommand(t, "npm")
 	outDir := t.TempDir()
 	srcDir := filepath.Join(outDir, "src")
 	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "package.json"), []byte("{}"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	eslintConfig := `{
@@ -911,10 +915,14 @@ func TestFormat_CanceledContext(t *testing.T) {
 
 func TestFormat_ExitCode1(t *testing.T) {
 	testhelper.RequireCommand(t, "eslint")
+	testhelper.RequireCommand(t, "npm")
 
 	outDir := t.TempDir()
 	srcDir := filepath.Join(outDir, "src")
 	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "package.json"), []byte("{}"), 0644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
The Format function runs eslint --fix on the library directory, but combine-library wipes the destination directory including node_modules. This means eslint and its dependencies are not available when Format runs.

This change adds an npm install step before invoking eslint to restore the required dependencies. Tests are updated to include a package.json so npm install succeeds in the test environment.

Fixes https://github.com/googleapis/librarian/issues/4456