### PR TITLE
refactor(internal/config): remove veneer field from Library

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -82,7 +82,6 @@ This document describes the schema for the librarian.yaml.
 | `skip_generate` | bool | Disables code generation for this library. |
 | `skip_release` | bool | Disables release for this library. |
 | `specification_format` | string | Specifies the API specification format. Valid values are "protobuf" (default) or "discovery". |
-| `veneer` | bool | Indicates this library has handwritten code. A veneer may contain generated libraries. |
 | `dotnet` | [DotnetPackage](#dotnetpackage-configuration) (optional) | Contains .NET-specific library configuration. |
 | `dart` | [DartPackage](#dartpackage-configuration) (optional) | Contains Dart-specific library configuration. |
 | `go` | [GoModule](#gomodule-configuration) (optional) | Contains Go-specific library configuration. |
@@ -280,7 +279,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | (embedded) | [RustDefault](#rustdefault-configuration) |  |
-| `modules` | list of [RustModule](#rustmodule-configuration) (optional) | Specifies generation targets for veneer crates. Each module defines a source proto path, output location, and template to use. This is only used when the library has veneer: true. |
+| `modules` | list of [RustModule](#rustmodule-configuration) (optional) | Specifies generation targets for veneer crates. Each module defines a source proto path, output location, and template to use. |
 | `per_service_features` | bool | Enables per-service feature flags. |
 | `module_path` | string | Is the module path for the crate. |
 | `template_override` | string | Overrides the default template. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,10 +198,6 @@ type Library struct {
 	// are "protobuf" (default) or "discovery".
 	SpecificationFormat string `yaml:"specification_format,omitempty"`
 
-	// Veneer indicates this library has handwritten code. A veneer may
-	// contain generated libraries.
-	Veneer bool `yaml:"veneer,omitempty"`
-
 	// Language-specific fields are below.
 
 	// Dotnet contains .NET-specific library configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -91,7 +91,6 @@ func TestRustRead(t *testing.T) {
 			{
 				Name:    "google-cloud-storage",
 				Version: "1.4.0",
-				Veneer:  true,
 				Rust: &RustCrate{
 					Modules: []*RustModule{
 						{

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -205,7 +205,6 @@ type RustCrate struct {
 
 	// Modules specifies generation targets for veneer crates. Each module
 	// defines a source proto path, output location, and template to use.
-	// This is only used when the library has veneer: true.
 	Modules []*RustModule `yaml:"modules,omitempty"`
 
 	// PerServiceFeatures enables per-service feature flags.

--- a/internal/config/testdata/librarian.yaml
+++ b/internal/config/testdata/librarian.yaml
@@ -67,7 +67,6 @@ libraries:
           replace: " \nThe `supports_under` field of the associated `Constraint`  defines whether"
   - name: google-cloud-storage
     version: 1.4.0
-    veneer: true
     rust:
       modules:
         - source: google/storage/v2

--- a/internal/config/testdata/rust/librarian.yaml
+++ b/internal/config/testdata/rust/librarian.yaml
@@ -60,7 +60,6 @@ libraries:
         - rustdoc::bare_urls
   - name: google-cloud-storage
     version: 1.4.0
-    veneer: true
     rust:
       modules:
         - api_path: google/storage/v2

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -167,7 +167,7 @@ func isVeneer(language string, lib *config.Library) bool {
 	if language == config.LanguageRust {
 		return rust.IsVeneer(lib)
 	}
-	return lib.Veneer
+	return false
 }
 
 // libraryOutput returns the output path for a library. If the library has an

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -459,7 +459,7 @@ func TestPrepareLibrary(t *testing.T) {
 		name        string
 		language    string
 		output      string
-		veneer      bool
+		rust        *config.RustCrate
 		apis        []*config.API
 		wantOutput  string
 		wantErr     bool
@@ -492,22 +492,23 @@ func TestPrepareLibrary(t *testing.T) {
 			wantAPIPath: "google/cloud/secretmanager/v1",
 		},
 		{
-			name:        "veneer rust with no apis does not derive path",
-			language:    config.LanguageRust,
-			output:      "src/storage/test/v1",
-			veneer:      true,
-			apis:        nil,
-			wantOutput:  "src/storage/test/v1",
-			wantAPIPath: "",
+			name:       "veneer rust with no apis does not derive path",
+			language:   config.LanguageRust,
+			output:     "src/storage/test/v1",
+			rust:       &config.RustCrate{Modules: []*config.RustModule{{APIPath: "google/storage/v2"}}},
+			apis:       nil,
+			wantOutput: "src/storage/test/v1",
 		},
 		{
-			name:    "veneer without output returns error",
-			veneer:  true,
-			wantErr: true,
+			name:     "veneer without output returns error",
+			language: config.LanguageRust,
+			rust:     &config.RustCrate{Modules: []*config.RustModule{{APIPath: "google/storage/v2"}}},
+			wantErr:  true,
 		},
 		{
 			name:       "veneer with explicit output succeeds",
-			veneer:     true,
+			language:   config.LanguageRust,
+			rust:       &config.RustCrate{Modules: []*config.RustModule{{APIPath: "google/storage/v2"}}},
 			output:     "src/storage",
 			wantOutput: "src/storage",
 		},
@@ -528,8 +529,8 @@ func TestPrepareLibrary(t *testing.T) {
 			lib := &config.Library{
 				Name:   "google-cloud-secretmanager-v1",
 				Output: test.output,
-				Veneer: test.veneer,
 				APIs:   test.apis,
+				Rust:   test.rust,
 			}
 			defaults := &config.Default{
 				Output: "src/generated",

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -41,7 +41,6 @@ func TestGenerateVeneer(t *testing.T) {
 
 	library := &config.Library{
 		Name:          "test-veneer",
-		Veneer:        true,
 		Output:        outDir,
 		CopyrightYear: "2025",
 		Rust: &config.RustCrate{
@@ -176,7 +175,6 @@ func TestGenerateVeneerNoModules(t *testing.T) {
 
 	library := &config.Library{
 		Name:          "test-veneer",
-		Veneer:        true,
 		Output:        outDir,
 		CopyrightYear: "2025",
 		Rust: &config.RustCrate{
@@ -238,7 +236,6 @@ func TestKeepVeneer(t *testing.T) {
 	}
 
 	library := &config.Library{
-		Veneer: true,
 		Output: dir,
 		Rust: &config.RustCrate{
 			Modules: []*config.RustModule{

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -174,8 +174,6 @@ func tidyRustConfig(lib *config.Library) *config.Library {
 		lib.Rust.Modules = deleteEmptyRustModules(lib.Rust.Modules)
 	}
 
-	// TODO(https://github.com/googleapis/librarian/issues/4276): Remove veneer field
-	lib.Veneer = false
 	return lib
 }
 

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -656,7 +656,6 @@ func TestTidy_VeneerSkipGenerate(t *testing.T) {
 		Libraries: []*config.Library{
 			{
 				Name:         "google-cloud-storage",
-				Veneer:       true,
 				SkipGenerate: true,
 				Output:       "src/storage",
 			},

--- a/tool/cmd/migrate/dotnet.go
+++ b/tool/cmd/migrate/dotnet.go
@@ -110,10 +110,6 @@ func buildDotnetConfig(apisJSON *DotnetAPIsJSON, src *config.Source) (*config.Co
 			}
 		}
 
-		if isHandwritten {
-			lib.Veneer = true
-		}
-
 		v := strings.ToLower(api.Version)
 		if strings.Contains(v, "alpha") || strings.Contains(v, "beta") {
 			lib.ReleaseLevel = "preview"

--- a/tool/cmd/migrate/dotnet_test.go
+++ b/tool/cmd/migrate/dotnet_test.go
@@ -111,7 +111,6 @@ func TestBuildDotnetConfig(t *testing.T) {
 				{
 					Name:    "Google.Cloud.Storage.V2",
 					Version: "4.0.0",
-					Veneer:  true,
 				},
 			}),
 		},


### PR DESCRIPTION
Remove unused veneer field from librarian.yaml.

Fixes https://github.com/googleapis/librarian/issues/4276