### PR TITLE
refactor(internal/repometadata): make FromAPI private

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -237,14 +237,10 @@ func postProcessLibrary(cfg *config.Config, library *config.Library, outDir, goo
 // information from the primary service configuration and library-level overrides.
 func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisDir string) (*repoMetadata, error) {
 	serviceconfig.SortAPIs(library.APIs)
-	api, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, config.LanguageJava)
+	sharedMetadata, err := repometadata.FromLibrary(cfg, library, googleapisDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find primary API for path %s: %w", library.APIs[0].Path, err)
+		return nil, err
 	}
-	if api == nil {
-		return nil, fmt.Errorf("failed to find primary API for path %s: not found", library.APIs[0].Path)
-	}
-	sharedMetadata := repometadata.FromAPI(cfg, api, library)
 
 	metadata := &repoMetadata{
 		APIShortname:         sharedMetadata.APIShortname,
@@ -316,7 +312,7 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/java/docs/reference/%s/latest/overview", artifactID)
 	}
 	// transport
-	apiCfg, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageJava)
+	apiCfg, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, config.LanguageJava)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find api config: %w", err)
 	}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -314,7 +314,8 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 	googleapis := "internal/testdata/googleapis"
 
 	cfg := &config.Config{
-		Repo: "googleapis/google-cloud-java",
+		Language: config.LanguageJava,
+		Repo:     "googleapis/google-cloud-java",
 	}
 	library := &config.Library{
 		Name: "secretmanager",

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -340,11 +340,10 @@ func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDi
 	if len(library.APIs) == 0 {
 		return nil
 	}
-	api, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, cfg.Language)
+	metadata, err := repometadata.FromLibrary(cfg, library, googleapisDir)
 	if err != nil {
-		return fmt.Errorf("failed to find API metadata: %w", err)
+		return err
 	}
-	metadata := repometadata.FromAPI(cfg, api, library)
 	metadata.DistributionName = DerivePackageName(library)
 	metadata.DefaultVersion = filepath.Base(library.APIs[0].Path)
 	metadata.LibraryType = repometadata.GAPICAutoLibraryType

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -121,11 +121,11 @@ func FromLibrary(cfg *config.Config, library *config.Library, googleapisDir stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to find API for path %s: %w", firstAPIPath, err)
 	}
-	return FromAPI(cfg, api, library), nil
+	return fromAPI(cfg, api, library), nil
 }
 
-// FromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
-func FromAPI(config *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
+// fromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
+func fromAPI(config *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
 	apiDescription := api.Description
 	if library.DescriptionOverride != "" {
 		apiDescription = library.DescriptionOverride


### PR DESCRIPTION
FromAPI is made private and renamed to fromAPI within the repometadata package. All external callers are updated to use the more comprehensive FromLibrary function which handles API lookup internally.

This refactoring ensures that API discovery and validation are handled consistently by the repometadata package. Tests for the Java post-processor are updated to provide the required language configuration for the new FromLibrary calls.

Fixes #4428