### PR TITLE
feat: enable google-cloud-visionai-v1 for Rust

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -3323,6 +3323,7 @@
     - java
     - nodejs
     - python
+    - rust
 - path: google/cloud/visionai/v1alpha1
   documentation_uri: https://cloud.google.com/vision-ai/docs
   languages:


### PR DESCRIPTION
Should fix https://github.com/googleapis/google-cloud-rust/issues/4987 