### PR TITLE
refactor(internal/config): add LibrarianYAML const for config filename

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,9 @@ package config
 
 //go:generate go run -tags configdocgen ../../cmd/config_doc_generate.go -input . -output ../../doc/config-schema.md
 
+// LibrarianYAML is the filename for the librarian configuration file.
+const LibrarianYAML = "librarian.yaml"
+
 // Config represents a librarian.yaml configuration file.
 type Config struct {
 	// Language is the language for this workspace (go, python, rust).

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -48,7 +48,7 @@ func addCommand() *cli.Command {
 			if len(apis) == 0 {
 				return errMissingAPI
 			}
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -99,7 +99,7 @@ func TestAddLibraryCommand(t *testing.T) {
 			cfg.Default.Output = "output"
 			cfg.Libraries = test.initialLibraries
 			cfg.Sources.Googleapis.Dir = googleapisDir
-			if err := yaml.Write(librarianConfigPath, cfg); err != nil {
+			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
 			err = runAdd(t.Context(), cfg, test.apis...)
@@ -113,7 +113,7 @@ func TestAddLibraryCommand(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gotCfg, err := yaml.Read[config.Config](librarianConfigPath)
+			gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -174,7 +174,7 @@ func TestAddCommand(t *testing.T) {
 			cfg.Default.Output = "output"
 			cfg.Libraries = nil
 			cfg.Sources.Googleapis.Dir = googleapisDir
-			if err := yaml.Write(librarianConfigPath, cfg); err != nil {
+			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
 			args := append([]string{"librarian", "add"}, test.apis...)
@@ -189,7 +189,7 @@ func TestAddCommand(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gotCfg, err := yaml.Read[config.Config](librarianConfigPath)
+			gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -253,7 +253,7 @@ func TestAddLibrary(t *testing.T) {
 					Output: "output/existinglib",
 				},
 			}
-			if err := yaml.Write(librarianConfigPath, cfg); err != nil {
+			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
 			gotName, cfg, err := addLibrary(cfg, test.apis...)

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -94,7 +94,7 @@ Examples:
 			if all && versionOverride != "" {
 				return errBothVersionAndAllFlag
 			}
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}
@@ -277,7 +277,7 @@ func deriveNextVersion(ctx context.Context, gitExe string, cfg *config.Config, l
 }
 
 func loadBranchLibraryVersion(ctx context.Context, gitExe, remote, branch, libName string) (string, error) {
-	branchLibrarianCfgFile, err := git.ShowFileAtRemoteBranch(ctx, gitExe, remote, branch, librarianConfigPath)
+	branchLibrarianCfgFile, err := git.ShowFileAtRemoteBranch(ctx, gitExe, remote, branch, config.LibrarianYAML)
 	if err != nil {
 		return "", err
 	}
@@ -338,7 +338,7 @@ func findReleasedLibraries(cfgBefore, cfgAfter *config.Config) ([]string, error)
 // release process has not yet been completed (e.g. to find which commit
 // *should* be tagged).
 func findLatestReleaseCommitHash(ctx context.Context, gitExe string) (string, error) {
-	commits, err := git.FindCommitsForPath(ctx, gitExe, librarianConfigPath)
+	commits, err := git.FindCommitsForPath(ctx, gitExe, config.LibrarianYAML)
 	if err != nil {
 		return "", err
 	}
@@ -348,7 +348,7 @@ func findLatestReleaseCommitHash(ctx context.Context, gitExe string) (string, er
 	var candidateConfig *config.Config
 	candidateCommit := ""
 	for _, commit := range commits {
-		commitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, commit, librarianConfigPath)
+		commitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, commit, config.LibrarianYAML)
 		if err != nil {
 			return "", err
 		}

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -102,7 +102,7 @@ func TestBumpCommand(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			got, err := yaml.Read[config.Config](librarianConfigPath)
+			got, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -135,7 +135,7 @@ func TestBumpCommandDeriveOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := yaml.Read[config.Config](librarianConfigPath)
+	got, err := yaml.Read[config.Config](config.LibrarianYAML)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1005,13 +1005,13 @@ func TestFindLatestReleaseCommitHash_Error(t *testing.T) {
 		{
 			name: "invalid config file",
 			setup: func(cfg *config.Config) {
-				writeFileAndCommit(t, librarianConfigPath, []byte("not a config file"), "broke config file")
+				writeFileAndCommit(t, config.LibrarianYAML, []byte("not a config file"), "broke config file")
 			},
 		},
 		{
 			name: "deleted config file",
 			setup: func(cfg *config.Config) {
-				if err := os.Remove(librarianConfigPath); err != nil {
+				if err := os.Remove(config.LibrarianYAML); err != nil {
 					t.Fatal(err)
 				}
 				testhelper.RunGit(t, "commit", "-m", "deleted config file", ".")
@@ -1180,7 +1180,7 @@ func TestLegacyRustBump(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			got, err := yaml.Read[config.Config](librarianConfigPath)
+			got, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1364,7 +1364,7 @@ func writeConfigAndCommitWithMessage(t *testing.T, cfg *config.Config, message s
 	if err != nil {
 		t.Fatal(err)
 	}
-	writeFileAndCommit(t, librarianConfigPath, data, message)
+	writeFileAndCommit(t, config.LibrarianYAML, data, message)
 }
 
 func writeFileAndCommit(t *testing.T, path string, content []byte, message string) {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -59,7 +59,7 @@ func generateCommand() *cli.Command {
 			if all && libraryName != "" {
 				return errBothLibraryAndAllFlag
 			}
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -114,7 +114,7 @@ func TestGenerateCommand(t *testing.T) {
 					},
 				},
 			}
-			if err := yaml.Write(filepath.Join(tempDir, librarianConfigPath), cfg); err != nil {
+			if err := yaml.Write(filepath.Join(tempDir, config.LibrarianYAML), cfg); err != nil {
 				t.Fatal(err)
 			}
 
@@ -239,7 +239,7 @@ libraries:
     apis:
       - path: google/cloud/texttospeech/v1
 `, googleapisDir, lib1, lib1Output, lib2, lib2Output)
-			if err := os.WriteFile(filepath.Join(tempDir, librarianConfigPath), []byte(configContent), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tempDir, config.LibrarianYAML), []byte(configContent), 0644); err != nil {
 				t.Fatal(err)
 			}
 			err := Run(t.Context(), test.args...)
@@ -305,7 +305,7 @@ libraries:
       - path: google/cloud/secretmanager/v1
 `, googleapisDir)
 
-	if err := os.WriteFile(filepath.Join(tempDir, librarianConfigPath), []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, config.LibrarianYAML), []byte(configContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -28,10 +28,6 @@ import (
 // ErrLibraryNotFound is returned when the specified library is not found in config.
 var ErrLibraryNotFound = errors.New("library not found")
 
-const (
-	librarianConfigPath = "librarian.yaml"
-)
-
 // Run executes the librarian command with the given arguments.
 func Run(ctx context.Context, args ...string) error {
 	cmd := &cli.Command{

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -54,7 +54,7 @@ func publishCommand() *cli.Command {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}
@@ -103,7 +103,7 @@ func publish(ctx context.Context, cfg *config.Config, releaseCommit string, exec
 		return err
 	}
 	// Reload the config after checking out the release commit.
-	cfg, err = yaml.Read[config.Config](librarianConfigPath)
+	cfg, err = yaml.Read[config.Config](config.LibrarianYAML)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func publish(ctx context.Context, cfg *config.Config, releaseCommit string, exec
 	// findLatestReleaseCommitHash, but keeps the interface simple - and means
 	// that if we want to be able to specify the release commit directly, we
 	// can skip findLatestReleaseCommitHash entirely.)
-	cfgContentBeforeCommit, err := git.ShowFileAtRevision(ctx, gitExe, "HEAD~", librarianConfigPath)
+	cfgContentBeforeCommit, err := git.ShowFileAtRevision(ctx, gitExe, "HEAD~", config.LibrarianYAML)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/tag.go
+++ b/internal/librarian/tag.go
@@ -52,7 +52,7 @@ func tagCommand() *cli.Command {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}
@@ -80,7 +80,7 @@ func tag(ctx context.Context, cfg *config.Config, releaseCommit string, createRe
 		}
 		releaseCommit = latestReleaseCommit
 	}
-	releaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, releaseCommit, librarianConfigPath)
+	releaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, releaseCommit, config.LibrarianYAML)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func tag(ctx context.Context, cfg *config.Config, releaseCommit string, createRe
 	// findLatestReleaseCommitHash, but keeps the interface simple - and means
 	// that if we specify the release commit directly, we can skip
 	// findLatestReleaseCommitHash entirely.)
-	beforeReleaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, releaseCommit+"~", librarianConfigPath)
+	beforeReleaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, releaseCommit+"~", config.LibrarianYAML)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -42,7 +42,7 @@ func tidyCommand() *cli.Command {
 		Usage:     "format and validate librarian.yaml",
 		UsageText: "librarian tidy",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func RunTidyOnConfig(ctx context.Context, repoDir string, cfg *config.Config) er
 		return errNoGoogleapiSourceInfo
 	}
 	cfg.Libraries = tidyLibraries(cfg)
-	return yaml.Write(filepath.Join(repoDir, librarianConfigPath), formatConfig(cfg))
+	return yaml.Write(filepath.Join(repoDir, config.LibrarianYAML), formatConfig(cfg))
 }
 
 func tidyLibraries(cfg *config.Config) []*config.Library {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -162,7 +162,7 @@ func TestFormatConfig(t *testing.T) {
 func TestTidyCommand(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Chdir(tempDir)
-	configPath := filepath.Join(tempDir, librarianConfigPath)
+	configPath := filepath.Join(tempDir, config.LibrarianYAML)
 	configContent := fmt.Sprintf(`language: rust
 version: %s
 sources:
@@ -303,7 +303,7 @@ func TestTidy_DerivableFields(t *testing.T) {
 			if err := RunTidyOnConfig(t.Context(), tempDir, test.config); err != nil {
 				t.Fatal(err)
 			}
-			cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
+			cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -409,7 +409,7 @@ func TestTidy_DerivableOutput(t *testing.T) {
 			if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 				t.Fatal(err)
 			}
-			got, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
+			got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -451,7 +451,7 @@ func TestTidy_DerivableAPIPath(t *testing.T) {
 	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	got, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
+	got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,7 +491,7 @@ func TestTidy_DerivableRoots(t *testing.T) {
 	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	got, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
+	got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +582,7 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 
 			RunTidyOnConfig(t.Context(), tempDir, test.cfg)
 
-			cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
+			cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -643,7 +643,7 @@ func TestTidy_VeneerSkipGenerate(t *testing.T) {
 	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 		t.Fatal(err)
 	}
-	cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, librarianConfigPath))
+	cfg, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarian/update.go
+++ b/internal/librarian/update.go
@@ -63,7 +63,7 @@ func updateCommand() *cli.Command {
 					return fmt.Errorf("%w: %s", errUnknownSource, arg)
 				}
 			}
-			cfg, err := yaml.Read[config.Config](librarianConfigPath)
+			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ func updateSource(endpoints *fetch.Endpoints, repo fetch.Repo, source *config.So
 	if oldCommit != commit || oldSHA256 != sha256 {
 		source.Commit = commit
 		source.SHA256 = sha256
-		if err := yaml.Write(librarianConfigPath, cfg); err != nil {
+		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 			return err
 		}
 	}

--- a/internal/librarian/update_test.go
+++ b/internal/librarian/update_test.go
@@ -119,7 +119,7 @@ func setupTestConfig(t *testing.T, conf *config.Config) string {
 	}
 	tempDir := t.TempDir()
 	t.Chdir(tempDir)
-	configPath := filepath.Join(tempDir, librarianConfigPath)
+	configPath := filepath.Join(tempDir, config.LibrarianYAML)
 	if err := yaml.Write(configPath, conf); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarianops/generate.go
+++ b/internal/librarianops/generate.go
@@ -121,7 +121,7 @@ func processRepo(ctx context.Context, repoName, repoDir, librarianBin string, ve
 	if err := createBranch(ctx, time.Now()); err != nil {
 		return err
 	}
-	cfg, err := yaml.Read[config.Config]("librarian.yaml")
+	cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 	if err != nil {
 		return err
 	}

--- a/internal/librarianops/generate_test.go
+++ b/internal/librarianops/generate_test.go
@@ -56,7 +56,7 @@ func TestGenerateCommand(t *testing.T) {
 			googleapisDir := filepath.Join(wd, "..", "testdata", "googleapis")
 			cfg := sample.Config()
 			cfg.Sources.Googleapis = &config.Source{Dir: googleapisDir}
-			if err := yaml.Write(filepath.Join(repoDir, "librarian.yaml"), cfg); err != nil {
+			if err := yaml.Write(filepath.Join(repoDir, config.LibrarianYAML), cfg); err != nil {
 				t.Fatal(err)
 			}
 			testhelper.RunGit(t, "-C", repoDir, "add", ".")

--- a/internal/librarianops/upgrade.go
+++ b/internal/librarianops/upgrade.go
@@ -94,7 +94,7 @@ func getLibrarianVersionAtMain(ctx context.Context) (string, error) {
 }
 
 func updateLibrarianVersion(version, repoDir string) error {
-	configPath := filepath.Join(repoDir, "librarian.yaml")
+	configPath := filepath.Join(repoDir, config.LibrarianYAML)
 	cfg, err := yaml.Read[config.Config](configPath)
 	if err != nil {
 		return err

--- a/internal/librarianops/upgrade_test.go
+++ b/internal/librarianops/upgrade_test.go
@@ -183,5 +183,5 @@ func TestUpgradeCommand_Error(t *testing.T) {
 
 func generateLibrarianConfigPath(t *testing.T, repoDir string) string {
 	t.Helper()
-	return filepath.Join(repoDir, "librarian.yaml")
+	return filepath.Join(repoDir, config.LibrarianYAML)
 }

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -227,7 +227,7 @@ func addLibrarianConfig(t *testing.T, cfg *config.Config) {
 	if cfg == nil {
 		return
 	}
-	if err := yaml.Write("librarian.yaml", cfg); err != nil {
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 		t.Fatal(err)
 	}
 	RunGit(t, "add", ".")


### PR DESCRIPTION
Add a config.LibrarianYAML constant and use it everywhere, so that the filename is defined in one place.