### PR TITLE
chore(internal/legacylibrarian): remove google-cloud-go generate from automation

### DIFF
--- a/internal/legacylibrarian/legacyautomation/prod/repositories.yaml
+++ b/internal/legacylibrarian/legacyautomation/prod/repositories.yaml
@@ -35,7 +35,6 @@ repositories:
     full-name: https://github.com/googleapis/google-cloud-go
     github-token-secret-name: "google-cloud-go-github-token"
     supported-commands:
-      - generate
       - stage-release
       - publish-release
   - name: "google-cloud-python"


### PR DESCRIPTION
Remove google-cloud-go from generate automation, prepare for librarian Go migration.