### PR TITLE
fix(python): infer release_level from version for handwritten libraries

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -138,11 +138,15 @@ func createRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 	} else {
 		// Handwritten library: populate from scratch (and then apply overrides
 		// as normal).
+		releaseLevel := "stable"
+		if library.Version == "" || strings.HasPrefix(library.Version, "0.") {
+			releaseLevel = "preview"
+		}
 		repoMetadata = &repometadata.RepoMetadata{
 			Name:             library.Name,
 			DistributionName: library.Name,
 			Language:         cfg.Language,
-			ReleaseLevel:     "stable",
+			ReleaseLevel:     releaseLevel,
 			Repo:             cfg.Repo,
 			// Allow even handwritten libraries to specify a default value in
 			// the package options if they want to. This would be unusual, but

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -1173,7 +1173,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "handwritten library",
+			name: "stable handwritten library",
 			library: &config.Library{
 				Name: "google-auth",
 				Python: &config.PythonPackage{
@@ -1181,6 +1181,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 						LibraryType: "AUTH",
 					},
 				},
+				Version: "1.2.3",
 			},
 			want: &repometadata.RepoMetadata{
 				Name:                "google-auth",
@@ -1190,6 +1191,27 @@ func TestCreateRepoMetadata(t *testing.T) {
 				LibraryType:         "AUTH",
 				Repo:                "googleapis/google-cloud-python",
 				ReleaseLevel:        "stable",
+			},
+		},
+		{
+			name: "preview handwritten library",
+			library: &config.Library{
+				Name: "google-auth",
+				Python: &config.PythonPackage{
+					PythonDefault: config.PythonDefault{
+						LibraryType: "AUTH",
+					},
+				},
+				Version: "0.1.2",
+			},
+			want: &repometadata.RepoMetadata{
+				Name:                "google-auth",
+				DistributionName:    "google-auth",
+				ClientDocumentation: "https://googleapis.dev/python/google-auth/latest",
+				Language:            config.LanguagePython,
+				LibraryType:         "AUTH",
+				Repo:                "googleapis/google-cloud-python",
+				ReleaseLevel:        "preview",
 			},
 		},
 		{
@@ -1211,7 +1233,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 				Language:            config.LanguagePython,
 				LibraryType:         "AUTH",
 				Repo:                "googleapis/google-cloud-python",
-				ReleaseLevel:        "stable",
+				ReleaseLevel:        "preview",
 			},
 		},
 	} {


### PR DESCRIPTION
When generating a fully-handwritten library (no APIs) the release_level is inferred from the version: if it's missing or starts with "0." then the release_level is deemed to be "preview". Otherwise, it's "stable".

Towards #4871