### PR TITLE
refactor(internal/fetch): rename Repo type and RepoDir function

### DIFF
--- a/internal/fetch/cache.go
+++ b/internal/fetch/cache.go
@@ -26,7 +26,7 @@ import (
 
 const envLibrarianCache = "LIBRARIAN_CACHE"
 
-// RepoDir downloads a repository tarball and returns the path to the extracted
+// Repo downloads a repository tarball and returns the path to the extracted
 // directory.
 //
 // The cache directory is determined by LIBRARIAN_CACHE environment variable,
@@ -61,7 +61,7 @@ const envLibrarianCache = "LIBRARIAN_CACHE"
 //     through to step 3.
 //  3. Download tarball, compute SHA256, verify it matches expectedSHA256 from
 //     librarian.yaml, extract, and return the path.
-func RepoDir(ctx context.Context, repo, commit, expectedSHA256 string) (string, error) {
+func Repo(ctx context.Context, repo, commit, expectedSHA256 string) (string, error) {
 	cacheDir, err := cacheDir()
 	if err != nil {
 		return "", err

--- a/internal/fetch/cache_test.go
+++ b/internal/fetch/cache_test.go
@@ -111,7 +111,7 @@ func TestExtractDir_Empty(t *testing.T) {
 	}
 }
 
-func TestRepoDir_ExtractedDirExists(t *testing.T) {
+func TestRepo_ExtractedDirExists(t *testing.T) {
 	cachedir := t.TempDir()
 	t.Setenv(envLibrarianCache, cachedir)
 
@@ -123,7 +123,7 @@ func TestRepoDir_ExtractedDirExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := RepoDir(t.Context(), testRepo, testCommit, testSHA256)
+	got, err := Repo(t.Context(), testRepo, testCommit, testSHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestRepoDir_ExtractedDirExists(t *testing.T) {
 	}
 }
 
-func TestRepoDir_TarballExists(t *testing.T) {
+func TestRepo_TarballExists(t *testing.T) {
 	cachedir := t.TempDir()
 	t.Setenv(envLibrarianCache, cachedir)
 
@@ -151,7 +151,7 @@ func TestRepoDir_TarballExists(t *testing.T) {
 	}
 
 	sha := fmt.Sprintf("%x", sha256.Sum256(tarballData))
-	got, err := RepoDir(t.Context(), testRepo, testCommit, sha)
+	got, err := Repo(t.Context(), testRepo, testCommit, sha)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestRepoDir_TarballExists(t *testing.T) {
 	}
 }
 
-func TestRepoDir_MismatchTarball(t *testing.T) {
+func TestRepo_MismatchTarball(t *testing.T) {
 	cache := t.TempDir()
 	t.Setenv(envLibrarianCache, cache)
 	// Set up a mock web server to fetch a tarball.
@@ -203,7 +203,7 @@ func TestRepoDir_MismatchTarball(t *testing.T) {
 	}
 	defer f.Close()
 
-	got, err := RepoDir(t.Context(), repo, testCommit, expectedSHA)
+	got, err := Repo(t.Context(), repo, testCommit, expectedSHA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestRepoDir_MismatchTarball(t *testing.T) {
 	}
 }
 
-func TestRepoDir_Download(t *testing.T) {
+func TestRepo_Download(t *testing.T) {
 	cachedir := t.TempDir()
 	t.Setenv(envLibrarianCache, cachedir)
 
@@ -245,7 +245,7 @@ func TestRepoDir_Download(t *testing.T) {
 
 	repo := strings.TrimPrefix(server.URL, "https://")
 	expectedSHA := fmt.Sprintf("%x", sha256.Sum256(tarballData))
-	got, err := RepoDir(t.Context(), repo, testCommit, expectedSHA)
+	got, err := Repo(t.Context(), repo, testCommit, expectedSHA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestRepoDir_Download(t *testing.T) {
 	}
 }
 
-func TestRepoDir_ContextDeadlineExceeded(t *testing.T) {
+func TestRepo_ContextDeadlineExceeded(t *testing.T) {
 	cachedir := t.TempDir()
 	t.Setenv(envLibrarianCache, cachedir)
 
@@ -281,7 +281,7 @@ func TestRepoDir_ContextDeadlineExceeded(t *testing.T) {
 	defer cancel()
 
 	repo := strings.TrimPrefix(server.URL, "https://")
-	_, err := RepoDir(ctx, repo, testCommit, "any-sha")
+	_, err := Repo(ctx, repo, testCommit, "any-sha")
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
 	}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -54,33 +54,33 @@ type Endpoints struct {
 	Download string
 }
 
-// Repo represents a GitHub repository name.
-type Repo struct {
+// RepoRef represents a GitHub repository name.
+type RepoRef struct {
 	// Branch is the name of the repository branch, such as `master` or `preview`.
 	Branch string
 
 	// Org defines the GitHub organization (or user), that owns the repository.
 	Org string
 
-	// Repo is the name of the repository, such as `googleapis` or `google-cloud-rust`.
-	Repo string
+	// Name is the name of the repository, such as `googleapis` or `google-cloud-rust`.
+	Name string
 }
 
 // repoFromArchiveLink extracts the GitHub account and repository (such as
 // `googleapis/googleapis`, or `googleapis/google-cloud-rust`) from an archive
 // link.
-// Note: This does **not** set [Repo.Branch] as it is not derivable from a
+// Note: This does **not** set [RepoRef.Branch] as it is not derivable from a
 // commit-based archive URL.
-func repoFromArchiveLink(githubDownload, archiveLink string) (*Repo, error) {
+func repoFromArchiveLink(githubDownload, archiveLink string) (*RepoRef, error) {
 	urlPath := strings.TrimPrefix(archiveLink, githubDownload)
 	urlPath = strings.TrimPrefix(urlPath, "/")
 	components := strings.Split(urlPath, "/")
 	if len(components) < 2 {
 		return nil, fmt.Errorf("invalid archive URL %q", archiveLink)
 	}
-	repo := &Repo{
+	repo := &RepoRef{
 		Org:  components[0],
-		Repo: components[1],
+		Name: components[1],
 	}
 	return repo, nil
 }
@@ -131,8 +131,8 @@ func latestSha(query string) (string, error) {
 
 // LatestCommitAndChecksum fetches the latest commit SHA and the SHA256 of the tarball for that
 // commit from the GitHub API for the given repository.
-func LatestCommitAndChecksum(endpoints *Endpoints, repo *Repo) (commit, sha256 string, err error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s", endpoints.API, repo.Org, repo.Repo, repo.Branch)
+func LatestCommitAndChecksum(endpoints *Endpoints, repo *RepoRef) (commit, sha256 string, err error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s", endpoints.API, repo.Org, repo.Name, repo.Branch)
 	commit, err = latestSha(apiURL)
 	if err != nil {
 		return "", "", err
@@ -148,10 +148,10 @@ func LatestCommitAndChecksum(endpoints *Endpoints, repo *Repo) (commit, sha256 s
 
 // tarballLink constructs a GitHub tarball download URL for the given
 // repository and commit SHA.
-// Note: This does **not** incorporate the [Repo.Branch] as this produces a
+// Note: This does **not** incorporate the [RepoRef.Branch] as this produces a
 // commit-based archive URL.
-func tarballLink(githubDownload string, repo *Repo, sha string) string {
-	return fmt.Sprintf("%s/%s/%s/archive/%s.tar.gz", githubDownload, repo.Org, repo.Repo, sha)
+func tarballLink(githubDownload string, repo *RepoRef, sha string) string {
+	return fmt.Sprintf("%s/%s/%s/archive/%s.tar.gz", githubDownload, repo.Org, repo.Name, sha)
 }
 
 // download downloads a file from the given url to the target path, verifying

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -44,9 +44,9 @@ func TestRepoFromArchiveLink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := &Repo{
+	want := &RepoRef{
 		Org:  "org-name",
-		Repo: "repo-name",
+		Name: "repo-name",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -190,19 +190,19 @@ func TestLatestShaError(t *testing.T) {
 func TestTarballLink(t *testing.T) {
 	for _, test := range []struct {
 		githubDownload string
-		repo           *Repo
+		repo           *RepoRef
 		sha            string
 		want           string
 	}{
 		{
 			githubDownload: "https://github.com",
-			repo:           &Repo{Org: "googleapis", Repo: "googleapis"},
+			repo:           &RepoRef{Org: "googleapis", Name: "googleapis"},
 			sha:            "abc123",
 			want:           "https://github.com/googleapis/googleapis/archive/abc123.tar.gz",
 		},
 		{
 			githubDownload: "https://test.example.com",
-			repo:           &Repo{Org: "my-org", Repo: "my-repo"},
+			repo:           &RepoRef{Org: "my-org", Name: "my-repo"},
 			sha:            "def456",
 			want:           "https://test.example.com/my-org/my-repo/archive/def456.tar.gz",
 		},
@@ -592,15 +592,15 @@ func TestLatestCommitAndChecksum(t *testing.T) {
 
 	for _, test := range []struct {
 		name              string
-		repo              *Repo
+		repo              *RepoRef
 		wantCommit        string
 		wantTarballSHA256 string
 	}{
 		{
 			name: "default branch master",
-			repo: &Repo{
+			repo: &RepoRef{
 				Org:    testOrg,
-				Repo:   testRepo,
+				Name:   testRepo,
 				Branch: DefaultBranchMaster,
 			},
 			wantCommit:        expectedMasterCommit,
@@ -608,9 +608,9 @@ func TestLatestCommitAndChecksum(t *testing.T) {
 		},
 		{
 			name: "specific repo branch",
-			repo: &Repo{
+			repo: &RepoRef{
 				Org:    testOrg,
-				Repo:   testRepo,
+				Name:   testRepo,
 				Branch: testBranch,
 			},
 			wantCommit:        expectedBranchCommit,
@@ -705,7 +705,7 @@ func TestLatestCommitAndChecksumFailure(t *testing.T) {
 		defer server.Close()
 
 		endpoints := &Endpoints{API: server.URL, Download: server.URL}
-		repo := &Repo{Org: testOrg, Repo: testRepo}
+		repo := &RepoRef{Org: testOrg, Name: testRepo}
 
 		_, _, err := LatestCommitAndChecksum(endpoints, repo)
 		if err == nil {
@@ -727,7 +727,7 @@ func TestLatestCommitAndChecksumFailure(t *testing.T) {
 		defer server.Close()
 
 		endpoints := &Endpoints{API: server.URL, Download: server.URL}
-		repo := &Repo{Org: testOrg, Repo: testRepo}
+		repo := &RepoRef{Org: testOrg, Name: testRepo}
 
 		_, _, err := LatestCommitAndChecksum(endpoints, repo)
 		if err == nil {

--- a/internal/librarian/source.go
+++ b/internal/librarian/source.go
@@ -102,7 +102,7 @@ func fetchSource(ctx context.Context, source *config.Source, repo string) (strin
 	if source.Dir != "" {
 		return source.Dir, nil
 	}
-	dir, err := fetch.RepoDir(ctx, repo, source.Commit, source.SHA256)
+	dir, err := fetch.Repo(ctx, repo, source.Commit, source.SHA256)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch %s: %w", repo, err)
 	}

--- a/internal/librarian/update.go
+++ b/internal/librarian/update.go
@@ -28,12 +28,12 @@ import (
 var (
 	githubAPI      = "https://api.github.com"
 	githubDownload = "https://github.com"
-	sourceRepos    = map[string]fetch.Repo{
-		"conformance": {Org: "protocolbuffers", Repo: "protobuf", Branch: fetch.DefaultBranchMain},
-		"discovery":   {Org: "googleapis", Repo: "discovery-artifact-manager", Branch: fetch.DefaultBranchMaster},
-		"googleapis":  {Org: "googleapis", Repo: "googleapis", Branch: fetch.DefaultBranchMaster},
-		"protobuf":    {Org: "protocolbuffers", Repo: "protobuf", Branch: fetch.DefaultBranchMain},
-		"showcase":    {Org: "googleapis", Repo: "gapic-showcase", Branch: fetch.DefaultBranchMain},
+	sourceRepos    = map[string]fetch.RepoRef{
+		"conformance": {Org: "protocolbuffers", Name: "protobuf", Branch: fetch.DefaultBranchMain},
+		"discovery":   {Org: "googleapis", Name: "discovery-artifact-manager", Branch: fetch.DefaultBranchMaster},
+		"googleapis":  {Org: "googleapis", Name: "googleapis", Branch: fetch.DefaultBranchMaster},
+		"protobuf":    {Org: "protocolbuffers", Name: "protobuf", Branch: fetch.DefaultBranchMain},
+		"showcase":    {Org: "googleapis", Name: "gapic-showcase", Branch: fetch.DefaultBranchMain},
 	}
 
 	errNoSourcesProvided = errors.New("at least one source must be provided")
@@ -100,7 +100,7 @@ func runUpdate(cfg *config.Config, sourceNames []string) error {
 	return nil
 }
 
-func updateSource(endpoints *fetch.Endpoints, repo fetch.Repo, source *config.Source, cfg *config.Config) error {
+func updateSource(endpoints *fetch.Endpoints, repo fetch.RepoRef, source *config.Source, cfg *config.Config) error {
 	if source == nil {
 		return nil
 	}

--- a/tool/cmd/migrate/legacylibrarian.go
+++ b/tool/cmd/migrate/legacylibrarian.go
@@ -241,9 +241,9 @@ func fetchGoogleapis(ctx context.Context) (*config.Source, error) {
 }
 
 func fetchGoogleapisWithCommit(ctx context.Context, endpoints *fetch.Endpoints, commitish string) (*config.Source, error) {
-	repo := &fetch.Repo{
+	repo := &fetch.RepoRef{
 		Org:    "googleapis",
-		Repo:   "googleapis",
+		Name:   "googleapis",
 		Branch: commitish,
 	}
 	commit, sha256, err := fetch.LatestCommitAndChecksum(endpoints, repo)
@@ -251,7 +251,7 @@ func fetchGoogleapisWithCommit(ctx context.Context, endpoints *fetch.Endpoints, 
 		return nil, err
 	}
 
-	dir, err := fetch.RepoDir(ctx, googleapisRepo, commit, sha256)
+	dir, err := fetch.Repo(ctx, googleapisRepo, commit, sha256)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The Repo struct is renamed to RepoRef to clarify that it holds a reference to a repository (org, name, branch), not the repository itself. The Repo field is renamed to Name since that is what it holds.

RepoDir is renamed to Repo so that callers read as fetch.Repo, which more clearly indicates that the function fetches a repo.