### PR TITLE
fix(python): fix Docker file for dependency versions and installation

### DIFF
--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -186,7 +186,7 @@ ENV PATH=${PATH}:${PYTHONPATH}/bin
 
 # Install Python dependencies, into /python-packages (so it's predictable).
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -t ${PYTHONPATH} --no-cache-dir --break-system-packages \
+    pip install -t ${PYTHONPATH} --no-cache-dir \
     gapic-generator==${PYTHON_GAPIC_VERSION} \
     nox==${NOX_VERSION} \
     ruff==${RUFF_VERSION} \


### PR DESCRIPTION
The PYTHONPATH and SYNTHTOOL_TEMPLATES environment variables are set to avoid synthtool using the latest templates from github. PYTHONPATH is explicitly set so that referring to it in SYNTHTOOL_TEMPLATES doesn't require knowing the version of Python we're using.

The versions of Python dependencies are updated to the latest versions used in google-cloud-python.

Fixes #4846