### PR TITLE
feat(tool/cmd/migrate): add .readme-partials.yaml to nodejs keep list

### DIFF
--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -45,6 +45,7 @@ var nodejsConfigFiles = []string{
 	".prettierignore",
 	".prettierrc.cjs",
 	".prettierrc.js",
+	".readme-partials.yaml",
 	".readme-partials.yml",
 	".repo-metadata.json",
 	"CHANGELOG.md",


### PR DESCRIPTION
Some Node.js libraries use .readme-partials.yaml instead of .readme-partials.yml. Adding the .yaml variant ensures these files are preserved during migration.