### PR TITLE
fix(.github): update gapic-generator-typescript clone URL

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
-    # TODO(https://github.com/googleapis/librarian/issues/4593): 
+    # TODO(https://github.com/googleapis/librarian/issues/4593):
     # gapic-generator-typescript installation takes over 4 minutes.
     # Improve installation speed and revert timeout to 5 minutes.
     timeout-minutes: 6
@@ -42,8 +42,8 @@ jobs:
       - uses: ./.github/actions/install-protoc
       - name: Install gapic-generator-typescript
         run: |
-          git clone --depth 1 https://github.com/googleapis/google-cloud-node-core.git /tmp/google-cloud-node-core
-          cd /tmp/google-cloud-node-core/generator/gapic-generator-typescript
+          git clone --depth 1 https://github.com/googleapis/google-cloud-node.git /tmp/google-cloud-node
+          cd /tmp/google-cloud-node/core/generator/gapic-generator-typescript
           npm install
           npm run compile
           npm link


### PR DESCRIPTION
The google-cloud-node-core repository has been moved into the google-cloud-node repository. This updates the nodejs workflow to clone google-cloud-node and use the core/generator/gapic-generator-typescript path.