### PR TITLE
feat(internal/librarianops): register upgrade command

### DIFF
--- a/internal/librarianops/librarianops.go
+++ b/internal/librarianops/librarianops.go
@@ -44,6 +44,7 @@ func Run(ctx context.Context, args ...string) error {
 		UsageText: "librarianops [command]",
 		Commands: []*cli.Command{
 			generateCommand(),
+			upgradeCommand(),
 		},
 	}
 	return cmd.Run(ctx, args)


### PR DESCRIPTION
The upgradeCommand function was implemented but never added to the Commands list in Run. Register it so that `librarianops upgrade` works.