### PR TITLE
fix(.github/workflows): replace google-cloud-node-core with google-cloud-node

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -40,10 +40,13 @@ jobs:
       - name: Display Python version
         run: python3 --version
       - uses: ./.github/actions/install-protoc
+      - name: Download gapic-generator-typescript
+        run: |
+          mkdir -p /tmp/gapic-generator-typescript
+          curl -sL https://github.com/googleapis/google-cloud-node/archive/refs/heads/main.tar.gz | tar xz --strip-components=3 -C /tmp/gapic-generator-typescript google-cloud-node-main/generator/gapic-generator-typescript
       - name: Install gapic-generator-typescript
         run: |
-          git clone --depth 1 https://github.com/googleapis/google-cloud-node-core.git /tmp/google-cloud-node-core
-          cd /tmp/google-cloud-node-core/generator/gapic-generator-typescript
+          cd /tmp/gapic-generator-typescript
           npm install
           npm run compile
           npm link


### PR DESCRIPTION
The google-cloud-node-core repo has been archived after its contents were moved into the google-cloud-node monorepo. This updates the nodejs workflow to download from google-cloud-node instead.

The download is split into its own step for visibility. Since a shallow clone of google-cloud-node takes over 4 minutes due to the size of the monorepo, this uses a tarball download with extraction of only the gapic-generator-typescript subdirectory.

Fixes https://github.com/googleapis/librarian/issues/4904