### PR TITLE
fix(.github/workflows): replace google-cloud-node-core with google-cloud-node

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -21,7 +21,7 @@ jobs:
     # TODO(https://github.com/googleapis/librarian/issues/4593): 
     # gapic-generator-typescript installation takes over 4 minutes.
     # Improve installation speed and revert timeout to 5 minutes.
-    timeout-minutes: 6
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
The google-cloud-node-core repo has been archived after its contents were moved into the google-cloud-node monorepo. This updates the nodejs workflow to download from google-cloud-node instead.

The download is split into its own step for visibility. Since a shallow clone of google-cloud-node takes over 4 minutes due to the size of the monorepo, this uses a tarball download with extraction of only the gapic-generator-typescript subdirectory.

Fixes https://github.com/googleapis/librarian/issues/4904