### PR TITLE
fix(internal/serviceconfig): update java transport default to GRPCRest

### DIFF
--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -114,7 +114,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 				"artifact=com.google.cloud:google-cloud-secretmanager",
 				"gapic-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_gapic.yaml"),
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
-				"transport=grpc",
+				"transport=grpc+rest",
 				"rest-numeric-enums",
 			},
 		},

--- a/internal/librarian/java/repometadata_test.go
+++ b/internal/librarian/java/repometadata_test.go
@@ -104,7 +104,7 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 		APIDescription:       "Custom description",
 		ClientDocumentation:  "https://custom.client.docs",
 		ReleaseLevel:         s.ReleaseLevel,
-		Transport:            "grpc",
+		Transport:            "both",
 		Language:             cfg.Language,
 		Repo:                 cfg.Repo,
 		RepoShort:            "java-secretmanager",

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -120,17 +120,13 @@ type API struct {
 // Transport gets transport for a given language.
 //
 // If language-specific transport is not defined, it falls back to the "all" language setting,
-// and then to the language-specific default: GRPC for Java, GRPCRest for all others.
+// and then to the default GRPCRest for all languages.
 func (api *API) Transport(language string) Transport {
 	if trans, ok := api.Transports[language]; ok {
 		return trans
 	}
 	if trans, ok := api.Transports[config.LanguageAll]; ok {
 		return trans
-	}
-
-	if language == config.LanguageJava {
-		return GRPC
 	}
 	return GRPCRest
 }

--- a/internal/serviceconfig/api_test.go
+++ b/internal/serviceconfig/api_test.go
@@ -264,12 +264,6 @@ func TestGetTransport(t *testing.T) {
 			want: GRPCRest,
 		},
 		{
-			name: "empty serviceconfig java default",
-			sc:   &API{},
-			lang: config.LanguageJava,
-			want: GRPC,
-		},
-		{
 			name: "go specific transport",
 			sc: &API{
 				Transports: map[string]Transport{
@@ -316,12 +310,6 @@ func TestRepoMetadataTransport(t *testing.T) {
 		language string
 		want     string
 	}{
-		{
-			name:     "java, default",
-			sc:       &API{},
-			language: config.LanguageJava,
-			want:     "grpc",
-		},
 		{
 			name: "java, grpc",
 			sc: &API{


### PR DESCRIPTION
Remove java specific transport default, use grpc+rest as default. This will allow for less diff in generate testing, as we work out final solution for #4912.

Fix #4912