### PR TITLE
chore(internal/serviceconfig): enable geocode for go

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -4066,6 +4066,7 @@
     python: grpc
 - path: google/maps/geocode/v4
   languages:
+    - go
     - python
   release_level:
     python: preview


### PR DESCRIPTION
Enable `google/maps/geocode/v4` for Go.

Internal ticket: b/494641000