### PR TITLE
chore(internal/serviceconfig): add `google/cloud/biglake/hive/v1beta` to allowlist

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -856,6 +856,10 @@
     - go
     - java
     - python
+  release_level:
+    go: beta
+    java: preview
+    python: preview
 - path: google/cloud/biglake/v1
   languages:
     - go


### PR DESCRIPTION
Add `google/cloud/biglake/hive/v1beta` to allowlist for Go, Java and Python.

Internal ticket: b/493630410