### PR TITLE
ci(.github): install tool in unit tests

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -62,6 +62,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
+      - uses: ./.github/actions/install-protoc
+      - name: Install Go tools
+        run: go install tool
       - name: Run tests
         run: |
           go test -race -coverprofile=coverage.out -covermode=atomic \


### PR DESCRIPTION
Install tool before running unit tests to enable all unit tests in golang package.

Fixes #4628