### PR TITLE
chore: increase target coverage of golang package to 80%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -43,9 +43,7 @@ coverage:
         paths:
           - internal/librarian/dart/**
       librarian-golang:
-        # TODO(https://github.com/googleapis/librarian/issues/4662): fix
-        # coverage back to 80%
-        target: 75%
+        target: 80%
         threshold: 0%
         if_ci_failed: error
         paths:


### PR DESCRIPTION
Increase target coverage of golang package to 80%.

Latest test coverage of golang package is 83.5% ([commit](https://github.com/googleapis/librarian/pull/4928)).

Fixes #4662