### PR TITLE
chore(internal/librarian): generate go libraries in parallel

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -169,17 +169,12 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		}
 		return fakePostGenerate()
 	case config.LanguageGo:
-		for _, library := range libraries {
-			// Generation cannot be parallelized because protoc writes to a
-			// shared cloud.google.com/go directory tree under each library's
-			// output, and concurrent MoveAndMerge calls would race.
-			if err := golang.Generate(ctx, library, src); err != nil {
-				return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
-			}
-		}
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {
 			g.Go(func() error {
+				if err := golang.Generate(gctx, library, src); err != nil {
+					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+				}
 				if err := golang.Format(gctx, library); err != nil {
 					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
 				}


### PR DESCRIPTION
Generate Go libraries in parallel.

We updated the generation to run in sequence because all libraries are generated into a shared location.

In #4577, we updated the library output to {repo name}/{library name} so library output is different from each other.

Fixes #4939