### PR TITLE
chore(internal/legacylibrarian): block update-image command in release only mode

### DIFF
--- a/internal/legacylibrarian/legacylibrarian/update_image.go
+++ b/internal/legacylibrarian/legacylibrarian/update_image.go
@@ -83,6 +83,9 @@ func newUpdateImageRunner(cfg *legacyconfig.Config) (*updateImageRunner, error) 
 }
 
 func (r *updateImageRunner) run(ctx context.Context) error {
+	if r.librarianConfig != nil && r.librarianConfig.ReleaseOnlyMode {
+		return errGenerateInReleaseOnlyMode
+	}
 	imagesClient := r.imagesClient
 	if imagesClient == nil {
 		slog.Info("no imagesClient provided, defaulting to ArtifactRegistry implementation")

--- a/internal/legacylibrarian/legacylibrarian/update_image_test.go
+++ b/internal/legacylibrarian/legacylibrarian/update_image_test.go
@@ -760,6 +760,21 @@ func TestUpdateImageRunnerRun(t *testing.T) {
 			wantBuildCalls:      0,
 			wantCheckoutCalls:   1,
 		},
+		{
+			name: "update-image in release only mode returns error",
+			librarianConfig: &legacyconfig.LibrarianConfig{
+				ReleaseOnlyMode: true,
+			},
+			containerClient:     &mockContainerClient{},
+			imagesClient:        &mockImagesClient{},
+			ghClient:            &mockGitHubClient{},
+			wantFindLatestCalls: 0,
+			wantGenerateCalls:   0,
+			wantBuildCalls:      0,
+			wantCheckoutCalls:   0,
+			wantErr:             true,
+			wantErrMsg:          "generate in release only mode",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			testRepo := newTestGitRepoWithState(t, test.state)


### PR DESCRIPTION
When `ReleaseOnlyMode` is enabled in the configuration, the `update-image` command now returns an error instead of proceeding.

This ensures that generation tasks through updating image are not executed when the system is specifically configured for release-only mode.

Fixes #4958