### PR TITLE
Revert "chore(internal/librarian): generate go libraries in parallel"

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -169,12 +169,17 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		}
 		return fakePostGenerate()
 	case config.LanguageGo:
+		for _, library := range libraries {
+			// Generation cannot be parallelized because protoc writes to a
+			// shared cloud.google.com/go directory tree under each library's
+			// output, and concurrent MoveAndMerge calls would race.
+			if err := golang.Generate(ctx, library, src); err != nil {
+				return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+			}
+		}
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {
 			g.Go(func() error {
-				if err := golang.Generate(gctx, library, src); err != nil {
-					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
-				}
 				if err := golang.Format(gctx, library); err != nil {
 					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
 				}


### PR DESCRIPTION
Reverts googleapis/librarian#4944 because we've seen two related issues, #4963 and #4959.