### PR TITLE
fix(python): remove transport from .repo-metadata.json

### DIFF
--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -956,7 +956,6 @@ func TestGenerate(t *testing.T) {
 				APIID:                "secretmanager.googleapis.com",
 				APIShortname:         "secretmanager",
 				APIDescription:       "Stores, manages, and secures access to application secrets.",
-				Transport:            "grpc+rest",
 				// Fields set by Generate.
 				LibraryType:         "GAPIC_AUTO",
 				ClientDocumentation: "https://cloud.google.com/python/docs/reference/secretmanager/latest",
@@ -1098,7 +1097,6 @@ func TestCreateRepoMetadata(t *testing.T) {
 				LibraryType:          "GAPIC_AUTO",
 				ClientDocumentation:  "https://cloud.google.com/python/docs/reference/google-cloud-secret-manager/latest",
 				DefaultVersion:       "v1",
-				Transport:            "grpc+rest",
 			},
 		},
 		{
@@ -1132,7 +1130,6 @@ func TestCreateRepoMetadata(t *testing.T) {
 				LibraryType:          "GAPIC_AUTO",
 				ClientDocumentation:  "https://googleapis.dev/python/google-apps-meet/latest",
 				DefaultVersion:       "v2",
-				Transport:            "grpc+rest",
 			},
 		},
 		{
@@ -1173,7 +1170,6 @@ func TestCreateRepoMetadata(t *testing.T) {
 				LibraryType:          "CORE",
 				ClientDocumentation:  "overridden client_documentation",
 				DefaultVersion:       "v1beta1",
-				Transport:            "grpc+rest",
 			},
 		},
 		{

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -42,8 +42,8 @@ func TestFromLibrary(t *testing.T) {
 				ProductDocumentation: "https://cloud.google.com/secret-manager/",
 				IssueTracker:         "https://issuetracker.google.com/issues/new?component=784854&template=1380926",
 				ReleaseLevel:         "stable",
-				Language:             config.LanguagePython,
-				Repo:                 "googleapis/google-cloud-python",
+				Language:             config.LanguageNodejs,
+				Repo:                 "googleapis/google-cloud-node",
 				DistributionName:     "google-cloud-secret-manager",
 				APIID:                "secretmanager.googleapis.com",
 				APIShortname:         "secretmanager",
@@ -64,8 +64,8 @@ func TestFromLibrary(t *testing.T) {
 				ProductDocumentation: "https://cloud.google.com/secret-manager/",
 				IssueTracker:         "https://issuetracker.google.com/issues/new?component=784854&template=1380926",
 				ReleaseLevel:         "stable",
-				Language:             config.LanguagePython,
-				Repo:                 "googleapis/google-cloud-python",
+				Language:             config.LanguageNodejs,
+				Repo:                 "googleapis/google-cloud-node",
 				DistributionName:     "google-cloud-secret-manager",
 				APIID:                "secretmanager.googleapis.com",
 				APIShortname:         "secretmanager",
@@ -84,7 +84,6 @@ func TestFromLibrary(t *testing.T) {
 				Language:         config.LanguagePython,
 				Repo:             "googleapis/google-cloud-python",
 				DistributionName: "google-longrunning",
-				Transport:        "grpc+rest",
 			},
 		},
 	} {
@@ -96,8 +95,8 @@ func TestFromLibrary(t *testing.T) {
 			}
 
 			cfg := &config.Config{
-				Language: config.LanguagePython,
-				Repo:     "googleapis/google-cloud-python",
+				Language: test.want.Language,
+				Repo:     test.want.Repo,
 			}
 
 			got, err := FromLibrary(cfg, test.library, "../testdata/googleapis")

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -191,8 +191,15 @@ func (api *API) RepoMetadataReleaseLevel(language string) string {
 // TODO(https://github.com/googleapis/librarian/issues/4854): delete
 // once the issue is resolved.
 // For Java, it maps the transport to "grpc", "http", or "both".
+// TODO(https://github.com/googleapis/librarian/issues/5000): remove the
+// Python exclusion, or change the comments.
+// For Python, transport is currently excluded to reduce the difference during
+// migration.
 func (api *API) RepoMetadataTransport(language string) string {
 	transport := api.Transport(language)
+	if language == config.LanguagePython {
+		return ""
+	}
 	if language == config.LanguageJava {
 		switch transport {
 		case GRPC:

--- a/internal/serviceconfig/api_test.go
+++ b/internal/serviceconfig/api_test.go
@@ -333,6 +333,20 @@ func TestRepoMetadataTransport(t *testing.T) {
 			want:     "grpc+rest",
 		},
 		{
+			name: "python, grpc",
+			sc: &API{
+				Transports: map[string]Transport{config.LanguagePython: GRPC},
+			},
+			language: config.LanguagePython,
+			want:     "",
+		},
+		{
+			name:     "python, default",
+			sc:       &API{},
+			language: config.LanguagePython,
+			want:     "",
+		},
+		{
 			name: "non-java, grpc",
 			sc: &API{
 				Transports: map[string]Transport{config.LanguageGo: GRPC},


### PR DESCRIPTION
The transport value for .repo-metadata.json is returned as an empty string for Python, regardless of the actual transport. This is to reduce differences in .repo-metadata.json files during migration. Issue #5000 tracks either including this again, or potentially leaving it out forever.

The test changes check that we're still populating the transport field, but using a single language for all cases turns out to be difficult, so we take the language and repo from the expected output.

Fixes #4984.