### PR TITLE
fix(librarian/golang): change writeLicenseHeader to accept io.Writer

### DIFF
--- a/internal/librarian/golang/version.go
+++ b/internal/librarian/golang/version.go
@@ -16,6 +16,7 @@ package golang
 
 import (
 	_ "embed"
+	"io"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -90,17 +91,17 @@ func generateClientVersionFile(library *config.Library, goAPI *config.GoAPI) (er
 	})
 }
 
-// writeLicenseHeader writes the license header as Go comments to the given file.
-func writeLicenseHeader(f *os.File, year string) error {
+// writeLicenseHeader writes the license header as Go comments to the given writer.
+func writeLicenseHeader(w io.Writer, year string) error {
 	if year == "" {
 		year = time.Now().Format("2006")
 	}
 	for _, line := range license.Header(year) {
-		if _, err := f.WriteString("//" + line + "\n"); err != nil {
+		if _, err := io.WriteString(w, "//"+line+"\n"); err != nil {
 			return err
 		}
 	}
-	if _, err := f.WriteString("\n"); err != nil {
+	if _, err := io.WriteString(w, "\n"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
writeLicenseHeader only calls WriteString on its argument, so it does not need the concrete *os.File type. Use io.Writer instead, which is more idiomatic and makes the function usable in contexts without real files.