### PR TITLE
feat(sidekick/swift): bootstrap comment formatting

### DIFF
--- a/internal/sidekick/swift/format_documentation.go
+++ b/internal/sidekick/swift/format_documentation.go
@@ -22,5 +22,8 @@ import "strings"
 // Both Swift and the Protobuf comments use markdown, but our markdown includes cross-reference
 // links and sometimes needs cleaning up work correctly on a different markdown engine.
 func (codec *codec) formatDocumentation(doc string) []string {
+	if doc == "" {
+		return nil
+	}
 	return strings.Split(doc, "\n")
 }

--- a/internal/sidekick/swift/format_documentation_test.go
+++ b/internal/sidekick/swift/format_documentation_test.go
@@ -31,7 +31,7 @@ func TestFormatDocumentation(t *testing.T) {
 		{
 			name: "empty",
 			doc:  "",
-			want: []string{""},
+			want: nil,
 		},
 		{
 			name: "single line",


### PR DESCRIPTION
In this change we introduce a function to format the markdown comments. This function is pretty trivial, but I expect it will grow in complexity as we deal with cross-reference links, and maybe some clean ups to make the output documentation not suck.

Part of the work for #5037 