### PR TITLE
cleanup(sidekick/swift): gemini review

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -24,10 +24,10 @@ type fieldAnnotations struct {
 }
 
 func (codec *codec) annotateField(field *api.Field) *fieldAnnotations {
-	fieldAnnotations := &fieldAnnotations{
+	annotations := &fieldAnnotations{
 		Name:     camelCase(field.Name),
 		DocLines: codec.formatDocumentation(field.Documentation),
 	}
-	field.Codec = fieldAnnotations
-	return fieldAnnotations
+	field.Codec = annotations
+	return annotations
 }


### PR DESCRIPTION
I did not wait for the review, and it reported that shadowing the type name was not a good idea. Make sense, fixing here.

Follow up from #5054. 