### PR TITLE
fix(internal/librarian/java): respect distribution override and unify coordinate logic

### DIFF
--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -180,12 +180,7 @@ func detectIndentation(content string, index int) string {
 // to ensure its dependency list is fully synchronized.
 func collectModules(library *config.Library, libraryDir, monorepoVersion string, metadata *repoMetadata, transports map[string]serviceconfig.Transport) ([]javaModule, error) {
 	var modules []javaModule
-	gapicCoord := deriveGAPICCoordinates(library)
-	parentCoord := coordinates{
-		GroupID:    gapicCoord.GroupID,
-		ArtifactID: fmt.Sprintf("%s-parent", gapicCoord.ArtifactID),
-		Version:    library.Version,
-	}
+	libCoords := deriveLibCoords(library)
 
 	protoModules := make([]coordinates, 0, len(library.APIs))
 	grpcModules := make([]coordinates, 0, len(library.APIs))
@@ -195,25 +190,25 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 			return nil, fmt.Errorf("failed to extract version from API path %q", api.Path)
 		}
 
-		moduleCoords := deriveModuleCoordinates(gapicCoord, version)
+		coords := deriveAPICoords(libCoords, version)
 
 		transport := transports[api.Path]
 		data := grpcProtoPomData{
-			Proto:          moduleCoords.proto,
-			Grpc:           moduleCoords.grpc,
-			Parent:         parentCoord,
-			MainArtifactID: gapicCoord.ArtifactID,
+			Proto:          coords.proto,
+			Grpc:           coords.grpc,
+			Parent:         libCoords.parent,
+			MainArtifactID: libCoords.gapic.ArtifactID,
 			Version:        library.Version,
 		}
 
 		// Proto module
-		protoDir := filepath.Join(libraryDir, moduleCoords.proto.ArtifactID)
+		protoDir := filepath.Join(libraryDir, coords.proto.ArtifactID)
 		isProtoMissing, err := isPomMissing(protoDir)
 		if err != nil {
 			return nil, err
 		}
 		modules = append(modules, javaModule{
-			artifactID:   moduleCoords.proto.ArtifactID,
+			artifactID:   coords.proto.ArtifactID,
 			dir:          protoDir,
 			isMissing:    isProtoMissing,
 			templateData: data,
@@ -223,13 +218,13 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 
 		// gRPC module
 		if transport == serviceconfig.GRPC || transport == serviceconfig.GRPCRest {
-			grpcDir := filepath.Join(libraryDir, moduleCoords.grpc.ArtifactID)
+			grpcDir := filepath.Join(libraryDir, coords.grpc.ArtifactID)
 			isGrpcMissing, err := isPomMissing(grpcDir)
 			if err != nil {
 				return nil, err
 			}
 			modules = append(modules, javaModule{
-				artifactID:   moduleCoords.grpc.ArtifactID,
+				artifactID:   coords.grpc.ArtifactID,
 				dir:          grpcDir,
 				isMissing:    isGrpcMissing,
 				templateData: data,
@@ -240,44 +235,43 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 	}
 
 	// Client module
-	clientDir := filepath.Join(libraryDir, gapicCoord.ArtifactID)
+	clientDir := filepath.Join(libraryDir, libCoords.gapic.ArtifactID)
 	isClientMissing, err := isPomMissing(clientDir)
 	if err != nil {
 		return nil, err
 	}
 	modules = append(modules, javaModule{
-		artifactID: gapicCoord.ArtifactID,
+		artifactID: libCoords.gapic.ArtifactID,
 		dir:        clientDir,
 		isMissing:  isClientMissing,
 		templateData: clientPomData{
-			Client:       gapicCoord,
+			Client:       libCoords.gapic,
 			Version:      library.Version,
 			Name:         metadata.NamePretty,
 			Description:  metadata.APIDescription,
-			Parent:       parentCoord,
+			Parent:       libCoords.parent,
 			ProtoModules: protoModules,
 			GrpcModules:  grpcModules,
 		},
 		template: clientPomTemplateName,
 	})
 
-	allModules := []coordinates{gapicCoord}
+	allModules := []coordinates{libCoords.gapic}
 	allModules = append(allModules, grpcModules...)
 	allModules = append(allModules, protoModules...)
 
 	// BOM module
-	bomArtifactID := fmt.Sprintf("%s-bom", gapicCoord.ArtifactID)
-	bomDir := filepath.Join(libraryDir, bomArtifactID)
+	bomDir := filepath.Join(libraryDir, libCoords.bom.ArtifactID)
 	isBomMissing, err := isPomMissing(bomDir)
 	if err != nil {
 		return nil, err
 	}
 	modules = append(modules, javaModule{
-		artifactID: bomArtifactID,
+		artifactID: libCoords.bom.ArtifactID,
 		dir:        bomDir,
 		isMissing:  isBomMissing,
 		templateData: bomParentPomData{
-			MainModule:      gapicCoord,
+			MainModule:      libCoords.gapic,
 			Name:            metadata.NamePretty,
 			MonorepoVersion: monorepoVersion,
 			Modules:         allModules,
@@ -292,11 +286,11 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 		return nil, err
 	}
 	modules = append(modules, javaModule{
-		artifactID: parentCoord.ArtifactID,
+		artifactID: libCoords.parent.ArtifactID,
 		dir:        parentDir,
 		isMissing:  isParentMissing,
 		templateData: bomParentPomData{
-			MainModule:      gapicCoord,
+			MainModule:      libCoords.gapic,
 			Name:            metadata.NamePretty,
 			MonorepoVersion: monorepoVersion,
 			Modules:         allModules,

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -46,8 +46,8 @@ type postProcessParams struct {
 func (p postProcessParams) gapicDir() string { return filepath.Join(p.outDir, p.version, "gapic") }
 func (p postProcessParams) grpcDir() string  { return filepath.Join(p.outDir, p.version, "grpc") }
 func (p postProcessParams) protoDir() string { return filepath.Join(p.outDir, p.version, "proto") }
-func (p postProcessParams) modules() javaModules {
-	return deriveModuleCoordinates(deriveGAPICCoordinates(p.library), p.version)
+func (p postProcessParams) coords() apiCoords {
+	return deriveAPICoords(deriveLibCoords(p.library), p.version)
 }
 
 func postProcessAPI(ctx context.Context, p postProcessParams) error {
@@ -81,8 +81,8 @@ func postProcessAPI(ctx context.Context, p postProcessParams) error {
 	}
 
 	// Generate clirr-ignored-differences.xml for the proto module.
-	modules := p.modules()
-	protoModuleRoot := filepath.Join(p.outDir, modules.proto.ArtifactID)
+	coords := p.coords()
+	protoModuleRoot := filepath.Join(p.outDir, coords.proto.ArtifactID)
 	if err := generateClirr(protoModuleRoot); err != nil {
 		return fmt.Errorf("failed to generate clirr ignore file: %w", err)
 	}
@@ -128,13 +128,19 @@ func buildLicenseText(year int) string {
 	return b.String()
 }
 
-type javaModules struct {
-	gapic coordinates
+type libCoords struct {
+	gapic  coordinates
+	parent coordinates
+	bom    coordinates
+}
+
+type apiCoords struct {
+	libCoords
 	proto coordinates
 	grpc  coordinates
 }
 
-func deriveGAPICCoordinates(library *config.Library) coordinates {
+func deriveLibCoords(library *config.Library) libCoords {
 	distName := deriveDistributionName(library)
 	parts := strings.SplitN(distName, ":", 2)
 	groupID := parts[0]
@@ -142,26 +148,39 @@ func deriveGAPICCoordinates(library *config.Library) coordinates {
 	if len(parts) == 2 {
 		artifactID = parts[1]
 	}
-	return coordinates{
+	gapic := coordinates{
 		GroupID:    groupID,
 		ArtifactID: artifactID,
 		Version:    library.Version,
 	}
+	return libCoords{
+		gapic: gapic,
+		parent: coordinates{
+			GroupID:    gapic.GroupID,
+			ArtifactID: fmt.Sprintf("%s-parent", gapic.ArtifactID),
+			Version:    gapic.Version,
+		},
+		bom: coordinates{
+			GroupID:    gapic.GroupID,
+			ArtifactID: fmt.Sprintf("%s-bom", gapic.ArtifactID),
+			Version:    gapic.Version,
+		},
+	}
 }
 
-func deriveModuleCoordinates(gapic coordinates, version string) javaModules {
-	protoGrpcGroupID := protoGroupID(gapic.GroupID)
-	return javaModules{
-		gapic: gapic,
+func deriveAPICoords(lc libCoords, version string) apiCoords {
+	protoGrpcGroupID := protoGroupID(lc.gapic.GroupID)
+	return apiCoords{
+		libCoords: lc,
 		proto: coordinates{
 			GroupID:    protoGrpcGroupID,
-			ArtifactID: fmt.Sprintf("%s%s-%s", protoPrefix, gapic.ArtifactID, version),
-			Version:    gapic.Version,
+			ArtifactID: fmt.Sprintf("%s%s-%s", protoPrefix, lc.gapic.ArtifactID, version),
+			Version:    lc.gapic.Version,
 		},
 		grpc: coordinates{
 			GroupID:    protoGrpcGroupID,
-			ArtifactID: fmt.Sprintf("%s%s-%s", grpcPrefix, gapic.ArtifactID, version),
-			Version:    gapic.Version,
+			ArtifactID: fmt.Sprintf("%s%s-%s", grpcPrefix, lc.gapic.ArtifactID, version),
+			Version:    lc.gapic.Version,
 		},
 	}
 }
@@ -214,7 +233,7 @@ func restructure(actions []moveAction) error {
 // tree into the destination root directory for GAPIC, Proto, gRPC, and samples.
 // It also copies the relevant proto files into the proto module.
 func restructureModules(p postProcessParams, destRoot string) error {
-	modules := p.modules()
+	coords := p.coords()
 	tempProtoSrcDir := p.protoDir()
 	if err := removeConflictingFiles(tempProtoSrcDir); err != nil {
 		return err
@@ -222,27 +241,27 @@ func restructureModules(p postProcessParams, destRoot string) error {
 	actions := []moveAction{
 		{
 			src:         tempProtoSrcDir,
-			dest:        filepath.Join(destRoot, modules.proto.ArtifactID, "src", "main", "java"),
+			dest:        filepath.Join(destRoot, coords.proto.ArtifactID, "src", "main", "java"),
 			description: "proto source",
 		},
 		{
 			src:         p.grpcDir(),
-			dest:        filepath.Join(destRoot, modules.grpc.ArtifactID, "src", "main", "java"),
+			dest:        filepath.Join(destRoot, coords.grpc.ArtifactID, "src", "main", "java"),
 			description: "grpc source",
 		},
 		{
 			src:         filepath.Join(p.gapicDir(), "src", "main"),
-			dest:        filepath.Join(destRoot, modules.gapic.ArtifactID, "src", "main"),
+			dest:        filepath.Join(destRoot, coords.gapic.ArtifactID, "src", "main"),
 			description: "gapic source",
 		},
 		{
 			src:         filepath.Join(p.gapicDir(), "src", "test"),
-			dest:        filepath.Join(destRoot, modules.gapic.ArtifactID, "src", "test"),
+			dest:        filepath.Join(destRoot, coords.gapic.ArtifactID, "src", "test"),
 			description: "gapic test",
 		},
 		{
 			src:         filepath.Join(p.gapicDir(), "proto", "src", "main", "java"),
-			dest:        filepath.Join(destRoot, modules.proto.ArtifactID, "src", "main", "java"),
+			dest:        filepath.Join(destRoot, coords.proto.ArtifactID, "src", "main", "java"),
 			description: "resource name source",
 		},
 	}
@@ -257,7 +276,7 @@ func restructureModules(p postProcessParams, destRoot string) error {
 		return err
 	}
 	// Copy proto files to proto-*/src/main/proto
-	protoFilesDestDir := filepath.Join(destRoot, modules.proto.ArtifactID, "src", "main", "proto")
+	protoFilesDestDir := filepath.Join(destRoot, coords.proto.ArtifactID, "src", "main", "proto")
 	if err := copyProtos(p.googleapisDir, p.apiProtos, protoFilesDestDir); err != nil {
 		return fmt.Errorf("failed to copy proto files: %w", err)
 	}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -405,11 +405,11 @@ func TestAddMissingHeaders(t *testing.T) {
 	}
 }
 
-func TestDeriveGAPICCoordinates(t *testing.T) {
+func TestDeriveLibCoords(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		library *config.Library
-		want    coordinates
+		want    libCoords
 	}{
 		{
 			name: "default case",
@@ -417,10 +417,22 @@ func TestDeriveGAPICCoordinates(t *testing.T) {
 				Name:    "secretmanager",
 				Version: "1.2.3",
 			},
-			want: coordinates{
-				GroupID:    "com.google.cloud",
-				ArtifactID: "google-cloud-secretmanager",
-				Version:    "1.2.3",
+			want: libCoords{
+				gapic: coordinates{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-cloud-secretmanager",
+					Version:    "1.2.3",
+				},
+				parent: coordinates{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-cloud-secretmanager-parent",
+					Version:    "1.2.3",
+				},
+				bom: coordinates{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-cloud-secretmanager-bom",
+					Version:    "1.2.3",
+				},
 			},
 		},
 		{
@@ -432,36 +444,50 @@ func TestDeriveGAPICCoordinates(t *testing.T) {
 					DistributionNameOverride: "com.google.cloud:google-secretmanager",
 				},
 			},
-			want: coordinates{
-				GroupID:    "com.google.cloud",
-				ArtifactID: "google-secretmanager",
-				Version:    "1.2.3",
+			want: libCoords{
+				gapic: coordinates{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-secretmanager",
+					Version:    "1.2.3",
+				},
+				parent: coordinates{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-secretmanager-parent",
+					Version:    "1.2.3",
+				},
+				bom: coordinates{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-secretmanager-bom",
+					Version:    "1.2.3",
+				},
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := deriveGAPICCoordinates(test.library)
-			if diff := cmp.Diff(test.want, got); diff != "" {
+			got := deriveLibCoords(test.library)
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(libCoords{}, coordinates{})); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeriveModuleNames(t *testing.T) {
+func TestDeriveAPICoords(t *testing.T) {
 	for _, test := range []struct {
 		name      string
-		gapic     coordinates
+		lc        libCoords
 		version   string
 		wantProto coordinates
 		wantGrpc  coordinates
 	}{
 		{
 			name: "standard cloud mapping",
-			gapic: coordinates{
-				GroupID:    "com.google.cloud",
-				ArtifactID: "google-cloud-secretmanager",
-				Version:    "1.2.3",
+			lc: libCoords{
+				gapic: coordinates{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-cloud-secretmanager",
+					Version:    "1.2.3",
+				},
 			},
 			version: "v1",
 			wantProto: coordinates{
@@ -477,10 +503,12 @@ func TestDeriveModuleNames(t *testing.T) {
 		},
 		{
 			name: "non-cloud mapping",
-			gapic: coordinates{
-				GroupID:    "com.google.maps",
-				ArtifactID: "google-maps-places",
-				Version:    "1.2.3",
+			lc: libCoords{
+				gapic: coordinates{
+					GroupID:    "com.google.maps",
+					ArtifactID: "google-maps-places",
+					Version:    "1.2.3",
+				},
 			},
 			version: "v1",
 			wantProto: coordinates{
@@ -496,11 +524,11 @@ func TestDeriveModuleNames(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := deriveModuleCoordinates(test.gapic, test.version)
-			if diff := cmp.Diff(test.wantProto, got.proto); diff != "" {
+			got := deriveAPICoords(test.lc, test.version)
+			if diff := cmp.Diff(test.wantProto, got.proto, cmp.AllowUnexported(coordinates{})); diff != "" {
 				t.Errorf("proto mismatch (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(test.wantGrpc, got.grpc); diff != "" {
+			if diff := cmp.Diff(test.wantGrpc, got.grpc, cmp.AllowUnexported(coordinates{})); diff != "" {
 				t.Errorf("grpc mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
The module derivation logic is updated to prioritize the artifact ID from distribution_name_override when present. This ensures that restructuring and POM generation use the correct paths.

Also refactored to centralize coordinate management and remove repeating logic. The javaModules struct is  extended to use full coordinate objects for all module types.


Fix #5048