### PR TITLE
feat(api): a `String()` helper for `Typez`

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -49,50 +49,34 @@ const (
 	SINT64_TYPE                 // 18
 )
 
+var _typez_name = [...]string{
+	"UNDEFINED",
+	"DOUBLE",
+	"FLOAT",
+	"INT64",
+	"UINT64",
+	"INT32",
+	"FIXED64",
+	"FIXED32",
+	"BOOL",
+	"STRING",
+	"GROUP",
+	"MESSAGE",
+	"BYTES",
+	"UINT32",
+	"ENUM",
+	"SFIXED32",
+	"SFIXED64",
+	"SINT32",
+	"SINT64",
+}
+
 // String returns the symbolic name for the Typez.
 func (t Typez) String() string {
-	switch t {
-	case UNDEFINED_TYPE:
-		return "UNDEFINED"
-	case DOUBLE_TYPE:
-		return "DOUBLE"
-	case FLOAT_TYPE:
-		return "FLOAT"
-	case INT64_TYPE:
-		return "INT64"
-	case UINT64_TYPE:
-		return "UINT64"
-	case INT32_TYPE:
-		return "INT32"
-	case FIXED64_TYPE:
-		return "FIXED64"
-	case FIXED32_TYPE:
-		return "FIXED32"
-	case BOOL_TYPE:
-		return "BOOL"
-	case STRING_TYPE:
-		return "STRING"
-	case GROUP_TYPE:
-		return "GROUP"
-	case MESSAGE_TYPE:
-		return "MESSAGE"
-	case BYTES_TYPE:
-		return "BYTES"
-	case UINT32_TYPE:
-		return "UINT32"
-	case ENUM_TYPE:
-		return "ENUM"
-	case SFIXED32_TYPE:
-		return "SFIXED32"
-	case SFIXED64_TYPE:
-		return "SFIXED64"
-	case SINT32_TYPE:
-		return "SINT32"
-	case SINT64_TYPE:
-		return "SINT64"
-	default:
+	if t < 0 || int(t) >= len(_typez_name) {
 		return fmt.Sprintf("Typez(%d)", t)
 	}
+	return _typez_name[t]
 }
 
 // FieldBehavior represents annotations for how the code generator handles a

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -278,6 +278,7 @@ func TestTypezString(t *testing.T) {
 		{"SINT32", SINT32_TYPE, "SINT32"},
 		{"SINT64", SINT64_TYPE, "SINT64"},
 		{"Default", Typez(99), "Typez(99)"},
+		{"Negative", Typez(-1), "Typez(-1)"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.t.String()


### PR DESCRIPTION
I want to print better error messages when a `Typez` is not handled or we get a weird branch.  I cannot remember if `9` is a string or an enum or what.

Motivated by  #5060
