### PR TITLE
cleanup: prepare for typos-cli in the CI builds

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,37 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[files]
+extend-exclude = [
+  # The test data have typos, or at least uncommon spelling. Not worth fixing.
+  "**/testdata/**",
+]
+
+[type.mustache]
+extend-glob = ["*.mustache"]
+
+# These are not good ideas for "extend-words" because they will catch too many
+# true positives
+[default]
+extend-ignore-re = [
+  # This is intentional, in the Rust ecosystem it is common to abbreviate
+  # `serialization` as `ser` (e.g. `serde::ser::`):
+  "serde::ser::",
+  "Error::ser",
+  "^ser_",
+  # Apparently we settled the debate:
+  "unmarshaling",
+  # typos-cli gets confused and thinks `pn` should be `on`.
+  "PluralName: \"pn\"",
+]

--- a/internal/docuploader/metadata.go
+++ b/internal/docuploader/metadata.go
@@ -89,7 +89,7 @@ type DocUploaderMetadata struct {
 // specified RepoMetadata. This does not populate UpdateTime or Version (which
 // should always be populated by the caller afterwards) or the advanced fields
 // (ServingPath, Stem, XRefServices, XRefs). No validation is performed for
-// whether the fields have been set to non-empty vlaues in repoMetadata.
+// whether the fields have been set to non-empty values in repoMetadata.
 func FromRepoMetadata(repoMetadata *repometadata.RepoMetadata) *DocUploaderMetadata {
 	return &DocUploaderMetadata{
 		DistributionName: repoMetadata.DistributionName,

--- a/internal/legacylibrarian/legacydocker/docker_test.go
+++ b/internal/legacylibrarian/legacydocker/docker_test.go
@@ -908,7 +908,7 @@ func TestWriteLibraryState(t *testing.T) {
 
 			if test.wantErr {
 				if err == nil {
-					t.Fatalf("writeLibraryState() shoud fail")
+					t.Fatalf("writeLibraryState() should fail")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {
@@ -1019,7 +1019,7 @@ func TestWriteLibrarianState(t *testing.T) {
 			err := writeLibrarianState(test.state, filePath)
 			if test.wantErr {
 				if err == nil {
-					t.Fatalf("writeLibrarianState() shoud fail")
+					t.Fatalf("writeLibrarianState() should fail")
 				}
 
 				if !strings.Contains(err.Error(), test.wantErrMsg) {

--- a/internal/legacylibrarian/legacyintegration/e2e_test.go
+++ b/internal/legacylibrarian/legacyintegration/e2e_test.go
@@ -101,7 +101,7 @@ func TestRunGenerate(t *testing.T) {
 				t.Fatalf("languageRepo prepare test error = %v", err)
 			}
 			if err := initRepo(t, apiSourceRepo, localAPISource, "initial commit"); err != nil {
-				t.Fatalf("APISouceRepo prepare test error = %v", err)
+				t.Fatalf("APISourceRepo prepare test error = %v", err)
 			}
 			if test.push {
 				// Create a local bare repository to act as the remote for the push.
@@ -209,7 +209,7 @@ func TestCleanAndCopy(t *testing.T) {
 		t.Fatalf("languageRepo prepare test error = %v", err)
 	}
 	if err := initRepo(t, apiSourceRepo, localAPISource, "initial commit"); err != nil {
-		t.Fatalf("APISouceRepo prepare test error = %v", err)
+		t.Fatalf("APISourceRepo prepare test error = %v", err)
 	}
 
 	cmd := exec.Command(
@@ -289,7 +289,7 @@ func TestRunConfigure(t *testing.T) {
 				t.Fatalf("prepare test error = %v", err)
 			}
 			if err := initRepo(t, apiSourceRepo, test.apiSource, "feat: add a new api\n\nPiperOrigin-RevId: 123456"); err != nil {
-				t.Fatalf("APISouceRepo prepare test error = %v", err)
+				t.Fatalf("APISourceRepo prepare test error = %v", err)
 			}
 
 			cmd := exec.Command(
@@ -392,7 +392,7 @@ func TestRunGenerate_MultipleLibraries(t *testing.T) {
 				t.Fatalf("languageRepo prepare test error = %v", err)
 			}
 			if err := initRepo(t, apiSourceRepo, localAPISource, "initial commit"); err != nil {
-				t.Fatalf("APISouceRepo prepare test error = %v", err)
+				t.Fatalf("APISourceRepo prepare test error = %v", err)
 			}
 
 			cmd := exec.Command(

--- a/internal/legacylibrarian/legacyintegration/system_test.go
+++ b/internal/legacylibrarian/legacyintegration/system_test.go
@@ -153,7 +153,7 @@ func TestPullRequestSystem(t *testing.T) {
 	}
 	err = localRepository.AddAll()
 	if err != nil {
-		t.Fatalf("unexepected error in AddAll() %s", err)
+		t.Fatalf("unexpected error in AddAll() %s", err)
 	}
 	err = localRepository.Commit("build: add test file")
 	if err != nil {

--- a/internal/legacylibrarian/legacylibrarian/gapic_metadata.go
+++ b/internal/legacylibrarian/legacylibrarian/gapic_metadata.go
@@ -161,7 +161,7 @@ func extractAPIVersions(metadataDocuments map[string]*gapic.GapicMetadata) []*li
 // readGapicMetadata traverses the [legacyconfig.LibraryState] SourceRoots under the
 // provided directory, parses any "gapic_metadata.json" file it finds, and
 // stores it in a map keyed by the [gapic.GapicMetadata] LibraryPackage.
-// There should be at most one "gapic_metadta.json" file per generated library
+// There should be at most one "gapic_metadata.json" file per generated library
 // package under SourceRoots, typically one per APIs entry, each with a unique
 // library package name.
 func readGapicMetadata(dir string, library *legacyconfig.LibraryState) (map[string]*gapic.GapicMetadata, error) {

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -165,7 +165,7 @@ func TestRoutingCombosFull(t *testing.T) {
 	}
 }
 
-func TestRoutingInfoVarianFieldName(t *testing.T) {
+func TestRoutingInfoVariantFieldName(t *testing.T) {
 	variant := &RoutingInfoVariant{
 		FieldPath: []string{"request", "b", "c"},
 	}

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -396,7 +396,7 @@ func TestEnrichSamplesOneOfExampleField(t *testing.T) {
 				Fields:  tc.fields,
 				OneOfs:  []*OneOf{group},
 			}
-			oneMesage := &Message{
+			oneMessage := &Message{
 				Name:    "OneMessage",
 				ID:      ".test.OneMessage",
 				Package: "test",
@@ -406,7 +406,7 @@ func TestEnrichSamplesOneOfExampleField(t *testing.T) {
 				ID:      ".test.AnotherMessage",
 				Package: "test",
 			}
-			model := NewTestAPI([]*Message{message, oneMesage, anotherMessage, mapMessage}, []*Enum{}, []*Service{})
+			model := NewTestAPI([]*Message{message, oneMessage, anotherMessage, mapMessage}, []*Enum{}, []*Service{})
 			if err := CrossReference(model); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -358,7 +358,7 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 			// Expressed as: 'package:<package name>' = '<version constraint>'
 			// For example: 'package:http' = '^1.3.0'
 			//
-			// If the package is needed as a dependency, then this constract is used.
+			// If the package is needed as a dependency, then this contract is used.
 			annotate.dependencyConstraints[strings.TrimPrefix(key, "package:")] = definition
 		}
 	}

--- a/internal/sidekick/parser/discovery/discovery_test.go
+++ b/internal/sidekick/parser/discovery/discovery_test.go
@@ -97,7 +97,7 @@ func TestBadParse(t *testing.T) {
 		{"unknown schema", `{"schemas": {"Bad": {"type": "unknown"}}}`},
 		{"schema must be object", `{"schemas": {"mustBeObject": {"type": "string"}}}`},
 		{"schema is ref", `{"schemas": {"cannotBeRef": {"$ref": "AnotherSchema"}}}`},
-		{"property parse", `{"schemas": {"badProperty": {"properties": {"typeShouldbeString": {"type": 123}}}}}`},
+		{"property parse", `{"schemas": {"badProperty": {"properties": {"typeShouldBeString": {"type": 123}}}}}`},
 		{"property with unknown schema", `{"schemas": {"badProperty": {"type": "object", "properties": {"bad": {"type": "unknown"}}}}}`},
 		{"property with bad array", `{"schemas": {"badProperty": {"type": "object", "properties": {"badArray": {"type": "array"}}}}}`},
 		{"property with bad array", `{"schemas": {"badProperty": {"type": "object", "properties": {"badItem": {"type": "array", "items": {"$ref": "notFound"}}}}}}`},

--- a/internal/sidekick/parser/parser_test.go
+++ b/internal/sidekick/parser/parser_test.go
@@ -146,7 +146,7 @@ func TestCreateModelOverrides(t *testing.T) {
 	}
 	for _, c := range testCases {
 		if c.got != c.want {
-			t.Errorf("mimatched override got=%q, want=%q", c.got, c.want)
+			t.Errorf("mismatched override got=%q, want=%q", c.got, c.want)
 		}
 	}
 }

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -593,7 +593,7 @@ type enumAnnotation struct {
 	// this is basically `QualifiedName`. For messages in the current package
 	// this includes `modelAnnotations.PackageName`.
 	NameInExamples string
-	// There's a missmatch between the sidekick model representation of wkt::NullValue
+	// There's a mismatch between the sidekick model representation of wkt::NullValue
 	// and the representation in Rust. We us this for sample generation.
 	IsWktNullValue bool
 	// If set, this enum is only enabled when some features are enabled
@@ -1378,7 +1378,7 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 		ann.OtherFieldsInGroup = language.FilterSlice(field.Group.Fields, func(f *api.Field) bool { return field != f })
 	}
 	ann.FieldTypeIsParentType = (field.MessageType == message || // Single or repeated field whose type is the same as the containing type.
-		// Map field whose value type is the same as the conaining type.
+		// Map field whose value type is the same as the containing type.
 		(ann.ValueField != nil && ann.ValueField.MessageType == message))
 	if !ann.FieldTypeIsParentType && // When the type of the field is the same as the containing type we don't import twice. No alias needed.
 		// Single or repeated field whose type's unqualified name is the same as the containing message's.

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -845,7 +845,7 @@ func isMultiLineListItem(lines []string, index int) bool {
 }
 
 // fixSetextHeadings avoids [setext headers] that were intended to be list
-// items, which may result from the discovery documentation pipepline.
+// items, which may result from the discovery documentation pipeline.
 //
 // [setext headers]: https://spec.commonmark.org/0.20/#setext-header
 func fixSetextHeadings(input string) string {


### PR DESCRIPTION
Configure typos-cli to skip some stuff, and then fix a number of typos. After this change we could enable typos-cli in one of the CI builds, but if we think that is too slow or something, it is still good to have it.