### PR TITLE
fix(sidekick/swift): propagate annotation errors

### DIFF
--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -53,9 +53,9 @@ func TestGenerate(t *testing.T) {
 	outDir := t.TempDir()
 	libraries := []*config.Library{
 		{
-			Name:          "GoogleCloudSecretmanagerV1",
-			APIs:          []*config.API{{Path: "google/cloud/secretmanager/v1"}},
-			CopyrightYear: "2025",
+			Name:          "GoogleType",
+			APIs:          []*config.API{{Path: "google/type"}},
+			CopyrightYear: "2038",
 		},
 	}
 	for _, library := range libraries {

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -25,7 +25,7 @@ type messageAnnotations struct {
 	DocLines      []string
 }
 
-func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) *messageAnnotations {
+func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) (*messageAnnotations, error) {
 	docLines := codec.formatDocumentation(message.Documentation)
 	messageAnnotations := &messageAnnotations{
 		CopyrightYear: model.CopyrightYear,
@@ -36,7 +36,9 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 
 	message.Codec = messageAnnotations
 	for _, field := range message.Fields {
-		codec.annotateField(field)
+		if _, err := codec.annotateField(field); err != nil {
+			return nil, err
+		}
 	}
-	return messageAnnotations
+	return messageAnnotations, nil
 }

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -32,6 +32,7 @@ func TestAnnotateMessage(t *testing.T) {
 			{
 				Name:          "secret_key",
 				Documentation: "The key.",
+				Typez:         api.STRING_TYPE,
 			},
 		},
 	}

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -26,7 +26,9 @@ func (codec *codec) annotateModel() error {
 	}
 	codec.Model.Codec = annotations
 	for _, message := range codec.Model.Messages {
-		codec.annotateMessage(message, annotations)
+		if _, err := codec.annotateMessage(message, annotations); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/sidekick/swift/generate_test.go
+++ b/internal/sidekick/swift/generate_test.go
@@ -38,8 +38,8 @@ func TestFromProtobuf(t *testing.T) {
 
 	cfg := &parser.ModelConfig{
 		SpecificationFormat: config.SpecProtobuf,
-		ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
-		SpecificationSource: "google/cloud/secretmanager/v1",
+		ServiceConfig:       "google/type/type.yaml",
+		SpecificationSource: "google/type",
 		Source: &sources.SourceConfig{
 			Sources: &sources.Sources{
 				Googleapis: filepath.Join(testdataDir, "googleapis"),
@@ -47,7 +47,7 @@ func TestFromProtobuf(t *testing.T) {
 			ActiveRoots: []string{"googleapis"},
 		},
 		Codec: map[string]string{
-			"copyright-year":      "2026",
+			"copyright-year":      "2038",
 			"not-for-publication": "true",
 			"version":             "0.1.0",
 			"skip-format":         "true",


### PR DESCRIPTION
Sidekick should return an error if any annotation step fails. I had missed a few places in a prior change.

That limits the APIs we can use in testing, so the tests have to limit themselves to `google/type`. We can add more complex APIs once the generator is ready.