### PR TITLE
cleanup(sidekick): no maps as nested messages

### DIFF
--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -576,8 +576,21 @@ func TestAnnotateMessage_OmitGeneration_Map(t *testing.T) {
 		Package: "google.rpc",
 	}
 	message := &api.Message{
+		Name:    "HasMap",
+		ID:      ".some.package.HasMap",
+		Package: "some.package",
+		Fields: []*api.Field{
+			{
+				Name:    "map_field",
+				ID:      ".some.package.HasMap.map_field",
+				Typez:   api.MESSAGE_TYPE,
+				TypezID: ".some.package.HasMap.MapFieldEntry",
+			},
+		},
+	}
+	mapMessage := &api.Message{
 		Name:    "Entry",
-		ID:      ".some.package.Entry",
+		ID:      ".some.package.HasMap.MapFieldEntry",
 		Package: "some.package",
 		IsMap:   true,
 		Fields: []*api.Field{
@@ -594,6 +607,7 @@ func TestAnnotateMessage_OmitGeneration_Map(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	model.State.MessageByID[status.ID] = status
+	model.State.MessageByID[mapMessage.ID] = mapMessage
 	annotate := newAnnotateModel(model)
 
 	annotate.annotateModel(map[string]string{
@@ -602,7 +616,7 @@ func TestAnnotateMessage_OmitGeneration_Map(t *testing.T) {
 	annotate.annotateMessage(message)
 
 	codec := message.Codec.(*messageAnnotation)
-	if !codec.OmitGeneration {
+	if codec.OmitGeneration {
 		t.Errorf("Expected OmitGeneration to be true for map entry")
 	}
 
@@ -1804,7 +1818,8 @@ func TestAnnotateField(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			model := api.NewTestAPI([]*api.Message{message, mapMessage}, []*api.Enum{enumState}, []*api.Service{})
+			model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enumState}, []*api.Service{})
+			model.State.MessageByID[mapMessage.ID] = mapMessage
 			annotate := newAnnotateModel(model)
 			registerMissingWkt(annotate.state)
 

--- a/internal/sidekick/dart/dart_test.go
+++ b/internal/sidekick/dart/dart_test.go
@@ -368,7 +368,8 @@ func TestFieldType_Maps(t *testing.T) {
 		Typez:    api.MESSAGE_TYPE,
 		TypezID:  map1.ID,
 	}
-	model := api.NewTestAPI([]*api.Message{map1}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model.State.MessageByID[map1.ID] = map1
 	annotate := newAnnotateModel(model)
 	annotate.annotateModel(map[string]string{})
 

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -600,7 +600,9 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 			if err != nil {
 				return nil, err
 			}
-			message.Messages = append(message.Messages, nmsg)
+			if !nmsg.IsMap {
+				message.Messages = append(message.Messages, nmsg)
+			}
 		}
 	}
 	for _, e := range m.GetEnumType() {

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -812,6 +812,10 @@ func TestProtobuf_MapFields(t *testing.T) {
 		},
 	})
 
+	if diff := cmp.Diff([]*api.Message(nil), message.Messages); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
 	message, ok = test.State.MessageByID[".test.Fake.SingularMapEntry"]
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake.SingularMapEntry")

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -1461,6 +1461,9 @@ func findUsedPackagesMessage(message *api.Message, model *api.API, c *codec, vis
 		case api.MESSAGE_TYPE:
 			if fm, ok := model.State.MessageByID[f.TypezID]; ok {
 				usePackage(fm.Package, model, c)
+				if f.Map {
+					findUsedPackagesMessage(fm, model, c, visited)
+				}
 			}
 		case api.ENUM_TYPE:
 			if fe, ok := model.State.EnumByID[f.TypezID]; ok {

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -704,7 +704,9 @@ func rustFieldTypesCases() *api.API {
 			},
 		},
 	}
-	return api.NewTestAPI([]*api.Message{target, mapMessage, message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{target, message}, []*api.Enum{}, []*api.Service{})
+	model.State.MessageByID[mapMessage.ID] = mapMessage
+	return model
 
 }
 
@@ -870,7 +872,8 @@ func TestFieldMapTypeValues(t *testing.T) {
 			IsMap:  true,
 			Fields: []*api.Field{key, value},
 		}
-		model := api.NewTestAPI([]*api.Message{message, other_message, map_thing}, []*api.Enum{}, []*api.Service{})
+		model := api.NewTestAPI([]*api.Message{message, other_message}, []*api.Enum{}, []*api.Service{})
+		model.State.MessageByID[map_thing.ID] = map_thing
 		api.LabelRecursiveFields(model)
 		c := createRustCodec()
 		got, err := c.fieldType(field, model.State, false, model.PackageName)
@@ -933,7 +936,8 @@ func TestFieldMapTypeKey(t *testing.T) {
 			Name: "EnumType",
 			ID:   ".test.EnumType",
 		}
-		model := api.NewTestAPI([]*api.Message{message, map_thing}, []*api.Enum{enum}, []*api.Service{})
+		model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enum}, []*api.Service{})
+		model.State.MessageByID[map_thing.ID] = map_thing
 		api.LabelRecursiveFields(model)
 		c := createRustCodec()
 		got, err := c.fieldType(field, model.State, false, model.PackageName)

--- a/internal/sidekick/rust/templates/common/message.mustache
+++ b/internal/sidekick/rust/templates/common/message.mustache
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{^IsMap}}
 {{^ServicePlaceholder}}
 
 {{#Codec.DocLines}}
@@ -244,4 +243,3 @@ pub mod {{Codec.ModuleName}} {
 {{#Codec.HasNestedTypes}}
 }
 {{/Codec.HasNestedTypes}}
-{{/IsMap}}

--- a/internal/sidekick/rust/templates/common/model/debug/message.mustache
+++ b/internal/sidekick/rust/templates/common/model/debug/message.mustache
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 
-{{^IsMap}}
 {{^ServicePlaceholder}}
 {{> /templates/common/feature_gate}}
 impl std::fmt::Debug for super::{{Codec.RelativeName}} {
@@ -33,7 +32,6 @@ impl std::fmt::Debug for super::{{Codec.RelativeName}} {
     }
 }
 {{/ServicePlaceholder}}
-{{/IsMap}}
 {{#Codec.HasNestedTypes}}
 {{#Messages}}
 {{> /templates/common/model/debug/message}}

--- a/internal/sidekick/rust/templates/common/model/deserialize/message.mustache
+++ b/internal/sidekick/rust/templates/common/model/deserialize/message.mustache
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 
-{{^IsMap}}
 {{^ServicePlaceholder}}
 {{> /templates/common/feature_gate}}
 #[doc(hidden)]
@@ -76,4 +75,3 @@ impl<'de> serde::de::Deserialize<'de> for super::{{Codec.RelativeName}} {
 {{/Messages}}
 {{/Codec.HasNestedTypes}}
 {{/ServicePlaceholder}}
-{{/IsMap}}

--- a/internal/sidekick/rust/templates/common/model/serialize/message.mustache
+++ b/internal/sidekick/rust/templates/common/model/serialize/message.mustache
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 
-{{^IsMap}}
 {{^ServicePlaceholder}}
 {{> /templates/common/feature_gate}}
 #[doc(hidden)]
@@ -49,4 +48,3 @@ impl serde::ser::Serialize for super::{{Codec.RelativeName}} {
 {{/Messages}}
 {{/Codec.HasNestedTypes}}
 {{/ServicePlaceholder}}
-{{/IsMap}}

--- a/internal/sidekick/rust/templates/convert-prost/message.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/message.mustache
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{^IsMap}}
 {{#Messages}}
 {{> message}}
 {{/Messages}}
@@ -117,4 +116,3 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
     }
 }
 {{/Codec.SkipConversion}}
-{{/IsMap}}

--- a/internal/sidekick/rust/used_by_test.go
+++ b/internal/sidekick/rust/used_by_test.go
@@ -336,3 +336,69 @@ func TestFindUsedPackages(t *testing.T) {
 		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
 	}
 }
+
+func TestFindUsedPackages_MapFields(t *testing.T) {
+	externalMessage := &api.Message{
+		Name:    "ExternalMessage",
+		ID:      ".external.ExternalMessage",
+		Package: "external",
+	}
+
+	mapEntry := &api.Message{
+		Name:    "FakeMapEntry",
+		ID:      ".test.Fake.FakeMapEntry",
+		Package: "test",
+		IsMap:   true,
+		Fields: []*api.Field{
+			{
+				Name:    "key",
+				Typez:   api.STRING_TYPE,
+				TypezID: "string",
+			},
+			{
+				Name:    "value",
+				Typez:   api.MESSAGE_TYPE,
+				TypezID: ".external.ExternalMessage",
+			},
+		},
+	}
+
+	message := &api.Message{
+		Name:    "Fake",
+		ID:      ".test.Fake",
+		Package: "test",
+		Fields: []*api.Field{
+			{
+				Name:    "map_field",
+				Typez:   api.MESSAGE_TYPE,
+				TypezID: ".test.Fake.FakeMapEntry",
+				Map:     true,
+			},
+		},
+	}
+
+	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+	model.State.MessageByID[".external.ExternalMessage"] = externalMessage
+	model.State.MessageByID[".test.Fake.FakeMapEntry"] = mapEntry
+
+	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
+		"package:external": "package=external-package,source=external",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	findUsedPackages(model, c)
+
+	want := []*packagez{
+		{
+			name:        "external",
+			packageName: "external-package",
+			used:        true,
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Protobuf creates synthetic nested messages for `map<>` fields. These are annoying as they must be skipped from the mustache templates and from any tests that happen to use map fields.

There was a long standing cleanup issue to remove them, and this PR finally implements it. I want to avoid the same annoying code in the Swift codec.

Fixes #1601 . Manually tested for Rust and Dart via `generate --all`.
