### PR TITLE
chore(.github/workflows): merge rust test steps into single coverage run

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -40,10 +40,8 @@ jobs:
         run: |
           git --version
           tar --version
-      - name: Run sidekick tests
-        run: go test -race ./internal/sidekick/...
-      - name: Run internal/librarian/rust tests and check coverage
-        run: go run ./tool/cmd/coverage ./internal/librarian/rust
+      - name: Run tests and check coverage
+        run: go run ./tool/cmd/coverage ./internal/sidekick/... ./internal/librarian/rust
   integration:
     runs-on: ubuntu-24.04
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
The Rust workflow had two separate test steps: one running sidekick tests with "go test -race" and another running librarian/rust tests with the coverage tool. Merges them into a single run using the coverage tool.