### PR TITLE
refactor(.github/workflows): split download and install in nodejs.yaml

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -40,10 +40,11 @@ jobs:
       - name: Display Python version
         run: python3 --version
       - uses: ./.github/actions/install-protoc
+      - name: Download google-cloud-node-core
+        run: git clone --depth 1 https://github.com/googleapis/google-cloud-node-core.git /tmp/google-cloud-node-core
       - name: Install gapic-generator-typescript
+        working-directory: /tmp/google-cloud-node-core/generator/gapic-generator-typescript
         run: |
-          git clone --depth 1 https://github.com/googleapis/google-cloud-node-core.git /tmp/google-cloud-node-core
-          cd /tmp/google-cloud-node-core/generator/gapic-generator-typescript
           npm install
           npm run compile
           npm link


### PR DESCRIPTION
Split the "Install gapic-generator-typescript" step in the Node.js workflow into two steps: downloading google-cloud-node-core and installing the generator into a single step. This makes it easier to identify which part is slow when debugging installation time issues.

For https://github.com/googleapis/librarian/issues/4904