### PR TITLE
feat(librarian/swift): format after generation

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -247,6 +247,9 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 				if err := swift.Generate(gctx, cfg, library, src); err != nil {
 					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
 				}
+				if err := swift.Format(gctx, library); err != nil {
+					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
+				}
 				return nil
 			})
 		}

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
@@ -42,6 +43,11 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		return err
 	}
 	return sidekickswift.Generate(ctx, model, library.Output, modelConfig)
+}
+
+// Format formats a generated Swift library.
+func Format(ctx context.Context, library *config.Library) error {
+	return command.Run(ctx, "swift-format", "format", "--in-place", "--recursive", library.Output)
 }
 
 // DefaultLibraryName derives a library name from an API path.

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -79,3 +79,26 @@ func TestGenerate(t *testing.T) {
 		}
 	}
 }
+
+func TestFormat(t *testing.T) {
+	testhelper.RequireCommand(t, "swift-format")
+
+	outDir := t.TempDir()
+	sourcesDir := filepath.Join(outDir, "Sources")
+	if err := os.MkdirAll(sourcesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(sourcesDir, "test.swift")
+	// Write a file that needs formatting.
+	if err := os.WriteFile(filePath, []byte("func foo(){\n  print(\"hello\")\n}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	library := &config.Library{
+		Output: outDir,
+	}
+
+	if err := Format(t.Context(), library); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Use `swift-format` to format each library after it is generated. This is safe to run in parallel, so let's do so. AFAICT, `swift-format` is installed with the rest of the Swift toolchain, so there is no need to call `swiftly install blah...` for it.

Fixes #5093 