### PR TITLE
feat(internal/config): add NPM and Pip tool types

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -40,17 +40,12 @@ jobs:
       - name: Display Python version
         run: python3 --version
       - uses: ./.github/actions/install-protoc
-      - name: Install gapic-generator-typescript
+      - name: Install Node.js tools
+        # TODO(https://github.com/googleapis/librarian/issues/4848): download
+        # librarian.yaml from google-cloud-node instead of creating a fake one.
         run: |
-          git clone --depth 1 https://github.com/googleapis/google-cloud-node-core.git /tmp/google-cloud-node-core
-          cd /tmp/google-cloud-node-core/generator/gapic-generator-typescript
-          npm install
-          npm run compile
-          npm link
-      - name: Install gapic-node-processing and gapic-tools
-        run: npm install -g gapic-node-processing@0.1.7 gapic-tools@1.0.5
-      - name: Install synthtool
-        run: |
-          pip install gcp-synthtool@git+https://github.com/googleapis/synthtool@5aa438a342707842d11fbbb302c6277fbf9e4655
+          echo 'language: nodejs' > librarian.yaml
+          go run ./cmd/librarian -v install
+          rm librarian.yaml
       - name: Run internal/librarian/nodejs tests and check coverage
         run: go run ./tool/cmd/coverage ./internal/librarian/nodejs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,8 @@ type Config struct {
 }
 
 // Release holds the configuration parameter for publish command.
+//
+// TODO(https://github.com/googleapis/librarian/issues/4910): delete Release.
 type Release struct {
 	// IgnoredChanges defines globs that are ignored in change analysis.
 	IgnoredChanges []string `yaml:"ignored_changes,omitempty"`
@@ -128,6 +130,12 @@ type Source struct {
 type Tools struct {
 	// Cargo defines tools to install via cargo.
 	Cargo []*CargoTool `yaml:"cargo,omitempty"`
+
+	// NPM defines tools to install via npm.
+	NPM []*NPMTool `yaml:"npm,omitempty"`
+
+	// Pip defines tools to install via pip.
+	Pip []*PipTool `yaml:"pip,omitempty"`
 }
 
 // CargoTool defines a tool to install via cargo.
@@ -137,6 +145,36 @@ type CargoTool struct {
 
 	// Version is the version to install.
 	Version string `yaml:"version"`
+}
+
+// NPMTool defines a tool to install via npm.
+type NPMTool struct {
+	// Name is the npm package name.
+	Name string `yaml:"name"`
+
+	// Version is the version to install.
+	Version string `yaml:"version"`
+
+	// Package is the URL or path of the package to install.
+	Package string `yaml:"package,omitempty"`
+
+	// Checksum is the SHA256 checksum of the package.
+	Checksum string `yaml:"checksum,omitempty"`
+
+	// Build defines the commands to run to build the tool after installation.
+	Build []string `yaml:"build,omitempty"`
+}
+
+// PipTool defines a tool to install via pip.
+type PipTool struct {
+	// Name is the pip package name.
+	Name string `yaml:"name"`
+
+	// Version is the version to install.
+	Version string `yaml:"version"`
+
+	// Package is the pip install specifier (e.g., "pkg@git+https://...").
+	Package string `yaml:"package,omitempty"`
 }
 
 // Default contains default settings for all libraries.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -271,6 +271,32 @@ func TestNodejsRead(t *testing.T) {
 				SHA256: "81e6057ffd85154af5268c2c3c8f2408745ca0f7fa03d43c68f4847f31eb5f98",
 			},
 		},
+		Tools: &Tools{
+			NPM: []*NPMTool{
+				{
+					Name:     "gapic-generator-typescript",
+					Version:  "76ba85a7f55c6e82943008b4eceb07a0f58b39e1",
+					Package:  "https://github.com/googleapis/google-cloud-node-core/archive/76ba85a7f55c6e82943008b4eceb07a0f58b39e1.tar.gz",
+					Checksum: "9561a116203761bad63bf1a0abc7a4a0db67608683c3d67b45abfc394df612ac",
+					Build:    []string{"npm install", "npm run compile", "npm link"},
+				},
+				{
+					Name:    "gapic-node-processing",
+					Version: "0.1.7",
+				},
+				{
+					Name:    "gapic-tools",
+					Version: "1.0.5",
+				},
+			},
+			Pip: []*PipTool{
+				{
+					Name:    "synthtool",
+					Version: "5aa438a342707842d11fbbb302c6277fbf9e4655",
+					Package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@5aa438a342707842d11fbbb302c6277fbf9e4655",
+				},
+			},
+		},
 		Default: &Default{
 			Output: "packages",
 			Keep:   []string{"CHANGELOG.md"},

--- a/internal/config/testdata/nodejs/librarian.yaml
+++ b/internal/config/testdata/nodejs/librarian.yaml
@@ -3,6 +3,24 @@ sources:
   googleapis:
     commit: 9fcfbea0aa5b50fa22e190faceb073d74504172b
     sha256: 81e6057ffd85154af5268c2c3c8f2408745ca0f7fa03d43c68f4847f31eb5f98
+tools:
+  npm:
+    - name: gapic-generator-typescript
+      version: "76ba85a7f55c6e82943008b4eceb07a0f58b39e1"
+      package: "https://github.com/googleapis/google-cloud-node-core/archive/76ba85a7f55c6e82943008b4eceb07a0f58b39e1.tar.gz"
+      checksum: "9561a116203761bad63bf1a0abc7a4a0db67608683c3d67b45abfc394df612ac"
+      build:
+        - "npm install"
+        - "npm run compile"
+        - "npm link"
+    - name: gapic-node-processing
+      version: "0.1.7"
+    - name: gapic-tools
+      version: "1.0.5"
+  pip:
+    - name: synthtool
+      version: "5aa438a342707842d11fbbb302c6277fbf9e4655"
+      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@5aa438a342707842d11fbbb302c6277fbf9e4655"
 default:
   output: packages
   keep:

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian/golang"
+	"github.com/googleapis/librarian/internal/librarian/nodejs"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/yaml"
 	"github.com/urfave/cli/v3"
@@ -77,6 +78,8 @@ func installCommand() *cli.Command {
 			switch cfg.Language {
 			case config.LanguageGo:
 				return golang.Install(ctx)
+			case config.LanguageNodejs:
+				return nodejs.Install(ctx)
 			case config.LanguageRust:
 				return rust.Install(ctx, cfg.Tools)
 			default:

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/command"
+)
+
+// TODO(https://github.com/googleapis/librarian/issues/4848): read tool
+// versions from google-cloud-node/librarian.yaml instead of hardcoding them.
+const (
+	// TODO(https://github.com/googleapis/librarian/issues/4904): use
+	// google-cloud-node instead of google-cloud-node-core.
+	gapicGeneratorTypescript     = "gapic-generator-typescript"
+	gapicGeneratorTypescriptRepo = "https://github.com/googleapis/google-cloud-node-core.git"
+	gapicNodeProcessingPkg       = "gapic-node-processing@0.1.7"
+	gapicToolsPkg                = "gapic-tools@1.0.5"
+	synthtoolPkg                 = "gcp-synthtool@git+https://github.com/googleapis/synthtool@5aa438a342707842d11fbbb302c6277fbf9e4655"
+)
+
+// Install installs Node.js tool dependencies.
+func Install(ctx context.Context) error {
+	if err := installGapicGeneratorTypescript(ctx); err != nil {
+		return err
+	}
+	if err := command.RunStreaming(ctx, "npm", "install", "-g", gapicNodeProcessingPkg, gapicToolsPkg); err != nil {
+		return err
+	}
+	return command.RunStreaming(ctx, "pip", "install", synthtoolPkg)
+}
+
+func installGapicGeneratorTypescript(ctx context.Context) error {
+	dir, err := os.MkdirTemp("", fmt.Sprintf("%s-*", gapicGeneratorTypescript))
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+	if err := command.RunStreaming(ctx, "git", "clone", "--depth", "1", gapicGeneratorTypescriptRepo, dir); err != nil {
+		return err
+	}
+	genDir := filepath.Join(dir, "generator", gapicGeneratorTypescript)
+	if err := command.RunInDir(ctx, genDir, "npm", "install"); err != nil {
+		return err
+	}
+	if err := command.RunInDir(ctx, genDir, "npm", "run", "compile"); err != nil {
+		return err
+	}
+	return command.RunInDir(ctx, genDir, "npm", "link")
+}

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstall(t *testing.T) {
+	bin := t.TempDir()
+	// The fake git stub creates the directory structure that
+	// installGapicGeneratorTypescript expects after cloning.
+	gitStub := `#!/bin/sh
+for last; do true; done
+mkdir -p "$last/generator/gapic-generator-typescript"
+`
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(gitStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "npm"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "pip"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := Install(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -195,6 +195,12 @@ func formatConfig(cfg *config.Config) *config.Config {
 		slices.SortFunc(cfg.Tools.Cargo, func(a, b *config.CargoTool) int {
 			return strings.Compare(a.Name, b.Name)
 		})
+		slices.SortFunc(cfg.Tools.NPM, func(a, b *config.NPMTool) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		slices.SortFunc(cfg.Tools.Pip, func(a, b *config.PipTool) int {
+			return strings.Compare(a.Name, b.Name)
+		})
 	}
 	if cfg.Default != nil && cfg.Default.Rust != nil {
 		slices.SortFunc(cfg.Default.Rust.PackageDependencies, func(a, b *config.RustPackageDependency) int {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -109,6 +109,15 @@ func TestFormatConfig(t *testing.T) {
 				{Name: "taplo-cli", Version: "0.10.0"},
 				{Name: "cargo-semver-checks", Version: "0.46.0"},
 			},
+			NPM: []*config.NPMTool{
+				{Name: "gapic-tools", Version: "1.0.5"},
+				{Name: "gapic-generator-typescript", Version: "1.0.0"},
+				{Name: "gapic-node-processing", Version: "0.1.7"},
+			},
+			Pip: []*config.PipTool{
+				{Name: "synthtool", Version: "abc123"},
+				{Name: "nox", Version: "2024.1.1"},
+			},
 		},
 		Default: &config.Default{
 			Rust: &config.RustDefault{
@@ -202,6 +211,28 @@ func TestFormatConfig(t *testing.T) {
 		want := []string{"cargo-semver-checks", "taplo-cli"}
 		var got []string
 		for _, tool := range cfg.Tools.Cargo {
+			got = append(got, tool.Name)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("sorts npm tools by name", func(t *testing.T) {
+		want := []string{"gapic-generator-typescript", "gapic-node-processing", "gapic-tools"}
+		var got []string
+		for _, tool := range cfg.Tools.NPM {
+			got = append(got, tool.Name)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("sorts pip tools by name", func(t *testing.T) {
+		want := []string{"nox", "synthtool"}
+		var got []string
+		for _, tool := range cfg.Tools.Pip {
 			got = append(got, tool.Name)
 		}
 		if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
Add support for npm and pip to librarian install. Add nodejs.Install to install gapic-generator-typescript, gapic-node-processing, gapic-tools, and synthtool, and wire it into the install command for nodejs.

For https://github.com/googleapis/librarian/issues/4848
