### PR TITLE
feat(sidekick/rust): remove `google_cloud_unstable_tracing` guards

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -34,7 +34,6 @@ pub struct {{Codec.Name}}<T>
 where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     inner: T,
     {{#Codec.DetailedTracingAttributes}}
-    #[cfg(google_cloud_unstable_tracing)]
     {{! Use a fully qualified name to avoid conflicts with any client called `DurationMetric` }}
     duration: gaxi::observability::DurationMetric,
     {{/Codec.DetailedTracingAttributes}}
@@ -49,7 +48,6 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         Self {
             inner,
             {{#Codec.DetailedTracingAttributes}}
-            #[cfg(google_cloud_unstable_tracing)]
             duration: gaxi::observability::DurationMetric::new(
                 &info::INSTRUMENTATION_CLIENT_INFO,
             ),
@@ -77,7 +75,6 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> Result<crate::Response<{{Codec.ReturnType}}>> {
         {{#Codec.DetailedTracingAttributes}}
-        #[cfg(google_cloud_unstable_tracing)]
         {
             let (_span, pending) = gaxi::client_request_signals!(
                 metric: self.duration.clone(),
@@ -86,9 +83,10 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                 self.inner.{{Codec.Name}}(req, options));
             pending.await
         }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        {{/Codec.DetailedTracingAttributes }}
+        {{/Codec.DetailedTracingAttributes}}
+        {{^Codec.DetailedTracingAttributes}}
         self.inner.{{Codec.Name}}(req, options).await
+        {{/Codec.DetailedTracingAttributes}}
     }
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}
@@ -112,7 +110,6 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
 {{/Codec.Services}}
 {{#Codec.HasServices}}
 {{#Codec.DetailedTracingAttributes}}
-#[cfg(google_cloud_unstable_tracing)]
 pub(crate) mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -54,10 +54,8 @@ impl std::fmt::Debug for {{Codec.Name}} {
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         {{#Codec.DetailedTracingAttributes}}
-        #[cfg(google_cloud_unstable_tracing)]
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
-        #[cfg(google_cloud_unstable_tracing)]
         let inner = if tracing_is_enabled {
             inner.with_instrumentation(&super::tracing::info::INSTRUMENTATION_CLIENT_INFO)
         } else {
@@ -201,7 +199,6 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             google_cloud_gax::error::Error::binding(BindingError { paths })
         })??;
         {{#Codec.DetailedTracingAttributes}}
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
             recorder.on_client_request(
                 gaxi::observability::ClientRequestAttributes::default()

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -84,14 +84,11 @@ impl std::fmt::Debug for {{Codec.Name}} {
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         {{#Codec.DetailedTracingAttributes}}
-        #[cfg(google_cloud_unstable_tracing)]
         let inner = if gaxi::options::tracing_enabled(&config) {
             gaxi::grpc::Client::new_with_instrumentation(config, DEFAULT_HOST, &super::tracing::info::INSTRUMENTATION_CLIENT_INFO).await?
         } else {
             gaxi::grpc::Client::new(config, DEFAULT_HOST).await?
         };
-        #[cfg(not(google_cloud_unstable_tracing))]
-        let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
@@ -164,7 +161,6 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         type TR = crate::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}};
         {{/ReturnsEmpty}}
         {{#Codec.DetailedTracingAttributes}}
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
             let attributes = gaxi::observability::ClientRequestAttributes::default()
                 .set_rpc_method("{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}");


### PR DESCRIPTION
Remove `google_cloud_unstable_tracing` conditional compilation guards from the Rust templates. This makes tracing unconditionally available in the generated code, subject to runtime configuration via `gaxi::options::tracing_enabled`.

This change prepares for the removal of the unstable feature flag in `google-cloud-rust`: [google-cloud-rust/pull/5292](https://github.com/googleapis/google-cloud-rust/pull/5292)

**The submission of this PR is blocked on the turbo launch.**