### PR TITLE
chore(.github/workflows): add setup job to cache Go modules

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -17,7 +17,18 @@ permissions:
   contents: read
   issues: write
 jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Download all modules
+        run: go mod download
   go-generate:
+    needs: setup
     runs-on: ubuntu-24.04
     # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
     timeout-minutes: 5
@@ -38,6 +49,7 @@ jobs:
             exit 1
           fi
   legacylibrarian:
+    needs: setup
     runs-on: ubuntu-24.04
     # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
     timeout-minutes: 5
@@ -49,6 +61,7 @@ jobs:
       - name: Run tests and check coverage
         run: go run ./tool/cmd/coverage ./internal/legacylibrarian/...
   test:
+    needs: setup
     runs-on: ubuntu-24.04
     # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
     timeout-minutes: 5


### PR DESCRIPTION
The actions/setup-go cache is immutable: whichever job finishes first saves the cache, and if that job only downloaded a subset of modules, subsequent runs re-download the rest every time. Adding a setup job that runs go mod download before other jobs ensures the cache is always populated with all modules.