### PR TITLE
refactor(internal/librarian): isolate preview and new library additions

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -142,7 +142,15 @@ func addLibrary(cfg *config.Config, apis ...string) (string, *config.Config, err
 	}
 	name := deriveLibraryName(cfg.Language, paths[0].Path)
 	existingLib, err := FindLibrary(cfg, name)
-	exists := !errors.Is(err, ErrLibraryNotFound)
+	var exists bool
+	switch {
+	case err == nil:
+		exists = true
+	case errors.Is(err, ErrLibraryNotFound):
+		exists = false
+	default:
+		return "", nil, err
+	}
 	if isPreview {
 		if !exists {
 			return "", nil, fmt.Errorf("%s: %w", name, errPreviewRequiresLibrary)


### PR DESCRIPTION
The addLibrary function is refactored to delegate the specific logic for adding preview libraries and new libraries to dedicated addPreviewLibrary and addNewLibrary helper functions.

Tests are not added/updated because there is no behavior change.

Prepare for functions to add APIs to an existing library.

For #4996