### PR TITLE
fix(.github/workflows): run all dart tests under coverage tool

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -36,7 +36,5 @@ jobs:
         run: dart --version
       - name: Verify git is available
         run: git --version
-      - name: Run internal/sidekick/dart tests
-        run: go test -race ./internal/sidekick/dart
-      - name: Run internal/librarian/dart tests and check coverage
-        run: go run ./tool/cmd/coverage ./internal/librarian/dart
+      - name: Run tests and check coverage
+        run: go run ./tool/cmd/coverage ./internal/sidekick/dart ./internal/librarian/dart


### PR DESCRIPTION
Previously internal/sidekick/dart tests ran with plain "go test -race" while only internal/librarian/dart ran under the coverage tool. Combine both packages into a single test step.