### PR TITLE
fix(.github/workflows): install librarian binary in rust integration job

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian
-        with:
-          install-tools: "false"
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/install-taplo


### PR DESCRIPTION
The integration job runs `librarian generate --all` but set `install-tools: "false"` to setup-librarian, which skips `go install ./cmd/librarian`. Remove this line to set the action to true and install the librarian binary.

Fixes https://github.com/googleapis/librarian/issues/5118