### PR TITLE
feat(sidekick/swift): initial mapping for messages

### DIFF
--- a/internal/sidekick/swift/templates/common/message.swift.mustache
+++ b/internal/sidekick/swift/templates/common/message.swift.mustache
@@ -31,6 +31,32 @@ public struct {{Codec.Name}}: Codable, Equatable {
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
-  public let {{Codec.Name}}: String
+  public var {{Codec.Name}}: {{Codec.FieldType}}
   {{/Fields}}
+
+  {{! Provide a memberwise initializer, with defaults for each field. }}
+  /// Initialize a new instance of `{{Codec.Name}}`.
+  public init(
+    {{#Fields}}
+    {{! Recall that fields can be Singular (and then Optional or not) or Repeated or Map }}
+    {{#Singular}}
+    {{^Optional}}
+    {{Codec.Name}}: {{Codec.FieldType}} = {{Codec.FieldType}}(),
+    {{/Optional}}
+    {{#Optional}}
+    {{Codec.Name}}: {{Codec.FieldType}} = nil,
+    {{/Optional}}
+    {{/Singular}}
+    {{#Repeated}}
+    {{Codec.Name}}: {{Codec.FieldType}} = [],
+    {{/Repeated}}
+    {{#Map}}
+    {{Codec.Name}}: {{Codec.FieldType}} = [:],
+    {{/Map}}
+    {{/Fields}}
+  ) {
+    {{#Fields}}
+    self.{{Codec.Name}} = {{Codec.Name}}
+    {{/Fields}}
+  }
 }


### PR DESCRIPTION
After much meandering, we can generate messages with the correct field types for strings, integers, and (current package) messages. These fields can be optional (messages always are), or repeated.

This is enough to generate the message types in
`google-cloud-publicca-v1`.

Fixes #5069 and fixes #5110 and fixes #5108 