### PR TITLE
fix(sidekick/swift): escaped message names

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -30,7 +30,7 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 	messageAnnotations := &messageAnnotations{
 		CopyrightYear: model.CopyrightYear,
 		BoilerPlate:   model.BoilerPlate,
-		Name:          message.Name,
+		Name:          pascalCase(message.Name),
 		DocLines:      docLines,
 	}
 

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -50,3 +50,25 @@ func TestAnnotateMessage(t *testing.T) {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 }
+
+func TestAnnotateMessage_EscapedName(t *testing.T) {
+	msg := &api.Message{
+		Name:          "Protocol",
+		Documentation: "A message named Protocol.",
+		ID:            ".test.Protocol",
+		Package:       "test",
+	}
+	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+	codec := newTestCodec(t, model, map[string]string{})
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+	want := &messageAnnotations{
+		Name:     "Protocol_",
+		DocLines: []string{"A message named Protocol."},
+	}
+
+	if diff := cmp.Diff(want, msg.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "BoilerPlate", "CopyrightYear")); diff != "" {
+		t.Errorf("mismatch (-want, +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Most Protobuf message names are already in `PascalCase`, the style used by Swift. So calling `pascalCase()` may seem redundant, but a few symbols need additional mangling.