### PR TITLE
fix(legacylibrarian): omitempty library service_config

### DIFF
--- a/internal/legacylibrarian/legacyconfig/state.go
+++ b/internal/legacylibrarian/legacyconfig/state.go
@@ -242,7 +242,7 @@ type API struct {
 	// The path to the API, relative to the root of the API definition repository (e.g., "google/storage/v1").
 	Path string `yaml:"path" json:"path"`
 	// The name of the service config file, relative to the API `path`.
-	ServiceConfig string `yaml:"service_config" json:"service_config"`
+	ServiceConfig string `yaml:"service_config,omitempty" json:"service_config,omitempty"`
 	// The status of the API, one of "new" or "existing".
 	// This field is ignored when writing to state.yaml.
 	Status string `yaml:"-" json:"status,omitempty"`


### PR DESCRIPTION
Now that new libraries are being generated by `librarian` and not `legacylibrarian`, the `service_config` field may go unset in the `.librarian/state.yaml`, and it shouldn't be serialized as `""` in that case.