### PR TITLE
refactor(internal/legacylibrarian): use `internal/yaml` for state serialization

### DIFF
--- a/internal/legacylibrarian/legacylibrarian/state.go
+++ b/internal/legacylibrarian/legacylibrarian/state.go
@@ -15,7 +15,6 @@
 package legacylibrarian
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/legacylibrarian/legacyconfig"
 	"github.com/googleapis/librarian/internal/legacylibrarian/legacygitrepo"
+	internalyaml "github.com/googleapis/librarian/internal/yaml"
 	"gopkg.in/yaml.v3"
 )
 
@@ -189,14 +189,7 @@ func findServiceConfigIn(path string) (string, error) {
 func saveLibrarianState(repoDir string, state *legacyconfig.LibrarianState) error {
 	sortByLibraryID(state)
 	stateFile := filepath.Join(repoDir, legacyconfig.LibrarianDir, librarianStateFile)
-	var buffer bytes.Buffer
-	encoder := yaml.NewEncoder(&buffer)
-	encoder.SetIndent(2)
-	err := encoder.Encode(state)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(stateFile, buffer.Bytes(), 0644)
+	return internalyaml.Write(stateFile, state)
 }
 
 // sortByLibraryID sorts legacyconfig.LibraryState with respect to ID.


### PR DESCRIPTION
The `saveLibrarianState` function is updated to use the `internal/yaml` package for writing the state file.

This change replaces manual YAML encoding with the internal utility to ensure that the state file is consistently formatted and includes the standard license header.

Tested locally with `go run ./cmd/legacylibrarian release stage -repo ../google-cloud-go`.

Fixes #5140