### PR TITLE
feat(internal/librarian/nodejs): replace bazel build with tsc and use google-cloud-node

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -275,10 +275,10 @@ func TestNodejsRead(t *testing.T) {
 			NPM: []*NPMTool{
 				{
 					Name:     "gapic-generator-typescript",
-					Version:  "76ba85a7f55c6e82943008b4eceb07a0f58b39e1",
-					Package:  "https://github.com/googleapis/google-cloud-node-core/archive/76ba85a7f55c6e82943008b4eceb07a0f58b39e1.tar.gz",
-					Checksum: "9561a116203761bad63bf1a0abc7a4a0db67608683c3d67b45abfc394df612ac",
-					Build:    []string{"npm install", "npm run compile", "npm link"},
+					Version:  "2ac5cf7a0dfb759be33ce24a40aae5b543ee375c",
+					Package:  "https://github.com/googleapis/google-cloud-node/archive/2ac5cf7a0dfb759be33ce24a40aae5b543ee375c.tar.gz",
+					Checksum: "1577eb76cd5fa5eb1298c8deaa190be073ae4160acedb87411c78a4df29fcc2f",
+					Build:    []string{"npm install", "npx tsc", "cp -r templates protos build/", "npm link"},
 				},
 				{
 					Name:    "gapic-node-processing",

--- a/internal/config/testdata/nodejs/librarian.yaml
+++ b/internal/config/testdata/nodejs/librarian.yaml
@@ -6,12 +6,13 @@ sources:
 tools:
   npm:
     - name: gapic-generator-typescript
-      version: "76ba85a7f55c6e82943008b4eceb07a0f58b39e1"
-      package: "https://github.com/googleapis/google-cloud-node-core/archive/76ba85a7f55c6e82943008b4eceb07a0f58b39e1.tar.gz"
-      checksum: "9561a116203761bad63bf1a0abc7a4a0db67608683c3d67b45abfc394df612ac"
+      version: "2ac5cf7a0dfb759be33ce24a40aae5b543ee375c"
+      package: "https://github.com/googleapis/google-cloud-node/archive/2ac5cf7a0dfb759be33ce24a40aae5b543ee375c.tar.gz"
+      checksum: "1577eb76cd5fa5eb1298c8deaa190be073ae4160acedb87411c78a4df29fcc2f"
       build:
         - "npm install"
-        - "npm run compile"
+        - "npx tsc"
+        - "cp -r templates protos build/"
         - "npm link"
     - name: gapic-node-processing
       version: "0.1.7"

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -28,9 +28,9 @@ import (
 )
 
 // gapicGeneratorSubdir is the sub-directory within the
-// google-cloud-node-core repo that contains the gapic-generator-typescript
+// google-cloud-node repo that contains the gapic-generator-typescript
 // source.
-const gapicGeneratorSubdir = "generator/gapic-generator-typescript"
+const gapicGeneratorSubdir = "core/generator/gapic-generator-typescript"
 
 //go:embed librarian.yaml
 var librarianYAML []byte
@@ -92,8 +92,8 @@ func installNPMToolFromSource(ctx context.Context, tool *config.NPMTool) error {
 }
 
 // repoFromPackageURL extracts the repository path (e.g.,
-// "github.com/googleapis/google-cloud-node-core") from a GitHub archive URL
-// like "https://github.com/googleapis/google-cloud-node-core/archive/<sha>.tar.gz".
+// "github.com/googleapis/google-cloud-node") from a GitHub archive URL
+// like "https://github.com/googleapis/google-cloud-node/archive/<sha>.tar.gz".
 func repoFromPackageURL(packageURL string) (string, error) {
 	parts := strings.SplitN(packageURL, "/archive/", 2)
 	if len(parts) != 2 {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -26,12 +26,15 @@ func TestInstall(t *testing.T) {
 	// installGapicGeneratorTypescript expects after cloning.
 	gitStub := `#!/bin/sh
 for last; do true; done
-mkdir -p "$last/generator/gapic-generator-typescript"
+mkdir -p "$last/core/generator/gapic-generator-typescript"
 `
 	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(gitStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(bin, "npm"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "npx"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(bin, "pip"), []byte("#!/bin/sh\n"), 0o755); err != nil {

--- a/internal/librarian/nodejs/librarian.yaml
+++ b/internal/librarian/nodejs/librarian.yaml
@@ -18,15 +18,16 @@
 language: nodejs
 tools:
   npm:
-    # TODO(https://github.com/googleapis/librarian/issues/4904): use the version
-    # of gapic-generator-typescript in google-cloud-node.
     - name: gapic-generator-typescript
-      version: "76ba85a7f55c6e82943008b4eceb07a0f58b39e1"
-      package: "https://github.com/googleapis/google-cloud-node-core/archive/76ba85a7f55c6e82943008b4eceb07a0f58b39e1.tar.gz"
-      checksum: "9561a116203761bad63bf1a0abc7a4a0db67608683c3d67b45abfc394df612ac"
+      version: "2ac5cf7a0dfb759be33ce24a40aae5b543ee375c"
+      package: "https://github.com/googleapis/google-cloud-node/archive/2ac5cf7a0dfb759be33ce24a40aae5b543ee375c.tar.gz"
+      checksum: "1577eb76cd5fa5eb1298c8deaa190be073ae4160acedb87411c78a4df29fcc2f"
       build:
         - "npm install"
-        - "npm run compile"
+        - "npx tsc"
+        # tsc only compiles TypeScript; the generator also needs templates/
+        # and protos/ in build/ (resolved via __dirname at runtime).
+        - "cp -r templates protos build/"
         - "npm link"
     - name: gapic-node-processing
       version: "0.1.7"


### PR DESCRIPTION
Now that google-cloud-node-core has been moved into google-cloud-node and archived as part of the monorepo consolidation, update all references to point to the new repository. The
gapic-generator-typescript subdirectory moved from generator/ to core/generator/ in the consolidated repo.

The npm run compile script invokes bazelisk, which pulls in a version of protobuf that fails to compile on CI runners due to a GCC/binutils incompatibility, and fails with error `as: option '--gsframe' doesn't allow an argument` (see
https://github.com/googleapis/librarian/actions/runs/24035669761/job/70094516884).

Since Bazel is only using tsc under the hood, call npx tsc directly to compile the TypeScript sources without Bazel.

Fix the previously failing TestInstall by adding a stub for npx.

For #4593
Fixes #4904