### PR TITLE
chore: update gapic-generator-go to v0.58.0

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   integration:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian


### PR DESCRIPTION
Update gapic-generator-go to v0.58.0.

Release note: https://github.com/googleapis/gapic-generator-go/releases/tag/v0.58.0