### PR TITLE
feat(.github/workflows): use librarian install for python

### DIFF
--- a/.github/actions/setup-librarian/action.yaml
+++ b/.github/actions/setup-librarian/action.yaml
@@ -32,10 +32,8 @@ runs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: go-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          go-${{ github.workflow }}-${{ github.job }}-
-          go-
+        key: go-build-${{ hashFiles('go.sum') }}
+        restore-keys: go-build-
     - if: inputs.install-protoc == 'true'
       uses: ./.github/actions/install-protoc
     - if: inputs.install-tools == 'true'

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -23,15 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian
-        with:
-          install-tools: "false"
-      - name: Display Go version
-        run: go version
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - name: Display Python version
-        run: python3 --version
       - name: Install pandoc
         run: |
           set -e
@@ -40,8 +34,6 @@ jobs:
           pandoc --version
         env:
           VERSION: 3.8.2
-      - name: Install librarian
-        run: go install ./cmd/librarian
       - name: "Install Python dependencies (resolve cache paths)"
         id: tool-paths
         run: |


### PR DESCRIPTION
Replace individual steps in the Python workflow with a single `librarian install python` command, and add caching for pip dependencies.

Rename the setup-librarian cache key to use a `go-build-` prefix instead of `go-${{ github.workflow }}-${{ github.job }}-`, since the cache is shared across all jobs.

For https://github.com/googleapis/librarian/issues/4848
For https://github.com/googleapis/librarian/issues/5117