### PR TITLE
ci(.github): remove post generation checks in go integration workflow

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,7 +54,7 @@ linters:
         limitations under the License.
       values:
         regexp:
-          YEAR: "(2019|202[0-9])"
+          YEAR: "202[0-9]"
   exclusions:
     rules:
       - path: internal/legacylibrarian/


### PR DESCRIPTION
The Golang integration workflow is updated to remove the post generation checks.

We only need to verify the generation process rather than running static checks against generated libraries because we need to fix the generator, not librarian if the code fails static checks.

Fixes #4894
Fixes #4895