### PR TITLE
fix(.github/workflows): remove flags from setup-librarian action

### DIFF
--- a/.github/actions/setup-librarian/action.yaml
+++ b/.github/actions/setup-librarian/action.yaml
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: Setup Librarian
-description: Set up Go with build caching, and optionally install protoc and Go tools.
-inputs:
-  install-protoc:
-    description: Whether to install protoc.
-    default: "true"
-  install-tools:
-    description: Whether to run `go install tool` and `go install ./cmd/librarian`.
-    default: "true"
+description: Set up Go with build caching, install protoc and Go tools.
 runs:
   using: composite
   steps:
@@ -34,10 +27,8 @@ runs:
           ~/go/pkg/mod
         key: go-build-${{ hashFiles('go.sum') }}
         restore-keys: go-build-
-    - if: inputs.install-protoc == 'true'
-      uses: ./.github/actions/install-protoc
-    - if: inputs.install-tools == 'true'
-      name: Install Go tools
+    - uses: ./.github/actions/install-protoc
+    - name: Install Go tools
       run: |
         go install tool
         go install ./cmd/librarian

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian
-        with:
-          install-tools: "false"
       - name: Display Go version
         run: go version
       - name: Install Dart SDK

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -23,9 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian
-        with:
-          install-protoc: "false"
-          install-tools: "false"
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@v4

--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian
-        with:
-          install-protoc: "false"
-          install-tools: "false"
       - name: Run tests and check coverage
         run: go run ./tool/cmd/coverage ./internal/legacylibrarian/...
   test:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian
-        with:
-          install-tools: "false"
       - name: Display Go version
         run: go version
       - name: Install Rust toolchain


### PR DESCRIPTION
The install-tools and install-protoc flags caused multiple cache variants to share the same key, leading to invalidation issues. Workflows that restored a cache built without tools ended up rebuilding on every run. With a warm cache, go install and protoc setup only takes seconds, so simplify the workflow by always performing a full setup and remove the flags.

Fixes https://github.com/googleapis/librarian/issues/5117