### PR TITLE
fix(sidekick/swift): default library location

### DIFF
--- a/internal/librarian/swift/default_output.go
+++ b/internal/librarian/swift/default_output.go
@@ -22,6 +22,6 @@ import (
 // DefaultOutput derives an output path from an API path and a default
 // output directory.
 func DefaultOutput(api, defaultOutput string) string {
-	path := strings.ReplaceAll(api, "/", "-")
+	path := strings.ReplaceAll(strings.Trim(api, "/"), "/", "-")
 	return filepath.Join(defaultOutput, path)
 }

--- a/internal/librarian/swift/default_output_test.go
+++ b/internal/librarian/swift/default_output_test.go
@@ -51,6 +51,24 @@ func TestDefaultOutput(t *testing.T) {
 			defOut: "generated",
 			want:   "generated/google-cloud-secretmanager-v1",
 		},
+		{
+			name:   "api path with trailing slash",
+			api:    "google/cloud/secretmanager/v1/",
+			defOut: "generated",
+			want:   "generated/google-cloud-secretmanager-v1",
+		},
+		{
+			name:   "api path with leading slash",
+			api:    "/google/cloud/secretmanager/v1",
+			defOut: "generated",
+			want:   "generated/google-cloud-secretmanager-v1",
+		},
+		{
+			name:   "api path with both leading and trailing slash (weird)",
+			api:    "/google/cloud/secretmanager/v1/",
+			defOut: "generated",
+			want:   "generated/google-cloud-secretmanager-v1",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultOutput(tt.api, tt.defOut)


### PR DESCRIPTION
Using the full path of the API was not as clever as I thought. The Swift package manager uses the last directory as the name of the package when used as a local dependency. Using dashes instead of slashes (so `google/cloud/secretmanager/v1` becomes `google-cloud-secretmanager-v1`) gives us something that works as unique identifiers.

Fixes #5151 