### PR TITLE
fix(python): only delete scripts when running the post-processor

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -86,11 +86,15 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		return err
 	}
 
-	// Run post processor (synthtool)
-	// The post processor needs to run from the repository root, not the package directory.
+	// Run post processor (synthtool) and then clean up afterwards.
+	// The post processor needs to run from the repository root, not the package
+	// directory.
 	if len(library.APIs) > 0 {
 		if err := runPostProcessor(ctx, repoRoot, outdir); err != nil {
 			return fmt.Errorf("failed to run post processor: %w", err)
+		}
+		if err := cleanUpFilesAfterPostProcessing(repoRoot, outdir); err != nil {
+			return fmt.Errorf("failed to cleanup after post processing: %w", err)
 		}
 	}
 
@@ -99,12 +103,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("failed to copy README to docs: %w", err)
 		}
 	}
-
-	// Clean up files that shouldn't be in the final output.
-	if err := cleanUpFilesAfterPostProcessing(repoRoot, outdir); err != nil {
-		return fmt.Errorf("failed to cleanup after post processing: %w", err)
-	}
-
 	return nil
 }
 

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -1030,6 +1030,34 @@ func TestGenerate_APIOrder(t *testing.T) {
 	}
 }
 
+func TestGenerate_Handwritten(t *testing.T) {
+	repoRoot := t.TempDir()
+	cfg := &config.Config{
+		Language: config.LanguagePython,
+		Repo:     "googleapis/google-cloud-python",
+	}
+
+	library := &config.Library{
+		Name:   "bigframes",
+		Output: filepath.Join(repoRoot, "packages", "bigframes"),
+		Python: &config.PythonPackage{
+			PythonDefault: config.PythonDefault{
+				LibraryType: "INTEGRATION",
+			},
+		},
+	}
+	scriptsDir := filepath.Join(library.Output, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "test.sh"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: googleapisDir}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDefaultOutput(t *testing.T) {
 	want := "packages/google-cloud-secret-manager"
 	got := DefaultOutput("google-cloud-secret-manager", "packages")


### PR DESCRIPTION
Instead of always cleaning up after the post-processor, this now only runs the cleanup if we're running the post-processor. We could potentially combine the two functions, but it's slightly simpler to test them separately.

This approach would fail with any library that had API generation *and* a scripts directory, but given that after mono-repo consolidation we're not in that situation, it seems unlikely that this will cause a problem - and all of the post-processor code should be overhauled post-migration anyway.

Fixes #5166