### PR TITLE
fix(.github/workflows): remove pip caching from python workflow

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -34,19 +34,7 @@ jobs:
           pandoc --version
         env:
           VERSION: 3.8.2
-      - name: "Install Python dependencies (resolve cache paths)"
-        id: tool-paths
-        run: |
-          echo "pip=$(python3 -c 'import site; print(site.getsitepackages()[0])')" >> "$GITHUB_OUTPUT"
-      - name: "Install Python dependencies (restore cache)"
-        uses: actions/cache@v5
-        id: tools-cache
-        with:
-          path: |
-            ${{ steps.tool-paths.outputs.pip }}
-          key: python-tools-${{ hashFiles('internal/librarian/python/librarian.yaml') }}
-      - name: "Install Python dependencies (run librarian install)"
-        if: steps.tools-cache.outputs.cache-hit != 'true'
+      - name: Install Python dependencies
         run: librarian install python
       - name: Run tests
         run: go run ./tool/cmd/coverage ./internal/librarian/python


### PR DESCRIPTION
Installing dependencies with pip is already pretty fast (less than 30s), so the pip caching steps added complexity without significant benefit. Remove this step.

For https://github.com/googleapis/librarian/issues/5117