### PR TITLE
feat(sidekick/swift): wrapper for dependencies

### DIFF
--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -14,8 +14,6 @@
 
 package config
 
-import "strings"
-
 // SwiftDefault contains the configuration shared by all Swift libraries.
 type SwiftDefault struct {
 	// Dependencies is a list of package dependencies.
@@ -81,23 +79,4 @@ type SwiftDependency struct {
 	// - The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.
 	// - The `GoogleCloudLocation` package will set this to `google.cloud.location`.
 	ApiPackage string `yaml:"api_package,omitempty"`
-}
-
-// LocalName returns the name of the dependency when used in a `Package.swift` file.
-//
-// For local dependencies this is the last directory in the path. For external dependencies this is
-// the last directory of the URL path.
-func (dep *SwiftDependency) LocalName() string {
-	var source string
-	if dep.Path != "" {
-		source = dep.Path
-	} else {
-		source = strings.TrimSuffix(dep.URL, ".git")
-	}
-	source = strings.Trim(source, "/")
-	idx := strings.LastIndex(source, "/")
-	if idx == -1 {
-		return source
-	}
-	return source[idx+1:]
 }

--- a/internal/sidekick/swift/dependency.go
+++ b/internal/sidekick/swift/dependency.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// Dependency wraps config.SwiftDependency to add helper methods.
+type Dependency struct {
+	config.SwiftDependency
+}
+
+// LocalName returns the name of the dependency when used in a `Package.swift` file.
+//
+// For local dependencies this is the last directory in the path. For external dependencies this is
+// the last directory of the URL path.
+func (dep *Dependency) LocalName() string {
+	var source string
+	if dep.Path != "" {
+		source = dep.Path
+	} else {
+		source = strings.TrimSuffix(dep.URL, ".git")
+	}
+	source = strings.Trim(source, "/")
+	idx := strings.LastIndex(source, "/")
+	if idx == -1 {
+		return source
+	}
+	return source[idx+1:]
+}

--- a/internal/sidekick/swift/dependency_test.go
+++ b/internal/sidekick/swift/dependency_test.go
@@ -12,43 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package swift
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestLocalName(t *testing.T) {
 	for _, test := range []struct {
 		name string
-		dep  SwiftDependency
+		dep  Dependency
 		want string
 	}{
 		{
 			name: "path simple",
-			dep:  SwiftDependency{Path: "packages/auth"},
+			dep:  Dependency{config.SwiftDependency{Path: "packages/auth"}},
 			want: "auth",
 		},
 		{
 			name: "path nested",
-			dep:  SwiftDependency{Path: "generated/google-cloud-location"},
+			dep:  Dependency{config.SwiftDependency{Path: "generated/google-cloud-location"}},
 			want: "google-cloud-location",
 		},
 		{
 			name: "path trailing slash",
-			dep:  SwiftDependency{Path: "packages/auth/"},
+			dep:  Dependency{config.SwiftDependency{Path: "packages/auth/"}},
 			want: "auth",
 		},
 		{
 			name: "url without git",
-			dep:  SwiftDependency{URL: "https://github.com/apple/swift-protobuf"},
+			dep:  Dependency{config.SwiftDependency{URL: "https://github.com/apple/swift-protobuf"}},
 			want: "swift-protobuf",
 		},
 		{
 			name: "url with git",
-			dep:  SwiftDependency{URL: "https://github.com/apple/swift-protobuf.git"},
+			dep:  Dependency{config.SwiftDependency{URL: "https://github.com/apple/swift-protobuf.git"}},
 			want: "swift-protobuf",
 		},
 	} {


### PR DESCRIPTION
In the mustache templates we will need annotations and functions to compute the local (to a `Package.swift` file) name of each dependency.

Towards #5165 