### PR TITLE
fix(sidekick/rust): optional enum conversions

### DIFF
--- a/internal/sidekick/rust/templates/convert-prost/message.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/message.mustache
@@ -73,12 +73,7 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}})
                 {{/Optional}}
                 {{#Optional}}
-                {{^IsEnum}}
                 .set_or_clear_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()).transpose()?)
-                {{/IsEnum}}
-                {{#IsEnum}}
-                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.into()))
-                {{/IsEnum}}
                 {{/Optional}}
                 {{/Singular}}
                 {{#Repeated}}


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-rust/issues/5314

BigQuery has our first optional enum field. It revealed this bug.