### PR TITLE
feat(dart): modernize JSON serialization and fix related lints

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
-          sdk: 3.6.0
+          sdk: 3.9.0
       - name: Display Dart version
         run: dart --version
       - name: Verify git is available

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -187,12 +187,10 @@ type fieldAnnotation struct {
 	// The default value for the string, e.g. "0" for an integer type.
 	DefaultValue string
 	// Whether the default value is constant or not, e.g. "0" is constant but "Uint8List(0)" is not.
-	ConstDefault    bool
-	FromJson        string
-	ToJson          string
-	ToJsonNullAware string
-	ToJsonWithValue string
-	ToJsonElement   string
+	ConstDefault  bool
+	FromJson      string
+	ToJson        string
+	ToJsonElement string
 }
 
 type enumAnnotation struct {
@@ -824,8 +822,6 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 		DefaultValue:          defaultValue,
 		FromJson:              annotate.createFromJsonLine(field, state, implicitPresence),
 		ToJson:                createToJsonLine(field, state, fieldName(field)),
-		ToJsonNullAware:       createToJsonNullAwareLine(field, state),
-		ToJsonWithValue:       createToJsonLine(field, state, "$1"),
 		ToJsonElement:         createToJsonElement(field, state),
 		ConstDefault:          constDefault,
 	}
@@ -1090,7 +1086,10 @@ func createToJsonElement(field *api.Field, state *api.APIState) string {
 		return fmt.Sprintf("if (%s case final $1?) '%s': encodeBytes($1)", name, jsonName)
 	default:
 		nullAware := createToJsonNullAwareLine(field, state)
-		return fmt.Sprintf("'%s': ?%s", jsonName, nullAware)
+		if field.Repeated || field.Map {
+			return fmt.Sprintf("'%s': %s", jsonName, nullAware)
+		}
+		return fmt.Sprintf("if (%s case final $1?) '%s': $1", nullAware, jsonName)
 	}
 }
 

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -1068,7 +1068,7 @@ func createToJsonElement(field *api.Field, state *api.APIState) string {
 		if field.Repeated || field.Map {
 			return fmt.Sprintf("'%s': %s", jsonName, nullAware)
 		}
-		return fmt.Sprintf("if (%s case final $1?) '%s': $1", nullAware, jsonName)
+		return fmt.Sprintf("'%s': ?%s", jsonName, nullAware)
 	}
 }
 
@@ -1137,8 +1137,14 @@ func (annotate *annotateModel) buildQueryLines(
 		// Handle lists; these should be lists of strings or other primitives.
 		switch field.Typez {
 		case api.STRING_TYPE:
+			if codec.Nullable {
+				return append(result, fmt.Sprintf("'%s': ?%s", param, ref))
+			}
 			return append(result, fmt.Sprintf("%s: $1", preamble))
 		case api.ENUM_TYPE:
+			if codec.Nullable {
+				return append(result, fmt.Sprintf("'%s': ?%s?.map((e) => e.value)", param, ref))
+			}
 			return append(result, fmt.Sprintf("%s: $1.map((e) => e.value)", preamble))
 		case api.BOOL_TYPE, api.INT32_TYPE, api.UINT32_TYPE, api.SINT32_TYPE,
 			api.FIXED32_TYPE, api.SFIXED32_TYPE, api.INT64_TYPE,
@@ -1177,8 +1183,14 @@ func (annotate *annotateModel) buildQueryLines(
 		return result
 
 	case field.Typez == api.STRING_TYPE:
+		if codec.Nullable {
+			return append(result, fmt.Sprintf("'%s': ?%s", param, ref))
+		}
 		return append(result, fmt.Sprintf("%s: $1", preamble))
 	case field.Typez == api.ENUM_TYPE:
+		if codec.Nullable {
+			return append(result, fmt.Sprintf("'%s': ?%s?.value", param, ref))
+		}
 		return append(result, fmt.Sprintf("%s: $1.value", preamble))
 	case field.Typez == api.BOOL_TYPE ||
 		field.Typez == api.INT32_TYPE ||

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -812,6 +812,10 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 		}
 	}
 	state := annotate.state
+	var toJsonElement string
+	if !implicitPresence {
+		toJsonElement = createToJsonElement(field)
+	}
 	field.Codec = &fieldAnnotation{
 		Name:                  fieldName(field),
 		Type:                  annotate.fieldType(field),
@@ -822,7 +826,7 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 		DefaultValue:          defaultValue,
 		FromJson:              annotate.createFromJsonLine(field, state, implicitPresence),
 		ToJson:                createToJsonLine(field, state, fieldName(field)),
-		ToJsonElement:         createToJsonElement(field, state),
+		ToJsonElement:         toJsonElement,
 		ConstDefault:          constDefault,
 	}
 }
@@ -1036,25 +1040,24 @@ func createToJsonLine(field *api.Field, state *api.APIState, name string) string
 }
 
 // createToJsonNullAwareLine creates a null-aware expression for JSON serialization.
-func createToJsonNullAwareLine(field *api.Field, state *api.APIState) string {
+func createToJsonNullAwareLine(field *api.Field) string {
 	name := fieldName(field)
 
-	if field.Repeated || field.Map {
-		return createToJsonLine(field, state, name)
-	}
-
-	switch field.Typez {
-	case api.MESSAGE_TYPE, api.ENUM_TYPE:
-		return fmt.Sprintf("%s?.toJson()", name)
-	case api.INT64_TYPE, api.SINT64_TYPE, api.SFIXED64_TYPE, api.FIXED64_TYPE, api.UINT64_TYPE:
-		return fmt.Sprintf("%s?.toString()", name)
-	default:
+	// Check if the type requires encoding.
+	_, required := encoder(field.Typez, name)
+	if !required {
 		return name
 	}
+
+	// For types that require encoding (like Messages or 64-bit ints),
+	// encoder appends ".toJson()" or ".toString()".
+	// Passing "name?" results in "name?.toJson()" or "name?.toString()".
+	enc, _ := encoder(field.Typez, name+"?")
+	return enc
 }
 
 // createToJsonElement creates a JSON element expression for map literals.
-func createToJsonElement(field *api.Field, state *api.APIState) string {
+func createToJsonElement(field *api.Field) string {
 	name := fieldName(field)
 	jsonName := field.JSONName
 
@@ -1064,10 +1067,7 @@ func createToJsonElement(field *api.Field, state *api.APIState) string {
 	case api.BYTES_TYPE:
 		return fmt.Sprintf("if (%s case final $1?) '%s': encodeBytes($1)", name, jsonName)
 	default:
-		nullAware := createToJsonNullAwareLine(field, state)
-		if field.Repeated || field.Map {
-			return fmt.Sprintf("'%s': %s", jsonName, nullAware)
-		}
+		nullAware := createToJsonNullAwareLine(field)
 		return fmt.Sprintf("'%s': ?%s", jsonName, nullAware)
 	}
 }

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -1035,30 +1035,12 @@ func createToJsonLine(field *api.Field, state *api.APIState, name string) string
 	return enc
 }
 
+// createToJsonNullAwareLine creates a null-aware expression for JSON serialization.
 func createToJsonNullAwareLine(field *api.Field, state *api.APIState) string {
 	name := fieldName(field)
 
-	switch {
-	case field.Repeated:
-		if encoder, encodingRequired := encoder(field.Typez, "i"); encodingRequired {
-			return fmt.Sprintf(
-				"[for (final i in %s) %s]",
-				name, encoder)
-		}
-		return name
-	case field.Map:
-		message := state.MessageByID[field.TypezID]
-		keyType := message.Fields[0].Typez
-		keyEncoder, keyEncodingRequired := keyEncoder(keyType, "e.key")
-		valueType := message.Fields[1].Typez
-		valueEncoder, valueEncodingRequired := encoder(valueType, "e.value")
-
-		if keyEncodingRequired || valueEncodingRequired {
-			return fmt.Sprintf(
-				"{for (final e in %s.entries) %s: %s}",
-				name, keyEncoder, valueEncoder)
-		}
-		return name
+	if field.Repeated || field.Map {
+		return createToJsonLine(field, state, name)
 	}
 
 	switch field.Typez {
@@ -1066,15 +1048,12 @@ func createToJsonNullAwareLine(field *api.Field, state *api.APIState) string {
 		return fmt.Sprintf("%s?.toJson()", name)
 	case api.INT64_TYPE, api.SINT64_TYPE, api.SFIXED64_TYPE, api.FIXED64_TYPE, api.UINT64_TYPE:
 		return fmt.Sprintf("%s?.toString()", name)
-	case api.FLOAT_TYPE, api.DOUBLE_TYPE:
-		return fmt.Sprintf("%s == null ? null : encodeDouble(%s)", name, name)
-	case api.BYTES_TYPE:
-		return fmt.Sprintf("%s == null ? null : encodeBytes(%s)", name, name)
 	default:
 		return name
 	}
 }
 
+// createToJsonElement creates a JSON element expression for map literals.
 func createToJsonElement(field *api.Field, state *api.APIState) string {
 	name := fieldName(field)
 	jsonName := field.JSONName

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -1137,14 +1137,8 @@ func (annotate *annotateModel) buildQueryLines(
 		// Handle lists; these should be lists of strings or other primitives.
 		switch field.Typez {
 		case api.STRING_TYPE:
-			if codec.Nullable {
-				return append(result, fmt.Sprintf("'%s': ?%s", param, ref))
-			}
 			return append(result, fmt.Sprintf("%s: $1", preamble))
 		case api.ENUM_TYPE:
-			if codec.Nullable {
-				return append(result, fmt.Sprintf("'%s': ?%s?.map((e) => e.value)", param, ref))
-			}
 			return append(result, fmt.Sprintf("%s: $1.map((e) => e.value)", preamble))
 		case api.BOOL_TYPE, api.INT32_TYPE, api.UINT32_TYPE, api.SINT32_TYPE,
 			api.FIXED32_TYPE, api.SFIXED32_TYPE, api.INT64_TYPE,

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -187,9 +187,12 @@ type fieldAnnotation struct {
 	// The default value for the string, e.g. "0" for an integer type.
 	DefaultValue string
 	// Whether the default value is constant or not, e.g. "0" is constant but "Uint8List(0)" is not.
-	ConstDefault bool
-	FromJson     string
-	ToJson       string
+	ConstDefault    bool
+	FromJson        string
+	ToJson          string
+	ToJsonNullAware string
+	ToJsonWithValue string
+	ToJsonElement   string
 }
 
 type enumAnnotation struct {
@@ -820,7 +823,10 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 		FieldBehaviorRequired: fieldRequired,
 		DefaultValue:          defaultValue,
 		FromJson:              annotate.createFromJsonLine(field, state, implicitPresence),
-		ToJson:                createToJsonLine(field, state),
+		ToJson:                createToJsonLine(field, state, fieldName(field)),
+		ToJsonNullAware:       createToJsonNullAwareLine(field, state),
+		ToJsonWithValue:       createToJsonLine(field, state, "$1"),
+		ToJsonElement:         createToJsonElement(field, state),
 		ConstDefault:          constDefault,
 	}
 }
@@ -1004,8 +1010,7 @@ func (annotate *annotateModel) createFromJsonLine(field *api.Field, state *api.A
 	return fmt.Sprintf("switch (%s) { null => %s, Object $1 => %s($1)}", data, defaultValue, decoder)
 }
 
-func createToJsonLine(field *api.Field, state *api.APIState) string {
-	name := fieldName(field)
+func createToJsonLine(field *api.Field, state *api.APIState, name string) string {
 
 	switch {
 	case field.Repeated:
@@ -1032,6 +1037,61 @@ func createToJsonLine(field *api.Field, state *api.APIState) string {
 
 	enc, _ := encoder(field.Typez, name)
 	return enc
+}
+
+func createToJsonNullAwareLine(field *api.Field, state *api.APIState) string {
+	name := fieldName(field)
+
+	switch {
+	case field.Repeated:
+		if encoder, encodingRequired := encoder(field.Typez, "i"); encodingRequired {
+			return fmt.Sprintf(
+				"[for (final i in %s) %s]",
+				name, encoder)
+		}
+		return name
+	case field.Map:
+		message := state.MessageByID[field.TypezID]
+		keyType := message.Fields[0].Typez
+		keyEncoder, keyEncodingRequired := keyEncoder(keyType, "e.key")
+		valueType := message.Fields[1].Typez
+		valueEncoder, valueEncodingRequired := encoder(valueType, "e.value")
+
+		if keyEncodingRequired || valueEncodingRequired {
+			return fmt.Sprintf(
+				"{for (final e in %s.entries) %s: %s}",
+				name, keyEncoder, valueEncoder)
+		}
+		return name
+	}
+
+	switch field.Typez {
+	case api.MESSAGE_TYPE, api.ENUM_TYPE:
+		return fmt.Sprintf("%s?.toJson()", name)
+	case api.INT64_TYPE, api.SINT64_TYPE, api.SFIXED64_TYPE, api.FIXED64_TYPE, api.UINT64_TYPE:
+		return fmt.Sprintf("%s?.toString()", name)
+	case api.FLOAT_TYPE, api.DOUBLE_TYPE:
+		return fmt.Sprintf("%s == null ? null : encodeDouble(%s)", name, name)
+	case api.BYTES_TYPE:
+		return fmt.Sprintf("%s == null ? null : encodeBytes(%s)", name, name)
+	default:
+		return name
+	}
+}
+
+func createToJsonElement(field *api.Field, state *api.APIState) string {
+	name := fieldName(field)
+	jsonName := field.JSONName
+
+	switch field.Typez {
+	case api.FLOAT_TYPE, api.DOUBLE_TYPE:
+		return fmt.Sprintf("if (%s case final $1?) '%s': encodeDouble($1)", name, jsonName)
+	case api.BYTES_TYPE:
+		return fmt.Sprintf("if (%s case final $1?) '%s': encodeBytes($1)", name, jsonName)
+	default:
+		nullAware := createToJsonNullAwareLine(field, state)
+		return fmt.Sprintf("'%s': ?%s", jsonName, nullAware)
+	}
 }
 
 // buildQueryLines builds a string or strings representing query parameters for the given field.

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -1671,7 +1671,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "0",
 				ConstDefault:          true,
-				ToJsonElement:         "'int32Field': ?int32Field",
+				ToJsonElement:         "",
 			},
 		},
 		{
@@ -1691,7 +1691,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "'int32Field': ?int32Field",
+				ToJsonElement:         "",
 			},
 		},
 		{
@@ -1731,7 +1731,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "const []",
 				ConstDefault:          true,
-				ToJsonElement:         "'int32List': int32List",
+				ToJsonElement:         "",
 			},
 		},
 		{
@@ -1752,7 +1752,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "const {}",
 				ConstDefault:          true,
-				ToJsonElement:         "'mapField': mapField",
+				ToJsonElement:         "",
 			},
 		},
 		{
@@ -1813,7 +1813,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "State.$default",
 				ConstDefault:          true,
-				ToJsonElement:         "'enumField': ?enumField?.toJson()",
+				ToJsonElement:         "",
 			},
 		},
 		{
@@ -1834,7 +1834,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "'enumField': ?enumField?.toJson()",
+				ToJsonElement:         "",
 			},
 		},
 		{

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -1671,9 +1671,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "0",
 				ConstDefault:          true,
-				ToJsonNullAware:       "int32Field",
-				ToJsonWithValue:       "$1",
-				ToJsonElement:         "'int32Field': ?int32Field",
+				ToJsonElement:         "if (int32Field case final $1?) 'int32Field': $1",
 			},
 		},
 		{
@@ -1693,9 +1691,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonNullAware:       "int32Field",
-				ToJsonWithValue:       "$1",
-				ToJsonElement:         "'int32Field': ?int32Field",
+				ToJsonElement:         "if (int32Field case final $1?) 'int32Field': $1",
 			},
 		},
 		{
@@ -1715,9 +1711,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonNullAware:       "int32Field",
-				ToJsonWithValue:       "$1",
-				ToJsonElement:         "'int32Field': ?int32Field",
+				ToJsonElement:         "if (int32Field case final $1?) 'int32Field': $1",
 			},
 		},
 		{
@@ -1737,9 +1731,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "const []",
 				ConstDefault:          true,
-				ToJsonNullAware:       "int32List",
-				ToJsonWithValue:       "$1",
-				ToJsonElement:         "'int32List': ?int32List",
+				ToJsonElement:         "'int32List': int32List",
 			},
 		},
 		{
@@ -1760,9 +1752,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "const {}",
 				ConstDefault:          true,
-				ToJsonNullAware:       "mapField",
-				ToJsonWithValue:       "$1",
-				ToJsonElement:         "'mapField': ?mapField",
+				ToJsonElement:         "'mapField': mapField",
 			},
 		},
 		{
@@ -1782,9 +1772,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonNullAware:       "messageField?.toJson()",
-				ToJsonWithValue:       "$1.toJson()",
-				ToJsonElement:         "'messageField': ?messageField?.toJson()",
+				ToJsonElement:         "if (messageField?.toJson() case final $1?) 'messageField': $1",
 			},
 		},
 		{
@@ -1805,9 +1793,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonNullAware:       "messageField?.toJson()",
-				ToJsonWithValue:       "$1.toJson()",
-				ToJsonElement:         "'messageField': ?messageField?.toJson()",
+				ToJsonElement:         "if (messageField?.toJson() case final $1?) 'messageField': $1",
 			},
 		},
 		{
@@ -1827,9 +1813,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "State.$default",
 				ConstDefault:          true,
-				ToJsonNullAware:       "enumField?.toJson()",
-				ToJsonWithValue:       "$1.toJson()",
-				ToJsonElement:         "'enumField': ?enumField?.toJson()",
+				ToJsonElement:         "if (enumField?.toJson() case final $1?) 'enumField': $1",
 			},
 		},
 		{
@@ -1850,14 +1834,10 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonNullAware:       "enumField?.toJson()",
-				ToJsonWithValue:       "$1.toJson()",
-				ToJsonElement:         "'enumField': ?enumField?.toJson()",
+				ToJsonElement:         "if (enumField?.toJson() case final $1?) 'enumField': $1",
 			},
 		},
 		{
-			// `google.protobuf.Empty` is a special because, in some cases, it is
-			// converted to the `void` Dart type. `void` is not nullable in Dart.
 			name: "google.protobuf.Empty",
 			field: &api.Field{
 				Name:     "empty_field",
@@ -1874,9 +1854,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonNullAware:       "emptyField?.toJson()",
-				ToJsonWithValue:       "$1.toJson()",
-				ToJsonElement:         "'emptyField': ?emptyField?.toJson()",
+				ToJsonElement:         "if (emptyField?.toJson() case final $1?) 'emptyField': $1",
 			},
 		},
 		{
@@ -1896,8 +1874,6 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonNullAware:       "floatField == null ? null : encodeDouble(floatField)",
-				ToJsonWithValue:       "encodeDouble($1)",
 				ToJsonElement:         "if (floatField case final $1?) 'floatField': encodeDouble($1)",
 			},
 		},

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -726,7 +726,7 @@ func TestBuildQueryLines_Primitives(t *testing.T) {
 			[]string{"if (result.doubleOpt case final $1?) 'double': '${$1}'"},
 		}, {
 			&api.Field{Name: "string_opt", JSONName: "string", Typez: api.STRING_TYPE, Optional: true},
-			[]string{"if (result.stringOpt case final $1?) 'string': $1"},
+			[]string{"'string': ?result.stringOpt"},
 		},
 
 		// one ofs
@@ -825,7 +825,7 @@ func TestBuildQueryLines_Enums(t *testing.T) {
 				Typez:    api.ENUM_TYPE,
 				TypezID:  enum.ID,
 				Optional: true},
-			[]string{"if (result.optionalEnum case final $1?) 'optionalJsonEnum': $1.value"},
+			[]string{"'optionalJsonEnum': ?result.optionalEnum?.value"},
 		},
 		{
 			&api.Field{
@@ -1671,7 +1671,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "0",
 				ConstDefault:          true,
-				ToJsonElement:         "if (int32Field case final $1?) 'int32Field': $1",
+				ToJsonElement:         "'int32Field': ?int32Field",
 			},
 		},
 		{
@@ -1691,7 +1691,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "if (int32Field case final $1?) 'int32Field': $1",
+				ToJsonElement:         "'int32Field': ?int32Field",
 			},
 		},
 		{
@@ -1711,7 +1711,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "if (int32Field case final $1?) 'int32Field': $1",
+				ToJsonElement:         "'int32Field': ?int32Field",
 			},
 		},
 		{
@@ -1772,7 +1772,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "if (messageField?.toJson() case final $1?) 'messageField': $1",
+				ToJsonElement:         "'messageField': ?messageField?.toJson()",
 			},
 		},
 		{
@@ -1793,7 +1793,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "if (messageField?.toJson() case final $1?) 'messageField': $1",
+				ToJsonElement:         "'messageField': ?messageField?.toJson()",
 			},
 		},
 		{
@@ -1813,7 +1813,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "State.$default",
 				ConstDefault:          true,
-				ToJsonElement:         "if (enumField?.toJson() case final $1?) 'enumField': $1",
+				ToJsonElement:         "'enumField': ?enumField?.toJson()",
 			},
 		},
 		{
@@ -1834,7 +1834,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "if (enumField?.toJson() case final $1?) 'enumField': $1",
+				ToJsonElement:         "'enumField': ?enumField?.toJson()",
 			},
 		},
 		{
@@ -1854,7 +1854,7 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
-				ToJsonElement:         "if (emptyField?.toJson() case final $1?) 'emptyField': $1",
+				ToJsonElement:         "'emptyField': ?emptyField?.toJson()",
 			},
 		},
 		{

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -531,7 +531,40 @@ func TestAnnotateMessage_ToString(t *testing.T) {
 	}
 }
 
-// Tests that messages that are allowlisted as not being generated are, in fact, not generated.
+func TestAnnotateMessage_HasFields(t *testing.T) {
+	model := api.NewTestAPI(
+		[]*api.Message{sample.Secret()},
+		[]*api.Enum{},
+		[]*api.Service{},
+	)
+	annotate := newAnnotateModel(model)
+	annotate.annotateModel(map[string]string{})
+
+	emptyMessage := &api.Message{
+		Name:    "EmptyMessage",
+		Package: "google.cloud.foo",
+		ID:      "google.cloud.foo.EmptyMessage",
+		Fields:  []*api.Field{},
+	}
+
+	t.Run("has fields", func(t *testing.T) {
+		secret := sample.Secret()
+		annotate.annotateMessage(secret)
+		codec := secret.Codec.(*messageAnnotation)
+		if !codec.HasFields() {
+			t.Errorf("Expected HasFields() to be true")
+		}
+	})
+
+	t.Run("no fields", func(t *testing.T) {
+		annotate.annotateMessage(emptyMessage)
+		codec := emptyMessage.Codec.(*messageAnnotation)
+		if codec.HasFields() {
+			t.Errorf("Expected HasFields() to be false")
+		}
+	})
+}
+
 func TestAnnotateMessage_OmitGeneration_Allowlisted(t *testing.T) {
 	status := &api.Message{
 		Name:    "Status",
@@ -1500,7 +1533,7 @@ func TestCreateToJsonLine(t *testing.T) {
 				"prefix:google.cloud.foo": "foo",
 			})
 
-			got := createToJsonLine(test.field, model.State)
+			got := createToJsonLine(test.field, model.State, fieldName(test.field))
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch in TestCreateToJsonLine (-want, +got)\n:%s", diff)
 			}
@@ -1638,6 +1671,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "0",
 				ConstDefault:          true,
+				ToJsonNullAware:       "int32Field",
+				ToJsonWithValue:       "$1",
+				ToJsonElement:         "'int32Field': ?int32Field",
 			},
 		},
 		{
@@ -1657,6 +1693,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
+				ToJsonNullAware:       "int32Field",
+				ToJsonWithValue:       "$1",
+				ToJsonElement:         "'int32Field': ?int32Field",
 			},
 		},
 		{
@@ -1676,6 +1715,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
+				ToJsonNullAware:       "int32Field",
+				ToJsonWithValue:       "$1",
+				ToJsonElement:         "'int32Field': ?int32Field",
 			},
 		},
 		{
@@ -1695,6 +1737,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "const []",
 				ConstDefault:          true,
+				ToJsonNullAware:       "int32List",
+				ToJsonWithValue:       "$1",
+				ToJsonElement:         "'int32List': ?int32List",
 			},
 		},
 		{
@@ -1715,6 +1760,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "const {}",
 				ConstDefault:          true,
+				ToJsonNullAware:       "mapField",
+				ToJsonWithValue:       "$1",
+				ToJsonElement:         "'mapField': ?mapField",
 			},
 		},
 		{
@@ -1734,6 +1782,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
+				ToJsonNullAware:       "messageField?.toJson()",
+				ToJsonWithValue:       "$1.toJson()",
+				ToJsonElement:         "'messageField': ?messageField?.toJson()",
 			},
 		},
 		{
@@ -1754,6 +1805,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
+				ToJsonNullAware:       "messageField?.toJson()",
+				ToJsonWithValue:       "$1.toJson()",
+				ToJsonElement:         "'messageField': ?messageField?.toJson()",
 			},
 		},
 		{
@@ -1773,6 +1827,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "State.$default",
 				ConstDefault:          true,
+				ToJsonNullAware:       "enumField?.toJson()",
+				ToJsonWithValue:       "$1.toJson()",
+				ToJsonElement:         "'enumField': ?enumField?.toJson()",
 			},
 		},
 		{
@@ -1793,6 +1850,9 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: true,
 				DefaultValue:          "",
 				ConstDefault:          true,
+				ToJsonNullAware:       "enumField?.toJson()",
+				ToJsonWithValue:       "$1.toJson()",
+				ToJsonElement:         "'enumField': ?enumField?.toJson()",
 			},
 		},
 		{
@@ -1814,6 +1874,31 @@ func TestAnnotateField(t *testing.T) {
 				FieldBehaviorRequired: false,
 				DefaultValue:          "",
 				ConstDefault:          true,
+				ToJsonNullAware:       "emptyField?.toJson()",
+				ToJsonWithValue:       "$1.toJson()",
+				ToJsonElement:         "'emptyField': ?emptyField?.toJson()",
+			},
+		},
+		{
+			name: "float",
+			field: &api.Field{
+				Name:     "float_field",
+				JSONName: "floatField",
+				Typez:    api.FLOAT_TYPE,
+				Optional: true,
+			},
+			want: &fieldAnnotation{
+				Name:                  "floatField",
+				Type:                  "double",
+				DocLines:              []string{},
+				Required:              false,
+				Nullable:              true,
+				FieldBehaviorRequired: false,
+				DefaultValue:          "",
+				ConstDefault:          true,
+				ToJsonNullAware:       "floatField == null ? null : encodeDouble(floatField)",
+				ToJsonWithValue:       "encodeDouble($1)",
+				ToJsonElement:         "if (floatField case final $1?) 'floatField': encodeDouble($1)",
 			},
 		},
 	} {

--- a/internal/sidekick/dart/generate_test.go
+++ b/internal/sidekick/dart/generate_test.go
@@ -125,6 +125,66 @@ func TestTemplatesAvailable(t *testing.T) {
 	}
 }
 
+func TestGenerate_EmptyMessage(t *testing.T) {
+	emptyMessage := &api.Message{
+		Name:    "EmptyMessage",
+		Package: "google.cloud.foo",
+		ID:      "google.cloud.foo.EmptyMessage",
+		Fields:  []*api.Field{},
+	}
+
+	model := api.NewTestAPI([]*api.Message{emptyMessage}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.foo"
+
+	outDir := t.TempDir()
+
+	// Skip format to make test faster and avoid dependency on dart sdk in minimal environments.
+	codec := map[string]string{
+		"skip-format":                    "true",
+		"package:google_cloud_rpc":       "^1.2.3",
+		"package:http":                   "^4.5.6",
+		"package:google_cloud_protobuf":  "^0.1.2",
+		"proto:google.protobuf":          "package:google_cloud_protobuf/protobuf.dart",
+		"api-keys-environment-variables": "GOOGLE_API_KEY",
+		"copyright-year":                 "2026",
+		"issue-tracker-url":              "http://www.example.com/issues",
+	}
+
+	if err := Generate(t.Context(), model, outDir, codec); err != nil {
+		t.Fatal(err)
+	}
+
+	// The file name is derived from package name.
+	// google.cloud.foo -> google_cloud_foo.dart
+	// Let's find it dynamically.
+	libDir := filepath.Join(outDir, "lib")
+	files, err := os.ReadDir(libDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var targetFile string
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".dart") {
+			targetFile = filepath.Join(libDir, f.Name())
+			break
+		}
+	}
+
+	if targetFile == "" {
+		t.Fatal("No .dart file generated in lib/")
+	}
+
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "factory EmptyMessage.fromJson(Object? _)"
+	if !strings.Contains(string(content), expected) {
+		t.Errorf("Expected content to contain %q, but it didn't.\nContent:\n%s", expected, string(content))
+	}
+}
 func requireProtoc(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("protoc"); err != nil {

--- a/internal/sidekick/dart/templates/lib/main.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/main.dart.mustache
@@ -25,7 +25,6 @@ limitations under the License.
 {{/Codec.DocLines}}
 library;
 
-// ignore_for_file: avoid_unused_constructor_parameters {{! `fromJson` may not use its arguments if the message is empty }}
 // ignore_for_file: camel_case_types {{! Nested messages have the parent/child separated by an underscore }}
 // ignore_for_file: comment_references {{! TODO(#25): improve the generated dartdocs }}
 // ignore_for_file: constant_identifier_names {{! enum values may not follow Dart naming conventions if there are multiple values that differ only in case }}
@@ -33,7 +32,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars {{! TODO(#25): improve the generated dartdocs }}
 // ignore_for_file: non_constant_identifier_names {{! field names may not follow Dart naming conventions if there are multiple fields that differ only in case }}
 // ignore_for_file: unintended_html_in_doc_comment {{! TODO(#25): improve the generated dartdocs }}
-// ignore_for_file: use_null_aware_elements {{! When serializing `NullValue`, we need to explicitly serialize `null` and it isn't worth special-casing that  }}
 
 {{#Codec.Imports}}
 {{{.}}}

--- a/internal/sidekick/dart/templates/lib/message.mustache
+++ b/internal/sidekick/dart/templates/lib/message.mustache
@@ -53,7 +53,7 @@ final class {{Codec.Name}} extends {{Codec.Model.Codec.ProtoPrefix}}ProtoMessage
   factory {{Codec.Name}}.fromJson(Object? json) => _{{Codec.Name}}Helper.decode(json);
   {{/Codec.HasCustomEncoding}}
   {{^Codec.HasCustomEncoding}}
-  factory {{Codec.Name}}.fromJson(Object? j) 
+  factory {{Codec.Name}}.fromJson(Object? {{#Codec.HasFields}}j{{/Codec.HasFields}}{{^Codec.HasFields}}_{{/Codec.HasFields}}) 
     {{#Codec.HasFields}}
     {
       final json = j as Map<String, Object?>;
@@ -77,7 +77,7 @@ final class {{Codec.Name}} extends {{Codec.Model.Codec.ProtoPrefix}}ProtoMessage
   Object toJson() => {
       {{#Fields}}
       {{#Codec.Nullable}}
-      if ({{{Codec.Name}}} case final {{{Codec.Name}}}?) '{{{JSONName}}}': {{{Codec.ToJson}}},
+          {{{Codec.ToJsonElement}}},
       {{/Codec.Nullable}}
       {{^Codec.Nullable}}
           {{^Codec.FieldBehaviorRequired}}if ({{{Codec.Name}}}.isNotDefault){{/Codec.FieldBehaviorRequired}} '{{{JSONName}}}': {{{Codec.ToJson}}},


### PR DESCRIPTION
- Implemented hybrid toJson generation strategy in annotate.go to handle function calls and null-aware elements efficiently.

- Used _ for fromJson parameter in empty messages to fix avoid_unused_constructor_parameters lint.

- Removed avoid_unused_constructor_parameters and use_null_aware_elements ignores in generated code.

- Added unit tests for HasFields and integration test for empty message fromJson.
