### PR TITLE
feat(internal/librarian/java): derive released version for readme from snapshot version

### DIFF
--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -477,8 +477,9 @@ func TestGenerateLibrary_Error(t *testing.T) {
 		{
 			name: "missing monorepo version",
 			library: &config.Library{
-				Name:   "secretmanager",
-				Output: t.TempDir(),
+				Name:    "secretmanager",
+				Version: "1.2.0",
+				Output:  t.TempDir(),
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -40,6 +40,7 @@ var (
 	errTemplatesMissing = errors.New("templates directory not found")
 	errRunOwlBot        = errors.New("failed to run owlbot.py")
 	errSyncPOMs         = errors.New("failed to generate or update pom.xml files")
+	errInvalidVersion   = errors.New("invalid java library version")
 )
 
 type postProcessParams struct {
@@ -275,9 +276,13 @@ func restructureModules(p postProcessParams, destRoot string) error {
 //  4. python3 is available on the system PATH and has the synthtool package
 //     installed (from google-cloud-java/sdk-platform-java).
 func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion string) error {
+	releasedVersion, err := releasedVersion(library.Version)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errInvalidVersion, library.Version)
+	}
 	// Versions used to populate README.md file.
 	env := map[string]string{
-		"SYNTHTOOL_LIBRARY_VERSION":       releasedVersion(library.Version),
+		"SYNTHTOOL_LIBRARY_VERSION":       releasedVersion,
 		"SYNTHTOOL_LIBRARIES_BOM_VERSION": bomVersion,
 	}
 	// Path to templates used for README.md file.
@@ -296,19 +301,22 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 // releasedVersion derives the last released version from a snapshot version
 // (e.g., x.y.0-SNAPSHOT) by decrementing the minor version.
 //
-// It assumes that the patch version is always 0 for snapshot releases,
-// because google-cloud-java always bumps minor.
-func releasedVersion(v string) string {
+// It returns an error if the snapshot version has a non-zero patch or a zero
+// minor version, as this repository is assumed to always bump the minor version.
+func releasedVersion(v string) (string, error) {
 	if !strings.HasSuffix(v, "-SNAPSHOT") {
-		return v
+		return v, nil
 	}
 	sv, err := semver.Parse(strings.TrimSuffix(v, "-SNAPSHOT"))
 	if err != nil {
-		return v
+		return "", err
+	}
+	if sv.Patch > 0 || (sv.Minor == 0 && sv.Patch == 0) {
+		return "", errInvalidVersion
 	}
 	sv.Minor--
 	sv.Patch = 0
-	return sv.String()
+	return sv.String(), nil
 }
 
 func copyProtos(googleapisDir string, protos []string, destDir string) error {

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -278,7 +278,7 @@ func restructureModules(p postProcessParams, destRoot string) error {
 func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion string) error {
 	releasedVersion, err := releasedVersion(library.Version)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errInvalidVersion, library.Version)
+		return fmt.Errorf("%w %q: %w", errInvalidVersion, library.Version, err)
 	}
 	// Versions used to populate README.md file.
 	env := map[string]string{
@@ -304,18 +304,19 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 // It returns an error if the snapshot version has a non-zero patch or a zero
 // minor version, as this repository is assumed to always bump the minor version.
 func releasedVersion(v string) (string, error) {
-	if !strings.HasSuffix(v, "-SNAPSHOT") {
-		return v, nil
-	}
-	sv, err := semver.Parse(strings.TrimSuffix(v, "-SNAPSHOT"))
+	sv, err := semver.Parse(v)
 	if err != nil {
 		return "", err
 	}
-	if sv.Patch > 0 || (sv.Minor == 0 && sv.Patch == 0) {
+	if sv.Prerelease != "SNAPSHOT" {
+		return sv.String(), nil
+	}
+	if sv.Patch > 0 || sv.Minor == 0 {
 		return "", errInvalidVersion
 	}
 	sv.Minor--
 	sv.Patch = 0
+	sv.Prerelease = ""
 	return sv.String(), nil
 }
 

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -276,7 +276,7 @@ func restructureModules(p postProcessParams, destRoot string) error {
 //  4. python3 is available on the system PATH and has the synthtool package
 //     installed (from google-cloud-java/sdk-platform-java).
 func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion string) error {
-	releasedVersion, err := releasedVersion(library.Version)
+	releasedVersion, err := deriveLastReleasedVersion(library.Version)
 	if err != nil {
 		return fmt.Errorf("%w %q: %w", errInvalidVersion, library.Version, err)
 	}
@@ -298,12 +298,12 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 	return nil
 }
 
-// releasedVersion derives the last released version from a snapshot version
+// deriveLastReleasedVersion derives the last released version from a snapshot version
 // (e.g., x.y.0-SNAPSHOT) by decrementing the minor version.
 //
 // It returns an error if the snapshot version has a non-zero patch or a zero
 // minor version, as this repository is assumed to always bump the minor version.
-func releasedVersion(v string) (string, error) {
+func deriveLastReleasedVersion(v string) (string, error) {
 	sv, err := semver.Parse(v)
 	if err != nil {
 		return "", err

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -294,10 +294,10 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 }
 
 // releasedVersion derives the last released version from a snapshot version
-// (e.g., x.y.z-SNAPSHOT).
+// (e.g., x.y.0-SNAPSHOT) by decrementing the minor version.
 //
-// If the patch version (z) is greater than 0, it resets the patch to 0.
-// Otherwise, it decrements the minor version (y).
+// It assumes that the patch version is always 0 for snapshot releases,
+// because google-cloud-java always bumps minor.
 func releasedVersion(v string) string {
 	if !strings.HasSuffix(v, "-SNAPSHOT") {
 		return v
@@ -306,11 +306,8 @@ func releasedVersion(v string) string {
 	if err != nil {
 		return v
 	}
-	if sv.Patch > 0 {
-		sv.Patch = 0
-	} else {
-		sv.Minor--
-	}
+	sv.Minor--
+	sv.Patch = 0
 	return sv.String()
 }
 

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/license"
+	"github.com/googleapis/librarian/internal/semver"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
@@ -276,7 +277,7 @@ func restructureModules(p postProcessParams, destRoot string) error {
 func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion string) error {
 	// Versions used to populate README.md file.
 	env := map[string]string{
-		"SYNTHTOOL_LIBRARY_VERSION":       library.Version,
+		"SYNTHTOOL_LIBRARY_VERSION":       releasedVersion(library.Version),
 		"SYNTHTOOL_LIBRARIES_BOM_VERSION": bomVersion,
 	}
 	// Path to templates used for README.md file.
@@ -290,6 +291,27 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 	}
 	// Staging dirs cleans up as part of owlbot.py
 	return nil
+}
+
+// releasedVersion derives the last released version from a snapshot version
+// (e.g., x.y.z-SNAPSHOT).
+//
+// If the patch version (z) is greater than 0, it resets the patch to 0.
+// Otherwise, it decrements the minor version (y).
+func releasedVersion(v string) string {
+	if !strings.HasSuffix(v, "-SNAPSHOT") {
+		return v
+	}
+	sv, err := semver.Parse(strings.TrimSuffix(v, "-SNAPSHOT"))
+	if err != nil {
+		return v
+	}
+	if sv.Patch > 0 {
+		sv.Patch = 0
+	} else {
+		sv.Minor--
+	}
+	return sv.String()
 }
 
 func copyProtos(googleapisDir string, protos []string, destDir string) error {

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -26,6 +26,7 @@ import (
 
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
@@ -388,6 +389,28 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			err := postProcessLibrary(t.Context(), params)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestReleasedVersion(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{"1.2.0-SNAPSHOT", "1.1.0"},
+		{"1.10.0-SNAPSHOT", "1.9.0"},
+		{"1.10.1-SNAPSHOT", "1.10.0"},
+		{"0.87.0-SNAPSHOT", "0.86.0"},
+		{"1.2.3", "1.2.3"},
+		{"invalid", "invalid"},
+		{"1.invalid.0-SNAPSHOT", "1.invalid.0-SNAPSHOT"},
+	} {
+		t.Run(test.input, func(t *testing.T) {
+			got := releasedVersion(test.input)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/semver"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
@@ -396,18 +397,23 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 
 func TestReleasedVersion(t *testing.T) {
 	for _, test := range []struct {
-		input string
-		want  string
+		input   string
+		want    string
+		wantErr error
 	}{
-		{"1.2.0-SNAPSHOT", "1.1.0"},
-		{"1.10.0-SNAPSHOT", "1.9.0"},
-		{"0.87.0-SNAPSHOT", "0.86.0"},
-		{"1.2.3", "1.2.3"},
-		{"invalid", "invalid"},
-		{"1.invalid.0-SNAPSHOT", "1.invalid.0-SNAPSHOT"},
+		{input: "1.2.0-SNAPSHOT", want: "1.1.0"},
+		{input: "1.10.0-SNAPSHOT", want: "1.9.0"},
+		{input: "0.87.0-SNAPSHOT", want: "0.86.0"},
+		{input: "1.2.3", want: "1.2.3"},
+		{input: "1.invalid.0-SNAPSHOT", want: "", wantErr: semver.ErrInvalidVersion},
+		{input: "1.0.0-SNAPSHOT", wantErr: errInvalidVersion},
+		{input: "1.10.1-SNAPSHOT", wantErr: errInvalidVersion},
 	} {
 		t.Run(test.input, func(t *testing.T) {
-			got := releasedVersion(test.input)
+			got, err := releasedVersion(test.input)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("error = %v, wantErr %v", err, test.wantErr)
+			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -397,25 +397,52 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 
 func TestDeriveLastReleasedVersion(t *testing.T) {
 	for _, test := range []struct {
-		input   string
-		want    string
-		wantErr error
+		input string
+		want  string
 	}{
 		{input: "1.2.0-SNAPSHOT", want: "1.1.0"},
 		{input: "1.10.0-SNAPSHOT", want: "1.9.0"},
 		{input: "0.87.0-SNAPSHOT", want: "0.86.0"},
 		{input: "1.2.3", want: "1.2.3"},
-		{input: "1.invalid.0-SNAPSHOT", want: "", wantErr: semver.ErrInvalidVersion},
-		{input: "1.0.0-SNAPSHOT", wantErr: errInvalidVersion},
-		{input: "1.10.1-SNAPSHOT", wantErr: errInvalidVersion},
 	} {
 		t.Run(test.input, func(t *testing.T) {
 			got, err := deriveLastReleasedVersion(test.input)
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("error = %v, wantErr %v", err, test.wantErr)
+			if err != nil {
+				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeriveLastReleasedVersion_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{
+			name:    "invalid version",
+			input:   "1.invalid.0-SNAPSHOT",
+			wantErr: semver.ErrInvalidVersion,
+		},
+		{
+			name:    "v1.0.0 snapshot",
+			input:   "1.0.0-SNAPSHOT",
+			wantErr: errInvalidVersion,
+		},
+		{
+			name:    "patch version snapshot",
+			input:   "1.10.1-SNAPSHOT",
+			wantErr: errInvalidVersion,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := deriveLastReleasedVersion(test.input)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -395,7 +395,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 	}
 }
 
-func TestReleasedVersion(t *testing.T) {
+func TestDeriveLastReleasedVersion(t *testing.T) {
 	for _, test := range []struct {
 		input   string
 		want    string
@@ -410,7 +410,7 @@ func TestReleasedVersion(t *testing.T) {
 		{input: "1.10.1-SNAPSHOT", wantErr: errInvalidVersion},
 	} {
 		t.Run(test.input, func(t *testing.T) {
-			got, err := releasedVersion(test.input)
+			got, err := deriveLastReleasedVersion(test.input)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("error = %v, wantErr %v", err, test.wantErr)
 			}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -401,7 +401,6 @@ func TestReleasedVersion(t *testing.T) {
 	}{
 		{"1.2.0-SNAPSHOT", "1.1.0"},
 		{"1.10.0-SNAPSHOT", "1.9.0"},
-		{"1.10.1-SNAPSHOT", "1.10.0"},
 		{"0.87.0-SNAPSHOT", "0.86.0"},
 		{"1.2.3", "1.2.3"},
 		{"invalid", "invalid"},


### PR DESCRIPTION
Derive last released version from library.version. The library.version in config is snapshot version for now, and is used for pom.xml generate and updates. We need to know last released version to for README generation. 

This implementation is a temp solution for migration, while https://github.com/googleapis/librarian/issues/5222 is decided.

Fix #5218