### PR TITLE
fix(sidekick/swift): missing import on Linux

### DIFF
--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -21,6 +21,10 @@ limitations under the License.
 {{/Codec.BoilerPlate}}
 
 import Foundation
+{{! On Linux we need this additional import for `URLSession`. }}
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
 import GoogleCloudAuth
 import GoogleCloudGax
 


### PR DESCRIPTION
On Linux we need an additional import for `URLSession` (the standard HTTP client).

Towards #5130 - the methods have a body, this PR is needed for them to compile.
