### PR TITLE
feat(sidekick/swift): generate empty enums

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+type enumAnnotations struct {
+	CopyrightYear string
+	BoilerPlate   []string
+	Name          string
+	DocLines      []string
+}
+
+func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) {
+	docLines := codec.formatDocumentation(enum.Documentation)
+	annotations := &enumAnnotations{
+		CopyrightYear: model.CopyrightYear,
+		BoilerPlate:   model.BoilerPlate,
+		Name:          pascalCase(enum.Name),
+		DocLines:      docLines,
+	}
+
+	enum.Codec = annotations
+}

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func TestAnnotateEnum(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		enumName      string
+		documentation string
+		wantName      string
+		wantDocs      []string
+	}{
+		{
+			name:          "basic enum",
+			enumName:      "Color",
+			documentation: "A color enum.\nWith two lines.",
+			wantName:      "Color",
+			wantDocs:      []string{"A color enum.", "With two lines."},
+		},
+		{
+			name:          "escaped name",
+			enumName:      "Protocol",
+			documentation: "An enum named Protocol.",
+			wantName:      "Protocol_",
+			wantDocs:      []string{"An enum named Protocol."},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			enum := &api.Enum{
+				Name:          test.enumName,
+				Documentation: test.documentation,
+				ID:            ".test." + test.enumName,
+				Package:       "test",
+			}
+			model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
+			codec := newTestCodec(t, model, map[string]string{})
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			want := &enumAnnotations{
+				Name:     test.wantName,
+				DocLines: test.wantDocs,
+			}
+
+			if diff := cmp.Diff(want, enum.Codec, cmpopts.IgnoreFields(enumAnnotations{}, "BoilerPlate", "CopyrightYear")); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -59,6 +59,9 @@ func (codec *codec) annotateModel() error {
 			return err
 		}
 	}
+	for _, enum := range codec.Model.Enums {
+		codec.annotateEnum(enum, annotations)
+	}
 	for _, service := range codec.Model.Services {
 		codec.annotateService(service, annotations)
 	}

--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -48,6 +48,9 @@ func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.Mo
 	if err := codec.generateMessages(outdir, model, provider); err != nil {
 		return err
 	}
+	if err := codec.generateEnums(outdir, model, provider); err != nil {
+		return err
+	}
 	if err := codec.generateServices(outdir, model, provider); err != nil {
 		return err
 	}
@@ -62,6 +65,19 @@ func (c *codec) generateMessages(outdir string, model *api.API, provider languag
 			OutputPath:   filepath.Join("Sources", c.PackageName, m.Name+".swift"),
 		}
 		if err := language.GenerateMessage(outdir, m, provider, generated); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *codec) generateEnums(outdir string, model *api.API, provider language.TemplateProvider) error {
+	for _, e := range model.Enums {
+		generated := language.GeneratedFile{
+			TemplatePath: "templates/common/enum.swift.mustache",
+			OutputPath:   filepath.Join("Sources", c.PackageName, e.Name+".swift"),
+		}
+		if err := language.GenerateEnum(outdir, e, provider, generated); err != nil {
 			return err
 		}
 	}

--- a/internal/sidekick/swift/generate_test.go
+++ b/internal/sidekick/swift/generate_test.go
@@ -127,3 +127,31 @@ func TestGenerateServiceFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateEnumFiles(t *testing.T) {
+	outDir := t.TempDir()
+
+	color := &api.Enum{Name: "Color", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.Color"}
+	kind := &api.Enum{Name: "Kind", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.Kind"}
+
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{color, kind}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+
+	cfg := &parser.ModelConfig{
+		Codec: map[string]string{
+			"copyright-year": "2038",
+		},
+	}
+
+	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	for _, expected := range []string{"Color.swift", "Kind.swift"} {
+		filename := filepath.Join(expectedDir, expected)
+		if _, err := os.Stat(filename); errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("missing %s: %s", filename, err)
+		}
+	}
+}

--- a/internal/sidekick/swift/templates/common/enum.swift.mustache
+++ b/internal/sidekick/swift/templates/common/enum.swift.mustache
@@ -1,0 +1,28 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+//
+// Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+//{{{.}}}
+{{/Codec.BoilerPlate}}
+
+import Foundation
+
+{{#Codec.DocLines}}
+/// {{{.}}}
+{{/Codec.DocLines}}
+public enum {{Codec.Name}}: Codable, Equatable {
+}


### PR DESCRIPTION
For package-level enums this generates the correct file with the copyright boilerplate and an empty enum. A future PR will add the missing enum values.

Fixes #5261 