### PR TITLE
chore(serviceconfig): allow-list google/bigtable/v2 for python

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -303,6 +303,7 @@
 - path: google/bigtable/v2
   languages:
     - go
+    - python
 - path: google/chat/v1
   languages:
     - go


### PR DESCRIPTION
Adds python to the list of allow-listed languages for google/bigtable/v2, to unblock Python migration.

It would probably be fine to use "all" here instead, but only allow-listing Python is a little more cautious.

Fixes #5278