### PR TITLE
feat(internal/librarian/java): support artifact IDs override via config

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -245,7 +245,6 @@ This document describes the schema for the librarian.yaml.
 | `path` | string | Is the source path. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |
-| `gapic_artifact_id_override` | string | Overrides the artifact ID for the GAPIC module. The artifact ID is also used as the name for the module's directory. |
 
 ## JavaModule Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -243,6 +243,9 @@ This document describes the schema for the librarian.yaml.
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `no_samples` | bool | Determines whether to generate samples for the API. |
 | `path` | string | Is the source path. |
+| `proto_artifact_id_override` | string | Is to override the artifact ID for the proto module. |
+| `grpc_artifact_id_override` | string | Is to override the artifact ID for the gRPC module. |
+| `gapic_artifact_id_override` | string | Is to override the artifact ID for the GAPIC module. |
 
 ## JavaModule Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -243,9 +243,9 @@ This document describes the schema for the librarian.yaml.
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `no_samples` | bool | Determines whether to generate samples for the API. |
 | `path` | string | Is the source path. |
-| `proto_artifact_id_override` | string | Is to override the artifact ID for the proto module. |
-| `grpc_artifact_id_override` | string | Is to override the artifact ID for the gRPC module. |
-| `gapic_artifact_id_override` | string | Is to override the artifact ID for the GAPIC module. |
+| `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
+| `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |
+| `gapic_artifact_id_override` | string | Overrides the artifact ID for the GAPIC module. The artifact ID is also used as the name for the module's directory. |
 
 ## JavaModule Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -580,10 +580,6 @@ type JavaAPI struct {
 	// GRPCArtifactIDOverride overrides the artifact ID for the gRPC module.
 	// The artifact ID is also used as the name for the module's directory.
 	GRPCArtifactIDOverride string `yaml:"grpc_artifact_id_override,omitempty"`
-
-	// GAPICArtifactIDOverride overrides the artifact ID for the GAPIC module.
-	// The artifact ID is also used as the name for the module's directory.
-	GAPICArtifactIDOverride string `yaml:"gapic_artifact_id_override,omitempty"`
 }
 
 // DotnetPackage contains .NET-specific library configuration.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -572,6 +572,15 @@ type JavaAPI struct {
 
 	// Path is the source path.
 	Path string `yaml:"path,omitempty"`
+
+	// ProtoArtifactIDOverride is the artifact ID for the proto module.
+	ProtoArtifactIDOverride string `yaml:"proto_artifact_id_override,omitempty"`
+
+	// GRPCArtifactIDOverride is the artifact ID for the gRPC module.
+	GRPCArtifactIDOverride string `yaml:"grpc_artifact_id_override,omitempty"`
+
+	// GAPICArtifactIDOverride is the artifact ID for the GAPIC module.
+	GAPICArtifactIDOverride string `yaml:"gapic_artifact_id_override,omitempty"`
 }
 
 // DotnetPackage contains .NET-specific library configuration.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -573,13 +573,13 @@ type JavaAPI struct {
 	// Path is the source path.
 	Path string `yaml:"path,omitempty"`
 
-	// ProtoArtifactIDOverride is the artifact ID for the proto module.
+	// ProtoArtifactIDOverride is to override the artifact ID for the proto module.
 	ProtoArtifactIDOverride string `yaml:"proto_artifact_id_override,omitempty"`
 
-	// GRPCArtifactIDOverride is the artifact ID for the gRPC module.
+	// GRPCArtifactIDOverride is to override the artifact ID for the gRPC module.
 	GRPCArtifactIDOverride string `yaml:"grpc_artifact_id_override,omitempty"`
 
-	// GAPICArtifactIDOverride is the artifact ID for the GAPIC module.
+	// GAPICArtifactIDOverride is to override the artifact ID for the GAPIC module.
 	GAPICArtifactIDOverride string `yaml:"gapic_artifact_id_override,omitempty"`
 }
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -573,13 +573,16 @@ type JavaAPI struct {
 	// Path is the source path.
 	Path string `yaml:"path,omitempty"`
 
-	// ProtoArtifactIDOverride is to override the artifact ID for the proto module.
+	// ProtoArtifactIDOverride overrides the artifact ID for the proto module.
+	// The artifact ID is also used as the name for the module's directory.
 	ProtoArtifactIDOverride string `yaml:"proto_artifact_id_override,omitempty"`
 
-	// GRPCArtifactIDOverride is to override the artifact ID for the gRPC module.
+	// GRPCArtifactIDOverride overrides the artifact ID for the gRPC module.
+	// The artifact ID is also used as the name for the module's directory.
 	GRPCArtifactIDOverride string `yaml:"grpc_artifact_id_override,omitempty"`
 
-	// GAPICArtifactIDOverride is to override the artifact ID for the GAPIC module.
+	// GAPICArtifactIDOverride overrides the artifact ID for the GAPIC module.
+	// The artifact ID is also used as the name for the module's directory.
 	GAPICArtifactIDOverride string `yaml:"gapic_artifact_id_override,omitempty"`
 }
 

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -98,6 +98,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 	p := postProcessParams{
 		cfg:            cfg,
 		library:        library,
+		javaAPI:        javaAPI,
 		metadata:       metadata,
 		outDir:         outdir,
 		version:        version,

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -94,7 +94,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 	if version == "" {
 		return fmt.Errorf("%s: %w", api.Path, errExtractVersion)
 	}
-	javaAPI := resolveJavaAPI(library, api)
+	javaAPI := ResolveJavaAPI(library, api)
 	p := postProcessParams{
 		cfg:            cfg,
 		library:        library,
@@ -281,9 +281,11 @@ func collectJavaFiles(root string) ([]string, error) {
 	return files, err
 }
 
-// resolveJavaAPI returns the Java-specific configuration for the given API,
+// ResolveJavaAPI returns the Java-specific configuration for the given API,
 // applying default values if no explicit configuration is found in the library.
-func resolveJavaAPI(library *config.Library, api *config.API) *config.JavaAPI {
+// TODO(https://github.com/googleapis/librarian/issues/5050):
+// Exported to use in migrate tool, unexport after migrate is done.
+func ResolveJavaAPI(library *config.Library, api *config.API) *config.JavaAPI {
 	res := &config.JavaAPI{
 		Path:             api.Path,
 		AdditionalProtos: []string{commonProtos},

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -305,7 +305,7 @@ func TestResolveJavaAPI(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := resolveJavaAPI(test.library, test.api)
+			got := ResolveJavaAPI(test.library, test.api)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -105,15 +105,14 @@ func DeriveLibraryCoordinates(library *config.Library) LibraryCoordinate {
 // artifacts associated with a specific API version.
 func DeriveAPICoordinates(lc LibraryCoordinate, version string, javaAPI *config.JavaAPI) APICoordinate {
 	protoGRPCGroupID := protoGroupID(lc.GAPIC.GroupID)
-	protoArtifactID := fmt.Sprintf("%s%s-%s", protoPrefix, lc.GAPIC.ArtifactID, version)
-	if javaAPI.ProtoArtifactIDOverride != "" {
-		protoArtifactID = javaAPI.ProtoArtifactIDOverride
+	protoArtifactID := javaAPI.ProtoArtifactIDOverride
+	if protoArtifactID == "" {
+		protoArtifactID = fmt.Sprintf("%s%s-%s", protoPrefix, lc.GAPIC.ArtifactID, version)
 	}
-	grpcArtifactID := fmt.Sprintf("%s%s-%s", gRPCPrefix, lc.GAPIC.ArtifactID, version)
-	if javaAPI.GRPCArtifactIDOverride != "" {
-		grpcArtifactID = javaAPI.GRPCArtifactIDOverride
+	grpcArtifactID := javaAPI.GRPCArtifactIDOverride
+	if grpcArtifactID == "" {
+		grpcArtifactID = fmt.Sprintf("%s%s-%s", gRPCPrefix, lc.GAPIC.ArtifactID, version)
 	}
-
 	return APICoordinate{
 		LibraryCoordinate: lc,
 		Proto: Coordinate{

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -103,18 +103,27 @@ func DeriveLibraryCoordinates(library *config.Library) LibraryCoordinate {
 
 // DeriveAPICoordinates returns the Maven coordinates for the proto and gRPC
 // artifacts associated with a specific API version.
-func DeriveAPICoordinates(lc LibraryCoordinate, version string) APICoordinate {
+func DeriveAPICoordinates(lc LibraryCoordinate, version string, javaAPI *config.JavaAPI) APICoordinate {
 	protoGRPCGroupID := protoGroupID(lc.GAPIC.GroupID)
+	protoArtifactID := fmt.Sprintf("%s%s-%s", protoPrefix, lc.GAPIC.ArtifactID, version)
+	if javaAPI != nil && javaAPI.ProtoArtifactIDOverride != "" {
+		protoArtifactID = javaAPI.ProtoArtifactIDOverride
+	}
+	grpcArtifactID := fmt.Sprintf("%s%s-%s", gRPCPrefix, lc.GAPIC.ArtifactID, version)
+	if javaAPI != nil && javaAPI.GRPCArtifactIDOverride != "" {
+		grpcArtifactID = javaAPI.GRPCArtifactIDOverride
+	}
+
 	return APICoordinate{
 		LibraryCoordinate: lc,
 		Proto: Coordinate{
 			GroupID:    protoGRPCGroupID,
-			ArtifactID: fmt.Sprintf("%s%s-%s", protoPrefix, lc.GAPIC.ArtifactID, version),
+			ArtifactID: protoArtifactID,
 			Version:    lc.GAPIC.Version,
 		},
 		GRPC: Coordinate{
 			GroupID:    protoGRPCGroupID,
-			ArtifactID: fmt.Sprintf("%s%s-%s", gRPCPrefix, lc.GAPIC.ArtifactID, version),
+			ArtifactID: grpcArtifactID,
 			Version:    lc.GAPIC.Version,
 		},
 	}

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -106,11 +106,11 @@ func DeriveLibraryCoordinates(library *config.Library) LibraryCoordinate {
 func DeriveAPICoordinates(lc LibraryCoordinate, version string, javaAPI *config.JavaAPI) APICoordinate {
 	protoGRPCGroupID := protoGroupID(lc.GAPIC.GroupID)
 	protoArtifactID := fmt.Sprintf("%s%s-%s", protoPrefix, lc.GAPIC.ArtifactID, version)
-	if javaAPI != nil && javaAPI.ProtoArtifactIDOverride != "" {
+	if javaAPI.ProtoArtifactIDOverride != "" {
 		protoArtifactID = javaAPI.ProtoArtifactIDOverride
 	}
 	grpcArtifactID := fmt.Sprintf("%s%s-%s", gRPCPrefix, lc.GAPIC.ArtifactID, version)
-	if javaAPI != nil && javaAPI.GRPCArtifactIDOverride != "" {
+	if javaAPI.GRPCArtifactIDOverride != "" {
 		grpcArtifactID = javaAPI.GRPCArtifactIDOverride
 	}
 

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -99,7 +99,7 @@ func TestProtoGroupID(t *testing.T) {
 	}
 }
 
-func TestDeriveLibCoords(t *testing.T) {
+func TestDeriveLibraryCoordinates(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		library *config.Library
@@ -166,7 +166,7 @@ func TestDeriveLibCoords(t *testing.T) {
 	}
 }
 
-func TestDeriveAPICoords(t *testing.T) {
+func TestDeriveAPICoordinates(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		lc        LibraryCoordinate
@@ -185,6 +185,7 @@ func TestDeriveAPICoords(t *testing.T) {
 				},
 			},
 			version: "v1",
+			javaAPI: &config.JavaAPI{},
 			wantProto: Coordinate{
 				GroupID:    "com.google.api.grpc",
 				ArtifactID: "proto-google-cloud-secretmanager-v1",
@@ -206,6 +207,7 @@ func TestDeriveAPICoords(t *testing.T) {
 				},
 			},
 			version: "v1",
+			javaAPI: &config.JavaAPI{},
 			wantProto: Coordinate{
 				GroupID:    "com.google.maps.api.grpc",
 				ArtifactID: "proto-google-maps-places-v1",

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -171,6 +171,7 @@ func TestDeriveAPICoords(t *testing.T) {
 		name      string
 		lc        LibraryCoordinate
 		version   string
+		javaAPI   *config.JavaAPI
 		wantProto Coordinate
 		wantGRPC  Coordinate
 	}{
@@ -216,9 +217,34 @@ func TestDeriveAPICoords(t *testing.T) {
 				Version:    "1.2.3",
 			},
 		},
+		{
+			name: "with overrides",
+			lc: LibraryCoordinate{
+				GAPIC: Coordinate{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-cloud-datastore",
+					Version:    "1.2.3",
+				},
+			},
+			version: "v1",
+			javaAPI: &config.JavaAPI{
+				ProtoArtifactIDOverride: "proto-google-cloud-datastore-admin-v1",
+				GRPCArtifactIDOverride:  "grpc-google-cloud-datastore-admin-v1",
+			},
+			wantProto: Coordinate{
+				GroupID:    "com.google.api.grpc",
+				ArtifactID: "proto-google-cloud-datastore-admin-v1",
+				Version:    "1.2.3",
+			},
+			wantGRPC: Coordinate{
+				GroupID:    "com.google.api.grpc",
+				ArtifactID: "grpc-google-cloud-datastore-admin-v1",
+				Version:    "1.2.3",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := DeriveAPICoordinates(test.lc, test.version)
+			got := DeriveAPICoordinates(test.lc, test.version, test.javaAPI)
 			if diff := cmp.Diff(test.wantProto, got.Proto, cmp.AllowUnexported(Coordinate{})); diff != "" {
 				t.Errorf("proto mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -220,7 +220,7 @@ func TestDeriveAPICoordinates(t *testing.T) {
 			},
 		},
 		{
-			name: "with overrides",
+			name: "with proto and grpc artifact overrides",
 			lc: LibraryCoordinate{
 				GAPIC: Coordinate{
 					GroupID:    "com.google.cloud",

--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -254,7 +254,8 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 			return nil, fmt.Errorf("failed to extract version from API path %q", api.Path)
 		}
 
-		apiCoord := DeriveAPICoordinates(libCoord, version)
+		javaAPI := resolveJavaAPI(library, api)
+		apiCoord := DeriveAPICoordinates(libCoord, version, javaAPI)
 
 		transport := transports[api.Path]
 		data := gRPCProtoPOMData{

--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -254,7 +254,7 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 			return nil, fmt.Errorf("failed to extract version from API path %q", api.Path)
 		}
 
-		javaAPI := resolveJavaAPI(library, api)
+		javaAPI := ResolveJavaAPI(library, api)
 		apiCoord := DeriveAPICoordinates(libCoord, version, javaAPI)
 
 		transport := transports[api.Path]

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -92,7 +92,7 @@ func (p postProcessParams) gapicDir() string { return filepath.Join(p.outDir, p.
 func (p postProcessParams) gRPCDir() string  { return filepath.Join(p.outDir, p.version, "grpc") }
 func (p postProcessParams) protoDir() string { return filepath.Join(p.outDir, p.version, "proto") }
 func (p postProcessParams) coords() APICoordinate {
-	return DeriveAPICoordinates(DeriveLibraryCoordinates(p.library), p.version)
+	return DeriveAPICoordinates(DeriveLibraryCoordinates(p.library), p.version, nil)
 }
 
 func postProcessAPI(ctx context.Context, p postProcessParams) error {

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -46,6 +46,7 @@ var (
 type postProcessParams struct {
 	cfg            *config.Config
 	library        *config.Library
+	javaAPI        *config.JavaAPI
 	metadata       *repoMetadata
 	outDir         string
 	version        string
@@ -92,7 +93,7 @@ func (p postProcessParams) gapicDir() string { return filepath.Join(p.outDir, p.
 func (p postProcessParams) gRPCDir() string  { return filepath.Join(p.outDir, p.version, "grpc") }
 func (p postProcessParams) protoDir() string { return filepath.Join(p.outDir, p.version, "proto") }
 func (p postProcessParams) coords() APICoordinate {
-	return DeriveAPICoordinates(DeriveLibraryCoordinates(p.library), p.version, nil)
+	return DeriveAPICoordinates(DeriveLibraryCoordinates(p.library), p.version, p.javaAPI)
 }
 
 func postProcessAPI(ctx context.Context, p postProcessParams) error {

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -360,7 +360,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 					t.Fatal(err)
 				}
 				libCoords := DeriveLibraryCoordinates(library)
-				apiCoords := DeriveAPICoordinates(libCoords, "v1")
+				apiCoords := DeriveAPICoordinates(libCoords, "v1", nil)
 				for _, dir := range []string{
 					filepath.Join(outDir, apiCoords.Proto.ArtifactID),
 					filepath.Join(outDir, apiCoords.GRPC.ArtifactID),

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -109,6 +109,7 @@ func TestPostProcessAPI(t *testing.T) {
 		googleapisDir:  googleapisDir,
 		apiProtos:      apiProtos,
 		includeSamples: true,
+		javaAPI:        &config.JavaAPI{},
 	}
 	if err := postProcessAPI(t.Context(), p); err != nil {
 		t.Fatal(err)
@@ -182,6 +183,7 @@ func TestRestructureModules(t *testing.T) {
 		googleapisDir:  googleapisDir,
 		apiProtos:      []string{protoPath},
 		includeSamples: true,
+		javaAPI:        &config.JavaAPI{},
 	}
 	destRoot := filepath.Join(tmpDir, "dest")
 	if err := restructureModules(p, destRoot); err != nil {
@@ -233,6 +235,7 @@ func TestRestructureModules_NoSamples(t *testing.T) {
 		googleapisDir:  googleapisDir,
 		apiProtos:      nil,
 		includeSamples: false,
+		javaAPI:        &config.JavaAPI{},
 	}
 	destRoot := filepath.Join(tmpDir, "dest")
 	if err := restructureModules(p, destRoot); err != nil {
@@ -360,7 +363,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 					t.Fatal(err)
 				}
 				libCoords := DeriveLibraryCoordinates(library)
-				apiCoords := DeriveAPICoordinates(libCoords, "v1", nil)
+				apiCoords := DeriveAPICoordinates(libCoords, "v1", &config.JavaAPI{})
 				for _, dir := range []string{
 					filepath.Join(outDir, apiCoords.Proto.ArtifactID),
 					filepath.Join(outDir, apiCoords.GRPC.ArtifactID),

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -484,7 +484,8 @@ func getModuleArtifactIDs(lib *config.Library) moduleArtifactIDs {
 	}
 	for _, api := range lib.APIs {
 		version := serviceconfig.ExtractVersion(api.Path)
-
+		// Find Java-specific API config to handle artifact ID overrides.
+		// Should export resolveJavaAPI if it gets more complicated
 		javaAPI := &config.JavaAPI{Path: api.Path}
 		if lib.Java != nil {
 			for _, ja := range lib.Java.JavaAPIs {
@@ -494,7 +495,6 @@ func getModuleArtifactIDs(lib *config.Library) moduleArtifactIDs {
 				}
 			}
 		}
-
 		apiCoord := java.DeriveAPICoordinates(lc, version, javaAPI)
 		ids.Protos = append(ids.Protos, apiCoord.Proto.ArtifactID)
 		ids.GRPCs = append(ids.GRPCs, apiCoord.GRPC.ArtifactID)

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -485,16 +485,7 @@ func getModuleArtifactIDs(lib *config.Library) moduleArtifactIDs {
 	for _, api := range lib.APIs {
 		version := serviceconfig.ExtractVersion(api.Path)
 		// Find Java-specific API config to handle artifact ID overrides.
-		// Should export resolveJavaAPI if it gets more complicated
-		javaAPI := &config.JavaAPI{Path: api.Path}
-		if lib.Java != nil {
-			for _, ja := range lib.Java.JavaAPIs {
-				if ja.Path == api.Path {
-					javaAPI = ja
-					break
-				}
-			}
-		}
+		javaAPI := java.ResolveJavaAPI(lib, api)
 		apiCoord := java.DeriveAPICoordinates(lc, version, javaAPI)
 		ids.Protos = append(ids.Protos, apiCoord.Proto.ArtifactID)
 		ids.GRPCs = append(ids.GRPCs, apiCoord.GRPC.ArtifactID)

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -484,7 +484,18 @@ func getModuleArtifactIDs(lib *config.Library) moduleArtifactIDs {
 	}
 	for _, api := range lib.APIs {
 		version := serviceconfig.ExtractVersion(api.Path)
-		apiCoord := java.DeriveAPICoordinates(lc, version)
+
+		var javaAPI *config.JavaAPI
+		if lib.Java != nil {
+			for _, ja := range lib.Java.JavaAPIs {
+				if ja.Path == api.Path {
+					javaAPI = ja
+					break
+				}
+			}
+		}
+
+		apiCoord := java.DeriveAPICoordinates(lc, version, javaAPI)
 		ids.Protos = append(ids.Protos, apiCoord.Proto.ArtifactID)
 		ids.GRPCs = append(ids.GRPCs, apiCoord.GRPC.ArtifactID)
 	}

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -485,7 +485,7 @@ func getModuleArtifactIDs(lib *config.Library) moduleArtifactIDs {
 	for _, api := range lib.APIs {
 		version := serviceconfig.ExtractVersion(api.Path)
 
-		var javaAPI *config.JavaAPI
+		javaAPI := &config.JavaAPI{Path: api.Path}
 		if lib.Java != nil {
 			for _, ja := range lib.Java.JavaAPIs {
 				if ja.Path == api.Path {


### PR DESCRIPTION
Support overriding artifact IDs via config per API path. These artifact IDs are also used in generated module output dir path.

For #5192
