### PR TITLE
feat(sidekick/swift): generate enum values

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -23,15 +23,29 @@ type enumAnnotations struct {
 	BoilerPlate   []string
 	Name          string
 	DocLines      []string
+	Values        []*enumValueAnnotations
 }
 
 func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) {
 	docLines := codec.formatDocumentation(enum.Documentation)
+
+	seen := map[string]*api.EnumValue{}
+	var unique []*enumValueAnnotations
+	for _, ev := range enum.Values {
+		codec.annotateEnumValue(ev)
+		ann := ev.Codec.(*enumValueAnnotations)
+		if _, ok := seen[ann.Name]; !ok {
+			unique = append(unique, ann)
+			seen[ann.Name] = ev
+		}
+	}
+
 	annotations := &enumAnnotations{
 		CopyrightYear: model.CopyrightYear,
 		BoilerPlate:   model.BoilerPlate,
 		Name:          pascalCase(enum.Name),
 		DocLines:      docLines,
+		Values:        unique,
 	}
 
 	enum.Codec = annotations

--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -23,30 +23,29 @@ type enumAnnotations struct {
 	BoilerPlate   []string
 	Name          string
 	DocLines      []string
-	Values        []*enumValueAnnotations
 }
 
-func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) {
-	docLines := codec.formatDocumentation(enum.Documentation)
-
-	seen := map[string]*api.EnumValue{}
-	var unique []*enumValueAnnotations
+func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
+	existing := map[int32]*enumValueAnnotations{}
 	for _, ev := range enum.UniqueNumberValues {
-		codec.annotateEnumValue(ev)
-		ann := ev.Codec.(*enumValueAnnotations)
-		if _, ok := seen[ann.Name]; !ok {
-			unique = append(unique, ann)
-			seen[ann.Name] = ev
+		codec.annotateUniqueEnumValue(ev)
+		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
+	}
+	for _, ev := range enum.Values {
+		if err := codec.annotateEnumValue(ev, existing); err != nil {
+			return err
 		}
+		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
 	}
 
+	docLines := codec.formatDocumentation(enum.Documentation)
 	annotations := &enumAnnotations{
 		CopyrightYear: model.CopyrightYear,
 		BoilerPlate:   model.BoilerPlate,
 		Name:          pascalCase(enum.Name),
 		DocLines:      docLines,
-		Values:        unique,
 	}
 
 	enum.Codec = annotations
+	return nil
 }

--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -31,7 +31,7 @@ func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) {
 
 	seen := map[string]*api.EnumValue{}
 	var unique []*enumValueAnnotations
-	for _, ev := range enum.Values {
+	for _, ev := range enum.UniqueNumberValues {
 		codec.annotateEnumValue(ev)
 		ann := ev.Codec.(*enumValueAnnotations)
 		if _, ok := seen[ann.Name]; !ok {

--- a/internal/sidekick/swift/annotate_enum_value.go
+++ b/internal/sidekick/swift/annotate_enum_value.go
@@ -15,23 +15,42 @@
 package swift
 
 import (
+	"fmt"
+
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
 type enumValueAnnotations struct {
-	Name        string
+	CaseName    string
 	Number      int32
 	StringValue string
 	DocLines    []string
 }
 
-func (codec *codec) annotateEnumValue(ev *api.EnumValue) {
+func (codec *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
 	docLines := codec.formatDocumentation(ev.Documentation)
 	ann := &enumValueAnnotations{
-		Name:        enumValueCaseName(ev),
+		CaseName:    enumValueCaseName(ev),
 		Number:      ev.Number,
 		StringValue: ev.Name,
 		DocLines:    docLines,
 	}
 	ev.Codec = ann
+}
+
+func (codec *codec) annotateEnumValue(ev *api.EnumValue, unique map[int32]*enumValueAnnotations) error {
+	if ev.Codec != nil {
+		return nil
+	}
+	existing, ok := unique[ev.Number]
+	if !ok {
+		return fmt.Errorf("expected an existing annotation for %s as it duplicates the integer value %d", ev.Name, ev.Number)
+	}
+	ann := &enumValueAnnotations{
+		CaseName:    existing.CaseName,
+		Number:      ev.Number,
+		StringValue: ev.Name,
+	}
+	ev.Codec = ann
+	return nil
 }

--- a/internal/sidekick/swift/annotate_enum_value.go
+++ b/internal/sidekick/swift/annotate_enum_value.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+type enumValueAnnotations struct {
+	Name        string
+	Number      int32
+	StringValue string
+	DocLines    []string
+}
+
+func (codec *codec) annotateEnumValue(ev *api.EnumValue) {
+	docLines := codec.formatDocumentation(ev.Documentation)
+	ann := &enumValueAnnotations{
+		Name:        enumValueCaseName(ev),
+		Number:      ev.Number,
+		StringValue: ev.Name,
+		DocLines:    docLines,
+	}
+	ev.Codec = ann
+}

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func TestAnnotateEnumValue(t *testing.T) {
+	enum := &api.Enum{Name: "Color"}
+	ev := &api.EnumValue{Name: "COLOR_RED", Number: 1, Documentation: "Red color", Parent: enum}
+
+	codec := &codec{}
+	codec.annotateEnumValue(ev)
+
+	ann, ok := ev.Codec.(*enumValueAnnotations)
+	if !ok {
+		t.Fatal("expected enumValueAnnotations")
+	}
+
+	if ann.Name != "red" {
+		t.Errorf("ann.Name = %q, want %q", ann.Name, "red")
+	}
+	if ann.Number != 1 {
+		t.Errorf("ann.Number = %d, want %d", ann.Number, 1)
+	}
+	if ann.StringValue != "COLOR_RED" {
+		t.Errorf("ann.StringValue = %q, want %q", ann.StringValue, "COLOR_RED")
+	}
+}
+
+func TestAnnotateEnum_Duplicates(t *testing.T) {
+	enum := &api.Enum{
+		Name: "Color",
+	}
+	enum.Values = []*api.EnumValue{
+		{Name: "COLOR_RED", Number: 1, Parent: enum},
+		{Name: "RED", Number: 2, Parent: enum},
+	}
+
+	codec := &codec{}
+	codec.annotateEnum(enum, &modelAnnotations{})
+
+	ann, ok := enum.Codec.(*enumAnnotations)
+	if !ok {
+		t.Fatal("expected enumAnnotations")
+	}
+
+	if len(ann.Values) != 1 {
+		t.Errorf("len(ann.Values) = %d, want 1", len(ann.Values))
+	}
+
+	if ann.Values[0].Name != "red" {
+		t.Errorf("ann.Values[0].Name = %q, want %q", ann.Values[0].Name, "red")
+	}
+}

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
-func TestAnnotateEnumValue(t *testing.T) {
+func TestAnnotateEnumValue_WithDocs(t *testing.T) {
 	enum := &api.Enum{Name: "Color"}
 	ev := &api.EnumValue{Name: "COLOR_RED", Number: 1, Documentation: "Red color", Parent: enum}
 	enum.Values = []*api.EnumValue{ev}
@@ -49,7 +49,7 @@ func TestAnnotateEnumValue(t *testing.T) {
 	}
 }
 
-func TestAnnotateEnum_Duplicates(t *testing.T) {
+func TestAnnotateEnumValue_Multiple(t *testing.T) {
 	enum := &api.Enum{Name: "Color"}
 	enum.Values = []*api.EnumValue{
 		{Name: "COLOR_RED", Number: 1, Parent: enum},
@@ -85,8 +85,10 @@ func TestAnnotateEnum_Duplicates(t *testing.T) {
 	}
 }
 
-func TestAnnotateEnum_Aliases(t *testing.T) {
+func TestAnnotateEnumValue_Aliases(t *testing.T) {
 	enum := &api.Enum{Name: "Color"}
+	// This may seem weird, but they do happen in Google Cloud APIs, see:
+	//     https://github.com/search?q=repo%3Agoogleapis%2Fgoogleapis+%22option+allow_alias+%3D+true%3B%22&type=code
 	enum.Values = []*api.EnumValue{
 		{Name: "RED_NEW", Number: 1, Parent: enum},
 		{Name: "RED_OLD", Number: 1, Parent: enum}, // Alias with same number

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -17,6 +17,7 @@ package swift
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -24,7 +25,8 @@ func TestAnnotateEnumValue(t *testing.T) {
 	enum := &api.Enum{Name: "Color"}
 	ev := &api.EnumValue{Name: "COLOR_RED", Number: 1, Documentation: "Red color", Parent: enum}
 
-	codec := &codec{}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
+	codec := newTestCodec(t, model, map[string]string{})
 	codec.annotateEnumValue(ev)
 
 	ann, ok := ev.Codec.(*enumValueAnnotations)
@@ -32,14 +34,14 @@ func TestAnnotateEnumValue(t *testing.T) {
 		t.Fatal("expected enumValueAnnotations")
 	}
 
-	if ann.Name != "red" {
-		t.Errorf("ann.Name = %q, want %q", ann.Name, "red")
+	want := &enumValueAnnotations{
+		Name:        "red",
+		Number:      1,
+		StringValue: "COLOR_RED",
+		DocLines:    []string{"Red color"},
 	}
-	if ann.Number != 1 {
-		t.Errorf("ann.Number = %d, want %d", ann.Number, 1)
-	}
-	if ann.StringValue != "COLOR_RED" {
-		t.Errorf("ann.StringValue = %q, want %q", ann.StringValue, "COLOR_RED")
+	if diff := cmp.Diff(want, ann); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -51,20 +53,62 @@ func TestAnnotateEnum_Duplicates(t *testing.T) {
 		{Name: "COLOR_RED", Number: 1, Parent: enum},
 		{Name: "RED", Number: 2, Parent: enum},
 	}
+	enum.UniqueNumberValues = enum.Values
 
-	codec := &codec{}
-	codec.annotateEnum(enum, &modelAnnotations{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
+	codec := newTestCodec(t, model, map[string]string{})
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
 
 	ann, ok := enum.Codec.(*enumAnnotations)
 	if !ok {
 		t.Fatal("expected enumAnnotations")
 	}
 
-	if len(ann.Values) != 1 {
-		t.Errorf("len(ann.Values) = %d, want 1", len(ann.Values))
+	want := []*enumValueAnnotations{
+		{
+			Name:        "red",
+			Number:      1,
+			StringValue: "COLOR_RED",
+		},
+	}
+	if diff := cmp.Diff(want, ann.Values); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAnnotateEnum_Aliases(t *testing.T) {
+	enum := &api.Enum{
+		Name: "Color",
+	}
+	enum.Values = []*api.EnumValue{
+		{Name: "RED_NEW", Number: 1, Parent: enum},
+		{Name: "RED_OLD", Number: 1, Parent: enum}, // Alias with same number
+	}
+	enum.UniqueNumberValues = []*api.EnumValue{enum.Values[0]}
+
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
+	codec := newTestCodec(t, model, map[string]string{})
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
 	}
 
-	if ann.Values[0].Name != "red" {
-		t.Errorf("ann.Values[0].Name = %q, want %q", ann.Values[0].Name, "red")
+	ann, ok := enum.Codec.(*enumAnnotations)
+	if !ok {
+		t.Fatal("expected enumAnnotations")
+	}
+
+	want := []*enumValueAnnotations{
+		{
+			Name:        "redNew",
+			Number:      1,
+			StringValue: "RED_NEW",
+		},
+	}
+	if diff := cmp.Diff(want, ann.Values); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -24,10 +24,14 @@ import (
 func TestAnnotateEnumValue(t *testing.T) {
 	enum := &api.Enum{Name: "Color"}
 	ev := &api.EnumValue{Name: "COLOR_RED", Number: 1, Documentation: "Red color", Parent: enum}
+	enum.Values = []*api.EnumValue{ev}
+	enum.UniqueNumberValues = enum.Values
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-	codec.annotateEnumValue(ev)
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
 
 	ann, ok := ev.Codec.(*enumValueAnnotations)
 	if !ok {
@@ -35,7 +39,7 @@ func TestAnnotateEnumValue(t *testing.T) {
 	}
 
 	want := &enumValueAnnotations{
-		Name:        "red",
+		CaseName:    "red",
 		Number:      1,
 		StringValue: "COLOR_RED",
 		DocLines:    []string{"Red color"},
@@ -46,43 +50,43 @@ func TestAnnotateEnumValue(t *testing.T) {
 }
 
 func TestAnnotateEnum_Duplicates(t *testing.T) {
-	enum := &api.Enum{
-		Name: "Color",
-	}
+	enum := &api.Enum{Name: "Color"}
 	enum.Values = []*api.EnumValue{
 		{Name: "COLOR_RED", Number: 1, Parent: enum},
-		{Name: "RED", Number: 2, Parent: enum},
+		{Name: "COLOR_GREEN", Number: 2, Parent: enum},
 	}
 	enum.UniqueNumberValues = enum.Values
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}
 
-	ann, ok := enum.Codec.(*enumAnnotations)
-	if !ok {
-		t.Fatal("expected enumAnnotations")
+	var got []*enumValueAnnotations
+	for _, ev := range enum.Values {
+		got = append(got, ev.Codec.(*enumValueAnnotations))
 	}
 
 	want := []*enumValueAnnotations{
 		{
-			Name:        "red",
+			CaseName:    "red",
 			Number:      1,
 			StringValue: "COLOR_RED",
 		},
+		{
+			CaseName:    "green",
+			Number:      2,
+			StringValue: "COLOR_GREEN",
+		},
 	}
-	if diff := cmp.Diff(want, ann.Values); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestAnnotateEnum_Aliases(t *testing.T) {
-	enum := &api.Enum{
-		Name: "Color",
-	}
+	enum := &api.Enum{Name: "Color"}
 	enum.Values = []*api.EnumValue{
 		{Name: "RED_NEW", Number: 1, Parent: enum},
 		{Name: "RED_OLD", Number: 1, Parent: enum}, // Alias with same number
@@ -91,24 +95,28 @@ func TestAnnotateEnum_Aliases(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}
 
-	ann, ok := enum.Codec.(*enumAnnotations)
-	if !ok {
-		t.Fatal("expected enumAnnotations")
+	var got []*enumValueAnnotations
+	for _, ev := range enum.Values {
+		got = append(got, ev.Codec.(*enumValueAnnotations))
 	}
 
 	want := []*enumValueAnnotations{
 		{
-			Name:        "redNew",
+			CaseName:    "redNew",
 			Number:      1,
 			StringValue: "RED_NEW",
 		},
+		{
+			CaseName:    "redNew",
+			Number:      1,
+			StringValue: "RED_OLD",
+		},
 	}
-	if diff := cmp.Diff(want, ann.Values); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in Values (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -60,7 +60,9 @@ func (codec *codec) annotateModel() error {
 		}
 	}
 	for _, enum := range codec.Model.Enums {
-		codec.annotateEnum(enum, annotations)
+		if err := codec.annotateEnum(enum, annotations); err != nil {
+			return err
+		}
 	}
 	for _, service := range codec.Model.Services {
 		codec.annotateService(service, annotations)

--- a/internal/sidekick/swift/names.go
+++ b/internal/sidekick/swift/names.go
@@ -16,9 +16,11 @@ package swift
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
+	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/iancoleman/strcase"
 )
 
@@ -178,4 +180,20 @@ func pascalCase(s string) string {
 		return escapeKeyword(s)
 	}
 	return escapeKeyword(strcase.ToCamel(s))
+}
+
+// enumValueCaseName returns the name of the Swift enumeration case for a given enumeration value.
+func enumValueCaseName(e *api.EnumValue) string {
+	prefix := strcase.ToScreamingSnake(e.Parent.Name) + "_"
+	trimmed := strings.TrimPrefix(e.Name, prefix)
+	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
+		return camelCase(trimmed)
+	}
+	trimNumbers := regexp.MustCompile(`_([0-9])`)
+	prefix = trimNumbers.ReplaceAllString(prefix, `$1`)
+	trimmed = strings.TrimPrefix(e.Name, prefix)
+	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
+		return camelCase(trimmed)
+	}
+	return camelCase(e.Name)
 }

--- a/internal/sidekick/swift/names.go
+++ b/internal/sidekick/swift/names.go
@@ -142,6 +142,9 @@ var keywords = map[string]bool{
 	"willSet":       true,
 }
 
+// For enum value names.
+var trimNumbers = regexp.MustCompile(`_([0-9])`)
+
 // escapeKeyword escapes a string if it is a keyword.
 func escapeKeyword(s string) string {
 	// In Swift we can use backtick escaping for most keywords except `Type`, `Protocol`, and `self`:
@@ -189,7 +192,6 @@ func enumValueCaseName(e *api.EnumValue) string {
 	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
 		return camelCase(trimmed)
 	}
-	trimNumbers := regexp.MustCompile(`_([0-9])`)
 	prefix = trimNumbers.ReplaceAllString(prefix, `$1`)
 	trimmed = strings.TrimPrefix(e.Name, prefix)
 	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {

--- a/internal/sidekick/swift/names_test.go
+++ b/internal/sidekick/swift/names_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
 func TestEscapeKeyword(t *testing.T) {
@@ -95,6 +96,69 @@ func TestPascalCase(t *testing.T) {
 			got := pascalCase(test.input)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnumValueCaseName(t *testing.T) {
+	tests := []struct {
+		name     string
+		enumName string
+		valName  string
+		want     string
+	}{
+		{
+			name:     "simple",
+			enumName: "Color",
+			valName:  "COLOR_RED",
+			want:     "red",
+		},
+		{
+			name:     "no prefix",
+			enumName: "Color",
+			valName:  "RED",
+			want:     "red",
+		},
+		{
+			name:     "numbers in prefix",
+			enumName: "InstancePrivateIpv6GoogleAccess",
+			valName:  "INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_ENABLED",
+			want:     "enabled",
+		},
+		{
+			name:     "keyword",
+			enumName: "Planet",
+			valName:  "PLANET_SELF",
+			want:     "self_", // keyword escaped
+		},
+		{
+			name:     "number suffix after strip",
+			enumName: "Foo",
+			valName:  "FOO_VALUE_1",
+			want:     "value1",
+		},
+		{
+			name:     "number only after strip falls back to full name",
+			enumName: "Foo",
+			valName:  "FOO_1",
+			want:     "foo1",
+		},
+		{
+			name:     "acronym in enum name",
+			enumName: "IAM",
+			valName:  "IAM_POLICY",
+			want:     "policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enum := &api.Enum{Name: tt.enumName}
+			ev := &api.EnumValue{Name: tt.valName, Parent: enum}
+			got := enumValueCaseName(ev)
+			if got != tt.want {
+				t.Errorf("enumValueCaseName() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/sidekick/swift/templates/common/enum.swift.mustache
+++ b/internal/sidekick/swift/templates/common/enum.swift.mustache
@@ -24,5 +24,28 @@ import Foundation
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
-public enum {{Codec.Name}}: Codable, Equatable {
+public enum {{Codec.Name}}: Int, Codable, Equatable {
+    {{#Codec.Values}}
+    {{#DocLines}}
+    /// {{{.}}}
+    {{/DocLines}}
+    case {{Name}} = {{Number}}
+    {{/Codec.Values}}
+
+    public var stringValue: String {
+        switch self {
+        {{#Codec.Values}}
+        case .{{Name}}: return "{{StringValue}}"
+        {{/Codec.Values}}
+        }
+    }
+
+    public init?(stringValue: String) {
+        switch stringValue {
+        {{#Codec.Values}}
+        case "{{StringValue}}": self = .{{Name}}
+        {{/Codec.Values}}
+        default: return nil
+        }
+    }
 }

--- a/internal/sidekick/swift/templates/common/enum.swift.mustache
+++ b/internal/sidekick/swift/templates/common/enum.swift.mustache
@@ -25,26 +25,26 @@ import Foundation
 /// {{{.}}}
 {{/Codec.DocLines}}
 public enum {{Codec.Name}}: Int, Codable, Equatable {
-    {{#Codec.Values}}
+    {{#UniqueNumberValues}}
     {{#DocLines}}
     /// {{{.}}}
     {{/DocLines}}
-    case {{Name}} = {{Number}}
-    {{/Codec.Values}}
+    case {{Codec.CaseName}} = {{Number}}
+    {{/UniqueNumberValues}}
 
     public var stringValue: String {
         switch self {
-        {{#Codec.Values}}
-        case .{{Name}}: return "{{StringValue}}"
-        {{/Codec.Values}}
+        {{#UniqueNumberValues}}
+        case .{{Codec.CaseName}}: return "{{Name}}"
+        {{/UniqueNumberValues}}
         }
     }
 
     public init?(stringValue: String) {
         switch stringValue {
-        {{#Codec.Values}}
-        case "{{StringValue}}": self = .{{Name}}
-        {{/Codec.Values}}
+        {{#Values}}
+        case "{{Name}}": self = .{{Codec.CaseName}}
+        {{/Values}}
         default: return nil
         }
     }


### PR DESCRIPTION
With this PR sidekick can generate the enum cases for each `api.EnumValue`. The generated code includes helper functions to convert enums to strings, and to parse strings as enums.

As usual, we strip the common prefix for the enum cases, because they are already qualified in Swift. We also deal with conflicts and enum values that conflict with Swift keywords.

Fixes #5286 