### PR TITLE
chore(internal/serviceconfig): add java to languages to google/datastore/v1

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -3018,6 +3018,7 @@
 - path: google/datastore/v1
   languages:
     - go
+    - java
     - python
 - path: google/devtools/artifactregistry/v1
   documentation_uri: https://cloud.google.com/artifact-registry


### PR DESCRIPTION
Allow Java to generate google/datastore/v1.

For #5194