### PR TITLE
fix(tool/cmd/migrate): add ArtifactOverrides in java migrate

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -241,27 +241,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				AdditionalProtos: info.AdditionalProtos,
 				NoSamples:        info.NoSamples,
 			}
-			// Hardcoded overrides for specific cases where artifact IDs don't follow the pattern
-			switch {
-			case name == "datastore" && g.ProtoPath == "google/datastore/admin/v1":
-				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-datastore-admin-v1"
-				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-datastore-admin-v1"
-			case name == "spanner" && g.ProtoPath == "google/spanner/admin/database/v1":
-				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-database-v1"
-				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-database-v1"
-			case name == "spanner" && g.ProtoPath == "google/spanner/admin/instance/v1":
-				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-instance-v1"
-				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-instance-v1"
-			case name == "spanner" && g.ProtoPath == "google/spanner/executor/v1":
-				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-spanner-executor-v1"
-				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-executor-v1"
-			case name == "errorreporting" && g.ProtoPath == "google/devtools/clouderrorreporting/v1beta1":
-				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-error-reporting-v1beta1"
-				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-error-reporting-v1beta1"
-			case name == "storage" && g.ProtoPath == "google/storage/control/v2":
-				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
-				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
-			}
+			applyJavaArtifactOverrides(name, javaAPI)
 			javaAPIs = append(javaAPIs, javaAPI)
 		}
 		libs = append(libs, &config.Library{
@@ -353,6 +333,31 @@ func parseArtifactID(distributionName, name string) string {
 		artifactID = artifactID[i+1:]
 	}
 	return artifactID
+}
+
+// applyJavaArtifactOverrides sets artifact ID overrides for specific cases where
+// they don't follow the standard pattern.
+func applyJavaArtifactOverrides(name string, api *config.JavaAPI) {
+	switch {
+	case name == "datastore" && api.Path == "google/datastore/admin/v1":
+		api.ProtoArtifactIDOverride = "proto-google-cloud-datastore-admin-v1"
+		api.GRPCArtifactIDOverride = "grpc-google-cloud-datastore-admin-v1"
+	case name == "spanner" && api.Path == "google/spanner/admin/database/v1":
+		api.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-database-v1"
+		api.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-database-v1"
+	case name == "spanner" && api.Path == "google/spanner/admin/instance/v1":
+		api.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-instance-v1"
+		api.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-instance-v1"
+	case name == "spanner" && api.Path == "google/spanner/executor/v1":
+		api.ProtoArtifactIDOverride = "proto-google-cloud-spanner-executor-v1"
+		api.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-executor-v1"
+	case name == "errorreporting" && api.Path == "google/devtools/clouderrorreporting/v1beta1":
+		api.ProtoArtifactIDOverride = "proto-google-cloud-error-reporting-v1beta1"
+		api.GRPCArtifactIDOverride = "grpc-google-cloud-error-reporting-v1beta1"
+	case name == "storage" && api.Path == "google/storage/control/v2":
+		api.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
+		api.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
+	}
 }
 
 func invertBoolPtr(p *bool) bool {

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -241,6 +241,27 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				AdditionalProtos: info.AdditionalProtos,
 				NoSamples:        info.NoSamples,
 			}
+			// Hardcoded overrides for specific cases where artifact IDs don't follow the pattern
+			switch {
+			case name == "datastore" && g.ProtoPath == "google/datastore/admin/v1":
+				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-datastore-admin-v1"
+				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-datastore-admin-v1"
+			case name == "spanner" && g.ProtoPath == "google/spanner/admin/database/v1":
+				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-database-v1"
+				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-database-v1"
+			case name == "spanner" && g.ProtoPath == "google/spanner/admin/instance/v1":
+				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-instance-v1"
+				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-instance-v1"
+			case name == "spanner" && g.ProtoPath == "google/spanner/executor/v1":
+				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-spanner-executor-v1"
+				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-executor-v1"
+			case name == "errorreporting" && g.ProtoPath == "google/devtools/clouderrorreporting/v1beta1":
+				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-error-reporting-v1beta1"
+				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-error-reporting-v1beta1"
+			case name == "storage" && g.ProtoPath == "google/storage/control/v2":
+				javaAPI.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
+				javaAPI.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
+			}
 			javaAPIs = append(javaAPIs, javaAPI)
 		}
 		libs = append(libs, &config.Library{

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -336,6 +336,60 @@ func TestBuildConfig(t *testing.T) {
 	}
 }
 
+func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
+	gen := &GenerationConfig{
+		Libraries: []LibraryConfig{
+			{
+				LibraryName: "datastore",
+				GAPICs: []GAPICConfig{
+					{ProtoPath: "google/datastore/admin/v1"},
+				},
+			},
+		},
+	}
+	srcDir := t.TempDir()
+	buildFile := filepath.Join(srcDir, "google/datastore/admin/v1", "BUILD.bazel")
+	if err := os.MkdirAll(filepath.Dir(buildFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(buildFile, []byte(`java_gapic_library(name = "datastore_java_gapic")`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	want := &config.Config{
+		Language: "java",
+		Repo:     "googleapis/google-cloud-java",
+		Default: &config.Default{
+			Java: &config.JavaModule{},
+		},
+		Sources: &config.Sources{
+			Googleapis: &config.Source{Dir: srcDir},
+		},
+		Libraries: []*config.Library{
+			{
+				Name: "datastore",
+				APIs: []*config.API{
+					{Path: "google/datastore/admin/v1"},
+				},
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{
+							Path:                    "google/datastore/admin/v1",
+							ProtoArtifactIDOverride: "proto-google-cloud-datastore-admin-v1",
+							GRPCArtifactIDOverride:  "grpc-google-cloud-datastore-admin-v1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := buildConfig(gen, ".", &config.Source{Dir: srcDir}, nil)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestBuildConfig_OwlBotKeep(t *testing.T) {
 	repoPath := "testdata/google-cloud-java"
 	gen := &GenerationConfig{


### PR DESCRIPTION
Add ArtifactOverrides in migrate. Hardcoding for now because these are only handful and migration script are for short term.

Fix https://github.com/googleapis/librarian/issues/5192