### PR TITLE
feat(sidekick/rust): inject `ResourceName` into gRPC request extensions in templates

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -87,8 +87,11 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
             pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
-        {{/Codec.DetailedTracingAttributes }}
         self.inner.{{Codec.Name}}(req, options).await
+        {{/Codec.DetailedTracingAttributes}}
+        {{^Codec.DetailedTracingAttributes}}
+        self.inner.{{Codec.Name}}(req, options).await
+        {{/Codec.DetailedTracingAttributes}}
     }
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -121,7 +121,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{PathInfo.Codec.IsIdempotent}},
             {{/HasAutoPopulatedFields}}
         );
-        let extensions = {
+        let mut extensions = {
             let mut e = Extensions::new();
             e.insert(GrpcMethod::new("{{SourceService.Package}}.{{SourceService.Name}}", "{{Name}}"));
             e
@@ -182,11 +182,15 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 Some(String::new())
                 {{/Codec.ResourceNameTemplateGrpc}}
             })();
-            let attributes = if let Some(rn) = resource_name.filter(|s| !s.is_empty()) {
-                attributes.set_resource_name(rn)
+            let attributes = if let Some(rn) = resource_name.as_ref().filter(|s| !s.is_empty()) {
+                attributes.set_resource_name(rn.clone())
             } else {
                 attributes
             };
+            
+            if let Some(rn) = resource_name {
+                extensions.insert(gaxi::observability::ResourceName::new(rn));
+            }
             {{/Codec.HasGrpcResourceNameArgs}}
             recorder.on_client_request(attributes);
         }


### PR DESCRIPTION
Update the gRPC client templates to inject `ResourceName` into `tonic::Extensions` (or `RequestOptions`) so that the gRPC tracing middleware can extract it and populate `gcp.resource.destination.id` in spans.
This ensures that both unary and streaming RPCs correctly propagate the resource name to the transport layer.