### PR TITLE
fix: create tempDir inside same filesystem

### DIFF
--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -40,6 +40,8 @@ var (
 	readmeTmplParsed = template.Must(template.New("readme").Parse(readmeTmpl))
 )
 
+var mkdirTempFunc = os.MkdirTemp
+
 // Generate generates a Go client library.
 func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources) error {
 	outDir, err := filepath.Abs(library.Output)
@@ -49,7 +51,7 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		return err
 	}
-	tempDir, err := os.MkdirTemp("", "librarian-gen-")
+	tempDir, err := mkdirTempFunc(outDir, "librarian-gen-")
 	defer func() {
 		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
 			err = errors.Join(err, removeErr)

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -40,6 +40,7 @@ var (
 	readmeTmplParsed = template.Must(template.New("readme").Parse(readmeTmpl))
 )
 
+// mkdirTempFunc allows overriding os.MkdirTemp for testing.
 var mkdirTempFunc = os.MkdirTemp
 
 // Generate generates a Go client library.

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -44,15 +44,20 @@ var (
 var mkdirTempFunc = os.MkdirTemp
 
 // Generate generates a Go client library.
-func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources) error {
-	outDir, err := filepath.Abs(library.Output)
+func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources) (err error) {
+	var outDir string
+	outDir, err = filepath.Abs(library.Output)
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err = os.MkdirAll(outDir, 0755); err != nil {
 		return err
 	}
-	tempDir, err := mkdirTempFunc(outDir, "librarian-gen-")
+	var tempDir string
+	tempDir, err = mkdirTempFunc(outDir, "librarian-gen-")
+	if err != nil {
+		return err
+	}
 	defer func() {
 		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
 			err = errors.Join(err, removeErr)

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -40,9 +40,6 @@ var (
 	readmeTmplParsed = template.Must(template.New("readme").Parse(readmeTmpl))
 )
 
-// mkdirTempFunc allows overriding os.MkdirTemp for testing.
-var mkdirTempFunc = os.MkdirTemp
-
 // Generate generates a Go client library.
 func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources) (err error) {
 	var outDir string
@@ -54,7 +51,7 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 		return err
 	}
 	var tempDir string
-	tempDir, err = mkdirTempFunc(outDir, "librarian-gen-")
+	tempDir, err = os.MkdirTemp(outDir, "librarian-gen-")
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -179,65 +179,7 @@ func TestGenerate_Error(t *testing.T) {
 	}
 }
 
-// TestGenerate_TempDirLocation verifies that the temporary directory is created
-// inside the output directory.
-func TestGenerate_TempDirLocation(t *testing.T) {
-	testhelper.RequireCommand(t, "protoc")
-	testhelper.RequireCommand(t, "protoc-gen-go")
-	testhelper.RequireCommand(t, "protoc-gen-go-grpc")
-	testhelper.RequireCommand(t, "protoc-gen-go_gapic")
 
-	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	outDir := t.TempDir()
-	library := &config.Library{
-		Name:          "secretmanager",
-		Version:       "0.1.0",
-		CopyrightYear: "2025",
-		Output:        outDir,
-		APIs: []*config.API{
-			{
-				Path: "google/cloud/secretmanager/v1",
-			},
-		},
-		Go: &config.GoModule{
-			GoAPIs: []*config.GoAPI{
-				{
-					ClientPackage: "secretmanager",
-					ImportPath:    "secretmanager/apiv1",
-					Path:          "google/cloud/secretmanager/v1",
-				},
-			},
-		},
-	}
-
-	// Mock mkdirTempFunc
-	oldMkdirTemp := mkdirTempFunc
-	defer func() { mkdirTempFunc = oldMkdirTemp }()
-
-	var capturedDir string
-	mkdirTempFunc = func(dir, pattern string) (string, error) {
-		capturedDir = dir
-		return os.MkdirTemp(dir, pattern)
-	}
-
-	err = Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify that the temp dir was created inside outDir
-	absOutDir, err := filepath.Abs(outDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(absOutDir, capturedDir); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}
 
 func TestGenerateLibrary(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -179,6 +179,64 @@ func TestGenerate_Error(t *testing.T) {
 	}
 }
 
+func TestGenerate_TempDirLocation(t *testing.T) {
+	testhelper.RequireCommand(t, "protoc")
+	testhelper.RequireCommand(t, "protoc-gen-go")
+	testhelper.RequireCommand(t, "protoc-gen-go-grpc")
+	testhelper.RequireCommand(t, "protoc-gen-go_gapic")
+
+	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := t.TempDir()
+	library := &config.Library{
+		Name:          "secretmanager",
+		Version:       "0.1.0",
+		CopyrightYear: "2025",
+		Output:        outDir,
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+			},
+		},
+		Go: &config.GoModule{
+			GoAPIs: []*config.GoAPI{
+				{
+					ClientPackage: "secretmanager",
+					ImportPath:    "secretmanager/apiv1",
+					Path:          "google/cloud/secretmanager/v1",
+				},
+			},
+		},
+	}
+
+	// Mock mkdirTempFunc
+	oldMkdirTemp := mkdirTempFunc
+	defer func() { mkdirTempFunc = oldMkdirTemp }()
+
+	var capturedDir string
+	mkdirTempFunc = func(dir, pattern string) (string, error) {
+		capturedDir = dir
+		return os.MkdirTemp(dir, pattern)
+	}
+
+	err = Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the temp dir was created inside outDir
+	absOutDir, err := filepath.Abs(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedDir != absOutDir {
+		t.Errorf("capturedDir = %q, want %q", capturedDir, absOutDir)
+	}
+}
+
 func TestGenerateLibrary(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "protoc-gen-go")

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -179,6 +179,8 @@ func TestGenerate_Error(t *testing.T) {
 	}
 }
 
+// TestGenerate_TempDirLocation verifies that the temporary directory is created
+// inside the output directory.
 func TestGenerate_TempDirLocation(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "protoc-gen-go")
@@ -232,8 +234,8 @@ func TestGenerate_TempDirLocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if capturedDir != absOutDir {
-		t.Errorf("capturedDir = %q, want %q", capturedDir, absOutDir)
+	if diff := cmp.Diff(absOutDir, capturedDir); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Creating the temporary directory in the default system temp directory (usually /tmp) can cause "invalid cross-device link" errors when moving files to the workspace if they are on different filesystems.
This change modifies the `Generate` function to create the temporary directory inside the target output directory instead. This guarantees that both directories are on the same filesystem, enabling fast and atomic `os.Rename` operations.

Fixes https://github.com/googleapis/librarian/issues/5301