### PR TITLE
fix(internal/librarian/java): check clirr file exist in output dir instead of staging dir

### DIFF
--- a/internal/librarian/java/clirr.go
+++ b/internal/librarian/java/clirr.go
@@ -39,7 +39,8 @@ const (
 	templateName = "clirr-ignored-differences.xml.tmpl"
 )
 
-// generateClirrIfMissing generates the clirr-ignored-differences.xml file if it doesn't exist.
+// generateClirrIfMissing generates the clirr-ignored-differences.xml file in the protoModulePath
+// if it doesn't already exist in the checkPath.
 //
 // It identifies Java packages containing Protobuf-generated code by searching for
 // files ending in "OrBuilder.java" under "src/main/java". The "OrBuilder" suffix
@@ -49,14 +50,16 @@ const (
 // The generated file contains a set of whitelist rules that tell the Clirr tool
 // to ignore specific changes (like method additions to interfaces) to
 // prevent false-positive binary compatibility failures in the build.
-func generateClirrIfMissing(protoModulePath string) error {
-	outputPath := filepath.Join(protoModulePath, clirrIgnoreFile)
-	_, err := os.Stat(outputPath)
-	switch {
-	case err == nil:
-		return nil
-	case !errors.Is(err, fs.ErrNotExist):
-		return fmt.Errorf("failed to check for %s: %w", outputPath, err)
+func generateClirrIfMissing(protoModulePath, checkPath string) error {
+	if checkPath != "" {
+		repoFilePath := filepath.Join(checkPath, clirrIgnoreFile)
+		_, err := os.Stat(repoFilePath)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to check for %s: %w", repoFilePath, err)
+		}
 	}
 	protoPaths, err := findProtoPackages(protoModulePath)
 	if err != nil {
@@ -65,6 +68,7 @@ func generateClirrIfMissing(protoModulePath string) error {
 	if len(protoPaths) == 0 {
 		return nil
 	}
+	outputPath := filepath.Join(protoModulePath, clirrIgnoreFile)
 	f, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %w", outputPath, err)

--- a/internal/librarian/java/clirr_test.go
+++ b/internal/librarian/java/clirr_test.go
@@ -33,7 +33,7 @@ func TestGenerateClirr(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := generateClirrIfMissing(protoModulePath); err != nil {
+	if err := generateClirrIfMissing(protoModulePath, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -51,21 +51,27 @@ func TestGenerateClirr(t *testing.T) {
 	}
 }
 
-func TestGenerateClirr_SkipExisting(t *testing.T) {
+func TestGenerateClirr_SkipExistingInCheckPath(t *testing.T) {
 	tmpDir := t.TempDir()
-	outputPath := filepath.Join(tmpDir, "clirr-ignored-differences.xml")
-	initialContent := "manual content"
-	if err := os.WriteFile(outputPath, []byte(initialContent), 0644); err != nil {
+	targetDir := filepath.Join(tmpDir, "target")
+	checkDir := filepath.Join(tmpDir, "check")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := generateClirrIfMissing(tmpDir); err != nil {
+	if err := os.MkdirAll(checkDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	newContent, err := os.ReadFile(outputPath)
-	if err != nil {
+	outputPath := filepath.Join(checkDir, "clirr-ignored-differences.xml")
+	if err := os.WriteFile(outputPath, []byte("exists"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if string(newContent) != initialContent {
-		t.Errorf("expected generateClirr to skip existing file, but content changed from %q to %q", initialContent, string(newContent))
+
+	if err := generateClirrIfMissing(targetDir, checkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	targetPath := filepath.Join(targetDir, "clirr-ignored-differences.xml")
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Errorf("expected %s NOT to exist because it exists in checkPath", targetPath)
 	}
 }

--- a/internal/librarian/java/clirr_test.go
+++ b/internal/librarian/java/clirr_test.go
@@ -15,6 +15,8 @@
 package java
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,7 +73,7 @@ func TestGenerateClirr_SkipExistingInCheckPath(t *testing.T) {
 	}
 
 	targetPath := filepath.Join(targetDir, "clirr-ignored-differences.xml")
-	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+	if _, err := os.Stat(targetPath); !errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("expected %s NOT to exist because it exists in checkPath", targetPath)
 	}
 }

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -122,7 +122,8 @@ func postProcessAPI(ctx context.Context, p postProcessParams) error {
 	// to their final destination yet.
 	coords := p.coords()
 	protoModuleStagingRoot := filepath.Join(p.outDir, "owl-bot-staging", p.version, coords.Proto.ArtifactID)
-	if err := generateClirrIfMissing(protoModuleStagingRoot); err != nil {
+	protoModuleRepoRoot := filepath.Join(p.outDir, coords.Proto.ArtifactID)
+	if err := generateClirrIfMissing(protoModuleStagingRoot, protoModuleRepoRoot); err != nil {
 		return fmt.Errorf("failed to generate clirr ignore file: %w", err)
 	}
 


### PR DESCRIPTION
Checks clirr file exist in output dir so that it is only generated for new modules in google-cloud-java. 
This was the the original intend. However when added support to run owlbot.py, generateClirrIfMissing tries to check missing in the staging dir, equivalent to always generating.

Fix #5295