### PR TITLE
chore(tool/cmd/migrate): support API shortname overrides for Java

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -273,7 +273,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				RpcDocumentation:             l.RpcDocumentation,
 			},
 		}
-		if shortnameOverride, ok := apiShortNameOverride[lib.Name]; ok {
+		if shortnameOverride, ok := apiShortnameOverrides[lib.Name]; ok {
 			lib.Java.APIShortnameOverride = shortnameOverride
 		}
 		libs = append(libs, lib)

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -244,7 +244,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			applyJavaArtifactOverrides(name, javaAPI)
 			javaAPIs = append(javaAPIs, javaAPI)
 		}
-		libs = append(libs, &config.Library{
+		lib := &config.Library{
 			Name:    name,
 			Version: version,
 			Keep:    parseOwlBotKeep(repoPath, output),
@@ -272,7 +272,11 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				RestDocumentation:            l.RestDocumentation,
 				RpcDocumentation:             l.RpcDocumentation,
 			},
-		})
+		}
+		if shortnameOverride, ok := apiShortNameOverride[lib.Name]; ok {
+			lib.Java.APIShortnameOverride = shortnameOverride
+		}
+		libs = append(libs, lib)
 	}
 	if len(libs) == 0 {
 		return nil

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 var (

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -1,0 +1,7 @@
+package main
+
+var (
+	apiShortNameOverride = map[string]string{
+		"beyondcorp-appconnections": "beyondcorp-appconnections",
+	}
+)

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -2,6 +2,13 @@ package main
 
 var (
 	apiShortNameOverride = map[string]string{
-		"beyondcorp-appconnections": "beyondcorp-appconnections",
+		"beyondcorp-appconnections":          "beyondcorp-appconnections",
+		"beyondcorp-appconnectors":           "beyondcorp-appconnectors",
+		"beyondcorp-appgateways":             "beyondcorp-appgateways",
+		"beyondcorp-clientconnectorservices": "beyondcorp-clientconnectorservices",
+		"beyondcorp-clientgateways":          "beyondcorp-clientgateways",
+		"dialogflow-cx":                      "dialogflow-cx",
+		"distributedcloudedge":               "distributedcloudedge",
+		"gke-backup":                         "gke-backup",
 	}
 )

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -1,7 +1,7 @@
 package main
 
 var (
-	apiShortNameOverride = map[string]string{
+	apiShortnameOverrides = map[string]string{
 		"beyondcorp-appconnections":          "beyondcorp-appconnections",
 		"beyondcorp-appconnectors":           "beyondcorp-appconnectors",
 		"beyondcorp-appgateways":             "beyondcorp-appgateways",

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -326,6 +326,32 @@ func TestBuildConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "api shortname overrides",
+			gen: &GenerationConfig{
+				Libraries: []LibraryConfig{
+					{APIShortName: "beyondcorp-appconnections"},
+				},
+			},
+			want: &config.Config{
+				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
+				Default: &config.Default{
+					Java: &config.JavaModule{},
+				},
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Dir: "../../internal/testdata/googleapis"},
+				},
+				Libraries: []*config.Library{
+					{
+						Name: "beyondcorp-appconnections",
+						Java: &config.JavaModule{
+							APIShortnameOverride: "beyondcorp-appconnections",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := buildConfig(test.gen, ".", &config.Source{Dir: "../../internal/testdata/googleapis"}, test.versions)


### PR DESCRIPTION
Support parsing API shortname overrides during Java library migration.

A mapping of library names to api shortname overrides is introduced to ensure correct configuration for specific libraries.

For #5296