### PR TITLE
chore(sidekick/rust): update version of prost_build

### DIFF
--- a/internal/sidekick/rust_prost/templates/prost/Cargo.toml.mustache
+++ b/internal/sidekick/rust_prost/templates/prost/Cargo.toml.mustache
@@ -27,7 +27,7 @@ build       = "build.rs"
 edition     = "2021"
 
 [build-dependencies]
-prost-build = { version = "0.13", optional = true }
+prost-build = { version = "0.14", optional = true }
 
 [features]
 _generate-protos = ["dep:prost-build"]


### PR DESCRIPTION
Related to https://github.com/googleapis/google-cloud-rust/issues/5333

FYI: This will make minor changes in `google-cloud-rust`. If we want to hold off until after the release, that's fine with me. I can sit on it.

```diff
--- a/src/storage/src/generated/protos/control/google.api.rs
+++ b/src/storage/src/generated/protos/control/google.api.rs
@@ -31,7 +31,7 @@ pub struct HttpRule {
 }
 /// Nested message and enum types in `HttpRule`.
 pub mod http_rule {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum Pattern {
         #[prost(string, tag = "2")]
         Get(::prost::alloc::string::String),
@@ -57,7 +57,7 @@ impl ::prost::Name for HttpRule {
         "type.googleapis.com/google.api.HttpRule".into()
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CustomHttpPattern {
     #[prost(string, tag = "1")]
     pub kind: ::prost::alloc::string::String,

// etc.
```