### PR TITLE
feat(sidekick/rust): add template for tonic protos

### DIFF
--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -153,8 +153,8 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *sourc
 		}
 		switch modelConfig.Language {
 		case config.LanguageRust:
-			if module.Template == "prost" {
-				err = rust_prost.Generate(ctx, model, module.Output, modelConfig)
+			if module.Template == "prost" || module.Template == "tonic" {
+				err = rust_prost.Generate(ctx, model, module.Output, module.Template, modelConfig)
 			} else {
 				err = sidekickrust.Generate(ctx, model, module.Output, modelConfig)
 			}

--- a/internal/sidekick/rust_prost/generate.go
+++ b/internal/sidekick/rust_prost/generate.go
@@ -34,7 +34,7 @@ import (
 var templates embed.FS
 
 // Generate generates Rust code from the model using prost.
-func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.ModelConfig) error {
+func Generate(ctx context.Context, model *api.API, outdir string, template string, cfg *parser.ModelConfig) error {
 	if cfg.SpecificationFormat != libconfig.SpecProtobuf {
 		return fmt.Errorf("the `rust+prost` generator only supports `protobuf` as a specification source, outdir=%s", outdir)
 	}
@@ -48,7 +48,7 @@ func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.Mo
 	codec := newCodec(cfg)
 	codec.annotateModel(model, cfg)
 	provider := templatesProvider()
-	generatedFiles := language.WalkTemplatesDir(templates, "templates/prost")
+	generatedFiles := language.WalkTemplatesDir(templates, "templates/"+template)
 	tmpDir, err := os.MkdirTemp("", "rust-prost-*")
 	if err != nil {
 		return fmt.Errorf("cannot create temporary directory for rust+prost output: %w", err)

--- a/internal/sidekick/rust_prost/templates/tonic/Cargo.toml.mustache
+++ b/internal/sidekick/rust_prost/templates/tonic/Cargo.toml.mustache
@@ -1,0 +1,37 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+# Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+#{{{.}}}
+{{/Codec.BoilerPlate}}
+
+[package]
+name        = "{{Codec.PackageName}}-code-generation"
+version     = "0.0.0"
+description = "Prost and Tonic generator for {{Codec.PackageName}}"
+publish     = false
+build       = "build.rs"
+edition     = "2021"
+
+[build-dependencies]
+prost-build = { version = "0.14", optional = true }
+tonic-prost-build = { version = "0.14", optional = true }
+
+[features]
+_generate-protos = ["dep:prost-build", "dep:tonic-prost-build"]
+
+# This is unrelated to the top-level workspace
+[workspace]

--- a/internal/sidekick/rust_prost/templates/tonic/build.rs.mustache
+++ b/internal/sidekick/rust_prost/templates/tonic/build.rs.mustache
@@ -1,0 +1,51 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+// Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+//{{{.}}}
+{{/Codec.BoilerPlate}}
+
+fn main() {
+    #[cfg(feature = "_generate-protos")]
+    {
+        let root = std::env::var("SOURCE_ROOT")
+            .expect("SOURCE_ROOT must be set");
+        let destination = std::env::var("DEST")
+            .expect("DEST must be set");
+        let files = &[
+            {{#Codec.Files}}
+            "{{{.}}}",
+            {{/Codec.Files}}
+        ];
+        let includes = &[
+            root.as_str()
+        ];
+        let mut config = prost_build::Config::new();
+        config.disable_comments(&["."]);
+        config.enable_type_names();
+        config.type_name_domain(&["."], "type.googleapis.com");
+        config.include_file("includes.rs");
+        tonic_prost_build::configure()
+            .type_attribute(".", "#[allow(clippy::large_enum_variant)]")
+            .bytes(".")
+            .out_dir(&destination)
+            .compile_with_config(config, files, includes)
+            .expect("error compiling protos");
+        {{#Codec.PostProcessProtos}}
+        {{{.}}}
+        {{/Codec.PostProcessProtos}}
+    }
+}

--- a/internal/sidekick/rust_prost/templates/tonic/src/lib.rs.mustache
+++ b/internal/sidekick/rust_prost/templates/tonic/src/lib.rs.mustache
@@ -1,0 +1,22 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+// Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+//{{{.}}}
+{{/Codec.BoilerPlate}}
+
+//! Placeholder to support `build.rs`.
+


### PR DESCRIPTION
Part of the work for https://github.com/googleapis/google-cloud-rust/issues/5333

Add a new template to generate protos using `tonic_prost_build`. The difference is that `tonic` generates gRPC service definitions. We don't use these for our production libraries, but we do want these for our `grpc-mock` libraries, where we fake the service.

`prost_build` vs. `tonic_prost_build` is different enough to where a separate template is cleaner than having a codec option for which to use.