### PR TITLE
cleanup: fix broken onboarding link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ we operate with a limited contribution model.
 ## Becoming a contributor
 
 Review the guide for
-[Onboarding to Librarian](https://github.com/googleapis/librarian/blob/main/doc/legacylibrarian/onboarding.md).
+[Onboarding to Librarian](/doc/legacylibrarian/onboarding.md).
 
 To contribute to this repository, ask a member of
 [cloud-sdk-librarian-admin](https://github.com/orgs/googleapis/teams/cloud-sdk-librarian-admin)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ we operate with a limited contribution model.
 ## Becoming a contributor
 
 Review the guide for
-[Onboarding to Librarian](https://github.com/googleapis/librarian/blob/main/doc/onboarding.md).
+[Onboarding to Librarian](https://github.com/googleapis/librarian/blob/main/doc/legacylibrarian/onboarding.md).
 
 To contribute to this repository, ask a member of
 [cloud-sdk-librarian-admin](https://github.com/orgs/googleapis/teams/cloud-sdk-librarian-admin)


### PR DESCRIPTION
I tried to click this link. Linking to `legacylibrarian` seems wrong, but I cannot find a replacement.

Happy to close this PR if someone has a better fix.