### PR TITLE
docs(internal/sidekick/rust): update `Working with enums` docs url

### DIFF
--- a/internal/sidekick/rust/templates/common/enum.mustache
+++ b/internal/sidekick/rust/templates/common/enum.mustache
@@ -30,7 +30,7 @@ limitations under the License.
 /// Please consult the [Working with enums] section in the user guide for some
 /// guidelines.
 ///
-/// [Working with enums]: https://google-cloud-rust.github.io/working_with_enums.html
+/// [Working with enums]: https://googleapis.github.io/google-cloud-rust/working_with_enums.html
 {{> /templates/common/feature_gate}}
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]


### PR DESCRIPTION
Rust docs moved from https://google-cloud-rust.github.io to https://googleapis.github.io/google-cloud-rust. Just fixing broken links.