### PR TITLE
chore(internal/librarian/java): split check exist and generate for clirr file for clarity

### DIFF
--- a/internal/librarian/java/clirr.go
+++ b/internal/librarian/java/clirr.go
@@ -39,28 +39,31 @@ const (
 	templateName = "clirr-ignored-differences.xml.tmpl"
 )
 
-// generateClirrIfMissing generates the clirr-ignored-differences.xml file in the protoModulePath
-// if it doesn't already exist in the checkPath.
+// clirrIgnoreExists checks if the clirr-ignored-differences.xml file exists in the
+// specified directory.
+func clirrIgnoreExists(dir string) (bool, error) {
+	path := filepath.Join(dir, clirrIgnoreFile)
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("failed to check for %s: %w", path, err)
+}
+
+// generateClirrIgnore identifies Java packages containing Protobuf-generated code
+// and generates the clirr-ignored-differences.xml file in the protoModulePath.
 //
-// It identifies Java packages containing Protobuf-generated code by searching for
-// files ending in "OrBuilder.java" under "src/main/java". The "OrBuilder" suffix
-// is used as a reliable marker because it is consistently generated for every
-// Protobuf message.
+// It identifies Java packages by searching for files ending in "OrBuilder.java"
+// under "src/main/java". The "OrBuilder" suffix is used as a reliable marker
+// because it is consistently generated for every Protobuf message.
 //
 // The generated file contains a set of whitelist rules that tell the Clirr tool
 // to ignore specific changes (like method additions to interfaces) to
 // prevent false-positive binary compatibility failures in the build.
-func generateClirrIfMissing(protoModulePath, checkPath string) error {
-	if checkPath != "" {
-		repoFilePath := filepath.Join(checkPath, clirrIgnoreFile)
-		_, err := os.Stat(repoFilePath)
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to check for %s: %w", repoFilePath, err)
-		}
-	}
+func generateClirrIgnore(protoModulePath string) error {
 	protoPaths, err := findProtoPackages(protoModulePath)
 	if err != nil {
 		return fmt.Errorf("failed to find proto packages in %s: %w", protoModulePath, err)

--- a/internal/librarian/java/clirr_test.go
+++ b/internal/librarian/java/clirr_test.go
@@ -15,15 +15,13 @@
 package java
 
 import (
-	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestGenerateClirr(t *testing.T) {
+func TestGenerateClirrIgnore(t *testing.T) {
 	tmpDir := t.TempDir()
 	protoModulePath := filepath.Join(tmpDir, "proto-google-cloud-test-v1")
 	srcDir := filepath.Join(protoModulePath, "src", "main", "java", "com", "google", "cloud", "test", "v1")
@@ -35,7 +33,7 @@ func TestGenerateClirr(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := generateClirrIfMissing(protoModulePath, ""); err != nil {
+	if err := generateClirrIgnore(protoModulePath); err != nil {
 		t.Fatal(err)
 	}
 
@@ -53,27 +51,40 @@ func TestGenerateClirr(t *testing.T) {
 	}
 }
 
-func TestGenerateClirr_SkipExistingInCheckPath(t *testing.T) {
-	tmpDir := t.TempDir()
-	targetDir := filepath.Join(tmpDir, "target")
-	checkDir := filepath.Join(tmpDir, "check")
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(checkDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	outputPath := filepath.Join(checkDir, "clirr-ignored-differences.xml")
-	if err := os.WriteFile(outputPath, []byte("exists"), 0644); err != nil {
-		t.Fatal(err)
-	}
+func TestClirrIgnoreExists(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+		want  bool
+	}{
+		{
+			name:  "not exists",
+			setup: func(t *testing.T, dir string) {},
+			want:  false,
+		},
+		{
+			name: "exists",
+			setup: func(t *testing.T, dir string) {
+				path := filepath.Join(dir, clirrIgnoreFile)
+				if err := os.WriteFile(path, []byte("exists"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			test.setup(t, dir)
 
-	if err := generateClirrIfMissing(targetDir, checkDir); err != nil {
-		t.Fatal(err)
-	}
-
-	targetPath := filepath.Join(targetDir, "clirr-ignored-differences.xml")
-	if _, err := os.Stat(targetPath); !errors.Is(err, fs.ErrNotExist) {
-		t.Errorf("expected %s NOT to exist because it exists in checkPath", targetPath)
+			got, err := clirrIgnoreExists(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("clirrIgnoreExists(%q) = %v, want %v", dir, got, test.want)
+			}
+		})
 	}
 }
+

--- a/internal/librarian/java/clirr_test.go
+++ b/internal/librarian/java/clirr_test.go
@@ -87,4 +87,3 @@ func TestClirrIgnoreExists(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -123,8 +123,14 @@ func postProcessAPI(ctx context.Context, p postProcessParams) error {
 	coords := p.coords()
 	protoModuleStagingRoot := filepath.Join(p.outDir, "owl-bot-staging", p.version, coords.Proto.ArtifactID)
 	protoModuleRepoRoot := filepath.Join(p.outDir, coords.Proto.ArtifactID)
-	if err := generateClirrIfMissing(protoModuleStagingRoot, protoModuleRepoRoot); err != nil {
-		return fmt.Errorf("failed to generate clirr ignore file: %w", err)
+	exists, err := clirrIgnoreExists(protoModuleRepoRoot)
+	if err != nil {
+		return fmt.Errorf("failed to check for clirr ignore file: %w", err)
+	}
+	if !exists {
+		if err := generateClirrIgnore(protoModuleStagingRoot); err != nil {
+			return fmt.Errorf("failed to generate clirr ignore file: %w", err)
+		}
 	}
 
 	// Cleanup intermediate protoc output directory after restructuring


### PR DESCRIPTION
Split check existence and generate to separate functions for Clirr ignore files. This is a readability improvement change from `generateClirrIfMissing` that does two steps and not immediate clear why it needs two paths for.

For https://github.com/googleapis/librarian/pull/5306#pullrequestreview-4099577546