### PR TITLE
refactor(internal/config): replace no_samples with optional samples field

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -241,7 +241,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
-| `no_samples` | bool | Determines whether to generate samples for the API. |
+| `samples` | bool | Determines whether to generate samples for all APIs in this module. |
 | `path` | string | Is the source path. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -241,7 +241,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
-| `samples` | bool | Determines whether to generate samples for all APIs in this module. |
+| `samples` | bool (optional) | Determines whether to generate samples for the API. |
 | `path` | string | Is the source path. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -579,7 +579,7 @@ type JavaAPI struct {
 	// AdditionalProtos is a list of additional proto files to include in generation.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 
-	// Samples determines whether to generate samples for all APIs in this module.
+	// Samples determines whether to generate samples for the API.
 	Samples *bool `yaml:"samples,omitempty"`
 
 	// Path is the source path.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -579,8 +579,8 @@ type JavaAPI struct {
 	// AdditionalProtos is a list of additional proto files to include in generation.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 
-	// NoSamples determines whether to generate samples for the API.
-	NoSamples bool `yaml:"no_samples,omitempty"`
+	// Samples determines whether to generate samples for all APIs in this module.
+	Samples *bool `yaml:"samples,omitempty"`
 
 	// Path is the source path.
 	Path string `yaml:"path,omitempty"`

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -99,7 +99,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		outDir:         outdir,
 		version:        version,
 		googleapisDir:  googleapisDir,
-		includeSamples: !javaAPI.NoSamples,
+		includeSamples: javaAPI.Samples == nil || *javaAPI.Samples,
 	}
 	gapicDir := p.gapicDir()
 	gRPCDir := p.gRPCDir()

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -256,7 +256,7 @@ func TestResolveJavaAPI(t *testing.T) {
 						{
 							Path:             "google/cloud/secretmanager/v1",
 							AdditionalProtos: []string{"other.proto"},
-							Samples:          boolPtr(false),
+							Samples:          new(false),
 						},
 					},
 				},
@@ -265,7 +265,7 @@ func TestResolveJavaAPI(t *testing.T) {
 			want: &config.JavaAPI{
 				Path:             "google/cloud/secretmanager/v1",
 				AdditionalProtos: []string{"other.proto"},
-				Samples:          boolPtr(false),
+				Samples:          new(false),
 			},
 		},
 		{
@@ -671,8 +671,4 @@ func TestCollectJavaFiles(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -256,7 +256,7 @@ func TestResolveJavaAPI(t *testing.T) {
 						{
 							Path:             "google/cloud/secretmanager/v1",
 							AdditionalProtos: []string{"other.proto"},
-							NoSamples:        true,
+							Samples:          boolPtr(false),
 						},
 					},
 				},
@@ -265,7 +265,7 @@ func TestResolveJavaAPI(t *testing.T) {
 			want: &config.JavaAPI{
 				Path:             "google/cloud/secretmanager/v1",
 				AdditionalProtos: []string{"other.proto"},
-				NoSamples:        true,
+				Samples:          boolPtr(false),
 			},
 		},
 		{
@@ -671,4 +671,8 @@ func TestCollectJavaFiles(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -207,7 +207,7 @@ func TestRestructureModules(t *testing.T) {
 	}
 }
 
-func TestRestructureModules_NoSamples(t *testing.T) {
+func TestRestructureModules_SamplesDisabled(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	version := "v1"

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -241,7 +241,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				AdditionalProtos: info.AdditionalProtos,
 			}
 			if !info.Samples {
-				javaAPI.Samples = boolPtr(false)
+				javaAPI.Samples = new(false)
 			}
 			applyJavaArtifactOverrides(name, javaAPI)
 			javaAPIs = append(javaAPIs, javaAPI)
@@ -364,10 +364,6 @@ func applyJavaArtifactOverrides(name string, api *config.JavaAPI) {
 		api.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
 		api.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
 	}
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 func invertBoolPtr(p *bool) bool {

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -48,7 +48,7 @@ var (
 )
 
 type javaGAPICInfo struct {
-	NoSamples        bool
+	Samples          bool
 	AdditionalProtos []string
 }
 
@@ -60,7 +60,7 @@ func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
 	if file == nil {
 		return nil, nil
 	}
-	info := &javaGAPICInfo{}
+	info := &javaGAPICInfo{Samples: true}
 	// 1. From java_gapic_library
 	if rules := file.Rules("java_gapic_library"); len(rules) > 0 {
 		if len(rules) > 1 {
@@ -73,7 +73,7 @@ func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
 			log.Printf("Warning: multiple java_gapic_assembly_gradle_pkg in %s/BUILD.bazel, using first", dir)
 		}
 		rule := rules[0]
-		info.NoSamples = rule.AttrLiteral("include_samples") == "False"
+		info.Samples = rule.AttrLiteral("include_samples") != "False"
 	}
 	// 3. From proto_library_with_info
 	if rules := file.Rules("proto_library_with_info"); len(rules) > 0 {
@@ -239,7 +239,9 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			javaAPI := &config.JavaAPI{
 				Path:             g.ProtoPath,
 				AdditionalProtos: info.AdditionalProtos,
-				NoSamples:        info.NoSamples,
+			}
+			if !info.Samples {
+				javaAPI.Samples = boolPtr(false)
 			}
 			applyJavaArtifactOverrides(name, javaAPI)
 			javaAPIs = append(javaAPIs, javaAPI)
@@ -362,6 +364,10 @@ func applyJavaArtifactOverrides(name string, api *config.JavaAPI) {
 		api.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
 		api.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
 	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 func invertBoolPtr(p *bool) bool {

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -517,7 +517,7 @@ func TestParseJavaBazel(t *testing.T) {
 			googleapisDir: "testdata/parse-bazel/success",
 			buildPath:     "google/cloud/bigquery/analyticshub/v1",
 			want: &javaGAPICInfo{
-				NoSamples: false,
+				Samples: true,
 				AdditionalProtos: []string{
 					"google/cloud/common_resources.proto",
 				},
@@ -527,6 +527,7 @@ func TestParseJavaBazel(t *testing.T) {
 			name:          "no GAPIC rules",
 			googleapisDir: "testdata/parse-bazel/no-gapic-rule",
 			want: &javaGAPICInfo{
+				Samples: true,
 				AdditionalProtos: []string{
 					"google/cloud/common_resources.proto",
 				},


### PR DESCRIPTION
Replaces the no_samples boolean field with an optional samples pointer-based boolean across the configuration schema and Java generation logic.

The previous `no_samples` field was counter-intuitive. Moving to samples *bool improves config clarity, while allows a default. 

For #5307