### PR TITLE
chore(.github): ignore cargo check failure in integration job

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,6 +58,7 @@ jobs:
         working-directory: google-cloud-rust
         run: librarian generate --all
       - name: Run cargo check
+        continue-on-error: true
         working-directory: google-cloud-rust
         run: cargo check -p google-cloud-showcase-v1beta1
   create-issue-on-failure:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,6 +58,7 @@ jobs:
         working-directory: google-cloud-rust
         run: librarian generate --all
       - name: Run cargo check
+        # TODO(#5349) Restore this once guards are removed in google-cloud-rust
         continue-on-error: true
         working-directory: google-cloud-rust
         run: cargo check -p google-cloud-showcase-v1beta1


### PR DESCRIPTION
The post-merge `integration` job fails because generated code cannot compile against the current `main` branch of `google-cloud-rust` due to missing tracing guards.

This PR adds the failure for now. This unblocks CI until we can update `google-cloud-rust`.

