### PR TITLE
fix(sidekick/rust): remove redundant braces in tracing template

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -75,14 +75,12 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> Result<crate::Response<{{Codec.ReturnType}}>> {
         {{#Codec.DetailedTracingAttributes}}
-        {
-            let (_span, pending) = gaxi::client_request_signals!(
-                metric: self.duration.clone(),
-                info: *info::INSTRUMENTATION_CLIENT_INFO,
-                method: "client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}",
-                self.inner.{{Codec.Name}}(req, options));
-            pending.await
-        }
+        let (_span, pending) = gaxi::client_request_signals!(
+            metric: self.duration.clone(),
+            info: *info::INSTRUMENTATION_CLIENT_INFO,
+            method: "client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}",
+            self.inner.{{Codec.Name}}(req, options));
+        pending.await
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         self.inner.{{Codec.Name}}(req, options).await


### PR DESCRIPTION
Remove the redundant braces from the `tracing.rs.mustache` template https://github.com/googleapis/google-cloud-rust/pull/5292, left behind during the removal of `google_cloud_unstable_tracing` guards in https://github.com/googleapis/librarian/pull/5103.