### PR TITLE
fix(tool/cmd/migrate): change default samples to false add hardcoded cases in java migrate

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -240,7 +240,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				Path:             g.ProtoPath,
 				AdditionalProtos: info.AdditionalProtos,
 			}
-			if !info.Samples {
+			if shouldExcludeSamples(name, info) {
 				javaAPI.Samples = new(false)
 			}
 			applyJavaArtifactOverrides(name, javaAPI)
@@ -364,6 +364,10 @@ func applyJavaArtifactOverrides(name string, api *config.JavaAPI) {
 		api.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
 		api.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
 	}
+}
+
+func shouldExcludeSamples(name string, info *javaGAPICInfo) bool {
+	return !info.Samples || excludedSamplesLibraries[name]
 }
 
 func invertBoolPtr(p *bool) bool {

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -60,7 +60,7 @@ func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
 	if file == nil {
 		return nil, nil
 	}
-	info := &javaGAPICInfo{Samples: true}
+	info := &javaGAPICInfo{Samples: false}
 	// 1. From java_gapic_library
 	if rules := file.Rules("java_gapic_library"); len(rules) > 0 {
 		if len(rules) > 1 {
@@ -73,7 +73,7 @@ func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
 			log.Printf("Warning: multiple java_gapic_assembly_gradle_pkg in %s/BUILD.bazel, using first", dir)
 		}
 		rule := rules[0]
-		info.Samples = rule.AttrLiteral("include_samples") != "False"
+		info.Samples = rule.AttrLiteral("include_samples") == "True"
 	}
 	// 3. From proto_library_with_info
 	if rules := file.Rules("proto_library_with_info"); len(rules) > 0 {

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -25,4 +25,11 @@ var (
 		"distributedcloudedge":               "distributedcloudedge",
 		"gke-backup":                         "gke-backup",
 	}
+
+	excludedSamplesLibraries = map[string]bool{
+		"bigquerystorage": true,
+		"datastore":       true,
+		"storage":         true,
+		"spanner":         true,
+	}
 )

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -362,6 +362,40 @@ func TestBuildConfig(t *testing.T) {
 	}
 }
 
+func TestShouldExcludeSamples(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lib  string
+		info *javaGAPICInfo
+		want bool
+	}{
+		{
+			name: "exclude if info.Samples is false",
+			lib:  "any-lib",
+			info: &javaGAPICInfo{Samples: false},
+			want: true,
+		},
+		{
+			name: "exclude if lib is in excludedSamplesLibraries",
+			lib:  "datastore",
+			info: &javaGAPICInfo{Samples: true},
+			want: true,
+		},
+		{
+			name: "include if info.Samples is true and lib not in map",
+			lib:  "any-lib",
+			info: &javaGAPICInfo{Samples: true},
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shouldExcludeSamples(test.lib, test.info); got != test.want {
+				t.Errorf("shouldExcludeSamples(%q, %+v) = %v, want %v", test.lib, test.info, got, test.want)
+			}
+		})
+	}
+}
+
 func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 	gen := &GenerationConfig{
 		Libraries: []LibraryConfig{
@@ -401,6 +435,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 					JavaAPIs: []*config.JavaAPI{
 						{
 							Path:                    "google/datastore/admin/v1",
+							Samples:                 func(b bool) *bool { return &b }(false),
 							ProtoArtifactIDOverride: "proto-google-cloud-datastore-admin-v1",
 							GRPCArtifactIDOverride:  "grpc-google-cloud-datastore-admin-v1",
 						},

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -527,7 +527,7 @@ func TestParseJavaBazel(t *testing.T) {
 			name:          "no GAPIC rules",
 			googleapisDir: "testdata/parse-bazel/no-gapic-rule",
 			want: &javaGAPICInfo{
-				Samples: true,
+				Samples: false,
 				AdditionalProtos: []string{
 					"google/cloud/common_resources.proto",
 				},


### PR DESCRIPTION
Changes default samples config to false when not found from BUILD.bazel and added a few hardcoded cases. 

`include_samples` defaults to false when not specified in java_gapic_assembly_gradle_pkg. 
Hardcoded a few cases to have config `samples: false`, to reflect reality in google-cloud-java. These are edge-cases (mostly hybrid libraries) that are effectively not generating samples: BUILD.bazel has `include_samples` as true, but after generate, it is not configured to move to final location via .OwlBot-hermetic.yaml.  e.g. [datastore](https://github.com/googleapis/google-cloud-java/blob/main/java-datastore/.OwlBot-hermetic.yaml).

For https://github.com/googleapis/librarian/issues/5307