### PR TITLE
feat(java): add proto_only option to skip GAPIC generation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -244,7 +244,7 @@ This document describes the schema for the librarian.yaml.
 | `samples` | bool (optional) | Determines whether to generate samples for the API. |
 | `path` | string | Is the source path. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
-| `proto_only` | bool |  |
+| `proto_only` | bool | Determines whether to generate a Proto-only client. A proto-only client does not define a service in the proto files. |
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |
 
 ## JavaModule Configuration
@@ -316,7 +316,7 @@ This document describes the schema for the librarian.yaml.
 | `api_id_override` | string | Allows the "api_id" field in .repo-metadata.json to be overridden, to reduce diffs while migrating. TODO(https://github.com/googleapis/librarian/issues/4175): remove this field. |
 | `client_documentation_override` | string | Allows the client_documentation field in .repo-metadata.json to be overridden from the default that's inferred. TODO(https://github.com/googleapis/librarian/issues/4175): reduce uses of this field to only cases where it's really needed. |
 | `issue_tracker_override` | string | Allows the issue_tracker field in .repo-metadata.json to be overridden, to reduce diffs while migrating. TODO(https://github.com/googleapis/librarian/issues/4175): remove this field. |
-| `metadata_name_override` | string | Allows the name in .repo-metadata.json (which is also used as part of the client documentation URI) to be overridden. By default it's the package name, but older packages use the API short name instead. |
+| `metadata_name_override` | string | Allows the name in .repo-metadata.json (which is also used as part of the client documentation URI) to be overridden. By default, it's the package name, but older packages use the API short name instead. |
 | `default_version` | string | Is the default version of the API to use. When omitted, the version in the first API path is used. |
 | `skip_readme_copy` | bool | Prevents generation from copying README.rst from the root directory to the docs directory. TODO(https://github.com/googleapis/librarian/issues/4738): revisit whether or not this field should exist after migration. |
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -244,6 +244,7 @@ This document describes the schema for the librarian.yaml.
 | `samples` | bool (optional) | Determines whether to generate samples for the API. |
 | `path` | string | Is the source path. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
+| `proto_only` | bool |  |
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |
 
 ## JavaModule Configuration

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -398,7 +398,7 @@ type PythonPackage struct {
 
 	// MetadataNameOverride allows the name in .repo-metadata.json (which is
 	// also used as part of the client documentation URI) to be overridden. By
-	// default it's the package name, but older packages use the API short name
+	// default, it's the package name, but older packages use the API short name
 	// instead.
 	MetadataNameOverride string `yaml:"metadata_name_override,omitempty"`
 
@@ -589,6 +589,8 @@ type JavaAPI struct {
 	// The artifact ID is also used as the name for the module's directory.
 	ProtoArtifactIDOverride string `yaml:"proto_artifact_id_override,omitempty"`
 
+	// ProtoOnly determines whether to generate a Proto-only client.
+	// A proto-only client does not define a service in the proto files.
 	ProtoOnly bool `yaml:"proto_only,omitempty"`
 
 	// GRPCArtifactIDOverride overrides the artifact ID for the gRPC module.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -589,6 +589,8 @@ type JavaAPI struct {
 	// The artifact ID is also used as the name for the module's directory.
 	ProtoArtifactIDOverride string `yaml:"proto_artifact_id_override,omitempty"`
 
+	ProtoOnly bool `yaml:"proto_only,omitempty"`
+
 	// GRPCArtifactIDOverride overrides the artifact ID for the gRPC module.
 	// The artifact ID is also used as the name for the module's directory.
 	GRPCArtifactIDOverride string `yaml:"grpc_artifact_id_override,omitempty"`

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -136,16 +136,18 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		}
 	}
 	// 3. Generate GAPIC library.
-	gapicOpts, err := resolveGAPICOptions(cfg, library, api, googleapisDir, apiCfg)
-	if err != nil {
-		return fmt.Errorf("failed to resolve gapic options: %w", err)
-	}
-	var additionalProtos []string
-	for _, p := range javaAPI.AdditionalProtos {
-		additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, filepath.FromSlash(p)))
-	}
-	if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, googleapisDir, gapicDir, gapicOpts)); err != nil {
-		return fmt.Errorf("failed to generate gapic: %w", err)
+	if !javaAPI.ProtoOnly {
+		gapicOpts, err := resolveGAPICOptions(cfg, library, api, googleapisDir, apiCfg)
+		if err != nil {
+			return fmt.Errorf("failed to resolve gapic options: %w", err)
+		}
+		var additionalProtos []string
+		for _, p := range javaAPI.AdditionalProtos {
+			additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, filepath.FromSlash(p)))
+		}
+		if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, googleapisDir, gapicDir, gapicOpts)); err != nil {
+			return fmt.Errorf("failed to generate gapic: %w", err)
+		}
 	}
 
 	if err := postProcessAPI(ctx, p); err != nil {

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -354,6 +354,62 @@ func TestGenerateAPI(t *testing.T) {
 	}
 }
 
+func TestGenerateAPI_ProtoOnly(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("slow test: Java GAPIC code generation")
+	}
+	testhelper.RequireCommand(t, "protoc")
+	testhelper.RequireCommand(t, "protoc-gen-java_grpc")
+	outdir := t.TempDir()
+	cfg := &config.Config{
+		Repo: "googleapis/google-cloud-java",
+		Default: &config.Default{
+			Java: &config.JavaModule{},
+		},
+		Libraries: []*config.Library{
+			{Name: "google-cloud-java", Version: "1.2.3"},
+		},
+	}
+	library := &config.Library{
+		Name:   "gkehub",
+		Output: outdir,
+		Java: &config.JavaModule{
+			JavaAPIs: []*config.JavaAPI{
+				{Path: "google/cloud/gkehub/policycontroller/v1beta", ProtoOnly: true},
+			},
+		},
+	}
+	for _, artifact := range []string{"proto-google-cloud-gkehub-v1beta", "google-cloud-gkehub-bom"} {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	apiCfg, err := serviceconfig.Find(googleapisDir, "google/cloud/gkehub/policycontroller/v1beta", config.LanguageJava)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = generateAPI(
+		t.Context(),
+		cfg,
+		&config.API{Path: "google/cloud/gkehub/policycontroller/v1beta"},
+		library,
+		googleapisDir,
+		outdir,
+		&repoMetadata{
+			NamePretty: "GKE Hub API",
+		},
+		apiCfg,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restructuredPath := filepath.Join(outdir, "owl-bot-staging", "v1beta", "proto-google-cloud-gkehub-v1beta", "src", "main", "java")
+	if _, err := os.Stat(restructuredPath); err != nil {
+		t.Errorf("expected restructured path %s to exist: %v", restructuredPath, err)
+	}
+}
+
 func TestGenerateAPI_NoTools(t *testing.T) {
 	// Temporarily mock runProtoc to avoid external tool requirements.
 	oldRunProtoc := runProtoc

--- a/internal/testdata/googleapis/google/cloud/gkehub/policycontroller/v1beta/policycontroller.proto
+++ b/internal/testdata/googleapis/google/cloud/gkehub/policycontroller/v1beta/policycontroller.proto
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.gkehub.policycontroller.v1beta;
+
+option csharp_namespace = "Google.Cloud.GkeHub.PolicyController.V1Beta";
+option go_package = "cloud.google.com/go/gkehub/policycontroller/apiv1beta/policycontrollerpb;policycontrollerpb";
+option java_multiple_files = true;
+option java_outer_classname = "PolicyControllerProto";
+option java_package = "com.google.cloud.gkehub.policycontroller.v1beta";
+option php_namespace = "Google\\Cloud\\GkeHub\\PolicyController\\V1beta";
+option ruby_package = "Google::Cloud::GkeHub::PolicyController::V1beta";
+
+message MembershipState {
+  enum LifecycleState {
+    LIFECYCLE_STATE_UNSPECIFIED = 0;
+  }
+  LifecycleState state = 4;
+}


### PR DESCRIPTION
A new `proto_only` field is added to the Java API configuration. When set to `true`, the Java generator skips the GAPIC library generation step and only processes the proto and gRPC artifacts.

For #5320