### PR TITLE
fix(tool/cmd/migrate): add logging to hardcoded skip sample list

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -29,6 +29,7 @@ var (
 	excludedSamplesLibraries = map[string]bool{
 		"bigquerystorage": true,
 		"datastore":       true,
+		"logging":         true,
 		"storage":         true,
 		"spanner":         true,
 	}


### PR DESCRIPTION
Add hardcoded config for logging to not generate samples, currently it relies on [.OwlBot-hermetic.yaml](https://github.com/googleapis/google-cloud-java/blob/main/java-logging/.OwlBot-hermetic.yaml#L27-L28) with no rule to copy samples.

Fixes #5307