### PR TITLE
fix(internal/librarian/java): move sample generation defaults in the Fill phase

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -241,7 +241,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
-| `samples` | bool (optional) | Determines whether to generate samples for the API. |
+| `samples` | bool (optional) | Determines whether to generate samples for the API, default is true when omitted. |
 | `path` | string | Is the source path. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -579,7 +579,8 @@ type JavaAPI struct {
 	// AdditionalProtos is a list of additional proto files to include in generation.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 
-	// Samples determines whether to generate samples for the API.
+	// Samples determines whether to generate samples for the API,
+	// default is true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
 
 	// Path is the source path.

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -33,6 +33,18 @@ func Fill(library *config.Library) (*config.Library, error) {
 	if library.Output == "" {
 		library.Output = deriveOutput(library.Name)
 	}
+	if library.Java == nil {
+		library.Java = &config.JavaModule{}
+	}
+	var javaAPIs []*config.JavaAPI
+	for _, api := range library.APIs {
+		javaAPI := ResolveJavaAPI(library, api)
+		if javaAPI.Samples == nil {
+			javaAPI.Samples = new(true)
+		}
+		javaAPIs = append(javaAPIs, javaAPI)
+	}
+	library.Java.JavaAPIs = javaAPIs
 	return library, nil
 }
 

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -36,6 +36,7 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "java-secretmanager",
+				Java:   &config.JavaModule{},
 			},
 		},
 		{
@@ -47,6 +48,63 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "custom-output",
+				Java:   &config.JavaModule{},
+			},
+		},
+		{
+			name: "fill samples default",
+			lib: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:   "secretmanager",
+				Output: "java-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{
+							Path:    "google/cloud/secretmanager/v1",
+							Samples: new(true),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "do not overwrite samples override",
+			lib: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{
+							Path:    "google/cloud/secretmanager/v1",
+							Samples: new(false),
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				Name:   "secretmanager",
+				Output: "java-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{
+							Path:    "google/cloud/secretmanager/v1",
+							Samples: new(false),
+						},
+					},
+				},
 			},
 		},
 	} {

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -99,7 +99,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		outDir:         outdir,
 		version:        version,
 		googleapisDir:  googleapisDir,
-		includeSamples: javaAPI.Samples == nil || *javaAPI.Samples,
+		includeSamples: *javaAPI.Samples,
 	}
 	gapicDir := p.gapicDir()
 	gRPCDir := p.gRPCDir()
@@ -288,11 +288,9 @@ func ResolveJavaAPI(library *config.Library, api *config.API) *config.JavaAPI {
 		return res
 	}
 	for _, javaAPI := range library.Java.JavaAPIs {
-		if javaAPI.Path != api.Path {
-			continue
+		if javaAPI.Path == api.Path {
+			return javaAPI
 		}
-		*res = *javaAPI
-		return res
 	}
 	return res
 }

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -315,11 +315,17 @@ func TestGenerateAPI(t *testing.T) {
 	library := &config.Library{
 		Name:   "secretmanager",
 		Output: outdir,
+		APIs: []*config.API{
+			{Path: "google/cloud/secretmanager/v1"},
+		},
 		Java: &config.JavaModule{
 			JavaAPIs: []*config.JavaAPI{
 				{Path: "google/cloud/secretmanager/v1", AdditionalProtos: []string{"google/cloud/common_resources.proto"}},
 			},
 		},
+	}
+	if _, err := Fill(library); err != nil {
+		t.Fatal(err)
 	}
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
 		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -382,6 +382,9 @@ func TestGenerateAPI_NoTools(t *testing.T) {
 			api,
 		},
 	}
+	if _, err := Fill(library); err != nil {
+		t.Fatal(err)
+	}
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
 		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
 			t.Fatal(err)
@@ -492,6 +495,9 @@ func TestGenerateLibrary_Error(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			if _, err := Fill(test.library); err != nil {
+				t.Fatal(err)
+			}
 			// Temporarily mock runProtoc to avoid external tool requirements.
 			oldRunProtoc := runProtoc
 			defer func() { runProtoc = oldRunProtoc }()
@@ -531,6 +537,9 @@ func TestGenerate_Logic(t *testing.T) {
 		APIs: []*config.API{
 			{Path: "google/cloud/secretmanager/v1"},
 		},
+	}
+	if _, err := Fill(library); err != nil {
+		t.Fatal(err)
 	}
 	cfg := &config.Config{
 		Language: config.LanguageJava,


### PR DESCRIPTION
Extract logic to set default config for JavaAPI.Samples to Fill defaults.

For https://github.com/googleapis/librarian/issues/5307