### PR TITLE
chore(.github): enable cargo check failure for google-cloud-rust generation comparison

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,8 +58,6 @@ jobs:
         working-directory: google-cloud-rust
         run: librarian generate --all
       - name: Run cargo check
-        # TODO(#5349) Restore this once guards are removed in google-cloud-rust
-        continue-on-error: true
         working-directory: google-cloud-rust
         run: cargo check -p google-cloud-showcase-v1beta1
   create-issue-on-failure:


### PR DESCRIPTION
Fixes #5349