### PR TITLE
refactor(internal/librarian/golang): generate in temp directory instead of output directory

### DIFF
--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -41,7 +41,7 @@ var (
 )
 
 // Generate generates a Go client library.
-func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources) error {
+func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources) (err error) {
 	outDir, err := filepath.Abs(library.Output)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path of output directory: %w", err)
@@ -49,6 +49,16 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
+
+	tempDir, err := os.MkdirTemp(outDir, "librarian-gen-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer func() {
+		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
+			err = errors.Join(err, removeErr)
+		}
+	}()
 
 	// For preview libraries, the API protos are rooted in the
 	// googleapis/preview subdirectory, so change the googleapisDir to target
@@ -59,16 +69,14 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 	}
 
 	for i, api := range library.APIs {
-		// TODO(https://github.com/googleapis/librarian/issues/4777): Generate APIs in a temp
-		// directory.
 		goAPI := findGoAPI(library, api.Path)
 		if goAPI == nil {
 			return fmt.Errorf("error finding goAPI associated with API %s: %w", api.Path, errGoAPINotFound)
 		}
-		if err := generateAPI(ctx, goAPI, googleapisDir, outDir); err != nil {
+		if err := generateAPI(ctx, goAPI, googleapisDir, tempDir); err != nil {
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
-		if err := moveGeneratedFiles(library, goAPI, outDir); err != nil {
+		if err := moveGeneratedFiles(library, goAPI, tempDir, outDir); err != nil {
 			return err
 		}
 		if err := generateClientVersionFile(library, goAPI); err != nil {
@@ -97,9 +105,6 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 				return fmt.Errorf("failed to delete generation output path %q: %w", p, err)
 			}
 		}
-	}
-	if err := os.RemoveAll(filepath.Join(outDir, "cloud.google.com")); err != nil {
-		return err
 	}
 	if _, err := os.Stat(filepath.Join(outDir, "go.mod")); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -189,17 +194,17 @@ func buildGAPICImportPath(goAPI *config.GoAPI) string {
 
 // moveGeneratedFiles moves generated API and snippet files from the protoc output
 // directory to their destination in the repository.
-func moveGeneratedFiles(library *config.Library, goAPI *config.GoAPI, outDir string) error {
-	if err := moveAPIDirectory(library, goAPI, outDir); err != nil {
+func moveGeneratedFiles(library *config.Library, goAPI *config.GoAPI, srcDir, outDir string) error {
+	if err := moveAPIDirectory(library, goAPI, srcDir, outDir); err != nil {
 		return err
 	}
-	return moveAndUpdateSnippets(library, goAPI, outDir)
+	return moveAndUpdateSnippets(library, goAPI, srcDir, outDir)
 }
 
 // moveAPIDirectory moves the generated API directory from the temporary location to its
 // final destination in the repository.
-func moveAPIDirectory(library *config.Library, goAPI *config.GoAPI, outDir string) error {
-	libraryDirPrefix := filepath.Join(outDir, "cloud.google.com", "go")
+func moveAPIDirectory(library *config.Library, goAPI *config.GoAPI, srcDir, outDir string) error {
+	libraryDirPrefix := filepath.Join(srcDir, "cloud.google.com", "go")
 	librarySrc := filepath.Join(libraryDirPrefix, goAPI.ImportPath)
 	libraryDest := filepath.Join(repoRootPath(outDir, library.Name), clientPathFromRepoRoot(library, goAPI))
 	if err := os.MkdirAll(libraryDest, 0755); err != nil {
@@ -210,7 +215,7 @@ func moveAPIDirectory(library *config.Library, goAPI *config.GoAPI, outDir strin
 
 // moveAndUpdateSnippets moves the generated snippets from the temporary location to their final
 // destination and updates their library versions.
-func moveAndUpdateSnippets(library *config.Library, goAPI *config.GoAPI, outDir string) error {
+func moveAndUpdateSnippets(library *config.Library, goAPI *config.GoAPI, srcDir, outDir string) error {
 	snippetDest := findSnippetDirectory(library, goAPI, outDir)
 	if snippetDest == "" {
 		return nil
@@ -218,7 +223,7 @@ func moveAndUpdateSnippets(library *config.Library, goAPI *config.GoAPI, outDir 
 	if err := os.MkdirAll(snippetDest, 0755); err != nil {
 		return err
 	}
-	snippetDirPrefix := filepath.Join(outDir, "cloud.google.com", "go", "internal", "generated", "snippets")
+	snippetDirPrefix := filepath.Join(srcDir, "cloud.google.com", "go", "internal", "generated", "snippets")
 	snippetSrc := filepath.Join(snippetDirPrefix, goAPI.ImportPath)
 	if err := filesystem.MoveAndMerge(snippetSrc, snippetDest); err != nil {
 		return err

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -946,7 +946,7 @@ func TestMoveGeneratedFiles(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			outDir, apiDir, snippetDir, lib := test.setup(t, tmpDir)
-			err := moveGeneratedFiles(lib, lib.Go.GoAPIs[0], outDir)
+			err := moveGeneratedFiles(lib, lib.Go.GoAPIs[0], outDir, outDir)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Refactors the Go client library generation process to use a temporary directory for protoc operations. This isolates intermediate generation artifacts from the repository, improving build safety and eliminating the need for manual cleanup scripts. Does so within the same filesystem to avoid the error `invalid cross-device` on different os's.

Fixes #4777
Fixes #5301 