### PR TITLE
impl(sidekick/rust): disable comments in tonic proto gen

### DIFF
--- a/internal/sidekick/rust_prost/templates/tonic/build.rs.mustache
+++ b/internal/sidekick/rust_prost/templates/tonic/build.rs.mustache
@@ -39,6 +39,14 @@ fn main() {
         config.type_name_domain(&["."], "type.googleapis.com");
         config.include_file("includes.rs");
         tonic_prost_build::configure()
+            .disable_comments([
+                {{#Services}}
+                "{{Package}}.{{Name}}",
+                {{#Methods}}
+                "{{Service.Package}}.{{Service.Name}}.{{Name}}",
+                {{/Methods}}
+                {{/Services}}
+            ])
             .type_attribute(".", "#[allow(clippy::large_enum_variant)]")
             .bytes(".")
             .out_dir(&destination)


### PR DESCRIPTION
Part of the work for https://github.com/googleapis/google-cloud-rust/issues/5333 

Disable comments for the service, and all of its methods. This is one way to avoid clippy warnings that also reduces the total lines of generated code. :shrug: 

(Note that disabling at the root `"."` works for `prost_build` but not `tonic_prost_build`. Great. :unamused: 