### PR TITLE
feat(sidekick/rust): add grpc-mock template

### DIFF
--- a/internal/sidekick/rust/templates/grpc-mock/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/grpc-mock/Cargo.toml.mustache
@@ -37,7 +37,7 @@ mockall.workspace     = true
 prost                 = { workspace = true, default-features = true }
 prost-types           = { workspace = true, default-features = true }
 serde_json.workspace  = true
-tokio                 = { workspace = true, features = ["macros"] }
+tokio                 = { workspace = true, features = ["macros", "net", "rt"] }
 tokio-stream          = { workspace = true }
 tonic                 = { workspace = true, default-features = true }
 tonic-prost.workspace = true

--- a/internal/sidekick/rust/templates/grpc-mock/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/grpc-mock/Cargo.toml.mustache
@@ -1,0 +1,43 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+# Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+#{{{.}}}
+{{/Codec.BoilerPlate}}
+
+[package]
+name              = "{{Codec.PackageName}}"
+description       = "A fake gRPC server for end to end testing of {{{Title}}}"
+version           = "0.0.0"
+publish           = false
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace      = true
+async-trait.workspace = true
+http.workspace        = true
+mockall.workspace     = true
+prost                 = { workspace = true, default-features = true }
+prost-types           = { workspace = true, default-features = true }
+serde_json.workspace  = true
+tokio                 = { workspace = true, features = ["macros"] }
+tokio-stream          = { workspace = true }
+tonic                 = { workspace = true, default-features = true }
+tonic-prost.workspace = true

--- a/internal/sidekick/rust/templates/grpc-mock/README.md.mustache
+++ b/internal/sidekick/rust/templates/grpc-mock/README.md.mustache
@@ -1,0 +1,38 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+# A mockable {{Title}} service implementation
+
+This crate provides a mockable implementation of the {{Title}} service over
+gRPC, analogous to the `httptest` crate but specific to this service. It is used
+in the client library tests, and not intended for any other use.
+
+## On streaming RPCs
+
+Streaming RPCs in Tonic use generics for the output (server-side) streams. To
+simplify the mocks, this crate only supports `tokio::sync::mpsc::Receiver<>` as
+the output type. These are easy to create in tests and good enough for that
+purpose.
+
+Streaming RPCs in Tonic use `tonic::Streaming<>` as the input (client-side)
+streams. It seemed easier to reason about the mock if it always used
+`Receiver<>`. If this proves to be a bad decision we can change the code it.
+
+## Usage
+
+Create a `mocks::Mock{{QuickstartService.Name}}` and call `start()` to launch a (local) server
+using the mock. Then connect your test to this mock server.
+
+The types have comments with trivial examples.

--- a/internal/sidekick/rust/templates/grpc-mock/README.md.mustache
+++ b/internal/sidekick/rust/templates/grpc-mock/README.md.mustache
@@ -28,7 +28,7 @@ purpose.
 
 Streaming RPCs in Tonic use `tonic::Streaming<>` as the input (client-side)
 streams. It seemed easier to reason about the mock if it always used
-`Receiver<>`. If this proves to be a bad decision we can change the code it.
+`Receiver<>`. If this proves to be a bad decision we can change the code.
 
 ## Usage
 

--- a/internal/sidekick/rust/templates/grpc-mock/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-mock/src/lib.rs.mustache
@@ -1,0 +1,126 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+// Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+//{{{.}}}
+{{/Codec.BoilerPlate}}
+
+{{#Codec.QuickstartService}}
+//! End-to-end mocks for the `{{Package}}.{{Name}}` gRPC service.
+//!
+//! Use this crate for end-to-end client library tests. Start a local server
+//! implementing the `{{Package}}.{{Name}}` API, with the implementation
+//! defined by a mock. Then test the client library against this mock.
+//!
+//! # Example
+//! ```no_rust
+//! use {{Model.Codec.PackageNamespace}}::{start, Mock{{Codec.Name}}};
+//! use google_cloud_{{Codec.ModuleName}}::client::{{Codec.Name}};
+//! use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+//!
+//! # async fn test() -> anyhow::Result<()> {
+//! let mut mock = Mock{{Codec.Name}}::new();
+{{#QuickstartMethod}}
+//! mock.expect_{{Codec.Name}}()
+{{/QuickstartMethod}}
+//!     .return_once(|_| Err(tonic::Status::invalid_argument("test message")));
+//! // Starts a service using `mock` and a random port.
+//! let (endpoint, server) = start("0.0.0.0:0", mock).await?;
+//! // Use the service in a test.
+//! let client = {{Codec.Name}}::builder()
+//!     .with_endpoint(endpoint)
+//!     .with_credentials(Anonymous::default().build())
+//!     .build()
+//!     .await?;
+//! let err = client
+{{#QuickstartMethod}}
+//!     .{{Codec.Name}}()
+{{/QuickstartMethod}}
+//!     .send()
+//!     .unwrap_err("mock returns an error");
+//! assert_eq!(err.status().is_some(), "{err:?}");
+//! # Ok(()) }
+//! ```
+{{/Codec.QuickstartService}}
+
+mod mocks;
+use std::net::SocketAddr;
+use tokio::task::JoinHandle;
+
+{{#Codec.Services}}
+/// A mock for the `{{Package}}.{{Name}}` gRPC service.
+///
+/// # Example
+{{! We build samples marked `ignore`, so use `no_rust` instead. }}
+/// ```no_rust
+/// use {{Model.Codec.PackageNamespace}}::Mock{{Codec.Name}};
+/// let mut mock = Mock{{Codec.Name}}::new();
+/// let (tx, rx) = tokio::sync::mpsc::channel(128);
+/// mock.expect_streaming_rpc() // Made up bidirectional streaming RPC.
+///     .return_once(|_request| Ok(tonic::Response::from(rx)));
+/// // use `tx` to mock streaming responses.
+/// ```
+pub use mocks::Mock{{Codec.Name}};
+
+{{! TODO(#5333) - `start()` should be scoped to a service. }}
+/// Starts a mock `{{Package}}.{{Name}}` gRPC service.
+///
+/// # Example
+/// ```
+/// use {{Model.Codec.PackageNamespace}}::{start, Mock{{Codec.Name}}};
+/// # async fn test() -> anyhow::Result<()> {
+/// let mut mock = Mock{{Codec.Name}}::new();
+{{#QuickstartMethod}}
+/// mock.expect_{{Codec.Name}}()
+{{/QuickstartMethod}}
+///     .return_once(|_| Err(tonic::Status::invalid_argument("test message")));
+/// // starts a service using `mock` and a random port.
+/// let (address, server) = start("0.0.0.0:0", mock).await?;
+/// // ... ... test goes here ... ...
+/// # Ok(()) }
+/// ```
+pub async fn start<T>(address: &str, service: T) -> anyhow::Result<(String, JoinHandle<()>)>
+where
+    T: {{Codec.PackageModuleName}}::{{Codec.ModuleName}}_server::{{Codec.Name}},
+{
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    let addr = listener.local_addr()?;
+
+    let server = tokio::spawn(async {
+        let stream = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+        let _ = tonic::transport::Server::builder()
+            .add_service({{Codec.PackageModuleName}}::{{Codec.ModuleName}}_server::{{Codec.Name}}Server::new(
+                service,
+            ))
+            .serve_with_incoming(stream)
+            .await;
+    });
+
+    Ok((to_uri(addr), server))
+}
+{{/Codec.Services}}
+
+// This function is public only for the sake of unit testing
+pub fn to_uri(addr: SocketAddr) -> String {
+    if addr.is_ipv6() {
+        format!("http://[{}]:{}", addr.ip(), addr.port())
+    } else {
+        format!("http://{}:{}", addr.ip(), addr.port())
+    }
+}
+
+include!("generated/protos/includes.rs");

--- a/internal/sidekick/rust/templates/grpc-mock/src/mocks.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-mock/src/mocks.rs.mustache
@@ -1,0 +1,125 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+// Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+//{{{.}}}
+{{/Codec.BoilerPlate}}
+
+use super::google;
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+{{#Codec.Services}}
+#[mockall::automock]
+#[async_trait]
+pub trait {{Codec.Name}} {
+    // In the mock we use an easy-to-create type (mpsc::Receiver) for the
+    // streams. The `impl` adapts between these concrete types and the more
+    // general types / traits that Tonic uses.
+
+    {{#Codec.Methods}}
+    async fn {{Codec.Name}}(
+        &self,
+        {{#ClientSideStreaming}}
+        request: tonic::Request<mpsc::Receiver<tonic::Result<{{InputType.Codec.PackageModuleName}}::{{InputType.Name}}>>>,
+        {{/ClientSideStreaming}}
+        {{^ClientSideStreaming}}
+        request: tonic::Request<{{InputType.Codec.PackageModuleName}}::{{InputType.Name}}>,
+        {{/ClientSideStreaming}}
+        {{#ServerSideStreaming}}
+    ) -> tonic::Result<tonic::Response<mpsc::Receiver<tonic::Result<{{OutputType.Codec.PackageModuleName}}::{{OutputType.Name}}>>>>;
+        {{/ServerSideStreaming}}
+        {{^ServerSideStreaming}}
+        {{#ReturnsEmpty}}
+    ) -> tonic::Result<tonic::Response<()>>;
+        {{/ReturnsEmpty}}
+        {{^ReturnsEmpty}}
+    ) -> tonic::Result<tonic::Response<{{OutputType.Codec.PackageModuleName}}::{{OutputType.Name}}>>;
+        {{/ReturnsEmpty}}
+        {{/ServerSideStreaming}}
+    {{/Codec.Methods}}
+}
+
+#[async_trait]
+impl {{Codec.PackageModuleName}}::{{Codec.ModuleName}}_server::{{Codec.Name}} for Mock{{Codec.Name}} {
+    {{#Codec.Methods}}
+    {{#ServerSideStreaming}}
+    type {{Codec.BuilderName}}Stream = ReceiverStream<tonic::Result<{{OutputType.Codec.PackageModuleName}}::{{OutputType.Name}}>>;
+    {{/ServerSideStreaming}}
+    async fn {{Codec.Name}}(
+        &self,
+        {{#ClientSideStreaming}}
+        request: tonic::Request<tonic::Streaming<{{InputType.Codec.PackageModuleName}}::{{InputType.Name}}>>,
+        {{/ClientSideStreaming}}
+        {{^ClientSideStreaming}}
+        request: tonic::Request<{{InputType.Codec.PackageModuleName}}::{{InputType.Name}}>,
+        {{/ClientSideStreaming}}
+        {{#ServerSideStreaming}}
+    ) -> tonic::Result<tonic::Response<Self::{{Codec.BuilderName}}Stream>> {
+        {{/ServerSideStreaming}}
+        {{^ServerSideStreaming}}
+        {{#ReturnsEmpty}}
+    ) -> tonic::Result<tonic::Response<()>> {
+        {{/ReturnsEmpty}}
+        {{^ReturnsEmpty}}
+    ) -> tonic::Result<tonic::Response<{{OutputType.Codec.PackageModuleName}}::{{OutputType.Name}}>> {
+        {{/ReturnsEmpty}}
+        {{/ServerSideStreaming}}
+        {{#ClientSideStreaming}}
+        let request = adapt_streaming_request(request);
+        {{/ClientSideStreaming}}
+        {{#ServerSideStreaming}}
+        let response = self::{{Service.Codec.Name}}::{{Codec.Name}}(self, request).await?;
+        let (metadata, receiver, extensions) = response.into_parts();
+        Ok(tonic::Response::from_parts(
+            metadata,
+            ReceiverStream::new(receiver),
+            extensions,
+        ))
+        {{/ServerSideStreaming}}
+        {{^ServerSideStreaming}}
+        self::{{Service.Codec.Name}}::{{Codec.Name}}(self, request).await
+        {{/ServerSideStreaming}}
+    }
+    {{/Codec.Methods}}
+}
+{{#HasClientSideStreaming}}
+
+fn adapt_streaming_request<T>(
+    request: tonic::Request<tonic::Streaming<T>>,
+) -> tonic::Request<mpsc::Receiver<tonic::Result<T>>>
+where
+    T: Send + 'static,
+{
+    let (tx, rx) = mpsc::channel(1);
+    let (metadata, extensions, stream) = request.into_parts();
+    forward(tx, stream);
+    tonic::Request::from_parts(metadata, extensions, rx)
+}
+
+fn forward<T>(tx: mpsc::Sender<tonic::Result<T>>, mut stream: tonic::Streaming<T>)
+where
+    T: Send + 'static,
+{
+    tokio::spawn(async move {
+        while let Some(r) = stream.message().await.transpose() {
+            let _ = tx.send(r).await; // Ignore errors caused by closed streams.
+        }
+    });
+}
+{{/HasClientSideStreaming}}
+{{/Codec.Services}}


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-rust/issues/5333

Add a template to generate a fake gRPC service. Credit to @coryan for writing this the first time.

At the moment the code will not compile if there are >1 services in the model. So far, that is not a problem. I will fix that problem only when I have to.

You can inspect the generated changes at: https://github.com/googleapis/google-cloud-rust/pull/5398