### PR TITLE
cleanup(sidekick/rust): keep using vec[u8] for gRPC mock

### DIFF
--- a/internal/sidekick/rust_prost/templates/tonic/build.rs.mustache
+++ b/internal/sidekick/rust_prost/templates/tonic/build.rs.mustache
@@ -48,7 +48,6 @@ fn main() {
                 {{/Services}}
             ])
             .type_attribute(".", "#[allow(clippy::large_enum_variant)]")
-            .bytes(".")
             .out_dir(&destination)
             .compile_with_config(config, files, includes)
             .expect("error compiling protos");


### PR DESCRIPTION
Related to https://github.com/googleapis/google-cloud-rust/issues/5396

While we would probably prefer to have fields as bytes, this will keep the diff down when we transition from the current `grpc-mock/build.rs` to using the `tonic` template.

There are like 100 instances I would need to manually change in spanner if we use `bytes::Bytes` instead of a `Vec[u8]`.