### PR TITLE
refactor(internal/librarian): remove rust_storage language hack

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -390,7 +390,6 @@ This document describes the schema for the librarian.yaml.
 | `include_list` | string | Is a list of proto files to include (e.g., "date.proto,expr.proto"). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
 | `internal_builders` | bool | Indicates whether generated builders should be internal to the crate. |
-| `language` | string | Can be used to select a variation of the Rust generator. For example, `rust_storage` enables special handling for the storage client. |
 | `module_path` | string | Is the Rust module path for converters (e.g., "crate::generated::gapic::model"). |
 | `module_roots` | map[string]string |  |
 | `name_overrides` | string | Contains codec-level overrides for type and service names. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -402,7 +402,7 @@ This document describes the schema for the librarian.yaml.
 | `skipped_ids` | list of string | Is a list of proto IDs to skip in generation. |
 | `specification_format` | string | Overrides the library-level specification format. |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
-| `template` | string | Specifies which generator template to use. Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod". |
+| `template` | string | Specifies which generator template to use. Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod", "storage". |
 
 ## RustPackageDependency Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -197,7 +197,7 @@ type RustModule struct {
 	APIPath string `yaml:"api_path"`
 
 	// Template specifies which generator template to use.
-	// Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod".
+	// Valid values: "grpc-client", "http-client", "prost", "convert-prost", "mod", "storage".
 	Template string `yaml:"template"`
 }
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -45,8 +45,6 @@ const (
 	LanguageRuby = "ruby"
 	// LanguageRust is the language identifier for Rust.
 	LanguageRust = "rust"
-	// LanguageRustStorage is a variation of the Rust generator for storage.
-	LanguageRustStorage = "rust_storage"
 	// LanguageSwift is the language identifier for Swift.
 	LanguageSwift = "swift"
 )
@@ -158,10 +156,6 @@ type RustModule struct {
 
 	// InternalBuilders indicates whether generated builders should be internal to the crate.
 	InternalBuilders bool `yaml:"internal_builders,omitempty"`
-
-	// Language can be used to select a variation of the Rust generator.
-	// For example, `rust_storage` enables special handling for the storage client.
-	Language string `yaml:"language,omitempty"`
 
 	// ModulePath is the Rust module path for converters
 	// (e.g., "crate::generated::gapic::model").

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -240,10 +240,6 @@ func moduleToModelConfig(library *config.Library, module *config.RustModule, src
 		}
 	}
 
-	language := config.LanguageRust
-	if module.Language != "" {
-		language = module.Language
-	}
 	specificationFormat := config.SpecProtobuf
 	if module.SpecificationFormat != "" {
 		specificationFormat = module.SpecificationFormat
@@ -257,7 +253,7 @@ func moduleToModelConfig(library *config.Library, module *config.RustModule, src
 	}
 
 	modelCfg := &parser.ModelConfig{
-		Language:            language,
+		Language:            config.LanguageRust,
 		SpecificationFormat: specificationFormat,
 		ServiceConfig:       module.ServiceConfig,
 		SpecificationSource: module.APIPath,

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -621,11 +621,6 @@ func TestModuleToModelConfig(t *testing.T) {
 					RustDefault: config.RustDefault{
 						ResourceNameHeuristic: ptr(false),
 					},
-					Modules: []*config.RustModule{
-						{
-							Language: config.LanguageRust,
-						},
-					},
 				},
 			},
 			want: &parser.ModelConfig{
@@ -644,11 +639,6 @@ func TestModuleToModelConfig(t *testing.T) {
 				Rust: &config.RustCrate{
 					RustDefault: config.RustDefault{
 						ResourceNameHeuristic: ptr(true),
-					},
-					Modules: []*config.RustModule{
-						{
-							Language: config.LanguageRust,
-						},
 					},
 				},
 			},
@@ -704,26 +694,6 @@ func TestModuleToModelConfig(t *testing.T) {
 						Match:   "bucket id",
 						Replace: "the id of the bucket",
 					},
-				},
-			},
-		},
-		{
-			name: "with custom module language",
-			library: &config.Library{
-				Name: "google-cloud-showcase",
-				Rust: &config.RustCrate{
-					Modules: []*config.RustModule{
-						{
-							Language: config.LanguageRustStorage,
-						},
-					},
-				},
-			},
-			want: &parser.ModelConfig{
-				Language:            config.LanguageRustStorage,
-				SpecificationFormat: config.SpecProtobuf,
-				Source: &sources.SourceConfig{
-					ActiveRoots: []string{"googleapis"},
 				},
 			},
 		},

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -151,17 +151,13 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *sourc
 		if err != nil {
 			return fmt.Errorf("CreateModel %q: %w", module.Output, err)
 		}
-		switch modelConfig.Language {
-		case config.LanguageRust:
-			if module.Template == "prost" || module.Template == "tonic" {
-				err = rust_prost.Generate(ctx, model, module.Output, module.Template, modelConfig)
-			} else {
-				err = sidekickrust.Generate(ctx, model, module.Output, modelConfig)
-			}
-		case config.LanguageRustStorage:
+		if module.Template == "storage" {
 			return generateRustStorage(ctx, library, module.Output, sources)
-		default:
-			err = fmt.Errorf("language %q not supported", modelConfig.Language)
+		}
+		if module.Template == "prost" || module.Template == "tonic" {
+			err = rust_prost.Generate(ctx, model, module.Output, module.Template, modelConfig)
+		} else {
+			err = sidekickrust.Generate(ctx, model, module.Output, modelConfig)
 		}
 		if err != nil {
 			return fmt.Errorf("module %q: %w", module.Output, err)

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -143,6 +143,9 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *sourc
 		return nil
 	}
 	for _, module := range library.Rust.Modules {
+		if module.Template == "storage" {
+			return generateRustStorage(ctx, library, module.Output, sources)
+		}
 		modelConfig, err := moduleToModelConfig(library, module, sources)
 		if err != nil {
 			return fmt.Errorf("moduleToModelConfig %q: %w", module.Output, err)
@@ -150,9 +153,6 @@ func generateVeneer(ctx context.Context, library *config.Library, sources *sourc
 		model, err := parser.CreateModel(modelConfig)
 		if err != nil {
 			return fmt.Errorf("CreateModel %q: %w", module.Output, err)
-		}
-		if module.Template == "storage" {
-			return generateRustStorage(ctx, library, module.Output, sources)
 		}
 		if module.Template == "prost" || module.Template == "tonic" {
 			err = rust_prost.Generate(ctx, model, module.Output, module.Template, modelConfig)

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -627,20 +627,17 @@ func TestFindModuleByOutput(t *testing.T) {
 				Rust: &config.RustCrate{
 					Modules: []*config.RustModule{
 						{
-							Language: config.LanguageRust,
-							Output:   "target-output",
+							Output: "target-output",
 						},
 						{
-							Language: config.LanguageRustStorage,
-							Output:   "other-output",
+							Output: "other-output",
 						},
 					},
 				},
 			},
 			output: "target-output",
 			want: &config.RustModule{
-				Language: config.LanguageRust,
-				Output:   "target-output",
+				Output: "target-output",
 			},
 		},
 		{
@@ -650,8 +647,7 @@ func TestFindModuleByOutput(t *testing.T) {
 				Rust: &config.RustCrate{
 					Modules: []*config.RustModule{
 						{
-							Language: config.LanguageRust,
-							Output:   "other-output",
+							Output: "other-output",
 						},
 					},
 				},

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -194,7 +194,7 @@ func tidyLanguageConfig(lib *config.Library, cfg *config.Config) *config.Library
 
 // isEmptyRustModule returns true if the module is a placeholder that can be removed.
 func isEmptyRustModule(module *config.RustModule) bool {
-	if module.Language == config.LanguageRustStorage {
+	if module.Template == "storage" {
 		// The Rust storage module has hardcoded API paths and templates, so it is never empty.
 		return false
 	}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -765,7 +765,7 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 							Modules: []*config.RustModule{
 								{
 									Output:   "src/storage/src/generated/protos/storage",
-									Language: config.LanguageRustStorage,
+									Template: "storage",
 								},
 							},
 						},


### PR DESCRIPTION
The rust_storage language was a hack used for special handling of the storage client in the Rust generator. Since it is not a different language, this change removes it from the Language enum and transitions to a template-based detection mechanism (Template == "storage") for specialized generation logic.

Additionally, the redundant Language field in RustModule is removed from the configuration as it always defaulted to LanguageRust. Tests and documentation are updated accordingly.

Fixes https://github.com/googleapis/librarian/issues/4291