### PR TITLE
feat(sidekick/swift): enums need a default

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -15,6 +15,8 @@
 package swift
 
 import (
+	"fmt"
+
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -37,8 +39,12 @@ func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error 
 		}
 	}
 	// Fallback to first case if no 0 value found (should not happen in proto3)
-	if defaultCaseName == "" && len(enum.UniqueNumberValues) > 0 {
-		defaultCaseName = enum.UniqueNumberValues[0].Codec.(*enumValueAnnotations).CaseName
+	if defaultCaseName == "" {
+		if len(enum.UniqueNumberValues) != 0 {
+			defaultCaseName = enum.UniqueNumberValues[0].Codec.(*enumValueAnnotations).CaseName
+		} else {
+			return fmt.Errorf("cannot determined a default value for enum: %s", enum.ID)
+		}
 	}
 	for _, ev := range enum.Values {
 		if err := codec.annotateEnumValue(ev, existing); err != nil {

--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -19,17 +19,26 @@ import (
 )
 
 type enumAnnotations struct {
-	CopyrightYear string
-	BoilerPlate   []string
-	Name          string
-	DocLines      []string
+	CopyrightYear   string
+	BoilerPlate     []string
+	Name            string
+	DocLines        []string
+	DefaultCaseName string
 }
 
 func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
 	existing := map[int32]*enumValueAnnotations{}
+	var defaultCaseName string
 	for _, ev := range enum.UniqueNumberValues {
 		codec.annotateUniqueEnumValue(ev)
 		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
+		if ev.Number == 0 {
+			defaultCaseName = ev.Codec.(*enumValueAnnotations).CaseName
+		}
+	}
+	// Fallback to first case if no 0 value found (should not happen in proto3)
+	if defaultCaseName == "" && len(enum.UniqueNumberValues) > 0 {
+		defaultCaseName = enum.UniqueNumberValues[0].Codec.(*enumValueAnnotations).CaseName
 	}
 	for _, ev := range enum.Values {
 		if err := codec.annotateEnumValue(ev, existing); err != nil {
@@ -40,10 +49,11 @@ func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error 
 
 	docLines := codec.formatDocumentation(enum.Documentation)
 	annotations := &enumAnnotations{
-		CopyrightYear: model.CopyrightYear,
-		BoilerPlate:   model.BoilerPlate,
-		Name:          pascalCase(enum.Name),
-		DocLines:      docLines,
+		CopyrightYear:   model.CopyrightYear,
+		BoilerPlate:     model.BoilerPlate,
+		Name:            pascalCase(enum.Name),
+		DocLines:        docLines,
+		DefaultCaseName: defaultCaseName,
 	}
 
 	enum.Codec = annotations

--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -43,7 +43,7 @@ func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error 
 		if len(enum.UniqueNumberValues) != 0 {
 			defaultCaseName = enum.UniqueNumberValues[0].Codec.(*enumValueAnnotations).CaseName
 		} else {
-			return fmt.Errorf("cannot determined a default value for enum: %s", enum.ID)
+			return fmt.Errorf("cannot determine a default value for enum: %s", enum.ID)
 		}
 	}
 	for _, ev := range enum.Values {

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -27,30 +27,46 @@ func TestAnnotateEnum(t *testing.T) {
 		name          string
 		enumName      string
 		documentation string
+		values        []*api.EnumValue
 		wantName      string
 		wantDocs      []string
+		wantDefault   string
 	}{
 		{
 			name:          "basic enum",
 			enumName:      "Color",
 			documentation: "A color enum.\nWith two lines.",
-			wantName:      "Color",
-			wantDocs:      []string{"A color enum.", "With two lines."},
+			values: []*api.EnumValue{
+				{Name: "COLOR_UNSPECIFIED", Number: 0},
+				{Name: "COLOR_RED", Number: 1},
+			},
+			wantName:    "Color",
+			wantDocs:    []string{"A color enum.", "With two lines."},
+			wantDefault: "unspecified",
 		},
 		{
 			name:          "escaped name",
 			enumName:      "Protocol",
 			documentation: "An enum named Protocol.",
-			wantName:      "Protocol_",
-			wantDocs:      []string{"An enum named Protocol."},
+			values: []*api.EnumValue{
+				{Name: "PROTOCOL_UNSPECIFIED", Number: 0},
+			},
+			wantName:    "Protocol_",
+			wantDocs:    []string{"An enum named Protocol."},
+			wantDefault: "unspecified",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			enum := &api.Enum{
-				Name:          test.enumName,
-				Documentation: test.documentation,
-				ID:            ".test." + test.enumName,
-				Package:       "test",
+				Name:               test.enumName,
+				Documentation:      test.documentation,
+				ID:                 ".test." + test.enumName,
+				Package:            "test",
+				Values:             test.values,
+				UniqueNumberValues: test.values,
+			}
+			for _, ev := range enum.Values {
+				ev.Parent = enum
 			}
 			model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 			codec := newTestCodec(t, model, map[string]string{})
@@ -58,8 +74,9 @@ func TestAnnotateEnum(t *testing.T) {
 				t.Fatal(err)
 			}
 			want := &enumAnnotations{
-				Name:     test.wantName,
-				DocLines: test.wantDocs,
+				Name:            test.wantName,
+				DocLines:        test.wantDocs,
+				DefaultCaseName: test.wantDefault,
 			}
 
 			if diff := cmp.Diff(want, enum.Codec, cmpopts.IgnoreFields(enumAnnotations{}, "BoilerPlate", "CopyrightYear")); diff != "" {

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -85,3 +85,18 @@ func TestAnnotateEnum(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotateEnum_Error(t *testing.T) {
+	enum := &api.Enum{
+		Name:    "Empty",
+		ID:      ".test.Empty",
+		Package: "test",
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
+	codec := newTestCodec(t, model, map[string]string{})
+
+	err := codec.annotateModel()
+	if err == nil {
+		t.Errorf("annotateModel() expected error for enum with no values, got nil")
+	}
+}

--- a/internal/sidekick/swift/generate_test.go
+++ b/internal/sidekick/swift/generate_test.go
@@ -132,7 +132,12 @@ func TestGenerateEnumFiles(t *testing.T) {
 	outDir := t.TempDir()
 
 	color := &api.Enum{Name: "Color", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.Color"}
+	color.Values = []*api.EnumValue{{Name: "COLOR_UNSPECIFIED", Number: 0, Parent: color}}
+	color.UniqueNumberValues = color.Values
+
 	kind := &api.Enum{Name: "Kind", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.Kind"}
+	kind.Values = []*api.EnumValue{{Name: "KIND_UNSPECIFIED", Number: 0, Parent: kind}}
+	kind.UniqueNumberValues = kind.Values
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{color, kind}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"

--- a/internal/sidekick/swift/templates/common/enum.swift.mustache
+++ b/internal/sidekick/swift/templates/common/enum.swift.mustache
@@ -32,6 +32,10 @@ public enum {{Codec.Name}}: Int, Codable, Equatable {
     case {{Codec.CaseName}} = {{Number}}
     {{/UniqueNumberValues}}
 
+    public init() {
+        self = .{{Codec.DefaultCaseName}}
+    }
+
     public var stringValue: String {
         switch self {
         {{#UniqueNumberValues}}


### PR DESCRIPTION
We need a default initializer for enums, so we can put them in messages, which also have a default initializer.

Fixes #5297 