### PR TITLE
feat(sidekick/swift): support enum fields

### DIFF
--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -51,7 +51,11 @@ func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
 		}
 		return c.messageTypeName(m)
 	case api.ENUM_TYPE:
-		return "", fmt.Errorf("TODO(#5060) - enum fields are not supported: %s", field.ID)
+		e, err := lookupEnum(c.Model, field.TypezID)
+		if err != nil {
+			return "", err
+		}
+		return c.enumTypeName(e)
 	default:
 		return scalarFieldTypeName(field)
 	}
@@ -104,6 +108,22 @@ func (c *codec) messageTypeName(m *api.Message) (string, error) {
 		return name, nil
 	}
 	parent, err := c.messageTypeName(m.Parent)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s", parent, name), nil
+}
+
+func (c *codec) enumTypeName(e *api.Enum) (string, error) {
+	if e.Package != c.Model.PackageName {
+		return "", fmt.Errorf("TODO(#5060) - support external enum types")
+	}
+	// Names can be qualified with nested objects.
+	name := pascalCase(e.Name)
+	if e.Parent == nil {
+		return name, nil
+	}
+	parent, err := c.messageTypeName(e.Parent)
 	if err != nil {
 		return "", err
 	}

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -133,6 +133,75 @@ func TestFieldTypeName_BaseMessage(t *testing.T) {
 	}
 }
 
+func TestFieldTypeName_BaseEnum(t *testing.T) {
+	outer := &api.Message{
+		Name:    "OuterMessage",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.OuterMessage",
+	}
+	nested := &api.Enum{
+		Name:    "NestedEnum",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.OuterMessage.NestedEnum",
+		Parent:  outer,
+	}
+	simple := &api.Enum{
+		Name:    "SimpleEnum",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.SimpleEnum",
+	}
+
+	c := &codec{
+		Model: &api.API{
+			PackageName: "google.cloud.test.v1",
+			State: &api.APIState{
+				EnumByID: map[string]*api.Enum{
+					".google.cloud.test.v1.SimpleEnum":              simple,
+					".google.cloud.test.v1.OuterMessage.NestedEnum": nested,
+				},
+				MessageByID: map[string]*api.Message{
+					".google.cloud.test.v1.OuterMessage": outer,
+				},
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name  string
+		field *api.Field
+		want  string
+	}{
+		{
+			name: "simple enum",
+			field: &api.Field{
+				Typez:   api.ENUM_TYPE,
+				TypezID: ".google.cloud.test.v1.SimpleEnum",
+				ID:      ".test.field1",
+			},
+			want: "SimpleEnum",
+		},
+		{
+			name: "nested enum",
+			field: &api.Field{
+				Typez:   api.ENUM_TYPE,
+				TypezID: ".google.cloud.test.v1.OuterMessage.NestedEnum",
+				ID:      ".test.field2",
+			},
+			want: "OuterMessage.NestedEnum",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := c.baseFieldTypeName(test.field)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestFieldTypeName_Optional(t *testing.T) {
 	secret := &api.Message{
 		Name:    "Secret",

--- a/internal/sidekick/swift/lookup.go
+++ b/internal/sidekick/swift/lookup.go
@@ -28,3 +28,12 @@ func lookupMessage(model *api.API, id string) (*api.Message, error) {
 	}
 	return m, nil
 }
+
+// lookupEnum finds an enum in the model by its fully-qualified ID.
+func lookupEnum(model *api.API, id string) (*api.Enum, error) {
+	e, ok := model.State.EnumByID[id]
+	if !ok {
+		return nil, fmt.Errorf("unable to lookup enum %q", id)
+	}
+	return e, nil
+}

--- a/internal/sidekick/swift/lookup_test.go
+++ b/internal/sidekick/swift/lookup_test.go
@@ -42,3 +42,25 @@ func TestLookupMessage_Error(t *testing.T) {
 		t.Errorf("lookupMessage() expected error, got nil")
 	}
 }
+
+func TestLookupEnum(t *testing.T) {
+	enum := &api.Enum{Name: "SecretType", ID: ".test.SecretType"}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
+
+	got, err := lookupEnum(model, ".test.SecretType")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(enum, got); diff != "" {
+		t.Errorf("lookupEnum() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLookupEnum_Error(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+
+	_, err := lookupEnum(model, ".test.Missing")
+	if err == nil {
+		t.Errorf("lookupEnum() expected error, got nil")
+	}
+}


### PR DESCRIPTION
With this PR we can generate messages that have enum fields. At the moment we are limited to enums in the same package, and only for enums at the package level.

Fixes #5292 