### PR TITLE
fix(tool/cmd/migrate): handle is variable when parsing for additional protos

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bazelbuild/buildtools/build"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
 	"github.com/googleapis/librarian/internal/librarian/java"
@@ -81,14 +82,16 @@ func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
 			log.Printf("Warning: multiple proto_library_with_info in %s/BUILD.bazel, using first", dir)
 		}
 		rule := rules[0]
-		// Search for specific common resource targets in deps
-		if deps := rule.AttrStrings("deps"); len(deps) > 0 {
+		// Search for specific common resource targets in deps.
+		// We use Attr instead of AttrStrings to handle cases where deps is
+		// a variable or an addition of lists.
+		if attr := rule.Attr("deps"); attr != nil {
 			protoMappings := map[string]string{
 				"//google/cloud:common_resources_proto":  "google/cloud/common_resources.proto",
 				"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
 				"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
 			}
-			for _, dep := range deps {
+			for _, dep := range extractStrings(attr) {
 				if protoPath, ok := protoMappings[dep]; ok {
 					info.AdditionalProtos = append(info.AdditionalProtos, protoPath)
 				}
@@ -634,4 +637,15 @@ func containsAny(block, targets []string) bool {
 func getLineIndent(line string) string {
 	trimmed := strings.TrimLeft(line, " \t")
 	return line[:len(line)-len(trimmed)]
+}
+
+// extractStrings returns all string literals found within a Bazel expression.
+func extractStrings(expr build.Expr) []string {
+	var res []string
+	build.Walk(expr, func(e build.Expr, _ []build.Expr) {
+		if s, ok := e.(*build.StringExpr); ok {
+			res = append(res, s.Value)
+		}
+	})
+	return res
 }

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -568,6 +568,18 @@ func TestParseJavaBazel(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "complex-deps",
+			googleapisDir: "testdata/parse-bazel/complex-deps",
+			buildPath:     "google/cloud/aiplatform/v1",
+			want: &javaGAPICInfo{
+				AdditionalProtos: []string{
+					"google/cloud/common_resources.proto",
+					"google/cloud/location/locations.proto",
+					"google/iam/v1/iam_policy.proto",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := parseJavaBazel(test.googleapisDir, test.buildPath)

--- a/tool/cmd/migrate/testdata/parse-bazel/complex-deps/google/cloud/aiplatform/v1/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/parse-bazel/complex-deps/google/cloud/aiplatform/v1/BUILD.bazel
@@ -1,0 +1,13 @@
+_PROTO_SUBPACKAGE_DEPS = [
+    "//google/cloud/aiplatform/v1/schema/predict/instance:instance_proto",
+]
+
+proto_library_with_info(
+    name = "aiplatform_proto_with_info",
+    deps = [
+        ":aiplatform_proto",
+        "//google/cloud:common_resources_proto",
+        "//google/cloud/location:location_proto",
+        "//google/iam/v1:iam_policy_proto",
+    ] + _PROTO_SUBPACKAGE_DEPS,
+)


### PR DESCRIPTION
Handle more complex case whre deps is variable when parsing for additional protos for Java migration.

 The deps attribute of the proto_library_with_info rule uses a list addition (+) with the variable _PROTO_SUBPACKAGE_DEPS (see [source](https://github.com/googleapis/googleapis/blob/fc968708d27f9aeb9f1c50a3e32d53810df843fd/google/cloud/aiplatform/v1/BUILD.bazel#L178-L186)).  Because of this structure, the previous implementation using AttrStrings("deps") failed to see any of the dependencies because it only handles simple, literal string lists. The updated implementation now walks the entire expression and collects all literal strings it finds.

For #5380
