### PR TITLE
test(tool/cmd/migrate): fix test setup

### DIFF
--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -627,6 +627,7 @@ func TestParseJavaBazel(t *testing.T) {
 					"google/cloud/location/locations.proto",
 					"google/iam/v1/iam_policy.proto",
 				},
+				ProtoOnly: true,
 			},
 		},
 	} {


### PR DESCRIPTION
The test failed due to test setup not up-to-date with changes in #5383. Test case added in https://github.com/googleapis/librarian/pull/5381.

Fix #5387