### PR TITLE
fix(internal/librarian/java): recursively gather protos and sort

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/command"
@@ -29,6 +30,12 @@ import (
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sources"
 )
+
+var nonRecursivePaths = map[string]bool{
+	"google/api":   true,
+	"google/cloud": true,
+	"google/rpc":   true,
+}
 
 var (
 	errExtractVersion    = errors.New("failed to extract version")
@@ -111,11 +118,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 	}
 
 	apiDir := filepath.Join(googleapisDir, api.Path)
-	// TODO(https://github.com/googleapis/librarian/issues/4198):
-	// Consider recursive gathering and explicit sorting
-	// of proto files to match the behavior of the hermetic build, ensuring
-	// a deterministic order in the generated gapic_metadata.json.
-	apiProtos, err := filepath.Glob(apiDir + "/*.proto")
+	apiProtos, err := gatherProtos(apiDir, api.Path)
 	if err != nil {
 		return fmt.Errorf("failed to find protos: %w", err)
 	}
@@ -304,4 +307,38 @@ func findBOMVersion(cfg *config.Config) (string, error) {
 		return cfg.Default.Java.LibrariesBOMVersion, nil
 	}
 	return "", errBOMVersionMissing
+}
+
+// gatherProtos returns a sorted list of proto files in the given root directory,
+// ensuring that subpackage protos (e.g., in a "schema" directory) are included
+// in the generation.
+//
+// recursion is disabled for certain base paths (google/api, google/cloud, google/rpc).
+func gatherProtos(root, relPath string) ([]string, error) {
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return nil, errNoProtos
+	}
+	var protos []string
+	recursive := !nonRecursivePaths[relPath]
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if !recursive && path != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Type().IsRegular() && filepath.Ext(path) == ".proto" {
+			protos = append(protos, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(protos)
+	return protos, nil
 }

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
+// nonRecursivePaths is a set of paths where proto gathering should not be recursive.
 var nonRecursivePaths = map[string]bool{
 	"google/api":   true,
 	"google/cloud": true,
@@ -315,11 +316,8 @@ func findBOMVersion(cfg *config.Config) (string, error) {
 //
 // recursion is disabled for certain base paths (google/api, google/cloud, google/rpc).
 func gatherProtos(root, relPath string) ([]string, error) {
-	if _, err := os.Stat(root); os.IsNotExist(err) {
-		return nil, errNoProtos
-	}
 	var protos []string
-	recursive := !nonRecursivePaths[relPath]
+	recursive := !nonRecursivePaths[filepath.ToSlash(relPath)]
 
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -336,6 +334,9 @@ func gatherProtos(root, relPath string) ([]string, error) {
 		}
 		return nil
 	})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, errNoProtos
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -314,7 +314,7 @@ func findBOMVersion(cfg *config.Config) (string, error) {
 // ensuring that subpackage protos (e.g., in a "schema" directory) are included
 // in the generation.
 //
-// recursion is disabled for certain base paths (google/api, google/cloud, google/rpc).
+// recursion is disabled for certain base paths in nonRecursivePaths.
 func gatherProtos(root, relPath string) ([]string, error) {
 	var protos []string
 	recursive := !nonRecursivePaths[filepath.ToSlash(relPath)]

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -754,9 +754,9 @@ func TestGatherProtos(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	files := []string{
-		"root.proto",
-		"sub/nested.proto",
-		"sub/deep/deep.proto",
+		"google/cloud/aiplatform/v1/aiplatform.proto",
+		"google/cloud/aiplatform/v1/sub/nested.proto",
+		"google/cloud/aiplatform/v1/sub/deep/deep.proto",
 		"google/api/api.proto",
 		"google/api/sub/sub.proto",
 		"google/cloud/location/locations.proto",
@@ -781,13 +781,9 @@ func TestGatherProtos(t *testing.T) {
 			name:    "recursive",
 			relPath: "google/cloud/aiplatform/v1",
 			want: []string{
-				filepath.Join(tmpDir, "google/api/api.proto"),
-				filepath.Join(tmpDir, "google/api/sub/sub.proto"),
-				filepath.Join(tmpDir, "google/cloud/location/locations.proto"),
-				filepath.Join(tmpDir, "google/cloud/location/sub/sub.proto"),
-				filepath.Join(tmpDir, "root.proto"),
-				filepath.Join(tmpDir, "sub/deep/deep.proto"),
-				filepath.Join(tmpDir, "sub/nested.proto"),
+				filepath.Join(tmpDir, "google/cloud/aiplatform/v1/aiplatform.proto"),
+				filepath.Join(tmpDir, "google/cloud/aiplatform/v1/sub/deep/deep.proto"),
+				filepath.Join(tmpDir, "google/cloud/aiplatform/v1/sub/nested.proto"),
 			},
 		},
 		{
@@ -808,10 +804,6 @@ func TestGatherProtos(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			root := filepath.Join(tmpDir, test.relPath)
-			if test.relPath == "google/cloud/aiplatform/v1" {
-				// Special case for recursive test to use tmpDir as root
-				root = tmpDir
-			}
 			got, err := gatherProtos(root, test.relPath)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -749,3 +749,76 @@ func TestCollectJavaFiles(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestGatherProtos(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	files := []string{
+		"root.proto",
+		"sub/nested.proto",
+		"sub/deep/deep.proto",
+		"google/api/api.proto",
+		"google/api/sub/sub.proto",
+		"google/cloud/location/locations.proto",
+		"google/cloud/location/sub/sub.proto",
+	}
+	for _, f := range files {
+		path := filepath.Join(tmpDir, f)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, test := range []struct {
+		name    string
+		relPath string
+		want    []string
+	}{
+		{
+			name:    "recursive",
+			relPath: "google/cloud/aiplatform/v1",
+			want: []string{
+				filepath.Join(tmpDir, "google/api/api.proto"),
+				filepath.Join(tmpDir, "google/api/sub/sub.proto"),
+				filepath.Join(tmpDir, "google/cloud/location/locations.proto"),
+				filepath.Join(tmpDir, "google/cloud/location/sub/sub.proto"),
+				filepath.Join(tmpDir, "root.proto"),
+				filepath.Join(tmpDir, "sub/deep/deep.proto"),
+				filepath.Join(tmpDir, "sub/nested.proto"),
+			},
+		},
+		{
+			name:    "non-recursive google/api",
+			relPath: "google/api",
+			want: []string{
+				filepath.Join(tmpDir, "google/api/api.proto"),
+			},
+		},
+		{
+			name:    "recursive google/cloud/location",
+			relPath: "google/cloud/location",
+			want: []string{
+				filepath.Join(tmpDir, "google/cloud/location/locations.proto"),
+				filepath.Join(tmpDir, "google/cloud/location/sub/sub.proto"),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := filepath.Join(tmpDir, test.relPath)
+			if test.relPath == "google/cloud/aiplatform/v1" {
+				// Special case for recursive test to use tmpDir as root
+				root = tmpDir
+			}
+			got, err := gatherProtos(root, test.relPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Recursively gather protos for generate, to include protos in nested dirs, sort to maintain deterministic order.

For #5380
Fix #4198