### PR TITLE
feat(internal/librarian/java): support config to exclude protos

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -242,6 +242,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
+| `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `samples` | bool (optional) | Determines whether to generate samples for the API, default is true when omitted. |
 | `path` | string | Is the source path. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -573,6 +573,11 @@ type JavaAPI struct {
 	// AdditionalProtos is a list of additional proto files to include in generation.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 
+	// ExcludedProtos is a list of proto files to exclude from generation.
+	// It expects the full path starting from the root of the googleapis
+	// directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto").
+	ExcludedProtos []string `yaml:"excluded_protos,omitempty"`
+
 	// Samples determines whether to generate samples for the API,
 	// default is true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -345,12 +345,12 @@ func filterProtos(fullPaths []string, relExcludes []string, root string) []strin
 	if len(relExcludes) == 0 {
 		return fullPaths
 	}
-	excludedSet := make(map[string]bool)
+	excludedSet := make(map[string]bool, len(relExcludes))
 	for _, e := range relExcludes {
 		fullPath := filepath.ToSlash(filepath.Join(root, filepath.FromSlash(e)))
 		excludedSet[fullPath] = true
 	}
-	var filtered []string
+	filtered := make([]string, 0, len(fullPaths))
 	for _, p := range fullPaths {
 		if excludedSet[filepath.ToSlash(p)] {
 			continue

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -118,6 +118,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 	if err != nil {
 		return fmt.Errorf("failed to find protos: %w", err)
 	}
+	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos)
 	if len(apiProtos) == 0 {
 		return fmt.Errorf("%s: %w", api.Path, errNoProtos)
 	}
@@ -337,4 +338,24 @@ func gatherProtos(root, relPath string) ([]string, error) {
 	}
 	sort.Strings(protos)
 	return protos, nil
+}
+
+// filterProtos applies path-specific exclusions to the list of proto files.
+func filterProtos(protos []string, excludedProtos []string) []string {
+	if len(excludedProtos) == 0 {
+		return protos
+	}
+	excludedSet := make(map[string]bool)
+	for _, e := range excludedProtos {
+		excludedSet[filepath.ToSlash(e)] = true
+	}
+	var filtered []string
+	for _, p := range protos {
+		if excludedSet[filepath.ToSlash(p)] {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+
+	return filtered
 }

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -118,7 +118,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 	if err != nil {
 		return fmt.Errorf("failed to find protos: %w", err)
 	}
-	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos)
+	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos, googleapisDir)
 	if len(apiProtos) == 0 {
 		return fmt.Errorf("%s: %w", api.Path, errNoProtos)
 	}
@@ -340,22 +340,22 @@ func gatherProtos(root, relPath string) ([]string, error) {
 	return protos, nil
 }
 
-// filterProtos applies path-specific exclusions to the list of proto files.
-func filterProtos(protos []string, excludedProtos []string) []string {
-	if len(excludedProtos) == 0 {
-		return protos
+// filterProtos removes entries from fullPaths that match root + relPath in relExcludes.
+func filterProtos(fullPaths []string, relExcludes []string, root string) []string {
+	if len(relExcludes) == 0 {
+		return fullPaths
 	}
 	excludedSet := make(map[string]bool)
-	for _, e := range excludedProtos {
-		excludedSet[filepath.ToSlash(e)] = true
+	for _, e := range relExcludes {
+		fullPath := filepath.ToSlash(filepath.Join(root, filepath.FromSlash(e)))
+		excludedSet[fullPath] = true
 	}
 	var filtered []string
-	for _, p := range protos {
+	for _, p := range fullPaths {
 		if excludedSet[filepath.ToSlash(p)] {
 			continue
 		}
 		filtered = append(filtered, p)
 	}
-
 	return filtered
 }

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -340,7 +340,7 @@ func gatherProtos(root, relPath string) ([]string, error) {
 	return protos, nil
 }
 
-// filterProtos removes entries from fullPaths that match root + relPath in relExcludes.
+// filterProtos returns entries from fullPaths that excludes root + relPath in relExcludes.
 func filterProtos(fullPaths []string, relExcludes []string, root string) []string {
 	if len(relExcludes) == 0 {
 		return fullPaths

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -803,3 +803,32 @@ func TestGatherProtos(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterProtos(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name           string
+		protos         []string
+		excludedProtos []string
+		want           []string
+	}{
+		{
+			name: "aiplatform exclusion",
+			protos: []string{
+				"google/cloud/aiplatform/v1beta1/aiplatform.proto",
+				"google/cloud/aiplatform/v1beta1/schema/io_format.proto",
+			},
+			excludedProtos: []string{"google/cloud/aiplatform/v1beta1/schema/io_format.proto"},
+			want: []string{
+				"google/cloud/aiplatform/v1beta1/aiplatform.proto",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := filterProtos(test.protos, test.excludedProtos)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -807,25 +807,25 @@ func TestGatherProtos(t *testing.T) {
 func TestFilterProtos(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
-		name           string
-		protos         []string
-		excludedProtos []string
-		want           []string
+		name        string
+		fullPaths   []string
+		relExcludes []string
+		want        []string
 	}{
 		{
 			name: "aiplatform exclusion",
-			protos: []string{
-				"google/cloud/aiplatform/v1beta1/aiplatform.proto",
-				"google/cloud/aiplatform/v1beta1/schema/io_format.proto",
+			fullPaths: []string{
+				filepath.Join(googleapisDir, "google/cloud/aiplatform/v1beta1/aiplatform.proto"),
+				filepath.Join(googleapisDir, "google/cloud/aiplatform/v1beta1/schema/io_format.proto"),
 			},
-			excludedProtos: []string{"google/cloud/aiplatform/v1beta1/schema/io_format.proto"},
+			relExcludes: []string{"google/cloud/aiplatform/v1beta1/schema/io_format.proto"},
 			want: []string{
-				"google/cloud/aiplatform/v1beta1/aiplatform.proto",
+				filepath.Join(googleapisDir, "google/cloud/aiplatform/v1beta1/aiplatform.proto"),
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := filterProtos(test.protos, test.excludedProtos)
+			got := filterProtos(test.fullPaths, test.relExcludes, googleapisDir)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Supports a new JavaAPI.ExcludedProtos config to exclude listed proto files from generation. There are a few cases where proto needs to be excluded, they are previously hardcoded with hermetic build in [here](https://github.com/googleapis/google-cloud-java/blob/5208fc94f69790dbe2ba65ab2685ad9674314b6c/sdk-platform-java/hermetic_build/library_generation/generate_library.sh#L141).

For #5380