### PR TITLE
chore(tool/cmd/migrate): rename runJavaMigration param

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -146,7 +146,7 @@ type GenerationConfig struct {
 	Libraries           []LibraryConfig `yaml:"libraries"`
 }
 
-func runJavaMigration(ctx context.Context, repoPath string, insert bool) error {
+func runJavaMigration(ctx context.Context, repoPath string, shouldInsertMarkers bool) error {
 	gen, err := readGenerationConfig(repoPath)
 	if err != nil {
 		return err
@@ -171,7 +171,7 @@ func runJavaMigration(ctx context.Context, repoPath string, insert bool) error {
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""
 
-	if insert {
+	if shouldInsertMarkers {
 		if err := insertMarkers(repoPath, cfg); err != nil {
 			return fmt.Errorf("failed to insert markers: %w", err)
 		}


### PR DESCRIPTION
Rename for clarity.

For https://github.com/googleapis/librarian/pull/5382#discussion_r3083356863