### PR TITLE
chore(tool/cmd/migrate): add proto artifact overrides for gsuite-addons

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -360,6 +360,18 @@ func applyJavaArtifactOverrides(name string, api *config.JavaAPI) {
 	case name == "datastore" && api.Path == "google/datastore/admin/v1":
 		api.ProtoArtifactIDOverride = "proto-google-cloud-datastore-admin-v1"
 		api.GRPCArtifactIDOverride = "grpc-google-cloud-datastore-admin-v1"
+	case name == "gsuite-addons" && api.Path == "google/apps/script/type":
+		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
+	case name == "gsuite-addons" && api.Path == "google/apps/script/type/docs":
+		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
+	case name == "gsuite-addons" && api.Path == "google/apps/script/type/drive":
+		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
+	case name == "gsuite-addons" && api.Path == "google/apps/script/type/gmail":
+		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
+	case name == "gsuite-addons" && api.Path == "google/apps/script/type/sheets":
+		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
+	case name == "gsuite-addons" && api.Path == "google/apps/script/type/slides":
+		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
 	case name == "spanner" && api.Path == "google/spanner/admin/database/v1":
 		api.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-database-v1"
 		api.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-database-v1"

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -436,6 +436,48 @@ func TestBuildConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "proto artifact overrides",
+			gen: &GenerationConfig{
+				Libraries: []LibraryConfig{
+					{
+						APIShortName: "gsuite-addons",
+						GAPICs: []GAPICConfig{
+							{ProtoPath: "google/apps/script/type"},
+						},
+					},
+				},
+			},
+			src: &config.Source{Dir: "testdata/googleapis"},
+			want: &config.Config{
+				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
+				Default: &config.Default{
+					Java: &config.JavaModule{},
+				},
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Dir: "testdata/googleapis"},
+				},
+				Libraries: []*config.Library{
+					{
+						Name: "gsuite-addons",
+						APIs: []*config.API{
+							{Path: "google/apps/script/type"},
+						},
+						Java: &config.JavaModule{
+							JavaAPIs: []*config.JavaAPI{
+								{
+									Path:                    "google/apps/script/type",
+									ProtoArtifactIDOverride: "proto-google-apps-script-type-protos",
+									ProtoOnly:               true,
+									Samples:                 new(false),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := buildConfig(test.gen, ".", test.src, test.versions)

--- a/tool/cmd/migrate/testdata/googleapis/google/apps/script/type/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/googleapis/google/apps/script/type/BUILD.bazel
@@ -1,0 +1,36 @@
+proto_library(
+    name = "type_proto",
+    srcs = [
+        "addon_widget_set.proto",
+        "extension_point.proto",
+        "script_manifest.proto",
+    ],
+    deps = [
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+java_proto_library(
+    name = "type_java_proto",
+    deps = [":type_proto"],
+)
+
+java_grpc_library(
+    name = "type_java_grpc",
+    srcs = [":type_proto"],
+    deps = [":type_java_proto"],
+)
+
+# Please DO-NOT-REMOVE this section.
+# This is required to generate java files for these protos.
+# Open Source Packages
+java_gapic_assembly_gradle_pkg(
+    name = "google-apps-script-type-java",
+    transport = "grpc+rest",
+    deps = [
+        ":type_java_grpc",
+        ":type_java_proto",
+        ":type_proto",
+    ],
+)


### PR DESCRIPTION
Artifact ID overrides for gsuite-addons are added to the Java migration tool.

This ensures that the generated Java configuration uses the correct Maven artifact names for the proto libraries associated with Google Apps Script types.

Fixes #5385