### PR TITLE
fix(tool/cmd/migrate): add hardcoded exclude include list for protos in java

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -256,6 +256,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				javaAPI.Samples = new(false)
 			}
 			applyJavaArtifactOverrides(name, javaAPI)
+			applyJavaProtoOverrides(javaAPI)
 			javaAPIs = append(javaAPIs, javaAPI)
 		}
 		lib := &config.Library{
@@ -375,6 +376,30 @@ func applyJavaArtifactOverrides(name string, api *config.JavaAPI) {
 	case name == "storage" && api.Path == "google/storage/control/v2":
 		api.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
 		api.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
+	}
+}
+
+// applyJavaProtoOverrides sets hardcoded proto inclusions and exclusions
+// for specific APIs, mirroring logic in sdk-platform-java.
+func applyJavaProtoOverrides(api *config.JavaAPI) {
+	switch {
+	case api.Path == "google/cloud":
+		api.ExcludedProtos = append(api.ExcludedProtos, "google/cloud/common_resources.proto")
+	case strings.HasPrefix(api.Path, "google/cloud/aiplatform/v1beta1"):
+		api.ExcludedProtos = append(api.ExcludedProtos,
+			"google/cloud/aiplatform/v1beta1/schema/io_format.proto",
+			"google/cloud/aiplatform/v1beta1/schema/annotation_payload.proto",
+			"google/cloud/aiplatform/v1beta1/schema/annotation_spec_color.proto",
+			"google/cloud/aiplatform/v1beta1/schema/data_item_payload.proto",
+			"google/cloud/aiplatform/v1beta1/schema/dataset_metadata.proto",
+			"google/cloud/aiplatform/v1beta1/schema/geometry.proto",
+		)
+	case strings.HasPrefix(api.Path, "google/cloud/filestore"):
+		api.AdditionalProtos = append(api.AdditionalProtos, "google/cloud/common/operation_metadata.proto")
+	case strings.HasPrefix(api.Path, "google/cloud/oslogin"):
+		api.AdditionalProtos = append(api.AdditionalProtos, "google/cloud/oslogin/common/common.proto")
+	case api.Path == "google/rpc":
+		api.ExcludedProtos = append(api.ExcludedProtos, "google/rpc/http.proto")
 	}
 }
 

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -28,6 +28,77 @@ import (
 	"github.com/googleapis/librarian/internal/fetch"
 )
 
+func TestApplyJavaProtoOverrides(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path string
+		want *config.JavaAPI
+	}{
+		{
+			name: "google/cloud",
+			path: "google/cloud",
+			want: &config.JavaAPI{
+				Path:           "google/cloud",
+				ExcludedProtos: []string{"google/cloud/common_resources.proto"},
+			},
+		},
+		{
+			name: "aiplatform/v1beta1",
+			path: "google/cloud/aiplatform/v1beta1",
+			want: &config.JavaAPI{
+				Path: "google/cloud/aiplatform/v1beta1",
+				ExcludedProtos: []string{
+					"google/cloud/aiplatform/v1beta1/schema/io_format.proto",
+					"google/cloud/aiplatform/v1beta1/schema/annotation_payload.proto",
+					"google/cloud/aiplatform/v1beta1/schema/annotation_spec_color.proto",
+					"google/cloud/aiplatform/v1beta1/schema/data_item_payload.proto",
+					"google/cloud/aiplatform/v1beta1/schema/dataset_metadata.proto",
+					"google/cloud/aiplatform/v1beta1/schema/geometry.proto",
+				},
+			},
+		},
+		{
+			name: "filestore",
+			path: "google/cloud/filestore/v1",
+			want: &config.JavaAPI{
+				Path:             "google/cloud/filestore/v1",
+				AdditionalProtos: []string{"google/cloud/common/operation_metadata.proto"},
+			},
+		},
+		{
+			name: "oslogin",
+			path: "google/cloud/oslogin/v1",
+			want: &config.JavaAPI{
+				Path:             "google/cloud/oslogin/v1",
+				AdditionalProtos: []string{"google/cloud/oslogin/common/common.proto"},
+			},
+		},
+		{
+			name: "google/rpc",
+			path: "google/rpc",
+			want: &config.JavaAPI{
+				Path:           "google/rpc",
+				ExcludedProtos: []string{"google/rpc/http.proto"},
+			},
+		},
+		{
+			name: "no override",
+			path: "google/cloud/language/v1",
+			want: &config.JavaAPI{
+				Path: "google/cloud/language/v1",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := &config.JavaAPI{Path: test.path}
+			applyJavaProtoOverrides(got)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestRunJavaMigration(t *testing.T) {
 	fetchSourceWithCommit = func(ctx context.Context, endpoints *fetch.Endpoints, commitish string) (*config.Source, error) {
 		return &config.Source{


### PR DESCRIPTION
Adds hardcoded list for ExcludedProtos and AdditionalProtos for Java migrate. These are currently hardcoded in [generate_library.sh](https://github.com/googleapis/google-cloud-java/blob/main/sdk-platform-java/hermetic_build/library_generation/generate_library.sh#L141), moving to config based exclusion (see #5392).

For https://github.com/googleapis/librarian/issues/5380https://github.com/googleapis/librarian/issues/5380