### PR TITLE
refactor(internal/librarian): unify rust bump code path with other languages

### DIFF
--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -108,9 +108,6 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
 		return err
 	}
-	if cfg.Language == config.LanguageRust {
-		return legacyRustBump(ctx, cfg, all, libraryName, versionOverride, gitExe)
-	}
 
 	librariesToBump, err := findLibrariesToBump(ctx, cfg, gitExe, all, libraryName)
 	if err != nil {
@@ -123,7 +120,7 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 	}
 
 	for _, lib := range librariesToBump {
-		if err := bumpLibrary(cfg, lib, versionOverride); err != nil {
+		if err := bumpLibrary(ctx, cfg, lib, versionOverride, gitExe); err != nil {
 			return err
 		}
 	}
@@ -207,13 +204,14 @@ func hasChangesIn(dir, exclusion string, filesChanged []string) bool {
 // bumpLibrary determines the next version of a library (using versionOverride
 // if that is non-empty), and applies the language-specific version bump logic
 // to update manifests, version files etc.
-func bumpLibrary(cfg *config.Config, lib *config.Library, versionOverride string) error {
+func bumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, versionOverride, gitExe string) error {
 	opts := languageVersioningOptions[cfg.Language]
 	version, err := deriveNextVersion(cfg, lib, opts, versionOverride)
 	if err != nil {
 		return err
 	}
 	output := libraryOutput(cfg.Language, lib, cfg.Default)
+
 	lib.Version = version
 
 	switch cfg.Language {
@@ -223,6 +221,8 @@ func bumpLibrary(cfg *config.Config, lib *config.Library, versionOverride string
 		return golang.Bump(lib, output, version)
 	case config.LanguagePython:
 		return python.Bump(output, version)
+	case config.LanguageRust:
+		return rust.Bump(lib, output, version)
 	default:
 		return fmt.Errorf("%q does not support bump", cfg.Language)
 	}
@@ -347,84 +347,4 @@ func findLatestReleaseCommitHash(ctx context.Context, gitExe string) (string, er
 		candidateCommit = commit
 	}
 	return "", errReleaseCommitNotFound
-}
-
-// legacyRustBump applies the legacy (but still in use) logic for Rust
-// releasing. This is separated from the main logic to allow non-Rust languages
-// to work on the newer "tag-per-library" logic without interrupting Rust
-// releases. The "fake" language is still valid here, for testing purposes.
-func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride, gitExe string) error {
-	lastTag, err := git.GetLastTag(ctx, gitExe, config.RemoteUpstream, config.BranchMain)
-	if err != nil {
-		return err
-	}
-
-	if all {
-		if err := legacyRustBumpAll(ctx, cfg, lastTag, gitExe); err != nil {
-			return err
-		}
-	} else {
-		lib, err := FindLibrary(cfg, libraryName)
-		if err != nil {
-			return err
-		}
-		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, gitExe, versionOverride); err != nil {
-			return err
-		}
-	}
-
-	if err := postBump(ctx, cfg); err != nil {
-		return err
-	}
-	return RunTidyOnConfig(ctx, ".", cfg)
-}
-
-// legacyRustBumpAll applies the legacy (but still in use) "bump all" approach
-// of assuming a single tag for the latest release, and checking everything
-// since that tag. (Compare this with findLibrariesToBump, which expects each
-// library to have its own tag for its last release.)
-func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string) error {
-	var ignoredChanges []string
-	if cfg.Release != nil {
-		ignoredChanges = cfg.Release.IgnoredChanges
-	}
-	filesChanged, err := git.FilesChangedSince(ctx, gitExe, lastTag, ignoredChanges)
-	if err != nil {
-		return err
-	}
-	for _, lib := range cfg.Libraries {
-		if lib.SkipRelease {
-			continue
-		}
-		output := libraryOutput(cfg.Language, lib, cfg.Default)
-		if !hasChangesIn(output, "", filesChanged) {
-			continue
-		}
-		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, gitExe, ""); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// legacyRustBumpLibrary applies the legacy (but still in use) approach of
-// assuming a single tag for the latest release, and passing that tag into the
-// rust.Bump code. (Compare this with bumpLibrary, which only uses git to derive
-// the next version.)
-func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, lastTag, gitExe, versionOverride string) error {
-	opts := languageVersioningOptions[cfg.Language]
-	version, err := deriveNextVersion(cfg, lib, opts, versionOverride)
-	if err != nil {
-		return err
-	}
-	output := libraryOutput(cfg.Language, lib, cfg.Default)
-	switch cfg.Language {
-	case config.LanguageRust:
-		return rust.Bump(ctx, lib, output, version, gitExe, lastTag)
-	case config.LanguageFake:
-		lib.Version = version
-		return fakeBumpLibrary(output, version)
-	default:
-		return fmt.Errorf("%q should not be using legacyRustBumpLibrary", cfg.Language)
-	}
 }

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -120,7 +120,7 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 	}
 
 	for _, lib := range librariesToBump {
-		if err := bumpLibrary(ctx, cfg, lib, versionOverride, gitExe); err != nil {
+		if err := bumpLibrary(cfg, lib, versionOverride); err != nil {
 			return err
 		}
 	}
@@ -204,7 +204,7 @@ func hasChangesIn(dir, exclusion string, filesChanged []string) bool {
 // bumpLibrary determines the next version of a library (using versionOverride
 // if that is non-empty), and applies the language-specific version bump logic
 // to update manifests, version files etc.
-func bumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, versionOverride, gitExe string) error {
+func bumpLibrary(cfg *config.Config, lib *config.Library, versionOverride string) error {
 	opts := languageVersioningOptions[cfg.Language]
 	version, err := deriveNextVersion(cfg, lib, opts, versionOverride)
 	if err != nil {

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -33,12 +33,6 @@ import (
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
-// testUnusedStringParam is used to fill the spot with a string parameter that
-// won't be provided in the test, because the test does not exercise the
-// functionality related to said parameter. It is an intentional signal
-// rather than an ambiguous empty string.
-const testUnusedStringParam = ""
-
 func TestBumpCommand(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 
@@ -330,7 +324,7 @@ func TestBumpLibrary(t *testing.T) {
 			testhelper.Setup(t, opts)
 
 			targetLibCfg := test.cfg.Libraries[0]
-			err := bumpLibrary(test.cfg, targetLibCfg, test.versionOverride)
+			err := bumpLibrary(t.Context(), test.cfg, targetLibCfg, test.versionOverride, "git")
 			if err != nil {
 				t.Fatalf("bumpLibrary() error = %v", err)
 			}
@@ -369,7 +363,7 @@ func TestBumpLibrary_Error(t *testing.T) {
 			name: "unsupported language",
 			cfg: func() *config.Config {
 				c := sample.Config()
-				c.Language = config.LanguageRust
+				c.Language = "unsupported"
 				return c
 			}(),
 			versionOverride: "2.0.0",
@@ -386,7 +380,7 @@ func TestBumpLibrary_Error(t *testing.T) {
 			testhelper.Setup(t, opts)
 
 			targetLibCfg := test.cfg.Libraries[0]
-			gotErr := bumpLibrary(test.cfg, targetLibCfg, test.versionOverride)
+			gotErr := bumpLibrary(t.Context(), test.cfg, targetLibCfg, test.versionOverride, "git")
 			if gotErr == nil {
 				t.Fatal("expected error; got nil")
 			}
@@ -1004,54 +998,7 @@ func TestFindLatestReleaseCommitHash_Error(t *testing.T) {
 	}
 }
 
-func TestLegacyRustBumpLibrary(t *testing.T) {
-	testhelper.RequireCommand(t, "git")
-
-	tests := []struct {
-		name            string
-		cfg             *config.Config
-		versionOverride string
-		wantVersion     string
-	}{
-		{
-			name:        "library released",
-			cfg:         sample.Config(),
-			wantVersion: sample.NextVersion,
-		},
-		{
-			name: "version override",
-			cfg: func() *config.Config {
-				c := sample.Config()
-				c.Libraries[0].Version = "1.3.0"
-				return c
-			}(),
-			versionOverride: "2.0.0",
-			wantVersion:     "2.0.0",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			opts := testhelper.SetupOptions{
-				Clone:  true,
-				Config: test.cfg,
-			}
-			testhelper.Setup(t, opts)
-
-			targetLibCfg := test.cfg.Libraries[0]
-			// Unused string param: lastTag.
-			err := legacyRustBumpLibrary(t.Context(), test.cfg, targetLibCfg, testUnusedStringParam, "git", test.versionOverride)
-			if err != nil {
-				t.Fatalf("legacyRustBumpLibrary() error = %v", err)
-			}
-			if targetLibCfg.Version != test.wantVersion {
-				t.Errorf("library %q version mismatch: want %q, got %q", targetLibCfg.Name, test.wantVersion, targetLibCfg.Version)
-			}
-		})
-	}
-}
-
-func TestLegacyRustBump(t *testing.T) {
+func TestRustBump(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 
 	lib1Change := filepath.Join(sample.Lib1Output, "src", "lib.rs")
@@ -1096,15 +1043,26 @@ func TestLegacyRustBump(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := sample.Config()
+			cfg.Language = config.LanguageRust
+			fakeCargo := filepath.Join(t.TempDir(), "fake-cargo")
+			script := "#!/bin/sh\nexit 0"
+			if err := os.WriteFile(fakeCargo, []byte(script), 0755); err != nil {
+				t.Fatal(err)
+			}
+			cfg.Release = &config.Release{
+				Preinstalled: map[string]string{
+					"cargo": fakeCargo,
+				},
+			}
 			opts := testhelper.SetupOptions{
 				Clone:       true,
 				Config:      cfg,
-				Tags:        []string{sample.InitialLegacyRustTag},
+				Tags:        []string{sample.InitialLib1Tag, sample.InitialLib2Tag},
 				WithChanges: test.withChanges,
 			}
 			testhelper.Setup(t, opts)
 
-			if err := legacyRustBump(t.Context(), cfg, test.all, test.libraryName, test.versionOverride, "git"); err != nil {
+			if err := runBump(t.Context(), cfg, test.all, test.libraryName, test.versionOverride); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1118,63 +1076,6 @@ func TestLegacyRustBump(t *testing.T) {
 						t.Errorf("library %s: got version %q, want %q", lib.Name, lib.Version, want)
 					}
 				}
-			}
-		})
-	}
-}
-
-func TestLegacyRustBumpAll(t *testing.T) {
-	testhelper.RequireCommand(t, "git")
-
-	for _, test := range []struct {
-		name        string
-		cfg         *config.Config
-		withChanges []string
-		skipPublish bool
-		wantVersion string
-	}{
-		{
-			name:        "library has changes",
-			cfg:         sample.Config(),
-			withChanges: []string{filepath.Join(sample.Lib1Output, "src", "lib.rs")},
-			wantVersion: sample.NextVersion,
-		},
-		{
-			name:        "library does not have any changes",
-			cfg:         sample.Config(),
-			wantVersion: sample.InitialVersion,
-		},
-		{
-			name: "library has changes but skipPublish is true",
-			cfg: func() *config.Config {
-				c := sample.Config()
-				c.Libraries[0].SkipRelease = true
-				return c
-			}(),
-			withChanges: []string{filepath.Join(sample.Lib1Output, "src", "lib.rs")},
-			wantVersion: sample.InitialVersion,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			targetCfg := test.cfg
-			sinceTag := sample.InitialLegacyRustTag
-			opts := testhelper.SetupOptions{
-				Clone:       true,
-				Config:      test.cfg,
-				Tags:        []string{sample.InitialLegacyRustTag},
-				WithChanges: test.withChanges,
-			}
-			testhelper.Setup(t, opts)
-
-			err := legacyRustBumpAll(t.Context(), targetCfg, sinceTag, "git")
-			if err != nil {
-				t.Fatal(err)
-			}
-			// releaseAll directly modifies the config provided, so we use it as
-			// our "got".
-			gotVersion := targetCfg.Libraries[0].Version
-			if gotVersion != test.wantVersion {
-				t.Errorf("got version %s, want %s", gotVersion, test.wantVersion)
 			}
 		})
 	}

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -324,7 +324,7 @@ func TestBumpLibrary(t *testing.T) {
 			testhelper.Setup(t, opts)
 
 			targetLibCfg := test.cfg.Libraries[0]
-			err := bumpLibrary(t.Context(), test.cfg, targetLibCfg, test.versionOverride, "git")
+			err := bumpLibrary(test.cfg, targetLibCfg, test.versionOverride)
 			if err != nil {
 				t.Fatalf("bumpLibrary() error = %v", err)
 			}
@@ -380,7 +380,7 @@ func TestBumpLibrary_Error(t *testing.T) {
 			testhelper.Setup(t, opts)
 
 			targetLibCfg := test.cfg.Libraries[0]
-			gotErr := bumpLibrary(t.Context(), test.cfg, targetLibCfg, test.versionOverride, "git")
+			gotErr := bumpLibrary(test.cfg, targetLibCfg, test.versionOverride)
 			if gotErr == nil {
 				t.Fatal("expected error; got nil")
 			}

--- a/internal/librarian/rust/bump.go
+++ b/internal/librarian/rust/bump.go
@@ -16,7 +16,6 @@
 package rust
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -32,19 +31,10 @@ var (
 	errMissingVersion = errors.New("must provide version")
 )
 
-// Bump checks if a version bump is required and performs it.
-// It returns without error if no bump is needed (version already updated since lastTag).
-func Bump(ctx context.Context, library *config.Library, output, version, gitExe, lastTag string) error {
+// Bump performs the version bump for Rust.
+func Bump(library *config.Library, output, version string) error {
 	if version == "" {
 		return errMissingVersion
-	}
-	cargoFile := filepath.Join(output, "Cargo.toml")
-	needed, err := shouldBumpManifestVersion(ctx, gitExe, lastTag, cargoFile)
-	if err != nil {
-		return err
-	}
-	if !needed {
-		return nil
 	}
 	return writeVersion(library, output, version)
 }

--- a/internal/librarian/rust/bump_test.go
+++ b/internal/librarian/rust/bump_test.go
@@ -123,7 +123,7 @@ func TestNoCargoFile(t *testing.T) {
 }
 
 func TestMissingVersion(t *testing.T) {
-	err := Bump(t.Context(), &config.Library{}, "", "", "", "")
+	err := Bump(&config.Library{}, "", "")
 	if !errors.Is(err, errMissingVersion) {
 		t.Errorf("expected error %v, got %v", errMissingVersion, err)
 	}

--- a/internal/librarian/rust/update_manifest.go
+++ b/internal/librarian/rust/update_manifest.go
@@ -15,7 +15,6 @@
 package rust
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -23,7 +22,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/semver"
 )
 
@@ -90,22 +88,4 @@ func updateWorkspaceVersion(path, crateName string, newVersion semver.Version) e
 		return nil
 	}
 	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
-}
-
-// shouldBumpManifestVersion checks if the manifest version needs to be bumped.
-// It returns false if the version has already been updated since the last tag.
-func shouldBumpManifestVersion(ctx context.Context, gitExe, lastTag, manifest string) (bool, error) {
-	delta := fmt.Sprintf("%s..HEAD", lastTag)
-	contents, err := command.Output(ctx, gitExe, "diff", delta, "--", manifest)
-	if err != nil {
-		return false, err
-	}
-	if len(contents) == 0 {
-		return true, nil
-	}
-	lines := strings.Split(contents, "\n")
-	has := func(prefix string) bool {
-		return slices.ContainsFunc(lines, func(line string) bool { return strings.HasPrefix(line, prefix) })
-	}
-	return !has("+version "), nil
 }

--- a/internal/librarian/rust/update_manifest_test.go
+++ b/internal/librarian/rust/update_manifest_test.go
@@ -19,89 +19,12 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"slices"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/googleapis/librarian/internal/semver"
-
-	"github.com/googleapis/librarian/internal/testhelper"
 )
-
-func TestShouldBumpManifestVersionSuccess(t *testing.T) {
-	const tag = "manifest-version-update-success"
-	testhelper.RequireCommand(t, "git")
-	testhelper.SetupForVersionBump(t, tag)
-
-	name := path.Join("src", "storage", "Cargo.toml")
-	contents, err := os.ReadFile(name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	lines := strings.Split(string(contents), "\n")
-	idx := slices.IndexFunc(lines, func(a string) bool { return strings.HasPrefix(a, "version ") })
-	if idx == -1 {
-		t.Fatalf("expected a line starting with `version ` in %v", lines)
-	}
-	lines[idx] = `version = "2.3.4"`
-	if err := os.WriteFile(name, []byte(strings.Join(lines, "\n")), 0644); err != nil {
-		t.Fatal(err)
-	}
-	testhelper.RunGit(t, "commit", "-m", "updated version", ".")
-
-	needsBump, err := shouldBumpManifestVersion(t.Context(), "git", tag, name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if needsBump {
-		t.Errorf("expected no need for a bump for %s", name)
-	}
-}
-
-func TestShouldBumpManifestVersionNewCrate(t *testing.T) {
-	const tag = "manifest-version-update-new-crate"
-	testhelper.RequireCommand(t, "git")
-	testhelper.SetupForVersionBump(t, tag)
-
-	testhelper.AddCrate(t, path.Join("src", "new"), "google-cloud-new")
-	testhelper.RunGit(t, "add", ".")
-	testhelper.RunGit(t, "commit", "-m", "new crate", ".")
-	name := path.Join("src", "new", "Cargo.toml")
-
-	needsBump, err := shouldBumpManifestVersion(t.Context(), "git", tag, name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if needsBump {
-		t.Errorf("no changes for new crates")
-	}
-}
-
-func TestShouldBumpManifestVersionNoChange(t *testing.T) {
-	const tag = "manifest-version-update-no-change"
-	testhelper.RequireCommand(t, "git")
-	testhelper.SetupForVersionBump(t, tag)
-	name := path.Join("src", "storage", "Cargo.toml")
-	needsBump, err := shouldBumpManifestVersion(t.Context(), "git", tag, name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !needsBump {
-		t.Errorf("expected no change for %s", name)
-	}
-}
-
-func TestShouldBumpManifestVersionBadDiff(t *testing.T) {
-	const tag = "manifest-version-update-success"
-	testhelper.RequireCommand(t, "git")
-	testhelper.SetupForVersionBump(t, tag)
-	name := path.Join("src", "storage", "Cargo.toml")
-	if updated, err := shouldBumpManifestVersion(t.Context(), "git", "not-a-valid-tag", name); err == nil {
-		t.Errorf("expected an error with an valid tag, got=%v", updated)
-	}
-}
 
 func TestUpdateCargoVersion(t *testing.T) {
 	content := "[package]\nname = \"test-crate\"\nversion = \"1.0.0\"\n"


### PR DESCRIPTION
The Rust bump code path is unified with other languages by removing legacy Rust-specific bump functions and simplifying the rust.Bump signature. The special safety check shouldBumpManifestVersion for Rust is removed to align its behavior with other languages, which directly update the version without checking for manual modifications since the last tag.

Previously, Rust used a separate code path and had an extra check to avoid overwriting manual edits in Cargo.toml. Now it relies on the central orchestrator to detect changes and performs the bump unconditionally if changes are found, consistent with the behavior for Go and Python.

Unused tests and files related to the removed safety check are deleted, and existing tests are updated to reflect the new simplified signatures.

Fixes https://github.com/googleapis/librarian/issues/4052