### PR TITLE
chore(internal/serviceconfig): update release level for java-workstations

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -2567,6 +2567,8 @@
 - path: google/cloud/workstations/v1
   languages:
     - all
+  release_level:
+    java: stable
 - path: google/cloud/workstations/v1beta
   languages:
     - go


### PR DESCRIPTION
Update the release level to `stable` for java-workstations.

The API is v1 but the library version is <1.0.0 so we need to override the default value.