### PR TITLE
fix(internal/librarian/java): do not derive GRPC module when proto only

### DIFF
--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -109,23 +109,27 @@ func DeriveAPICoordinates(lc LibraryCoordinate, version string, javaAPI *config.
 	if protoArtifactID == "" {
 		protoArtifactID = fmt.Sprintf("%s%s-%s", protoPrefix, lc.GAPIC.ArtifactID, version)
 	}
-	grpcArtifactID := javaAPI.GRPCArtifactIDOverride
-	if grpcArtifactID == "" {
-		grpcArtifactID = fmt.Sprintf("%s%s-%s", gRPCPrefix, lc.GAPIC.ArtifactID, version)
-	}
-	return APICoordinate{
+	res := APICoordinate{
 		LibraryCoordinate: lc,
 		Proto: Coordinate{
 			GroupID:    protoGRPCGroupID,
 			ArtifactID: protoArtifactID,
 			Version:    lc.GAPIC.Version,
 		},
-		GRPC: Coordinate{
-			GroupID:    protoGRPCGroupID,
-			ArtifactID: grpcArtifactID,
-			Version:    lc.GAPIC.Version,
-		},
 	}
+	if javaAPI.ProtoOnly {
+		return res
+	}
+	grpcArtifactID := javaAPI.GRPCArtifactIDOverride
+	if grpcArtifactID == "" {
+		grpcArtifactID = fmt.Sprintf("%s%s-%s", gRPCPrefix, lc.GAPIC.ArtifactID, version)
+	}
+	res.GRPC = Coordinate{
+		GroupID:    protoGRPCGroupID,
+		ArtifactID: grpcArtifactID,
+		Version:    lc.GAPIC.Version,
+	}
+	return res
 }
 
 // protoGroupID returns the Maven Group ID for the generated proto and gRPC

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -244,6 +244,26 @@ func TestDeriveAPICoordinates(t *testing.T) {
 				Version:    "1.2.3",
 			},
 		},
+		{
+			name: "proto-only mapping",
+			lc: LibraryCoordinate{
+				GAPIC: Coordinate{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-cloud-secretmanager",
+					Version:    "1.2.3",
+				},
+			},
+			version: "v1",
+			javaAPI: &config.JavaAPI{
+				ProtoOnly: true,
+			},
+			wantProto: Coordinate{
+				GroupID:    "com.google.api.grpc",
+				ArtifactID: "proto-google-cloud-secretmanager-v1",
+				Version:    "1.2.3",
+			},
+			wantGRPC: Coordinate{},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := DeriveAPICoordinates(test.lc, test.version, test.javaAPI)


### PR DESCRIPTION
When proto only configured, should not derive GRPC module coordinates. Proto only is a newly added config in #5354.

Fix #5415