### PR TITLE
fix(internal/librarian/java): clean to use derived module names

### DIFF
--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -51,21 +51,21 @@ func Clean(library *config.Library) error {
 }
 
 func cleanPatterns(library *config.Library) map[string]bool {
-	lc := DeriveLibraryCoordinates(library)
+	libraryCoordinates := DeriveLibraryCoordinates(library)
 	patterns := map[string]bool{
-		filepath.Join(lc.GAPIC.ArtifactID, "src"):         true,
-		filepath.Join("samples", "snippets", "generated"): true,
-		".repo-metadata.json":                             true,
+		filepath.Join(libraryCoordinates.GAPIC.ArtifactID, "src"): true,
+		filepath.Join("samples", "snippets", "generated"):         true,
+		".repo-metadata.json": true,
 	}
 	for _, api := range library.APIs {
 		javaAPI := ResolveJavaAPI(library, api)
 		version := filepath.Base(api.Path)
-		ac := DeriveAPICoordinates(lc, version, javaAPI)
-		if ac.Proto.ArtifactID != "" {
-			patterns[filepath.Join(ac.Proto.ArtifactID, "src")] = true
+		apiCoordinates := DeriveAPICoordinates(libraryCoordinates, version, javaAPI)
+		if apiCoordinates.Proto.ArtifactID != "" {
+			patterns[filepath.Join(apiCoordinates.Proto.ArtifactID, "src")] = true
 		}
-		if ac.GRPC.ArtifactID != "" {
-			patterns[filepath.Join(ac.GRPC.ArtifactID, "src")] = true
+		if apiCoordinates.GRPC.ArtifactID != "" {
+			patterns[filepath.Join(apiCoordinates.GRPC.ArtifactID, "src")] = true
 		}
 	}
 	return patterns

--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -16,7 +16,6 @@ package java
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -32,19 +31,12 @@ var versionRegexp = regexp.MustCompile(`src/main/java/com/google/cloud/.*/v.*/st
 // Clean removes files in the library's output directory that are not in the keep list.
 // It targets patterns like proto-*, grpc-*, and the main GAPIC module.
 func Clean(library *config.Library) error {
-	libraryName := ensureCloudPrefix(library.Name)
-	patterns := []string{
-		fmt.Sprintf("proto-%s-*", libraryName),
-		fmt.Sprintf("grpc-%s-*", libraryName),
-		libraryName,
-		filepath.Join("samples", "snippets", "generated"),
-		".repo-metadata.json",
-	}
+	patterns := cleanPatterns(library)
 	keepSet := make(map[string]bool)
 	for _, k := range library.Keep {
 		keepSet[k] = true
 	}
-	for _, pattern := range patterns {
+	for pattern := range patterns {
 		matches, err := filepath.Glob(filepath.Join(library.Output, pattern))
 		if err != nil {
 			return err
@@ -56,6 +48,27 @@ func Clean(library *config.Library) error {
 		}
 	}
 	return nil
+}
+
+func cleanPatterns(library *config.Library) map[string]bool {
+	lc := DeriveLibraryCoordinates(library)
+	patterns := map[string]bool{
+		filepath.Join(lc.GAPIC.ArtifactID, "src"):         true,
+		filepath.Join("samples", "snippets", "generated"): true,
+		".repo-metadata.json":                             true,
+	}
+	for _, api := range library.APIs {
+		javaAPI := ResolveJavaAPI(library, api)
+		version := filepath.Base(api.Path)
+		ac := DeriveAPICoordinates(lc, version, javaAPI)
+		if ac.Proto.ArtifactID != "" {
+			patterns[filepath.Join(ac.Proto.ArtifactID, "src")] = true
+		}
+		if ac.GRPC.ArtifactID != "" {
+			patterns[filepath.Join(ac.GRPC.ArtifactID, "src")] = true
+		}
+	}
+	return patterns
 }
 
 func cleanPath(targetPath, root string, keepSet map[string]bool) error {

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -177,31 +177,6 @@ func TestCleanPatterns(t *testing.T) {
 			},
 		},
 		{
-			name: "with proto only path",
-			library: &config.Library{
-				Name: "accesscontextmanager",
-				APIs: []*config.API{
-					{Path: "google/identity/accesscontextmanager/v1"},
-					{Path: "google/identity/accesscontextmanager/type"},
-				},
-				Java: &config.JavaModule{
-					JavaAPIs: []*config.JavaAPI{
-						{Path: "google/identity/accesscontextmanager/type",
-							ProtoOnly: true},
-						{Path: "google/identity/accesscontextmanager/v1"},
-					},
-				},
-			},
-			want: map[string]bool{
-				"google-cloud-accesscontextmanager/src":            true,
-				"proto-google-cloud-accesscontextmanager-type/src": true,
-				"proto-google-cloud-accesscontextmanager-v1/src":   true,
-				"grpc-google-cloud-accesscontextmanager-v1/src":    true,
-				filepath.Join("samples", "snippets", "generated"):  true,
-				".repo-metadata.json":                              true,
-			},
-		},
-		{
 			name: "with_overrides",
 			library: &config.Library{
 				Name: "secretmanager",
@@ -218,29 +193,6 @@ func TestCleanPatterns(t *testing.T) {
 				filepath.Join("grpc-secretmanager-special-v1", "src"):  true,
 				filepath.Join("samples", "snippets", "generated"):      true,
 				".repo-metadata.json":                                  true,
-			},
-		},
-		{
-			name: "proto_only",
-			library: &config.Library{
-				Name: "secretmanager",
-				Java: &config.JavaModule{
-					JavaAPIs: []*config.JavaAPI{
-						{
-							Path:      "google/cloud/secretmanager/v1",
-							ProtoOnly: true,
-						},
-					},
-				},
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			want: map[string]bool{
-				filepath.Join("google-cloud-secretmanager", "src"):          true,
-				filepath.Join("proto-google-cloud-secretmanager-v1", "src"): true,
-				filepath.Join("samples", "snippets", "generated"):           true,
-				".repo-metadata.json":                                       true,
 			},
 		},
 	} {

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 )
 
@@ -68,6 +69,9 @@ func TestClean(t *testing.T) {
 		Name:   "secretmanager",
 		Output: tmpDir,
 		Keep:   []string{"kept-file.txt", "kept-dir"},
+		APIs: []*config.API{
+			{Path: "google/cloud/secretmanager/v1"},
+		},
 	}
 	if err := Clean(lib); err != nil {
 		t.Fatal(err)
@@ -76,8 +80,8 @@ func TestClean(t *testing.T) {
 	// Verify cleaned paths
 	cleanedPaths := []string{
 		filepath.Join(tmpDir, libraryName, "src", "Main.java"),
-		filepath.Join(tmpDir, fmt.Sprintf("proto-%s-%s", libraryName, version)),
-		filepath.Join(tmpDir, fmt.Sprintf("grpc-%s-%s", libraryName, version)),
+		filepath.Join(tmpDir, fmt.Sprintf("proto-%s-%s", libraryName, version), "src"),
+		filepath.Join(tmpDir, fmt.Sprintf("grpc-%s-%s", libraryName, version), "src"),
 		filepath.Join(tmpDir, "samples", "snippets", "generated"),
 		filepath.Join(tmpDir, libraryName, "src", "main", "java", "com", "google", "cloud", "secretmanager", "v1", "Version.java"),
 	}
@@ -91,6 +95,8 @@ func TestClean(t *testing.T) {
 		filepath.Join(tmpDir, "kept-file.txt"),
 		filepath.Join(tmpDir, "kept-dir", "file.txt"),
 		filepath.Join(tmpDir, libraryName, "pom.xml"),
+		filepath.Join(tmpDir, fmt.Sprintf("proto-%s-%s", libraryName, version)),
+		filepath.Join(tmpDir, fmt.Sprintf("grpc-%s-%s", libraryName, version)),
 		filepath.Join(tmpDir, libraryName, "src", "main", "java", "com", "google", "cloud", "secretmanager", "v1", "stub", "Version.java"),
 		filepath.Join(tmpDir, libraryName, "src", "test", "java", "com", "google", "cloud", "secretmanager", "v1", "it", "ITSecretManagerTest.java"),
 	}
@@ -142,6 +148,106 @@ func TestIsDirNotEmpty(t *testing.T) {
 			got := isDirNotEmpty(test.err)
 			if got != test.want {
 				t.Errorf("isDirNotEmpty(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCleanPatterns(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		want    map[string]bool
+	}{
+		{
+			name: "default_case",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: map[string]bool{
+				filepath.Join("google-cloud-secretmanager", "src"):          true,
+				filepath.Join("proto-google-cloud-secretmanager-v1", "src"): true,
+				filepath.Join("grpc-google-cloud-secretmanager-v1", "src"):  true,
+				filepath.Join("samples", "snippets", "generated"):           true,
+				".repo-metadata.json": true,
+			},
+		},
+		{
+			name: "with proto only path",
+			library: &config.Library{
+				Name: "accesscontextmanager",
+				APIs: []*config.API{
+					{Path: "google/identity/accesscontextmanager/v1"},
+					{Path: "google/identity/accesscontextmanager/type"},
+				},
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{Path: "google/identity/accesscontextmanager/type",
+							ProtoOnly: true},
+						{Path: "google/identity/accesscontextmanager/v1"},
+					},
+				},
+			},
+			want: map[string]bool{
+				"google-cloud-accesscontextmanager/src":            true,
+				"proto-google-cloud-accesscontextmanager-type/src": true,
+				"proto-google-cloud-accesscontextmanager-v1/src":   true,
+				"grpc-google-cloud-accesscontextmanager-v1/src":    true,
+				filepath.Join("samples", "snippets", "generated"):  true,
+				".repo-metadata.json":                              true,
+			},
+		},
+		{
+			name: "with_overrides",
+			library: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{
+					DistributionNameOverride: "com.google.cloud:secretmanager-special",
+				},
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: map[string]bool{
+				filepath.Join("secretmanager-special", "src"):          true,
+				filepath.Join("proto-secretmanager-special-v1", "src"): true,
+				filepath.Join("grpc-secretmanager-special-v1", "src"):  true,
+				filepath.Join("samples", "snippets", "generated"):      true,
+				".repo-metadata.json":                                  true,
+			},
+		},
+		{
+			name: "proto_only",
+			library: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{
+							Path:      "google/cloud/secretmanager/v1",
+							ProtoOnly: true,
+						},
+					},
+				},
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: map[string]bool{
+				filepath.Join("google-cloud-secretmanager", "src"):          true,
+				filepath.Join("proto-google-cloud-secretmanager-v1", "src"): true,
+				filepath.Join("samples", "snippets", "generated"):           true,
+				".repo-metadata.json":                                       true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := cleanPatterns(test.library)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Change clean to derive clean patterns with `DeriveAPICoordinates` so that it uses same source as generate. Also changed clean scope to /src dirs under each module, to be consistent with that owlbot.yaml does today.

Fix #5417