### PR TITLE
feat(internal/librarian/python): populate attributes when adding new library

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -205,6 +205,12 @@ func addNewLibrary(cfg *config.Config, apis []*config.API, name string) (string,
 	switch cfg.Language {
 	case config.LanguageGo:
 		lib = golang.Add(lib)
+	case config.LanguagePython:
+		var err error
+		lib, err = python.Add(lib)
+		if err != nil {
+			return "", nil, err
+		}
 	case config.LanguageRust:
 		lib = rust.Add(lib)
 	case config.LanguageFake:

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -25,7 +25,7 @@ import (
 // This is set on the initial `librarian add` for a new API.
 const defaultVersion = "0.0.0"
 
-var errNewLibraryMustHaveOneAPI = errors.New("a newly added library must have exactly one API")
+var errNewLibraryMustHaveOneAPI = errors.New("a newly added library (in Python) must have exactly one API so that the default version can be populated")
 
 // Add initializes a new Python library with default values.
 func Add(lib *config.Library) (*config.Library, error) {

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package python
+
+import (
+	"errors"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+)
+
+// defaultVersion is the first version used for a new library.
+// This is set on the initial `librarian add` for a new API.
+const defaultVersion = "0.0.0"
+
+var errNewLibraryMustHaveOneAPI = errors.New("a newly added library must have exactly one API")
+
+// Add initializes a new Python library with default values.
+func Add(lib *config.Library) (*config.Library, error) {
+	lib.Version = defaultVersion
+	if len(lib.APIs) != 1 {
+		return nil, errNewLibraryMustHaveOneAPI
+	}
+	packageDefaultVersion := serviceconfig.ExtractVersion(lib.APIs[0].Path)
+	if packageDefaultVersion != "" {
+		lib.Python = &config.PythonPackage{
+			DefaultVersion: packageDefaultVersion,
+		}
+	}
+	return lib, nil
+}

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -33,8 +33,7 @@ func Add(lib *config.Library) (*config.Library, error) {
 	if len(lib.APIs) != 1 {
 		return nil, errNewLibraryMustHaveOneAPI
 	}
-	packageDefaultVersion := serviceconfig.ExtractVersion(lib.APIs[0].Path)
-	if packageDefaultVersion != "" {
+	if packageDefaultVersion := serviceconfig.ExtractVersion(lib.APIs[0].Path); packageDefaultVersion != "" {
 		lib.Python = &config.PythonPackage{
 			DefaultVersion: packageDefaultVersion,
 		}

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package python
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestAdd(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		lib     *config.Library
+		wantLib *config.Library
+	}{
+		{
+			name: "non-versioned API",
+			lib: &config.Library{
+				Name: "google-cloud-foo",
+				APIs: []*config.API{
+					{Path: "google/cloud/foo/type"},
+				},
+			},
+			wantLib: &config.Library{
+				Name: "google-cloud-foo",
+				APIs: []*config.API{
+					{Path: "google/cloud/foo/type"},
+				},
+				Version: defaultVersion,
+			},
+		},
+		{
+			name: "versioned API",
+			lib: &config.Library{
+				Name: "google-cloud-foo",
+				APIs: []*config.API{
+					{Path: "google/cloud/foo/v1beta"},
+				},
+			},
+			wantLib: &config.Library{
+				Name: "google-cloud-foo",
+				APIs: []*config.API{
+					{Path: "google/cloud/foo/v1beta"},
+				},
+				Version: defaultVersion,
+				Python: &config.PythonPackage{
+					DefaultVersion: "v1beta",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotLib, err := Add(test.lib)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.wantLib, gotLib); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAdd_Error(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		lib     *config.Library
+		wantErr error
+	}{
+		{
+			name: "no APIs",
+			lib: &config.Library{
+				Name: "no-apis",
+			},
+			wantErr: errNewLibraryMustHaveOneAPI,
+		},
+		{
+			name: "multiple APIs",
+			lib: &config.Library{
+				Name: "multiple-apis",
+				APIs: []*config.API{
+					{Path: "google/cloud/api/v1"},
+					{Path: "google/cloud/api/v2"},
+				},
+			},
+			wantErr: errNewLibraryMustHaveOneAPI,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, gotErr := Add(test.lib)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Set Library.Version and (where appropriate)
Library.PythonPackage.DefaultVersion.

More work will be potentially be required, setting GAPIC options, which can be addressed separately after more research.

Towards #5163