### PR TITLE
chore(tool/cmd/migrate): add keep override for Java migration

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -287,9 +287,10 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				RpcDocumentation:             l.RpcDocumentation,
 			},
 		}
-		lib.Keep = parseOwlBotKeep(repoPath, output)
 		if override, ok := keepOverride[lib.Name]; ok {
 			lib.Keep = override
+		} else {
+			lib.Keep = parseOwlBotKeep(repoPath, output)
 		}
 		if shortnameOverride, ok := apiShortnameOverrides[lib.Name]; ok {
 			lib.Java.APIShortnameOverride = shortnameOverride

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -262,7 +262,6 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 		lib := &config.Library{
 			Name:    name,
 			Version: version,
-			Keep:    parseOwlBotKeep(repoPath, output),
 			APIs:    apis,
 			Java: &config.JavaModule{
 				APIIDOverride:                l.APIID,
@@ -287,6 +286,10 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				RestDocumentation:            l.RestDocumentation,
 				RpcDocumentation:             l.RpcDocumentation,
 			},
+		}
+		lib.Keep = parseOwlBotKeep(repoPath, output)
+		if override, ok := keepOverride[lib.Name]; ok {
+			lib.Keep = override
 		}
 		if shortnameOverride, ok := apiShortnameOverrides[lib.Name]; ok {
 			lib.Java.APIShortnameOverride = shortnameOverride

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -33,4 +33,34 @@ var (
 		"storage":         true,
 		"spanner":         true,
 	}
+
+	keepOverride = map[string][]string{
+		"translate": {
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/Detection.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/Language.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/Option.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/Translate.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateException.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateFactory.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateImpl.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateOptions.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/Translation.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/package-info.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/TranslateRpcFactory.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/HttpTranslateRpc.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/TranslateRpc.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/RemoteTranslateHelper.java",
+			"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/package-info.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/DetectionTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/LanguageTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/OptionTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/SerializationTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateExceptionTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateImplTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateOptionsTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslationTest.java",
+			"google-cloud-translate/src/test/java/com/google/cloud/translate/it/ITTranslateTest.java",
+		},
+	}
 )

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -549,6 +549,72 @@ func TestBuildConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "keep overrides",
+			gen: &GenerationConfig{
+				Libraries: []LibraryConfig{
+					{
+						APIShortName: "translate",
+						GAPICs: []GAPICConfig{
+							{ProtoPath: "google/cloud/translate/v3"},
+						},
+					},
+				},
+			},
+			src: &config.Source{Dir: "testdata/googleapis"},
+			want: &config.Config{
+				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
+				Default: &config.Default{
+					Java: &config.JavaModule{},
+				},
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Dir: "testdata/googleapis"},
+				},
+				Libraries: []*config.Library{
+					{
+						Name: "translate",
+						APIs: []*config.API{
+							{Path: "google/cloud/translate/v3"},
+						},
+						Keep: []string{
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/Detection.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/Language.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/Option.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/Translate.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateException.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateFactory.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateImpl.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateOptions.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/Translation.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/package-info.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/TranslateRpcFactory.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/HttpTranslateRpc.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/TranslateRpc.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/RemoteTranslateHelper.java",
+							"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/package-info.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/DetectionTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/LanguageTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/OptionTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/SerializationTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateExceptionTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateImplTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateOptionsTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslationTest.java",
+							"google-cloud-translate/src/test/java/com/google/cloud/translate/it/ITTranslateTest.java",
+						},
+						Java: &config.JavaModule{
+							JavaAPIs: []*config.JavaAPI{
+								{
+									Path: "google/cloud/translate/v3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := buildConfig(test.gen, ".", test.src, test.versions)

--- a/tool/cmd/migrate/testdata/googleapis/google/cloud/translate/v3/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/googleapis/google/cloud/translate/v3/BUILD.bazel
@@ -4,6 +4,37 @@ load(
     "nodejs_gapic_library",
 )
 
+java_gapic_library(
+    name = "translation_java_gapic",
+    srcs = [":translation_proto_with_info"],
+    gapic_yaml = None,
+    grpc_service_config = "translate_grpc_service_config.json",
+    rest_numeric_enums = True,
+    service_yaml = "translate_v3.yaml",
+    test_deps = [
+        ":translation_java_grpc",
+        "//google/cloud/location:location_java_grpc",
+    ],
+    transport = "grpc+rest",
+    deps = [
+        ":translation_java_proto",
+        "//google/api:api_java_proto",
+        "//google/iam/v1:iam_java_proto",
+    ],
+)
+
+java_gapic_assembly_gradle_pkg(
+    name = "google-cloud-translation-v3-java",
+    include_samples = True,
+    transport = "grpc+rest",
+    deps = [
+        ":translation_java_gapic",
+        ":translation_java_grpc",
+        ":translation_java_proto",
+        ":translation_proto",
+    ],
+)
+
 nodejs_gapic_library(
     name = "translate_nodejs_gapic",
     package_name = "@google-cloud/translate",


### PR DESCRIPTION
The Java migration tool is updated to support manual overrides for the Keep field in library configurations.

These keep files can't be parsed from `.OwlBot-hermetic.yaml`.