### PR TITLE
feat(sidekick/swift): nested messages and enums

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -40,5 +40,15 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 			return err
 		}
 	}
+	for _, nested := range message.Messages {
+		if err := codec.annotateMessage(nested, model); err != nil {
+			return err
+		}
+	}
+	for _, enum := range message.Enums {
+		if err := codec.annotateEnum(enum, model); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
@@ -48,5 +49,111 @@ func TestGenerateMessage_Files(t *testing.T) {
 		if _, err := os.Stat(filename); err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func TestGenerateMessage_WithNestedMessages(t *testing.T) {
+	outDir := t.TempDir()
+
+	nested1 := &api.Message{Name: "Nested1", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.WithNested.Nested1"}
+	nested2 := &api.Message{Name: "Nested2", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.WithNested.Nested2"}
+	withNested := &api.Message{
+		Name:     "WithNested",
+		Package:  "google.cloud.test.v1",
+		ID:       ".google.cloud.test.v1.WithNested",
+		Messages: []*api.Message{nested1, nested2},
+	}
+
+	model := api.NewTestAPI([]*api.Message{withNested}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+
+	cfg := &parser.ModelConfig{
+		Codec: map[string]string{
+			"copyright-year": "2038",
+		},
+	}
+
+	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	filename := filepath.Join(expectedDir, "WithNested.swift")
+	if _, err := os.Stat(filename); err != nil {
+		t.Error(err)
+	}
+	for _, unexpected := range []string{"Nested1.swift", "Nested2.swift"} {
+		unexpectedFilename := filepath.Join(expectedDir, unexpected)
+		if _, err := os.Stat(unexpectedFilename); err == nil {
+			t.Errorf("unexpected file generated: %s", unexpectedFilename)
+		}
+	}
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+
+	gotBlock1 := extractBlock(t, contentStr, "public struct Nested1", "Equatable {")
+	wantBlock1 := "public struct Nested1: Codable, Equatable {"
+	if diff := cmp.Diff(wantBlock1, gotBlock1); diff != "" {
+		t.Errorf("mismatch in Nested1 (-want +got):\n%s", diff)
+	}
+
+	gotBlock2 := extractBlock(t, contentStr, "public struct Nested2", "Equatable {")
+	wantBlock2 := "public struct Nested2: Codable, Equatable {"
+	if diff := cmp.Diff(wantBlock2, gotBlock2); diff != "" {
+		t.Errorf("mismatch in Nested2 (-want +got):\n%s", diff)
+	}
+}
+
+func TestGenerateMessage_WithNestedEnum(t *testing.T) {
+	outDir := t.TempDir()
+
+	nestedEnum := &api.Enum{Name: "NestedEnum", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.WithNestedEnum.NestedEnum"}
+	nestedEnum.Values = []*api.EnumValue{{Name: "NESTED_ENUM_UNSPECIFIED", Number: 0, Parent: nestedEnum}}
+	nestedEnum.UniqueNumberValues = nestedEnum.Values
+
+	withNested := &api.Message{
+		Name:    "WithNestedEnum",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.WithNestedEnum",
+		Enums:   []*api.Enum{nestedEnum},
+	}
+
+	model := api.NewTestAPI([]*api.Message{withNested}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+
+	cfg := &parser.ModelConfig{
+		Codec: map[string]string{
+			"copyright-year": "2038",
+		},
+	}
+
+	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	filename := filepath.Join(expectedDir, "WithNestedEnum.swift")
+	if _, err := os.Stat(filename); err != nil {
+		t.Error(err)
+	}
+	unexpectedFilename := filepath.Join(expectedDir, "NestedEnum.swift")
+	if _, err := os.Stat(unexpectedFilename); err == nil {
+		t.Errorf("unexpected file generated: %s", unexpectedFilename)
+	}
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+
+	gotBlock := extractBlock(t, contentStr, "public enum NestedEnum", "Equatable {")
+	wantBlock := "public enum NestedEnum: Int, Codable, Equatable {"
+	if diff := cmp.Diff(wantBlock, gotBlock); diff != "" {
+		t.Errorf("mismatch in NestedEnum (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -50,4 +50,12 @@ public struct {{Codec.Name}}: Codable, Equatable {
     self.{{Codec.Name}} = {{Codec.Name}}
     {{/Fields}}
   }
+  {{#Messages}}
+
+  {{> /templates/common/message}}
+  {{/Messages}}
+  {{#Enums}}
+
+  {{> /templates/common/enum}}
+  {{/Enums}}
 }


### PR DESCRIPTION
With this change the Swift coded generate nested messages and enums.

Towards #5396 and #5397 
