### PR TITLE
fix(internal/librarian/java): support non-versioned API path for processing pom

### DIFF
--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -249,9 +249,9 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 	protoModules := make([]Coordinate, 0, len(library.APIs))
 	gRPCModules := make([]Coordinate, 0, len(library.APIs))
 	for _, api := range library.APIs {
-		version := serviceconfig.ExtractVersion(api.Path)
+		apiBase := filepath.Base(api.Path)
 		javaAPI := ResolveJavaAPI(library, api)
-		apiCoord := DeriveAPICoordinates(libCoord, version, javaAPI)
+		apiCoord := DeriveAPICoordinates(libCoord, apiBase, javaAPI)
 
 		transport := transports[api.Path]
 		data := gRPCProtoPOMData{

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -378,6 +378,47 @@ func TestCollectModules(t *testing.T) {
 			},
 		},
 		{
+			name: "non versioned proto only skips grpc module",
+			library: &config.Library{
+				Name:    "accesscontextmanager",
+				Version: "1.2.3",
+				APIs: []*config.API{
+					{Path: "google/identity/accesscontextmanager/type"},
+				},
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{Path: "google/identity/accesscontextmanager/type", ProtoOnly: true},
+					},
+				},
+			},
+			monorepoVersion: "1.2.3",
+			metadata: &repoMetadata{
+				NamePretty: "Secret Manager",
+			},
+			transports: map[string]serviceconfig.Transport{
+				"google/identity/accesscontextmanager/type": serviceconfig.GRPC,
+			},
+			setup: func(t *testing.T, libraryDir string) {
+				dirs := []string{
+					"proto-google-cloud-accesscontextmanager-type",
+					"google-cloud-accesscontextmanager",
+					"google-cloud-accesscontextmanager-bom",
+					"", // parent
+				}
+				for _, d := range dirs {
+					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0755); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			want: []javaModule{
+				{artifactID: "proto-google-cloud-accesscontextmanager-type", isMissing: true, template: protoPOMTemplateName},
+				{artifactID: "google-cloud-accesscontextmanager", isMissing: true, template: clientPOMTemplateName},
+				{artifactID: "google-cloud-accesscontextmanager-bom", isMissing: true, template: bomPOMTemplateName},
+				{artifactID: "google-cloud-accesscontextmanager-parent", isMissing: true, template: parentPOMTemplateName},
+			},
+		},
+		{
 			name: "existing poms",
 			library: &config.Library{
 				Name:    "secretmanager",

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -392,9 +392,7 @@ func TestCollectModules(t *testing.T) {
 				},
 			},
 			monorepoVersion: "1.2.3",
-			metadata: &repoMetadata{
-				NamePretty: "Secret Manager",
-			},
+			metadata:        &repoMetadata{},
 			transports: map[string]serviceconfig.Transport{
 				"google/identity/accesscontextmanager/type": serviceconfig.GRPC,
 			},

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -26,7 +26,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
 	"github.com/googleapis/librarian/internal/librarian/java"
-	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -572,10 +571,10 @@ func getModuleArtifactIDs(lib *config.Library) moduleArtifactIDs {
 		BOM:    lc.BOM.ArtifactID,
 	}
 	for _, api := range lib.APIs {
-		version := serviceconfig.ExtractVersion(api.Path)
+		apiBase := filepath.Base(api.Path)
 		// Find Java-specific API config to handle artifact ID overrides.
 		javaAPI := java.ResolveJavaAPI(lib, api)
-		apiCoord := java.DeriveAPICoordinates(lc, version, javaAPI)
+		apiCoord := java.DeriveAPICoordinates(lc, apiBase, javaAPI)
 		ids.Protos = append(ids.Protos, apiCoord.Proto.ArtifactID)
 		ids.GRPCs = append(ids.GRPCs, apiCoord.GRPC.ArtifactID)
 	}

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -958,11 +958,12 @@ func TestGetModuleArtifactIDs(t *testing.T) {
 		APIs: []*config.API{
 			{Path: "google/cloud/vision/v1"},
 			{Path: "google/cloud/vision/v1p1beta1"},
+			{Path: "google/cloud/vision/type"},
 		},
 	}
 	ids := getModuleArtifactIDs(lib)
-	wantProto := []string{"proto-google-cloud-vision-v1", "proto-google-cloud-vision-v1p1beta1"}
-	wantGrpc := []string{"grpc-google-cloud-vision-v1", "grpc-google-cloud-vision-v1p1beta1"}
+	wantProto := []string{"proto-google-cloud-vision-v1", "proto-google-cloud-vision-v1p1beta1", "proto-google-cloud-vision-type"}
+	wantGrpc := []string{"grpc-google-cloud-vision-v1", "grpc-google-cloud-vision-v1p1beta1", "grpc-google-cloud-vision-type"}
 	if diff := cmp.Diff(wantProto, ids.Protos); diff != "" {
 		t.Errorf("mismatch in protoIDs (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
 Updated collectModules to ensures that artifact IDs (e.g., proto-google-identity-accesscontextmanager-type) and directory paths are correctly derived for non-versioned API paths. Applied the same logic for consistency during library migration.

Tested locally now `accesscontextmanager` do not generate diffs.

Fix #5229