### PR TITLE
fix(tool/cmd/migrate): add apigee-registry to apiShortnameOverrides

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -24,6 +24,7 @@ var (
 		"dialogflow-cx":                      "dialogflow-cx",
 		"distributedcloudedge":               "distributedcloudedge",
 		"gke-backup":                         "gke-backup",
+		"apigee-registry":                    "apigee-registry",
 	}
 
 	excludedSamplesLibraries = map[string]bool{


### PR DESCRIPTION
Adds apigee-registry to apiShortnameOverrides. This resolves diff produced in repo-metadata for apigee-registry.

For #5296