### PR TITLE
fix(tool/cmd/migrate): add hardcoded keep override for aiplatform

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -62,5 +62,11 @@ var (
 			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslationTest.java",
 			"google-cloud-translate/src/test/java/com/google/cloud/translate/it/ITTranslateTest.java",
 		},
+		"aiplatform": {
+			"google-cloud-aiplatform/src/test/java/com/google/cloud/location/MockLocations.java",
+			"google-cloud-aiplatform/src/test/java/com/google/cloud/location/MockLocationsImpl.java",
+			"google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicy.java",
+			"google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicyImpl.java",
+		},
 	}
 )

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -389,18 +389,11 @@ func TestBuildConfig(t *testing.T) {
 							{ProtoPath: "google/cloud/accessapproval/v1"},
 						},
 					},
-					{
-						APIShortName: "aiplatform",
-						GAPICs: []GAPICConfig{
-							{ProtoPath: "google/cloud/aiplatform/v1"},
-						},
-					},
 				},
 			},
 			versions: map[string]string{
 				"google-cloud-java":           "1.79.0",
 				"google-cloud-accessapproval": "2.86.0",
-				"google-cloud-aiplatform":     "3.86.0",
 			},
 			src: &config.Source{Dir: "../../internal/testdata/googleapis"},
 			want: &config.Config{
@@ -427,14 +420,6 @@ func TestBuildConfig(t *testing.T) {
 						Java: &config.JavaModule{
 							DistributionNameOverride: "com.google.cloud:" + "google-cloud-accessapproval",
 						},
-					},
-					{
-						Name:    "aiplatform",
-						Version: "3.86.0",
-						APIs: []*config.API{
-							{Path: "google/cloud/aiplatform/v1"},
-						},
-						Java: &config.JavaModule{},
 					},
 				},
 			},


### PR DESCRIPTION
Add hardcoded config for keep files that are not listed in [.OwlBot-hermetic.yaml](https://github.com/googleapis/google-cloud-java/blob/main/java-aiplatform/.OwlBot-hermetic.yaml).

For #5380