### PR TITLE
test(internal/librarianops): skip flaky TestRunUpgrade

### DIFF
--- a/internal/librarianops/upgrade_test.go
+++ b/internal/librarianops/upgrade_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestRunUpgrade(t *testing.T) {
+	t.Skip("TODO(https://github.com/googleapis/librarian/issues/5311): re-enable once the flake fetching librarian version from the Go proxy is resolved")
 	wantVersion, err := getLibrarianVersionAtMain(t.Context())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
TestRunUpgrade fetches the librarian version from the Go proxy, which has flaked in CI. Skip the test until this is addressed.

For https://github.com/googleapis/librarian/issues/5311