### PR TITLE
feat(sidekick/swift): support map fields

### DIFF
--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -47,7 +47,7 @@ func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
 			return "", err
 		}
 		if m.IsMap {
-			return "", fmt.Errorf("TODO(#5060) - map fields are not supported: %s", field.ID)
+			return c.mapFieldTypeName(m)
 		}
 		return c.messageTypeName(m)
 	case api.ENUM_TYPE:
@@ -59,6 +59,30 @@ func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
 	default:
 		return scalarFieldTypeName(field)
 	}
+}
+
+func (c *codec) mapFieldTypeName(m *api.Message) (string, error) {
+	var keyField, valueField *api.Field
+	for _, f := range m.Fields {
+		switch f.Name {
+		case "key":
+			keyField = f
+		case "value":
+			valueField = f
+		}
+	}
+	if keyField == nil || valueField == nil {
+		return "", fmt.Errorf("map message %q missing key or value field", m.ID)
+	}
+	keyType, err := c.baseFieldTypeName(keyField)
+	if err != nil {
+		return "", err
+	}
+	valueType, err := c.baseFieldTypeName(valueField)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("[%s: %s]", keyType, valueType), nil
 }
 
 func scalarFieldTypeName(field *api.Field) (string, error) {

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -333,3 +333,42 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 		})
 	}
 }
+
+func TestFieldTypeName_Map(t *testing.T) {
+	mapEntry := &api.Message{
+		Name:    "SingularMapEntry",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.WithMap.SingularMapEntry",
+		IsMap:   true,
+		Fields: []*api.Field{
+			{Name: "key", Typez: api.STRING_TYPE, ID: ".google.cloud.test.v1.WithMap.SingularMapEntry.key"},
+			{Name: "value", Typez: api.INT32_TYPE, ID: ".google.cloud.test.v1.WithMap.SingularMapEntry.value"},
+		},
+	}
+
+	c := &codec{
+		Model: &api.API{
+			PackageName: "google.cloud.test.v1",
+			State: &api.APIState{
+				MessageByID: map[string]*api.Message{
+					".google.cloud.test.v1.WithMap.SingularMapEntry": mapEntry,
+				},
+			},
+		},
+	}
+
+	field := &api.Field{
+		Typez:   api.MESSAGE_TYPE,
+		TypezID: ".google.cloud.test.v1.WithMap.SingularMapEntry",
+		ID:      ".test.field1",
+	}
+
+	got, err := c.baseFieldTypeName(field)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "[String: Int32]"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -346,16 +346,10 @@ func TestFieldTypeName_Map(t *testing.T) {
 		},
 	}
 
-	c := &codec{
-		Model: &api.API{
-			PackageName: "google.cloud.test.v1",
-			State: &api.APIState{
-				MessageByID: map[string]*api.Message{
-					".google.cloud.test.v1.WithMap.SingularMapEntry": mapEntry,
-				},
-			},
-		},
-	}
+	model := api.NewTestAPI(nil, nil, nil)
+	model.PackageName = mapEntry.Package
+	model.State.MessageByID[mapEntry.ID] = mapEntry
+	c := newTestCodec(t, model, map[string]string{})
 
 	field := &api.Field{
 		Typez:   api.MESSAGE_TYPE,


### PR DESCRIPTION
The codec uses `[K:V]` for map types, where `K` is the mapped type of the key and `V` is the mapped type of the value.

Fixes #5398 