### PR TITLE
feat(sidekick/swift): towards external packages

### DIFF
--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -67,11 +67,9 @@ func (codec *codec) annotateModel() error {
 	for _, service := range codec.Model.Services {
 		codec.annotateService(service, annotations)
 	}
-	if len(codec.Model.Services) != 0 {
-		for _, p := range codec.Dependencies {
-			if p.RequiredByServices {
-				annotations.DependsOn[p.Name] = p
-			}
+	for _, p := range codec.Dependencies {
+		if p.Required || (p.RequiredByServices && len(codec.Model.Services) != 0) {
+			annotations.DependsOn[p.Name] = p
 		}
 	}
 	return nil

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -36,6 +37,78 @@ func TestModelAnnotations(t *testing.T) {
 		MonorepoRoot:  ".",
 	}
 	if diff := cmp.Diff(want, model.Codec, cmpopts.IgnoreFields(modelAnnotations{}, "BoilerPlate", "DependsOn")); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
+	externalMessage := &api.Message{
+		Name:    "ExternalMessage",
+		Package: "google.cloud.external.v1",
+		ID:      ".google.cloud.external.v1.ExternalMessage",
+	}
+
+	message := &api.Message{
+		Name:    "LocalMessage",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.LocalMessage",
+		Fields: []*api.Field{
+			{
+				Name:    "ext_field",
+				Typez:   api.MESSAGE_TYPE,
+				TypezID: ".google.cloud.external.v1.ExternalMessage",
+			},
+		},
+	}
+
+	model := api.NewTestAPI(
+		[]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+
+	model.State = &api.APIState{
+		MessageByID: map[string]*api.Message{
+			".google.cloud.external.v1.ExternalMessage": externalMessage,
+		},
+	}
+
+	codec := newTestCodec(t, model, nil)
+	dep := &Dependency{
+		SwiftDependency: config.SwiftDependency{
+			ApiPackage: "google.cloud.external.v1",
+			Name:       "external-package",
+		},
+	}
+	dep2 := &Dependency{
+		SwiftDependency: config.SwiftDependency{
+			ApiPackage: "google.cloud.unused.v1",
+			Name:       "unused-package",
+		},
+	}
+	codec.ApiPackages = map[string]*Dependency{
+		"google.cloud.external.v1": dep,
+		"google.cloud.unused.v1":   dep2,
+	}
+	codec.Dependencies = []*Dependency{dep, dep2}
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	ann, ok := model.Codec.(*modelAnnotations)
+	if !ok {
+		t.Fatalf("expected model.Codec to be *modelAnnotations, got %T", model.Codec)
+	}
+
+	wantDependsOn := map[string]*Dependency{
+		"external-package": {
+			SwiftDependency: config.SwiftDependency{
+				ApiPackage: "google.cloud.external.v1",
+				Name:       "external-package",
+			},
+			Required: true,
+		},
+	}
+
+	if diff := cmp.Diff(wantDependsOn, ann.DependsOn); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -63,15 +63,9 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 
 	model := api.NewTestAPI(
 		[]*api.Message{message}, []*api.Enum{}, []*api.Service{})
-
-	model.State = &api.APIState{
-		MessageByID: map[string]*api.Message{
-			".google.cloud.external.v1.ExternalMessage": externalMessage,
-		},
-	}
-
+	model.State.MessageByID[externalMessage.ID] = externalMessage
 	codec := newTestCodec(t, model, nil)
-	dep := &Dependency{
+	dep1 := &Dependency{
 		SwiftDependency: config.SwiftDependency{
 			ApiPackage: "google.cloud.external.v1",
 			Name:       "external-package",
@@ -84,10 +78,10 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 		},
 	}
 	codec.ApiPackages = map[string]*Dependency{
-		"google.cloud.external.v1": dep,
+		"google.cloud.external.v1": dep1,
 		"google.cloud.unused.v1":   dep2,
 	}
-	codec.Dependencies = []*Dependency{dep, dep2}
+	codec.Dependencies = []*Dependency{dep1, dep2}
 
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -70,7 +70,7 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 	}
 	if swiftCfg != nil {
 		for _, d := range swiftCfg.Dependencies {
-			dependency := Dependency{d}
+			dependency := Dependency{SwiftDependency: d}
 			result.Dependencies = append(result.Dependencies, &dependency)
 			if d.ApiPackage != "" {
 				result.ApiPackages[d.ApiPackage] = &dependency

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -66,15 +66,15 @@ func TestNewCodec_WithSwiftCfg(t *testing.T) {
 	}
 
 	wantDeps := []*Dependency{
-		{swiftCfg.Dependencies[0]},
-		{swiftCfg.Dependencies[1]},
+		{SwiftDependency: swiftCfg.Dependencies[0]},
+		{SwiftDependency: swiftCfg.Dependencies[1]},
 	}
 	if diff := cmp.Diff(wantDeps, got.Dependencies); diff != "" {
 		t.Errorf("mismatch in Dependencies (-want +got):\n%s", diff)
 	}
 
 	wantApiPackages := map[string]*Dependency{
-		"google.cloud.location": {swiftCfg.Dependencies[1]},
+		"google.cloud.location": {SwiftDependency: swiftCfg.Dependencies[1]},
 	}
 	if diff := cmp.Diff(wantApiPackages, got.ApiPackages); diff != "" {
 		t.Errorf("mismatch in ApiPackages (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/dependency.go
+++ b/internal/sidekick/swift/dependency.go
@@ -23,6 +23,7 @@ import (
 // Dependency wraps config.SwiftDependency to add helper methods.
 type Dependency struct {
 	config.SwiftDependency
+	Required bool
 }
 
 // LocalName returns the name of the dependency when used in a `Package.swift` file.

--- a/internal/sidekick/swift/dependency_test.go
+++ b/internal/sidekick/swift/dependency_test.go
@@ -29,27 +29,27 @@ func TestLocalName(t *testing.T) {
 	}{
 		{
 			name: "path simple",
-			dep:  Dependency{config.SwiftDependency{Path: "packages/auth"}},
+			dep:  Dependency{SwiftDependency: config.SwiftDependency{Path: "packages/auth"}},
 			want: "auth",
 		},
 		{
 			name: "path nested",
-			dep:  Dependency{config.SwiftDependency{Path: "generated/google-cloud-location"}},
+			dep:  Dependency{SwiftDependency: config.SwiftDependency{Path: "generated/google-cloud-location"}},
 			want: "google-cloud-location",
 		},
 		{
 			name: "path trailing slash",
-			dep:  Dependency{config.SwiftDependency{Path: "packages/auth/"}},
+			dep:  Dependency{SwiftDependency: config.SwiftDependency{Path: "packages/auth/"}},
 			want: "auth",
 		},
 		{
 			name: "url without git",
-			dep:  Dependency{config.SwiftDependency{URL: "https://github.com/apple/swift-protobuf"}},
+			dep:  Dependency{SwiftDependency: config.SwiftDependency{URL: "https://github.com/apple/swift-protobuf"}},
 			want: "swift-protobuf",
 		},
 		{
 			name: "url with git",
-			dep:  Dependency{config.SwiftDependency{URL: "https://github.com/apple/swift-protobuf.git"}},
+			dep:  Dependency{SwiftDependency: config.SwiftDependency{URL: "https://github.com/apple/swift-protobuf.git"}},
 			want: "swift-protobuf",
 		},
 	} {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -123,12 +123,12 @@ func scalarFieldTypeName(field *api.Field) (string, error) {
 }
 
 func (c *codec) messageTypeName(m *api.Message) (string, error) {
-	prefix, err := c.externalTypePrefix(m.Package)
-	if err != nil {
-		return "", err
-	}
 	name := pascalCase(m.Name)
 	if m.Parent == nil {
+		prefix, err := c.externalTypePrefix(m.Package)
+		if err != nil {
+			return "", err
+		}
 		if prefix != "" {
 			return fmt.Sprintf("%s.%s", prefix, name), nil
 		}
@@ -142,12 +142,12 @@ func (c *codec) messageTypeName(m *api.Message) (string, error) {
 }
 
 func (c *codec) enumTypeName(e *api.Enum) (string, error) {
-	prefix, err := c.externalTypePrefix(e.Package)
-	if err != nil {
-		return "", err
-	}
 	name := pascalCase(e.Name)
 	if e.Parent == nil {
+		prefix, err := c.externalTypePrefix(e.Package)
+		if err != nil {
+			return "", err
+		}
 		if prefix != "" {
 			return fmt.Sprintf("%s.%s", prefix, name), nil
 		}

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -123,12 +123,15 @@ func scalarFieldTypeName(field *api.Field) (string, error) {
 }
 
 func (c *codec) messageTypeName(m *api.Message) (string, error) {
-	if m.Package != c.Model.PackageName {
-		return "", fmt.Errorf("TODO(#5060) - support external message types")
+	prefix, err := c.externalTypePrefix(m.Package)
+	if err != nil {
+		return "", err
 	}
-	// Names can be qualified with nested objects.
 	name := pascalCase(m.Name)
 	if m.Parent == nil {
+		if prefix != "" {
+			return fmt.Sprintf("%s.%s", prefix, name), nil
+		}
 		return name, nil
 	}
 	parent, err := c.messageTypeName(m.Parent)
@@ -139,12 +142,15 @@ func (c *codec) messageTypeName(m *api.Message) (string, error) {
 }
 
 func (c *codec) enumTypeName(e *api.Enum) (string, error) {
-	if e.Package != c.Model.PackageName {
-		return "", fmt.Errorf("TODO(#5060) - support external enum types")
+	prefix, err := c.externalTypePrefix(e.Package)
+	if err != nil {
+		return "", err
 	}
-	// Names can be qualified with nested objects.
 	name := pascalCase(e.Name)
 	if e.Parent == nil {
+		if prefix != "" {
+			return fmt.Sprintf("%s.%s", prefix, name), nil
+		}
 		return name, nil
 	}
 	parent, err := c.messageTypeName(e.Parent)
@@ -152,4 +158,16 @@ func (c *codec) enumTypeName(e *api.Enum) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%s.%s", parent, name), nil
+}
+
+func (c *codec) externalTypePrefix(packageName string) (string, error) {
+	if packageName == c.Model.PackageName {
+		return "", nil
+	}
+	dep, ok := c.ApiPackages[packageName]
+	if !ok {
+		return "", fmt.Errorf("package %q not found in ApiPackages", packageName)
+	}
+	dep.Required = true
+	return PackageName(&api.API{PackageName: dep.ApiPackage}), nil
 }

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -169,5 +169,5 @@ func (c *codec) externalTypePrefix(packageName string) (string, error) {
 		return "", fmt.Errorf("package %q not found in ApiPackages", packageName)
 	}
 	dep.Required = true
-	return PackageName(&api.API{PackageName: dep.ApiPackage}), nil
+	return dep.Name, nil
 }

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -357,17 +357,14 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 		ID:      ".google.cloud.external.v1.ExternalMessage",
 	}
 
-	c := &codec{
-		Model: &api.API{
-			PackageName: "google.cloud.test.v1",
-		},
-		ApiPackages: map[string]*Dependency{
-			"google.cloud.external.v1": {
-				SwiftDependency: config.SwiftDependency{
-					ApiPackage: "google.cloud.external.v1",
-					Name:       "ExternalPackage",
-				},
-			},
+	model := api.NewTestAPI(nil, nil, nil)
+	model.PackageName = "google.cloud.test.v1"
+	model.State.MessageByID[externalMessage.ID] = externalMessage
+	c := newTestCodec(t, model, nil)
+	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
+		SwiftDependency: config.SwiftDependency{
+			ApiPackage: "google.cloud.external.v1",
+			Name:       "ExternalPackage",
 		},
 	}
 
@@ -393,17 +390,14 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 		ID:      ".google.cloud.external.v1.ExternalEnum",
 	}
 
-	c := &codec{
-		Model: &api.API{
-			PackageName: "google.cloud.test.v1",
-		},
-		ApiPackages: map[string]*Dependency{
-			"google.cloud.external.v1": {
-				SwiftDependency: config.SwiftDependency{
-					ApiPackage: "google.cloud.external.v1",
-					Name:       "ExternalPackage",
-				},
-			},
+	model := api.NewTestAPI(nil, nil, nil)
+	model.PackageName = "google.cloud.test.v1"
+	model.State.EnumByID[externalEnum.ID] = externalEnum
+	c := newTestCodec(t, model, nil)
+	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
+		SwiftDependency: config.SwiftDependency{
+			ApiPackage: "google.cloud.external.v1",
+			Name:       "ExternalPackage",
 		},
 	}
 
@@ -434,18 +428,17 @@ func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
 		ID:      ".google.cloud.external.v1.OuterMessage.NestedMessage",
 		Parent:  externalOuter,
 	}
+	externalOuter.Messages = append(externalOuter.Messages, externalNested)
 
-	c := &codec{
-		Model: &api.API{
-			PackageName: "google.cloud.test.v1",
-		},
-		ApiPackages: map[string]*Dependency{
-			"google.cloud.external.v1": {
-				SwiftDependency: config.SwiftDependency{
-					ApiPackage: "google.cloud.external.v1",
-					Name:       "ExternalPackage",
-				},
-			},
+	model := api.NewTestAPI(nil, nil, nil)
+	model.PackageName = "google.cloud.test.v1"
+	model.State.MessageByID[externalNested.ID] = externalNested
+	model.State.MessageByID[externalOuter.ID] = externalOuter
+	c := newTestCodec(t, model, nil)
+	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
+		SwiftDependency: config.SwiftDependency{
+			ApiPackage: "google.cloud.external.v1",
+			Name:       "ExternalPackage",
 		},
 	}
 

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -365,7 +365,7 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 			"google.cloud.external.v1": {
 				SwiftDependency: config.SwiftDependency{
 					ApiPackage: "google.cloud.external.v1",
-					Name:       "external-package",
+					Name:       "ExternalPackage",
 				},
 			},
 		},
@@ -375,7 +375,7 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "GoogleCloudExternalV1.ExternalMessage"
+	want := "ExternalPackage.ExternalMessage"
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -401,7 +401,7 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 			"google.cloud.external.v1": {
 				SwiftDependency: config.SwiftDependency{
 					ApiPackage: "google.cloud.external.v1",
-					Name:       "external-package",
+					Name:       "ExternalPackage",
 				},
 			},
 		},
@@ -411,7 +411,7 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "GoogleCloudExternalV1.ExternalEnum"
+	want := "ExternalPackage.ExternalEnum"
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -443,7 +443,7 @@ func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
 			"google.cloud.external.v1": {
 				SwiftDependency: config.SwiftDependency{
 					ApiPackage: "google.cloud.external.v1",
-					Name:       "external-package",
+					Name:       "ExternalPackage",
 				},
 			},
 		},
@@ -453,7 +453,7 @@ func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "GoogleCloudExternalV1.OuterMessage.NestedMessage"
+	want := "ExternalPackage.OuterMessage.NestedMessage"
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -367,6 +367,12 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 			Name:       "ExternalPackage",
 		},
 	}
+	c.ApiPackages["google.cloud.unused.v1"] = &Dependency{
+		SwiftDependency: config.SwiftDependency{
+			ApiPackage: "google.cloud.unused.v1",
+			Name:       "UnusedPackage",
+		},
+	}
 
 	got, err := c.messageTypeName(externalMessage)
 	if err != nil {
@@ -377,9 +383,16 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	dep := c.ApiPackages["google.cloud.external.v1"]
-	if !dep.Required {
-		t.Errorf("expected dependency to be marked as required")
+	wantRequired := map[string]bool{
+		"google.cloud.external.v1": true,
+		"google.cloud.unused.v1":   false,
+	}
+	gotRequired := map[string]bool{}
+	for k, v := range c.ApiPackages {
+		gotRequired[k] = v.Required
+	}
+	if diff := cmp.Diff(wantRequired, gotRequired); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -400,6 +413,12 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 			Name:       "ExternalPackage",
 		},
 	}
+	c.ApiPackages["google.cloud.unused.v1"] = &Dependency{
+		SwiftDependency: config.SwiftDependency{
+			ApiPackage: "google.cloud.unused.v1",
+			Name:       "UnusedPackage",
+		},
+	}
 
 	got, err := c.enumTypeName(externalEnum)
 	if err != nil {
@@ -410,9 +429,16 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	dep := c.ApiPackages["google.cloud.external.v1"]
-	if !dep.Required {
-		t.Errorf("expected dependency to be marked as required")
+	wantRequired := map[string]bool{
+		"google.cloud.external.v1": true,
+		"google.cloud.unused.v1":   false,
+	}
+	gotRequired := map[string]bool{}
+	for k, v := range c.ApiPackages {
+		gotRequired[k] = v.Required
+	}
+	if diff := cmp.Diff(wantRequired, gotRequired); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -344,6 +345,115 @@ func TestFieldTypeName_Map(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := "[String: Int32]"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFieldTypeName_ExternalMessage(t *testing.T) {
+	externalMessage := &api.Message{
+		Name:    "ExternalMessage",
+		Package: "google.cloud.external.v1",
+		ID:      ".google.cloud.external.v1.ExternalMessage",
+	}
+
+	c := &codec{
+		Model: &api.API{
+			PackageName: "google.cloud.test.v1",
+		},
+		ApiPackages: map[string]*Dependency{
+			"google.cloud.external.v1": {
+				SwiftDependency: config.SwiftDependency{
+					ApiPackage: "google.cloud.external.v1",
+					Name:       "external-package",
+				},
+			},
+		},
+	}
+
+	got, err := c.messageTypeName(externalMessage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "GoogleCloudExternalV1.ExternalMessage"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	dep := c.ApiPackages["google.cloud.external.v1"]
+	if !dep.Required {
+		t.Errorf("expected dependency to be marked as required")
+	}
+}
+
+func TestFieldTypeName_ExternalEnum(t *testing.T) {
+	externalEnum := &api.Enum{
+		Name:    "ExternalEnum",
+		Package: "google.cloud.external.v1",
+		ID:      ".google.cloud.external.v1.ExternalEnum",
+	}
+
+	c := &codec{
+		Model: &api.API{
+			PackageName: "google.cloud.test.v1",
+		},
+		ApiPackages: map[string]*Dependency{
+			"google.cloud.external.v1": {
+				SwiftDependency: config.SwiftDependency{
+					ApiPackage: "google.cloud.external.v1",
+					Name:       "external-package",
+				},
+			},
+		},
+	}
+
+	got, err := c.enumTypeName(externalEnum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "GoogleCloudExternalV1.ExternalEnum"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	dep := c.ApiPackages["google.cloud.external.v1"]
+	if !dep.Required {
+		t.Errorf("expected dependency to be marked as required")
+	}
+}
+
+func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
+	externalOuter := &api.Message{
+		Name:    "OuterMessage",
+		Package: "google.cloud.external.v1",
+		ID:      ".google.cloud.external.v1.OuterMessage",
+	}
+	externalNested := &api.Message{
+		Name:    "NestedMessage",
+		Package: "google.cloud.external.v1",
+		ID:      ".google.cloud.external.v1.OuterMessage.NestedMessage",
+		Parent:  externalOuter,
+	}
+
+	c := &codec{
+		Model: &api.API{
+			PackageName: "google.cloud.test.v1",
+		},
+		ApiPackages: map[string]*Dependency{
+			"google.cloud.external.v1": {
+				SwiftDependency: config.SwiftDependency{
+					ApiPackage: "google.cloud.external.v1",
+					Name:       "external-package",
+				},
+			},
+		},
+	}
+
+	got, err := c.messageTypeName(externalNested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "GoogleCloudExternalV1.OuterMessage.NestedMessage"
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
Some of the libraries reference enums and messages in external packages. The best known examples are mixins, but we also have a sprinkling of other common packages in the APIs.

When annotating fields that reference these external packages we need to name the field type correctly.

We also mark the external package as "required", the `librarian.yaml` file will have a large list of all the common packages, and each library will just select the packages that are (directly) needed by that library.

Towards #5395 and #5399. I still need to support add the correct import statements, and we need to figure out methods that use messages in external packages as inputs or outputs.
