### PR TITLE
cleanup(sidekick/swift): redundant `os.Stat()`

### DIFF
--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -79,9 +79,6 @@ func TestGenerateMessage_WithNestedMessages(t *testing.T) {
 
 	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
 	filename := filepath.Join(expectedDir, "WithNested.swift")
-	if _, err := os.Stat(filename); err != nil {
-		t.Error(err)
-	}
 	for _, unexpected := range []string{"Nested1.swift", "Nested2.swift"} {
 		unexpectedFilename := filepath.Join(expectedDir, unexpected)
 		if _, err := os.Stat(unexpectedFilename); err == nil {
@@ -137,9 +134,6 @@ func TestGenerateMessage_WithNestedEnum(t *testing.T) {
 
 	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
 	filename := filepath.Join(expectedDir, "WithNestedEnum.swift")
-	if _, err := os.Stat(filename); err != nil {
-		t.Error(err)
-	}
 	unexpectedFilename := filepath.Join(expectedDir, "NestedEnum.swift")
 	if _, err := os.Stat(unexpectedFilename); err == nil {
 		t.Errorf("unexpected file generated: %s", unexpectedFilename)


### PR DESCRIPTION
Some tests called `os.Stat()` to verify the file was created, and then called `os.ReadFile()` to read the contents. The `os.Stat()` is redudant, we will quickly find out the file is missing when the `ReadFile()` fails.