### PR TITLE
chore(.github/workflows): remove protoc from install_java_tools.sh

### DIFF
--- a/.github/workflows/scripts/install_java_tools.sh
+++ b/.github/workflows/scripts/install_java_tools.sh
@@ -9,7 +9,6 @@
 set -e
 
 # Versions
-PROTOC_VERSION="33.2"
 GRPC_VERSION="1.76.2"
 GAPIC_GENERATOR_VERSION="2.66.1"
 FORMATTER_VERSION="1.25.2"
@@ -32,13 +31,6 @@ download_from() {
 }
 
 echo "Starting installation of Java tools to $INSTALL_DIR..."
-
-# 1. protoc
-echo "Installing protoc..."
-mkdir -p "$INSTALL_DIR/protoc"
-curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OS_ARCHITECTURE}.zip"
-unzip -o -q /tmp/protoc.zip -d "$INSTALL_DIR/protoc"
-ln -sf "$INSTALL_DIR/protoc/bin/protoc" "$BIN_DIR/protoc"
 
 # 2. gRPC Plugin
 echo "Installing gRPC plugin..."

--- a/.github/workflows/scripts/install_java_tools.sh
+++ b/.github/workflows/scripts/install_java_tools.sh
@@ -32,14 +32,14 @@ download_from() {
 
 echo "Starting installation of Java tools to $INSTALL_DIR..."
 
-# 2. gRPC Plugin
+# 1. gRPC Plugin
 echo "Installing gRPC plugin..."
 GRPC_PLUGIN="$INSTALL_DIR/protoc-gen-java_grpc_bin"
 download_from "https://maven-central.storage-download.googleapis.com/maven2/io/grpc/protoc-gen-grpc-java/${GRPC_VERSION}/protoc-gen-grpc-java-${GRPC_VERSION}-${OS_ARCHITECTURE}.exe" "$GRPC_PLUGIN"
 chmod +x "$GRPC_PLUGIN"
 ln -sf "$GRPC_PLUGIN" "$BIN_DIR/protoc-gen-java_grpc"
 
-# 3. Java Formatter
+# 2. Java Formatter
 echo "Installing Java Formatter..."
 FORMATTER_JAR="$INSTALL_DIR/google-java-format.jar"
 download_from "https://maven-central.storage-download.googleapis.com/maven2/com/google/googlejavaformat/google-java-format/${FORMATTER_VERSION}/google-java-format-${FORMATTER_VERSION}-all-deps.jar" "$FORMATTER_JAR"
@@ -49,7 +49,7 @@ exec java -jar "$FORMATTER_JAR" "\$@"
 EOF
 chmod +x "$BIN_DIR/google-java-format"
 
-# 4. GAPIC Generator Java
+# 3. GAPIC Generator Java
 echo "Installing GAPIC Generator Java..."
 GAPIC_JAR="$INSTALL_DIR/gapic-generator-java.jar"
 download_from "https://maven-central.storage-download.googleapis.com/maven2/com/google/api/gapic-generator-java/${GAPIC_GENERATOR_VERSION}/gapic-generator-java-${GAPIC_GENERATOR_VERSION}.jar" "$GAPIC_JAR"


### PR DESCRIPTION
Remove download protoc step from install_java_tools.sh
The ./.github/actions/setup-librarian step in java.yaml already downloads protoc. Although Java needs to be generated with a different protoc, it is sufficient for testing librarian's purpose to use the same version as other langs.

for #5317