### PR TITLE
feat(sidekick/rust): update `from_stub` templates to accept `Into<Arc<T>>`

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -102,9 +102,8 @@ impl {{Codec.Name}} {
     ///
     /// The most common case for calling this function is in tests mocking the
     /// client's behavior.
-    pub fn from_stub<T, U>(stub: U) -> Self
-    where T: super::stub::{{Codec.Name}} + 'static,
-          U: Into<std::sync::Arc<T>> {
+    pub fn from_stub<T>(stub: impl Into<std::sync::Arc<T>>) -> Self
+    where T: super::stub::{{Codec.Name}} + 'static {
         Self { inner: stub.into() }
     }
 

--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -102,9 +102,10 @@ impl {{Codec.Name}} {
     ///
     /// The most common case for calling this function is in tests mocking the
     /// client's behavior.
-    pub fn from_stub<T>(stub: T) -> Self
-    where T: super::stub::{{Codec.Name}} + 'static {
-        Self { inner: std::sync::Arc::new(stub) }
+    pub fn from_stub<T, U>(stub: U) -> Self
+    where T: super::stub::{{Codec.Name}} + 'static,
+          U: Into<std::sync::Arc<T>> {
+        Self { inner: stub.into() }
     }
 
     pub(crate) async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {

--- a/internal/sidekick/rust/templates/storage/client.rs.mustache
+++ b/internal/sidekick/rust/templates/storage/client.rs.mustache
@@ -57,14 +57,15 @@ impl StorageControl {
     ///
     /// The most common case for calling this function is in tests mocking the
     /// client's behavior.
-    pub fn from_stub<T>(stub: T) -> Self
+    pub fn from_stub<T, U>(stub: U) -> Self
     where
         T: crate::stub::StorageControl + 'static,
+        U: Into<std::sync::Arc<T>>,
     {
-        let stub = std::sync::Arc::new(stub);
+        let stub: std::sync::Arc<T> = stub.into();
         Self {
-            storage: crate::generated::gapic::client::StorageControl::from_stub(stub.clone()),
-            control: crate::generated::gapic_control::client::StorageControl::from_stub(stub),
+            storage: crate::generated::gapic::client::StorageControl::from_stub::<std::sync::Arc<T>, std::sync::Arc<T>>(stub.clone()),
+            control: crate::generated::gapic_control::client::StorageControl::from_stub::<std::sync::Arc<T>, std::sync::Arc<T>>(stub),
         }
     }
 

--- a/internal/sidekick/rust/templates/storage/client.rs.mustache
+++ b/internal/sidekick/rust/templates/storage/client.rs.mustache
@@ -57,15 +57,14 @@ impl StorageControl {
     ///
     /// The most common case for calling this function is in tests mocking the
     /// client's behavior.
-    pub fn from_stub<T, U>(stub: U) -> Self
+    pub fn from_stub<T>(stub: impl Into<std::sync::Arc<T>>) -> Self
     where
         T: crate::stub::StorageControl + 'static,
-        U: Into<std::sync::Arc<T>>,
     {
         let stub: std::sync::Arc<T> = stub.into();
         Self {
-            storage: crate::generated::gapic::client::StorageControl::from_stub::<std::sync::Arc<T>, std::sync::Arc<T>>(stub.clone()),
-            control: crate::generated::gapic_control::client::StorageControl::from_stub::<std::sync::Arc<T>, std::sync::Arc<T>>(stub),
+            storage: crate::generated::gapic::client::StorageControl::from_stub::<std::sync::Arc<T>>(stub.clone()),
+            control: crate::generated::gapic_control::client::StorageControl::from_stub::<std::sync::Arc<T>>(stub),
         }
     }
 


### PR DESCRIPTION
Change `from_stub` constructor to accept `U: Into<Arc<T>>` instead of just `T` for both `common` and `storage`. 

This allows higher flexibility when providing raw stubs or already-existing `Arc`-wrapped stubs in `tests/mocking`.

Staged @ https://github.com/googleapis/google-cloud-rust/pull/5457

Fixes https://github.com/googleapis/librarian/issues/3967