### PR TITLE
cleanup(sidekick/swift): codec init in tests

### DIFF
--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -86,6 +86,7 @@ func TestFieldTypeName_BaseMessage(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{outer, simple}, nil, nil)
+	model.State.MessageByID[nested.ID] = nested
 	c := newTestCodec(t, model, map[string]string{})
 
 	for _, test := range []struct {
@@ -144,6 +145,7 @@ func TestFieldTypeName_BaseEnum(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{outer}, []*api.Enum{simple}, nil)
+	model.State.EnumByID[nested.ID] = nested
 	c := newTestCodec(t, model, map[string]string{})
 
 	for _, test := range []struct {

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -78,24 +78,15 @@ func TestFieldTypeName_BaseMessage(t *testing.T) {
 		ID:      ".google.cloud.test.v1.OuterMessage.NestedMessage",
 		Parent:  outer,
 	}
+	outer.Messages = append(outer.Messages, nested)
 	simple := &api.Message{
 		Name:    "SimpleMessage",
 		Package: "google.cloud.test.v1",
 		ID:      ".google.cloud.test.v1.SimpleMessage",
 	}
 
-	c := &codec{
-		Model: &api.API{
-			PackageName: "google.cloud.test.v1",
-			State: &api.APIState{
-				MessageByID: map[string]*api.Message{
-					".google.cloud.test.v1.SimpleMessage":              simple,
-					".google.cloud.test.v1.OuterMessage":               outer,
-					".google.cloud.test.v1.OuterMessage.NestedMessage": nested,
-				},
-			},
-		},
-	}
+	model := api.NewTestAPI([]*api.Message{outer, simple}, nil, nil)
+	c := newTestCodec(t, model, map[string]string{})
 
 	for _, test := range []struct {
 		name  string
@@ -145,26 +136,15 @@ func TestFieldTypeName_BaseEnum(t *testing.T) {
 		ID:      ".google.cloud.test.v1.OuterMessage.NestedEnum",
 		Parent:  outer,
 	}
+	outer.Enums = append(outer.Enums, nested)
 	simple := &api.Enum{
 		Name:    "SimpleEnum",
 		Package: "google.cloud.test.v1",
 		ID:      ".google.cloud.test.v1.SimpleEnum",
 	}
 
-	c := &codec{
-		Model: &api.API{
-			PackageName: "google.cloud.test.v1",
-			State: &api.APIState{
-				EnumByID: map[string]*api.Enum{
-					".google.cloud.test.v1.SimpleEnum":              simple,
-					".google.cloud.test.v1.OuterMessage.NestedEnum": nested,
-				},
-				MessageByID: map[string]*api.Message{
-					".google.cloud.test.v1.OuterMessage": outer,
-				},
-			},
-		},
-	}
+	model := api.NewTestAPI([]*api.Message{outer}, []*api.Enum{simple}, nil)
+	c := newTestCodec(t, model, map[string]string{})
 
 	for _, test := range []struct {
 		name  string

--- a/internal/sidekick/swift/package_name_test.go
+++ b/internal/sidekick/swift/package_name_test.go
@@ -53,7 +53,9 @@ func TestPackageName(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := PackageName(&api.API{PackageName: test.input})
+			model := api.NewTestAPI(nil, nil, nil)
+			model.PackageName = test.input
+			got := PackageName(model)
 			if got != test.want {
 				t.Errorf("mismatch got = %q, want %q", got, test.want)
 			}


### PR DESCRIPTION
Several tests harcoded the `api.API` and codec initialization. This cleanup makes it marginally easier to understand what the tests are doing.