### PR TITLE
fix(internal/librarian/rust): remove comma-separated handling for include_list

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -389,7 +389,7 @@ This document describes the schema for the librarian.yaml.
 | `has_veneer` | bool | Indicates whether this module has a handwritten wrapper. |
 | `included_ids` | list of string | Is a list of proto IDs to include in generation. |
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
-| `include_list` | list of string | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
+| `include_list` | yaml.StringSlice | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
 | `internal_builders` | bool | Indicates whether generated builders should be internal to the crate. |
 | `module_path` | string | Is the Rust module path for converters (e.g., "crate::generated::gapic::model"). |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -389,7 +389,7 @@ This document describes the schema for the librarian.yaml.
 | `has_veneer` | bool | Indicates whether this module has a handwritten wrapper. |
 | `included_ids` | list of string | Is a list of proto IDs to include in generation. |
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
-| `include_list` | yaml.FlexibleStringSlice | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). TODO(https://github.com/googleapis/librarian/issues/4298): remove comma-separated string fallback unmarshaling in PR 3 (https://github.com/googleapis/librarian/issues/4769#issuecomment-4117482367) once google-cloud-rust is updated. |
+| `include_list` | list of string | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
 | `internal_builders` | bool | Indicates whether generated builders should be internal to the crate. |
 | `module_path` | string | Is the Rust module path for converters (e.g., "crate::generated::gapic::model"). |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -148,7 +148,7 @@ type RustModule struct {
 	IncludeGrpcOnlyMethods bool `yaml:"include_grpc_only_methods,omitempty"`
 
 	// IncludeList is a list of proto files to include (e.g., "date.proto", "expr.proto").
-	IncludeList []string `yaml:"include_list,omitempty"`
+	IncludeList yaml.StringSlice `yaml:"include_list,omitempty"`
 
 	// IncludeStreamingMethods indicates whether to include gRPC streaming
 	// methods.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -148,11 +148,7 @@ type RustModule struct {
 	IncludeGrpcOnlyMethods bool `yaml:"include_grpc_only_methods,omitempty"`
 
 	// IncludeList is a list of proto files to include (e.g., "date.proto", "expr.proto").
-	// TODO(https://github.com/googleapis/librarian/issues/4298):
-	// remove comma-separated string fallback unmarshaling in PR 3
-	// (https://github.com/googleapis/librarian/issues/4769#issuecomment-4117482367)
-	// once google-cloud-rust is updated.
-	IncludeList yaml.FlexibleStringSlice `yaml:"include_list,omitempty"`
+	IncludeList []string `yaml:"include_list,omitempty"`
 
 	// IncludeStreamingMethods indicates whether to include gRPC streaming
 	// methods.

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
+	"github.com/googleapis/librarian/internal/yaml"
 )
 
 const (
@@ -779,7 +780,7 @@ func TestModuleToModelConfig(t *testing.T) {
 							Template:    "prost",
 							IncludedIds: []string{"id1", "id2"},
 							SkippedIds:  []string{"id3", "id4"},
-							IncludeList: []string{"example-list"},
+							IncludeList: yaml.StringSlice{"example-list"},
 						},
 					},
 				},

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
-	"github.com/googleapis/librarian/internal/yaml"
 )
 
 const (
@@ -780,7 +779,7 @@ func TestModuleToModelConfig(t *testing.T) {
 							Template:    "prost",
 							IncludedIds: []string{"id1", "id2"},
 							SkippedIds:  []string{"id3", "id4"},
-							IncludeList: yaml.FlexibleStringSlice{"example-list"},
+							IncludeList: []string{"example-list"},
 						},
 					},
 				},

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -44,7 +44,6 @@ func (s StringSlice) IsZero() bool {
 	return s == nil
 }
 
-
 // Unmarshal parses YAML data into a value of type T.
 func Unmarshal[T any](data []byte) (*T, error) {
 	var v T

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -17,7 +17,6 @@ package yaml
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -45,47 +44,6 @@ func (s StringSlice) IsZero() bool {
 	return s == nil
 }
 
-// TODO: delete the FlexibleStringSlice once Rust has been migrated according to list syntax
-// (according to this PR):
-// https://github.com/googleapis/librarian/issues/4769#issuecomment-4117482367
-
-// FlexibleStringSlice is a custom slice of strings that unmarshals from either
-// a single comma-separated string or a YAML sequence of strings.
-//
-// By implementing the yaml.IsZeroer interface, it ensures that:
-//  1. A nil slice is considered "zero" and is omitted from the output.
-//  2. An empty but initialized slice (e.g., []string{}) is NOT considered "zero"
-//     and is explicitly marshaled as an empty YAML sequence ([]).
-type FlexibleStringSlice []string
-
-// IsZero implements the yaml.IsZeroer interface, which determines whether a
-// field should be considered "empty" when the 'omitempty' struct tag is used.
-func (s FlexibleStringSlice) IsZero() bool {
-	return s == nil
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface to support unmarshaling
-// from either a single comma-separated string or a YAML sequence of strings.
-func (s *FlexibleStringSlice) UnmarshalYAML(n *yaml.Node) error {
-	switch n.Kind {
-	case yaml.ScalarNode:
-		var res []string
-		parts := strings.Split(n.Value, ",")
-		for _, p := range parts {
-			if p = strings.TrimSpace(p); p != "" {
-				res = append(res, p)
-			}
-		}
-		*s = res
-		return nil
-
-	case yaml.SequenceNode:
-		return n.Decode((*[]string)(s))
-
-	default:
-		return fmt.Errorf("yaml: line %d: expected string or sequence, got %v", n.Line, n.ShortTag())
-	}
-}
 
 // Unmarshal parses YAML data into a value of type T.
 func Unmarshal[T any](data []byte) (*T, error) {

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -141,4 +141,3 @@ func TestStringSlice_NilSlice(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
-

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -141,45 +141,4 @@ func TestStringSlice_NilSlice(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
-func TestFlexibleStringSlice_Unmarshal(t *testing.T) {
-	type testStruct struct {
-		List FlexibleStringSlice `yaml:"list"`
-	}
 
-	for _, test := range []struct {
-		name  string
-		input string
-		want  []string
-	}{
-		{
-			name:  "sequence",
-			input: "list:\n  - a\n  - b\n",
-			want:  []string{"a", "b"},
-		},
-		{
-			name:  "string",
-			input: "list: a, b\n",
-			want:  []string{"a", "b"},
-		},
-		{
-			name:  "string_no_spaces",
-			input: "list: a,b\n",
-			want:  []string{"a", "b"},
-		},
-		{
-			name:  "empty",
-			input: "list: \"\"\n",
-			want:  nil,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := Unmarshal[testStruct]([]byte(test.input))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(test.want, []string(got.List)); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}


### PR DESCRIPTION
This change modifies Librarian to remove the FlexibleStringSlice type and its custom unmarshaling logic, which allowed include_list to be specified as a comma-separated string in librarian.yaml for Rust modules. Now, include_list must be specified as a YAML sequence (list) of strings. Tests and documentation are updated accordingly.

Fixes https://github.com/googleapis/librarian/issues/4298
For https://github.com/googleapis/librarian/issues/4769