### PR TITLE
fix(tool/cmd/migrate): preserve .readme-partials.yaml for nodejs

### DIFF
--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -47,6 +47,7 @@ var nodejsConfigFiles = []string{
 	".prettierignore",
 	".prettierrc.cjs",
 	".prettierrc.js",
+	".readme-partials.yaml",
 	".readme-partials.yml",
 	".repo-metadata.json",
 	"CHANGELOG.md",


### PR DESCRIPTION
Some google-cloud-node libraries use the .yaml extension rather than .yml for their README partials. Keep both filenames for the migration.

For https://github.com/googleapis/librarian/issues/4413
For https://github.com/googleapis/librarian/issues/5455