### PR TITLE
feat(sidekick/swift): support oneof groups

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -23,6 +23,7 @@ type messageAnnotations struct {
 	BoilerPlate   []string
 	Name          string
 	DocLines      []string
+	OneOfs        map[string]*oneOfAnnotations
 }
 
 func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
@@ -35,6 +36,13 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 	}
 
 	message.Codec = annotations
+	if len(message.OneOfs) != 0 {
+		annotations.OneOfs = make(map[string]*oneOfAnnotations)
+		for _, oneof := range message.OneOfs {
+			ann := codec.annotateOneOf(oneof)
+			annotations.OneOfs[oneof.Name] = ann
+		}
+	}
 	for _, field := range message.Fields {
 		if err := codec.annotateField(field); err != nil {
 			return err

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -23,7 +23,6 @@ type messageAnnotations struct {
 	BoilerPlate   []string
 	Name          string
 	DocLines      []string
-	OneOfs        map[string]*oneOfAnnotations
 }
 
 func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
@@ -36,12 +35,8 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 	}
 
 	message.Codec = annotations
-	if len(message.OneOfs) != 0 {
-		annotations.OneOfs = make(map[string]*oneOfAnnotations)
-		for _, oneof := range message.OneOfs {
-			ann := codec.annotateOneOf(oneof)
-			annotations.OneOfs[oneof.Name] = ann
-		}
+	for _, oneof := range message.OneOfs {
+		codec.annotateOneOf(oneof)
 	}
 	for _, field := range message.Fields {
 		if err := codec.annotateField(field); err != nil {

--- a/internal/sidekick/swift/annotate_oneof.go
+++ b/internal/sidekick/swift/annotate_oneof.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+type oneOfAnnotations struct {
+	Name         string
+	PropertyName string
+	DocLines     []string
+}
+
+func (codec *codec) annotateOneOf(oneof *api.OneOf) *oneOfAnnotations {
+	docLines := codec.formatDocumentation(oneof.Documentation)
+	annotations := &oneOfAnnotations{
+		Name:         "OneOf_" + pascalCase(oneof.Name),
+		PropertyName: camelCase(oneof.Name),
+		DocLines:     docLines,
+	}
+	oneof.Codec = annotations
+	return annotations
+}

--- a/internal/sidekick/swift/annotate_oneof.go
+++ b/internal/sidekick/swift/annotate_oneof.go
@@ -24,7 +24,7 @@ type oneOfAnnotations struct {
 	DocLines     []string
 }
 
-func (codec *codec) annotateOneOf(oneof *api.OneOf) *oneOfAnnotations {
+func (codec *codec) annotateOneOf(oneof *api.OneOf) {
 	docLines := codec.formatDocumentation(oneof.Documentation)
 	annotations := &oneOfAnnotations{
 		Name:         "OneOf_" + pascalCase(oneof.Name),
@@ -32,5 +32,4 @@ func (codec *codec) annotateOneOf(oneof *api.OneOf) *oneOfAnnotations {
 		DocLines:     docLines,
 	}
 	oneof.Codec = annotations
-	return annotations
 }

--- a/internal/sidekick/swift/annotate_oneof_test.go
+++ b/internal/sidekick/swift/annotate_oneof_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func TestAnnotateOneOf(t *testing.T) {
+	oneof := &api.OneOf{
+		Name:          "test_alternatives",
+		Documentation: "A test oneof.",
+	}
+	message := &api.Message{
+		Name:    "TestMessage",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.TestMessage",
+		OneOfs:  []*api.OneOf{oneof},
+	}
+	model := api.NewTestAPI([]*api.Message{message}, nil, nil)
+	model.PackageName = "google.cloud.test.v1"
+	codec := newTestCodec(t, model, map[string]string{})
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	gotAnn, ok := message.Codec.(*messageAnnotations)
+	if !ok {
+		t.Fatalf("expected message.Codec to be *messageAnnotations, got %T", message.Codec)
+	}
+
+	wantAnn := &oneOfAnnotations{
+		Name:         "OneOf_TestAlternatives",
+		PropertyName: "testAlternatives",
+		DocLines:     []string{"A test oneof."},
+	}
+	want := map[string]*oneOfAnnotations{oneof.Name: wantAnn}
+
+	if diff := cmp.Diff(want, gotAnn.OneOfs); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/annotate_oneof_test.go
+++ b/internal/sidekick/swift/annotate_oneof_test.go
@@ -39,19 +39,13 @@ func TestAnnotateOneOf(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotAnn, ok := message.Codec.(*messageAnnotations)
-	if !ok {
-		t.Fatalf("expected message.Codec to be *messageAnnotations, got %T", message.Codec)
-	}
-
-	wantAnn := &oneOfAnnotations{
+	want := &oneOfAnnotations{
 		Name:         "OneOf_TestAlternatives",
 		PropertyName: "testAlternatives",
 		DocLines:     []string{"A test oneof."},
 	}
-	want := map[string]*oneOfAnnotations{oneof.Name: wantAnn}
 
-	if diff := cmp.Diff(want, gotAnn.OneOfs); diff != "" {
+	if diff := cmp.Diff(want, oneof.Codec); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -102,7 +102,7 @@ func TestGenerateOneOf(t *testing.T) {
 	got := contentStr[startIdx:]
 
 	// I (coryan@) don't particularly like testing a big string like this. It is a bit of a change
-	// detector test. On the other hand, checking that the oneof fields are defined propertly, and
+	// detector test. On the other hand, checking that the oneof fields are defined properly, and
 	// that the constructor has the right arguments is more tedious and also becomes a change detector
 	// test.
 	//

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerateOneOf(t *testing.T) {
+	outDir := t.TempDir()
+
+	inner := &api.Message{
+		Name:    "Inner",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.Inner",
+	}
+
+	oneof := &api.OneOf{
+		Name:          "choice",
+		Documentation: "A group of fields where only one is set.",
+	}
+
+	outer := &api.Message{
+		Name:    "Outer",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.Outer",
+		Fields: []*api.Field{
+			{
+				Name:          "string_field",
+				ID:            ".google.cloud.test.v1.Outer.string_field",
+				Documentation: "A string field that is part of the oneof.",
+				Typez:         api.STRING_TYPE,
+				IsOneOf:       true,
+				Group:         oneof,
+			},
+			{
+				Name:          "message_field",
+				ID:            ".google.cloud.test.v1.Outer.message_field",
+				Documentation: "A message field that is part of the oneof.",
+				Typez:         api.MESSAGE_TYPE,
+				TypezID:       ".google.cloud.test.v1.Inner",
+				IsOneOf:       true,
+				Group:         oneof,
+			},
+			{
+				Name:          "regular_int32",
+				ID:            ".google.cloud.test.v1.Outer.regular_int32",
+				Documentation: "A regular field.",
+				Typez:         api.INT32_TYPE,
+			},
+			{
+				Name:          "regular_string",
+				ID:            ".google.cloud.test.v1.Outer.regular_string",
+				Documentation: "Another regular field.",
+				Typez:         api.STRING_TYPE,
+			},
+		},
+		OneOfs: []*api.OneOf{oneof},
+	}
+	oneof.Fields = []*api.Field{outer.Fields[0], outer.Fields[1]}
+
+	model := api.NewTestAPI([]*api.Message{outer, inner}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+	cfg := &parser.ModelConfig{}
+	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	filename := filepath.Join(expectedDir, "Outer.swift")
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+
+	// Extract content from "public struct Outer" to the end
+	startIdx := strings.Index(contentStr, "public struct Outer")
+	if startIdx == -1 {
+		t.Fatal("file does not contain 'public struct Outer'")
+	}
+	got := contentStr[startIdx:]
+
+	// I (coryan@) don't particularly like testing a big string like this. It is a bit of a change
+	// detector test. On the other hand, checking that the oneof fields are defined propertly, and
+	// that the constructor has the right arguments is more tedious and also becomes a change detector
+	// test.
+	//
+	// To verify the code compile, use something like: https://godbolt.org/z/EE9G7KTr8
+	want := `public struct Outer: Codable, Equatable {
+
+  /// A regular field.
+  public var regularInt32: Int32
+
+  /// Another regular field.
+  public var regularString: String
+
+  /// A group of fields where only one is set.
+  public var choice: OneOf_Choice?
+
+  /// Initialize a new instance of ` + "`Outer`" + `.
+  public init(
+    regularInt32: Int32 = Int32(),
+    regularString: String = String(),
+    choice: OneOf_Choice? = nil,
+  ) {
+    self.regularInt32 = regularInt32
+    self.regularString = regularString
+    self.choice = choice
+  }
+
+  /// A group of fields where only one is set.
+  public enum OneOf_Choice: Codable, Equatable {
+    /// A string field that is part of the oneof.
+    case stringField(String)
+    /// A message field that is part of the oneof.
+    indirect case messageField(Inner)
+  }
+}
+`
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -18,17 +18,27 @@ limitations under the License.
 {{/Codec.DocLines}}
 public struct {{Codec.Name}}: Codable, Equatable {
   {{#Fields}}
+  {{^IsOneOf}}
 
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
   public var {{Codec.Name}}: {{Codec.FieldType}}
+  {{/IsOneOf}}
   {{/Fields}}
+  {{#OneOfs}}
+
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  public var {{Codec.PropertyName}}: {{Codec.Name}}?
+  {{/OneOfs}}
 
   {{! Provide a memberwise initializer, with defaults for each field. }}
   /// Initialize a new instance of `{{Codec.Name}}`.
   public init(
     {{#Fields}}
+    {{^IsOneOf}}
     {{! Recall that fields can be Singular (and then Optional or not) or Repeated or Map }}
     {{#Singular}}
     {{^Optional}}
@@ -44,11 +54,20 @@ public struct {{Codec.Name}}: Codable, Equatable {
     {{#Map}}
     {{Codec.Name}}: {{Codec.FieldType}} = [:],
     {{/Map}}
+    {{/IsOneOf}}
     {{/Fields}}
+    {{#OneOfs}}
+    {{Codec.PropertyName}}: {{Codec.Name}}? = nil,
+    {{/OneOfs}}
   ) {
     {{#Fields}}
+    {{^IsOneOf}}
     self.{{Codec.Name}} = {{Codec.Name}}
+    {{/IsOneOf}}
     {{/Fields}}
+    {{#OneOfs}}
+    self.{{Codec.PropertyName}} = {{Codec.PropertyName}}
+    {{/OneOfs}}
   }
   {{#Messages}}
 
@@ -58,4 +77,8 @@ public struct {{Codec.Name}}: Codable, Equatable {
 
   {{> /templates/common/enum}}
   {{/Enums}}
+  {{#OneOfs}}
+
+  {{> /templates/common/oneof}}
+  {{/OneOfs}}
 }

--- a/internal/sidekick/swift/templates/common/oneof.mustache
+++ b/internal/sidekick/swift/templates/common/oneof.mustache
@@ -1,0 +1,31 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{#Codec.DocLines}}
+/// {{{.}}}
+{{/Codec.DocLines}}
+public enum {{Codec.Name}}: Codable, Equatable {
+  {{#Fields}}
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  {{^IsObject}}
+  case {{Codec.Name}}({{Codec.FieldType}})
+  {{/IsObject}}
+  {{#IsObject}}
+  indirect case {{Codec.Name}}({{Codec.FieldType}})
+  {{/IsObject}}
+  {{/Fields}}
+}


### PR DESCRIPTION
Oneofs are mapped to `enum` (the Swift sum types). They need a few annotations to handle naming. I used existing functions to generate `indirect case foo` vs. `case foo`.

It is useful to remember that `oneof` cannot contain repeated or map fields, that simplifies the generation of the different cases.

Fixes #5123 