### PR TITLE
ci: deflake downloads using `curl`

### DIFF
--- a/.github/actions/install-taplo/action.yaml
+++ b/.github/actions/install-taplo/action.yaml
@@ -18,7 +18,7 @@ runs:
     - name: Install taplo
       run: |
         set -e
-        curl -fsSL https://github.com/tamasfe/taplo/releases/download/$VERSION/taplo-linux-x86_64.gz | gunzip -c - | sudo install -m 0755 /dev/stdin /usr/local/bin/taplo
+        curl -fsSL --retry 5 --retry-delay 15 https://github.com/tamasfe/taplo/releases/download/$VERSION/taplo-linux-x86_64.gz | gunzip -c - | sudo install -m 0755 /dev/stdin /usr/local/bin/taplo
         sha512sum -c <(echo "$CHECKSUM /usr/local/bin/taplo")
         taplo --version
       shell: bash

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -107,7 +107,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install protoc
-RUN curl -fsSL -o /tmp/protoc.zip \
+RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
         https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
     echo "${PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip
@@ -127,7 +127,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust toolchain
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --retry 5 --retry-delay 15 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install Rust and components
@@ -166,14 +166,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pandoc
-RUN curl -fsSL -o /tmp/pandoc.tar.gz \
+RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/pandoc.tar.gz \
         https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz && \
     echo "${PANDOC_CHECKSUM} /tmp/pandoc.tar.gz" | sha512sum -c - && \
     tar -xvf /tmp/pandoc.tar.gz -C /usr/local --strip-components=1 && \
     rm /tmp/pandoc.tar.gz
 
 # Install Python-specific protoc version
-RUN curl -fsSL -o /tmp/protoc.zip \
+RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
         https://github.com/protocolbuffers/protobuf/releases/download/v${PYTHON_PROTOC_VERSION}/protoc-${PYTHON_PROTOC_VERSION}-linux-x86_64.zip && \
     echo "${PYTHON_PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip
@@ -227,7 +227,7 @@ RUN (export GOTOOLCHAIN='auto' && \
     go install golang.org/x/tools/cmd/goimports@${GO_GOIMPORTS_VERSION})
 
 # Install Go-specific protoc version
-RUN curl -fsSL -o /tmp/protoc.zip \
+RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
         https://github.com/protocolbuffers/protobuf/releases/download/v${GO_PROTOC_VERSION}/protoc-${GO_PROTOC_VERSION}-linux-x86_64.zip && \
     echo "${GO_PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip

--- a/infra/imagebuilders/cli/Dockerfile
+++ b/infra/imagebuilders/cli/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get install -y unzip \
 
 # Add Docker's official GPG key
 RUN install -m 0755 -d /etc/apt/keyrings
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+RUN curl -fsSL --retry 5 --retry-delay 15 https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 RUN chmod a+r /etc/apt/keyrings/docker.asc
 
 # Add the repository to Apt sources:
@@ -89,7 +89,7 @@ RUN apt update && \
 # Add the Google Cloud SDK distribution URI as a package source
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
     > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    curl -fsSL --retry 5 --retry-delay 15 https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
     gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 
 # Install the gcloud CLI

--- a/infra/test/token-access-test.yaml
+++ b/infra/test/token-access-test.yaml
@@ -46,7 +46,7 @@ steps:
           exit 1
         fi
         permission_url="https://api.github.com/repos/googleapis/${repo_name}/collaborators/${ROBOT_ACCOUNT}/permission"
-        curl --fail -H "Authorization: token ${GITHUB_TOKEN}" "${permission_url}"
+        curl --retry 5 --retry-delay 15 --fail -H "Authorization: token ${GITHUB_TOKEN}" "${permission_url}"
         if [[ $? -ne 0 ]]; then
           echo "Failed to validate credentials for repository: ${repo_name} via ${permission_url}"
           exit 1


### PR DESCRIPTION
Downloads via `curl` can and do fail due to transient errors. With this change we instruct `curl` to retry failures at least 5 times. This has no effect on successful downloads. It avoids temporary errors by trying again. It does slow down failures when the error is not temporary, but that seems like the lesser evil.

Fixes #5458 