### PR TITLE
feat(internal/librarian/java): add GapicArtifactIDOverride and enhance debug logging

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -250,13 +250,14 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `path` | string | Is the source path. |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
-| `samples` | bool (optional) | Determines whether to generate samples for the API, default is true when omitted. |
-| `path` | string | Is the source path. |
+| `gapic_artifact_id_override` | string | Overrides the artifact ID for the GAPIC module. It determines the module's directory name and is used to derive proto and gRPC artifact IDs if they are not explicitly overridden. |
+| `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
 | `proto_only` | bool | Determines whether to generate a Proto-only client. A proto-only client does not define a service in the proto files. |
-| `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |
+| `samples` | bool (optional) | Determines whether to generate samples for the API, default is true when omitted. |
 
 ## JavaModule Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -570,6 +570,9 @@ type JavaModule struct {
 
 // JavaAPI represents configuration for a single API within a Java module.
 type JavaAPI struct {
+	// Path is the source path.
+	Path string `yaml:"path,omitempty"`
+
 	// AdditionalProtos is a list of additional proto files to include in generation.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 
@@ -578,12 +581,14 @@ type JavaAPI struct {
 	// directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto").
 	ExcludedProtos []string `yaml:"excluded_protos,omitempty"`
 
-	// Samples determines whether to generate samples for the API,
-	// default is true when omitted.
-	Samples *bool `yaml:"samples,omitempty"`
+	// GapicArtifactIDOverride overrides the artifact ID for the GAPIC module.
+	// It determines the module's directory name and is used to derive proto
+	// and gRPC artifact IDs if they are not explicitly overridden.
+	GapicArtifactIDOverride string `yaml:"gapic_artifact_id_override,omitempty"`
 
-	// Path is the source path.
-	Path string `yaml:"path,omitempty"`
+	// GRPCArtifactIDOverride overrides the artifact ID for the gRPC module.
+	// The artifact ID is also used as the name for the module's directory.
+	GRPCArtifactIDOverride string `yaml:"grpc_artifact_id_override,omitempty"`
 
 	// ProtoArtifactIDOverride overrides the artifact ID for the proto module.
 	// The artifact ID is also used as the name for the module's directory.
@@ -593,9 +598,9 @@ type JavaAPI struct {
 	// A proto-only client does not define a service in the proto files.
 	ProtoOnly bool `yaml:"proto_only,omitempty"`
 
-	// GRPCArtifactIDOverride overrides the artifact ID for the gRPC module.
-	// The artifact ID is also used as the name for the module's directory.
-	GRPCArtifactIDOverride string `yaml:"grpc_artifact_id_override,omitempty"`
+	// Samples determines whether to generate samples for the API,
+	// default is true when omitted.
+	Samples *bool `yaml:"samples,omitempty"`
 }
 
 // DotnetPackage contains .NET-specific library configuration.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -581,10 +581,10 @@ type JavaAPI struct {
 	// directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto").
 	ExcludedProtos []string `yaml:"excluded_protos,omitempty"`
 
-	// GapicArtifactIDOverride overrides the artifact ID for the GAPIC module.
+	// GAPICArtifactIDOverride overrides the artifact ID for the GAPIC module.
 	// It determines the module's directory name and is used to derive proto
 	// and gRPC artifact IDs if they are not explicitly overridden.
-	GapicArtifactIDOverride string `yaml:"gapic_artifact_id_override,omitempty"`
+	GAPICArtifactIDOverride string `yaml:"gapic_artifact_id_override,omitempty"`
 
 	// GRPCArtifactIDOverride overrides the artifact ID for the gRPC module.
 	// The artifact ID is also used as the name for the module's directory.

--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -16,14 +16,12 @@ package java
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"syscall"
 
-	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 )
 
@@ -34,12 +32,6 @@ var versionRegexp = regexp.MustCompile(`src/main/java/com/google/cloud/.*/v.*/st
 // It targets patterns like proto-*, grpc-*, and the main GAPIC module.
 func Clean(library *config.Library) error {
 	patterns := cleanPatterns(library)
-	if command.Verbose {
-		fmt.Printf("Cleaning library %q in %q\n", library.Name, library.Output)
-		for p := range patterns {
-			fmt.Printf("  Cleaning pattern: %s\n", p)
-		}
-	}
 	keepSet := make(map[string]bool)
 	for _, k := range library.Keep {
 		keepSet[k] = true

--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -16,12 +16,14 @@ package java
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"syscall"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 )
 
@@ -32,6 +34,12 @@ var versionRegexp = regexp.MustCompile(`src/main/java/com/google/cloud/.*/v.*/st
 // It targets patterns like proto-*, grpc-*, and the main GAPIC module.
 func Clean(library *config.Library) error {
 	patterns := cleanPatterns(library)
+	if command.Verbose {
+		fmt.Printf("Cleaning library %q in %q\n", library.Name, library.Output)
+		for p := range patterns {
+			fmt.Printf("  Cleaning pattern: %s\n", p)
+		}
+	}
 	keepSet := make(map[string]bool)
 	for _, k := range library.Keep {
 		keepSet[k] = true
@@ -53,9 +61,8 @@ func Clean(library *config.Library) error {
 func cleanPatterns(library *config.Library) map[string]bool {
 	libraryCoordinates := DeriveLibraryCoordinates(library)
 	patterns := map[string]bool{
-		filepath.Join(libraryCoordinates.GAPIC.ArtifactID, "src"): true,
-		filepath.Join("samples", "snippets", "generated"):         true,
-		".repo-metadata.json": true,
+		filepath.Join("samples", "snippets", "generated"): true,
+		".repo-metadata.json":                             true,
 	}
 	for _, api := range library.APIs {
 		javaAPI := ResolveJavaAPI(library, api)
@@ -66,6 +73,9 @@ func cleanPatterns(library *config.Library) map[string]bool {
 		}
 		if apiCoordinates.GRPC.ArtifactID != "" {
 			patterns[filepath.Join(apiCoordinates.GRPC.ArtifactID, "src")] = true
+		}
+		if apiCoordinates.GAPIC.ArtifactID != "" {
+			patterns[filepath.Join(apiCoordinates.GAPIC.ArtifactID, "src")] = true
 		}
 	}
 	return patterns

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -211,7 +211,7 @@ func TestCleanPatterns(t *testing.T) {
 				filepath.Join("proto-google-cloud-secretmanager-v1beta1", "src"): true,
 				filepath.Join("grpc-google-cloud-secretmanager-v1beta1", "src"):  true,
 				filepath.Join("samples", "snippets", "generated"):                true,
-				".repo-metadata.json":                                            true,
+				".repo-metadata.json": true,
 			},
 		},
 		{

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -225,7 +225,7 @@ func TestCleanPatterns(t *testing.T) {
 					JavaAPIs: []*config.JavaAPI{
 						{
 							Path:                    "google/cloud/secretmanager/v1",
-							GapicArtifactIDOverride: "custom-gapic-artifact",
+							GAPICArtifactIDOverride: "custom-gapic-artifact",
 						},
 					},
 				},

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -195,6 +195,49 @@ func TestCleanPatterns(t *testing.T) {
 				".repo-metadata.json":                                  true,
 			},
 		},
+		{
+			name: "multiple_apis",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+					{Path: "google/cloud/secretmanager/v1beta1"},
+				},
+			},
+			want: map[string]bool{
+				filepath.Join("google-cloud-secretmanager", "src"):               true,
+				filepath.Join("proto-google-cloud-secretmanager-v1", "src"):      true,
+				filepath.Join("grpc-google-cloud-secretmanager-v1", "src"):       true,
+				filepath.Join("proto-google-cloud-secretmanager-v1beta1", "src"): true,
+				filepath.Join("grpc-google-cloud-secretmanager-v1beta1", "src"):  true,
+				filepath.Join("samples", "snippets", "generated"):                true,
+				".repo-metadata.json":                                            true,
+			},
+		},
+		{
+			name: "gapic_artifact_id_override",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{
+							Path:                    "google/cloud/secretmanager/v1",
+							GapicArtifactIDOverride: "custom-gapic-artifact",
+						},
+					},
+				},
+			},
+			want: map[string]bool{
+				filepath.Join("custom-gapic-artifact", "src"):          true,
+				filepath.Join("proto-custom-gapic-artifact-v1", "src"): true,
+				filepath.Join("grpc-custom-gapic-artifact-v1", "src"):  true,
+				filepath.Join("samples", "snippets", "generated"):      true,
+				".repo-metadata.json":                                  true,
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := cleanPatterns(test.library)

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -104,6 +104,9 @@ func DeriveLibraryCoordinates(library *config.Library) LibraryCoordinate {
 // DeriveAPICoordinates returns the Maven coordinates for the proto and gRPC
 // artifacts associated with a specific API version.
 func DeriveAPICoordinates(lc LibraryCoordinate, version string, javaAPI *config.JavaAPI) APICoordinate {
+	if javaAPI.GapicArtifactIDOverride != "" {
+		lc.GAPIC.ArtifactID = javaAPI.GapicArtifactIDOverride
+	}
 	protoGRPCGroupID := protoGroupID(lc.GAPIC.GroupID)
 	protoArtifactID := javaAPI.ProtoArtifactIDOverride
 	if protoArtifactID == "" {

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -104,8 +104,8 @@ func DeriveLibraryCoordinates(library *config.Library) LibraryCoordinate {
 // DeriveAPICoordinates returns the Maven coordinates for the proto and gRPC
 // artifacts associated with a specific API version.
 func DeriveAPICoordinates(lc LibraryCoordinate, version string, javaAPI *config.JavaAPI) APICoordinate {
-	if javaAPI.GapicArtifactIDOverride != "" {
-		lc.GAPIC.ArtifactID = javaAPI.GapicArtifactIDOverride
+	if javaAPI.GAPICArtifactIDOverride != "" {
+		lc.GAPIC.ArtifactID = javaAPI.GAPICArtifactIDOverride
 	}
 	protoGRPCGroupID := protoGroupID(lc.GAPIC.GroupID)
 	protoArtifactID := javaAPI.ProtoArtifactIDOverride

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -264,6 +264,30 @@ func TestDeriveAPICoordinates(t *testing.T) {
 			},
 			wantGRPC: Coordinate{},
 		},
+		{
+			name: "with gapic artifact id override",
+			lc: LibraryCoordinate{
+				GAPIC: Coordinate{
+					GroupID:    "com.google.cloud",
+					ArtifactID: "google-cloud-secretmanager",
+					Version:    "1.2.3",
+				},
+			},
+			version: "v1",
+			javaAPI: &config.JavaAPI{
+				GapicArtifactIDOverride: "custom-gapic-artifact",
+			},
+			wantProto: Coordinate{
+				GroupID:    "com.google.api.grpc",
+				ArtifactID: "proto-custom-gapic-artifact-v1",
+				Version:    "1.2.3",
+			},
+			wantGRPC: Coordinate{
+				GroupID:    "com.google.api.grpc",
+				ArtifactID: "grpc-custom-gapic-artifact-v1",
+				Version:    "1.2.3",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := DeriveAPICoordinates(test.lc, test.version, test.javaAPI)

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -275,7 +275,7 @@ func TestDeriveAPICoordinates(t *testing.T) {
 			},
 			version: "v1",
 			javaAPI: &config.JavaAPI{
-				GapicArtifactIDOverride: "custom-gapic-artifact",
+				GAPICArtifactIDOverride: "custom-gapic-artifact",
 			},
 			wantProto: Coordinate{
 				GroupID:    "com.google.api.grpc",

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -207,6 +207,9 @@ type moveAction struct {
 func restructure(actions []moveAction) error {
 	for _, action := range actions {
 		if _, err := os.Stat(action.src); err == nil {
+			if command.Verbose {
+				fmt.Printf("  Moving %s: %s -> %s\n", action.description, action.src, action.dest)
+			}
 			if err := os.MkdirAll(action.dest, 0755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", action.dest, err)
 			}
@@ -223,6 +226,16 @@ func restructure(actions []moveAction) error {
 // It also copies the relevant proto files into the proto module.
 func restructureModules(p postProcessParams, destRoot string) error {
 	coords := p.coords()
+
+	if command.Verbose {
+		fmt.Printf("Restructuring modules for API %q:\n", p.apiBase)
+		fmt.Printf("  Artifact IDs: Proto=%s, GRPC=%s, GAPIC=%s\n", coords.Proto.ArtifactID, coords.GRPC.ArtifactID, coords.GAPIC.ArtifactID)
+		fmt.Printf("  Staging paths (relative to %s):\n", destRoot)
+		fmt.Printf("    Proto: %s\n", coords.Proto.ArtifactID)
+		fmt.Printf("    GRPC:  %s\n", coords.GRPC.ArtifactID)
+		fmt.Printf("    GAPIC: %s\n", coords.GAPIC.ArtifactID)
+	}
+
 	tempProtoSrcDir := p.protoDir()
 	if err := removeConflictingFiles(tempProtoSrcDir); err != nil {
 		return err
@@ -329,6 +342,9 @@ func deriveLastReleasedVersion(v string) (string, error) {
 }
 
 func copyProtos(googleapisDir string, protos []string, destDir string) error {
+	if command.Verbose {
+		fmt.Printf("  Copying %d protos to %s\n", len(protos), destDir)
+	}
 	for _, proto := range protos {
 		// Calculate relative path from googleapisDir to preserve directory structure
 		rel, err := filepath.Rel(googleapisDir, proto)
@@ -336,6 +352,9 @@ func copyProtos(googleapisDir string, protos []string, destDir string) error {
 			return fmt.Errorf("failed to calculate relative path for %s: %w", proto, err)
 		}
 		target := filepath.Join(destDir, rel)
+		if command.Verbose {
+			fmt.Printf("    %s -> %s\n", rel, target)
+		}
 		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(target), err)
 		}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -207,9 +207,6 @@ type moveAction struct {
 func restructure(actions []moveAction) error {
 	for _, action := range actions {
 		if _, err := os.Stat(action.src); err == nil {
-			if command.Verbose {
-				fmt.Printf("  Moving %s: %s -> %s\n", action.description, action.src, action.dest)
-			}
 			if err := os.MkdirAll(action.dest, 0755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", action.dest, err)
 			}
@@ -226,16 +223,6 @@ func restructure(actions []moveAction) error {
 // It also copies the relevant proto files into the proto module.
 func restructureModules(p postProcessParams, destRoot string) error {
 	coords := p.coords()
-
-	if command.Verbose {
-		fmt.Printf("Restructuring modules for API %q:\n", p.apiBase)
-		fmt.Printf("  Artifact IDs: Proto=%s, GRPC=%s, GAPIC=%s\n", coords.Proto.ArtifactID, coords.GRPC.ArtifactID, coords.GAPIC.ArtifactID)
-		fmt.Printf("  Staging paths (relative to %s):\n", destRoot)
-		fmt.Printf("    Proto: %s\n", coords.Proto.ArtifactID)
-		fmt.Printf("    GRPC:  %s\n", coords.GRPC.ArtifactID)
-		fmt.Printf("    GAPIC: %s\n", coords.GAPIC.ArtifactID)
-	}
-
 	tempProtoSrcDir := p.protoDir()
 	if err := removeConflictingFiles(tempProtoSrcDir); err != nil {
 		return err
@@ -342,9 +329,6 @@ func deriveLastReleasedVersion(v string) (string, error) {
 }
 
 func copyProtos(googleapisDir string, protos []string, destDir string) error {
-	if command.Verbose {
-		fmt.Printf("  Copying %d protos to %s\n", len(protos), destDir)
-	}
 	for _, proto := range protos {
 		// Calculate relative path from googleapisDir to preserve directory structure
 		rel, err := filepath.Rel(googleapisDir, proto)
@@ -352,9 +336,6 @@ func copyProtos(googleapisDir string, protos []string, destDir string) error {
 			return fmt.Errorf("failed to calculate relative path for %s: %w", proto, err)
 		}
 		target := filepath.Join(destDir, rel)
-		if command.Verbose {
-			fmt.Printf("    %s -> %s\n", rel, target)
-		}
 		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(target), err)
 		}


### PR DESCRIPTION
Adds GapicArtifactIDOverride field  to the JavaAPI configuration, allowing for the customization of the GAPIC artifact ID on a per-API basis. This override is also used to derive proto and gRPC artifact IDs and output paths when they are not explicitly specified.

Libraries like storage and spanner needs this override.

The cleaning logic is updated to identify and remove files in overridden GAPIC directories. Restructure logic in post-processing is unchanged as it is per API path. Added debug logging to provide clearer visibility into the cleaning patterns used and the file restructuring actions.

Note that syncPOMs logic is not updated to deal with this override, will introduce a skip config separately.

For #5194