### PR TITLE
feat(sidekick/swift): external messages in methods

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -26,6 +26,9 @@ type messageAnnotations struct {
 }
 
 func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
+	if dep, ok := codec.ApiPackages[message.Package]; ok {
+		dep.Required = true
+	}
 	if message.Codec != nil {
 		return nil
 	}

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -26,6 +26,9 @@ type messageAnnotations struct {
 }
 
 func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
+	if message.Codec != nil {
+		return nil
+	}
 	docLines := codec.formatDocumentation(message.Documentation)
 	annotations := &messageAnnotations{
 		CopyrightYear: model.CopyrightYear,

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -28,7 +28,17 @@ type methodAnnotations struct {
 	BodyField      string
 }
 
-func (codec *codec) annotateMethod(method *api.Method) {
+func (codec *codec) annotateMethod(method *api.Method, model *modelAnnotations) error {
+	if method.InputType != nil {
+		if err := codec.annotateMessage(method.InputType, model); err != nil {
+			return err
+		}
+	}
+	if method.OutputType != nil {
+		if err := codec.annotateMessage(method.OutputType, model); err != nil {
+			return err
+		}
+	}
 	docLines := codec.formatDocumentation(method.Documentation)
 	binding := method.PathInfo.Bindings[0]
 	path := formatPath(binding.PathTemplate)
@@ -47,4 +57,5 @@ func (codec *codec) annotateMethod(method *api.Method) {
 		IsBodyWildcard: isBodyWildcard,
 		BodyField:      bodyField,
 	}
+	return nil
 }

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -155,3 +155,44 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotateMethod_WithExternalMessages(t *testing.T) {
+	inputMessage := &api.Message{
+		Name:    "InputMessage",
+		Package: "google.cloud.external.v1",
+		ID:      ".google.cloud.external.v1.InputMessage",
+	}
+	outputMessage := &api.Message{
+		Name:    "OutputMessage",
+		Package: "google.cloud.external.v1",
+		ID:      ".google.cloud.external.v1.OutputMessage",
+	}
+	method := &api.Method{
+		Name:       "TestMethod",
+		InputType:  inputMessage,
+		OutputType: outputMessage,
+		PathInfo: &api.PathInfo{
+			Bindings: []*api.PathBinding{{Verb: "POST", PathTemplate: &api.PathTemplate{}}},
+		},
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, nil, []*api.Service{service})
+	model.PackageName = "google.cloud.test.v1"
+	model.State.MessageByID[inputMessage.ID] = inputMessage
+	model.State.MessageByID[outputMessage.ID] = outputMessage
+	codec := newTestCodec(t, model, nil)
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	if inputMessage.Codec == nil {
+		t.Error("expected input message to be annotated")
+	}
+	if outputMessage.Codec == nil {
+		t.Error("expected output message to be annotated")
+	}
+}

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -65,7 +65,9 @@ func (codec *codec) annotateModel() error {
 		}
 	}
 	for _, service := range codec.Model.Services {
-		codec.annotateService(service, annotations)
+		if err := codec.annotateService(service, annotations); err != nil {
+			return err
+		}
 	}
 	for _, p := range codec.Dependencies {
 		if p.Required || (p.RequiredByServices && len(codec.Model.Services) != 0) {

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -28,12 +28,14 @@ type serviceAnnotations struct {
 	QuickstartMethod *api.Method
 }
 
-func (codec *codec) annotateService(service *api.Service, model *modelAnnotations) {
+func (codec *codec) annotateService(service *api.Service, model *modelAnnotations) error {
 	docLines := codec.formatDocumentation(service.Documentation)
 	var restMethods []*api.Method
 	for _, method := range service.Methods {
 		if isGeneratedMethod(method) {
-			codec.annotateMethod(method)
+			if err := codec.annotateMethod(method, model); err != nil {
+				return err
+			}
 			restMethods = append(restMethods, method)
 		}
 	}
@@ -51,6 +53,7 @@ func (codec *codec) annotateService(service *api.Service, model *modelAnnotation
 		QuickstartMethod: quickstartMethod,
 	}
 	service.Codec = annotations
+	return nil
 }
 
 func isGeneratedMethod(method *api.Method) bool {


### PR DESCRIPTION
Methods may use external messages, this is common with mixins. We need to annotate the message if they appear as the input or output type of a method.

Methods may use messages in external packages, they need to be annotated and their packages become "required". Towards #5395 