### PR TITLE
feat(internal/librarian/java): adds TransportOverride for .repo-metadata and update migrate tool

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -285,6 +285,7 @@ This document describes the schema for the librarian.yaml.
 | `billing_not_required` | bool | Indicates whether the API does NOT require billing. This is typically false. |
 | `rest_documentation` | string | Is the URL for the REST documentation. |
 | `rpc_documentation` | string | Is the URL for the RPC documentation. |
+| `transport_override` | string | Allows the "transport" field in .repo-metadata.json to be overridden. |
 
 ## NodejsAPI Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -566,6 +566,10 @@ type JavaModule struct {
 
 	// RpcDocumentation is the URL for the RPC documentation.
 	RpcDocumentation string `yaml:"rpc_documentation,omitempty"`
+
+	// TransportOverride allows the "transport" field in .repo-metadata.json
+	// to be overridden.
+	TransportOverride string `yaml:"transport_override,omitempty"`
 }
 
 // JavaAPI represents configuration for a single API within a Java module.

--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -148,6 +148,9 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		metadata.RecommendedPackage = library.Java.RecommendedPackage
 		metadata.RestDocumentation = library.Java.RestDocumentation
 		metadata.RpcDocumentation = library.Java.RpcDocumentation
+		if library.Java.TransportOverride != "" {
+			metadata.Transport = library.Java.TransportOverride
+		}
 	}
 
 	// distribution_name default for Java is groupId:artifactId
@@ -161,10 +164,12 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/java/docs/reference/%s/latest/overview", artifactID)
 	}
 	// transport
-	apiCfg, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, config.LanguageJava)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find api config: %w", err)
+	if metadata.Transport == "" {
+		apiCfg, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, config.LanguageJava)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find api config: %w", err)
+		}
+		metadata.Transport = apiCfg.RepoMetadataTransport(config.LanguageJava)
 	}
-	metadata.Transport = apiCfg.RepoMetadataTransport(config.LanguageJava)
 	return metadata, nil
 }

--- a/internal/librarian/java/repometadata_test.go
+++ b/internal/librarian/java/repometadata_test.go
@@ -79,11 +79,9 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 	cfg.Language = config.LanguageJava
 	cfg.Repo = "googleapis/google-cloud-java"
 	s := sample.RepoMetadata()
-
 	wantNamePretty := "Secret Manager"
 	wantProductDoc := "https://cloud.google.com/secret-manager/"
 	wantAPIDescription := "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security."
-
 	for _, test := range []struct {
 		name string
 		java *config.JavaModule

--- a/internal/librarian/java/repometadata_test.go
+++ b/internal/librarian/java/repometadata_test.go
@@ -73,12 +73,17 @@ func TestRepoMetadata_write(t *testing.T) {
 func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 	t.Parallel()
 	apiPath := "google/cloud/secretmanager/v1"
-	googleapis := "internal/testdata/googleapis"
+	googleapis := "../../testdata/googleapis"
 
 	cfg := sample.Config()
 	cfg.Language = config.LanguageJava
 	cfg.Repo = "googleapis/google-cloud-java"
 	s := sample.RepoMetadata()
+
+	wantNamePretty := "Secret Manager"
+	wantProductDoc := "https://cloud.google.com/secret-manager/"
+	wantAPIDescription := "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security."
+
 	for _, test := range []struct {
 		name string
 		java *config.JavaModule
@@ -121,18 +126,43 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 				APIShortnameOverride: "custom-shortname",
 			},
 			want: &repoMetadata{
-				APIShortname:        "custom-shortname",
-				ClientDocumentation: "https://cloud.google.com/java/docs/reference/google-cloud-secretmanager/latest/overview",
-				ReleaseLevel:        "stable",
-				Transport:           "both",
-				Language:            "java",
-				Repo:                "googleapis/google-cloud-java",
-				RepoShort:           "java-secretmanager",
-				DistributionName:    "com.google.cloud:google-cloud-secretmanager",
+				APIShortname:         "custom-shortname",
+				NamePretty:           wantNamePretty,
+				ProductDocumentation: wantProductDoc,
+				APIDescription:       wantAPIDescription,
+				ClientDocumentation:  "https://cloud.google.com/java/docs/reference/google-cloud-secretmanager/latest/overview",
+				ReleaseLevel:         "stable",
+				Transport:            "both",
+				Language:             "java",
+				Repo:                 "googleapis/google-cloud-java",
+				RepoShort:            "java-secretmanager",
+				DistributionName:     "com.google.cloud:google-cloud-secretmanager",
 				// API ID is also override.
 				APIID:           "custom-shortname.googleapis.com",
 				LibraryType:     "GAPIC_AUTO",
 				RequiresBilling: true,
+			},
+		},
+		{
+			name: "transport override",
+			java: &config.JavaModule{
+				TransportOverride: "rest",
+			},
+			want: &repoMetadata{
+				APIShortname:         "secretmanager",
+				NamePretty:           wantNamePretty,
+				ProductDocumentation: wantProductDoc,
+				APIDescription:       wantAPIDescription,
+				ClientDocumentation:  "https://cloud.google.com/java/docs/reference/google-cloud-secretmanager/latest/overview",
+				ReleaseLevel:         "stable",
+				Transport:            "rest",
+				Language:             "java",
+				Repo:                 "googleapis/google-cloud-java",
+				RepoShort:            "java-secretmanager",
+				DistributionName:     "com.google.cloud:google-cloud-secretmanager",
+				APIID:                "secretmanager.googleapis.com",
+				LibraryType:          "GAPIC_AUTO",
+				RequiresBilling:      true,
 			},
 		},
 	} {

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -284,6 +284,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				BillingNotRequired:           invertBoolPtr(l.RequiresBilling),
 				RestDocumentation:            l.RestDocumentation,
 				RpcDocumentation:             l.RpcDocumentation,
+				TransportOverride:            l.Transport,
 			},
 		}
 		if override, ok := keepOverride[lib.Name]; ok {

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -373,6 +373,7 @@ func TestBuildConfig(t *testing.T) {
 							BillingNotRequired:           true,
 							RestDocumentation:            "https://rest-doc.com",
 							RpcDocumentation:             "https://rpc-doc.com",
+							TransportOverride:            "grpc",
 						},
 					},
 				},


### PR DESCRIPTION
Adds TransportOverride for .repo-metadata only, and update migrate tool to migrate from generation_config.yaml field.

Fix #5480