### PR TITLE
feat(tool/cmd/migrate): add Java hardcoded GAPIC artifact ID overrides

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -261,7 +261,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			if shouldExcludeSamples(name, info) {
 				javaAPI.Samples = new(false)
 			}
-			applyJavaArtifactOverrides(name, javaAPI)
+			applyJavaArtifactOverrides(javaAPI)
 			applyJavaProtoOverrides(javaAPI)
 			javaAPIs = append(javaAPIs, javaAPI)
 		}
@@ -394,38 +394,17 @@ func parseArtifactID(distributionName, name string) string {
 
 // applyJavaArtifactOverrides sets artifact ID overrides for specific cases where
 // they don't follow the standard pattern.
-func applyJavaArtifactOverrides(name string, api *config.JavaAPI) {
-	switch {
-	case name == "datastore" && api.Path == "google/datastore/admin/v1":
-		api.ProtoArtifactIDOverride = "proto-google-cloud-datastore-admin-v1"
-		api.GRPCArtifactIDOverride = "grpc-google-cloud-datastore-admin-v1"
-	case name == "gsuite-addons" && api.Path == "google/apps/script/type":
-		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
-	case name == "gsuite-addons" && api.Path == "google/apps/script/type/docs":
-		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
-	case name == "gsuite-addons" && api.Path == "google/apps/script/type/drive":
-		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
-	case name == "gsuite-addons" && api.Path == "google/apps/script/type/gmail":
-		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
-	case name == "gsuite-addons" && api.Path == "google/apps/script/type/sheets":
-		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
-	case name == "gsuite-addons" && api.Path == "google/apps/script/type/slides":
-		api.ProtoArtifactIDOverride = "proto-google-apps-script-type-protos"
-	case name == "spanner" && api.Path == "google/spanner/admin/database/v1":
-		api.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-database-v1"
-		api.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-database-v1"
-	case name == "spanner" && api.Path == "google/spanner/admin/instance/v1":
-		api.ProtoArtifactIDOverride = "proto-google-cloud-spanner-admin-instance-v1"
-		api.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-admin-instance-v1"
-	case name == "spanner" && api.Path == "google/spanner/executor/v1":
-		api.ProtoArtifactIDOverride = "proto-google-cloud-spanner-executor-v1"
-		api.GRPCArtifactIDOverride = "grpc-google-cloud-spanner-executor-v1"
-	case name == "errorreporting" && api.Path == "google/devtools/clouderrorreporting/v1beta1":
-		api.ProtoArtifactIDOverride = "proto-google-cloud-error-reporting-v1beta1"
-		api.GRPCArtifactIDOverride = "grpc-google-cloud-error-reporting-v1beta1"
-	case name == "storage" && api.Path == "google/storage/control/v2":
-		api.ProtoArtifactIDOverride = "proto-google-cloud-storage-control-v2"
-		api.GRPCArtifactIDOverride = "grpc-google-cloud-storage-control-v2"
+func applyJavaArtifactOverrides(api *config.JavaAPI) {
+	if override, ok := javaArtifactIDOverrides[api.Path]; ok {
+		if override.protoArtifactID != "" {
+			api.ProtoArtifactIDOverride = override.protoArtifactID
+		}
+		if override.grpcArtifactID != "" {
+			api.GRPCArtifactIDOverride = override.grpcArtifactID
+		}
+		if override.gapicArtifactID != "" {
+			api.GAPICArtifactIDOverride = override.gapicArtifactID
+		}
 	}
 }
 

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -70,4 +70,61 @@ var (
 			"google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicyImpl.java",
 		},
 	}
+
+	javaArtifactIDOverrides = map[string]javaArtifactOverrides{
+		"google/datastore/admin/v1": {
+			protoArtifactID: "proto-google-cloud-datastore-admin-v1",
+			grpcArtifactID:  "grpc-google-cloud-datastore-admin-v1",
+		},
+		"google/apps/script/type": {
+			protoArtifactID: "proto-google-apps-script-type-protos",
+		},
+		"google/apps/script/type/docs": {
+			protoArtifactID: "proto-google-apps-script-type-protos",
+		},
+		"google/apps/script/type/drive": {
+			protoArtifactID: "proto-google-apps-script-type-protos",
+		},
+		"google/apps/script/type/gmail": {
+			protoArtifactID: "proto-google-apps-script-type-protos",
+		},
+		"google/apps/script/type/sheets": {
+			protoArtifactID: "proto-google-apps-script-type-protos",
+		},
+		"google/apps/script/type/slides": {
+			protoArtifactID: "proto-google-apps-script-type-protos",
+		},
+		"google/spanner/admin/database/v1": {
+			protoArtifactID: "proto-google-cloud-spanner-admin-database-v1",
+			grpcArtifactID:  "grpc-google-cloud-spanner-admin-database-v1",
+		},
+		"google/spanner/admin/instance/v1": {
+			protoArtifactID: "proto-google-cloud-spanner-admin-instance-v1",
+			grpcArtifactID:  "grpc-google-cloud-spanner-admin-instance-v1",
+		},
+		"google/spanner/executor/v1": {
+			protoArtifactID: "proto-google-cloud-spanner-executor-v1",
+			grpcArtifactID:  "grpc-google-cloud-spanner-executor-v1",
+		},
+		"google/devtools/clouderrorreporting/v1beta1": {
+			protoArtifactID: "proto-google-cloud-error-reporting-v1beta1",
+			grpcArtifactID:  "grpc-google-cloud-error-reporting-v1beta1",
+		},
+		"google/storage/v2": {
+			protoArtifactID: "proto-google-cloud-storage-v2",
+			grpcArtifactID:  "grpc-google-cloud-storage-v2",
+			gapicArtifactID: "gapic-google-cloud-storage-v2",
+		},
+		"google/storage/control/v2": {
+			protoArtifactID: "proto-google-cloud-storage-control-v2",
+			grpcArtifactID:  "grpc-google-cloud-storage-control-v2",
+			gapicArtifactID: "google-cloud-storage-control",
+		},
+	}
 )
+
+type javaArtifactOverrides struct {
+	protoArtifactID string
+	grpcArtifactID  string
+	gapicArtifactID string
+}

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -660,7 +660,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 			protoPath:   "google/datastore/admin/v1",
 			wantJavaAPI: &config.JavaAPI{
 				Path:                    "google/datastore/admin/v1",
-				Samples:                 func(b bool) *bool { return &b }(false),
+				Samples:                 new(false),
 				ProtoArtifactIDOverride: "proto-google-cloud-datastore-admin-v1",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-datastore-admin-v1",
 			},
@@ -671,7 +671,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 			protoPath:   "google/storage/control/v2",
 			wantJavaAPI: &config.JavaAPI{
 				Path:                    "google/storage/control/v2",
-				Samples:                 func(b bool) *bool { return &b }(false),
+				Samples:                 new(false),
 				GAPICArtifactIDOverride: "google-cloud-storage-control",
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-control-v2",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-control-v2",

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -648,60 +648,86 @@ func TestShouldExcludeSamples(t *testing.T) {
 }
 
 func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
-	gen := &GenerationConfig{
-		Libraries: []LibraryConfig{
-			{
-				LibraryName: "datastore",
-				GAPICs: []GAPICConfig{
-					{ProtoPath: "google/datastore/admin/v1"},
-				},
+	for _, test := range []struct {
+		name        string
+		libraryName string
+		protoPath   string
+		wantJavaAPI *config.JavaAPI
+	}{
+		{
+			name:        "datastore admin v1",
+			libraryName: "datastore",
+			protoPath:   "google/datastore/admin/v1",
+			wantJavaAPI: &config.JavaAPI{
+				Path:                    "google/datastore/admin/v1",
+				Samples:                 func(b bool) *bool { return &b }(false),
+				ProtoArtifactIDOverride: "proto-google-cloud-datastore-admin-v1",
+				GRPCArtifactIDOverride:  "grpc-google-cloud-datastore-admin-v1",
 			},
 		},
-	}
-	srcDir := t.TempDir()
-	buildFile := filepath.Join(srcDir, "google/datastore/admin/v1", "BUILD.bazel")
-	if err := os.MkdirAll(filepath.Dir(buildFile), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(buildFile, []byte(`java_gapic_library(name = "datastore_java_gapic")`), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	want := &config.Config{
-		Language: "java",
-		Repo:     "googleapis/google-cloud-java",
-		Default: &config.Default{
-			Java: &config.JavaModule{},
+		{
+			name:        "storage control v2",
+			libraryName: "storage",
+			protoPath:   "google/storage/control/v2",
+			wantJavaAPI: &config.JavaAPI{
+				Path:                    "google/storage/control/v2",
+				Samples:                 func(b bool) *bool { return &b }(false),
+				GAPICArtifactIDOverride: "google-cloud-storage-control",
+				ProtoArtifactIDOverride: "proto-google-cloud-storage-control-v2",
+				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-control-v2",
+			},
 		},
-		Sources: &config.Sources{
-			Googleapis: &config.Source{Dir: srcDir},
-		},
-		Libraries: []*config.Library{
-			{
-				Name: "datastore",
-				APIs: []*config.API{
-					{Path: "google/datastore/admin/v1"},
-				},
-				Java: &config.JavaModule{
-					JavaAPIs: []*config.JavaAPI{
-						{
-							Path:                    "google/datastore/admin/v1",
-							Samples:                 func(b bool) *bool { return &b }(false),
-							ProtoArtifactIDOverride: "proto-google-cloud-datastore-admin-v1",
-							GRPCArtifactIDOverride:  "grpc-google-cloud-datastore-admin-v1",
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gen := &GenerationConfig{
+				Libraries: []LibraryConfig{
+					{
+						LibraryName: test.libraryName,
+						GAPICs: []GAPICConfig{
+							{ProtoPath: test.protoPath},
 						},
 					},
 				},
-			},
-		},
-	}
+			}
+			srcDir := t.TempDir()
+			buildFile := filepath.Join(srcDir, test.protoPath, "BUILD.bazel")
+			if err := os.MkdirAll(filepath.Dir(buildFile), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(buildFile, []byte(`java_gapic_library(name = "test_java_gapic")`), 0644); err != nil {
+				t.Fatal(err)
+			}
 
-	got, err := buildConfig(gen, ".", &config.Source{Dir: srcDir}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+			want := &config.Config{
+				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
+				Default: &config.Default{
+					Java: &config.JavaModule{},
+				},
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Dir: srcDir},
+				},
+				Libraries: []*config.Library{
+					{
+						Name: test.libraryName,
+						APIs: []*config.API{
+							{Path: test.protoPath},
+						},
+						Java: &config.JavaModule{
+							JavaAPIs: []*config.JavaAPI{test.wantJavaAPI},
+						},
+					},
+				},
+			}
+
+			got, err := buildConfig(gen, ".", &config.Source{Dir: srcDir}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The hardcoded Java artifact ID overrides in applyJavaArtifactOverrides are moved to a structured map in java_module.go. 

Additionally, GAPIC artifact ID overrides are added for the google/storage/control/v2 and google/storage/v2 API paths to support custom module names in the migration tool.

For #5194