### PR TITLE
feat(sidekick/swift): generate query parameters

### DIFF
--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -32,7 +32,8 @@ type methodAnnotations struct {
 
 // HasQueryParams returns true if the method's default binding has query parameters
 //
-// The mustache templates use this to avoid
+// The mustache templates use this to (1) use a `var query` vs. `let query` for the collection of
+// query parameters, and (2) generate the query parameter encoder only once, and only if needed.
 func (ann *methodAnnotations) HasQueryParams() bool {
 	return len(ann.QueryParams) != 0
 }

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/language"
 )
 
 type methodAnnotations struct {
@@ -26,6 +27,14 @@ type methodAnnotations struct {
 	HasBody        bool
 	IsBodyWildcard bool
 	BodyField      string
+	QueryParams    []*api.Field
+}
+
+// HasQueryParams returns true if the method's default binding has query parameters
+//
+// The mustache templates use this to avoid
+func (ann *methodAnnotations) HasQueryParams() bool {
+	return len(ann.QueryParams) != 0
 }
 
 func (codec *codec) annotateMethod(method *api.Method) {
@@ -46,5 +55,6 @@ func (codec *codec) annotateMethod(method *api.Method) {
 		HasBody:        hasBody,
 		IsBodyWildcard: isBodyWildcard,
 		BodyField:      bodyField,
+		QueryParams:    language.QueryParams(method, binding),
 	}
 }

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -22,6 +22,19 @@ import (
 )
 
 func TestAnnotateMethod(t *testing.T) {
+	keyField := &api.Field{Name: "key", ID: ".test.Request.key", Typez: api.STRING_TYPE}
+	inputType := &api.Message{
+		Name:   "Request",
+		ID:     ".test.Request",
+		Fields: []*api.Field{keyField},
+	}
+	outputType := &api.Message{
+		Name: "Response",
+		ID:   ".test.Response",
+		Fields: []*api.Field{
+			{Name: "value", ID: ".test.Request.value", Typez: api.STRING_TYPE},
+		},
+	}
 	for _, test := range []struct {
 		name   string
 		method *api.Method
@@ -94,10 +107,40 @@ func TestAnnotateMethod(t *testing.T) {
 				IsBodyWildcard: true,
 			},
 		},
+		{
+			name: "List request",
+			method: &api.Method{
+				Name:          "ListThings",
+				Documentation: "Lists things.",
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							Verb:            "GET",
+							PathTemplate:    api.NewPathTemplate().WithLiteral("v1").WithLiteral("things"),
+							QueryParameters: map[string]bool{"key": true},
+						},
+					},
+				},
+			},
+			want: &methodAnnotations{
+				Name:        "listThings",
+				Path:        "/v1/things",
+				DocLines:    []string{"Lists things."},
+				HTTPMethod:  "GET",
+				HasBody:     false,
+				QueryParams: []*api.Field{keyField},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			test.method.InputType = inputType
+			test.method.InputTypeID = inputType.ID
+			test.method.OutputType = outputType
+			test.method.OutputTypeID = outputType.ID
 			service := &api.Service{
 				Name:    "TestService",
+				ID:      ".test.TestService",
+				Package: "test",
 				Methods: []*api.Method{test.method},
 			}
 			model := api.NewTestAPI(nil, nil, []*api.Service{service})
@@ -124,12 +167,30 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 		{"escaped default", "Default", "`default`"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			inputType := &api.Message{
+				Name: "Request",
+				ID:   ".test.Request",
+				Fields: []*api.Field{
+					{Name: "key", ID: ".test.Request.key", Typez: api.STRING_TYPE},
+				},
+			}
+			outputType := &api.Message{
+				Name: "Response",
+				ID:   ".test.Response",
+				Fields: []*api.Field{
+					{Name: "value", ID: ".test.Request.value", Typez: api.STRING_TYPE},
+				},
+			}
 			method := &api.Method{
 				Name:          test.methodName,
 				Documentation: "Test documentation.",
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
 				},
+				InputTypeID:  inputType.ID,
+				InputType:    inputType,
+				OutputTypeID: outputType.ID,
+				OutputType:   outputType,
 			}
 			service := &api.Service{
 				Name:    "TestService",

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -111,7 +111,6 @@ func TestAnnotateService_SkipNoBindings(t *testing.T) {
 				InputType:    inputType,
 				OutputTypeID: outputType.ID,
 				OutputType:   outputType,
-				PathInfo:     nil,
 			},
 		},
 	}

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -70,24 +70,48 @@ func TestAnnotateService(t *testing.T) {
 }
 
 func TestAnnotateService_SkipNoBindings(t *testing.T) {
+	inputType := &api.Message{
+		Name:    "Request",
+		ID:      ".test.Request",
+		Package: "test",
+	}
+	outputType := &api.Message{
+		Name:    "Response",
+		ID:      ".test.Response",
+		Package: "test",
+	}
 	service := &api.Service{
-		Name: "TestService",
+		Name:    "TestService",
+		ID:      ".test.TestService",
+		Package: "test",
 		Methods: []*api.Method{
 			{
-				Name: "ValidMethod",
+				Name:         "ValidMethod",
+				InputTypeID:  inputType.ID,
+				InputType:    inputType,
+				OutputTypeID: outputType.ID,
+				OutputType:   outputType,
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
 				},
 			},
 			{
-				Name: "NoBindingMethod",
+				Name:         "NoBindingMethod",
+				InputTypeID:  inputType.ID,
+				InputType:    inputType,
+				OutputTypeID: outputType.ID,
+				OutputType:   outputType,
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{},
 				},
 			},
 			{
-				Name:     "NilPathInfoMethod",
-				PathInfo: nil,
+				Name:         "NilPathInfoMethod",
+				InputTypeID:  inputType.ID,
+				InputType:    inputType,
+				OutputTypeID: outputType.ID,
+				OutputType:   outputType,
+				PathInfo:     nil,
 			},
 		},
 	}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -55,9 +55,20 @@ public class {{Codec.Name}} {
     -> {{OutputType.Codec.Name}}
     {{/ReturnsEmpty}}
   {
-    let query = [
-      URLQueryItem(name: "$alt", value: "json")
-    ]
+    {{#Codec.HasQueryParams}}
+    var query = [URLQueryItem(name: "$alt", value: "json")]
+    let encoder = GoogleCloudGax.QueryParameterEncoder()
+    {{/Codec.HasQueryParams}}
+    {{^Codec.HasQueryParams}}
+    let query = [URLQueryItem(name: "$alt", value: "json")]
+    {{/Codec.HasQueryParams}}
+    {{#Codec.QueryParams}}
+    {{!
+      Note that `Codec.Name` includes mangling and escaping, while `JSONName` does not. We want the latter
+      for the query parameter name, and the former to access the field in the Swift struct.
+    }}
+    query.append(contentsOf: try encoder.encode(request.{{Codec.Name}}, prefix: "{{JSONName}}"))
+    {{/Codec.QueryParams}}
     var req = try await self.inner.Request(path: "{{{Codec.Path}}}", query: query)
     req.httpMethod = "{{Codec.HTTPMethod}}"
     {{#Codec.HasBody}}


### PR DESCRIPTION
Compute the query parameters for the default binding and use them in the generated code. We have existing code in sidekick to compute the query parameters, so this is not that difficult.

Fixes #5220 