### PR TITLE
chore(tool/cmd/migrate): add containeranalysis to hardcoded no samples

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -28,11 +28,12 @@ var (
 	}
 
 	excludedSamplesLibraries = map[string]bool{
-		"bigquerystorage": true,
-		"datastore":       true,
-		"logging":         true,
-		"storage":         true,
-		"spanner":         true,
+		"bigquerystorage":   true,
+		"datastore":         true,
+		"logging":           true,
+		"storage":           true,
+		"spanner":           true,
+		"containeranalysis": true,
 	}
 
 	keepOverride = map[string][]string{


### PR DESCRIPTION
Added containeranalysis to hardcoded no samples list. Currently in google-cloud-java, this is done via [.OwlBot-hermetic.yaml](https://github.com/googleapis/google-cloud-java/blob/b9747401648621103ef02d2c0f62a27177251bf8/java-containeranalysis/.OwlBot-hermetic.yaml#L29-L35) missing copy sample dir lines.

For https://github.com/googleapis/librarian/issues/5498