### PR TITLE
fix(internal/legacylibrarian/legacygithub): imporve retry backoffs

### DIFF
--- a/internal/legacylibrarian/legacygithub/github.go
+++ b/internal/legacylibrarian/legacygithub/github.go
@@ -71,10 +71,8 @@ func (t *retryableTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 		if resp != nil {
 			if after := resp.Header.Get("Retry-After"); after != "" {
-				if d, err := time.ParseDuration(after + "s"); err == nil {
-					if d > delay {
-						delay = d
-					}
+				if d, err := time.ParseDuration(after + "s"); err == nil && d > delay {
+					delay = d
 				}
 			}
 		}

--- a/internal/legacylibrarian/legacygithub/github.go
+++ b/internal/legacylibrarian/legacygithub/github.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -30,9 +31,10 @@ import (
 )
 
 const (
-	maxRetries = 3
+	maxRetries = 5
 	retryDelay = 2 * time.Second
 	maxDelay   = 60 * time.Second
+	multiplier = 2.0
 )
 
 type retryableTransport struct {
@@ -46,6 +48,7 @@ type retryableTransport struct {
 func (t *retryableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
+	b := newBackoff()
 	for i := 0; i < maxRetries; i++ {
 		resp, err = t.transport.RoundTrip(req)
 		if err == nil &&
@@ -63,15 +66,16 @@ func (t *retryableTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 		delay := t.delay
 		if delay == 0 {
-			if resp != nil {
-				if after := resp.Header.Get("Retry-After"); after != "" {
-					if d, err := time.ParseDuration(after + "s"); err == nil {
+			delay = b.pause()
+		}
+
+		if resp != nil {
+			if after := resp.Header.Get("Retry-After"); after != "" {
+				if d, err := time.ParseDuration(after + "s"); err == nil {
+					if d > delay {
 						delay = d
 					}
 				}
-			}
-			if delay == 0 {
-				delay = retryDelay
 			}
 		}
 		if delay > maxDelay {
@@ -81,6 +85,36 @@ func (t *retryableTransport) RoundTrip(req *http.Request) (*http.Response, error
 		t.sleep(delay)
 	}
 	return resp, err
+}
+
+// backoff implements exponential backoff for retry delays with jitter.
+type backoff struct {
+	initial    time.Duration
+	max        time.Duration
+	multiplier float64
+	cur        time.Duration
+}
+
+// newBackoff creates a new backoff with default settings.
+func newBackoff() *backoff {
+	return &backoff{
+		initial:    retryDelay,
+		max:        maxDelay,
+		multiplier: multiplier,
+	}
+}
+
+// pause returns the time to wait before the next retry.
+func (b *backoff) pause() time.Duration {
+	if b.cur == 0 {
+		b.cur = b.initial
+	}
+	d := time.Duration(1 + rand.Int63n(int64(b.cur)))
+	b.cur = time.Duration(float64(b.cur) * b.multiplier)
+	if b.cur > b.max {
+		b.cur = b.max
+	}
+	return d
 }
 
 // PullRequest is a type alias for the go-github type.

--- a/internal/legacylibrarian/legacygithub/github_test.go
+++ b/internal/legacylibrarian/legacygithub/github_test.go
@@ -1085,7 +1085,7 @@ func TestRetryableTransport(t *testing.T) {
 			},
 			wantStatusCode:   http.StatusServiceUnavailable,
 			wantErr:          true,
-			wantRequestCount: 3,
+			wantRequestCount: 5,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -1176,5 +1176,56 @@ func TestNewClient(t *testing.T) {
 				t.Fatalf("expected to create a new client")
 			}
 		})
+	}
+}
+
+func TestBackoff(t *testing.T) {
+	b := &backoff{
+		initial:    2 * time.Second,
+		max:        10 * time.Second,
+		multiplier: 2.0,
+	}
+
+	// Attempt 1
+	d1 := b.pause()
+	if d1 < 1 || d1 > 2*time.Second {
+		t.Errorf("pause() = %v, want in range [1ns, 2s]", d1)
+	}
+
+	// Attempt 2
+	d2 := b.pause()
+	if d2 < 1 || d2 > 4*time.Second {
+		t.Errorf("pause() = %v, want in range [1ns, 4s]", d2)
+	}
+
+	// Attempt 3
+	d3 := b.pause()
+	if d3 < 1 || d3 > 8*time.Second {
+		t.Errorf("pause() = %v, want in range [1ns, 8s]", d3)
+	}
+
+	// Attempt 4 (should hit max)
+	d4 := b.pause()
+	if d4 < 1 || d4 > 10*time.Second {
+		t.Errorf("pause() = %v, want in range [1ns, 10s]", d4)
+	}
+
+	// Attempt 5 (should still hit max)
+	d5 := b.pause()
+	if d5 < 1 || d5 > 10*time.Second {
+		t.Errorf("pause() = %v, want in range [1ns, 10s]", d5)
+	}
+}
+
+func TestNewBackoff(t *testing.T) {
+	b := newBackoff()
+	if b.initial != retryDelay {
+		t.Errorf("newBackoff().initial = %v, want %v", b.initial, retryDelay)
+	}
+	if b.max != maxDelay {
+		t.Errorf("newBackoff().max = %v, want %v", b.max, maxDelay)
+	}
+	if b.multiplier != multiplier {
+		t.Errorf("newBackoff().multiplier = %v, want %v", b.multiplier, multiplier)
 	}
 }


### PR DESCRIPTION
I noticed we have been susceptible to mini outages with github which can cause churn for the rotation. Because of this I have reworked how to retry as well as increase the time we spend retrying. On average we will retry for 15 seconds instead of the flat 6 seconds with the previous logic. Additionally, since we now support jitter there is a max of 30 seconds. This logic is a simplified version of what is done in gax-go: https://github.com/googleapis/gax-go/blob/a50a68cbfd92781c64d586f0052c498f99346180/v2/call_option.go#L169-L208

Internal Bug: b/504721078