### PR TITLE
chore(internal/librarian): switch preview resolution on language

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -94,11 +94,11 @@ func runGenerate(ctx context.Context, cfg *config.Config, all bool, libraryName 
 			return err
 		}
 		if !all && isPreview {
-			prepared = ResolvePreview(prepared)
+			prepared = ResolvePreview(prepared, cfg.Language)
 		} else if all && lib.Preview != nil {
 			// Generate both stable and preview libraries by first appending the
 			// resolved library config for the preview variant.
-			libraries = append(libraries, ResolvePreview(prepared))
+			libraries = append(libraries, ResolvePreview(prepared, cfg.Language))
 		}
 		libraries = append(libraries, prepared)
 	}

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -304,7 +304,7 @@ func FindLibrary(c *config.Config, name string) (*config.Library, error) {
 // ResolvePreview returns a library where fields from lib.Preview override
 // those in the base lib, if set. If lib.Preview is not set or lib itself is nil
 // this returns nil.
-func ResolvePreview(lib *config.Library) *config.Library {
+func ResolvePreview(lib *config.Library, language string) *config.Library {
 	if lib == nil || lib.Preview == nil {
 		return nil
 	}
@@ -343,13 +343,22 @@ func ResolvePreview(lib *config.Library) *config.Library {
 	if p.SpecificationFormat != "" {
 		res.SpecificationFormat = p.SpecificationFormat
 	}
-	res.Dotnet = mergeDotnet(res.Dotnet, p.Dotnet)
-	res.Dart = mergeDart(res.Dart, p.Dart)
-	res.Go = mergeGo(res.Go, p.Go)
-	res.Java = mergeJava(res.Java, p.Java)
-	res.Nodejs = mergeNodejs(res.Nodejs, p.Nodejs)
-	res.Python = mergePython(res.Python, p.Python)
-	res.Rust = mergeRust(res.Rust, p.Rust)
+	switch language {
+	case config.LanguageDotnet:
+		res.Dotnet = mergeDotnet(res.Dotnet, p.Dotnet)
+	case config.LanguageDart:
+		res.Dart = mergeDart(res.Dart, p.Dart)
+	case config.LanguageGo:
+		res.Go = mergeGo(res.Go, p.Go)
+	case config.LanguageJava:
+		res.Java = mergeJava(res.Java, p.Java)
+	case config.LanguageNodejs:
+		res.Nodejs = mergeNodejs(res.Nodejs, p.Nodejs)
+	case config.LanguagePython:
+		res.Python = mergePython(res.Python, p.Python)
+	case config.LanguageRust:
+		res.Rust = mergeRust(res.Rust, p.Rust)
+	}
 	res.Preview = nil
 	return &res
 }

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -760,7 +760,7 @@ func TestResolvePreview(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := ResolvePreview(test.lib)
+			got := ResolvePreview(test.lib, config.LanguageGo)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -787,7 +787,7 @@ func TestResolvePreview_NoMutation(t *testing.T) {
 
 	want := *lib
 
-	_ = ResolvePreview(lib)
+	_ = ResolvePreview(lib, config.LanguageGo)
 
 	if diff := cmp.Diff(want, *lib); diff != "" {
 		t.Errorf("ResolvePreview mutated the input library (-want +got):\n%s", diff)


### PR DESCRIPTION
Simple refactor to make `ResolvePreview` less wasteful/error prone around extraneous, language-specific merge calls.