### PR TITLE
feat(sidekick/swift): generate `Any` support code

### DIFF
--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -56,6 +56,13 @@ func TestGenerate(t *testing.T) {
 			Name:          "GoogleType",
 			APIs:          []*config.API{{Path: "google/type"}},
 			CopyrightYear: "2038",
+			Swift: &config.SwiftPackage{
+				SwiftDefault: config.SwiftDefault{
+					Dependencies: []config.SwiftDependency{
+						{Name: "GoogleCloudWkt", ApiPackage: "google.protobuf"},
+					},
+				},
+			},
 		},
 	}
 	for _, library := range libraries {

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	typeUrlPrefix = "type.googleapis.com/"
+	typeURLPrefix = "type.googleapis.com/"
 )
 
 type messageAnnotations struct {
@@ -39,7 +39,7 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 		BoilerPlate:   model.BoilerPlate,
 		Name:          pascalCase(message.Name),
 		DocLines:      docLines,
-		TypeURL:       typeUrlPrefix + strings.TrimPrefix(message.ID, "."),
+		TypeURL:       typeURLPrefix + strings.TrimPrefix(message.ID, "."),
 	}
 
 	message.Codec = annotations

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -15,7 +15,13 @@
 package swift
 
 import (
+	"strings"
+
 	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+const (
+	typeUrlPrefix = "type.googleapis.com/"
 )
 
 type messageAnnotations struct {
@@ -23,6 +29,7 @@ type messageAnnotations struct {
 	BoilerPlate   []string
 	Name          string
 	DocLines      []string
+	TypeURL       string
 }
 
 func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
@@ -32,6 +39,7 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 		BoilerPlate:   model.BoilerPlate,
 		Name:          pascalCase(message.Name),
 		DocLines:      docLines,
+		TypeURL:       typeUrlPrefix + strings.TrimPrefix(message.ID, "."),
 	}
 
 	message.Codec = annotations

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -44,6 +44,7 @@ func TestAnnotateMessage(t *testing.T) {
 	want := &messageAnnotations{
 		Name:     "Secret",
 		DocLines: []string{"A secret message.", "With two lines."},
+		TypeURL:  "type.googleapis.com/test.Secret",
 	}
 
 	if diff := cmp.Diff(want, msg.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "BoilerPlate", "CopyrightYear")); diff != "" {
@@ -66,6 +67,7 @@ func TestAnnotateMessage_EscapedName(t *testing.T) {
 	want := &messageAnnotations{
 		Name:     "Protocol_",
 		DocLines: []string{"A message named Protocol."},
+		TypeURL:  "type.googleapis.com/test.Protocol",
 	}
 
 	if diff := cmp.Diff(want, msg.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "BoilerPlate", "CopyrightYear")); diff != "" {

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -59,6 +59,11 @@ func (codec *codec) annotateModel() error {
 			return err
 		}
 	}
+	// If there is at least one message, the generated library depends on `GoogleCloudWkt` because
+	// the generated messages must conform to the `GoogleCloudWkt._AnyPackable` protocol.
+	if dep, ok := codec.ApiPackages[wellKnownPackage]; ok && len(codec.Model.Messages) != 0 {
+		dep.Required = true
+	}
 	for _, enum := range codec.Model.Enums {
 		if err := codec.annotateEnum(enum, annotations); err != nil {
 			return err

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	"cmp"
+	"fmt"
 	"maps"
 	"slices"
 
@@ -45,6 +46,13 @@ func (ann *modelAnnotations) Dependencies() []*Dependency {
 	return deps
 }
 
+func (ann *modelAnnotations) WktPackage() string {
+	if dep, ok := ann.DependsOn[wellKnownPackage]; ok {
+		return dep.Name
+	}
+	panic("if the wkt package is missing we would return an error in the annotation phase")
+}
+
 func (codec *codec) annotateModel() error {
 	annotations := &modelAnnotations{
 		CopyrightYear: codec.GenerationYear,
@@ -61,8 +69,12 @@ func (codec *codec) annotateModel() error {
 	}
 	// If there is at least one message, the generated library depends on `GoogleCloudWkt` because
 	// the generated messages must conform to the `GoogleCloudWkt._AnyPackable` protocol.
-	if dep, ok := codec.ApiPackages[wellKnownPackage]; ok && len(codec.Model.Messages) != 0 {
-		dep.Required = true
+	if len(codec.Model.Messages) != 0 {
+		if dep, ok := codec.ApiPackages[wellKnownPackage]; ok {
+			dep.Required = true
+		} else {
+			return fmt.Errorf("missing dependency for `google.protobuf` this is required to generate the `Any` extensions")
+		}
 	}
 	for _, enum := range codec.Model.Enums {
 		if err := codec.annotateEnum(enum, annotations); err != nil {

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -41,6 +41,53 @@ func TestModelAnnotations(t *testing.T) {
 	}
 }
 
+func TestModelAnnotations_MessagesWithWkt(t *testing.T) {
+	enum := &api.Enum{
+		Name: "SomeEnum", ID: ".test.SomeSnum", Package: "test",
+		Values: []*api.EnumValue{{Name: "UNSPECIFIED", Number: 0}},
+	}
+	enum.UniqueNumberValues = enum.Values
+	for _, test := range []struct {
+		name  string
+		model *api.API
+		want  map[string]bool
+	}{
+		{
+			name: "Messages with wkt",
+			model: api.NewTestAPI(
+				[]*api.Message{{Name: "Request", ID: ".test.Request", Package: "test"}}, nil, nil),
+			want: map[string]bool{"GoogleCloudWkt": true},
+		},
+		{
+			name:  "Enum with wkt",
+			model: api.NewTestAPI(nil, []*api.Enum{enum}, nil),
+			want:  map[string]bool{"GoogleCloudWkt": false},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			codec := newTestCodec(t, test.model, map[string]string{})
+			wkt := &Dependency{
+				SwiftDependency: config.SwiftDependency{
+					ApiPackage: "google.protobuf",
+					Name:       "GoogleCloudWkt",
+				},
+			}
+			codec.ApiPackages = map[string]*Dependency{wkt.ApiPackage: wkt}
+			codec.Dependencies = []*Dependency{wkt}
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			got := map[string]bool{}
+			for _, d := range codec.Dependencies {
+				got[d.Name] = d.Required
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 	externalMessage := &api.Message{
 		Name:    "ExternalMessage",

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -66,14 +66,6 @@ func TestModelAnnotations_MessagesWithWkt(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			codec := newTestCodec(t, test.model, map[string]string{})
-			wkt := &Dependency{
-				SwiftDependency: config.SwiftDependency{
-					ApiPackage: "google.protobuf",
-					Name:       "GoogleCloudWkt",
-				},
-			}
-			codec.ApiPackages = map[string]*Dependency{wkt.ApiPackage: wkt}
-			codec.Dependencies = []*Dependency{wkt}
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
@@ -112,23 +104,10 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 		[]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	model.State.MessageByID[externalMessage.ID] = externalMessage
 	codec := newTestCodec(t, model, nil)
-	dep1 := &Dependency{
-		SwiftDependency: config.SwiftDependency{
-			ApiPackage: "google.cloud.external.v1",
-			Name:       "external-package",
-		},
-	}
-	dep2 := &Dependency{
-		SwiftDependency: config.SwiftDependency{
-			ApiPackage: "google.cloud.unused.v1",
-			Name:       "unused-package",
-		},
-	}
-	codec.ApiPackages = map[string]*Dependency{
-		"google.cloud.external.v1": dep1,
-		"google.cloud.unused.v1":   dep2,
-	}
-	codec.Dependencies = []*Dependency{dep1, dep2}
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{ApiPackage: "google.cloud.external.v1", Name: "external-package"},
+		{ApiPackage: "google.cloud.unused.v1", Name: "unused-package"},
+	})
 
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
@@ -144,6 +123,13 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 			SwiftDependency: config.SwiftDependency{
 				ApiPackage: "google.cloud.external.v1",
 				Name:       "external-package",
+			},
+			Required: true,
+		},
+		"GoogleCloudWkt": {
+			SwiftDependency: config.SwiftDependency{
+				ApiPackage: "google.protobuf",
+				Name:       "GoogleCloudWkt",
 			},
 			Required: true,
 		},

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -24,6 +24,10 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
+const (
+	wellKnownPackage = "google.protobuf"
+)
+
 // codec represents the configuration for a Swift sidekick Codec.
 //
 // A sideckick Codec is a package that generates libraries from an `api.API`

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -87,9 +87,30 @@ func newTestCodec(t *testing.T, model *api.API, options map[string]string) *code
 	cfg := &parser.ModelConfig{
 		Codec: options,
 	}
-	codec, err := newCodec(model, cfg, nil, ".")
+	swiftCfg := &config.SwiftPackage{
+		SwiftDefault: config.SwiftDefault{
+			Dependencies: []config.SwiftDependency{
+				{Name: "GoogleCloudWkt", ApiPackage: wellKnownPackage},
+			},
+		},
+	}
+	codec, err := newCodec(model, cfg, swiftCfg, ".")
 	if err != nil {
 		t.Fatal(err)
 	}
 	return codec
+}
+
+func (codec *codec) withExtraDependencies(t *testing.T, deps []config.SwiftDependency) {
+	t.Helper()
+	for _, d := range deps {
+		dep := &Dependency{SwiftDependency: d}
+		if d.ApiPackage != "" {
+			if _, ok := codec.ApiPackages[d.ApiPackage]; ok {
+				t.Fatalf("conflicting definition for %s", d.ApiPackage)
+			}
+			codec.ApiPackages[d.ApiPackage] = dep
+		}
+		codec.Dependencies = append(codec.Dependencies, dep)
+	}
 }

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -361,18 +361,16 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 	model.PackageName = "google.cloud.test.v1"
 	model.State.MessageByID[externalMessage.ID] = externalMessage
 	c := newTestCodec(t, model, nil)
-	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+	c.withExtraDependencies(t, []config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.external.v1",
 			Name:       "ExternalPackage",
 		},
-	}
-	c.ApiPackages["google.cloud.unused.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.unused.v1",
 			Name:       "UnusedPackage",
 		},
-	}
+	})
 
 	got, err := c.messageTypeName(externalMessage)
 	if err != nil {
@@ -384,6 +382,7 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 	}
 
 	wantRequired := map[string]bool{
+		"google.protobuf":          false,
 		"google.cloud.external.v1": true,
 		"google.cloud.unused.v1":   false,
 	}
@@ -407,18 +406,16 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 	model.PackageName = "google.cloud.test.v1"
 	model.State.EnumByID[externalEnum.ID] = externalEnum
 	c := newTestCodec(t, model, nil)
-	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+	c.withExtraDependencies(t, []config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.external.v1",
 			Name:       "ExternalPackage",
 		},
-	}
-	c.ApiPackages["google.cloud.unused.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.unused.v1",
 			Name:       "UnusedPackage",
 		},
-	}
+	})
 
 	got, err := c.enumTypeName(externalEnum)
 	if err != nil {
@@ -430,6 +427,7 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 	}
 
 	wantRequired := map[string]bool{
+		"google.protobuf":          false,
 		"google.cloud.external.v1": true,
 		"google.cloud.unused.v1":   false,
 	}
@@ -461,12 +459,12 @@ func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
 	model.State.MessageByID[externalNested.ID] = externalNested
 	model.State.MessageByID[externalOuter.ID] = externalOuter
 	c := newTestCodec(t, model, nil)
-	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+	c.withExtraDependencies(t, []config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.external.v1",
 			Name:       "ExternalPackage",
 		},
-	}
+	})
 
 	got, err := c.messageTypeName(externalNested)
 	if err != nil {

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -92,14 +92,14 @@ func TestGenerateMessage_WithNestedMessages(t *testing.T) {
 	}
 	contentStr := string(content)
 
-	gotBlock1 := extractBlock(t, contentStr, "public struct Nested1", "Equatable {")
-	wantBlock1 := "public struct Nested1: Codable, Equatable {"
+	gotBlock1 := extractBlock(t, contentStr, "public struct Nested1", "._AnyPackable {")
+	wantBlock1 := "public struct Nested1: Codable, Equatable, GoogleCloudWkt._AnyPackable {"
 	if diff := cmp.Diff(wantBlock1, gotBlock1); diff != "" {
 		t.Errorf("mismatch in Nested1 (-want +got):\n%s", diff)
 	}
 
-	gotBlock2 := extractBlock(t, contentStr, "public struct Nested2", "Equatable {")
-	wantBlock2 := "public struct Nested2: Codable, Equatable {"
+	gotBlock2 := extractBlock(t, contentStr, "public struct Nested2", "._AnyPackable {")
+	wantBlock2 := "public struct Nested2: Codable, Equatable, GoogleCloudWkt._AnyPackable {"
 	if diff := cmp.Diff(wantBlock2, gotBlock2); diff != "" {
 		t.Errorf("mismatch in Nested2 (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -20,9 +20,20 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
+
+func testSwiftConfig() *config.SwiftPackage {
+	return &config.SwiftPackage{
+		SwiftDefault: config.SwiftDefault{
+			Dependencies: []config.SwiftDependency{
+				{Name: "GoogleCloudWkt", ApiPackage: wellKnownPackage},
+			},
+		},
+	}
+}
 
 func TestGenerateMessage_Files(t *testing.T) {
 	outDir := t.TempDir()
@@ -39,7 +50,7 @@ func TestGenerateMessage_Files(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, testSwiftConfig()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -73,7 +84,7 @@ func TestGenerateMessage_WithNestedMessages(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, testSwiftConfig()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +139,7 @@ func TestGenerateMessage_WithNestedEnum(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, testSwiftConfig()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_test.go
+++ b/internal/sidekick/swift/generate_test.go
@@ -58,7 +58,7 @@ func TestFromProtobuf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, testSwiftConfig()); err != nil {
 		t.Fatal(err)
 	}
 	filename := filepath.Join(outDir, "README.md")

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -60,10 +60,10 @@ public struct {{Codec.Name}}: Codable, Equatable, GoogleCloudWkt._AnyPackable {
   {{/Enums}}
 
   public static var _anyTypeUrl: String { return "{{Codec.TypeURL}}" }
-  public init(fromAny any: GoogleCloudWkt.`Any`) throws {
-    self = try GoogleCloudWkt._slowAnyDeserialize(Self.self, from: any)
+  public init(fromAny any: {{Model.Codec.WktPackage}}.`Any`) throws {
+    self = try {{Model.Codec.WktPackage}}._slowAnyDeserialize(Self.self, from: any)
   }
-  public func _pack() throws -> GoogleCloudWkt.Struct {
-    return try GoogleCloudWkt._slowAnySerialize(message: self)
+  public func _pack() throws -> {{Model.Codec.WktPackage}}.Struct {
+    return try {{Model.Codec.WktPackage}}._slowAnySerialize(message: self)
   }
 }

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -16,7 +16,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
-public struct {{Codec.Name}}: Codable, Equatable {
+public struct {{Codec.Name}}: Codable, Equatable, GoogleCloudWkt._AnyPackable {
   {{#Fields}}
 
   {{#Codec.DocLines}}
@@ -58,4 +58,12 @@ public struct {{Codec.Name}}: Codable, Equatable {
 
   {{> /templates/common/enum}}
   {{/Enums}}
+
+  public static var _anyTypeUrl: String { return "{{Codec.TypeURL}}" }
+  public init(fromAny any: GoogleCloudWkt.`Any`) throws {
+    self = try GoogleCloudWkt._slowAnyDeserialize(Self.self, from: any)
+  }
+  public func _pack() throws -> Struct {
+    return try GoogleCloudWkt._slowAnySerialize(message: self)
+  }
 }

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -63,7 +63,7 @@ public struct {{Codec.Name}}: Codable, Equatable, GoogleCloudWkt._AnyPackable {
   public init(fromAny any: GoogleCloudWkt.`Any`) throws {
     self = try GoogleCloudWkt._slowAnyDeserialize(Self.self, from: any)
   }
-  public func _pack() throws -> Struct {
+  public func _pack() throws -> GoogleCloudWkt.Struct {
     return try GoogleCloudWkt._slowAnySerialize(message: self)
   }
 }


### PR DESCRIPTION
All generated messages need to conform to the `*Wkt._AnyPackable` protocol. Which means that any package with messages also depends on whatever package providers the `google.protobuf` source package.

Fixes #5401 
