### PR TITLE
feat(sidekick/swift): methods returning nothing

### DIFF
--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -51,8 +51,9 @@ public class {{Codec.Name}} {
   /// {{{.}}}
   {{/Codec.DocLines}}
   public func {{Codec.Name}}(request: {{InputType.Codec.Name}}) async throws
-    {{! TODO(#5138) - deal with `google.proto.Empty` and other complex return types }}
+    {{^ReturnsEmpty}}
     -> {{OutputType.Codec.Name}}
+    {{/ReturnsEmpty}}
   {
     let query = [
       URLQueryItem(name: "$alt", value: "json")
@@ -79,7 +80,9 @@ public class {{Codec.Name}} {
         payload: data,
       ))
     }
+    {{^ReturnsEmpty}}
     return try JSONDecoder().decode({{OutputType.Codec.Name}}.self, from: data)
+    {{/ReturnsEmpty}}
   }
   {{/Codec.RestMethods}}
 }


### PR DESCRIPTION
For methods returning `google.protobuf.Empty` (or the equivalent OpenAPI and discovery-doc construct) we want to generate Swift methods that return nothing.

Fixes #5138 