### PR TITLE
cleanup(sidekick/swift): return modified arguments

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -28,7 +28,7 @@ type enumAnnotations struct {
 	DefaultCaseName string
 }
 
-func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
+func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) (*api.Enum, error) {
 	existing := map[int32]*enumValueAnnotations{}
 	var defaultCaseName string
 	for _, ev := range enum.UniqueNumberValues {
@@ -43,12 +43,12 @@ func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error 
 		if len(enum.UniqueNumberValues) != 0 {
 			defaultCaseName = enum.UniqueNumberValues[0].Codec.(*enumValueAnnotations).CaseName
 		} else {
-			return fmt.Errorf("cannot determine a default value for enum: %s", enum.ID)
+			return nil, fmt.Errorf("cannot determine a default value for enum: %s", enum.ID)
 		}
 	}
 	for _, ev := range enum.Values {
-		if err := codec.annotateEnumValue(ev, existing); err != nil {
-			return err
+		if _, err := codec.annotateEnumValue(ev, existing); err != nil {
+			return nil, err
 		}
 		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
 	}
@@ -63,5 +63,5 @@ func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error 
 	}
 
 	enum.Codec = annotations
-	return nil
+	return enum, nil
 }

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -70,7 +70,7 @@ func TestAnnotateEnum(t *testing.T) {
 			}
 			model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 			codec := newTestCodec(t, model, map[string]string{})
-			if err := codec.annotateModel(); err != nil {
+			if _, err := annotateModel(codec); err != nil {
 				t.Fatal(err)
 			}
 			want := &enumAnnotations{
@@ -95,7 +95,7 @@ func TestAnnotateEnum_Error(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
 
-	err := codec.annotateModel()
+	_, err := annotateModel(codec)
 	if err == nil {
 		t.Errorf("annotateModel() expected error for enum with no values, got nil")
 	}

--- a/internal/sidekick/swift/annotate_enum_value.go
+++ b/internal/sidekick/swift/annotate_enum_value.go
@@ -27,7 +27,7 @@ type enumValueAnnotations struct {
 	DocLines    []string
 }
 
-func (codec *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
+func (codec *codec) annotateUniqueEnumValue(ev *api.EnumValue) *api.EnumValue {
 	docLines := codec.formatDocumentation(ev.Documentation)
 	ann := &enumValueAnnotations{
 		CaseName:    enumValueCaseName(ev),
@@ -36,15 +36,16 @@ func (codec *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
 		DocLines:    docLines,
 	}
 	ev.Codec = ann
+	return ev
 }
 
-func (codec *codec) annotateEnumValue(ev *api.EnumValue, unique map[int32]*enumValueAnnotations) error {
+func (codec *codec) annotateEnumValue(ev *api.EnumValue, unique map[int32]*enumValueAnnotations) (*api.EnumValue, error) {
 	if ev.Codec != nil {
-		return nil
+		return ev, nil
 	}
 	existing, ok := unique[ev.Number]
 	if !ok {
-		return fmt.Errorf("expected an existing annotation for %s as it duplicates the integer value %d", ev.Name, ev.Number)
+		return nil, fmt.Errorf("expected an existing annotation for %s as it duplicates the integer value %d", ev.Name, ev.Number)
 	}
 	ann := &enumValueAnnotations{
 		CaseName:    existing.CaseName,
@@ -52,5 +53,5 @@ func (codec *codec) annotateEnumValue(ev *api.EnumValue, unique map[int32]*enumV
 		StringValue: ev.Name,
 	}
 	ev.Codec = ann
-	return nil
+	return ev, nil
 }

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -29,7 +29,7 @@ func TestAnnotateEnumValue_WithDocs(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 
@@ -59,7 +59,7 @@ func TestAnnotateEnumValue_Multiple(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 
@@ -97,7 +97,7 @@ func TestAnnotateEnumValue_Aliases(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -24,10 +24,10 @@ type fieldAnnotations struct {
 	DocLines  []string
 }
 
-func (codec *codec) annotateField(field *api.Field) error {
+func (codec *codec) annotateField(field *api.Field) (*api.Field, error) {
 	fieldType, err := codec.fieldTypeName(field)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	annotations := &fieldAnnotations{
 		Name:      camelCase(field.Name),
@@ -35,5 +35,5 @@ func (codec *codec) annotateField(field *api.Field) error {
 		DocLines:  codec.formatDocumentation(field.Documentation),
 	}
 	field.Codec = annotations
-	return nil
+	return field, nil
 }

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -36,7 +36,7 @@ func TestAnnotateField(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 	want := &fieldAnnotations{
@@ -75,7 +75,7 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 			}
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 			codec := newTestCodec(t, model, map[string]string{})
-			if err := codec.annotateModel(); err != nil {
+			if _, err := annotateModel(codec); err != nil {
 				t.Fatal(err)
 			}
 			want := &fieldAnnotations{

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -24,12 +24,12 @@ type messageAnnotations struct {
 	Model    *modelAnnotations
 }
 
-func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
+func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) (*api.Message, error) {
 	if dep, ok := codec.ApiPackages[message.Package]; ok {
 		dep.Required = true
 	}
 	if message.Codec != nil {
-		return nil
+		return nil, nil
 	}
 	docLines := codec.formatDocumentation(message.Documentation)
 	annotations := &messageAnnotations{
@@ -40,22 +40,22 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 
 	message.Codec = annotations
 	for _, oneof := range message.OneOfs {
-		codec.annotateOneOf(oneof)
+		_ = codec.annotateOneOf(oneof)
 	}
 	for _, field := range message.Fields {
-		if err := codec.annotateField(field); err != nil {
-			return err
+		if _, err := codec.annotateField(field); err != nil {
+			return nil, err
 		}
 	}
 	for _, nested := range message.Messages {
-		if err := codec.annotateMessage(nested, model); err != nil {
-			return err
+		if _, err := codec.annotateMessage(nested, model); err != nil {
+			return nil, err
 		}
 	}
 	for _, enum := range message.Enums {
-		if err := codec.annotateEnum(enum, model); err != nil {
-			return err
+		if _, err := codec.annotateEnum(enum, model); err != nil {
+			return nil, err
 		}
 	}
-	return nil
+	return message, nil
 }

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -29,7 +29,7 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 		dep.Required = true
 	}
 	if message.Codec != nil {
-		return nil, nil
+		return message, nil
 	}
 	docLines := codec.formatDocumentation(message.Documentation)
 	annotations := &messageAnnotations{

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -38,7 +38,7 @@ func TestAnnotateMessage(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 	want := &messageAnnotations{
@@ -60,7 +60,7 @@ func TestAnnotateMessage_EscapedName(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 	want := &messageAnnotations{

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -38,15 +38,15 @@ func (ann *methodAnnotations) HasQueryParams() bool {
 	return len(ann.QueryParams) != 0
 }
 
-func (codec *codec) annotateMethod(method *api.Method, model *modelAnnotations) error {
+func (codec *codec) annotateMethod(method *api.Method, model *modelAnnotations) (*api.Method, error) {
 	if method.InputType != nil {
-		if err := codec.annotateMessage(method.InputType, model); err != nil {
-			return err
+		if _, err := codec.annotateMessage(method.InputType, model); err != nil {
+			return nil, err
 		}
 	}
 	if method.OutputType != nil {
-		if err := codec.annotateMessage(method.OutputType, model); err != nil {
-			return err
+		if _, err := codec.annotateMessage(method.OutputType, model); err != nil {
+			return nil, err
 		}
 	}
 	docLines := codec.formatDocumentation(method.Documentation)
@@ -68,5 +68,5 @@ func (codec *codec) annotateMethod(method *api.Method, model *modelAnnotations) 
 		BodyField:      bodyField,
 		QueryParams:    language.QueryParams(method, binding),
 	}
-	return nil
+	return method, nil
 }

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -145,7 +145,7 @@ func TestAnnotateMethod(t *testing.T) {
 			}
 			model := api.NewTestAPI(nil, nil, []*api.Service{service})
 			codec := newTestCodec(t, model, nil)
-			if err := codec.annotateModel(); err != nil {
+			if _, err := annotateModel(codec); err != nil {
 				t.Fatal(err)
 			}
 			got := test.method.Codec.(*methodAnnotations)
@@ -199,7 +199,7 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 			model := api.NewTestAPI(nil, nil, []*api.Service{service})
 			codec := newTestCodec(t, model, nil)
 
-			if err := codec.annotateModel(); err != nil {
+			if _, err := annotateModel(codec); err != nil {
 				t.Fatal(err)
 			}
 
@@ -246,7 +246,7 @@ func TestAnnotateMethod_WithExternalMessages(t *testing.T) {
 	model.State.MessageByID[outputMessage.ID] = outputMessage
 	codec := newTestCodec(t, model, nil)
 
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -46,7 +46,7 @@ func (ann *modelAnnotations) Dependencies() []*Dependency {
 	return deps
 }
 
-func (codec *codec) annotateModel() error {
+func annotateModel(codec *codec) (*codec, error) {
 	annotations := &modelAnnotations{
 		CopyrightYear: codec.GenerationYear,
 		BoilerPlate:   license.HeaderBulk(),
@@ -56,18 +56,18 @@ func (codec *codec) annotateModel() error {
 	}
 	codec.Model.Codec = annotations
 	for _, message := range codec.Model.Messages {
-		if err := codec.annotateMessage(message, annotations); err != nil {
-			return err
+		if _, err := codec.annotateMessage(message, annotations); err != nil {
+			return nil, err
 		}
 	}
 	for _, enum := range codec.Model.Enums {
-		if err := codec.annotateEnum(enum, annotations); err != nil {
-			return err
+		if _, err := codec.annotateEnum(enum, annotations); err != nil {
+			return nil, err
 		}
 	}
 	for _, service := range codec.Model.Services {
-		if err := codec.annotateService(service, annotations); err != nil {
-			return err
+		if _, err := codec.annotateService(service, annotations); err != nil {
+			return nil, err
 		}
 	}
 	var imports []string
@@ -81,5 +81,5 @@ func (codec *codec) annotateModel() error {
 	}
 	slices.Sort(imports)
 	annotations.MessageImports = imports
-	return nil
+	return codec, nil
 }

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -28,7 +28,7 @@ func TestModelAnnotations(t *testing.T) {
 		[]*api.Message{}, []*api.Enum{},
 		[]*api.Service{{Name: "Workflows", Package: "google.cloud.workflows.v1"}})
 	codec := newTestCodec(t, model, map[string]string{"copyright-year": "2038"})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 	want := &modelAnnotations{
@@ -90,7 +90,7 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 	}
 	codec.Dependencies = []*Dependency{dep1, dep2, dep3}
 
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/annotate_oneof.go
+++ b/internal/sidekick/swift/annotate_oneof.go
@@ -24,7 +24,7 @@ type oneOfAnnotations struct {
 	DocLines     []string
 }
 
-func (codec *codec) annotateOneOf(oneof *api.OneOf) {
+func (codec *codec) annotateOneOf(oneof *api.OneOf) *api.OneOf {
 	docLines := codec.formatDocumentation(oneof.Documentation)
 	annotations := &oneOfAnnotations{
 		Name:         "OneOf_" + pascalCase(oneof.Name),
@@ -32,4 +32,5 @@ func (codec *codec) annotateOneOf(oneof *api.OneOf) {
 		DocLines:     docLines,
 	}
 	oneof.Codec = annotations
+	return oneof
 }

--- a/internal/sidekick/swift/annotate_oneof_test.go
+++ b/internal/sidekick/swift/annotate_oneof_test.go
@@ -35,7 +35,7 @@ func TestAnnotateOneOf(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{message}, nil, nil)
 	model.PackageName = "google.cloud.test.v1"
 	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -28,13 +28,13 @@ type serviceAnnotations struct {
 	QuickstartMethod *api.Method
 }
 
-func (codec *codec) annotateService(service *api.Service, model *modelAnnotations) error {
+func (codec *codec) annotateService(service *api.Service, model *modelAnnotations) (*api.Service, error) {
 	docLines := codec.formatDocumentation(service.Documentation)
 	var restMethods []*api.Method
 	for _, method := range service.Methods {
 		if isGeneratedMethod(method) {
-			if err := codec.annotateMethod(method, model); err != nil {
-				return err
+			if _, err := codec.annotateMethod(method, model); err != nil {
+				return nil, err
 			}
 			restMethods = append(restMethods, method)
 		}
@@ -53,7 +53,7 @@ func (codec *codec) annotateService(service *api.Service, model *modelAnnotation
 		QuickstartMethod: quickstartMethod,
 	}
 	service.Codec = annotations
-	return nil
+	return service, nil
 }
 
 func isGeneratedMethod(method *api.Method) bool {

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -53,7 +53,7 @@ func TestAnnotateService(t *testing.T) {
 			model := api.NewTestAPI(nil, nil, []*api.Service{s})
 			codec := newTestCodec(t, model, nil)
 
-			if err := codec.annotateModel(); err != nil {
+			if _, err := annotateModel(codec); err != nil {
 				t.Fatal(err)
 			}
 
@@ -117,7 +117,7 @@ func TestAnnotateService_SkipNoBindings(t *testing.T) {
 
 	model := api.NewTestAPI(nil, nil, []*api.Service{service})
 	codec := newTestCodec(t, model, nil)
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		t.Fatal(err)
 	}
 
@@ -180,7 +180,7 @@ func TestAnnotateService_Quickstart(t *testing.T) {
 
 			model := api.NewTestAPI(nil, nil, []*api.Service{service})
 			codec := newTestCodec(t, model, nil)
-			if err := codec.annotateModel(); err != nil {
+			if _, err := annotateModel(codec); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -35,7 +35,7 @@ func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.Mo
 	if err != nil {
 		return err
 	}
-	if err := codec.annotateModel(); err != nil {
+	if _, err := annotateModel(codec); err != nil {
 		return err
 	}
 	provider := func(name string) (string, error) {


### PR DESCRIPTION
In the `annotate*()` functions we modify one of the input parameters. The convention is to return any modified inputs and these functions were not following the convention.

Fixes #5144 for realsies this time.
