### PR TITLE
test(sidekick/swift): use helper for dependencies

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -28,11 +28,11 @@ type enumAnnotations struct {
 	DefaultCaseName string
 }
 
-func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
+func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
 	existing := map[int32]*enumValueAnnotations{}
 	var defaultCaseName string
 	for _, ev := range enum.UniqueNumberValues {
-		codec.annotateUniqueEnumValue(ev)
+		c.annotateUniqueEnumValue(ev)
 		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
 		if ev.Number == 0 {
 			defaultCaseName = ev.Codec.(*enumValueAnnotations).CaseName
@@ -47,13 +47,13 @@ func (codec *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error 
 		}
 	}
 	for _, ev := range enum.Values {
-		if err := codec.annotateEnumValue(ev, existing); err != nil {
+		if err := c.annotateEnumValue(ev, existing); err != nil {
 			return err
 		}
 		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
 	}
 
-	docLines := codec.formatDocumentation(enum.Documentation)
+	docLines := c.formatDocumentation(enum.Documentation)
 	annotations := &enumAnnotations{
 		CopyrightYear:   model.CopyrightYear,
 		BoilerPlate:     model.BoilerPlate,

--- a/internal/sidekick/swift/annotate_enum_value.go
+++ b/internal/sidekick/swift/annotate_enum_value.go
@@ -27,8 +27,8 @@ type enumValueAnnotations struct {
 	DocLines    []string
 }
 
-func (codec *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
-	docLines := codec.formatDocumentation(ev.Documentation)
+func (c *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
+	docLines := c.formatDocumentation(ev.Documentation)
 	ann := &enumValueAnnotations{
 		CaseName:    enumValueCaseName(ev),
 		Number:      ev.Number,
@@ -38,7 +38,7 @@ func (codec *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
 	ev.Codec = ann
 }
 
-func (codec *codec) annotateEnumValue(ev *api.EnumValue, unique map[int32]*enumValueAnnotations) error {
+func (c *codec) annotateEnumValue(ev *api.EnumValue, unique map[int32]*enumValueAnnotations) error {
 	if ev.Codec != nil {
 		return nil
 	}

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -24,15 +24,15 @@ type fieldAnnotations struct {
 	DocLines  []string
 }
 
-func (codec *codec) annotateField(field *api.Field) error {
-	fieldType, err := codec.fieldTypeName(field)
+func (c *codec) annotateField(field *api.Field) error {
+	fieldType, err := c.fieldTypeName(field)
 	if err != nil {
 		return err
 	}
 	annotations := &fieldAnnotations{
 		Name:      camelCase(field.Name),
 		FieldType: fieldType,
-		DocLines:  codec.formatDocumentation(field.Documentation),
+		DocLines:  c.formatDocumentation(field.Documentation),
 	}
 	field.Codec = annotations
 	return nil

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -24,14 +24,14 @@ type messageAnnotations struct {
 	Model    *modelAnnotations
 }
 
-func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
-	if dep, ok := codec.ApiPackages[message.Package]; ok {
+func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
+	if dep, ok := c.ApiPackages[message.Package]; ok {
 		dep.Required = true
 	}
 	if message.Codec != nil {
 		return nil
 	}
-	docLines := codec.formatDocumentation(message.Documentation)
+	docLines := c.formatDocumentation(message.Documentation)
 	annotations := &messageAnnotations{
 		Name:     pascalCase(message.Name),
 		DocLines: docLines,
@@ -40,20 +40,20 @@ func (codec *codec) annotateMessage(message *api.Message, model *modelAnnotation
 
 	message.Codec = annotations
 	for _, oneof := range message.OneOfs {
-		codec.annotateOneOf(oneof)
+		c.annotateOneOf(oneof)
 	}
 	for _, field := range message.Fields {
-		if err := codec.annotateField(field); err != nil {
+		if err := c.annotateField(field); err != nil {
 			return err
 		}
 	}
 	for _, nested := range message.Messages {
-		if err := codec.annotateMessage(nested, model); err != nil {
+		if err := c.annotateMessage(nested, model); err != nil {
 			return err
 		}
 	}
 	for _, enum := range message.Enums {
-		if err := codec.annotateEnum(enum, model); err != nil {
+		if err := c.annotateEnum(enum, model); err != nil {
 			return err
 		}
 	}

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -38,18 +38,18 @@ func (ann *methodAnnotations) HasQueryParams() bool {
 	return len(ann.QueryParams) != 0
 }
 
-func (codec *codec) annotateMethod(method *api.Method, model *modelAnnotations) error {
+func (c *codec) annotateMethod(method *api.Method, model *modelAnnotations) error {
 	if method.InputType != nil {
-		if err := codec.annotateMessage(method.InputType, model); err != nil {
+		if err := c.annotateMessage(method.InputType, model); err != nil {
 			return err
 		}
 	}
 	if method.OutputType != nil {
-		if err := codec.annotateMessage(method.OutputType, model); err != nil {
+		if err := c.annotateMessage(method.OutputType, model); err != nil {
 			return err
 		}
 	}
-	docLines := codec.formatDocumentation(method.Documentation)
+	docLines := c.formatDocumentation(method.Documentation)
 	binding := method.PathInfo.Bindings[0]
 	path := formatPath(binding.PathTemplate)
 	hasBody := method.PathInfo.BodyFieldPath != ""

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -54,34 +54,34 @@ func (ann *modelAnnotations) HasMessageImports() bool {
 	return len(ann.MessageImports) != 0
 }
 
-func (codec *codec) annotateModel() error {
+func (c *codec) annotateModel() error {
 	annotations := &modelAnnotations{
-		CopyrightYear: codec.GenerationYear,
+		CopyrightYear: c.GenerationYear,
 		BoilerPlate:   license.HeaderBulk(),
-		PackageName:   codec.PackageName,
-		MonorepoRoot:  codec.MonorepoRoot,
+		PackageName:   c.PackageName,
+		MonorepoRoot:  c.MonorepoRoot,
 		DependsOn:     map[string]*Dependency{},
 	}
-	codec.Model.Codec = annotations
-	for _, message := range codec.Model.Messages {
-		if err := codec.annotateMessage(message, annotations); err != nil {
+	c.Model.Codec = annotations
+	for _, message := range c.Model.Messages {
+		if err := c.annotateMessage(message, annotations); err != nil {
 			return err
 		}
 	}
-	for _, enum := range codec.Model.Enums {
-		if err := codec.annotateEnum(enum, annotations); err != nil {
+	for _, enum := range c.Model.Enums {
+		if err := c.annotateEnum(enum, annotations); err != nil {
 			return err
 		}
 	}
-	for _, service := range codec.Model.Services {
-		if err := codec.annotateService(service, annotations); err != nil {
+	for _, service := range c.Model.Services {
+		if err := c.annotateService(service, annotations); err != nil {
 			return err
 		}
 	}
 	var serviceImports []string
 	var messageImports []string
-	for _, p := range codec.Dependencies {
-		if p.RequiredByServices && len(codec.Model.Services) != 0 {
+	for _, p := range c.Dependencies {
+		if p.RequiredByServices && len(c.Model.Services) != 0 {
 			serviceImports = append(serviceImports, p.Name)
 			annotations.DependsOn[p.Name] = p
 		} else if p.Required {

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -61,33 +61,21 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 		},
 	}
 
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".google.cloud.test.v1.TestService",
+		Package: "google.cloud.test.v1",
+	}
+
 	model := api.NewTestAPI(
-		[]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+		[]*api.Message{message}, []*api.Enum{}, []*api.Service{service})
 	model.State.MessageByID[externalMessage.ID] = externalMessage
 	codec := newTestCodec(t, model, nil)
-	dep1 := &Dependency{
-		SwiftDependency: config.SwiftDependency{
-			ApiPackage: "google.cloud.external.v1",
-			Name:       "GoogleCloudExternalWithOverrideV1",
-		},
-	}
-	dep2 := &Dependency{
-		SwiftDependency: config.SwiftDependency{
-			ApiPackage: "google.cloud.unused.v1",
-			Name:       "unused-package",
-		},
-	}
-	dep3 := &Dependency{
-		SwiftDependency: config.SwiftDependency{
-			Name:               "GoogleCloudGax",
-			RequiredByServices: true,
-		},
-	}
-	codec.ApiPackages = map[string]*Dependency{
-		dep1.ApiPackage: dep1,
-		dep2.ApiPackage: dep2,
-	}
-	codec.Dependencies = []*Dependency{dep1, dep2, dep3}
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{ApiPackage: "google.cloud.external.v1", Name: "GoogleCloudExternalWithOverrideV1"},
+		{ApiPackage: "google.cloud.unused.v1", Name: "GoogleUnusedPackage"},
+		{Name: "GoogleCloudGax", RequiredByServices: true},
+	})
 
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
@@ -98,11 +86,16 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 		t.Fatalf("expected model.Codec to be *modelAnnotations, got %T", model.Codec)
 	}
 
-	wantDependsOn := map[string]*Dependency{
-		dep1.Name: dep1,
+	want := map[string]bool{
+		"GoogleCloudExternalWithOverrideV1": true,
+		"GoogleCloudGax":                    false, // required by the service, but not messages
+	}
+	got := map[string]bool{}
+	for name, dep := range ann.DependsOn {
+		got[name] = dep.Required
 	}
 
-	if diff := cmp.Diff(wantDependsOn, ann.DependsOn); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 

--- a/internal/sidekick/swift/annotate_oneof.go
+++ b/internal/sidekick/swift/annotate_oneof.go
@@ -24,8 +24,8 @@ type oneOfAnnotations struct {
 	DocLines     []string
 }
 
-func (codec *codec) annotateOneOf(oneof *api.OneOf) {
-	docLines := codec.formatDocumentation(oneof.Documentation)
+func (c *codec) annotateOneOf(oneof *api.OneOf) {
+	docLines := c.formatDocumentation(oneof.Documentation)
 	annotations := &oneOfAnnotations{
 		Name:         "OneOf_" + pascalCase(oneof.Name),
 		PropertyName: camelCase(oneof.Name),

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -27,12 +27,12 @@ type serviceAnnotations struct {
 	Model            *modelAnnotations
 }
 
-func (codec *codec) annotateService(service *api.Service, model *modelAnnotations) error {
-	docLines := codec.formatDocumentation(service.Documentation)
+func (c *codec) annotateService(service *api.Service, model *modelAnnotations) error {
+	docLines := c.formatDocumentation(service.Documentation)
 	var restMethods []*api.Method
 	for _, method := range service.Methods {
 		if isGeneratedMethod(method) {
-			if err := codec.annotateMethod(method, model); err != nil {
+			if err := c.annotateMethod(method, model); err != nil {
 				return err
 			}
 			restMethods = append(restMethods, method)
@@ -46,7 +46,7 @@ func (codec *codec) annotateService(service *api.Service, model *modelAnnotation
 		Name:             pascalCase(service.Name),
 		DocLines:         docLines,
 		RestMethods:      restMethods,
-		PackageName:      codec.PackageName,
+		PackageName:      c.PackageName,
 		QuickstartMethod: quickstartMethod,
 		Model:            model,
 	}

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -93,3 +93,17 @@ func newTestCodec(t *testing.T, model *api.API, options map[string]string) *code
 	}
 	return codec
 }
+
+func (c *codec) withExtraDependencies(t *testing.T, deps []config.SwiftDependency) {
+	t.Helper()
+	for _, d := range deps {
+		dep := &Dependency{SwiftDependency: d}
+		if d.ApiPackage != "" {
+			if _, ok := c.ApiPackages[d.ApiPackage]; ok {
+				t.Fatalf("conflicting definition for %s", d.ApiPackage)
+			}
+			c.ApiPackages[d.ApiPackage] = dep
+		}
+		c.Dependencies = append(c.Dependencies, dep)
+	}
+}

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -361,18 +361,16 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 	model.PackageName = "google.cloud.test.v1"
 	model.State.MessageByID[externalMessage.ID] = externalMessage
 	c := newTestCodec(t, model, nil)
-	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+	c.withExtraDependencies(t, []config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.external.v1",
 			Name:       "ExternalPackage",
 		},
-	}
-	c.ApiPackages["google.cloud.unused.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.unused.v1",
 			Name:       "UnusedPackage",
 		},
-	}
+	})
 
 	got, err := c.messageTypeName(externalMessage)
 	if err != nil {
@@ -407,18 +405,16 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 	model.PackageName = "google.cloud.test.v1"
 	model.State.EnumByID[externalEnum.ID] = externalEnum
 	c := newTestCodec(t, model, nil)
-	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+	c.withExtraDependencies(t, []config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.external.v1",
 			Name:       "ExternalPackage",
 		},
-	}
-	c.ApiPackages["google.cloud.unused.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.unused.v1",
 			Name:       "UnusedPackage",
 		},
-	}
+	})
 
 	got, err := c.enumTypeName(externalEnum)
 	if err != nil {
@@ -461,12 +457,12 @@ func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
 	model.State.MessageByID[externalNested.ID] = externalNested
 	model.State.MessageByID[externalOuter.ID] = externalOuter
 	c := newTestCodec(t, model, nil)
-	c.ApiPackages["google.cloud.external.v1"] = &Dependency{
-		SwiftDependency: config.SwiftDependency{
+	c.withExtraDependencies(t, []config.SwiftDependency{
+		{
 			ApiPackage: "google.cloud.external.v1",
 			Name:       "ExternalPackage",
 		},
-	}
+	})
 
 	got, err := c.messageTypeName(externalNested)
 	if err != nil {

--- a/internal/sidekick/swift/format_documentation.go
+++ b/internal/sidekick/swift/format_documentation.go
@@ -21,7 +21,7 @@ import "strings"
 //
 // Both Swift and the Protobuf comments use markdown, but our markdown includes cross-reference
 // links and sometimes needs cleaning up work correctly on a different markdown engine.
-func (codec *codec) formatDocumentation(doc string) []string {
+func (c *codec) formatDocumentation(doc string) []string {
 	if doc == "" {
 		return nil
 	}


### PR DESCRIPTION
Introduce a test helper function to simplify the tests that check the behavior of the codec when using external dependencies.

Towards #5401 