### PR TITLE
feat(internal/librarian/java): derive default library name and version for add command

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/librarian/internal/legacylibrarian/legacyconfig"
 	"github.com/googleapis/librarian/internal/librarian/dart"
 	"github.com/googleapis/librarian/internal/librarian/golang"
+	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
@@ -112,6 +113,8 @@ func deriveLibraryName(language string, api string) string {
 		return fakeDefaultLibraryName(api)
 	case config.LanguageGo:
 		return golang.DefaultLibraryName(api)
+	case config.LanguageJava:
+		return java.DefaultLibraryName(api)
 	case config.LanguagePython:
 		return python.DefaultLibraryName(api)
 	case config.LanguageRust:
@@ -205,6 +208,8 @@ func addNewLibrary(cfg *config.Config, apis []*config.API, name string) (string,
 	switch cfg.Language {
 	case config.LanguageGo:
 		lib = golang.Add(lib)
+	case config.LanguageJava:
+		lib = java.Add(lib)
 	case config.LanguagePython:
 		var err error
 		lib, err = python.Add(lib)

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -549,6 +549,12 @@ func TestDeriveLibraryName(t *testing.T) {
 		{config.LanguageRust, "google/cloud/secretmanager/v1beta2", "google-cloud-secretmanager-v1beta2"},
 		{config.LanguageFake, "google/cloud/secretmanager/v1", "google-cloud-secretmanager-v1"},
 		{config.LanguageGo, "google/cloud/secretmanager/v1", "secretmanager"},
+		{config.LanguageJava, "google/cloud/secretmanager/v1", "secretmanager"},
+		{config.LanguageJava, "google/api/serviceusage/v1", "serviceusage"},
+		{config.LanguageJava, "google/devtools/cloudbuild/v1", "cloudbuild"},
+		{config.LanguageJava, "google/pubsub/v1", "pubsub"},
+		{config.LanguageJava, "other/api/v1", "other-api"},
+		{config.LanguageJava, "google/cloud/datacatalog/lineage/v1", "datacatalog-lineage"},
 	} {
 		t.Run(test.language+"/"+test.apiPath, func(t *testing.T) {
 			got := deriveLibraryName(test.language, test.apiPath)

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package java
+
+import (
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// knownPrefixes contains API path prefixes to be stripped when deriving a
+// library name. The order matters: more specific prefixes must come before
+// less specific ones (e.g., "google/cloud/" before "google/").
+var knownPrefixes = []string{
+	"google/cloud/",
+	"google/api/",
+	"google/devtools/",
+	"google/",
+}
+
+const defaultVersion = "0.1.0-SNAPSHOT"
+
+// Add initializes a new Java library with default values.
+func Add(lib *config.Library) *config.Library {
+	lib.Version = defaultVersion
+	return lib
+}
+
+// DefaultLibraryName derives a default library name from an API path by stripping
+// known prefixes (e.g., "google/cloud/", "google/api/") and returning all
+// segments except the last one, joined by dashes.
+func DefaultLibraryName(api string) string {
+	path := api
+	if idx := strings.LastIndex(api, "/"); idx != -1 {
+		path = api[:idx]
+	}
+	for _, p := range knownPrefixes {
+		if strings.HasPrefix(path, p) {
+			path = strings.TrimPrefix(path, p)
+			break
+		}
+	}
+	return strings.ReplaceAll(path, "/", "-")
+}

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package java
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestAdd(t *testing.T) {
+	lib := &config.Library{
+		Name: "test-library",
+	}
+	want := &config.Library{
+		Name:    "test-library",
+		Version: defaultVersion,
+	}
+	got := Add(lib)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDefaultLibraryName(t *testing.T) {
+	for _, test := range []struct {
+		api  string
+		want string
+	}{
+		{"google/cloud/secretmanager/v1", "secretmanager"},
+		{"google/api/serviceusage/v1", "serviceusage"},
+		{"google/devtools/cloudbuild/v1", "cloudbuild"},
+		{"google/pubsub/v1", "pubsub"},
+		{"other/api/v1", "other-api"},
+		{"google/cloud/datacatalog/lineage/v1", "datacatalog-lineage"},
+		{"google/cloud/aiplatform/v1beta1", "aiplatform"},
+		{"google/shopping/merchant/datasources/v1", "shopping-merchant-datasources"},
+	} {
+		t.Run(test.api, func(t *testing.T) {
+			got := DefaultLibraryName(test.api)
+			if got != test.want {
+				t.Errorf("DefaultLibraryName(%q) = %q, want %q", test.api, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -51,8 +51,8 @@ func TestDefaultLibraryName(t *testing.T) {
 	} {
 		t.Run(test.api, func(t *testing.T) {
 			got := DefaultLibraryName(test.api)
-			if got != test.want {
-				t.Errorf("DefaultLibraryName(%q) = %q, want %q", test.api, got, test.want)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Derive Java library names based on the provided API paths. It strips common prefixes and removes the last segment of the path, joining the remaining segments with dashes. Also setup default version for Java libraries add command.

For #5363