### PR TITLE
fix(internal/librarian/nodejs): move backup directory to parent of outDir

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -232,7 +232,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 	// combine-library wipes the destination directory before writing generated
 	// files (src/, protos/). Save the keep files it would delete, then restore
 	// them afterward.
-	backupDir, err := os.MkdirTemp("", "librarian-backup-*")
+	backupDir, err := os.MkdirTemp(filepath.Dir(outDir), "librarian-backup-*")
 	if err != nil {
 		return fmt.Errorf("failed to create backup dir: %w", err)
 	}


### PR DESCRIPTION
Create the backup directory in the parent of outDir to avoid cross-filesystem rename errors. Creating it inside outDir fails because combine-library wipes the destination directory.

Similar to https://github.com/googleapis/librarian/issues/5301