### PR TITLE
chore(sdk.yaml): allowlist maps/mapmanagement/v2beta

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -2886,6 +2886,12 @@
     - python
   release_level:
     java: stable
+- path: google/maps/mapmanagement/v2beta
+  languages:
+    - go
+    - java
+    - nodejs
+    - python
 - path: google/maps/mapsplatformdatasets/v1
   languages:
     - java


### PR DESCRIPTION
Allowlisting `google/maps/mapmanagement/v2beta` for generation in Go, Java, Node.js, and Python (as per request bugs).

b/503324539