### PR TITLE
fix(internal/serviceconfig): skip rest numeric enums for google/cloud/compute/v1

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -969,6 +969,7 @@
   new_issue_uri: https://issuetracker.google.com/issues/new?component=187134&template=0
   skip_rest_numeric_enums:
     - go
+    - java
     - python
   transports:
     csharp: rest

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -167,7 +167,7 @@ func TestFind(t *testing.T) {
 				Title:                "Google Compute Engine API",
 				Languages:            []string{config.LanguageAll},
 				Transports:           map[string]Transport{config.LanguageCsharp: Rest, config.LanguageGo: Rest, config.LanguageJava: Rest, config.LanguagePhp: Rest},
-				SkipRESTNumericEnums: []string{"go", "python"},
+				SkipRESTNumericEnums: []string{"go", "java", "python"},
 			},
 		},
 	} {


### PR DESCRIPTION
Set skip_rest_numeric_enums for java in google/cloud/compute/v1.

For #5523