### PR TITLE
feat(sidekick/swift): detect wkt package name

### DIFF
--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -24,6 +24,19 @@ import (
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
+func defaultSwiftConfig(t *testing.T) *config.SwiftPackage {
+	// A package providing the `google.protobuf` API is required, as that package provides the
+	// well-known types and the support for `Any`.
+	t.Helper()
+	return &config.SwiftPackage{
+		SwiftDefault: config.SwiftDefault{
+			Dependencies: []config.SwiftDependency{
+				{Name: "FakeWkt", ApiPackage: "google.protobuf"},
+			},
+		},
+	}
+}
+
 func TestDefaultLibraryName(t *testing.T) {
 	for _, test := range []struct {
 		api  string
@@ -56,6 +69,7 @@ func TestGenerate(t *testing.T) {
 			Name:          "GoogleType",
 			APIs:          []*config.API{{Path: "google/type"}},
 			CopyrightYear: "2038",
+			Swift:         defaultSwiftConfig(t),
 		},
 	}
 	for _, library := range libraries {

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -83,7 +83,7 @@ func (c *codec) annotateModel() error {
 			dep.Required = true
 			annotations.WktPackage = dep.Name
 		} else {
-			return fmt.Errorf("missing dependency for `google.protobuf` this is required to generate the `Any` extensions")
+			return fmt.Errorf("missing dependency for %q; required to generate Any extensions", wellKnownPackage)
 		}
 	}
 	for _, service := range c.Model.Services {

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	"cmp"
+	"fmt"
 	"maps"
 	"slices"
 
@@ -28,6 +29,7 @@ type modelAnnotations struct {
 	PackageName    string
 	MonorepoRoot   string
 	DependsOn      map[string]*Dependency
+	WktPackage     string
 	ServiceImports []string
 	MessageImports []string
 }
@@ -61,6 +63,7 @@ func (c *codec) annotateModel() error {
 		PackageName:   c.PackageName,
 		MonorepoRoot:  c.MonorepoRoot,
 		DependsOn:     map[string]*Dependency{},
+		WktPackage:    wellKnownSwiftPackage,
 	}
 	c.Model.Codec = annotations
 	for _, message := range c.Model.Messages {
@@ -71,6 +74,16 @@ func (c *codec) annotateModel() error {
 	for _, enum := range c.Model.Enums {
 		if err := c.annotateEnum(enum, annotations); err != nil {
 			return err
+		}
+	}
+	// If there is at least one message, the generated library depends on `GoogleCloudWkt` because
+	// the generated messages must conform to the `GoogleCloudWkt._AnyPackable` protocol.
+	if len(c.Model.Messages) != 0 {
+		if dep, ok := c.ApiPackages[wellKnownPackage]; ok {
+			dep.Required = true
+			annotations.WktPackage = dep.Name
+		} else {
+			return fmt.Errorf("missing dependency for `google.protobuf` this is required to generate the `Any` extensions")
 		}
 	}
 	for _, service := range c.Model.Services {

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -84,7 +84,6 @@ func (c *codec) annotateModel() error {
 	if len(c.Model.Messages) != 0 {
 		if dep, ok := c.ApiPackages[wellKnownPackage]; ok {
 			dep.Required = true
-			annotations.WktPackage = dep.Name
 		} else {
 			return fmt.Errorf("missing dependency for %q; required to generate Any extensions", wellKnownPackage)
 		}

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -65,6 +65,9 @@ func (c *codec) annotateModel() error {
 		DependsOn:     map[string]*Dependency{},
 		WktPackage:    wellKnownSwiftPackage,
 	}
+	if dep, ok := c.ApiPackages[wellKnownPackage]; ok {
+		annotations.WktPackage = dep.Name
+	}
 	c.Model.Codec = annotations
 	for _, message := range c.Model.Messages {
 		if err := c.annotateMessage(message, annotations); err != nil {

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -65,7 +65,7 @@ func (c *codec) annotateModel() error {
 		DependsOn:     map[string]*Dependency{},
 		WktPackage:    wellKnownSwiftPackage,
 	}
-	if dep, ok := c.ApiPackages[wellKnownPackage]; ok {
+	if dep, ok := c.ApiPackages[wellKnownProtobufPackage]; ok {
 		annotations.WktPackage = dep.Name
 	}
 	c.Model.Codec = annotations
@@ -82,10 +82,10 @@ func (c *codec) annotateModel() error {
 	// If there is at least one message, the generated library depends on `GoogleCloudWkt` because
 	// the generated messages must conform to the `GoogleCloudWkt._AnyPackable` protocol.
 	if len(c.Model.Messages) != 0 {
-		if dep, ok := c.ApiPackages[wellKnownPackage]; ok {
+		if dep, ok := c.ApiPackages[wellKnownProtobufPackage]; ok {
 			dep.Required = true
 		} else {
-			return fmt.Errorf("missing dependency for %q; required to generate Any extensions", wellKnownPackage)
+			return fmt.Errorf("missing dependency for %q; required to generate Any extensions", wellKnownProtobufPackage)
 		}
 	}
 	for _, service := range c.Model.Services {

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -15,6 +15,7 @@
 package swift
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -164,8 +165,13 @@ func TestModelAnnotations_IgnoreSelfDependency(t *testing.T) {
 		{ApiPackage: "google.cloud.placeholder.v1", Name: "GoogleCloudPlaceholderV1"},
 		{ApiPackage: "google.cloud.other.v1", Name: "GoogleCloudOtherV1", RequiredByServices: true},
 	})
-	// Make it required to verify the rest of the code works.
-	codec.Dependencies[0].Required = true
+	// Make GoogleCloudPlaceholderV1 required to verify the rest of the code works. Its position may
+	// change as the implementation of `withExtraDependencies()` changes, so search for it:
+	idx := slices.IndexFunc(codec.Dependencies, func(d *Dependency) bool { return d.Name == "GoogleCloudPlaceholderV1" })
+	if idx == -1 {
+		t.Fatalf("GoogleCloudPlaceholderV1 not found")
+	}
+	codec.Dependencies[idx].Required = true
 
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -35,9 +35,49 @@ func TestModelAnnotations(t *testing.T) {
 		PackageName:   "GoogleCloudWorkflowsV1",
 		CopyrightYear: "2038",
 		MonorepoRoot:  ".",
+		WktPackage:    "GoogleCloudWkt",
 	}
 	if diff := cmp.Diff(want, model.Codec, cmpopts.IgnoreFields(modelAnnotations{}, "BoilerPlate", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestModelAnnotations_MessagesWithWkt(t *testing.T) {
+	enum := &api.Enum{
+		Name: "SomeEnum", ID: ".test.SomeSnum", Package: "test",
+		Values: []*api.EnumValue{{Name: "UNSPECIFIED", Number: 0}},
+	}
+	enum.UniqueNumberValues = enum.Values
+	for _, test := range []struct {
+		name  string
+		model *api.API
+		want  map[string]bool
+	}{
+		{
+			name: "Messages with wkt",
+			model: api.NewTestAPI(
+				[]*api.Message{{Name: "Request", ID: ".test.Request", Package: "test"}}, nil, nil),
+			want: map[string]bool{"GoogleCloudWkt": true},
+		},
+		{
+			name:  "Enum with wkt",
+			model: api.NewTestAPI(nil, []*api.Enum{enum}, nil),
+			want:  map[string]bool{"GoogleCloudWkt": false},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			codec := newTestCodec(t, test.model, map[string]string{})
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			got := map[string]bool{}
+			for _, d := range codec.Dependencies {
+				got[d.Name] = d.Required
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -89,6 +129,7 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 	want := map[string]bool{
 		"GoogleCloudExternalWithOverrideV1": true,
 		"GoogleCloudGax":                    false, // required by the service, but not messages
+		"GoogleCloudWkt":                    true,
 	}
 	got := map[string]bool{}
 	for name, dep := range ann.DependsOn {
@@ -99,7 +140,7 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	wantMessageImports := []string{"GoogleCloudExternalWithOverrideV1"}
+	wantMessageImports := []string{"GoogleCloudExternalWithOverrideV1", "GoogleCloudWkt"}
 	if diff := cmp.Diff(wantMessageImports, ann.MessageImports); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -24,6 +24,11 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
+const (
+	wellKnownPackage      = "google.protobuf"
+	wellKnownSwiftPackage = "GoogleCloudWkt"
+)
+
 // codec represents the configuration for a Swift sidekick Codec.
 //
 // A sideckick Codec is a package that generates libraries from an `api.API`

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -25,7 +25,10 @@ import (
 )
 
 const (
-	wellKnownPackage      = "google.protobuf"
+	// The name of the Protobuf package that contains the well-known Protobuf types.
+	wellKnownProtobufPackage = "google.protobuf"
+	// The name of the corresponding Swift package that contains the Swift implementations of these
+	// types.
 	wellKnownSwiftPackage = "GoogleCloudWkt"
 )
 

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -87,7 +87,15 @@ func newTestCodec(t *testing.T, model *api.API, options map[string]string) *code
 	cfg := &parser.ModelConfig{
 		Codec: options,
 	}
-	codec, err := newCodec(model, cfg, nil, ".")
+	// Configure the package for well-known types by default.
+	swiftCfg := &config.SwiftPackage{
+		SwiftDefault: config.SwiftDefault{
+			Dependencies: []config.SwiftDependency{
+				{Name: wellKnownSwiftPackage, ApiPackage: wellKnownPackage},
+			},
+		},
+	}
+	codec, err := newCodec(model, cfg, swiftCfg, ".")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -91,7 +91,7 @@ func newTestCodec(t *testing.T, model *api.API, options map[string]string) *code
 	swiftCfg := &config.SwiftPackage{
 		SwiftDefault: config.SwiftDefault{
 			Dependencies: []config.SwiftDependency{
-				{Name: wellKnownSwiftPackage, ApiPackage: wellKnownPackage},
+				{Name: wellKnownSwiftPackage, ApiPackage: wellKnownProtobufPackage},
 			},
 		},
 	}

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -384,6 +384,7 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 	wantRequired := map[string]bool{
 		"google.cloud.external.v1": true,
 		"google.cloud.unused.v1":   false,
+		"google.protobuf":          false,
 	}
 	gotRequired := map[string]bool{}
 	for k, v := range c.ApiPackages {
@@ -428,6 +429,7 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 	wantRequired := map[string]bool{
 		"google.cloud.external.v1": true,
 		"google.cloud.unused.v1":   false,
+		"google.protobuf":          false,
 	}
 	gotRequired := map[string]bool{}
 	for k, v := range c.ApiPackages {

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -29,7 +29,7 @@ import (
 func swiftConfig(t *testing.T, extraDependencies []config.SwiftDependency) *config.SwiftPackage {
 	t.Helper()
 	deps := []config.SwiftDependency{
-		{Name: "GoogleCloudWkt", ApiPackage: wellKnownPackage},
+		{Name: "GoogleCloudWkt", ApiPackage: wellKnownProtobufPackage},
 	}
 	deps = append(deps, extraDependencies...)
 	return &config.SwiftPackage{

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -26,6 +26,19 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
+func swiftConfig(t *testing.T, extraDependencies []config.SwiftDependency) *config.SwiftPackage {
+	t.Helper()
+	deps := []config.SwiftDependency{
+		{Name: "GoogleCloudWkt", ApiPackage: wellKnownPackage},
+	}
+	deps = append(deps, extraDependencies...)
+	return &config.SwiftPackage{
+		SwiftDefault: config.SwiftDefault{
+			Dependencies: deps,
+		},
+	}
+}
+
 func TestGenerateMessage_Files(t *testing.T) {
 	outDir := t.TempDir()
 
@@ -41,7 +54,7 @@ func TestGenerateMessage_Files(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,7 +88,7 @@ func TestGenerateMessage_WithNestedMessages(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,7 +143,7 @@ func TestGenerateMessage_WithNestedEnum(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -190,20 +203,16 @@ func TestGenerateMessage_WithExternalImports(t *testing.T) {
 		},
 	}
 
-	swiftCfg := &config.SwiftPackage{
-		SwiftDefault: config.SwiftDefault{
-			Dependencies: []config.SwiftDependency{
-				{
-					ApiPackage: "google.cloud.external.v1",
-					Name:       "GoogleCloudExternalV1",
-				},
-				{
-					ApiPackage: "google.cloud.unused.v1",
-					Name:       "GoogleCloudUnusedV1",
-				},
-			},
+	swiftCfg := swiftConfig(t, []config.SwiftDependency{
+		{
+			ApiPackage: "google.cloud.external.v1",
+			Name:       "GoogleCloudExternalV1",
 		},
-	}
+		{
+			ApiPackage: "google.cloud.unused.v1",
+			Name:       "GoogleCloudUnusedV1",
+		},
+	})
 
 	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -81,7 +81,7 @@ func TestGenerateOneOf(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{outer, inner}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 	cfg := &parser.ModelConfig{}
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -182,6 +182,10 @@ func TestGenerateService_WithImports(t *testing.T) {
 					ApiPackage: "google.cloud.external.v1",
 					Name:       "GoogleCloudExternalV1",
 				},
+				{
+					ApiPackage: "google.protobuf",
+					Name:       "GoogleCloudWkt",
+				},
 			},
 		},
 	}

--- a/internal/sidekick/swift/generate_test.go
+++ b/internal/sidekick/swift/generate_test.go
@@ -58,7 +58,7 @@ func TestFromProtobuf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
 		t.Fatal(err)
 	}
 	filename := filepath.Join(outDir, "README.md")


### PR DESCRIPTION
Make the name of the `GoogleCloudWkt` package configurable. This is mostly for testing and to centralize the name. It is unlikely that we will rename this package, but it is confusing to see hard-coded names and configurable names sprinkled through the code.

Towards #5401 