### PR TITLE
fix(tool/cmd/migrate): derive APIShortnameOverride instead of hardcode

### DIFF
--- a/internal/testdata/googleapis/google/maps/places/v1/places_v1.yaml
+++ b/internal/testdata/googleapis/google/maps/places/v1/places_v1.yaml
@@ -1,0 +1,6 @@
+type: google.api.Service
+config_version: 3
+name: places.googleapis.com
+title: Places API (New)
+publishing:
+  api_short_name: places

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -30,6 +30,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
 	"github.com/googleapis/librarian/internal/librarian/java"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -294,6 +295,17 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				TransportOverride:            l.Transport,
 			},
 		}
+		if len(apis) > 0 {
+			derivedShortName := name
+			serviceconfig.SortAPIs(apis)
+			api, err := serviceconfig.Find(src.Dir, apis[0].Path, config.LanguageJava)
+			if err == nil && api.ShortName != "" {
+				derivedShortName = api.ShortName
+			}
+			if derivedShortName != l.APIShortName {
+				lib.Java.APIShortnameOverride = l.APIShortName
+			}
+		}
 		if override, ok := keepOverride[lib.Name]; ok {
 			lib.Keep = override
 		} else {
@@ -302,9 +314,6 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				return nil, err
 			}
 			lib.Keep = keep
-		}
-		if shortnameOverride, ok := apiShortnameOverrides[lib.Name]; ok {
-			lib.Java.APIShortnameOverride = shortnameOverride
 		}
 		libs = append(libs, lib)
 	}

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -15,18 +15,6 @@
 package main
 
 var (
-	apiShortnameOverrides = map[string]string{
-		"beyondcorp-appconnections":          "beyondcorp-appconnections",
-		"beyondcorp-appconnectors":           "beyondcorp-appconnectors",
-		"beyondcorp-appgateways":             "beyondcorp-appgateways",
-		"beyondcorp-clientconnectorservices": "beyondcorp-clientconnectorservices",
-		"beyondcorp-clientgateways":          "beyondcorp-clientgateways",
-		"dialogflow-cx":                      "dialogflow-cx",
-		"distributedcloudedge":               "distributedcloudedge",
-		"gke-backup":                         "gke-backup",
-		"apigee-registry":                    "apigee-registry",
-	}
-
 	excludedSamplesLibraries = map[string]bool{
 		"bigquerystorage":   true,
 		"datastore":         true,

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -190,15 +190,15 @@ func TestBuildConfig(t *testing.T) {
 			gen: &GenerationConfig{
 				Libraries: []LibraryConfig{
 					{
-						LibraryName:  "language-v1",
-						APIShortName: "language",
+						LibraryName:  "secretmanager-v1",
+						APIShortName: "secretmanager",
 						GAPICs: []GAPICConfig{
-							{ProtoPath: "google/cloud/language/v1"},
+							{ProtoPath: "google/cloud/secretmanager/v1"},
 						},
 					},
 				},
 			},
-			src: &config.Source{},
+			src: &config.Source{Dir: "../../../internal/testdata/googleapis"},
 			want: &config.Config{
 				Language: "java",
 				Repo:     "googleapis/google-cloud-java",
@@ -206,13 +206,13 @@ func TestBuildConfig(t *testing.T) {
 					Java: &config.JavaModule{},
 				},
 				Sources: &config.Sources{
-					Googleapis: &config.Source{},
+					Googleapis: &config.Source{Dir: "../../../internal/testdata/googleapis"},
 				},
 				Libraries: []*config.Library{
 					{
-						Name: "language-v1",
+						Name: "secretmanager-v1",
 						APIs: []*config.API{
-							{Path: "google/cloud/language/v1"},
+							{Path: "google/cloud/secretmanager/v1"},
 						},
 						Java: &config.JavaModule{},
 					},
@@ -429,10 +429,16 @@ func TestBuildConfig(t *testing.T) {
 			name: "api shortname overrides",
 			gen: &GenerationConfig{
 				Libraries: []LibraryConfig{
-					{APIShortName: "beyondcorp-appconnections"},
+					{
+						LibraryName:  "maps-places",
+						APIShortName: "maps-places",
+						GAPICs: []GAPICConfig{
+							{ProtoPath: "google/maps/places/v1"},
+						},
+					},
 				},
 			},
-			src: &config.Source{},
+			src: &config.Source{Dir: "../../../internal/testdata/googleapis"},
 			want: &config.Config{
 				Language: "java",
 				Repo:     "googleapis/google-cloud-java",
@@ -440,13 +446,16 @@ func TestBuildConfig(t *testing.T) {
 					Java: &config.JavaModule{},
 				},
 				Sources: &config.Sources{
-					Googleapis: &config.Source{},
+					Googleapis: &config.Source{Dir: "../../../internal/testdata/googleapis"},
 				},
 				Libraries: []*config.Library{
 					{
-						Name: "beyondcorp-appconnections",
+						Name: "maps-places",
+						APIs: []*config.API{
+							{Path: "google/maps/places/v1"},
+						},
 						Java: &config.JavaModule{
-							APIShortnameOverride: "beyondcorp-appconnections",
+							APIShortnameOverride: "maps-places",
 						},
 					},
 				},


### PR DESCRIPTION
 This change refactors how api_shortname is determined and migrated for Java libraries to ensure behavioral parity with the hermetic build while minimizing configuration noise.

Migration Script (java.go) now mimics the derives the shortname logic (using serviceconfig.Find) and only adds an APIShortnameOverride to librarian.yaml if the legacy configuration differs. This replaces the hardcoded map in java_module.go.
Updated migration tests to use testdata (e.g., secretmanager, places) to verify both standard discovery and discrepancy-based overriding.

Confirmed local running migrate, the previous hardcoded overrides are kept.

Fix #5296