### PR TITLE
fix(internal/librarian/java): java add command resets copyright year

### DIFF
--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -35,6 +35,9 @@ const defaultVersion = "0.1.0-SNAPSHOT"
 // Add initializes a new Java library with default values.
 func Add(lib *config.Library) *config.Library {
 	lib.Version = defaultVersion
+	// Java generation defaults to the system year for license headers,
+	// so we reset it here to avoid redundancy in librarian.yaml.
+	lib.CopyrightYear = ""
 	return lib
 }
 

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -26,8 +26,9 @@ func TestAdd(t *testing.T) {
 		Name: "test-library",
 	}
 	want := &config.Library{
-		Name:    "test-library",
-		Version: defaultVersion,
+		Name:          "test-library",
+		Version:       defaultVersion,
+		CopyrightYear: "",
 	}
 	got := Add(lib)
 	if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
Resets copyright to empty to avoid unused configs in librarian.yaml. 
There are a few valid approaches of header year (see go/copyright#the-year), Java follows this [doc](https://g3doc.corp.google.com/company/teams/cloud-sdk/client-libraries/team/generators/index.md#copyright-headers) that the generated files always gets the current year, and this field in config is not used. A mix of copyright year policies will be confusing.

For https://github.com/googleapis/librarian/issues/5363