### PR TITLE
feat(sidekick/rust): Format resource names in RPC samples.

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -576,6 +576,16 @@ type SampleInfo struct {
 	MessageField *Field
 	// UpdateMaskField is the field containing the update mask, present in Update methods.
 	UpdateMaskField *Field
+	// IsRequestResourceName is true if the main resource name associated to this sample,
+	// i.e. the name of the resource manipulated by the RPC, is a field of the request
+	// object itself, e.g. for Delete or Get operations.
+	IsRequestResourceName bool
+	// IsMessageResourceName is true if the main resource name associated to this sample,
+	// i.e. the name of the resource manipulated by the RPC, is a field of the message body of
+	// the request object, e.g. for Update operations.
+	IsMessageResourceName bool
+	// Codec is a placeholder to put language specific annotations.
+	Codec any
 }
 
 const (
@@ -1017,6 +1027,9 @@ type Field struct {
 	// ResourceReference contains the data from the `google.api.resource_reference`
 	// annotation.
 	ResourceReference *ResourceReference
+	// ResourceNamePattern is a parsed representation of the resource pattern associated
+	// with this field.
+	ResourceNamePattern *ResourceNamePattern
 	// Codec is a placeholder to put language specific annotations.
 	Codec any
 }
@@ -1166,6 +1179,19 @@ type Resource struct {
 
 // ResourcePattern is a sequence of path segments that defines the structure of a resource's unique identifier.
 type ResourcePattern []PathSegment
+
+// ResourceNameSegment is a segment of a resource name pattern.
+type ResourceNameSegment struct {
+	// Literal is the literal part of the segment, including any separators.
+	Literal string
+	// Variable is the name of the variable part of the segment, if any.
+	Variable string
+}
+
+// ResourceNamePattern describes the structure of a resource name.
+type ResourceNamePattern struct {
+	Segments []ResourceNameSegment
+}
 
 // ResourceReference describes a field's relationship to another resource type.
 // It acts as a foreign key, indicating that the field's value identifies an instance of another resource.

--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -105,6 +105,9 @@ func enrichSamples(model *API) {
 				o.ExampleField = slices.MaxFunc(o.Fields, sortOneOfFieldForExamples)
 			}
 		}
+		for _, f := range m.Fields {
+			enrichWithResourceNamePattern(f, m, model)
+		}
 	}
 
 	for m := range model.AllMethods() {
@@ -381,6 +384,69 @@ func enrichMethodSamples(m *Method) {
 	m.IsAIPStandard = m.SampleInfo != nil
 }
 
+func enrichWithResourceNamePattern(f *Field, m *Message, model *API) {
+	var resource *Resource
+	truncateChild := false
+
+	if f.ResourceReference != nil {
+		// The field is a resource reference.
+		if res := model.Resource(f.ResourceReference.Type); res != nil {
+			resource = res
+		} else if res := model.Resource(f.ResourceReference.ChildType); res != nil {
+			resource = res
+			truncateChild = true
+		}
+	} else if f.Name == StandardFieldNameForResourceRef {
+		// The field is the `name` field.
+		resource = m.Resource
+	}
+
+	if resource != nil && len(resource.Patterns) > 0 {
+		f.ResourceNamePattern = toResourceNamePattern(resource.Patterns[0], truncateChild)
+	}
+}
+
+// toResourceNamePattern converts a ResourcePattern into a ResourceNamePattern.
+func toResourceNamePattern(pattern ResourcePattern, skipLast bool) *ResourceNamePattern {
+	var segments []ResourceNameSegment
+	for i := 0; i < len(pattern); i++ {
+		s := pattern[i]
+		if s.Literal != nil && strings.HasPrefix(*s.Literal, "//") {
+			continue
+		}
+		seg := ResourceNameSegment{}
+		if s.Literal != nil {
+			seg.Literal = *s.Literal
+		}
+		if s.Variable != nil && len(s.Variable.FieldPath) > 0 {
+			// The parser used for parsing resource name patterns is the same used for
+			// parsing HTTP rules. Resource patterns do not have "field paths",
+			// instead they only have "placeholders" for each of the resource IDs of
+			// the resources that are part of the resource name hierarchy.
+			// These placeholders end up on the first, and only, field path
+			// that results when parsing a segment of a resource name pattern.
+			seg.Variable = s.Variable.FieldPath[0]
+		}
+
+		// Try to combine with next segment if this is a literal and next is variable
+		if s.Literal != nil && i+1 < len(pattern) && pattern[i+1].Variable != nil {
+			if len(pattern[i+1].Variable.FieldPath) > 0 {
+				seg.Variable = pattern[i+1].Variable.FieldPath[0]
+			}
+			i++
+		}
+
+		// Clean up leading and trailing slashes
+		seg.Literal = strings.TrimSuffix(strings.TrimPrefix(seg.Literal, "/"), "/")
+
+		segments = append(segments, seg)
+	}
+	if skipLast && len(segments) > 0 {
+		segments = segments[:len(segments)-1]
+	}
+	return &ResourceNamePattern{Segments: segments}
+}
+
 func aipStandardGetInfo(m *Method) *SampleInfo {
 	if !m.IsSimple || m.InputType == nil || m.ReturnsEmpty {
 		return nil
@@ -410,7 +476,8 @@ func aipStandardGetInfo(m *Method) *SampleInfo {
 	}
 
 	return &SampleInfo{
-		ResourceNameField: resourceField,
+		ResourceNameField:     resourceField,
+		IsRequestResourceName: true,
 	}
 }
 
@@ -434,7 +501,8 @@ func aipStandardDeleteInfo(m *Method) *SampleInfo {
 	}
 
 	return &SampleInfo{
-		ResourceNameField: resourceField,
+		ResourceNameField:     resourceField,
+		IsRequestResourceName: true,
 	}
 }
 
@@ -458,7 +526,8 @@ func aipStandardUndeleteInfo(m *Method) *SampleInfo {
 	}
 
 	return &SampleInfo{
-		ResourceNameField: resourceField,
+		ResourceNameField:     resourceField,
+		IsRequestResourceName: true,
 	}
 }
 
@@ -502,8 +571,9 @@ func aipStandardCreateInfo(m *Method) *SampleInfo {
 	resourceIDField := findResourceIDField(m.InputType, maybeSingular)
 
 	info := &SampleInfo{
-		ResourceNameField: parentField,
-		MessageField:      resourceField,
+		ResourceNameField:     parentField,
+		IsRequestResourceName: true,
+		MessageField:          resourceField,
 	}
 	if resourceIDField != nil {
 		info.ResourceIDField = resourceIDField
@@ -548,9 +618,21 @@ func aipStandardUpdateInfo(m *Method) *SampleInfo {
 		}
 	}
 
+	var resourceNameField *Field
+	if resourceField.MessageType != nil {
+		for _, f := range resourceField.MessageType.Fields {
+			if f.Name == StandardFieldNameForResourceRef {
+				resourceNameField = f
+				break
+			}
+		}
+	}
+
 	return &SampleInfo{
-		MessageField:    resourceField,
-		UpdateMaskField: updateMaskField,
+		ResourceNameField:     resourceNameField,
+		IsMessageResourceName: true,
+		MessageField:          resourceField,
+		UpdateMaskField:       updateMaskField,
 	}
 }
 
@@ -585,7 +667,8 @@ func aipStandardListInfo(m *Method) *SampleInfo {
 	}
 
 	return &SampleInfo{
-		ResourceNameField: parentField,
+		ResourceNameField:     parentField,
+		IsRequestResourceName: true,
 	}
 }
 

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -419,6 +419,207 @@ func TestEnrichSamplesOneOfExampleField(t *testing.T) {
 	}
 }
 
+func TestEnrichSamplesWithResourceNamePattern(t *testing.T) {
+	t.Run("resource type resolution", func(t *testing.T) {
+		res := &Resource{
+			Type: "test.googleapis.com/Resource",
+			Patterns: []ResourcePattern{
+				{
+					*(&PathSegment{}).WithLiteral("resources"),
+					*(&PathSegment{}).WithVariable(NewPathVariable("resource").WithMatch()),
+				},
+			},
+		}
+		field := &Field{
+			Name:  "notName",
+			ID:    ".test.ResourceMessage.name",
+			Typez: TypezString,
+			ResourceReference: &ResourceReference{
+				Type: "test.googleapis.com/Resource",
+			},
+		}
+		message := &Message{
+			Name:     "ResourceMessage",
+			ID:       ".test.ResourceMessage",
+			Fields:   []*Field{field},
+			Resource: res,
+		}
+		model := NewTestAPI([]*Message{message}, []*Enum{}, []*Service{})
+
+		if err := CrossReference(model); err != nil {
+			t.Fatal(err)
+		}
+
+		got := field.ResourceNamePattern
+		want := &ResourceNamePattern{
+			Segments: []ResourceNameSegment{
+				{Literal: "resources", Variable: "resource"},
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("child type resolution", func(t *testing.T) {
+		res := &Resource{
+			Type: "test.googleapis.com/Child",
+			Patterns: []ResourcePattern{
+				{
+					*(&PathSegment{}).WithLiteral("parents"),
+					*(&PathSegment{}).WithVariable(NewPathVariable("parent").WithMatch()),
+					*(&PathSegment{}).WithLiteral("children"),
+					*(&PathSegment{}).WithVariable(NewPathVariable("child").WithMatch()),
+				},
+			},
+		}
+		field := &Field{
+			Name:  "parent",
+			ID:    ".test.Message.parent",
+			Typez: TypezString,
+			ResourceReference: &ResourceReference{
+				ChildType: "test.googleapis.com/Child",
+			},
+		}
+		message := &Message{
+			Name:   "Message",
+			ID:     ".test.Message",
+			Fields: []*Field{field},
+		}
+		model := NewTestAPI([]*Message{message}, []*Enum{}, []*Service{})
+		model.AddResource(res)
+
+		if err := CrossReference(model); err != nil {
+			t.Fatal(err)
+		}
+
+		got := field.ResourceNamePattern
+		want := &ResourceNamePattern{
+			Segments: []ResourceNameSegment{
+				{Literal: "parents", Variable: "parent"},
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("name field resolution", func(t *testing.T) {
+		res := &Resource{
+			Type: "test.googleapis.com/Resource",
+			Patterns: []ResourcePattern{
+				{
+					*(&PathSegment{}).WithLiteral("resources"),
+					*(&PathSegment{}).WithVariable(NewPathVariable("resource").WithMatch()),
+				},
+			},
+		}
+		field := &Field{
+			Name:  "name",
+			ID:    ".test.ResourceMessage.name",
+			Typez: TypezString,
+		}
+		message := &Message{
+			Name:     "ResourceMessage",
+			ID:       ".test.ResourceMessage",
+			Fields:   []*Field{field},
+			Resource: res,
+		}
+		field.MessageType = message
+		model := NewTestAPI([]*Message{message}, []*Enum{}, []*Service{})
+
+		if err := CrossReference(model); err != nil {
+			t.Fatal(err)
+		}
+
+		got := field.ResourceNamePattern
+		want := &ResourceNamePattern{
+			Segments: []ResourceNameSegment{
+				{Literal: "resources", Variable: "resource"},
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestToResourceNamePattern(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		pattern  ResourcePattern
+		skipLast bool
+		want     *ResourceNamePattern
+	}{
+		{
+			name: "simple",
+			pattern: ResourcePattern{
+				*(&PathSegment{}).WithLiteral("projects"),
+				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
+			},
+			skipLast: false,
+			want: &ResourceNamePattern{
+				Segments: []ResourceNameSegment{
+					{Literal: "projects", Variable: "project"},
+				},
+			},
+		},
+		{
+			name: "multi-segment",
+			pattern: ResourcePattern{
+				*(&PathSegment{}).WithLiteral("projects"),
+				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
+				*(&PathSegment{}).WithLiteral("secrets"),
+				*(&PathSegment{}).WithVariable(NewPathVariable("secret").WithMatch()),
+			},
+			skipLast: false,
+			want: &ResourceNamePattern{
+				Segments: []ResourceNameSegment{
+					{Literal: "projects", Variable: "project"},
+					{Literal: "secrets", Variable: "secret"},
+				},
+			},
+		},
+		{
+			name: "multi-segment-skip-last",
+			pattern: ResourcePattern{
+				*(&PathSegment{}).WithLiteral("projects"),
+				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
+				*(&PathSegment{}).WithLiteral("secrets"),
+				*(&PathSegment{}).WithVariable(NewPathVariable("secret").WithMatch()),
+			},
+			skipLast: true,
+			want: &ResourceNamePattern{
+				Segments: []ResourceNameSegment{
+					{Literal: "projects", Variable: "project"},
+				},
+			},
+		},
+		{
+			name: "with trailing literal",
+			pattern: ResourcePattern{
+				*(&PathSegment{}).WithLiteral("projects"),
+				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
+				*(&PathSegment{}).WithLiteral("config"),
+			},
+			skipLast: false,
+			want: &ResourceNamePattern{
+				Segments: []ResourceNameSegment{
+					{Literal: "projects", Variable: "project"},
+					{Literal: "config", Variable: ""},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := toResourceNamePattern(test.pattern, test.skipLast)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestIsSimpleMethod(t *testing.T) {
 	somePagination := &Field{}
 	someOperationInfo := &OperationInfo{}
@@ -801,7 +1002,8 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.wildcardResourceField,
+				ResourceNameField:     f.wildcardResourceField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -813,7 +1015,8 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameField,
+				ResourceNameField:     f.resourceNameField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -827,7 +1030,8 @@ func TestAIPStandardGetInfo(t *testing.T) {
 				Model: f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameNoSingularField,
+				ResourceNameField:     f.resourceNameNoSingularField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -967,7 +1171,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				Model:        f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.wildcardResourceField,
+				ResourceNameField:     f.wildcardResourceField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -979,7 +1184,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				Model:        f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameField,
+				ResourceNameField:     f.resourceNameField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -991,7 +1197,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				Model:        f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameNoSingularField,
+				ResourceNameField:     f.resourceNameNoSingularField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1003,7 +1210,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				Model:         f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameField,
+				ResourceNameField:     f.resourceNameField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1015,7 +1223,8 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 				Model:        f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceOtherNameField,
+				ResourceNameField:     f.resourceOtherNameField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1097,7 +1306,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				Model: f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.wildcardResourceField,
+				ResourceNameField:     f.wildcardResourceField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1111,7 +1321,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				Model: f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameField,
+				ResourceNameField:     f.resourceNameField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1125,7 +1336,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				Model: f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameNoSingularField,
+				ResourceNameField:     f.resourceNameNoSingularField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1137,7 +1349,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				Model:         f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceNameField,
+				ResourceNameField:     f.resourceNameField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1151,7 +1364,8 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 				Model: f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: f.resourceOtherNameField,
+				ResourceNameField:     f.resourceOtherNameField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1257,9 +1471,10 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: parentField,
-				ResourceIDField:   idField,
-				MessageField:      resourceField,
+				ResourceNameField:     parentField,
+				IsRequestResourceName: true,
+				ResourceIDField:       idField,
+				MessageField:          resourceField,
 			},
 		},
 		{
@@ -1277,8 +1492,9 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: parentField,
-				MessageField:      resourceField,
+				ResourceNameField:     parentField,
+				IsRequestResourceName: true,
+				MessageField:          resourceField,
 			},
 		},
 		{
@@ -1314,13 +1530,19 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 	f := newAIPTestFixture()
 
 	// Setup for Update
-	secretMessage := &Message{ID: "secret_message_id"}
+	secretMessage := &Message{
+		ID: "secret_message_id",
+		Fields: []*Field{
+			f.resourceNameField,
+		},
+	}
 	f.resource.Self = secretMessage
 
 	resourceField := &Field{
-		Name:    "secret",
-		Typez:   TypezMessage,
-		TypezID: secretMessage.ID,
+		Name:        "secret",
+		Typez:       TypezMessage,
+		TypezID:     secretMessage.ID,
+		MessageType: secretMessage,
 	}
 	updateMaskField := &Field{
 		Name:    "update_mask",
@@ -1347,8 +1569,10 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				MessageField:    resourceField,
-				UpdateMaskField: updateMaskField,
+				ResourceNameField:     f.resourceNameField,
+				MessageField:          resourceField,
+				IsMessageResourceName: true,
+				UpdateMaskField:       updateMaskField,
 			},
 		},
 		{
@@ -1365,7 +1589,9 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				MessageField: resourceField,
+				ResourceNameField:     f.resourceNameField,
+				MessageField:          resourceField,
+				IsMessageResourceName: true,
 			},
 		},
 		{
@@ -1467,7 +1693,8 @@ func TestAIPStandardListInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: parentField,
+				ResourceNameField:     parentField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1479,7 +1706,8 @@ func TestAIPStandardListInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: otherParentField,
+				ResourceNameField:     otherParentField,
+				IsRequestResourceName: true,
 			},
 		},
 		{
@@ -1491,7 +1719,8 @@ func TestAIPStandardListInfo(t *testing.T) {
 				Model:      f.model,
 			},
 			want: &SampleInfo{
-				ResourceNameField: plainParentField,
+				ResourceNameField:     plainParentField,
+				IsRequestResourceName: true,
 			},
 		},
 		{

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -462,6 +462,14 @@ func (b *pathBindingAnnotation) PathTemplate() string {
 	return template
 }
 
+type sampleInfoAnnotation struct {
+	// StringParameters is the set of parameters of type string that should be shown
+	// on the sample method for any given RPC sample.
+	StringParameters []string
+	// FormatResourceName is true if the resource name format is known and shoulw be shown in the sample.
+	FormatResourceName bool
+}
+
 type oneOfAnnotation struct {
 	// In Rust, `oneof` fields are fields inside a struct. These must be
 	// `snake_case`. Possibly mangled with `r#` if the name is a Rust reserved
@@ -547,6 +555,16 @@ type fieldAnnotations struct {
 	// If this field is part of a oneof group, this will contain the other fields
 	// in the group.
 	OtherFieldsInGroup []*api.Field
+	// FormattedResource contains information on how to format the resource name.
+	FormattedResource *FormattedResource
+}
+
+// FormattedResource contain the format string and the format arguments of a resource name.
+type FormattedResource struct {
+	// The Rust format string, e.g., "projects/{}/secrets/{}"
+	FormatString string
+	// The variables used in the format string.
+	FormatArgs []string
 }
 
 // SkipIfIsEmpty returns true if the field should be skipped if it is empty.
@@ -670,6 +688,9 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 				if err := codec.annotateMessage(m, model, true); err != nil {
 					return nil, err
 				}
+			}
+			if si := m.SampleInfo; si != nil {
+				codec.annotateSampleInfo(si, m)
 			}
 		}
 		if _, err := codec.annotateService(s); err != nil {
@@ -1194,6 +1215,30 @@ func (c *codec) annotatePathInfo(m *api.Method) error {
 	return nil
 }
 
+func (c *codec) annotateSampleInfo(si *api.SampleInfo, m *api.Method) {
+	var parameters []string
+	var formatResourceName bool
+	if rn := si.ResourceNameField; rn != nil {
+		fieldAnn := rn.Codec.(*fieldAnnotations)
+		if fieldAnn.FormattedResource != nil && len(fieldAnn.FormattedResource.FormatArgs) > 0 {
+			parameters = fieldAnn.FormattedResource.FormatArgs
+			formatResourceName = true
+		} else {
+			parameters = []string{fieldAnn.SetterName}
+		}
+	} else if m.IsAIPStandardUpdate {
+		parameters = []string{"name"}
+	} else {
+		parameters = []string{}
+	}
+
+	ann := &sampleInfoAnnotation{
+		StringParameters:   parameters,
+		FormatResourceName: formatResourceName,
+	}
+	si.Codec = ann
+}
+
 func (c *codec) annotateOneOf(oneof *api.OneOf, message *api.Message, model *api.API) (*oneOfAnnotation, error) {
 	scope, err := c.messageScopeName(message, "", model.PackageName)
 	if err != nil {
@@ -1391,6 +1436,32 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 			ann.AliasInExamples = fmt.Sprintf("%sField", ann.AliasInExamples)
 		}
 	}
+
+	if field.ResourceNamePattern != nil && len(field.ResourceNamePattern.Segments) > 0 {
+		fr := &FormattedResource{}
+		var formatString []string
+		hasLiterals := false
+		for _, s := range field.ResourceNamePattern.Segments {
+			if s.Literal != "" {
+				hasLiterals = true
+				formatString = append(formatString, s.Literal)
+			}
+			if s.Variable != "" {
+				// Convert variable to snake_case and add _id suffix if needed
+				arg := toSnakeNoMangling(s.Variable)
+				if !strings.HasSuffix(arg, "_id") && !strings.HasSuffix(arg, "_name") {
+					arg += "_id"
+				}
+				formatString = append(formatString, "{"+arg+"}")
+				fr.FormatArgs = append(fr.FormatArgs, arg)
+			}
+		}
+		if hasLiterals && len(fr.FormatArgs) > 0 {
+			fr.FormatString = strings.Join(formatString, "/")
+			ann.FormattedResource = fr
+		}
+	}
+
 	return ann, nil
 }
 

--- a/internal/sidekick/rust/annotate_field_test.go
+++ b/internal/sidekick/rust/annotate_field_test.go
@@ -908,3 +908,74 @@ func TestEnumFieldAnnotations(t *testing.T) {
 		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
 	}
 }
+
+func TestFormattedResourceAnnotations(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		segments   []api.ResourceNameSegment
+		wantString string
+		wantArgs   []string
+	}{
+		{name: "standard",
+			segments: []api.ResourceNameSegment{
+				{Literal: "projects"},
+				{Variable: "project"},
+				{Literal: "locations"},
+				{Variable: "location"},
+				{Literal: "secrets"},
+				{Variable: "secret"},
+			},
+			wantString: "projects/{project_id}/locations/{location_id}/secrets/{secret_id}",
+			wantArgs:   []string{"project_id", "location_id", "secret_id"},
+		},
+		{
+			name: "with name suffix",
+			segments: []api.ResourceNameSegment{
+				{Literal: "topics"},
+				{Variable: "topicName"},
+			},
+			wantString: "topics/{topic_name}",
+			wantArgs:   []string{"topic_name"},
+		},
+		{
+			name: "already has id suffix",
+			segments: []api.ResourceNameSegment{
+				{Literal: "projects"},
+				{Variable: "projectId"},
+			},
+			wantString: "projects/{project_id}",
+			wantArgs:   []string{"project_id"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			field := &api.Field{
+				Name:  "name",
+				ID:    ".test.v1.Message.name",
+				Typez: api.TypezString,
+				ResourceNamePattern: &api.ResourceNamePattern{
+					Segments: test.segments,
+				},
+			}
+			message := &api.Message{
+				Name:    "TestMessage",
+				Package: "test.v1",
+				ID:      ".test.v1.TestMessage",
+				Fields:  []*api.Field{field},
+			}
+
+			model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+			api.CrossReference(model)
+			codec := newTestCodec(t, libconfig.SpecProtobuf, "test", map[string]string{})
+			annotateModel(model, codec)
+
+			got := field.Codec.(*fieldAnnotations).FormattedResource
+			want := &FormattedResource{
+				FormatString: test.wantString,
+				FormatArgs:   test.wantArgs,
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -511,3 +511,46 @@ func TestFormatResourceNameTemplateFromPath(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotateSampleInfo(t *testing.T) {
+	field := &api.Field{
+		Name:  "name",
+		ID:    ".test.v1.Message.name",
+		Typez: api.TypezString,
+		ResourceNamePattern: &api.ResourceNamePattern{
+			Segments: []api.ResourceNameSegment{
+				{Literal: "projects"},
+				{Variable: "project"},
+			},
+		},
+	}
+	message := &api.Message{
+		Name:    "TestMessage",
+		Package: "test.v1",
+		ID:      ".test.v1.TestMessage",
+		Fields:  []*api.Field{field},
+	}
+	method := &api.Method{
+		Name: "TestMethod",
+		ID:   ".test.v1.Service.TestMethod",
+	}
+	si := &api.SampleInfo{
+		ResourceNameField: field,
+	}
+
+	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+	api.CrossReference(model)
+	codec := newTestCodec(t, libconfig.SpecProtobuf, "test", map[string]string{})
+	annotateModel(model, codec)
+
+	codec.annotateSampleInfo(si, method)
+
+	got := si.Codec.(*sampleInfoAnnotation)
+	want := &sampleInfoAnnotation{
+		StringParameters:   []string{"project_id"},
+		FormatResourceName: true,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -420,7 +420,7 @@ func checkApiVersionComments(t *testing.T, outDir string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lines := strings.Split(string(contents), "\n")
+	lines := strings.Split(strings.ReplaceAll(string(contents), "\r\n", "\n"), "\n")
 	for _, test := range []struct {
 		featureName string
 		wantVersion string

--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -67,3 +67,6 @@ all-features = true
 {{#Codec.RequiredPackages}}
 {{{.}}}
 {{/Codec.RequiredPackages}}
+
+[dev-dependencies]
+anyhow.workspace = true

--- a/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/builder_fields.mustache
@@ -15,17 +15,36 @@ limitations under the License.
 }}
 {{#IsAIPStandard}}
 {{#SampleInfo}}
-{{#ResourceNameField}}
-///         .set_{{Codec.SetterName}}({{Codec.SetterName}})
-{{/ResourceNameField}}
+{{#IsRequestResourceName}}
+{{#Codec.FormatResourceName}}
+///         .set_{{ResourceNameField.Codec.SetterName}}(format!("{{ResourceNameField.Codec.FormattedResource.FormatString}}"))
+{{/Codec.FormatResourceName}}
+{{^Codec.FormatResourceName}}
+///         .set_{{ResourceNameField.Codec.SetterName}}({{#Codec.StringParameters}}{{.}}{{/Codec.StringParameters}})
+{{/Codec.FormatResourceName}}
+{{/IsRequestResourceName}}
 {{#ResourceIDField}}
 ///         .set_{{Codec.SetterName}}("{{Codec.SetterName}}_value")
 {{/ResourceIDField}}
+{{#IsMessageResourceName}}
+{{#Codec.FormatResourceName}}
+///         .set_{{MessageField.Codec.SetterName}}(
+///             {{MessageField.MessageType.Codec.Name}}::new().set_name(format!("{{ResourceNameField.Codec.FormattedResource.FormatString}}"))/* set fields */
+///         )
+{{/Codec.FormatResourceName}}
+{{^Codec.FormatResourceName}}
+///         .set_{{MessageField.Codec.SetterName}}(
+///             {{MessageField.MessageType.Codec.Name}}::new().set_name({{#Codec.StringParameters}}{{.}}{{/Codec.StringParameters}})/* set fields */
+///         )
+{{/Codec.FormatResourceName}}
+{{/IsMessageResourceName}}
+{{^IsMessageResourceName}}
 {{#MessageField}}
 ///         .set_{{Codec.SetterName}}(
-///             {{MessageType.Codec.Name}}::new(){{#IsAIPStandardUpdate}}.set_name(name){{/IsAIPStandardUpdate}}/* set fields */
+///             {{MessageType.Codec.Name}}::new()/* set fields */
 ///         )
 {{/MessageField}}
+{{/IsMessageResourceName}}
 {{#UpdateMaskField}}
 ///         .set_{{Codec.SetterName}}(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
 {{/UpdateMaskField}}

--- a/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/parameters.mustache
@@ -13,11 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{#IsAIPStandard}}
-{{#SampleInfo}}
-///    client: &{{Service.Codec.Name}}{{#ResourceNameField}}, {{Codec.SetterName}}: &str{{/ResourceNameField}}{{#IsAIPStandardUpdate}}, name: &str{{/IsAIPStandardUpdate}}
-{{/SampleInfo}}
-{{/IsAIPStandard}}
-{{^IsAIPStandard}}
-///    client: &{{Service.Codec.Name}}
-{{/IsAIPStandard}}
+///    client: &{{Service.Codec.Name}}{{#SampleInfo}}{{#Codec.StringParameters}}, {{.}}: &str{{/Codec.StringParameters}}{{/SampleInfo}}

--- a/internal/sidekick/rust/templates/common/quickstart.mustache
+++ b/internal/sidekick/rust/templates/common/quickstart.mustache
@@ -23,20 +23,20 @@ limitations under the License.
 {{> /templates/common/client_method_samples/use_statements}}
 {{/QuickstartMethod}}
 {{/Model.Codec.GenerateRpcSamples}}
-/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+/// async fn sample(
+{{#Model.Codec.GenerateRpcSamples}}
+{{#QuickstartMethod}}
+{{#SampleInfo}}
+{{#Codec.StringParameters}}
+///    {{.}}: &str,
+{{/Codec.StringParameters}}
+{{/SampleInfo}}
+{{/QuickstartMethod}}
+{{/Model.Codec.GenerateRpcSamples}}
+/// ) -> anyhow::Result<()> {
 ///     let client = {{Codec.Name}}::builder().build().await?;
 {{#Model.Codec.GenerateRpcSamples}}
 {{#QuickstartMethod}}
-{{#IsAIPStandard}}
-{{#SampleInfo}}
-{{#ResourceNameField}}
-///     let {{Codec.SetterName}} = "{{Codec.SetterName}}_value";
-{{/ResourceNameField}}
-{{#IsAIPStandardUpdate}}
-///     let name = "name_value";
-{{/IsAIPStandardUpdate}}
-{{/SampleInfo}}
-{{/IsAIPStandard}}
 {{> /templates/common/client_method_samples/method_call}}
 {{/QuickstartMethod}}
 {{^QuickstartMethod}}
@@ -46,6 +46,7 @@ limitations under the License.
 {{^Model.Codec.GenerateRpcSamples}}
 ///     // use `client` to make requests to the {{Codec.APITitle}}.
 {{/Model.Codec.GenerateRpcSamples}}
-/// # Ok(()) }
+///     Ok(())
+/// }
 /// ```
 {{/Model.Codec.InternalBuilders}}


### PR DESCRIPTION
RPC rely on resource names to identify the resource they operate on. If we know the format of the resource name, we show it on RPC samples.