### PR TITLE
feat(dart): support a SSE allowlist

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -157,6 +157,7 @@ This document describes the schema for the librarian.yaml.
 | `readme_after_title_text` | string | Is text to insert in the README after the title. |
 | `readme_quickstart_text` | string | Is text to use for the quickstart section in the README. |
 | `repository_url` | string | Is the URL to the repository for this package. |
+| `supports_sse` | bool | Indicates whether the target API supports Server-Sent Events (SSE) for methods where `ServerSideStreaming` is `true`. |
 | `title_override` | string | Overrides the API title. |
 | `version` | string | Is the version of the dart package. |
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -475,7 +475,7 @@ type DartPackage struct {
 	// RepositoryURL is the URL to the repository for this package.
 	RepositoryURL string `yaml:"repository_url,omitempty"`
 
-	// SupportsSSE indicates whether the taget API supports Server-Sent Events (SSE) for methods
+	// SupportsSSE indicates whether the target API supports Server-Sent Events (SSE) for methods
 	// where `ServerSideStreaming` is `true`.
 	SupportsSSE bool `yaml:"supports_sse,omitempty"`
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -475,6 +475,10 @@ type DartPackage struct {
 	// RepositoryURL is the URL to the repository for this package.
 	RepositoryURL string `yaml:"repository_url,omitempty"`
 
+	// SupportsSSE indicates whether the taget API supports Server-Sent Events (SSE) for methods
+	// where `ServerSideStreaming` is `true`.
+	SupportsSSE bool `yaml:"supports_sse,omitempty"`
+
 	// TitleOverride overrides the API title.
 	TitleOverride string `yaml:"title_override,omitempty"`
 

--- a/internal/librarian/dart/codec.go
+++ b/internal/librarian/dart/codec.go
@@ -117,6 +117,9 @@ func buildCodec(library *config.Library) map[string]string {
 	if dart.RepositoryURL != "" {
 		codec["repository-url"] = dart.RepositoryURL
 	}
+	if dart.SupportsSSE {
+		codec["supports-sse"] = "true"
+	}
 	for key, value := range dart.Packages {
 		codec[key] = value
 	}

--- a/internal/librarian/dart/codec_test.go
+++ b/internal/librarian/dart/codec_test.go
@@ -194,6 +194,17 @@ func TestBuildCodec(t *testing.T) {
 			},
 		},
 		{
+			name: "supports sse",
+			library: &config.Library{
+				Dart: &config.DartPackage{
+					SupportsSSE: true,
+				},
+			},
+			want: map[string]string{
+				"supports-sse": "true",
+			},
+		},
+		{
 			name: "all fields",
 			library: &config.Library{
 				CopyrightYear: "2025",
@@ -219,6 +230,7 @@ func TestBuildCodec(t *testing.T) {
 					Protos: map[string]string{
 						"proto:google.api": "package:google_cloud_api/api.dart",
 					},
+					SupportsSSE: true,
 				},
 			},
 			want: map[string]string{
@@ -235,6 +247,7 @@ func TestBuildCodec(t *testing.T) {
 				"readme-after-title-text":        "**Note:** This package is experimental.",
 				"readme-quickstart-text":         "Run `dart pub add` to install.",
 				"repository-url":                 "https://github.com/googleapis/google-cloud-dart",
+				"supports-sse":                   "true",
 				"package:googleapis_auth":        "^2.0.0",
 				"prefix:google.protobuf":         "pb",
 				"proto:google.api":               "package:google_cloud_api/api.dart",

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -150,7 +150,8 @@ type methodAnnotation struct {
 	BodyMessageName     string
 	QueryLines          []string
 	IsLROGetOperation   bool
-	ServerSideStreaming bool // Whether the server supports streaming via server-sent events (SSE).
+	ServerSideStreaming bool // Whether the method produces a stream of results (or list if `EnableSSE` is `false`).
+	EnableSSE           bool // Whether the taget API supports Server-Sent Events (SSE).
 }
 
 // HasBody returns true if the method has a body.
@@ -230,6 +231,8 @@ type annotateModel struct {
 	packagePrefixes map[string]string
 	// A mapping from a package name (e.g. "http") to its version constraint (e.g. "^1.3.0").
 	dependencyConstraints map[string]string
+	// Whether the target API supports Server-Sent Events (SSE).
+	supportsSSE bool
 }
 
 func newAnnotateModel(model *api.API) *annotateModel {
@@ -326,6 +329,16 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 				)
 			}
 			doNotPublish = value
+		case key == "supports-sse":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return fmt.Errorf(
+					"cannot convert `supports-sse` value %q to boolean: %w",
+					definition,
+					err,
+				)
+			}
+			annotate.supportsSSE = value
 		case key == "readme-after-title-text":
 			// Markdown that will be inserted into the README.md after the title section.
 			readMeAfterTitleText = definition
@@ -722,6 +735,7 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 		QueryLines:          queryLines,
 		IsLROGetOperation:   isGetOperation,
 		ServerSideStreaming: method.ServerSideStreaming,
+		EnableSSE:           method.ServerSideStreaming && annotate.supportsSSE,
 	}
 	method.Codec = annotation
 }

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -151,7 +151,7 @@ type methodAnnotation struct {
 	QueryLines          []string
 	IsLROGetOperation   bool
 	ServerSideStreaming bool // Whether the method produces a stream of results (or list if `EnableSSE` is `false`).
-	EnableSSE           bool // Whether the taget API supports Server-Sent Events (SSE).
+	EnableSSE           bool // Whether the target API supports Server-Sent Events (SSE).
 }
 
 // HasBody returns true if the method has a body.

--- a/internal/sidekick/dart/templates/lib/method.mustache
+++ b/internal/sidekick/dart/templates/lib/method.mustache
@@ -32,7 +32,9 @@ Stream<{{Codec.ResponseType}}> {{Codec.Name}}({{Codec.RequestType}} request) {
     {{/Codec.HasQueryLines}}
   );
   return _client
-      .{{Codec.RequestMethod}}Streaming(url{{#Codec.HasBody}}, body: {{Codec.BodyMessageName}}{{/Codec.HasBody}})
+      .{{Codec.RequestMethod}}Streaming(url{{#Codec.HasBody}},
+        body: {{Codec.BodyMessageName}}{{/Codec.HasBody}},
+        enableSse: {{Codec.EnableSSE}})
       .map({{Codec.ResponseType}}.fromJson);
 }
 {{/Codec.ServerSideStreaming}}


### PR DESCRIPTION
Not all APIs with results marked `stream` support Server-Sent Events (SSE).

This PR adds a configuration option to enable SSE for the API.

```yaml
  - name: google_cloud_showcase_v1beta1
    apis:
      - path: schema/google/showcase/v1beta1
    dart:
      supports_sse: true
```

Based on this configuration, a boolean configuration option, `enableSse`, is passed to the transport layer: 

```dart
  Stream<GenerateContentResponse> streamGenerateContent(
    GenerateContentRequest request,
  ) {
    final url = _endPoint.replace(
      path: '/v1beta/${request.model}:streamGenerateContent',
    );
    return _client
        .postStreaming(url, body: request, enableSse: true)
        .map(GenerateContentResponse.fromJson);
  }
```

`enableSse` is used to decide whether to request SSE from the server.