### PR TITLE
refactor(sidekick): transition from APIState to API in function signatures

### DIFF
--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -364,7 +364,7 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 	}
 
 	// Register any missing WKTs.
-	registerMissingWkt(annotate.state)
+	registerMissingWkt(annotate.model)
 
 	model := annotate.model
 
@@ -438,7 +438,7 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 			}
 			return ""
 		}(),
-		DocLines:                   formatDocComments(model.Description, model.State),
+		DocLines:                   formatDocComments(model.Description, model),
 		Imports:                    calculateImports(annotate.imports, pkgName, mainFileNameWithExtension),
 		PartFileReference:          partFileReference,
 		PackageDependencies:        packageDependencies,
@@ -582,7 +582,7 @@ func (annotate *annotateModel) annotateService(s *api.Service) {
 	}
 	ann := &serviceAnnotations{
 		Name:        s.Name,
-		DocLines:    formatDocComments(s.Documentation, annotate.state),
+		DocLines:    formatDocComments(s.Documentation, annotate.model),
 		Methods:     methods,
 		FieldName:   strcase.ToLowerCamel(s.Name),
 		StructName:  s.Name,
@@ -629,7 +629,7 @@ func (annotate *annotateModel) annotateMessage(m *api.Message) {
 		Parent:          m,
 		Name:            messageName(m),
 		QualifiedName:   qualifiedName(m),
-		DocLines:        formatDocComments(m.Documentation, annotate.state),
+		DocLines:        formatDocComments(m.Documentation, annotate.model),
 		OmitGeneration:  m.IsMap,
 		ConstructorBody: constructorBody,
 		ToStringLines:   toStringLines,
@@ -707,7 +707,7 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 	queryParams := language.QueryParams(method, method.PathInfo.Bindings[0])
 	queryLines := []string{}
 	for _, field := range queryParams {
-		queryLines = annotate.buildQueryLines(queryLines, "request.", false, "", field, state)
+		queryLines = annotate.buildQueryLines(queryLines, "request.", false, "", field)
 	}
 
 	annotation := &methodAnnotation{
@@ -716,7 +716,7 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 		RequestMethod:       strings.ToLower(method.PathInfo.Bindings[0].Verb),
 		RequestType:         annotate.resolveMessageName(state.MessageByID[method.InputTypeID], true),
 		ResponseType:        annotate.resolveMessageName(state.MessageByID[method.OutputTypeID], true),
-		DocLines:            formatDocComments(method.Documentation, state),
+		DocLines:            formatDocComments(method.Documentation, annotate.model),
 		ReturnsValue:        !method.ReturnsEmpty,
 		BodyMessageName:     bodyMessageName,
 		QueryLines:          queryLines,
@@ -739,7 +739,7 @@ func (annotate *annotateModel) annotateOperationInfo(operationInfo *api.Operatio
 func (annotate *annotateModel) annotateOneOf(oneof *api.OneOf) {
 	oneof.Codec = &oneOfAnnotation{
 		Name:     strcase.ToLowerCamel(oneof.Name),
-		DocLines: formatDocComments(oneof.Documentation, annotate.state),
+		DocLines: formatDocComments(oneof.Documentation, annotate.model),
 	}
 }
 
@@ -810,22 +810,21 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 			constDefault = defaultValues[field.Typez].IsConst
 		}
 	}
-	state := annotate.state
 	field.Codec = &fieldAnnotation{
 		Name:                  fieldName(field),
 		Type:                  annotate.fieldType(field),
-		DocLines:              formatDocComments(field.Documentation, state),
+		DocLines:              formatDocComments(field.Documentation, annotate.model),
 		Required:              implicitPresence,
 		Nullable:              !implicitPresence,
 		FieldBehaviorRequired: fieldRequired,
 		DefaultValue:          defaultValue,
-		FromJson:              annotate.createFromJsonLine(field, state, implicitPresence),
-		ToJson:                createToJsonLine(field, state),
+		FromJson:              annotate.createFromJsonLine(field, implicitPresence),
+		ToJson:                createToJsonLine(field, annotate.model),
 		ConstDefault:          constDefault,
 	}
 }
 
-func (annotate *annotateModel) decoder(typez api.Typez, typeid string, state *api.APIState) string {
+func (annotate *annotateModel) decoder(typez api.Typez, typeid string) string {
 	switch typez {
 	case api.INT64_TYPE,
 		api.SINT64_TYPE,
@@ -850,10 +849,10 @@ func (annotate *annotateModel) decoder(typez api.Typez, typeid string, state *ap
 	case api.BYTES_TYPE:
 		return "decodeBytes"
 	case api.ENUM_TYPE:
-		typeName := annotate.resolveEnumName(state.EnumByID[typeid])
+		typeName := annotate.resolveEnumName(annotate.state.EnumByID[typeid])
 		return fmt.Sprintf("%s.fromJson", typeName)
 	case api.MESSAGE_TYPE:
-		typeName := annotate.resolveMessageName(state.MessageByID[typeid], false)
+		typeName := annotate.resolveMessageName(annotate.state.MessageByID[typeid], false)
 		return fmt.Sprintf("%s.fromJson", typeName)
 	default:
 		panic(fmt.Sprintf("unsupported type: %d", typez))
@@ -959,7 +958,7 @@ func keyEncoder(typez api.Typez, name string) (string, bool) {
 	}
 }
 
-func (annotate *annotateModel) createFromJsonLine(field *api.Field, state *api.APIState, required bool) string {
+func (annotate *annotateModel) createFromJsonLine(field *api.Field, required bool) string {
 	data := fmt.Sprintf("json['%s']", field.JSONName)
 
 	defaultValue := "null"
@@ -981,18 +980,18 @@ func (annotate *annotateModel) createFromJsonLine(field *api.Field, state *api.A
 	switch {
 	// Value.NullValue is encoded as null in JSON so lists and map values must match on nullable objects.
 	case field.Repeated:
-		decoder := annotate.decoder(field.Typez, field.TypezID, state)
+		decoder := annotate.decoder(field.Typez, field.TypezID)
 		return fmt.Sprintf(
 			"switch (%s) { null => %s, List<Object?> $1 => [for (final i in $1) %s(i)], "+
 				"_ => throw const FormatException('\"%s\" is not a list') }",
 			data, defaultValue, decoder, field.JSONName)
 	case field.Map:
-		message := state.MessageByID[field.TypezID]
+		message := annotate.state.MessageByID[field.TypezID]
 		keyType := message.Fields[0].Typez
 		keyDecoder := annotate.keyDecoder(keyType)
 		valueType := message.Fields[1].Typez
 		valueTypeID := message.Fields[1].TypezID
-		valueDecoder := annotate.decoder(valueType, valueTypeID, state)
+		valueDecoder := annotate.decoder(valueType, valueTypeID)
 
 		return fmt.Sprintf(
 			"switch (%s) { null => %s, Map<String, Object?> $1 => {for (final e in $1.entries) %s(e.key): %s(e.value)}, "+
@@ -1000,11 +999,11 @@ func (annotate *annotateModel) createFromJsonLine(field *api.Field, state *api.A
 			data, defaultValue, keyDecoder, valueDecoder, field.JSONName)
 	}
 
-	decoder := annotate.decoder(field.Typez, field.TypezID, state)
+	decoder := annotate.decoder(field.Typez, field.TypezID)
 	return fmt.Sprintf("switch (%s) { null => %s, Object $1 => %s($1)}", data, defaultValue, decoder)
 }
 
-func createToJsonLine(field *api.Field, state *api.APIState) string {
+func createToJsonLine(field *api.Field, model *api.API) string {
 	name := fieldName(field)
 
 	switch {
@@ -1016,7 +1015,7 @@ func createToJsonLine(field *api.Field, state *api.APIState) string {
 		}
 		return name
 	case field.Map:
-		message := state.MessageByID[field.TypezID]
+		message := model.State.MessageByID[field.TypezID]
 		keyType := message.Fields[0].Typez
 		keyEncoder, keyEncodingRequired := keyEncoder(keyType, "e.key")
 		valueType := message.Fields[1].Typez
@@ -1070,9 +1069,9 @@ func createToJsonLine(field *api.Field, state *api.APIState) string {
 //	// if (request.sub?.id case final $1? when $1.isNotDefault) 'sub.id=$1'
 func (annotate *annotateModel) buildQueryLines(
 	result []string, refPrefix string, couldRefPrefixBeNull bool,
-	paramPrefix string, field *api.Field, state *api.APIState,
+	paramPrefix string, field *api.Field,
 ) []string {
-	message := state.MessageByID[field.TypezID]
+	message := annotate.state.MessageByID[field.TypezID]
 	isMap := message != nil && message.IsMap
 
 	if field.Codec == nil {
@@ -1134,7 +1133,7 @@ func (annotate *annotateModel) buildQueryLines(
 		// Unroll the fields for messages.
 		for _, field := range message.Fields {
 			result = annotate.buildQueryLines(
-				result, ref+deref, couldRefPrefixBeNull || codec.Nullable, param+".", field, state)
+				result, ref+deref, couldRefPrefixBeNull || codec.Nullable, param+".", field)
 		}
 		return result
 
@@ -1201,7 +1200,7 @@ func (annotate *annotateModel) annotateEnum(enum *api.Enum) {
 
 	enum.Codec = &enumAnnotation{
 		Name:         enumName(enum),
-		DocLines:     formatDocComments(enum.Documentation, annotate.state),
+		DocLines:     formatDocComments(enum.Documentation, annotate.model),
 		DefaultValue: defaultValue,
 		Model:        annotate.model,
 	}
@@ -1210,7 +1209,7 @@ func (annotate *annotateModel) annotateEnum(enum *api.Enum) {
 func (annotate *annotateModel) annotateEnumValue(ev *api.EnumValue, enumValueToName map[*api.EnumValue]string) {
 	ev.Codec = &enumValueAnnotation{
 		Name:     enumValueToName[ev],
-		DocLines: formatDocComments(ev.Documentation, annotate.state),
+		DocLines: formatDocComments(ev.Documentation, annotate.model),
 	}
 }
 
@@ -1310,7 +1309,7 @@ func (annotate *annotateModel) updateUsedPackages(packageName string) {
 	}
 }
 
-func registerMissingWkt(state *api.APIState) {
+func registerMissingWkt(model *api.API) {
 	// If these definitions weren't provided by protoc then provide our own
 	// placeholders.
 	for _, message := range []struct {
@@ -1321,9 +1320,9 @@ func registerMissingWkt(state *api.APIState) {
 		{".google.protobuf.Any", "Any", "google.protobuf"},
 		{".google.protobuf.Empty", "Empty", "google.protobuf"},
 	} {
-		_, ok := state.MessageByID[message.ID]
+		_, ok := model.State.MessageByID[message.ID]
 		if !ok {
-			state.MessageByID[message.ID] = &api.Message{
+			model.State.MessageByID[message.ID] = &api.Message{
 				ID:      message.ID,
 				Name:    message.Name,
 				Package: message.Package,

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -740,7 +740,7 @@ func TestBuildQueryLines_Primitives(t *testing.T) {
 			annotate := newAnnotateModel(model)
 			annotate.annotateModel(map[string]string{})
 
-			got := annotate.buildQueryLines([]string{}, "result.", false, "", test.field, model.State)
+			got := annotate.buildQueryLines([]string{}, "result.", false, "", test.field)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
 			}
@@ -805,7 +805,7 @@ func TestBuildQueryLines_Enums(t *testing.T) {
 		},
 	} {
 		t.Run(test.enumField.Name, func(t *testing.T) {
-			got := annotate.buildQueryLines([]string{}, "result.", false, "", test.enumField, model.State)
+			got := annotate.buildQueryLines([]string{}, "result.", false, "", test.enumField)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch in TestBuildQueryLinesEnums (-want, +got)\n:%s", diff)
 			}
@@ -868,7 +868,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 	}
 
 	// messages
-	got := annotate.buildQueryLines([]string{}, "result.", false, "", messageField1, model.State)
+	got := annotate.buildQueryLines([]string{}, "result.", false, "", messageField1)
 	want := []string{
 		"if (result.message1?.name case final $1? when $1.isNotDefault) 'message1.name': $1",
 		"if (result.message1?.state case final $1? when $1.isNotDefault) 'message1.state': $1.value",
@@ -877,7 +877,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
 	}
 
-	got = annotate.buildQueryLines([]string{}, "result.", false, "", messageField2, model.State)
+	got = annotate.buildQueryLines([]string{}, "result.", false, "", messageField2)
 	want = []string{
 		"if (result.message2?.data case final $1?) 'message2.data': encodeBytes($1)!",
 		"if (result.message2?.dataCrc32C case final $1?) 'message2.dataCrc32c': '${$1}'",
@@ -887,7 +887,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 	}
 
 	// nested messages
-	got = annotate.buildQueryLines([]string{}, "result.", false, "", messageField3, model.State)
+	got = annotate.buildQueryLines([]string{}, "result.", false, "", messageField3)
 	want = []string{
 		"if (result.message3?.secret?.name case final $1? when $1.isNotDefault) 'message3.secret.name': $1",
 		"if (result.message3?.fieldMask case final $1?) 'message3.fieldMask': $1.toJson()",
@@ -897,7 +897,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 	}
 
 	// custom encoded messages
-	got = annotate.buildQueryLines([]string{}, "result.", false, "", fieldMaskField, model.State)
+	got = annotate.buildQueryLines([]string{}, "result.", false, "", fieldMaskField)
 	want = []string{
 		"if (result.fieldMask case final $1?) 'fieldMask': $1.toJson()",
 	}
@@ -905,7 +905,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
 	}
 
-	got = annotate.buildQueryLines([]string{}, "result.", false, "", durationField, model.State)
+	got = annotate.buildQueryLines([]string{}, "result.", false, "", durationField)
 	want = []string{
 		"if (result.duration case final $1?) 'duration': $1.toJson()",
 	}
@@ -913,7 +913,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
 	}
 
-	got = annotate.buildQueryLines([]string{}, "result.", false, "", timestampField, model.State)
+	got = annotate.buildQueryLines([]string{}, "result.", false, "", timestampField)
 	want = []string{
 		"if (result.time case final $1?) 'time': $1.toJson()",
 	}
@@ -1153,7 +1153,7 @@ func TestCreateFromJsonLine(t *testing.T) {
 			})
 			codec := test.field.Codec.(*fieldAnnotation)
 
-			got := annotate.createFromJsonLine(test.field, model.State, codec.Required)
+			got := annotate.createFromJsonLine(test.field, codec.Required)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
 			}
@@ -1500,7 +1500,7 @@ func TestCreateToJsonLine(t *testing.T) {
 				"prefix:google.cloud.foo": "foo",
 			})
 
-			got := createToJsonLine(test.field, model.State)
+			got := createToJsonLine(test.field, model)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch in TestCreateToJsonLine (-want, +got)\n:%s", diff)
 			}
@@ -1821,7 +1821,7 @@ func TestAnnotateField(t *testing.T) {
 			model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enumState}, []*api.Service{})
 			model.State.MessageByID[mapMessage.ID] = mapMessage
 			annotate := newAnnotateModel(model)
-			registerMissingWkt(annotate.state)
+			registerMissingWkt(annotate.model)
 
 			annotate.annotateField(test.field)
 			got := test.field.Codec.(*fieldAnnotation)

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -192,7 +192,7 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 // - `[google.rpc.Code][]`.
 var commentRefsRegex = regexp.MustCompile(`\[([\w\d\._]+)\]\[([\d\w\._]*)\]`)
 
-func formatDocComments(documentation string, _ *api.APIState) []string {
+func formatDocComments(documentation string, _ *api.API) []string {
 	lines := strings.Split(documentation, "\n")
 
 	// Remove trailing whitespace.

--- a/internal/sidekick/dart/dart_test.go
+++ b/internal/sidekick/dart/dart_test.go
@@ -511,8 +511,7 @@ We want to respect whitespace at the beginning, because it important in Markdown
 		"///   - A nested thing",
 		"/// - The next thing",
 	}
-	state := &api.APIState{}
-	got := formatDocComments(input, state)
+	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -522,8 +521,7 @@ func TestFormatDocCommentsEmpty(t *testing.T) {
 	input := ``
 
 	want := []string{}
-	state := &api.APIState{}
-	got := formatDocComments(input, state)
+	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -539,8 +537,7 @@ This line has trailing spaces.  `
 		"///",
 		"/// This line has trailing spaces.",
 	}
-	state := &api.APIState{}
-	got := formatDocComments(input, state)
+	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -558,16 +555,13 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
 		"/// sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
 		"/// Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
 	}
-	state := &api.APIState{}
-	got := formatDocComments(input, state)
+	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
 }
 
 func TestFormatDocCommentsRewriteReferences(t *testing.T) {
-	state := &api.APIState{}
-
 	for _, test := range []struct {
 		testName string
 		input    string
@@ -609,7 +603,7 @@ is set to true, this field will contain the sentiment for the sentence.`,
 		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			gotLines := formatDocComments(test.input, state)
+			gotLines := formatDocComments(test.input, nil)
 			got := strings.Join(gotLines, "\n")
 			if diff := cmp.Diff(test.output, got); diff != "" {
 				t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)

--- a/internal/sidekick/language/codec.go
+++ b/internal/sidekick/language/codec.go
@@ -38,8 +38,8 @@ type GeneratedFile struct {
 type TemplateProvider func(templateName string) (string, error)
 
 // PathParams returns the path parameters for a method.
-func PathParams(m *api.Method, state *api.APIState) ([]*api.Field, error) {
-	msg, ok := state.MessageByID[m.InputTypeID]
+func PathParams(m *api.Method, model *api.API) ([]*api.Field, error) {
+	msg, ok := model.State.MessageByID[m.InputTypeID]
 	if !ok {
 		return nil, fmt.Errorf("unable to lookup request type: %q", m.InputTypeID)
 	}
@@ -111,11 +111,11 @@ func HasNestedTypes(m *api.Message) bool {
 }
 
 // FieldIsMap returns true if the field is a map.
-func FieldIsMap(f *api.Field, state *api.APIState) bool {
+func FieldIsMap(f *api.Field, model *api.API) bool {
 	if f.Typez != api.MESSAGE_TYPE {
 		return false
 	}
-	if m, ok := state.MessageByID[f.TypezID]; ok {
+	if m, ok := model.State.MessageByID[f.TypezID]; ok {
 		return m.IsMap
 	}
 	return false

--- a/internal/sidekick/language/codec_test.go
+++ b/internal/sidekick/language/codec_test.go
@@ -77,7 +77,7 @@ func TestPathParams(t *testing.T) {
 
 	less := func(a, b *api.Field) bool { return a.Name < b.Name }
 
-	got, err := PathParams(sample.MethodCreate(), test.State)
+	got, err := PathParams(sample.MethodCreate(), test)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestPathParams(t *testing.T) {
 		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
 	}
 
-	got, err = PathParams(sample.MethodUpdate(), test.State)
+	got, err = PathParams(sample.MethodUpdate(), test)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,13 +207,13 @@ func TestFieldIsMap(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{parent, map_message}, []*api.Enum{}, []*api.Service{})
 
-	if !FieldIsMap(field0, model.State) {
+	if !FieldIsMap(field0, model) {
 		t.Errorf("expected FieldIsMap(field0) to be true")
 	}
-	if FieldIsMap(field1, model.State) {
+	if FieldIsMap(field1, model) {
 		t.Errorf("expected FieldIsMap(field1) to be false")
 	}
-	if FieldIsMap(field2, model.State) {
+	if FieldIsMap(field2, model) {
 		t.Errorf("expected FieldIsMap(field2) to be false")
 	}
 }

--- a/internal/sidekick/parser/mixin.go
+++ b/internal/sidekick/parser/mixin.go
@@ -135,7 +135,7 @@ func applyServiceConfigMethodOverrides(
 		if selector != originalID {
 			continue
 		}
-		pathInfo, err := processRule(rule, api.State, targetMethod.InputTypeID)
+		pathInfo, err := processRule(rule, api, targetMethod.InputTypeID)
 		if err != nil {
 			return fmt.Errorf("unsupported http rule %q in method %s", rule, targetMethod.ID)
 		}

--- a/internal/sidekick/parser/openapi.go
+++ b/internal/sidekick/parser/openapi.go
@@ -105,7 +105,7 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 		if err != nil {
 			return nil, err
 		}
-		fields, err := makeMessageFields(result.State, packageName, name, schema)
+		fields, err := makeMessageFields(result, packageName, name, schema)
 		if err != nil {
 			return nil, err
 		}
@@ -384,7 +384,7 @@ func makeQueryParameters(operation *v3.Operation) map[string]bool {
 	return queryParameters
 }
 
-func makeMessageFields(state *api.APIState, packageName, messageName string, message *base.Schema) ([]*api.Field, error) {
+func makeMessageFields(model *api.API, packageName, messageName string, message *base.Schema) ([]*api.Field, error) {
 	var fields []*api.Field
 	for name, f := range message.Properties.FromOldest() {
 		schema, err := f.BuildSchema()
@@ -398,7 +398,7 @@ func makeMessageFields(state *api.APIState, packageName, messageName string, mes
 				break
 			}
 		}
-		field, err := makeField(state, packageName, messageName, name, optional, schema)
+		field, err := makeField(model, packageName, messageName, name, optional, schema)
 		if err != nil {
 			return nil, err
 		}
@@ -407,10 +407,10 @@ func makeMessageFields(state *api.APIState, packageName, messageName string, mes
 	return fields, nil
 }
 
-func makeField(state *api.APIState, packageName, messageName, name string, optional bool, field *base.Schema) (*api.Field, error) {
+func makeField(model *api.API, packageName, messageName, name string, optional bool, field *base.Schema) (*api.Field, error) {
 	if len(field.AllOf) != 0 {
 		// Simple object fields name an AllOf attribute, but no `Type` attribute.
-		return makeObjectField(state, packageName, messageName, name, field)
+		return makeObjectField(model, packageName, messageName, name, field)
 	}
 	if len(field.Type) == 0 {
 		return nil, fmt.Errorf("missing field type for field %s.%s", messageName, name)
@@ -419,9 +419,9 @@ func makeField(state *api.APIState, packageName, messageName, name string, optio
 	case "boolean", "integer", "number", "string":
 		return makeScalarField(messageName, name, field, optional, field)
 	case "object":
-		return makeObjectField(state, packageName, messageName, name, field)
+		return makeObjectField(model, packageName, messageName, name, field)
 	case "array":
-		return makeArrayField(state, packageName, messageName, name, field)
+		return makeArrayField(model, packageName, messageName, name, field)
 	default:
 		return nil, fmt.Errorf("unknown type for field %q", name)
 	}
@@ -443,7 +443,7 @@ func makeScalarField(messageName, name string, schema *base.Schema, optional boo
 	}, nil
 }
 
-func makeObjectField(state *api.APIState, packageName, messageName, name string, field *base.Schema) (*api.Field, error) {
+func makeObjectField(model *api.API, packageName, messageName, name string, field *base.Schema) (*api.Field, error) {
 	if len(field.AllOf) != 0 {
 		return makeObjectFieldAllOf(packageName, messageName, name, field)
 	}
@@ -467,7 +467,7 @@ func makeObjectField(state *api.APIState, packageName, messageName, name string,
 				Optional:      true,
 			}, nil
 		}
-		message, err := makeMapMessage(state, messageName, name, schema)
+		message, err := makeMapMessage(model, messageName, name, schema)
 		if err != nil {
 			return nil, err
 		}
@@ -499,7 +499,7 @@ func makeObjectField(state *api.APIState, packageName, messageName, name string,
 	return nil, fmt.Errorf("unknown object field type for field %s.%s", messageName, name)
 }
 
-func makeArrayField(state *api.APIState, packageName, messageName, name string, field *base.Schema) (*api.Field, error) {
+func makeArrayField(model *api.API, packageName, messageName, name string, field *base.Schema) (*api.Field, error) {
 	if !field.Items.IsA() {
 		return nil, fmt.Errorf("cannot handle arrays without an `Items` field for %s.%s", messageName, name)
 	}
@@ -528,7 +528,7 @@ func makeArrayField(state *api.APIState, packageName, messageName, name string, 
 			}
 			result = new
 		} else {
-			result, err = makeObjectField(state, packageName, messageName, name, schema)
+			result, err = makeObjectField(model, packageName, messageName, name, schema)
 		}
 	default:
 		return nil, fmt.Errorf("unknown array field type for %s.%s %q", messageName, name, schema.Type[0])
@@ -558,7 +558,7 @@ func makeObjectFieldAllOf(packageName, messageName, name string, field *base.Sch
 	return nil, fmt.Errorf("cannot build any AllOf schema for field %s.%s", messageName, name)
 }
 
-func makeMapMessage(state *api.APIState, messageName, name string, schema *base.Schema) (*api.Message, error) {
+func makeMapMessage(model *api.API, messageName, name string, schema *base.Schema) (*api.Message, error) {
 	value_typez, value_id, err := scalarType(messageName, name, schema)
 	if err != nil {
 		return nil, err
@@ -571,7 +571,7 @@ func makeMapMessage(state *api.APIState, messageName, name string, schema *base.
 	}
 
 	id := fmt.Sprintf("$map<string, %s>", value.TypezID)
-	message := state.MessageByID[id]
+	message := model.State.MessageByID[id]
 	if message == nil {
 		// The map was not found, insert the type.
 		key := &api.Field{
@@ -589,7 +589,7 @@ func makeMapMessage(state *api.APIState, messageName, name string, schema *base.
 			Parent:        nil,
 			Package:       "$",
 		}
-		state.MessageByID[id] = placeholder
+		model.State.MessageByID[id] = placeholder
 		message = placeholder
 	}
 	return message, nil

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -294,14 +294,14 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		fFQN := "." + f.GetPackage()
 		for _, m := range f.MessageType {
 			mFQN := fFQN + "." + m.GetName()
-			if _, err := processMessage(state, m, mFQN, f.GetPackage(), nil); err != nil {
+			if _, err := processMessage(result, m, mFQN, f.GetPackage(), nil); err != nil {
 				return nil, err
 			}
 		}
 
 		for _, e := range f.EnumType {
 			eFQN := fFQN + "." + e.GetName()
-			_ = processEnum(state, e, eFQN, f.GetPackage(), nil)
+			_ = processEnum(result, e, eFQN, f.GetPackage(), nil)
 		}
 		resources, err := processFileResourceDefinitions(f)
 		if err != nil {
@@ -354,11 +354,11 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		// Services
 		for _, s := range f.Service {
 			sFQN := fFQN + "." + s.GetName()
-			service := processService(state, s, sFQN, f.GetPackage())
+			service := processService(result, s, sFQN, f.GetPackage())
 			for _, m := range s.Method {
 				mFQN := sFQN + "." + m.GetName()
 				apiVersion := parseAPIVersion(sFQN, s.GetOptions())
-				method, err := processMethod(state, m, mFQN, f.GetPackage(), sFQN, apiVersion)
+				method, err := processMethod(result, m, mFQN, f.GetPackage(), sFQN, apiVersion)
 				if err != nil {
 					return nil, err
 				}
@@ -379,13 +379,13 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 				// Because of message nesting we need to call recursively and
 				// strip out parts of the path.
 				m := f.MessageType[p[1]]
-				addMessageDocumentation(state, m, p[2:], loc.GetLeadingComments(), fFQN+"."+m.GetName())
+				addMessageDocumentation(result, m, p[2:], loc.GetLeadingComments(), fFQN+"."+m.GetName())
 			case fileDescriptorEnumType:
 				e := f.EnumType[p[1]]
-				addEnumDocumentation(state, p[2:], loc.GetLeadingComments(), fFQN+"."+e.GetName())
+				addEnumDocumentation(result, p[2:], loc.GetLeadingComments(), fFQN+"."+e.GetName())
 			case fileDescriptorService:
 				sFQN := fFQN + "." + f.GetService()[p[1]].GetName()
-				addServiceDocumentation(state, p[2:], loc.GetLeadingComments(), sFQN)
+				addServiceDocumentation(result, p[2:], loc.GetLeadingComments(), sFQN)
 			case fileDescriptorName, fileDescriptorPackage, fileDescriptorDependency,
 				fileDescriptorExtension, fileDescriptorOptions, fileDescriptorSourceCodeInfo,
 				fileDescriptorPublicDependency, fileDescriptorWeakDependency,
@@ -405,7 +405,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 			fFQN := "." + f.GetPackage()
 			for _, mixinProto := range f.Service {
 				sFQN := fFQN + "." + mixinProto.GetName()
-				mixin := processService(state, mixinProto, sFQN, f.GetPackage())
+				mixin := processService(result, mixinProto, sFQN, f.GetPackage())
 				for _, m := range mixinProto.Method {
 					// We want to include the method in the existing service,
 					// and not on the mixin.
@@ -421,7 +421,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 						continue
 					}
 					apiVersion := parseAPIVersion(sFQN, mixinProto.GetOptions())
-					method, err := processMethod(state, m, mFQN, service.Package, sFQN, apiVersion)
+					method, err := processMethod(result, m, mFQN, service.Package, sFQN, apiVersion)
 					if err != nil {
 						return nil, err
 					}
@@ -481,7 +481,7 @@ var descriptorpbToTypez = map[descriptorpb.FieldDescriptorProto_Type]api.Typez{
 	descriptorpb.FieldDescriptorProto_TYPE_ENUM:     api.ENUM_TYPE,
 }
 
-func normalizeTypes(state *api.APIState, in *descriptorpb.FieldDescriptorProto, field *api.Field) {
+func normalizeTypes(model *api.API, in *descriptorpb.FieldDescriptorProto, field *api.Field) {
 	field.Typez = descriptorpbToTypez[in.GetType()]
 	field.TypezID = in.GetTypeName()
 	field.Repeated = in.Label != nil && *in.Label == descriptorpb.FieldDescriptorProto_LABEL_REPEATED
@@ -494,7 +494,7 @@ func normalizeTypes(state *api.APIState, in *descriptorpb.FieldDescriptorProto, 
 		// Repeated fields are not optional, they can be empty, but always have
 		// presence.
 		field.Optional = !field.Repeated
-		if message, ok := state.MessageByID[field.TypezID]; ok && message.IsMap {
+		if message, ok := model.State.MessageByID[field.TypezID]; ok && message.IsMap {
 			// Map fields appear as repeated in Protobuf. This is confusing,
 			// as they typically are represented by a single `map<k, v>`-like
 			// datatype. Protobuf leaks the wire-representation of maps, i.e.,
@@ -530,7 +530,7 @@ func normalizeTypes(state *api.APIState, in *descriptorpb.FieldDescriptorProto, 
 	}
 }
 
-func processService(state *api.APIState, s *descriptorpb.ServiceDescriptorProto, sFQN, packagez string) *api.Service {
+func processService(model *api.API, s *descriptorpb.ServiceDescriptorProto, sFQN, packagez string) *api.Service {
 	service := &api.Service{
 		Name:        s.GetName(),
 		ID:          sFQN,
@@ -538,12 +538,12 @@ func processService(state *api.APIState, s *descriptorpb.ServiceDescriptorProto,
 		DefaultHost: parseDefaultHost(s.GetOptions()),
 		Deprecated:  s.GetOptions().GetDeprecated(),
 	}
-	state.ServiceByID[service.ID] = service
+	model.State.ServiceByID[service.ID] = service
 	return service
 }
 
-func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, mFQN, packagez, serviceID, apiVersion string) (*api.Method, error) {
-	pathInfo, err := parsePathInfo(m, state)
+func processMethod(model *api.API, m *descriptorpb.MethodDescriptorProto, mFQN, packagez, serviceID, apiVersion string) (*api.Method, error) {
+	pathInfo, err := parsePathInfo(m, model)
 	if err != nil {
 		return nil, fmt.Errorf("unsupported http method for %q: %w", mFQN, err)
 	}
@@ -567,11 +567,11 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		SourceServiceID:     serviceID,
 		APIVersion:          apiVersion,
 	}
-	state.MethodByID[mFQN] = method
+	model.State.MethodByID[mFQN] = method
 	return method, nil
 }
 
-func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, packagez string, parent *api.Message) (*api.Message, error) {
+func processMessage(model *api.API, m *descriptorpb.DescriptorProto, mFQN, packagez string, parent *api.Message) (*api.Message, error) {
 	message := &api.Message{
 		Name:       m.GetName(),
 		ID:         mFQN,
@@ -579,20 +579,20 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 		Package:    packagez,
 		Deprecated: m.GetOptions().GetDeprecated(),
 	}
-	state.MessageByID[mFQN] = message
+	model.State.MessageByID[mFQN] = message
 
 	if opts := m.GetOptions(); opts != nil {
 		if opts.GetMapEntry() {
 			message.IsMap = true
 		}
-		if err := processResourceAnnotation(opts, message, state); err != nil {
+		if err := processResourceAnnotation(opts, message, model); err != nil {
 			return nil, err
 		}
 	}
 	if len(m.GetNestedType()) > 0 {
 		for _, nm := range m.GetNestedType() {
 			nmFQN := mFQN + "." + nm.GetName()
-			nmsg, err := processMessage(state, nm, nmFQN, packagez, message)
+			nmsg, err := processMessage(model, nm, nmFQN, packagez, message)
 			if err != nil {
 				return nil, err
 			}
@@ -603,7 +603,7 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 	}
 	for _, e := range m.GetEnumType() {
 		eFQN := mFQN + "." + e.GetName()
-		e := processEnum(state, e, eFQN, packagez, message)
+		e := processEnum(model, e, eFQN, packagez, message)
 		message.Enums = append(message.Enums, e)
 	}
 	for _, oneof := range m.OneofDecl {
@@ -628,7 +628,7 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 		if err := processResourceReference(mf, field); err != nil {
 			return nil, err
 		}
-		normalizeTypes(state, mf, field)
+		normalizeTypes(model, mf, field)
 		message.Fields = append(message.Fields, field)
 		if field.IsOneOf {
 			message.OneOfs[*mf.OneofIndex].Fields = append(message.OneOfs[*mf.OneofIndex].Fields, field)
@@ -652,7 +652,7 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 	return message, nil
 }
 
-func processResourceAnnotation(opts *descriptorpb.MessageOptions, message *api.Message, state *api.APIState) error {
+func processResourceAnnotation(opts *descriptorpb.MessageOptions, message *api.Message, model *api.API) error {
 	if !proto.HasExtension(opts, eResource) {
 		return nil
 	}
@@ -675,7 +675,7 @@ func processResourceAnnotation(opts *descriptorpb.MessageOptions, message *api.M
 		Self:     message,
 	}
 	message.Resource = resource
-	state.ResourceByType[resource.Type] = resource
+	model.State.ResourceByType[resource.Type] = resource
 	return nil
 }
 
@@ -742,7 +742,7 @@ func processResourceReference(f *descriptorpb.FieldDescriptorProto, field *api.F
 	return nil
 }
 
-func processEnum(state *api.APIState, e *descriptorpb.EnumDescriptorProto, eFQN, packagez string, parent *api.Message) *api.Enum {
+func processEnum(model *api.API, e *descriptorpb.EnumDescriptorProto, eFQN, packagez string, parent *api.Message) *api.Enum {
 	enum := &api.Enum{
 		Name:       e.GetName(),
 		ID:         eFQN,
@@ -750,7 +750,7 @@ func processEnum(state *api.APIState, e *descriptorpb.EnumDescriptorProto, eFQN,
 		Package:    packagez,
 		Deprecated: e.GetOptions().GetDeprecated(),
 	}
-	state.EnumByID[eFQN] = enum
+	model.State.EnumByID[eFQN] = enum
 	for _, ev := range e.Value {
 		enumValue := &api.EnumValue{
 			Name:       ev.GetName(),
@@ -779,14 +779,14 @@ func processEnum(state *api.APIState, e *descriptorpb.EnumDescriptorProto, eFQN,
 	return enum
 }
 
-func addServiceDocumentation(state *api.APIState, p []int32, doc string, sFQN string) {
+func addServiceDocumentation(model *api.API, p []int32, doc string, sFQN string) {
 	switch {
 	case len(p) == 0:
 		// This is a comment for a service
-		state.ServiceByID[sFQN].Documentation = trimLeadingSpacesInDocumentation(doc)
+		model.State.ServiceByID[sFQN].Documentation = trimLeadingSpacesInDocumentation(doc)
 	case p[0] == serviceDescriptorProtoMethod && len(p) == 2:
 		// This is a comment for a method
-		state.ServiceByID[sFQN].Methods[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
+		model.State.ServiceByID[sFQN].Methods[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
 	case p[0] == serviceDescriptorProtoMethod:
 		// A comment for something within a method (options, arguments, etc).
 		// Ignored, as these comments do not refer to any artifact in the
@@ -799,24 +799,24 @@ func addServiceDocumentation(state *api.APIState, p []int32, doc string, sFQN st
 	}
 }
 
-func addMessageDocumentation(state *api.APIState, m *descriptorpb.DescriptorProto, p []int32, doc string, mFQN string) {
+func addMessageDocumentation(model *api.API, m *descriptorpb.DescriptorProto, p []int32, doc string, mFQN string) {
 	// Beware of refactoring the calls to `trimLeadingSpacesInDocumentation`.
 	// We should modify `doc` only once, upon assignment to `.Documentation`
 	switch {
 	case len(p) == 0:
 		// This is a comment for a top level message
-		state.MessageByID[mFQN].Documentation = trimLeadingSpacesInDocumentation(doc)
+		model.State.MessageByID[mFQN].Documentation = trimLeadingSpacesInDocumentation(doc)
 	case p[0] == messageDescriptorNestedType:
 		nmsg := m.GetNestedType()[p[1]]
 		nmFQN := mFQN + "." + nmsg.GetName()
-		addMessageDocumentation(state, nmsg, p[2:], doc, nmFQN)
+		addMessageDocumentation(model, nmsg, p[2:], doc, nmFQN)
 	case p[0] == messageDescriptorField && len(p) == 2:
-		state.MessageByID[mFQN].Fields[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
+		model.State.MessageByID[mFQN].Fields[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
 	case p[0] == messageDescriptorEnum:
 		eFQN := mFQN + "." + m.GetEnumType()[p[1]].GetName()
-		addEnumDocumentation(state, p[2:], doc, eFQN)
+		addEnumDocumentation(model, p[2:], doc, eFQN)
 	case p[0] == messageDescriptorOneOf && len(p) == 2:
-		state.MessageByID[mFQN].OneOfs[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
+		model.State.MessageByID[mFQN].OneOfs[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
 	case p[0] == messageDescriptorExtensionRange:
 	case p[0] == messageDescriptorOptions:
 	case p[0] == messageDescriptorExtension:
@@ -830,12 +830,12 @@ func addMessageDocumentation(state *api.APIState, m *descriptorpb.DescriptorProt
 }
 
 // addEnumDocumentation adds documentation to an enum.
-func addEnumDocumentation(state *api.APIState, p []int32, doc string, eFQN string) {
+func addEnumDocumentation(model *api.API, p []int32, doc string, eFQN string) {
 	if len(p) == 0 {
 		// This is a comment for an enum
-		state.EnumByID[eFQN].Documentation = trimLeadingSpacesInDocumentation(doc)
+		model.State.EnumByID[eFQN].Documentation = trimLeadingSpacesInDocumentation(doc)
 	} else if len(p) == 2 && p[0] == enumDescriptorValue {
-		state.EnumByID[eFQN].Values[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
+		model.State.EnumByID[eFQN].Values[p[1]].Documentation = trimLeadingSpacesInDocumentation(doc)
 	} else {
 		slog.Warn("enum dropped documentation", "loc", p, "docs", doc)
 	}

--- a/internal/sidekick/parser/protobuf_annotations.go
+++ b/internal/sidekick/parser/protobuf_annotations.go
@@ -54,14 +54,14 @@ func parseOperationInfo(packagez string, m *descriptorpb.MethodDescriptorProto) 
 	return operationInfo
 }
 
-func parsePathInfo(m *descriptorpb.MethodDescriptorProto, state *api.APIState) (*api.PathInfo, error) {
+func parsePathInfo(m *descriptorpb.MethodDescriptorProto, model *api.API) (*api.PathInfo, error) {
 	eHTTP := proto.GetExtension(m.GetOptions(), eHttp)
 	httpRule := eHTTP.(*httpRule)
-	return processRule(httpRule, state, m.GetInputType())
+	return processRule(httpRule, model, m.GetInputType())
 }
 
-func processRule(httpRule *httpRule, state *api.APIState, mID string) (*api.PathInfo, error) {
-	binding, body, err := processRuleShallow(httpRule, state, mID)
+func processRule(httpRule *httpRule, model *api.API, mID string) (*api.PathInfo, error) {
+	binding, body, err := processRuleShallow(httpRule, model, mID)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func processRule(httpRule *httpRule, state *api.APIState, mID string) (*api.Path
 	}
 
 	for _, binding := range httpRule.GetAdditionalBindings() {
-		binding, body, err := processRuleShallow(binding, state, mID)
+		binding, body, err := processRuleShallow(binding, model, mID)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func processRule(httpRule *httpRule, state *api.APIState, mID string) (*api.Path
 	return pathInfo, nil
 }
 
-func processRuleShallow(httpRule *httpRule, state *api.APIState, mID string) (*api.PathBinding, string, error) {
+func processRuleShallow(httpRule *httpRule, model *api.API, mID string) (*api.PathBinding, string, error) {
 	var verb string
 	var rawPath string
 	switch httpRule.GetPattern().(type) {
@@ -119,7 +119,7 @@ func processRuleShallow(httpRule *httpRule, state *api.APIState, mID string) (*a
 	if err != nil {
 		return nil, "", err
 	}
-	queryParameters, err := queryParameters(mID, pathTemplate, httpRule.GetBody(), state)
+	queryParameters, err := queryParameters(mID, pathTemplate, httpRule.GetBody(), model)
 	if err != nil {
 		return nil, "", err
 	}
@@ -131,8 +131,8 @@ func processRuleShallow(httpRule *httpRule, state *api.APIState, mID string) (*a
 	}, httpRule.GetBody(), nil
 }
 
-func queryParameters(msgID string, pathTemplate *api.PathTemplate, body string, state *api.APIState) (map[string]bool, error) {
-	msg, ok := state.MessageByID[msgID]
+func queryParameters(msgID string, pathTemplate *api.PathTemplate, body string, model *api.API) (map[string]bool, error) {
+	msg, ok := model.State.MessageByID[msgID]
 	if !ok {
 		return nil, fmt.Errorf("unable to lookup type %s", msgID)
 	}

--- a/internal/sidekick/rust/annotate.go
+++ b/internal/sidekick/rust/annotate.go
@@ -860,7 +860,7 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 	serviceName := c.ServiceName(s)
 	moduleName := toSnake(serviceName)
 	docLines, err := c.formatDocComments(
-		s.Documentation, s.ID, s.Model.State, []string{s.ID, s.Package})
+		s.Documentation, s.ID, s.Model, []string{s.ID, s.Package})
 	if err != nil {
 		return nil, err
 	}
@@ -935,7 +935,7 @@ func (c *codec) annotateMessage(m *api.Message, model *api.API, full bool) error
 		return !f.IsOneOf
 	})
 
-	docLines, err := c.formatDocComments(m.Documentation, m.ID, model.State, m.Scopes())
+	docLines, err := c.formatDocComments(m.Documentation, m.ID, model, m.Scopes())
 	if err != nil {
 		return err
 	}
@@ -965,7 +965,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 			variant.Codec = routingVariantAnnotations
 		}
 	}
-	returnType, err := c.methodInOutTypeName(m.OutputTypeID, m.Model.State, m.Model.PackageName)
+	returnType, err := c.methodInOutTypeName(m.OutputTypeID, m.Model, m.Model.PackageName)
 	if err != nil {
 		return nil, err
 	}
@@ -980,7 +980,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 			Value: m.APIVersion,
 		})
 	}
-	docLines, err := c.formatDocComments(m.Documentation, m.ID, m.Model.State, m.Service.Scopes())
+	docLines, err := c.formatDocComments(m.Documentation, m.ID, m.Model, m.Service.Scopes())
 	if err != nil {
 		return nil, err
 	}
@@ -1011,11 +1011,11 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		annotation.Attributes = []string{"#[allow(clippy::should_implement_trait)]"}
 	}
 	if m.OperationInfo != nil {
-		metadataType, err := c.methodInOutTypeName(m.OperationInfo.MetadataTypeID, m.Model.State, m.Model.PackageName)
+		metadataType, err := c.methodInOutTypeName(m.OperationInfo.MetadataTypeID, m.Model, m.Model.PackageName)
 		if err != nil {
 			return nil, err
 		}
-		responseType, err := c.methodInOutTypeName(m.OperationInfo.ResponseTypeID, m.Model.State, m.Model.PackageName)
+		responseType, err := c.methodInOutTypeName(m.OperationInfo.ResponseTypeID, m.Model, m.Model.PackageName)
 		if err != nil {
 			return nil, err
 		}
@@ -1207,7 +1207,7 @@ func (c *codec) annotateOneOf(oneof *api.OneOf, message *api.Message, model *api
 		return nil, err
 	}
 	nameInExamples := c.nameInExamplesFromQualifiedName(qualifiedName, model)
-	docLines, err := c.formatDocComments(oneof.Documentation, oneof.ID, model.State, message.Scopes())
+	docLines, err := c.formatDocComments(oneof.Documentation, oneof.ID, model, message.Scopes())
 	if err != nil {
 		return nil, err
 	}
@@ -1310,15 +1310,15 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 	if err != nil {
 		return nil, err
 	}
-	docLines, err := c.formatDocComments(field.Documentation, field.ID, model.State, message.Scopes())
+	docLines, err := c.formatDocComments(field.Documentation, field.ID, model, message.Scopes())
 	if err != nil {
 		return nil, err
 	}
-	fieldType, err := c.fieldType(field, model.State, false, model.PackageName)
+	fieldType, err := c.fieldType(field, model, false, model.PackageName)
 	if err != nil {
 		return nil, err
 	}
-	primitiveFieldType, err := c.fieldType(field, model.State, true, model.PackageName)
+	primitiveFieldType, err := c.fieldType(field, model, true, model.PackageName)
 	if err != nil {
 		return nil, err
 	}
@@ -1346,11 +1346,11 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 			if len(msg.Fields) != 2 {
 				return nil, fmt.Errorf("expected exactly two fields for field's map message (%q), fieldId=%s", field.TypezID, field.ID)
 			}
-			keyType, err := c.mapType(msg.Fields[0], model.State, model.PackageName)
+			keyType, err := c.mapType(msg.Fields[0], model, model.PackageName)
 			if err != nil {
 				return nil, err
 			}
-			valueType, err := c.mapType(msg.Fields[1], model.State, model.PackageName)
+			valueType, err := c.mapType(msg.Fields[1], model, model.PackageName)
 			if err != nil {
 				return nil, err
 			}
@@ -1446,7 +1446,7 @@ func (c *codec) annotateEnum(e *api.Enum, model *api.API, full bool) error {
 		return nil
 	}
 
-	lines, err := c.formatDocComments(e.Documentation, e.ID, model.State, e.Scopes())
+	lines, err := c.formatDocComments(e.Documentation, e.ID, model, e.Scopes())
 	if err != nil {
 		return err
 	}
@@ -1468,7 +1468,7 @@ func (c *codec) annotateEnumValue(ev *api.EnumValue, model *api.API, full bool) 
 		// We have basic annotations, we are done.
 		return nil
 	}
-	lines, err := c.formatDocComments(ev.Documentation, ev.ID, model.State, ev.Scopes())
+	lines, err := c.formatDocComments(ev.Documentation, ev.ID, model, ev.Scopes())
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -447,12 +447,12 @@ func scalarFieldType(f *api.Field) (string, error) {
 	return out, nil
 }
 
-func (c *codec) oneOfFieldType(f *api.Field, state *api.APIState, sourceSpecificationPackageName string) (string, error) {
-	baseType, err := c.baseFieldType(f, state, sourceSpecificationPackageName)
+func (c *codec) oneOfFieldType(f *api.Field, model *api.API, sourceSpecificationPackageName string) (string, error) {
+	baseType, err := c.baseFieldType(f, model, sourceSpecificationPackageName)
 	if err != nil {
 		return "", err
 	}
-	return oneOfFieldTypeFormatter(f, language.FieldIsMap(f, state), baseType), nil
+	return oneOfFieldTypeFormatter(f, language.FieldIsMap(f, model), baseType), nil
 }
 
 func oneOfFieldTypeFormatter(f *api.Field, fieldIsMap bool, baseType string) string {
@@ -471,8 +471,8 @@ func oneOfFieldTypeFormatter(f *api.Field, fieldIsMap bool, baseType string) str
 	}
 }
 
-func (c *codec) fieldType(f *api.Field, state *api.APIState, primitive bool, sourceSpecificationPackageName string) (string, error) {
-	baseType, err := c.baseFieldType(f, state, sourceSpecificationPackageName)
+func (c *codec) fieldType(f *api.Field, model *api.API, primitive bool, sourceSpecificationPackageName string) (string, error) {
+	baseType, err := c.baseFieldType(f, model, sourceSpecificationPackageName)
 	if err != nil {
 		return "", err
 	}
@@ -480,14 +480,14 @@ func (c *codec) fieldType(f *api.Field, state *api.APIState, primitive bool, sou
 	case primitive:
 		return baseType, nil
 	case f.IsOneOf:
-		return c.oneOfFieldType(f, state, sourceSpecificationPackageName)
+		return c.oneOfFieldType(f, model, sourceSpecificationPackageName)
 	case f.Repeated:
 		return fmt.Sprintf("std::vec::Vec<%s>", baseType), nil
 	case f.Recursive:
 		if f.Optional {
 			return fmt.Sprintf("std::option::Option<std::boxed::Box<%s>>", baseType), nil
 		}
-		if language.FieldIsMap(f, state) {
+		if language.FieldIsMap(f, model) {
 			// Maps are never boxed.
 			return baseType, nil
 		}
@@ -499,17 +499,17 @@ func (c *codec) fieldType(f *api.Field, state *api.APIState, primitive bool, sou
 	}
 }
 
-func (c *codec) mapType(f *api.Field, state *api.APIState, sourceSpecificationPackageName string) (string, error) {
+func (c *codec) mapType(f *api.Field, model *api.API, sourceSpecificationPackageName string) (string, error) {
 	switch f.Typez {
 	case api.MESSAGE_TYPE:
-		m, ok := state.MessageByID[f.TypezID]
+		m, ok := model.State.MessageByID[f.TypezID]
 		if !ok {
 			return "", fmt.Errorf("unable to lookup type (%q) for message field %s", f.TypezID, f.ID)
 		}
 		return c.fullyQualifiedMessageName(m, sourceSpecificationPackageName)
 
 	case api.ENUM_TYPE:
-		e, ok := state.EnumByID[f.TypezID]
+		e, ok := model.State.EnumByID[f.TypezID]
 		if !ok {
 			return "", fmt.Errorf("unable to lookup type (%q) for enum field %s", f.TypezID, f.ID)
 		}
@@ -521,19 +521,19 @@ func (c *codec) mapType(f *api.Field, state *api.APIState, sourceSpecificationPa
 
 // baseFieldType returns the field type, ignoring any repeated or optional
 // attributes.
-func (c *codec) baseFieldType(f *api.Field, state *api.APIState, sourceSpecificationPackageName string) (string, error) {
+func (c *codec) baseFieldType(f *api.Field, model *api.API, sourceSpecificationPackageName string) (string, error) {
 	switch f.Typez {
 	case api.MESSAGE_TYPE:
-		m, ok := state.MessageByID[f.TypezID]
+		m, ok := model.State.MessageByID[f.TypezID]
 		if !ok {
 			return "", fmt.Errorf("unable to lookup field type (%q) for field %s", f.TypezID, f.ID)
 		}
 		if m.IsMap {
-			key, err := c.mapType(m.Fields[0], state, sourceSpecificationPackageName)
+			key, err := c.mapType(m.Fields[0], model, sourceSpecificationPackageName)
 			if err != nil {
 				return "", err
 			}
-			val, err := c.mapType(m.Fields[1], state, sourceSpecificationPackageName)
+			val, err := c.mapType(m.Fields[1], model, sourceSpecificationPackageName)
 			if err != nil {
 				return "", err
 			}
@@ -541,7 +541,7 @@ func (c *codec) baseFieldType(f *api.Field, state *api.APIState, sourceSpecifica
 		}
 		return c.fullyQualifiedMessageName(m, sourceSpecificationPackageName)
 	case api.ENUM_TYPE:
-		e, ok := state.EnumByID[f.TypezID]
+		e, ok := model.State.EnumByID[f.TypezID]
 		if !ok {
 			return "", fmt.Errorf("unable to lookup field type (%q) for field %s", f.TypezID, f.ID)
 		}
@@ -599,11 +599,11 @@ func addQueryParameterOneOf(f *api.Field) string {
 	}
 }
 
-func (c *codec) methodInOutTypeName(id string, state *api.APIState, sourceSpecificationPackageName string) (string, error) {
+func (c *codec) methodInOutTypeName(id string, model *api.API, sourceSpecificationPackageName string) (string, error) {
 	if id == "" {
 		return "", nil
 	}
-	m, ok := state.MessageByID[id]
+	m, ok := model.State.MessageByID[id]
 	if !ok {
 		return "", fmt.Errorf("unable to lookup message %q", id)
 	}
@@ -888,7 +888,7 @@ func fixSetextHeadings(input string) string {
 //
 // [spec]: https://spec.commonmark.org/0.13/#block-quotes
 func (c *codec) formatDocComments(
-	documentation, elementID string, state *api.APIState, scopes []string) ([]string, error) {
+	documentation, elementID string, model *api.API, scopes []string) ([]string, error) {
 	var results []string
 
 	md := goldmark.New(
@@ -943,7 +943,7 @@ func (c *codec) formatDocComments(
 	})
 
 	for _, link := range protobufLinkMapping(doc, documentationBytes) {
-		rusty, err := c.docLink(link, state, scopes)
+		rusty, err := c.docLink(link, model, scopes)
 		if err != nil {
 			return nil, err
 		}
@@ -1291,7 +1291,7 @@ func fetchLinkDefinitions(node ast.Node, line string, documentationBytes []byte)
 	return linkDefinitions
 }
 
-func (c *codec) docLink(link string, state *api.APIState, scopes []string) (string, error) {
+func (c *codec) docLink(link string, model *api.API, scopes []string) (string, error) {
 	// Sometimes the documentation uses relative links, so instead of saying:
 	//     [google.package.v1.Message]
 	// they just say
@@ -1299,7 +1299,7 @@ func (c *codec) docLink(link string, state *api.APIState, scopes []string) (stri
 	// we need to lookup the local symbols first.
 	for _, s := range scopes {
 		localId := fmt.Sprintf(".%s.%s", s, link)
-		result, err := c.tryDocLinkWithId(localId, state, s)
+		result, err := c.tryDocLinkWithId(localId, model, s)
 		if err != nil {
 			return "", err
 		}
@@ -1312,34 +1312,34 @@ func (c *codec) docLink(link string, state *api.APIState, scopes []string) (stri
 		packageName = scopes[len(scopes)-1]
 	}
 	localId := fmt.Sprintf(".%s", link)
-	return c.tryDocLinkWithId(localId, state, packageName)
+	return c.tryDocLinkWithId(localId, model, packageName)
 }
 
-func (c *codec) tryDocLinkWithId(id string, state *api.APIState, scope string) (string, error) {
-	m, ok := state.MessageByID[id]
+func (c *codec) tryDocLinkWithId(id string, model *api.API, scope string) (string, error) {
+	m, ok := model.State.MessageByID[id]
 	if ok {
 		return c.fullyQualifiedMessageName(m, scope)
 	}
-	e, ok := state.EnumByID[id]
+	e, ok := model.State.EnumByID[id]
 	if ok {
 		return c.fullyQualifiedEnumName(e, scope)
 	}
-	me, ok := state.MethodByID[id]
+	me, ok := model.State.MethodByID[id]
 	if ok {
-		return c.methodRustdocLink(me, state), nil
+		return c.methodRustdocLink(me, model), nil
 	}
-	s, ok := state.ServiceByID[id]
+	s, ok := model.State.ServiceByID[id]
 	if ok {
 		return c.serviceRustdocLink(s), nil
 	}
-	rdLink, err := c.tryFieldRustdocLink(id, state, scope)
+	rdLink, err := c.tryFieldRustdocLink(id, model, scope)
 	if err != nil {
 		return "", err
 	}
 	if rdLink != "" {
 		return rdLink, nil
 	}
-	rdLink, err = c.tryEnumValueRustdocLink(id, state, scope)
+	rdLink, err = c.tryEnumValueRustdocLink(id, model, scope)
 	if err != nil {
 		return "", err
 	}
@@ -1349,14 +1349,14 @@ func (c *codec) tryDocLinkWithId(id string, state *api.APIState, scope string) (
 	return "", nil
 }
 
-func (c *codec) tryFieldRustdocLink(id string, state *api.APIState, scope string) (string, error) {
+func (c *codec) tryFieldRustdocLink(id string, model *api.API, scope string) (string, error) {
 	idx := strings.LastIndex(id, ".")
 	if idx == -1 {
 		return "", nil
 	}
 	messageId := id[0:idx]
 	fieldName := id[idx+1:]
-	m, ok := state.MessageByID[messageId]
+	m, ok := model.State.MessageByID[messageId]
 	if !ok {
 		return "", nil
 	}
@@ -1399,14 +1399,14 @@ func (c *codec) tryOneOfRustdocLink(field *api.Field, message *api.Message, scop
 	return "", nil
 }
 
-func (c *codec) tryEnumValueRustdocLink(id string, state *api.APIState, scope string) (string, error) {
+func (c *codec) tryEnumValueRustdocLink(id string, model *api.API, scope string) (string, error) {
 	idx := strings.LastIndex(id, ".")
 	if idx == -1 {
 		return "", nil
 	}
 	enumId := id[0:idx]
 	valueName := id[idx+1:]
-	e, ok := state.EnumByID[enumId]
+	e, ok := model.State.EnumByID[enumId]
 	if !ok {
 		return "", nil
 	}
@@ -1418,7 +1418,7 @@ func (c *codec) tryEnumValueRustdocLink(id string, state *api.APIState, scope st
 	return "", nil
 }
 
-func (c *codec) methodRustdocLink(m *api.Method, state *api.APIState) string {
+func (c *codec) methodRustdocLink(m *api.Method, model *api.API) string {
 	// Sometimes we remove methods from a service. In that case we cannot
 	// reference the method.
 	if !c.generateMethod(m) {
@@ -1429,7 +1429,7 @@ func (c *codec) methodRustdocLink(m *api.Method, state *api.APIState) string {
 		return ""
 	}
 	serviceId := m.ID[0:idx]
-	s, ok := state.ServiceByID[serviceId]
+	s, ok := model.State.ServiceByID[serviceId]
 	if !ok {
 		return ""
 	}

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -510,7 +510,7 @@ func TestWellKnownTypesAsMethod(t *testing.T) {
 	c := createRustCodec()
 
 	want := "wkt::Empty"
-	got, err := c.methodInOutTypeName(".google.protobuf.Empty", model.State, model.PackageName)
+	got, err := c.methodInOutTypeName(".google.protobuf.Empty", model, model.PackageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -589,7 +589,7 @@ func TestMethodInOut(t *testing.T) {
 	c := createRustCodec()
 
 	want := "crate::model::Target"
-	got, err := c.methodInOutTypeName("..Target", model.State, model.PackageName)
+	got, err := c.methodInOutTypeName("..Target", model, model.PackageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -598,7 +598,7 @@ func TestMethodInOut(t *testing.T) {
 	}
 
 	want = "crate::model::target::Nested"
-	got, err = c.methodInOutTypeName("..Target.Nested", model.State, model.PackageName)
+	got, err = c.methodInOutTypeName("..Target.Nested", model, model.PackageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -762,7 +762,7 @@ func TestFieldType(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing expected value for %s", field.Name)
 		}
-		got, err := c.fieldType(field, model.State, false, model.PackageName)
+		got, err := c.fieldType(field, model, false, model.PackageName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -774,7 +774,7 @@ func TestFieldType(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing expected value for %s", field.Name)
 		}
-		got, err = c.fieldType(field, model.State, true, model.PackageName)
+		got, err = c.fieldType(field, model, true, model.PackageName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -812,7 +812,7 @@ func TestOneOfFieldType(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing expected value for %s", field.Name)
 		}
-		got, err := c.oneOfFieldType(field, model.State, model.PackageName)
+		got, err := c.oneOfFieldType(field, model, model.PackageName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -886,7 +886,7 @@ func TestFieldMapTypeValues(t *testing.T) {
 		model.State.MessageByID[map_thing.ID] = map_thing
 		api.LabelRecursiveFields(model)
 		c := createRustCodec()
-		got, err := c.fieldType(field, model.State, false, model.PackageName)
+		got, err := c.fieldType(field, model, false, model.PackageName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -950,7 +950,7 @@ func TestFieldMapTypeKey(t *testing.T) {
 		model.State.MessageByID[map_thing.ID] = map_thing
 		api.LabelRecursiveFields(model)
 		c := createRustCodec()
-		got, err := c.fieldType(field, model.State, false, model.PackageName)
+		got, err := c.fieldType(field, model, false, model.PackageName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1255,7 +1255,7 @@ Maybe they wanted to show some JSON:
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1284,7 +1284,7 @@ func TestFormatDocCommentsBullets(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := createRustCodec()
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1340,7 +1340,7 @@ func TestFormatDocCommentsNumbers(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := createRustCodec()
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1419,7 +1419,7 @@ block:
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1443,7 +1443,7 @@ func TestFormatDocCommentsImplicitBlockQuoteClosing(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1473,7 +1473,7 @@ Second [example][].
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1567,7 +1567,7 @@ func TestFormatDocCommentsCrossLinks(t *testing.T) {
 	// in a separate function to make this more readable.
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{"test.v1"})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{"test.v1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1629,7 +1629,7 @@ func TestFormatDocCommentsRelativeCrossLinks(t *testing.T) {
 	// in a separate function to make this more readable.
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{"test.v1"})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{"test.v1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1689,7 +1689,7 @@ func TestFormatDocCommentsSetextHeadings(t *testing.T) {
 			}
 			codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{})
 
-			comments, err := codec.formatDocComments(testCase.input, "test-only-ID", model.State, []string{})
+			comments, err := codec.formatDocComments(testCase.input, "test-only-ID", model, []string{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1754,7 +1754,7 @@ implied enum value reference [SomeMessage.SomeEnum.ENUM_VALUE][]
 	// in a separate function to make this more readable.
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{"test.v1.Message", "test.v1"})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{"test.v1.Message", "test.v1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1792,7 +1792,7 @@ func TestFormatDocCommentsHTMLTags(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1987,7 +1987,7 @@ Truncated link: [text](https://example11.com`
 	// in a separate function to make this more readable.
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 
-	got, err := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
API is passed instead of APIState to prepare for hiding all of APIState from the consumer.