### PR TITLE
chore: compute only supports the rest transport, regardless of language

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -972,10 +972,7 @@
     - java
     - python
   transports:
-    csharp: rest
-    go: rest
-    java: rest
-    php: rest
+    all: rest
 - path: google/cloud/compute/v1beta
   languages:
     - go
@@ -985,8 +982,7 @@
     - go
     - python
   transports:
-    go: rest
-    java: rest
+    all: rest
 - path: google/cloud/confidentialcomputing/v1
   languages:
     - all

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -166,7 +166,7 @@ func TestFind(t *testing.T) {
 				ShortName:            "compute",
 				Title:                "Google Compute Engine API",
 				Languages:            []string{config.LanguageAll},
-				Transports:           map[string]Transport{config.LanguageCsharp: Rest, config.LanguageGo: Rest, config.LanguageJava: Rest, config.LanguagePhp: Rest},
+				Transports:           map[string]Transport{config.LanguageAll: Rest},
 				SkipRESTNumericEnums: []string{"go", "java", "python"},
 			},
 		},


### PR DESCRIPTION
Language-specific transport settings are always suspect, but for compute we absolutely know that only REST is supported.

Towards #5542