### PR TITLE
chore: remove special-casing for Python in transport determination

### DIFF
--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -200,15 +200,8 @@ func (api *API) RepoMetadataReleaseLevel(language, version string) string {
 // TODO(https://github.com/googleapis/librarian/issues/4854): delete
 // once the issue is resolved.
 // For Java, it maps the transport to "grpc", "http", or "both".
-// TODO(https://github.com/googleapis/librarian/issues/5000): remove the
-// Python exclusion, or change the comments.
-// For Python, transport is currently excluded to reduce the difference during
-// migration.
 func (api *API) RepoMetadataTransport(language string) string {
 	transport := api.Transport(language)
-	if language == config.LanguagePython {
-		return ""
-	}
 	if language == config.LanguageJava {
 		switch transport {
 		case GRPC:

--- a/internal/serviceconfig/api_test.go
+++ b/internal/serviceconfig/api_test.go
@@ -389,20 +389,6 @@ func TestRepoMetadataTransport(t *testing.T) {
 			want:     "grpc+rest",
 		},
 		{
-			name: "python, grpc",
-			sc: &API{
-				Transports: map[string]Transport{config.LanguagePython: GRPC},
-			},
-			language: config.LanguagePython,
-			want:     "",
-		},
-		{
-			name:     "python, default",
-			sc:       &API{},
-			language: config.LanguagePython,
-			want:     "",
-		},
-		{
 			name: "non-java, grpc",
 			sc: &API{
 				Transports: map[string]Transport{config.LanguageGo: GRPC},


### PR DESCRIPTION
We don't populate transport in .repo-metadata.json at the moment other than in Java, so there's no need for a special case. If we *do* start doing so, we can consult with the Python team as to whether we should explicitly prevent it, or just live with the extra field.

Fixes #5000