### PR TITLE
fix(internal/librarian/python): remove hard-coded gRPC service config exception

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -325,11 +325,6 @@ func createProtocOptions(api *config.API, library *config.Library, googleapisDir
 	if err != nil {
 		return nil, err
 	}
-	// TODO(https://github.com/googleapis/librarian/issues/3827): remove this
-	// hardcoding once we can use the gRPC service config for Compute.
-	if strings.HasPrefix(library.Name, "google-cloud-compute") {
-		grpcConfigPath = ""
-	}
 	if grpcConfigPath != "" {
 		opts = append(opts, fmt.Sprintf("retry-config=%s", grpcConfigPath))
 	}

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -156,22 +156,6 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "library starting google-cloud-compute does not use gRPC service config",
-			api: &config.API{
-				Path: "google/cloud/secretmanager/v1",
-			},
-			library: &config.Library{
-				// It's odd to use a Compute name for a path that's using secretmanager,
-				// but it's simpler than making the test realistic by importing the
-				// (huge) Compute protos etc.
-				Name: "google-cloud-compute-beta",
-			},
-			expected: []string{
-				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
-			},
-		},
-		{
 			name: "transport specified in OptArgsByAPI",
 			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{


### PR DESCRIPTION
The Compute packages in Python previously ignored the gRPC service config, to match the original BUILD.bazel config and produce a minimal diff for migration. This exception is removed, so that the gRPC service config is used in Python as it is in other languages.

Fixes #4175