### PR TITLE
refactor(internal/serviceconfig): centralize transport logic for repometadata

### DIFF
--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -148,9 +148,6 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		metadata.RecommendedPackage = library.Java.RecommendedPackage
 		metadata.RestDocumentation = library.Java.RestDocumentation
 		metadata.RpcDocumentation = library.Java.RpcDocumentation
-		if library.Java.TransportOverride != "" {
-			metadata.Transport = library.Java.TransportOverride
-		}
 	}
 
 	// distribution_name default for Java is groupId:artifactId
@@ -164,12 +161,10 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/java/docs/reference/%s/latest/overview", artifactID)
 	}
 	// transport
-	if metadata.Transport == "" {
-		apiCfg, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, config.LanguageJava)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find api config: %w", err)
-		}
-		metadata.Transport = apiCfg.RepoMetadataTransport(config.LanguageJava)
+	apiCfg, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, config.LanguageJava)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find api config: %w", err)
 	}
+	metadata.Transport = apiCfg.RepoMetadataTransport(config.LanguageJava, library)
 	return metadata, nil
 }

--- a/internal/librarian/java/repometadata_test.go
+++ b/internal/librarian/java/repometadata_test.go
@@ -153,7 +153,7 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 				APIDescription:       wantAPIDescription,
 				ClientDocumentation:  "https://cloud.google.com/java/docs/reference/google-cloud-secretmanager/latest/overview",
 				ReleaseLevel:         "stable",
-				Transport:            "rest",
+				Transport:            "http",
 				Language:             "java",
 				Repo:                 "googleapis/google-cloud-java",
 				RepoShort:            "java-secretmanager",

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -204,8 +204,11 @@ func (api *API) RepoMetadataReleaseLevel(language, version string) string {
 // Python exclusion, or change the comments.
 // For Python, transport is currently excluded to reduce the difference during
 // migration.
-func (api *API) RepoMetadataTransport(language string) string {
+func (api *API) RepoMetadataTransport(language string, library *config.Library) string {
 	transport := api.Transport(language)
+	if language == config.LanguageJava && library != nil && library.Java != nil && library.Java.TransportOverride != "" {
+		transport = Transport(library.Java.TransportOverride)
+	}
 	if language == config.LanguagePython {
 		return ""
 	}

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -202,10 +202,10 @@ func (api *API) RepoMetadataReleaseLevel(language, version string) string {
 // For Java, it maps the transport to "grpc", "http", or "both".
 func (api *API) RepoMetadataTransport(language string, library *config.Library) string {
 	transport := api.Transport(language)
-	if language == config.LanguageJava && library != nil && library.Java != nil && library.Java.TransportOverride != "" {
-		transport = Transport(library.Java.TransportOverride)
-	}
 	if language == config.LanguageJava {
+		if library != nil && library.Java != nil && library.Java.TransportOverride != "" {
+			transport = Transport(library.Java.TransportOverride)
+		}
 		switch transport {
 		case GRPC:
 			return "grpc"

--- a/internal/serviceconfig/api_test.go
+++ b/internal/serviceconfig/api_test.go
@@ -364,6 +364,7 @@ func TestRepoMetadataTransport(t *testing.T) {
 		name     string
 		sc       *API
 		language string
+		library  *config.Library
 		want     string
 	}{
 		{
@@ -418,9 +419,22 @@ func TestRepoMetadataTransport(t *testing.T) {
 			language: config.LanguageGo,
 			want:     "rest",
 		},
+		{
+			name: "java, transport override",
+			sc: &API{
+				Transports: map[string]Transport{config.LanguageJava: GRPC},
+			},
+			language: config.LanguageJava,
+			library: &config.Library{
+				Java: &config.JavaModule{
+					TransportOverride: "rest",
+				},
+			},
+			want: "http",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.sc.RepoMetadataTransport(test.language)
+			got := test.sc.RepoMetadataTransport(test.language, test.library)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
RepoMetadataTransport now accepts a *config.Library argument to internalize transport override logic. This ensures that transport values, including overrides, undergo the same platform-specific transformations (such as mapping "rest" to "http" for Java) in a single location.

Fix #5547