### PR TITLE
feat(internal/librarian/java): introduce config for file copy within GAPIC module

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -257,7 +257,15 @@ This document describes the schema for the librarian.yaml.
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |
 | `proto_artifact_id_override` | string | Overrides the artifact ID for the proto module. The artifact ID is also used as the name for the module's directory. |
 | `proto_only` | bool | Determines whether to generate a Proto-only client. A proto-only client does not define a service in the proto files. |
+| `copy_files` | list of [JavaFileCopy](#javafilecopy-configuration) (optional) | Is a list of file copies to perform after generation. It applies to files in the GAPIC module. |
 | `samples` | bool (optional) | Determines whether to generate samples for the API, default is true when omitted. |
+
+## JavaFileCopy Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `source` | string | Is the source path relative to the generated GAPIC module directory (e.g., "src/main/java/com/google/storage/v2/gapic_metadata.json"). These paths are used before restructuring the output into Maven modules. |
+| `destination` | string | Is the destination path relative to the generated GAPIC module directory. These paths are used before restructuring the output into Maven modules. |
 
 ## JavaModule Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -613,11 +613,11 @@ type JavaAPI struct {
 
 // JavaFileRelocation represents a file relocation for Java.
 type JavaFileRelocation struct {
-	// Source is the source path relative to the API version directory
-	// (e.g., "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json").
+	// Source is the source path relative to the generated GAPIC module directory
+	// (e.g., "src/main/java/com/google/storage/v2/gapic_metadata.json").
 	// These paths are used before restructuring the output into Maven modules.
 	Source string `yaml:"source"`
-	// Destination is the destination path relative to the API version directory.
+	// Destination is the destination path relative to the generated GAPIC module directory.
 	// These paths are used before restructuring the output into Maven modules.
 	Destination string `yaml:"destination"`
 }

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -602,9 +602,24 @@ type JavaAPI struct {
 	// A proto-only client does not define a service in the proto files.
 	ProtoOnly bool `yaml:"proto_only,omitempty"`
 
+	// FileRelocations is a list of file relocations to perform after generation.
+	// It applies to files in GAPIC, gRPC, and proto modules.
+	FileRelocations []*JavaFileRelocation `yaml:"file_relocations,omitempty"`
+
 	// Samples determines whether to generate samples for the API,
 	// default is true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
+}
+
+// JavaFileRelocation represents a file relocation for Java.
+type JavaFileRelocation struct {
+	// Source is the source path relative to the API version directory
+	// (e.g., "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json").
+	// These paths are used before restructuring the output into Maven modules.
+	Source string `yaml:"source"`
+	// Destination is the destination path relative to the API version directory.
+	// These paths are used before restructuring the output into Maven modules.
+	Destination string `yaml:"destination"`
 }
 
 // DotnetPackage contains .NET-specific library configuration.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -602,17 +602,17 @@ type JavaAPI struct {
 	// A proto-only client does not define a service in the proto files.
 	ProtoOnly bool `yaml:"proto_only,omitempty"`
 
-	// FileRelocations is a list of file relocations to perform after generation.
-	// It applies to files in GAPIC, gRPC, and proto modules.
-	FileRelocations []*JavaFileRelocation `yaml:"file_relocations,omitempty"`
+	// CopyFiles is a list of file copies to perform after generation.
+	// It applies to files in the GAPIC module.
+	CopyFiles []*JavaFileCopy `yaml:"copy_files,omitempty"`
 
 	// Samples determines whether to generate samples for the API,
 	// default is true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
 }
 
-// JavaFileRelocation represents a file relocation for Java.
-type JavaFileRelocation struct {
+// JavaFileCopy represents a file copy for Java.
+type JavaFileCopy struct {
 	// Source is the source path relative to the generated GAPIC module directory
 	// (e.g., "src/main/java/com/google/storage/v2/gapic_metadata.json").
 	// These paths are used before restructuring the output into Maven modules.

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -113,7 +113,7 @@ func postProcessAPI(ctx context.Context, p postProcessParams) error {
 		}
 	}
 	if err := copyFiles(p); err != nil {
-		return err
+		return fmt.Errorf("failed to copy files: %w", err)
 	}
 	if err := restructureToStaging(p); err != nil {
 		return fmt.Errorf("failed to restructure to staging: %w", err)

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -112,7 +112,9 @@ func postProcessAPI(ctx context.Context, p postProcessParams) error {
 			return fmt.Errorf("failed to fix headers in %s: %w", dir, err)
 		}
 	}
-
+	if err := relocateFiles(p); err != nil {
+		return err
+	}
 	if err := restructureToStaging(p); err != nil {
 		return fmt.Errorf("failed to restructure to staging: %w", err)
 	}
@@ -158,6 +160,26 @@ func addMissingHeaders(dir string) error {
 		}
 		return os.WriteFile(path, append([]byte(licenseText), content...), 0644)
 	})
+}
+
+func relocateFiles(p postProcessParams) error {
+	if p.javaAPI == nil || len(p.javaAPI.FileRelocations) == 0 {
+		return nil
+	}
+	for _, r := range p.javaAPI.FileRelocations {
+		src := filepath.Join(p.outDir, p.apiBase, r.Source)
+		dest := filepath.Join(p.outDir, p.apiBase, r.Destination)
+		if _, err := os.Stat(src); err != nil {
+			return fmt.Errorf("failed to stat relocation source %s: %w", src, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return fmt.Errorf("failed to create destination directory for %s: %w", dest, err)
+		}
+		if err := os.Rename(src, dest); err != nil {
+			return fmt.Errorf("failed to relocate %s to %s: %w", src, dest, err)
+		}
+	}
+	return nil
 }
 
 // buildLicenseText constructs the complete license header text for the given year.

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -112,7 +112,7 @@ func postProcessAPI(ctx context.Context, p postProcessParams) error {
 			return fmt.Errorf("failed to fix headers in %s: %w", dir, err)
 		}
 	}
-	if err := relocateFiles(p); err != nil {
+	if err := copyFiles(p); err != nil {
 		return err
 	}
 	if err := restructureToStaging(p); err != nil {
@@ -162,22 +162,22 @@ func addMissingHeaders(dir string) error {
 	})
 }
 
-func relocateFiles(p postProcessParams) error {
-	if p.javaAPI == nil || len(p.javaAPI.FileRelocations) == 0 {
+func copyFiles(p postProcessParams) error {
+	if p.javaAPI == nil || len(p.javaAPI.CopyFiles) == 0 {
 		return nil
 	}
 	gapicDir := p.gapicDir()
-	for _, r := range p.javaAPI.FileRelocations {
-		src := filepath.Join(gapicDir, r.Source)
-		dest := filepath.Join(gapicDir, r.Destination)
+	for _, c := range p.javaAPI.CopyFiles {
+		src := filepath.Join(gapicDir, c.Source)
+		dest := filepath.Join(gapicDir, c.Destination)
 		if _, err := os.Stat(src); err != nil {
-			return fmt.Errorf("failed to stat relocation source %s: %w", src, err)
+			return fmt.Errorf("failed to stat copy source %s: %w", src, err)
 		}
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 			return fmt.Errorf("failed to create destination directory for %s: %w", dest, err)
 		}
-		if err := os.Rename(src, dest); err != nil {
-			return fmt.Errorf("failed to relocate %s to %s: %w", src, dest, err)
+		if err := filesystem.CopyFile(src, dest); err != nil {
+			return fmt.Errorf("failed to copy %s to %s: %w", src, dest, err)
 		}
 	}
 	return nil

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -166,9 +166,10 @@ func relocateFiles(p postProcessParams) error {
 	if p.javaAPI == nil || len(p.javaAPI.FileRelocations) == 0 {
 		return nil
 	}
+	gapicDir := p.gapicDir()
 	for _, r := range p.javaAPI.FileRelocations {
-		src := filepath.Join(p.outDir, p.apiBase, r.Source)
-		dest := filepath.Join(p.outDir, p.apiBase, r.Destination)
+		src := filepath.Join(gapicDir, r.Source)
+		dest := filepath.Join(gapicDir, r.Destination)
 		if _, err := os.Stat(src); err != nil {
 			return fmt.Errorf("failed to stat relocation source %s: %w", src, err)
 		}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -573,3 +573,77 @@ func TestAddMissingHeaders(t *testing.T) {
 		})
 	}
 }
+
+func TestRelocateFiles(t *testing.T) {
+	t.Parallel()
+	outdir := t.TempDir()
+	apiBase := "v1"
+	srcPath := "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json"
+	destPath := "gapic/src/main/resources/com/google/storage/v2/gapic_metadata.json"
+
+	fullSrcPath := filepath.Join(outdir, apiBase, srcPath)
+	if err := os.MkdirAll(filepath.Dir(fullSrcPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"schema": "1.0"}`
+	if err := os.WriteFile(fullSrcPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := postProcessParams{
+		outDir:  outdir,
+		apiBase: apiBase,
+		javaAPI: &config.JavaAPI{
+			FileRelocations: []*config.JavaFileRelocation{
+				{
+					Source:      srcPath,
+					Destination: destPath,
+				},
+			},
+		},
+	}
+
+	if err := relocateFiles(p); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify relocation
+	fullDestPath := filepath.Join(outdir, apiBase, destPath)
+	if _, err := os.Stat(fullDestPath); err != nil {
+		t.Errorf("destination file %s does not exist: %v", fullDestPath, err)
+	}
+	if _, err := os.Stat(fullSrcPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("source file %s should not exist", fullSrcPath)
+	}
+
+	gotContent, err := os.ReadFile(fullDestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotContent) != content {
+		t.Errorf("content mismatch: got %q, want %q", string(gotContent), content)
+	}
+}
+
+func TestRelocateFiles_Error(t *testing.T) {
+	t.Parallel()
+	outdir := t.TempDir()
+	apiBase := "v1"
+
+	p := postProcessParams{
+		outDir:  outdir,
+		apiBase: apiBase,
+		javaAPI: &config.JavaAPI{
+			FileRelocations: []*config.JavaFileRelocation{
+				{
+					Source:      "non-existent",
+					Destination: "dest",
+				},
+			},
+		},
+	}
+
+	if err := relocateFiles(p); err == nil {
+		t.Error("relocateFiles() error = nil, want error for non-existent source")
+	}
+}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -574,7 +574,7 @@ func TestAddMissingHeaders(t *testing.T) {
 	}
 }
 
-func TestRelocateFiles(t *testing.T) {
+func TestCopyFiles(t *testing.T) {
 	t.Parallel()
 	outdir := t.TempDir()
 	apiBase := "v1"
@@ -595,7 +595,7 @@ func TestRelocateFiles(t *testing.T) {
 		outDir:  outdir,
 		apiBase: apiBase,
 		javaAPI: &config.JavaAPI{
-			FileRelocations: []*config.JavaFileRelocation{
+			CopyFiles: []*config.JavaFileCopy{
 				{
 					Source:      srcPath,
 					Destination: destPath,
@@ -604,17 +604,17 @@ func TestRelocateFiles(t *testing.T) {
 		},
 	}
 
-	if err := relocateFiles(p); err != nil {
+	if err := copyFiles(p); err != nil {
 		t.Fatal(err)
 	}
 
-	// Verify relocation
+	// Verify copy
 	fullDestPath := filepath.Join(gapicDir, destPath)
 	if _, err := os.Stat(fullDestPath); err != nil {
 		t.Errorf("destination file %s does not exist: %v", fullDestPath, err)
 	}
-	if _, err := os.Stat(fullSrcPath); !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("source file %s should not exist", fullSrcPath)
+	if _, err := os.Stat(fullSrcPath); err != nil {
+		t.Errorf("source file %s should still exist", fullSrcPath)
 	}
 
 	gotContent, err := os.ReadFile(fullDestPath)
@@ -626,7 +626,7 @@ func TestRelocateFiles(t *testing.T) {
 	}
 }
 
-func TestRelocateFiles_Error(t *testing.T) {
+func TestCopyFiles_Error(t *testing.T) {
 	t.Parallel()
 	outdir := t.TempDir()
 	apiBase := "v1"
@@ -635,7 +635,7 @@ func TestRelocateFiles_Error(t *testing.T) {
 		outDir:  outdir,
 		apiBase: apiBase,
 		javaAPI: &config.JavaAPI{
-			FileRelocations: []*config.JavaFileRelocation{
+			CopyFiles: []*config.JavaFileCopy{
 				{
 					Source:      "non-existent",
 					Destination: "dest",
@@ -644,7 +644,7 @@ func TestRelocateFiles_Error(t *testing.T) {
 		},
 	}
 
-	if err := relocateFiles(p); err == nil {
-		t.Error("relocateFiles() error = nil, want error for non-existent source")
+	if err := copyFiles(p); err == nil {
+		t.Error("copyFiles() error = nil, want error for non-existent source")
 	}
 }

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -578,10 +578,11 @@ func TestRelocateFiles(t *testing.T) {
 	t.Parallel()
 	outdir := t.TempDir()
 	apiBase := "v1"
-	srcPath := "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json"
-	destPath := "gapic/src/main/resources/com/google/storage/v2/gapic_metadata.json"
+	gapicDir := filepath.Join(outdir, apiBase, "gapic")
+	srcPath := "src/main/java/com/google/storage/v2/gapic_metadata.json"
+	destPath := "src/main/resources/com/google/storage/v2/gapic_metadata.json"
 
-	fullSrcPath := filepath.Join(outdir, apiBase, srcPath)
+	fullSrcPath := filepath.Join(gapicDir, srcPath)
 	if err := os.MkdirAll(filepath.Dir(fullSrcPath), 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -608,7 +609,7 @@ func TestRelocateFiles(t *testing.T) {
 	}
 
 	// Verify relocation
-	fullDestPath := filepath.Join(outdir, apiBase, destPath)
+	fullDestPath := filepath.Join(gapicDir, destPath)
 	if _, err := os.Stat(fullDestPath); err != nil {
 		t.Errorf("destination file %s does not exist: %v", fullDestPath, err)
 	}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -590,7 +590,6 @@ func TestCopyFiles(t *testing.T) {
 	if err := os.WriteFile(fullSrcPath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
-
 	p := postProcessParams{
 		outDir:  outdir,
 		apiBase: apiBase,
@@ -603,11 +602,9 @@ func TestCopyFiles(t *testing.T) {
 			},
 		},
 	}
-
 	if err := copyFiles(p); err != nil {
 		t.Fatal(err)
 	}
-
 	// Verify copy
 	fullDestPath := filepath.Join(gapicDir, destPath)
 	if _, err := os.Stat(fullDestPath); err != nil {
@@ -616,13 +613,12 @@ func TestCopyFiles(t *testing.T) {
 	if _, err := os.Stat(fullSrcPath); err != nil {
 		t.Errorf("source file %s should still exist", fullSrcPath)
 	}
-
 	gotContent, err := os.ReadFile(fullDestPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(gotContent) != content {
-		t.Errorf("content mismatch: got %q, want %q", string(gotContent), content)
+	if diff := cmp.Diff(content, string(gotContent)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -630,7 +626,6 @@ func TestCopyFiles_Error(t *testing.T) {
 	t.Parallel()
 	outdir := t.TempDir()
 	apiBase := "v1"
-
 	p := postProcessParams{
 		outDir:  outdir,
 		apiBase: apiBase,
@@ -643,7 +638,6 @@ func TestCopyFiles_Error(t *testing.T) {
 			},
 		},
 	}
-
 	if err := copyFiles(p); err == nil {
 		t.Error("copyFiles() error = nil, want error for non-existent source")
 	}

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -266,7 +266,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			applyJavaProtoOverrides(javaAPI)
 
 			if name == "storage" && g.ProtoPath == "google/storage/v2" {
-				javaAPI.FileRelocations = []*config.JavaFileRelocation{
+				javaAPI.CopyFiles = []*config.JavaFileCopy{
 					{
 						Source:      "src/main/java/com/google/storage/v2/gapic_metadata.json",
 						Destination: "src/main/resources/com/google/storage/v2/gapic_metadata.json",
@@ -274,7 +274,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				}
 			}
 			if name == "storage" && g.ProtoPath == "google/storage/control/v2" {
-				javaAPI.FileRelocations = []*config.JavaFileRelocation{
+				javaAPI.CopyFiles = []*config.JavaFileCopy{
 					{
 						Source:      "src/main/java/com/google/storage/control/v2/gapic_metadata.json",
 						Destination: "src/main/resources/com/google/storage/control/v2/gapic_metadata.json",

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -264,6 +264,23 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			}
 			applyJavaArtifactOverrides(javaAPI)
 			applyJavaProtoOverrides(javaAPI)
+
+			if name == "storage" && g.ProtoPath == "google/storage/v2" {
+				javaAPI.FileRelocations = []*config.JavaFileRelocation{
+					{
+						Source:      "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json",
+						Destination: "gapic/src/main/resources/com/google/storage/v2/gapic_metadata.json",
+					},
+				}
+			}
+			if name == "storage" && g.ProtoPath == "google/storage/control/v2" {
+				javaAPI.FileRelocations = []*config.JavaFileRelocation{
+					{
+						Source:      "gapic/src/main/java/com/google/storage/control/v2/gapic_metadata.json",
+						Destination: "gapic/src/main/resources/com/google/storage/control/v2/gapic_metadata.json",
+					},
+				}
+			}
 			javaAPIs = append(javaAPIs, javaAPI)
 		}
 		lib := &config.Library{

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -268,16 +268,16 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			if name == "storage" && g.ProtoPath == "google/storage/v2" {
 				javaAPI.FileRelocations = []*config.JavaFileRelocation{
 					{
-						Source:      "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json",
-						Destination: "gapic/src/main/resources/com/google/storage/v2/gapic_metadata.json",
+						Source:      "src/main/java/com/google/storage/v2/gapic_metadata.json",
+						Destination: "src/main/resources/com/google/storage/v2/gapic_metadata.json",
 					},
 				}
 			}
 			if name == "storage" && g.ProtoPath == "google/storage/control/v2" {
 				javaAPI.FileRelocations = []*config.JavaFileRelocation{
 					{
-						Source:      "gapic/src/main/java/com/google/storage/control/v2/gapic_metadata.json",
-						Destination: "gapic/src/main/resources/com/google/storage/control/v2/gapic_metadata.json",
+						Source:      "src/main/java/com/google/storage/control/v2/gapic_metadata.json",
+						Destination: "src/main/resources/com/google/storage/control/v2/gapic_metadata.json",
 					},
 				}
 			}

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -687,8 +687,8 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-control-v2",
 				FileRelocations: []*config.JavaFileRelocation{
 					{
-						Source:      "gapic/src/main/java/com/google/storage/control/v2/gapic_metadata.json",
-						Destination: "gapic/src/main/resources/com/google/storage/control/v2/gapic_metadata.json",
+						Source:      "src/main/java/com/google/storage/control/v2/gapic_metadata.json",
+						Destination: "src/main/resources/com/google/storage/control/v2/gapic_metadata.json",
 					},
 				},
 			},
@@ -705,8 +705,8 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-v2",
 				FileRelocations: []*config.JavaFileRelocation{
 					{
-						Source:      "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json",
-						Destination: "gapic/src/main/resources/com/google/storage/v2/gapic_metadata.json",
+						Source:      "src/main/java/com/google/storage/v2/gapic_metadata.json",
+						Destination: "src/main/resources/com/google/storage/v2/gapic_metadata.json",
 					},
 				},
 			},

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -685,6 +685,30 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				GAPICArtifactIDOverride: "google-cloud-storage-control",
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-control-v2",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-control-v2",
+				FileRelocations: []*config.JavaFileRelocation{
+					{
+						Source:      "gapic/src/main/java/com/google/storage/control/v2/gapic_metadata.json",
+						Destination: "gapic/src/main/resources/com/google/storage/control/v2/gapic_metadata.json",
+					},
+				},
+			},
+		},
+		{
+			name:        "storage v2",
+			libraryName: "storage",
+			protoPath:   "google/storage/v2",
+			wantJavaAPI: &config.JavaAPI{
+				Path:                    "google/storage/v2",
+				Samples:                 new(false),
+				GAPICArtifactIDOverride: "gapic-google-cloud-storage-v2",
+				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-v2",
+				ProtoArtifactIDOverride: "proto-google-cloud-storage-v2",
+				FileRelocations: []*config.JavaFileRelocation{
+					{
+						Source:      "gapic/src/main/java/com/google/storage/v2/gapic_metadata.json",
+						Destination: "gapic/src/main/resources/com/google/storage/v2/gapic_metadata.json",
+					},
+				},
 			},
 		},
 	} {

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -685,7 +685,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				GAPICArtifactIDOverride: "google-cloud-storage-control",
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-control-v2",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-control-v2",
-				FileRelocations: []*config.JavaFileRelocation{
+				CopyFiles: []*config.JavaFileCopy{
 					{
 						Source:      "src/main/java/com/google/storage/control/v2/gapic_metadata.json",
 						Destination: "src/main/resources/com/google/storage/control/v2/gapic_metadata.json",
@@ -703,7 +703,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				GAPICArtifactIDOverride: "gapic-google-cloud-storage-v2",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-v2",
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-v2",
-				FileRelocations: []*config.JavaFileRelocation{
+				CopyFiles: []*config.JavaFileCopy{
 					{
 						Source:      "src/main/java/com/google/storage/v2/gapic_metadata.json",
 						Destination: "src/main/resources/com/google/storage/v2/gapic_metadata.json",


### PR DESCRIPTION
Adds a config to allow file copy within the GAPIC module for Java. This is likely only going to be used by storage, to mimic this special copy rule in [java-storage/.OwlBot-hermetic.yaml](https://screenshot.googleplex.com/BhVSTLr2rVuRX9i). Restricted the scope to only allow copy within GAPIC modules, we can extend to proto and gRPC modules if needed in the future.



Fix #5194