### PR TITLE
fix(tool/cmd/migrate): add hardcoded transport override for Java

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -287,7 +287,7 @@ This document describes the schema for the librarian.yaml.
 | `billing_not_required` | bool | Indicates whether the API does NOT require billing. This is typically false. |
 | `rest_documentation` | string | Is the URL for the REST documentation. |
 | `rpc_documentation` | string | Is the URL for the RPC documentation. |
-| `transport_override` | string | Allows the "transport" field in .repo-metadata.json to be overridden. |
+| `transport_override` | string | Allows the "transport" field in .repo-metadata.json to be overridden. TODO(https://github.com/googleapis/librarian/issues/5561): investigate and determine if can remove |
 
 ## NodejsAPI Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -573,6 +573,8 @@ type JavaModule struct {
 
 	// TransportOverride allows the "transport" field in .repo-metadata.json
 	// to be overridden.
+	// TODO(https://github.com/googleapis/librarian/issues/5561):
+	// investigate and determine if can remove
 	TransportOverride string `yaml:"transport_override,omitempty"`
 }
 

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -295,6 +295,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				TransportOverride:            l.Transport,
 			},
 		}
+		applyJavaLibraryOverrides(lib)
 		if len(apis) > 0 {
 			derivedShortName := name
 			serviceconfig.SortAPIs(apis)
@@ -415,6 +416,13 @@ func applyJavaArtifactOverrides(api *config.JavaAPI) {
 		if override.gapicArtifactID != "" {
 			api.GAPICArtifactIDOverride = override.gapicArtifactID
 		}
+	}
+}
+
+// applyJavaLibraryOverrides sets library-level overrides.
+func applyJavaLibraryOverrides(lib *config.Library) {
+	if transport, ok := javaTransportOverrides[lib.Name]; ok {
+		lib.Java.TransportOverride = transport
 	}
 }
 

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -110,6 +110,10 @@ var (
 			gapicArtifactID: "google-cloud-storage-control",
 		},
 	}
+
+	javaTransportOverrides = map[string]string{
+		"alloydb-connectors": "grpc",
+	}
 )
 
 type javaArtifactOverrides struct {

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -113,7 +113,7 @@ var (
 
 	javaTransportOverrides = map[string]string{
 		//This is added here instead of sdk.yaml change because this is
-		//a proto-only library and transport affect on Java code generation.
+		//a proto-only library and transport does not affect Java code generated.
 		"alloydb-connectors": "grpc",
 	}
 )

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -112,6 +112,8 @@ var (
 	}
 
 	javaTransportOverrides = map[string]string{
+		//This is added here instead of sdk.yaml change because this is
+		//a proto-only library and transport affect on Java code generation.
 		"alloydb-connectors": "grpc",
 	}
 )

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -659,10 +659,11 @@ func TestShouldExcludeSamples(t *testing.T) {
 
 func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 	for _, test := range []struct {
-		name        string
-		libraryName string
-		protoPath   string
-		wantJavaAPI *config.JavaAPI
+		name          string
+		libraryName   string
+		protoPath     string
+		wantJavaAPI   *config.JavaAPI
+		wantTransport string
 	}{
 		{
 			name:        "datastore admin v1",
@@ -686,6 +687,16 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-control-v2",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-control-v2",
 			},
+		},
+		{
+			name:        "alloydb-connectors transport override",
+			libraryName: "alloydb-connectors",
+			protoPath:   "google/cloud/alloydb/connectors/v1",
+			wantJavaAPI: &config.JavaAPI{
+				Path:    "google/cloud/alloydb/connectors/v1",
+				Samples: new(false),
+			},
+			wantTransport: "grpc",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -724,7 +735,8 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 							{Path: test.protoPath},
 						},
 						Java: &config.JavaModule{
-							JavaAPIs: []*config.JavaAPI{test.wantJavaAPI},
+							JavaAPIs:          []*config.JavaAPI{test.wantJavaAPI},
+							TransportOverride: test.wantTransport,
 						},
 					},
 				},


### PR DESCRIPTION
Adds a hardcoded transport override for `alloydb-connectors`. This is used only for .repo-metadata.json and documentation to minimize generation diff, no affect on Java code generation because this is an proto-only library. 
More context in #5554.

Fix #5554