### PR TITLE
fix(internal/librarian/java): only generate clirr ignore files for proto-google- modules

### DIFF
--- a/internal/librarian/java/clirr.go
+++ b/internal/librarian/java/clirr.go
@@ -37,18 +37,28 @@ const (
 	clirrIgnoreFile = "clirr-ignored-differences.xml"
 	// templateName is the name of the template used to generate Clirr ignore file.
 	templateName = "clirr-ignored-differences.xml.tmpl"
+	// protoGooglePrefix is the prefix used to identify proto modules
+	// for Clirr ignore generation.
+	protoGooglePrefix = "proto-google-"
 )
 
-// clirrIgnoreExists checks if the clirr-ignored-differences.xml file exists in the
-// specified directory.
-func clirrIgnoreExists(dir string) (bool, error) {
-	path := filepath.Join(dir, clirrIgnoreFile)
+// clirrIgnoreShouldGenerate determines if the clirr-ignored-differences.xml file
+// should be generated for the specified proto module.
+//
+// It returns true only if the artifactID starts with "proto-google-" AND the file
+// does not already exist in the repo directory.
+func clirrIgnoreShouldGenerate(artifactID, repoDir string) (bool, error) {
+	if !strings.HasPrefix(artifactID, protoGooglePrefix) {
+		return false, nil
+	}
+	path := filepath.Join(repoDir, clirrIgnoreFile)
 	_, err := os.Stat(path)
 	if err == nil {
-		return true, nil
+		// File already exists
+		return false, nil
 	}
 	if errors.Is(err, fs.ErrNotExist) {
-		return false, nil
+		return true, nil
 	}
 	return false, fmt.Errorf("failed to check for %s: %w", path, err)
 }

--- a/internal/librarian/java/clirr.go
+++ b/internal/librarian/java/clirr.go
@@ -45,7 +45,7 @@ const (
 // clirrIgnoreShouldGenerate determines if the clirr-ignored-differences.xml file
 // should be generated for the specified proto module.
 //
-// It returns true only if the artifactID starts with "proto-google-" AND the file
+// It returns true only if the artifactID starts with protoGooglePrefix AND the file
 // does not already exist in the repo directory.
 func clirrIgnoreShouldGenerate(artifactID, repoDir string) (bool, error) {
 	if !strings.HasPrefix(artifactID, protoGooglePrefix) {

--- a/internal/librarian/java/clirr_test.go
+++ b/internal/librarian/java/clirr_test.go
@@ -51,38 +51,46 @@ func TestGenerateClirrIgnore(t *testing.T) {
 	}
 }
 
-func TestClirrIgnoreExists(t *testing.T) {
+func TestClirrIgnoreShouldGenerate(t *testing.T) {
 	for _, test := range []struct {
-		name  string
-		setup func(t *testing.T, dir string)
-		want  bool
+		name       string
+		artifactID string
+		setup      func(t *testing.T, dir string)
+		want       bool
 	}{
 		{
-			name:  "not exists",
-			setup: func(t *testing.T, dir string) {},
-			want:  false,
+			name:       "should generate - prefix matches and not exists",
+			artifactID: "proto-google-cloud-test-v1",
+			setup:      func(t *testing.T, dir string) {},
+			want:       true,
 		},
 		{
-			name: "exists",
+			name:       "should not generate - prefix mismatch",
+			artifactID: "proto-data-manager-v1",
+			setup:      func(t *testing.T, dir string) {},
+			want:       false,
+		},
+		{
+			name:       "should not generate - already exists",
+			artifactID: "proto-google-cloud-test-v1",
 			setup: func(t *testing.T, dir string) {
 				path := filepath.Join(dir, clirrIgnoreFile)
 				if err := os.WriteFile(path, []byte("exists"), 0644); err != nil {
 					t.Fatal(err)
 				}
 			},
-			want: true,
+			want: false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 			test.setup(t, dir)
-
-			got, err := clirrIgnoreExists(dir)
+			got, err := clirrIgnoreShouldGenerate(test.artifactID, dir)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if got != test.want {
-				t.Errorf("clirrIgnoreExists(%q) = %v, want %v", dir, got, test.want)
+				t.Errorf("clirrIgnoreShouldGenerate(%q, %q) = %v, want %v", test.artifactID, dir, got, test.want)
 			}
 		})
 	}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -121,13 +121,13 @@ func postProcessAPI(ctx context.Context, p postProcessParams) error {
 	// We target the staging directory because runOwlBot hasn't moved the files
 	// to their final destination yet.
 	coords := p.coords()
-	protoModuleStagingRoot := filepath.Join(p.outDir, "owl-bot-staging", p.apiBase, coords.Proto.ArtifactID)
 	protoModuleRepoRoot := filepath.Join(p.outDir, coords.Proto.ArtifactID)
-	exists, err := clirrIgnoreExists(protoModuleRepoRoot)
+	shouldGenerate, err := clirrIgnoreShouldGenerate(coords.Proto.ArtifactID, protoModuleRepoRoot)
 	if err != nil {
 		return fmt.Errorf("failed to check for clirr ignore file: %w", err)
 	}
-	if !exists {
+	if shouldGenerate {
+		protoModuleStagingRoot := filepath.Join(p.outDir, "owl-bot-staging", p.apiBase, coords.Proto.ArtifactID)
 		if err := generateClirrIgnore(protoModuleStagingRoot); err != nil {
 			return fmt.Errorf("failed to generate clirr ignore file: %w", err)
 		}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -63,6 +63,14 @@ func TestPostProcessAPI(t *testing.T) {
 	if err := os.WriteFile(protoFile, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
+	orBuilderDir := filepath.Join(protoDir, "com", "google", "cloud", "secretmanager", "v1")
+	if err := os.MkdirAll(orBuilderDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	orBuilderFile := filepath.Join(orBuilderDir, "SomeOrBuilder.java")
+	if err := os.WriteFile(orBuilderFile, []byte("package com.google.cloud.secretmanager.v1; public interface SomeOrBuilder {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a dummy srcjar (which is a zip)
 	srcjarPath := filepath.Join(gapicDir, "temp-codegen.srcjar")
@@ -138,6 +146,12 @@ func TestPostProcessAPI(t *testing.T) {
 	unzippedTestPath := filepath.Join(outdir, "owl-bot-staging", apiBase, "google-cloud-secretmanager", "src", "test", "java", "com", "google", "cloud", "secretmanager", "v1", "SomeTest.java")
 	if _, err := os.Stat(unzippedTestPath); err != nil {
 		t.Errorf("expected unzipped test file at %s, but it was not found: %v", unzippedTestPath, err)
+	}
+
+	// Verify that clirr-ignored-differences.xml is generated.
+	clirrPath := filepath.Join(outdir, "owl-bot-staging", apiBase, "proto-google-cloud-secretmanager-v1", "clirr-ignored-differences.xml")
+	if _, err := os.Stat(clirrPath); err != nil {
+		t.Errorf("expected clirr ignore file at %s, but it was not found: %v", clirrPath, err)
 	}
 
 	// Verify that the apiBase directory was cleaned up


### PR DESCRIPTION
Check for module name and only generate "clirr-ignored-differences.xml" if module name starts with proto-google- and the file does not already exist.
This matches the current strategy in google-cloud-java and should eliminate generation diff in these 3 libraries.
java-marketingplatformadminapi
java-admanager
java-datamanager

Fix #5558