### PR TITLE
fix(librarian): remove rust default version in bump

### DIFF
--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -256,13 +256,10 @@ func deriveNextVersion(cfg *config.Config, library *config.Library, opts semver.
 		return versionOverride, nil
 	}
 
-	// First release, use the appropriate default starting version.
+	// First release, use the appropriate default starting version. Many languages
+	// have their own default starting version, set at add time. This is a
+	// fallback for the case where it wasn't.
 	if library.Version == "" {
-		// Keep this logic until we know we no longer need it i.e. all entries
-		// have a version set.
-		if cfg.Language == config.LanguageRust {
-			return rust.DefaultVersion, nil
-		}
 		return defaultVersion, nil
 	}
 

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -212,7 +212,7 @@ func hasChangesIn(dir, exclusion string, filesChanged []string) bool {
 // to update manifests, version files etc.
 func bumpLibrary(cfg *config.Config, lib *config.Library, versionOverride string) error {
 	opts := languageVersioningOptions[cfg.Language]
-	version, err := deriveNextVersion(cfg, lib, opts, versionOverride)
+	version, err := deriveNextVersion(lib, opts, versionOverride)
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func postBump(ctx context.Context, cfg *config.Config) error {
 	return nil
 }
 
-func deriveNextVersion(cfg *config.Config, library *config.Library, opts semver.DeriveNextOptions, versionOverride string) (string, error) {
+func deriveNextVersion(library *config.Library, opts semver.DeriveNextOptions, versionOverride string) (string, error) {
 	// If a version override has been specified, use it - but
 	// check that it's not a regression or a no-op.
 	if versionOverride != "" {
@@ -409,7 +409,7 @@ func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe 
 // the next version.)
 func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, lastTag, gitExe, versionOverride string) error {
 	opts := languageVersioningOptions[cfg.Language]
-	version, err := deriveNextVersion(cfg, lib, opts, versionOverride)
+	version, err := deriveNextVersion(lib, opts, versionOverride)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -709,7 +709,7 @@ func TestDeriveNextVersion(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			got, err := deriveNextVersion(test.cfg, test.cfg.Libraries[0], test.versionOpts, test.versionOverride)
+			got, err := deriveNextVersion(test.cfg.Libraries[0], test.versionOpts, test.versionOverride)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -747,7 +747,7 @@ func TestDeriveNextVersion_Error(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := deriveNextVersion(test.cfg, test.cfg.Libraries[0], test.versionOpts, test.versionOverride)
+			got, err := deriveNextVersion(test.cfg.Libraries[0], test.versionOpts, test.versionOverride)
 			if err == nil {
 				t.Errorf("DeriveNextVersion() expected error; returned no error and version %s", got)
 			}

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/git"
-	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/sample"
 	"github.com/googleapis/librarian/internal/semver"
 	"github.com/googleapis/librarian/internal/testhelper"
@@ -669,17 +668,6 @@ func TestDeriveNextVersion(t *testing.T) {
 			wantVersion: sample.NextVersion,
 		},
 		{
-			name: "rust new library default version",
-			cfg: func() *config.Config {
-				c := sample.Config()
-				c.Language = config.LanguageRust
-				c.Libraries[0].Version = ""
-				return c
-			}(),
-			versionOpts: languageVersioningOptions[config.LanguageRust],
-			wantVersion: rust.DefaultVersion,
-		},
-		{
 			name:        "default semver options next GA version",
 			cfg:         sample.Config(),
 			wantVersion: sample.NextVersion,
@@ -693,6 +681,15 @@ func TestDeriveNextVersion(t *testing.T) {
 			}(),
 			versionOverride: "1.0.0-override.1",
 			wantVersion:     "1.0.0-override.1",
+		},
+		{
+			name: "unreleased library, default version",
+			cfg: func() *config.Config {
+				c := sample.Config()
+				c.Libraries[0].Version = ""
+				return c
+			}(),
+			wantVersion:     defaultVersion,
 		},
 		{
 			name: "version override, already released library, later version",

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -689,7 +689,7 @@ func TestDeriveNextVersion(t *testing.T) {
 				c.Libraries[0].Version = ""
 				return c
 			}(),
-			wantVersion:     defaultVersion,
+			wantVersion: defaultVersion,
 		},
 		{
 			name: "version override, already released library, later version",

--- a/internal/librarian/rust/add.go
+++ b/internal/librarian/rust/add.go
@@ -16,16 +16,16 @@ package rust
 
 import "github.com/googleapis/librarian/internal/config"
 
-// DefaultVersion is the first version used for a new library. This is set on
+// defaultVersion is the first version used for a new library. This is set on
 // the initial `librarian add` for a new API.
-const DefaultVersion = "1.0.0"
+const defaultVersion = "1.0.0"
 
 // Add executes Rust-specific mutations of the given [config.Library]
 // entry to be added to the librarian.yaml via `librarian add`.
 //
 // Currently, it only sets the [config.Library.Version] property to the
-// [DefaultVersion] for Rust.
+// [defaultVersion] for Rust.
 func Add(lib *config.Library) *config.Library {
-	lib.Version = DefaultVersion
+	lib.Version = defaultVersion
 	return lib
 }

--- a/internal/librarian/rust/add_test.go
+++ b/internal/librarian/rust/add_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestAdd(t *testing.T) {
 	lib := &config.Library{}
-	want := &config.Library{Version: DefaultVersion}
+	want := &config.Library{Version: defaultVersion}
 	got := Add(lib)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Remove the Rust specific default version logic present as a bridge while migrating the default version population to be part of `librarian add` instead of `bump`.

As noted, other languages have started to do the same, explicitly setting `version: 0.0.0` when initial `librarian add`'d, but for the time being it is good to have a sensible default in `bump` for new languages as they onboard.

Fixes #4924