### PR TITLE
cleanup(sidekick): add missing documentation for rust code

### DIFF
--- a/internal/sidekick/rust/templates/common/enum.mustache
+++ b/internal/sidekick/rust/templates/common/enum.mustache
@@ -17,6 +17,9 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
+{{^Codec.DocLines}}
+/// Enum for [{{Codec.Name}}].
+{{/Codec.DocLines}}
 ///
 /// # Working with unknown values
 ///
@@ -41,6 +44,9 @@ pub enum {{Codec.Name}} {
     {{#Codec.UniqueNames}}
     {{#Codec.DocLines}}
     {{{.}}}
+    {{/Codec.DocLines}}
+    {{^Codec.DocLines}}
+    #[allow(missing_docs)]
     {{/Codec.DocLines}}
     {{#Deprecated}}
     #[deprecated]

--- a/internal/sidekick/rust/templates/common/message.mustache
+++ b/internal/sidekick/rust/templates/common/message.mustache
@@ -18,6 +18,9 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
+{{^Codec.DocLines}}
+#[allow(missing_docs)]
+{{/Codec.DocLines}}
 {{> /templates/common/feature_gate}}
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
@@ -35,6 +38,9 @@ pub struct {{Codec.Name}} {
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
+    {{^Codec.DocLines}}
+    #[allow(missing_docs)]
+    {{/Codec.DocLines}}
     {{#Deprecated}}
     #[deprecated]
     {{/Deprecated}}
@@ -45,6 +51,9 @@ pub struct {{Codec.Name}} {
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
+    {{^Codec.DocLines}}
+    #[allow(missing_docs)]
+    {{/Codec.DocLines}}
     pub {{Codec.FieldName}}: std::option::Option<{{{Codec.FieldType}}}>,
     {{/OneOfs}}
 
@@ -53,6 +62,7 @@ pub struct {{Codec.Name}} {
 
 {{> /templates/common/feature_gate}}
 impl {{Codec.Name}} {
+    /// Creates a new default instance.
     pub fn new() -> Self {
         std::default::Default::default()
     }

--- a/internal/sidekick/rust/templates/common/oneof.mustache
+++ b/internal/sidekick/rust/templates/common/oneof.mustache
@@ -17,6 +17,9 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
+{{^Codec.DocLines}}
+#[allow(missing_docs)]
+{{/Codec.DocLines}}
 {{> /templates/common/feature_gate}}
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
@@ -24,6 +27,9 @@ pub enum {{Codec.EnumName}} {
     {{#Fields}}
     {{#Codec.DocLines}}
     {{{.}}}
+    {{/Codec.DocLines}}
+    {{^Codec.DocLines}}
+    #[allow(missing_docs)]
     {{/Codec.DocLines}}
     {{#Deprecated}}
     #[deprecated]

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -19,6 +19,7 @@ limitations under the License.
 {{/Codec.BoilerPlate}}
 {{#Codec.Services}}
 
+/// Request and client builders for [{{Codec.Name}}][crate::client::{{Codec.Name}}].
 {{#Codec.PerServiceFeatures}}
 #[cfg(feature = "{{Codec.FeatureName}}")]
 #[cfg_attr(docsrs, doc(cfg(feature = "{{Codec.FeatureName}}")))]

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -159,5 +159,6 @@ pub(crate) use google_cloud_gax::response::Response;
 {{/Codec.HasServices}}
 {{#Codec.ExtraModules}}
 
+#[allow(missing_docs)]
 pub mod {{{.}}};
 {{/Codec.ExtraModules}}

--- a/internal/sidekick/rust/templates/grpc-mock/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-mock/src/lib.rs.mustache
@@ -18,6 +18,8 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.BoilerPlate}}
 
+#![allow(missing_docs)]
+
 {{#Codec.QuickstartService}}
 //! End-to-end mocks for the `{{Package}}.{{Name}}` gRPC service.
 //!


### PR DESCRIPTION
Documentation is added to the rust code generation templates to document the new function in message templates and to the builder modules to ensure they are documented.

This also updates the Rust code generation templates to add allow(missing_docs) annotations to structs, enums, fields, and variants that do not have doc comments derived from upstream definitions, in order to facilitate easier linting of the generated code for real issues with missing documentation.

Fixes #5564 