### PR TITLE
refactor(internal/surfer): move gcloud generate

### DIFF
--- a/internal/surfer/generate.go
+++ b/internal/surfer/generate.go
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package gcloud provides a simple API for generating gcloud commands.
-package gcloud
+package surfer
 
 import (
-	sidekickgcloud "github.com/googleapis/librarian/internal/sidekick/gcloud"
+	"github.com/googleapis/librarian/internal/sidekick/gcloud"
 	"github.com/googleapis/librarian/internal/sidekick/gcloud/provider"
 )
 
-// GenerateConfig contains parameters for generating gcloud commands.
-type GenerateConfig struct {
+// generateConfig contains parameters for generating gcloud commands.
+type generateConfig struct {
 	GcloudConfig              string
 	ServiceConfig             string
 	IncludeList               string
@@ -32,8 +31,8 @@ type GenerateConfig struct {
 	BaseModule                string
 }
 
-// Generate generates gcloud commands for a service.
-func Generate(cfg GenerateConfig) error {
+// generate generates gcloud commands for a service.
+func generate(cfg generateConfig) error {
 	overrides, err := provider.ReadGcloudConfig(cfg.GcloudConfig)
 	if err != nil {
 		return err
@@ -42,5 +41,5 @@ func Generate(cfg GenerateConfig) error {
 	if err != nil {
 		return err
 	}
-	return sidekickgcloud.Generate(model, overrides, cfg.Output, cfg.BaseModule)
+	return gcloud.Generate(model, overrides, cfg.Output, cfg.BaseModule)
 }

--- a/internal/surfer/generate_test.go
+++ b/internal/surfer/generate_test.go
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcloud
+package surfer
 
 import (
 	"testing"
 )
 
 func TestGenerate_InvalidConfig(t *testing.T) {
-	err := Generate(GenerateConfig{
+	err := generate(generateConfig{
 		GcloudConfig: "nonexistent_config.yaml",
 	})
 	if err == nil {
-		t.Error("Generate() error = nil, want error for nonexistent config")
+		t.Error("generate() error = nil, want error for nonexistent config")
 	}
 }
 
 func TestGenerate_InvalidModel(t *testing.T) {
 	// GcloudConfig is empty, so it might pass (or not, depending on implementation),
 	// but Googleapis being nonexistent should definitely fail during model creation.
-	err := Generate(GenerateConfig{
+	err := generate(generateConfig{
 		Googleapis: "nonexistent_googleapis_dir",
 	})
 	if err == nil {
-		t.Error("Generate() error = nil, want error for nonexistent googleapis dir")
+		t.Error("generate() error = nil, want error for nonexistent googleapis dir")
 	}
 }

--- a/internal/surfer/surfer.go
+++ b/internal/surfer/surfer.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/googleapis/librarian/internal/librarian/gcloud"
 	"github.com/urfave/cli/v3"
 )
 
@@ -90,7 +89,7 @@ service config yaml, and gcloud.yaml.`,
 			descriptorFiles := cmd.String("descriptor-files")
 			descriptorFilesToGenerate := cmd.String("descriptor-files-to-generate")
 			baseModule := cmd.String("base-module")
-			return gcloud.Generate(gcloud.GenerateConfig{
+			return generate(generateConfig{
 				GcloudConfig:              config,
 				ServiceConfig:             serviceConfig,
 				IncludeList:               includeList,


### PR DESCRIPTION
The current generate logic will only ever be used by surfer. Move it into the surfer package.