### PR TITLE
chore: remove accidentally-included binary from root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,25 @@ cmd/librarianops/librarianops
 cmd/sidekick/sidekick
 cmd/surfer/surfer
 tool/cmd/builddockerimages/builddockerimages
+tool/cmd/configcheck/configcheck
 tool/cmd/importconfigs/importconfigs
 tool/cmd/importmetadata/importmetadata
 tool/cmd/migrate/migrate
 tool/cmd/syncversion/syncversion
+
+# The same binaries, but in the root directory
+/legacyautomation
+/legacylibrarian
+/librarian
+/librarianops
+/sidekick
+/surfer
+/builddockerimages
+/configcheck
+/importconfigs
+/importmetadata
+/migrate
+/syncversion
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ tool/cmd/migrate/migrate
 tool/cmd/syncversion/syncversion
 
 # The same binaries, but in the root directory
+# (These are in the same order as the list above,
+# which means they're not strictly sorted because
+# all the /cmd binaries come before /tool/cmd ones.)
 /legacyautomation
 /legacylibrarian
 /librarian


### PR DESCRIPTION
Remove a binary accidentally added in #5553, and add appropriate .gitignore lines to avoid it happening again.