### PR TITLE
feat(internal/librarian/python): derive Python GAPIC generator options

### DIFF
--- a/internal/librarian/python/clean.go
+++ b/internal/librarian/python/clean.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
 // gapicGenerationInfo contains useful information about the expected directory
@@ -46,7 +47,6 @@ type gapicGenerationInfo struct {
 const neutralSourcePlaceholder = "{neutral-source}"
 
 var (
-	errBadAPIPath               = errors.New("invalid API path")
 	errNoCommonGAPICFilesConfig = errors.New("when cleaning a GAPIC package, a config with common GAPIC paths must be provided")
 	// versionedGAPICRelativePathsToClean is the set of paths to remove for each
 	// API-versioned GAPIC output directory, relative to that directory.
@@ -129,10 +129,7 @@ func cleanProtoOnly(api *config.API, lib *config.Library) error {
 // be completely deleted. Likewise the documentation directory (e.g.
 // "docs/run_v2") will be completely deleted.
 func cleanGAPIC(api *config.API, lib *config.Library) error {
-	generationInfo, err := deriveGAPICGenerationInfo(api, lib)
-	if err != nil {
-		return err
-	}
+	generationInfo := deriveGAPICGenerationInfo(api, lib)
 	// Unusual, but it does happen, e.g. google/shopping/type and
 	// google/apps/script/type/{xyz}. We'll delete files as "common" GAPIC
 	// files instead.
@@ -152,10 +149,7 @@ func cleanGAPIC(api *config.API, lib *config.Library) error {
 // cleanGAPICCommon cleans the common output created for packages containing
 // any GAPIC libraries.
 func cleanGAPICCommon(lib *config.Library) error {
-	apiInfo, err := deriveGAPICGenerationInfo(lib.APIs[0], lib)
-	if err != nil {
-		return err
-	}
+	apiInfo := deriveGAPICGenerationInfo(lib.APIs[0], lib)
 	if lib.Python == nil {
 		return errNoCommonGAPICFilesConfig
 	}
@@ -208,59 +202,27 @@ func deleteUnlessKept(lib *config.Library, path string) error {
 
 // deriveGAPICGenerationInfo derives a gapicGenerationInfo for a single API within a library,
 // using the API path and the options from the configuration.
-func deriveGAPICGenerationInfo(api *config.API, lib *config.Library) (*gapicGenerationInfo, error) {
-	splitPath := strings.Split(api.Path, "/")
-	if len(splitPath) < 2 {
-		return nil, fmt.Errorf("not enough path segments in %s: %w", api.Path, errBadAPIPath)
+func deriveGAPICGenerationInfo(api *config.API, lib *config.Library) *gapicGenerationInfo {
+	options := []string{}
+	if lib.Python != nil {
+		options = lib.Python.OptArgsByAPI[api.Path]
 	}
-	namespace := findOptArg(api, lib.Python, "python-gapic-namespace")
-	gapicName := findOptArg(api, lib.Python, "python-gapic-name")
-
-	lastElement := splitPath[len(splitPath)-1]
-	version := ""
-	if strings.HasPrefix(lastElement, "v") {
-		version = lastElement
-		splitPath = splitPath[:len(splitPath)-1]
+	namespace, gotNamespace := findOption(options, gapicNamespaceOption)
+	if !gotNamespace {
+		namespace = deriveGAPICNamespace(api.Path)
 	}
-	var rootDir string
-	if namespace == "" {
-		rootDir = strings.Join(splitPath[:len(splitPath)-1], "/")
-	} else {
-		rootDir = strings.ReplaceAll(namespace, ".", "/")
+	name, gotName := findOption(options, gapicNameOption)
+	if !gotName {
+		name = deriveGAPICName(api.Path)
 	}
-	if gapicName == "" {
-		gapicName = splitPath[len(splitPath)-1]
-	}
+	version := serviceconfig.ExtractVersion(api.Path)
 	versionDir := ""
 	if version != "" {
-		versionDir = fmt.Sprintf("%s_%s", gapicName, version)
+		versionDir = fmt.Sprintf("%s_%s", name, version)
 	}
 	return &gapicGenerationInfo{
-		RootDir:    rootDir,
-		NeutralDir: gapicName,
+		RootDir:    strings.ReplaceAll(namespace, ".", "/"),
+		NeutralDir: name,
 		VersionDir: versionDir,
-	}, nil
-}
-
-// findOptArg finds the value for the named option within the configuration for
-// a Python package, with respect to a specific API path.
-// Note: this does not use PythonPackage.OptArgs, only OptArgsByAPI.
-// TODO(https://github.com/googleapis/librarian/issues/4107): remove the above
-// comment when OptArgs doesn't exist, or change this function to use OptArgs
-// if we decide to keep it.
-func findOptArg(api *config.API, cfg *config.PythonPackage, optName string) string {
-	if cfg == nil || cfg.OptArgsByAPI == nil {
-		return ""
 	}
-	args, ok := cfg.OptArgsByAPI[api.Path]
-	if !ok {
-		return ""
-	}
-	prefix := optName + "="
-	for _, arg := range args {
-		if strings.HasPrefix(arg, prefix) {
-			return arg[len(prefix):]
-		}
-	}
-	return ""
 }

--- a/internal/librarian/python/clean.go
+++ b/internal/librarian/python/clean.go
@@ -207,12 +207,12 @@ func deriveGAPICGenerationInfo(api *config.API, lib *config.Library) *gapicGener
 	if lib.Python != nil {
 		options = lib.Python.OptArgsByAPI[api.Path]
 	}
-	namespace, gotNamespace := findOption(options, gapicNamespaceOption)
-	if !gotNamespace {
+	namespace, ok := findOption(options, gapicNamespaceOption)
+	if !ok {
 		namespace = deriveGAPICNamespace(api.Path)
 	}
-	name, gotName := findOption(options, gapicNameOption)
-	if !gotName {
+	name, ok := findOption(options, gapicNameOption)
+	if !ok {
 		name = deriveGAPICName(api.Path)
 	}
 	version := serviceconfig.ExtractVersion(api.Path)

--- a/internal/librarian/python/clean_test.go
+++ b/internal/librarian/python/clean_test.go
@@ -164,14 +164,6 @@ func TestClean_Error(t *testing.T) {
 			wantErr: syscall.ENOTDIR,
 		},
 		{
-			name: "cleanGAPIC fails",
-			lib: &config.Library{
-				Name: "gapic-bad-path",
-				APIs: []*config.API{{Path: "google"}},
-			},
-			wantErr: errBadAPIPath,
-		},
-		{
 			name: "cleanGAPICCommon fails",
 			lib: &config.Library{
 				Name: "google-cloud-functions",
@@ -225,11 +217,11 @@ func TestDeriveGAPICGenerationInfo(t *testing.T) {
 		},
 		{
 			name:    "overridden configuration",
-			apiPath: "google/cloud/secrets/v1beta1",
+			apiPath: "google/other/secrets/v1beta1",
 			lib: &config.Library{
 				Python: &config.PythonPackage{
 					OptArgsByAPI: map[string][]string{
-						"google/cloud/secrets/v1beta1": {"python-gapic-namespace=google.cloud", "python-gapic-name=secretmanager"},
+						"google/other/secrets/v1beta1": {"python-gapic-namespace=google.cloud", "python-gapic-name=secretmanager"},
 					},
 				},
 			},
@@ -244,104 +236,8 @@ func TestDeriveGAPICGenerationInfo(t *testing.T) {
 			api := &config.API{
 				Path: test.apiPath,
 			}
-			info, err := deriveGAPICGenerationInfo(api, test.lib)
-			if err != nil {
-				t.Fatal(err)
-			}
+			info := deriveGAPICGenerationInfo(api, test.lib)
 			if diff := cmp.Diff(test.want, info); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestDeriveGAPICGenerationInfo_Error(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		apiPath string
-		lib     *config.Library
-		wantErr error
-	}{
-		{
-			name:    "no path",
-			apiPath: "",
-			wantErr: errBadAPIPath,
-		},
-		{
-			name:    "single-element path",
-			apiPath: "google",
-			wantErr: errBadAPIPath,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			api := &config.API{
-				Path: test.apiPath,
-			}
-			_, gotErr := deriveGAPICGenerationInfo(api, test.lib)
-			if !errors.Is(gotErr, test.wantErr) {
-				t.Errorf("deriveGAPICGenerationInfo error = %v, wantErr %v", gotErr, test.wantErr)
-			}
-		})
-	}
-}
-
-func TestFindOptArg(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		cfg  *config.PythonPackage
-		want string
-	}{
-		{
-			name: "option present",
-			cfg: &config.PythonPackage{
-				OptArgsByAPI: map[string][]string{
-					"path/to/api": {"other=x", "findme=foundvalue"},
-				},
-			},
-			want: "foundvalue",
-		},
-		{
-			name: "nil config",
-			cfg:  nil,
-		},
-		{
-			name: "nil OptArgsByAPI",
-			cfg: &config.PythonPackage{
-				ProtoOnlyAPIs: []string{"ignored"},
-			},
-		},
-		{
-			name: "no args for specified API",
-			cfg: &config.PythonPackage{
-				OptArgsByAPI: map[string][]string{
-					"path/to/other": {"other=x", "findme=foundvalue"},
-				},
-			},
-		},
-		{
-			name: "args for specified API, but none with given name",
-			cfg: &config.PythonPackage{
-				OptArgsByAPI: map[string][]string{
-					"path/to/api": {"other=x"},
-				},
-			},
-		},
-		{
-			name: "args for specified API, but only a prefix match",
-			cfg: &config.PythonPackage{
-				OptArgsByAPI: map[string][]string{
-					"path/to/api": {"other=x,findmenot=xyz"},
-				},
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			api := &config.API{
-				Path: "path/to/api",
-			}
-			optName := "findme"
-			got := findOptArg(api, test.cfg, optName)
-			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -481,13 +377,6 @@ func TestCleanGAPIC_Error(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "bad API path",
-			lib: &config.Library{
-				APIs: []*config.API{{Path: "google"}},
-			},
-			wantErr: errBadAPIPath,
-		},
-		{
 			name: "error during deletion",
 			lib: &config.Library{
 				APIs: []*config.API{{Path: "google/cloud/functions/v1"}},
@@ -580,13 +469,6 @@ func TestCleanGAPICCommon_Error(t *testing.T) {
 		lib     *config.Library
 		wantErr error
 	}{
-		{
-			name: "bad API path",
-			lib: &config.Library{
-				APIs: []*config.API{{Path: "google"}},
-			},
-			wantErr: errBadAPIPath,
-		},
 		{
 			name: "no python configuration",
 			lib: &config.Library{

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -36,6 +36,10 @@ import (
 const (
 	cloudGoogleComDocumentationTemplate = "https://cloud.google.com/python/docs/reference/%s/latest"
 	googleapisDevDocumentationTemplate  = "https://googleapis.dev/python/%s/latest"
+	transportOption                     = "transport"
+	gapicNamespaceOption                = "python-gapic-namespace"
+	gapicNameOption                     = "python-gapic-name"
+	warehousePackageNameOption          = "warehouse-package-name"
 )
 
 var errNoDefaultVersion = errors.New("default version must be specified for every library with generated APIs")
@@ -304,15 +308,21 @@ func createProtocOptions(api *config.API, library *config.Library, googleapisDir
 		opts = append(opts, "rest-numeric-enums")
 	}
 
-	addTransport := true
-	for _, opt := range opts {
-		if strings.HasPrefix(opt, "transport=") {
-			addTransport = false
-		}
-	}
 	// Add transport option, if we haven't already got it.
-	if addTransport {
-		opts = append(opts, fmt.Sprintf("transport=%s", transport))
+	if _, gotOption := findOption(opts, transportOption); !gotOption {
+		opts = append(opts, fmt.Sprintf("%s=%s", transportOption, transport))
+	}
+	// Add derived python-gapic-namespace option, if we haven't already got it.
+	if _, gotOption := findOption(opts, gapicNamespaceOption); !gotOption {
+		opts = append(opts, fmt.Sprintf("%s=%s", gapicNamespaceOption, deriveGAPICNamespace(api.Path)))
+	}
+	// Add derived python-gapic-name option, if we haven't already got it.
+	if _, gotOption := findOption(opts, gapicNameOption); !gotOption {
+		opts = append(opts, fmt.Sprintf("%s=%s", gapicNameOption, deriveGAPICName(api.Path)))
+	}
+	// Add the library name as warehouse-package-name option, if we haven't already got it.
+	if _, gotOption := findOption(opts, warehousePackageNameOption); !gotOption {
+		opts = append(opts, fmt.Sprintf("%s=%s", warehousePackageNameOption, library.Name))
 	}
 
 	// Add gapic-version from library version
@@ -469,4 +479,45 @@ func DefaultLibraryName(api string) string {
 // preview library.
 func isPreview(output string) bool {
 	return strings.Contains(output, "preview-packages")
+}
+
+// deriveGAPICNamespace derives the value to pass as python-gapic-namespace when
+// it's not specified explicitly. This is the first two components of the API
+// path, dot-separated.
+func deriveGAPICNamespace(path string) string {
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return path
+	}
+	return parts[0] + "." + parts[1]
+}
+
+// deriveGAPICName derives the value to pass as python-gapic-name when it's not
+// specified explicitly. This is the path, without the leading namespace (after
+// replacing dots with slashes), and without any version suffix, and then
+// replacing slashes with underscores. Example:
+// a path of google/cloud/foo/bar/v1 would have a GAPIC name of "foo_bar".
+func deriveGAPICName(path string) string {
+	version := serviceconfig.ExtractVersion(path)
+	if version != "" {
+		path = strings.TrimSuffix(path, version)
+	}
+	derivedNamespace := deriveGAPICNamespace(path)
+	path = strings.TrimPrefix(path, strings.ReplaceAll(derivedNamespace, ".", "/"))
+	path = strings.TrimSuffix(path, version)
+	path = strings.Trim(path, "/")
+	return strings.ReplaceAll(path, "/", "_")
+}
+
+// findOption finds the value of a named option within a list of name=value
+// strings. If the option isn't found, an empty string is returned. The second
+// value indicates whether the option was found or not.
+func findOption(options []string, name string) (string, bool) {
+	prefix := name + "="
+	for _, candidate := range options {
+		if strings.HasPrefix(candidate, prefix) {
+			return strings.TrimPrefix(candidate, prefix), true
+		}
+	}
+	return "", false
 }

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -309,19 +309,19 @@ func createProtocOptions(api *config.API, library *config.Library, googleapisDir
 	}
 
 	// Add transport option, if we haven't already got it.
-	if _, gotOption := findOption(opts, transportOption); !gotOption {
+	if _, ok := findOption(opts, transportOption); !ok {
 		opts = append(opts, fmt.Sprintf("%s=%s", transportOption, transport))
 	}
 	// Add derived python-gapic-namespace option, if we haven't already got it.
-	if _, gotOption := findOption(opts, gapicNamespaceOption); !gotOption {
+	if _, ok := findOption(opts, gapicNamespaceOption); !ok {
 		opts = append(opts, fmt.Sprintf("%s=%s", gapicNamespaceOption, deriveGAPICNamespace(api.Path)))
 	}
 	// Add derived python-gapic-name option, if we haven't already got it.
-	if _, gotOption := findOption(opts, gapicNameOption); !gotOption {
+	if _, ok := findOption(opts, gapicNameOption); !ok {
 		opts = append(opts, fmt.Sprintf("%s=%s", gapicNameOption, deriveGAPICName(api.Path)))
 	}
 	// Add the library name as warehouse-package-name option, if we haven't already got it.
-	if _, gotOption := findOption(opts, warehousePackageNameOption); !gotOption {
+	if _, ok := findOption(opts, warehousePackageNameOption); !ok {
 		opts = append(opts, fmt.Sprintf("%s=%s", warehousePackageNameOption, library.Name))
 	}
 

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -483,8 +483,12 @@ func isPreview(output string) bool {
 
 // deriveGAPICNamespace derives the value to pass as python-gapic-namespace when
 // it's not specified explicitly. This is the first two components of the API
-// path, dot-separated.
+// path (excluding any trailing version), dot-separated.
 func deriveGAPICNamespace(path string) string {
+	version := serviceconfig.ExtractVersion(path)
+	if version != "" {
+		path = strings.TrimSuffix(path, "/"+version)
+	}
 	parts := strings.Split(path, "/")
 	if len(parts) < 2 {
 		return path
@@ -504,7 +508,6 @@ func deriveGAPICName(path string) string {
 	}
 	derivedNamespace := deriveGAPICNamespace(path)
 	path = strings.TrimPrefix(path, strings.ReplaceAll(derivedNamespace, ".", "/"))
-	path = strings.TrimSuffix(path, version)
 	path = strings.Trim(path, "/")
 	return strings.ReplaceAll(path, "/", "_")
 }

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -105,12 +105,14 @@ func TestCreateProtocOptions(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:    "basic case",
-			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
-			library: &config.Library{},
+			name: "basic case",
+			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
+			library: &config.Library{
+				Name: "google-cloud-secret-manager",
+			},
 			expected: []string{
 				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,python-gapic-namespace=google.cloud,python-gapic-name=secretmanager,warehouse-package-name=google-cloud-secret-manager,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
 			},
 		},
 		{
@@ -127,7 +129,7 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 			expected: []string{
 				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,opt1,opt2,rest-numeric-enums,transport=grpc+rest,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				"--python_gapic_opt=metadata,opt1,opt2,rest-numeric-enums,transport=grpc+rest,python-gapic-namespace=google.cloud,python-gapic-name=secretmanager,warehouse-package-name=google-cloud-secret-manager,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
 			},
 		},
 		{
@@ -139,7 +141,7 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 			expected: []string{
 				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,gapic-version=1.2.3,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,python-gapic-namespace=google.cloud,python-gapic-name=secretmanager,warehouse-package-name=google-cloud-secret-manager,gapic-version=1.2.3,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
 			},
 		},
 		{
@@ -152,7 +154,7 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 			expected: []string{
 				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,python-gapic-namespace=google.cloud,python-gapic-name=secretmanager,warehouse-package-name=google-cloud-secret-manager,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
 			},
 		},
 		{
@@ -168,26 +170,28 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 			expected: []string{
 				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,transport=rest,rest-numeric-enums,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				"--python_gapic_opt=metadata,transport=rest,rest-numeric-enums,python-gapic-namespace=google.cloud,python-gapic-name=secretmanager,warehouse-package-name=google-cloud-secret-manager,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
 			},
 		},
 		{
 			name: "proto-only exists but doesn't include API path",
 			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{
+				Name: "google-cloud-secret-manager",
 				Python: &config.PythonPackage{
 					ProtoOnlyAPIs: []string{"google/cloud/secretmanager/type"},
 				},
 			},
 			expected: []string{
 				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				"--python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,python-gapic-namespace=google.cloud,python-gapic-name=secretmanager,warehouse-package-name=google-cloud-secret-manager,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
 			},
 		},
 		{
 			name: "proto-only exists and includes API path",
 			api:  &config.API{Path: "google/cloud/secretmanager/type"},
 			library: &config.Library{
+				Name: "google-cloud-secret-manager",
 				Python: &config.PythonPackage{
 					ProtoOnlyAPIs: []string{"google/cloud/secretmanager/type"},
 				},
@@ -195,6 +199,26 @@ func TestCreateProtocOptions(t *testing.T) {
 			expected: []string{
 				"--python_out=staging",
 				"--pyi_out=staging",
+			},
+		},
+		{
+			name: "potentially derived options specified explicitly",
+			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
+			library: &config.Library{
+				Name: "google-cloud-secret-manager",
+				Python: &config.PythonPackage{
+					OptArgsByAPI: map[string][]string{
+						"google/cloud/secretmanager/v1": {
+							"python-gapic-namespace=x",
+							"python-gapic-name=y",
+							"warehouse-package-name=z",
+						},
+					},
+				},
+			},
+			expected: []string{
+				"--python_gapic_out=staging",
+				"--python_gapic_opt=metadata,python-gapic-namespace=x,python-gapic-name=y,warehouse-package-name=z,rest-numeric-enums,transport=grpc+rest,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
 			},
 		},
 	} {
@@ -1323,6 +1347,106 @@ func TestCreateRepoMetadata_Error(t *testing.T) {
 			}
 			if test.wantErr != nil && !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("stageProtoFiles error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeriveGAPICNamespace(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "single path element",
+			path: "grafeas",
+			want: "grafeas",
+		},
+		{
+			name: "multiple path elements",
+			path: "google/cloud/datacatalog/lineage/v1",
+			want: "google.cloud",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := deriveGAPICNamespace(test.path)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeriveGAPICName(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "single path element in name",
+			path: "google/cloud/datacatalog/v1",
+			want: "datacatalog",
+		},
+		{
+			name: "multiple path elements in name",
+			path: "google/cloud/datacatalog/lineage/v1",
+			want: "datacatalog_lineage",
+		},
+		{
+			name: "no version",
+			path: "google/apps/script/type",
+			want: "script_type",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := deriveGAPICName(test.path)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindOption(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		options   []string
+		wantValue string
+		wantFound bool
+	}{
+		{
+			name:    "empty options",
+			options: []string{},
+		},
+		{
+			name:    "requested option not present",
+			options: []string{"a=b"},
+		},
+		{
+			name:    "requested option not present, but similar names are",
+			options: []string{"othertest=a", "testother=b"},
+		},
+		{
+			name:      "option present with value",
+			options:   []string{"a=b", "test=test-value", "c=d"},
+			wantValue: "test-value",
+			wantFound: true,
+		},
+		{
+			name:      "option present without value",
+			options:   []string{"a=b", "test=", "c=d"},
+			wantFound: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotValue, gotFound := findOption(test.options, "test")
+			if diff := cmp.Diff(test.wantValue, gotValue); diff != "" {
+				t.Errorf("mismatch in value (-want +got):\n%s", diff)
+			}
+			if test.wantFound != gotFound {
+				t.Errorf("mismatch in found: want %v, got %v", test.wantFound, gotFound)
 			}
 		})
 	}

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -1364,6 +1364,11 @@ func TestDeriveGAPICNamespace(t *testing.T) {
 			want: "grafeas",
 		},
 		{
+			name: "single path element with version",
+			path: "grafeas/v1",
+			want: "grafeas",
+		},
+		{
 			name: "multiple path elements",
 			path: "google/cloud/datacatalog/lineage/v1",
 			want: "google.cloud",

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -1419,7 +1419,7 @@ func TestFindOption(t *testing.T) {
 		name      string
 		options   []string
 		wantValue string
-		wantFound bool
+		wantOk    bool
 	}{
 		{
 			name:    "empty options",
@@ -1437,21 +1437,21 @@ func TestFindOption(t *testing.T) {
 			name:      "option present with value",
 			options:   []string{"a=b", "test=test-value", "c=d"},
 			wantValue: "test-value",
-			wantFound: true,
+			wantOk:    true,
 		},
 		{
-			name:      "option present without value",
-			options:   []string{"a=b", "test=", "c=d"},
-			wantFound: true,
+			name:    "option present without value",
+			options: []string{"a=b", "test=", "c=d"},
+			wantOk:  true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			gotValue, gotFound := findOption(test.options, "test")
+			gotValue, gotOk := findOption(test.options, "test")
 			if diff := cmp.Diff(test.wantValue, gotValue); diff != "" {
 				t.Errorf("mismatch in value (-want +got):\n%s", diff)
 			}
-			if test.wantFound != gotFound {
-				t.Errorf("mismatch in found: want %v, got %v", test.wantFound, gotFound)
+			if test.wantOk != gotOk {
+				t.Errorf("mismatch in found: want %v, got %v", test.wantOk, gotOk)
 			}
 		})
 	}


### PR DESCRIPTION
The GAPIC generator options for package-warehouse-name, python-gapic-namespace and python-gapic-name are *always* specified to the generator. They are derived if they're not specified explicitly in librarian.yaml. This makes the inference algorithm in the GAPIC generator irrelevant.

This change is a no-op for the current librarian.yaml for Python, as we explicitly specify *all* options. After updating to a version of librarian.yaml that includes this code, we can then drop options that already have the same value that would be inferred.

Towards #5163