### PR TITLE
chore(internal/serviceconfig): set java transport to grpc for networkconnectivity/v1beta

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1780,6 +1780,7 @@
     - python
   transports:
     go: grpc
+    java: grpc
     python: grpc
 - path: google/cloud/networkmanagement/v1
   documentation_uri: https://cloud.google.com/network-management


### PR DESCRIPTION
Updates java transport to grpc for API path `google/cloud/networkconnectivity/v1beta`.

Fix #5590