### PR TITLE
fix(tool/cmd/migrate): switches java to opt-out config for common resources proto

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -252,7 +252,8 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `path` | string | Is the source path. |
-| `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
+| `additional_protos` | list of string | Is a list of additional proto files to include in generation. Note: google/cloud/common_resources.proto is included by default unless OmitCommonResources is set to true. |
+| `omit_common_resources` | bool | Indicates whether to omit the default inclusion of google/cloud/common_resources.proto. |
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `gapic_artifact_id_override` | string | Overrides the artifact ID for the GAPIC module. It determines the module's directory name and is used to derive proto and gRPC artifact IDs if they are not explicitly overridden. |
 | `grpc_artifact_id_override` | string | Overrides the artifact ID for the gRPC module. The artifact ID is also used as the name for the module's directory. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -584,7 +584,13 @@ type JavaAPI struct {
 	Path string `yaml:"path,omitempty"`
 
 	// AdditionalProtos is a list of additional proto files to include in generation.
+	// Note: google/cloud/common_resources.proto is included by default unless
+	// OmitCommonResources is set to true.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
+
+	// OmitCommonResources indicates whether to omit the default inclusion of
+	// google/cloud/common_resources.proto.
+	OmitCommonResources bool `yaml:"omit_common_resources,omitempty"`
 
 	// ExcludedProtos is a list of proto files to exclude from generation.
 	// It expects the full path starting from the root of the googleapis

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -53,9 +53,10 @@ var (
 )
 
 type javaGAPICInfo struct {
-	AdditionalProtos []string
-	ProtoOnly        bool
-	Samples          bool
+	AdditionalProtos    []string
+	ProtoOnly           bool
+	Samples             bool
+	OmitCommonResources bool
 }
 
 func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
@@ -66,7 +67,7 @@ func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
 	if file == nil {
 		return nil, nil
 	}
-	info := &javaGAPICInfo{Samples: false}
+	info := &javaGAPICInfo{Samples: false, OmitCommonResources: true}
 	// 1. From java_gapic_library
 	rules := file.Rules("java_gapic_library")
 	if len(rules) == 0 {
@@ -95,11 +96,14 @@ func parseJavaBazel(googleapisDir, dir string) (*javaGAPICInfo, error) {
 		// a variable or an addition of lists.
 		if attr := rule.Attr("deps"); attr != nil {
 			protoMappings := map[string]string{
-				"//google/cloud:common_resources_proto":  "google/cloud/common_resources.proto",
 				"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
 				"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
 			}
 			for _, dep := range extractStrings(attr) {
+				if dep == "//google/cloud:common_resources_proto" {
+					info.OmitCommonResources = false
+					continue
+				}
 				if protoPath, ok := protoMappings[dep]; ok {
 					info.AdditionalProtos = append(info.AdditionalProtos, protoPath)
 				}
@@ -253,8 +257,9 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 				continue
 			}
 			javaAPI := &config.JavaAPI{
-				Path:             g.ProtoPath,
-				AdditionalProtos: info.AdditionalProtos,
+				Path:                g.ProtoPath,
+				AdditionalProtos:    info.AdditionalProtos,
+				OmitCommonResources: info.OmitCommonResources,
 			}
 			if info.ProtoOnly {
 				javaAPI.ProtoOnly = true

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -492,9 +492,10 @@ func TestBuildConfig(t *testing.T) {
 						Java: &config.JavaModule{
 							JavaAPIs: []*config.JavaAPI{
 								{
-									Path:      "google/cloud/gkehub/policycontroller/v1beta",
-									Samples:   new(false),
-									ProtoOnly: true,
+									Path:                "google/cloud/gkehub/policycontroller/v1beta",
+									Samples:             new(false),
+									ProtoOnly:           true,
+									OmitCommonResources: true, // common_resources_proto not in testdata BUILD.bazel
 								},
 							},
 						},
@@ -537,6 +538,7 @@ func TestBuildConfig(t *testing.T) {
 									ProtoArtifactIDOverride: "proto-google-apps-script-type-protos",
 									ProtoOnly:               true,
 									Samples:                 new(false),
+									OmitCommonResources:     true, // common_resources_proto not in testdata BUILD.bazel
 								},
 							},
 						},
@@ -602,7 +604,8 @@ func TestBuildConfig(t *testing.T) {
 						Java: &config.JavaModule{
 							JavaAPIs: []*config.JavaAPI{
 								{
-									Path: "google/cloud/translate/v3",
+									Path:                "google/cloud/translate/v3",
+									OmitCommonResources: true, // common_resources_proto not in testdata BUILD.bazel
 								},
 							},
 						},
@@ -674,6 +677,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				Samples:                 new(false),
 				ProtoArtifactIDOverride: "proto-google-cloud-datastore-admin-v1",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-datastore-admin-v1",
+				OmitCommonResources:     true, // dummy BUILD.bazel has no deps
 			},
 		},
 		{
@@ -686,6 +690,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				GAPICArtifactIDOverride: "google-cloud-storage-control",
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-control-v2",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-control-v2",
+				OmitCommonResources:     true, // dummy BUILD.bazel has no deps
 				CopyFiles: []*config.JavaFileCopy{
 					{
 						Source:      "src/main/java/com/google/storage/control/v2/gapic_metadata.json",
@@ -704,6 +709,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				GAPICArtifactIDOverride: "gapic-google-cloud-storage-v2",
 				GRPCArtifactIDOverride:  "grpc-google-cloud-storage-v2",
 				ProtoArtifactIDOverride: "proto-google-cloud-storage-v2",
+				OmitCommonResources:     true, // dummy BUILD.bazel has no deps
 				CopyFiles: []*config.JavaFileCopy{
 					{
 						Source:      "src/main/java/com/google/storage/v2/gapic_metadata.json",
@@ -717,8 +723,9 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 			libraryName: "alloydb-connectors",
 			protoPath:   "google/cloud/alloydb/connectors/v1",
 			wantJavaAPI: &config.JavaAPI{
-				Path:    "google/cloud/alloydb/connectors/v1",
-				Samples: new(false),
+				Path:                "google/cloud/alloydb/connectors/v1",
+				Samples:             new(false),
+				OmitCommonResources: true, // dummy BUILD.bazel has no deps
 			},
 			wantTransport: "grpc",
 		},
@@ -890,21 +897,17 @@ func TestParseJavaBazel(t *testing.T) {
 			googleapisDir: "testdata/parse-bazel/success",
 			buildPath:     "google/cloud/bigquery/analyticshub/v1",
 			want: &javaGAPICInfo{
-				Samples: true,
-				AdditionalProtos: []string{
-					"google/cloud/common_resources.proto",
-				},
+				Samples:             true,
+				OmitCommonResources: false,
 			},
 		},
 		{
 			name:          "no GAPIC rules",
 			googleapisDir: "testdata/parse-bazel/no-gapic-rule",
 			want: &javaGAPICInfo{
-				Samples: false,
-				AdditionalProtos: []string{
-					"google/cloud/common_resources.proto",
-				},
-				ProtoOnly: true,
+				Samples:             false,
+				OmitCommonResources: false,
+				ProtoOnly:           true,
 			},
 		},
 		{
@@ -913,11 +916,19 @@ func TestParseJavaBazel(t *testing.T) {
 			buildPath:     "google/cloud/aiplatform/v1",
 			want: &javaGAPICInfo{
 				AdditionalProtos: []string{
-					"google/cloud/common_resources.proto",
 					"google/cloud/location/locations.proto",
 					"google/iam/v1/iam_policy.proto",
 				},
-				ProtoOnly: true,
+				OmitCommonResources: false,
+				ProtoOnly:           true,
+			},
+		},
+		{
+			name:          "omit-common-resources",
+			googleapisDir: "testdata/parse-bazel/omit-common-resources",
+			want: &javaGAPICInfo{
+				OmitCommonResources: true,
+				ProtoOnly:           true,
 			},
 		},
 	} {

--- a/tool/cmd/migrate/testdata/parse-bazel/omit-common-resources/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/parse-bazel/omit-common-resources/BUILD.bazel
@@ -1,0 +1,1 @@
+proto_library_with_info(name = "foo", deps = [":bar"])

--- a/tool/cmd/migrate/testdata/parse-bazel/omit-common-resources/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/parse-bazel/omit-common-resources/BUILD.bazel
@@ -1,1 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 proto_library_with_info(name = "foo", deps = [":bar"])


### PR DESCRIPTION
In migrate scripts, switch to new opt-out config for  common resources proto instead explicitly of listing it in`additional_protos`. Introduces a `omit_common_resources` config in `java_apis`. 

In current google-cloud-java, migrated librarian.yaml has 21 APIs that needs omit_common_resources true. This config is false by default when adding new libraries.

For #5225