### PR TITLE
fix(internal/librarian/java): derive additional protos from OmitCommonResources and AdditionalProtos

### DIFF
--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -61,18 +61,35 @@ var (
 	// ErrInvalidDistributionName is returned when a distribution name override
 	// is incorrectly formatted.
 	ErrInvalidDistributionName = fmt.Errorf("invalid distribution name override")
+
+	// ErrOmitCommonResourcesConflict is returned when OmitCommonResources is true
+	// but common_resources.proto is also explicitly listed in AdditionalProtos.
+	ErrOmitCommonResourcesConflict = fmt.Errorf("conflict: OmitCommonResources is true but google/cloud/common_resources.proto is explicitly listed in AdditionalProtos")
 )
 
 // Validate checks that the Java-specific configuration for a library is
 // correctly formatted. It ensures that the distribution name override
-// contains exactly two parts separated by a colon.
+// contains exactly two parts separated by a colon, and that there are no
+// conflicts in common resources configuration.
 func Validate(library *config.Library) error {
-	if library.Java == nil || library.Java.DistributionNameOverride == "" {
+	if library.Java == nil {
 		return nil
 	}
-	parts := strings.Split(library.Java.DistributionNameOverride, ":")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return fmt.Errorf("%w: %s: want \"groupId:artifactId\", got %q", ErrInvalidDistributionName, library.Name, library.Java.DistributionNameOverride)
+	if library.Java.DistributionNameOverride != "" {
+		parts := strings.Split(library.Java.DistributionNameOverride, ":")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("%w: %s: want \"groupId:artifactId\", got %q", ErrInvalidDistributionName, library.Name, library.Java.DistributionNameOverride)
+		}
+	}
+	for _, javaAPI := range library.Java.JavaAPIs {
+		if !javaAPI.OmitCommonResources {
+			continue
+		}
+		for _, p := range javaAPI.AdditionalProtos {
+			if p == commonResourcesProto {
+				return fmt.Errorf("%s: %w", javaAPI.Path, ErrOmitCommonResourcesConflict)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -36,9 +36,7 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "java-secretmanager",
-				Java: &config.JavaModule{
-					JavaAPIs: nil,
-				},
+				Java:   &config.JavaModule{},
 			},
 		},
 		{
@@ -50,9 +48,7 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "custom-output",
-				Java: &config.JavaModule{
-					JavaAPIs: nil,
-				},
+				Java:   &config.JavaModule{},
 			},
 		},
 		{

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -36,7 +36,9 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "java-secretmanager",
-				Java:   &config.JavaModule{},
+				Java: &config.JavaModule{
+					JavaAPIs: nil,
+				},
 			},
 		},
 		{
@@ -48,7 +50,9 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "custom-output",
-				Java:   &config.JavaModule{},
+				Java: &config.JavaModule{
+					JavaAPIs: nil,
+				},
 			},
 		},
 		{
@@ -192,8 +196,9 @@ func TestValidate(t *testing.T) {
 
 func TestValidate_Error(t *testing.T) {
 	for _, test := range []struct {
-		name string
-		lib  *config.Library
+		name    string
+		lib     *config.Library
+		wantErr error
 	}{
 		{
 			name: "missing colon",
@@ -202,14 +207,16 @@ func TestValidate_Error(t *testing.T) {
 					DistributionNameOverride: "nocolon",
 				},
 			},
+			wantErr: ErrInvalidDistributionName,
 		},
 		{
 			name: "too many colons",
 			lib: &config.Library{
 				Java: &config.JavaModule{
-					DistributionNameOverride: "part1:part2:part3",
+					DistributionNameOverride: "too:many:colons",
 				},
 			},
+			wantErr: ErrInvalidDistributionName,
 		},
 		{
 			name: "empty parts",
@@ -218,28 +225,46 @@ func TestValidate_Error(t *testing.T) {
 					DistributionNameOverride: ":",
 				},
 			},
+			wantErr: ErrInvalidDistributionName,
 		},
 		{
 			name: "missing artifact id",
 			lib: &config.Library{
 				Java: &config.JavaModule{
-					DistributionNameOverride: "part1:",
+					DistributionNameOverride: "groupid:",
 				},
 			},
+			wantErr: ErrInvalidDistributionName,
 		},
 		{
 			name: "missing group id",
 			lib: &config.Library{
 				Java: &config.JavaModule{
-					DistributionNameOverride: ":part2",
+					DistributionNameOverride: ":artifactid",
 				},
 			},
+			wantErr: ErrInvalidDistributionName,
+		},
+		{
+			name: "omit common resources conflict",
+			lib: &config.Library{
+				Java: &config.JavaModule{
+					JavaAPIs: []*config.JavaAPI{
+						{
+							Path:                "google/cloud/conflict/v1",
+							OmitCommonResources: true,
+							AdditionalProtos:    []string{"google/cloud/common_resources.proto"},
+						},
+					},
+				},
+			},
+			wantErr: ErrOmitCommonResourcesConflict,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := Validate(test.lib)
-			if !errors.Is(err, ErrInvalidDistributionName) {
-				t.Errorf("expected %v, got %v", ErrInvalidDistributionName, err)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Validate() error = %v, want %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -161,7 +161,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 func deriveAdditionalProtoPaths(javaAPI *config.JavaAPI, googleapisDir string) []string {
 	var additionalProtos []string
 	if !javaAPI.OmitCommonResources {
-		additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, commonResourcesProto))
+		additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, filepath.FromSlash(commonResourcesProto)))
 	}
 	for _, p := range javaAPI.AdditionalProtos {
 		if p == commonResourcesProto {

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -31,6 +31,8 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
+const commonResourcesProto = "google/cloud/common_resources.proto"
+
 // nonRecursivePaths is a set of paths where proto gathering should not be recursive.
 var nonRecursivePaths = map[string]bool{
 	"google/api":   true,
@@ -141,10 +143,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		if err != nil {
 			return fmt.Errorf("failed to resolve gapic options: %w", err)
 		}
-		var additionalProtos []string
-		for _, p := range javaAPI.AdditionalProtos {
-			additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, filepath.FromSlash(p)))
-		}
+		additionalProtos := deriveAdditionalProtoPaths(javaAPI, googleapisDir)
 		if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, googleapisDir, gapicDir, gapicOpts)); err != nil {
 			return fmt.Errorf("failed to generate gapic: %w", err)
 		}
@@ -154,6 +153,23 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		return fmt.Errorf("failed to post process: %w", err)
 	}
 	return nil
+}
+
+// deriveAdditionalProtoPaths returns the absolute paths to additional proto files
+// configured via AdditionalProtos to include in GAPIC generation. It includes
+// google/cloud/common_resources.proto unless opted out via OmitCommonResources.
+func deriveAdditionalProtoPaths(javaAPI *config.JavaAPI, googleapisDir string) []string {
+	var additionalProtos []string
+	if !javaAPI.OmitCommonResources {
+		additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, commonResourcesProto))
+	}
+	for _, p := range javaAPI.AdditionalProtos {
+		if p == commonResourcesProto {
+			continue
+		}
+		additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, filepath.FromSlash(p)))
+	}
+	return additionalProtos
 }
 
 var runProtoc = func(ctx context.Context, args []string) error {

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -832,3 +832,62 @@ func TestFilterProtos(t *testing.T) {
 		})
 	}
 }
+
+func TestDeriveAdditionalProtoPaths(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		javaAPI *config.JavaAPI
+		want    []string
+	}{
+		{
+			name:    "included by default",
+			javaAPI: &config.JavaAPI{},
+			want: []string{
+				filepath.Join(googleapisDir, commonResourcesProto),
+			},
+		},
+		{
+			name: "omitted via flag",
+			javaAPI: &config.JavaAPI{
+				OmitCommonResources: true,
+			},
+			want: nil,
+		},
+		{
+			name: "explicitly included in AdditionalProtos (still only one)",
+			javaAPI: &config.JavaAPI{
+				AdditionalProtos: []string{commonResourcesProto},
+			},
+			want: []string{
+				filepath.Join(googleapisDir, commonResourcesProto),
+			},
+		},
+		{
+			name: "other additional protos",
+			javaAPI: &config.JavaAPI{
+				AdditionalProtos: []string{"other.proto"},
+			},
+			want: []string{
+				filepath.Join(googleapisDir, commonResourcesProto),
+				filepath.Join(googleapisDir, "other.proto"),
+			},
+		},
+		{
+			name: "omitted via flag with other additional protos",
+			javaAPI: &config.JavaAPI{
+				OmitCommonResources: true,
+				AdditionalProtos:    []string{"other.proto"},
+			},
+			want: []string{
+				filepath.Join(googleapisDir, "other.proto"),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := deriveAdditionalProtoPaths(test.javaAPI, googleapisDir)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Update generate logic to respect OmitCommonResources config. Also update validate logic to return err with librarian tidy when both OmitCommonResources is true and AdditionalProtos includes "google/cloud/common_resources.proto".
This is a follow-up change to https://github.com/googleapis/librarian/pull/5592.

Fix #5225