### PR TITLE
feat(internal/librarian/python): prevent explicit transport option

### DIFF
--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -42,7 +42,10 @@ const (
 	warehousePackageNameOption          = "warehouse-package-name"
 )
 
-var errNoDefaultVersion = errors.New("default version must be specified for every library with generated APIs")
+var (
+	errNoDefaultVersion        = errors.New("default version must be specified for every library with generated APIs")
+	errExplicitTransportOption = errors.New("transport option is derived from sdk.yaml and must not be specified explicitly")
+)
 
 // Generate generates a Python client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, srcs *sources.Sources) error {
@@ -300,18 +303,20 @@ func createProtocOptions(api *config.API, library *config.Library, googleapisDir
 	if err != nil {
 		return nil, err
 	}
+	if apiMetadata.HasRESTNumericEnums(config.LanguagePython) {
+		opts = append(opts, "rest-numeric-enums")
+	}
+	// The transport option should never be specified explicitly. Ensure it
+	// hasn't been specified, and add the derived transport.
+	if _, explicitTransport := findOption(opts, transportOption); explicitTransport {
+		return nil, fmt.Errorf("error creating GAPIC options for %s: %w", api.Path, errExplicitTransportOption)
+	}
 	transport := serviceconfig.GRPCRest
 	if apiMetadata != nil {
 		transport = apiMetadata.Transport(config.LanguagePython)
 	}
-	if apiMetadata.HasRESTNumericEnums(config.LanguagePython) {
-		opts = append(opts, "rest-numeric-enums")
-	}
+	opts = append(opts, fmt.Sprintf("%s=%s", transportOption, transport))
 
-	// Add transport option, if we haven't already got it.
-	if _, ok := findOption(opts, transportOption); !ok {
-		opts = append(opts, fmt.Sprintf("%s=%s", transportOption, transport))
-	}
 	// Add derived python-gapic-namespace option, if we haven't already got it.
 	if _, ok := findOption(opts, gapicNamespaceOption); !ok {
 		opts = append(opts, fmt.Sprintf("%s=%s", gapicNamespaceOption, deriveGAPICNamespace(api.Path)))

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -102,7 +102,6 @@ func TestCreateProtocOptions(t *testing.T) {
 		api      *config.API
 		library  *config.Library
 		expected []string
-		wantErr  bool
 	}{
 		{
 			name: "basic case",
@@ -158,22 +157,6 @@ func TestCreateProtocOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "transport specified in OptArgsByAPI",
-			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
-			library: &config.Library{
-				Name: "google-cloud-secret-manager",
-				Python: &config.PythonPackage{
-					OptArgsByAPI: map[string][]string{
-						"google/cloud/secretmanager/v1": {"transport=rest"},
-					},
-				},
-			},
-			expected: []string{
-				"--python_gapic_out=staging",
-				"--python_gapic_opt=metadata,transport=rest,rest-numeric-enums,python-gapic-namespace=google.cloud,python-gapic-name=secretmanager,warehouse-package-name=google-cloud-secret-manager,retry-config=google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json,service-yaml=google/cloud/secretmanager/v1/secretmanager_v1.yaml",
-			},
-		},
-		{
 			name: "proto-only exists but doesn't include API path",
 			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{
@@ -224,12 +207,43 @@ func TestCreateProtocOptions(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := createProtocOptions(test.api, test.library, googleapisDir, "staging")
-			if (err != nil) != test.wantErr {
-				t.Fatalf("createProtocOptions() error = %v, wantErr %v", err, test.wantErr)
+			if err != nil {
+				t.Fatal(err)
 			}
 
 			if diff := cmp.Diff(test.expected, got); diff != "" {
 				t.Errorf("createProtocOptions() returned diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCreateProtocOptions_Error(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		api     *config.API
+		library *config.Library
+		wantErr error
+	}{
+		{
+			name: "transport specified in OptArgsByAPI",
+			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
+			library: &config.Library{
+				Name: "google-cloud-secret-manager",
+				Python: &config.PythonPackage{
+					OptArgsByAPI: map[string][]string{
+						"google/cloud/secretmanager/v1": {"transport=rest"},
+					},
+				},
+			},
+			wantErr: errExplicitTransportOption,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, gotErr := createProtocOptions(test.api, test.library, googleapisDir, "staging")
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("createProtocOptions error = %v, wantErr %v", gotErr, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
The transport option to the GAPIC generator should always be derived from sdk.yaml. It cannot now be present in OptArgsByAPI.

Provided additional safeguards for #5542.