### PR TITLE
feat(sidekick/swift): handle optional path parameters

### DIFF
--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -50,6 +50,7 @@ type pathVariable struct {
 	Name       string
 	Expression string
 	Test       string
+	FieldPath  string
 }
 
 // HasQueryParams returns true if the method's default binding has query parameters

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -22,12 +22,34 @@ import (
 type methodAnnotations struct {
 	Name           string
 	DocLines       []string
-	Path           string
+	PathVariables  []*pathVariable
+	PathExpression string
 	HTTPMethod     string
 	HasBody        bool
 	IsBodyWildcard bool
 	BodyField      string
 	QueryParams    []*api.Field
+}
+
+// pathVariable describes a variable used to build a request URL path.
+//
+// Most services have a single path variable, something like `request.parent` or `request.name`,
+// where the field is a (required) string.
+//
+// In general they can take more complex forms, including:
+//   - `request.secret.name` where `secret` is optional and name is a string, typically a full
+//     resource name.
+//   - `request.name` where `name` is an optional string (common in OpenAPI and discovery docs).
+//   - `request.value` where the value is some enum, or integer field.
+//   - `request.project` and `request.resource` where each is a string and are combined to construct
+//     the path (again, common in OpenAPI and discovery docs).
+//
+// And of course all of these can be combined, such as nested fields that point to enums or nested
+// fields that point to nested fields.
+type pathVariable struct {
+	Name       string
+	Expression string
+	Test       string
 }
 
 // HasQueryParams returns true if the method's default binding has query parameters
@@ -38,30 +60,34 @@ func (ann *methodAnnotations) HasQueryParams() bool {
 	return len(ann.QueryParams) != 0
 }
 
-func (c *codec) annotateMethod(method *api.Method, model *modelAnnotations) error {
+func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) error {
 	if method.InputType != nil {
-		if err := c.annotateMessage(method.InputType, model); err != nil {
+		if err := c.annotateMessage(method.InputType, modelAnn); err != nil {
 			return err
 		}
 	}
 	if method.OutputType != nil {
-		if err := c.annotateMessage(method.OutputType, model); err != nil {
+		if err := c.annotateMessage(method.OutputType, modelAnn); err != nil {
 			return err
 		}
 	}
 	docLines := c.formatDocumentation(method.Documentation)
 	binding := method.PathInfo.Bindings[0]
-	path := formatPath(binding.PathTemplate)
 	hasBody := method.PathInfo.BodyFieldPath != ""
 	isBodyWildcard := method.PathInfo.BodyFieldPath == "*"
 	var bodyField string
 	if hasBody && !isBodyWildcard {
 		bodyField = camelCase(method.PathInfo.BodyFieldPath)
 	}
+	pathVariables, err := c.pathVariables(method.InputType, binding.PathTemplate)
+	if err != nil {
+		return err
+	}
 	method.Codec = &methodAnnotations{
 		Name:           camelCase(method.Name),
 		DocLines:       docLines,
-		Path:           path,
+		PathExpression: pathExpression(binding.PathTemplate),
+		PathVariables:  pathVariables,
 		HTTPMethod:     binding.Verb,
 		HasBody:        hasBody,
 		IsBodyWildcard: isBodyWildcard,

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -55,11 +55,11 @@ func TestAnnotateMethod(t *testing.T) {
 				},
 			},
 			want: &methodAnnotations{
-				Name:       "getOperation",
-				Path:       "/v1/operations",
-				DocLines:   []string{"Gets a thing.", "", "Test multiple comment lines.", ""},
-				HTTPMethod: "GET",
-				HasBody:    false,
+				Name:           "getOperation",
+				PathExpression: "/v1/operations",
+				DocLines:       []string{"Gets a thing.", "", "Test multiple comment lines.", ""},
+				HTTPMethod:     "GET",
+				HasBody:        false,
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func TestAnnotateMethod(t *testing.T) {
 			},
 			want: &methodAnnotations{
 				Name:           "createKey",
-				Path:           "/v1/keys",
+				PathExpression: "/v1/keys",
 				HTTPMethod:     "POST",
 				HasBody:        true,
 				IsBodyWildcard: false,
@@ -101,7 +101,7 @@ func TestAnnotateMethod(t *testing.T) {
 			},
 			want: &methodAnnotations{
 				Name:           "uploadData",
-				Path:           "/v1/data",
+				PathExpression: "/v1/data",
 				HTTPMethod:     "POST",
 				HasBody:        true,
 				IsBodyWildcard: true,
@@ -123,12 +123,12 @@ func TestAnnotateMethod(t *testing.T) {
 				},
 			},
 			want: &methodAnnotations{
-				Name:        "listThings",
-				Path:        "/v1/things",
-				DocLines:    []string{"Lists things."},
-				HTTPMethod:  "GET",
-				HasBody:     false,
-				QueryParams: []*api.Field{keyField},
+				Name:           "listThings",
+				PathExpression: "/v1/things",
+				DocLines:       []string{"Lists things."},
+				HTTPMethod:     "GET",
+				HasBody:        false,
+				QueryParams:    []*api.Field{keyField},
 			},
 		},
 	} {
@@ -204,10 +204,10 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 			}
 
 			want := &methodAnnotations{
-				Name:       test.wantName,
-				DocLines:   []string{"Test documentation."},
-				Path:       "/",
-				HTTPMethod: "GET",
+				Name:           test.wantName,
+				DocLines:       []string{"Test documentation."},
+				PathExpression: "/",
+				HTTPMethod:     "GET",
 			}
 
 			if diff := cmp.Diff(want, method.Codec); diff != "" {

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -62,6 +62,9 @@ func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable
 		if err != nil {
 			return nil, err
 		}
+		if field.IsOneOf {
+			return nil, fmt.Errorf("unsupported path parameter: field %s in message %s is part of a oneof", field.Name, current.ID)
+		}
 		fieldCodec, ok := field.Codec.(*fieldAnnotations)
 		if !ok {
 			return nil, fmt.Errorf("internal error: field %s in message %s does not have swift fieldAnnotations", field.Name, current.ID)

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -81,6 +81,10 @@ func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable
 		optional = field.Optional
 		switch field.Typez {
 		case api.TypezMessage:
+			if !field.Optional {
+				// Panics are the right way to deal with bugs in other parts of the code.
+				panic(fmt.Sprintf("invalid state: field %s in message %s has message type but is not optional", field.Name, current.ID))
+			}
 			current, err = lookupMessage(c.Model, field.TypezID)
 			if err != nil {
 				return nil, err

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -21,18 +21,79 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
-func formatPath(t *api.PathTemplate) string {
+func pathExpression(t *api.PathTemplate) string {
+	count := 0
 	var pathComponents []string
 	for _, segment := range t.Segments {
 		if segment.Literal != nil {
 			pathComponents = append(pathComponents, *segment.Literal)
 		} else if segment.Variable != nil {
-			var fieldParts []string
-			for _, p := range segment.Variable.FieldPath {
-				fieldParts = append(fieldParts, camelCase(p))
-			}
-			pathComponents = append(pathComponents, fmt.Sprintf(`\(request.%s)`, strings.Join(fieldParts, ".")))
+			pathComponents = append(pathComponents, fmt.Sprintf(`\(pathVariable%d)`, count))
+			count += 1
 		}
 	}
 	return "/" + strings.Join(pathComponents, "/")
+}
+
+func (c *codec) pathVariables(message *api.Message, t *api.PathTemplate) ([]*pathVariable, error) {
+	count := 0
+	var variables []*pathVariable
+	for _, segment := range t.Segments {
+		if segment.Variable != nil {
+			new, err := c.newPathVariable(message, segment.Variable, count)
+			if err != nil {
+				return nil, err
+			}
+			variables = append(variables, new)
+			count += 1
+		}
+	}
+	return variables, nil
+}
+
+func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable, count int) (*pathVariable, error) {
+	test := ""
+	name := fmt.Sprintf("pathVariable%d", count)
+	var expression strings.Builder
+	optional := false
+	current := message
+	for _, v := range variable.FieldPath {
+		field, err := lookupField(current, v)
+		if err != nil {
+			return nil, err
+		}
+		fieldCodec, ok := field.Codec.(*fieldAnnotations)
+		if !ok {
+			return nil, fmt.Errorf("internal error: field %s in message %s does not have swift fieldAnnotations", field.Name, current.ID)
+		}
+		if optional && field.Optional {
+			fmt.Fprintf(&expression, ".flatMap({ $0.%s })", fieldCodec.Name)
+		} else if optional {
+			fmt.Fprintf(&expression, ".map({ $0.%s })", fieldCodec.Name)
+		} else if field.Optional {
+			fmt.Fprintf(&expression, ".%s", fieldCodec.Name)
+		} else {
+			fmt.Fprintf(&expression, ".%s as %s?", fieldCodec.Name, fieldCodec.FieldType)
+		}
+		optional = field.Optional
+		switch field.Typez {
+		case api.TypezMessage:
+			current, err = lookupMessage(c.Model, field.TypezID)
+			if err != nil {
+				return nil, err
+			}
+		case api.TypezString:
+			test = fmt.Sprintf("!%s.isEmpty", name)
+		case api.TypezBytes:
+			return nil, fmt.Errorf("unsupported path parameter type %q, message=%q, path=%q", field.Typez.String(), message.ID, variable.FieldPath)
+		default:
+			test = ""
+		}
+	}
+	new := &pathVariable{
+		Name:       name,
+		Expression: expression.String(),
+		Test:       test,
+	}
+	return new, nil
 }

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -62,22 +62,11 @@ func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable
 		if err != nil {
 			return nil, err
 		}
-		if field.IsOneOf {
-			return nil, fmt.Errorf("unsupported path parameter: field %s in message %s is part of a oneof", field.Name, current.ID)
+		expr, err := c.fieldPathParameterExpression(optional, field)
+		if err != nil {
+			return nil, err
 		}
-		fieldCodec, ok := field.Codec.(*fieldAnnotations)
-		if !ok {
-			return nil, fmt.Errorf("internal error: field %s in message %s does not have swift fieldAnnotations", field.Name, current.ID)
-		}
-		if optional && field.Optional {
-			fmt.Fprintf(&expression, ".flatMap({ $0.%s })", fieldCodec.Name)
-		} else if optional {
-			fmt.Fprintf(&expression, ".map({ $0.%s })", fieldCodec.Name)
-		} else if field.Optional {
-			fmt.Fprintf(&expression, ".%s", fieldCodec.Name)
-		} else {
-			fmt.Fprintf(&expression, ".%s as %s?", fieldCodec.Name, fieldCodec.FieldType)
-		}
+		expression.WriteString(expr)
 		optional = field.Optional
 		switch field.Typez {
 		case api.TypezMessage:
@@ -104,4 +93,24 @@ func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable
 		FieldPath:  strings.Join(variable.FieldPath, "."),
 	}
 	return pathVar, nil
+}
+
+func (*codec) fieldPathParameterExpression(optional bool, field *api.Field) (string, error) {
+	if field.IsOneOf {
+		return "", fmt.Errorf("unsupported path parameter: field %s", field.ID)
+	}
+	fieldCodec, ok := field.Codec.(*fieldAnnotations)
+	if !ok {
+		return "", fmt.Errorf("internal error: field %s does not have swift fieldAnnotations", field.ID)
+	}
+	if optional && field.Optional {
+		return fmt.Sprintf(".flatMap({ $0.%s })", fieldCodec.Name), nil
+	}
+	if optional {
+		return fmt.Sprintf(".map({ $0.%s })", fieldCodec.Name), nil
+	}
+	if field.Optional {
+		return fmt.Sprintf(".%s", fieldCodec.Name), nil
+	}
+	return fmt.Sprintf(".%s as %s?", fieldCodec.Name, fieldCodec.FieldType), nil
 }

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -40,11 +40,11 @@ func (c *codec) pathVariables(message *api.Message, t *api.PathTemplate) ([]*pat
 	var variables []*pathVariable
 	for _, segment := range t.Segments {
 		if segment.Variable != nil {
-			new, err := c.newPathVariable(message, segment.Variable, count)
+			pathVar, err := c.newPathVariable(message, segment.Variable, count)
 			if err != nil {
 				return nil, err
 			}
-			variables = append(variables, new)
+			variables = append(variables, pathVar)
 			count += 1
 		}
 	}
@@ -97,11 +97,11 @@ func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable
 			test = ""
 		}
 	}
-	new := &pathVariable{
+	pathVar := &pathVariable{
 		Name:       name,
 		Expression: expression.String(),
 		Test:       test,
 		FieldPath:  strings.Join(variable.FieldPath, "."),
 	}
-	return new, nil
+	return pathVar, nil
 }

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -92,7 +92,7 @@ func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable
 		case api.TypezString:
 			test = fmt.Sprintf("!%s.isEmpty", name)
 		case api.TypezBytes:
-			return nil, fmt.Errorf("unsupported path parameter type %q, message=%q, path=%q", field.Typez.String(), message.ID, variable.FieldPath)
+			return nil, fmt.Errorf("unsupported path parameter type %q, message=%q, path=%q", field.Typez.String(), message.ID, strings.Join(variable.FieldPath, "."))
 		default:
 			test = ""
 		}
@@ -101,6 +101,7 @@ func (c *codec) newPathVariable(message *api.Message, variable *api.PathVariable
 		Name:       name,
 		Expression: expression.String(),
 		Test:       test,
+		FieldPath:  strings.Join(variable.FieldPath, "."),
 	}
 	return new, nil
 }

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -104,6 +104,7 @@ func TestPathVariables(t *testing.T) {
 					Name:       "pathVariable0",
 					Expression: ".name as String?",
 					Test:       "!pathVariable0.isEmpty",
+					FieldPath:  "name",
 				},
 			},
 		},
@@ -119,11 +120,13 @@ func TestPathVariables(t *testing.T) {
 					Name:       "pathVariable0",
 					Expression: ".name as String?",
 					Test:       "!pathVariable0.isEmpty",
+					FieldPath:  "name",
 				},
 				{
 					Name:       "pathVariable1",
 					Expression: ".second as String?",
 					Test:       "!pathVariable1.isEmpty",
+					FieldPath:  "second",
 				},
 			},
 		},
@@ -232,6 +235,7 @@ func TestNewPathVariable(t *testing.T) {
 				Name:       "pathVariable0",
 				Expression: ".parent as String?",
 				Test:       "!pathVariable0.isEmpty",
+				FieldPath:  "parent",
 			},
 		},
 		{
@@ -245,6 +249,7 @@ func TestNewPathVariable(t *testing.T) {
 				Name:       "pathVariable1",
 				Expression: ".displayName",
 				Test:       "!pathVariable1.isEmpty",
+				FieldPath:  "display_name",
 			},
 		},
 		{
@@ -267,6 +272,7 @@ func TestNewPathVariable(t *testing.T) {
 				Name:       "pathVariable2",
 				Expression: ".secret.map({ $0.name })",
 				Test:       "!pathVariable2.isEmpty",
+				FieldPath:  "secret.name",
 			},
 		},
 		{
@@ -280,6 +286,7 @@ func TestNewPathVariable(t *testing.T) {
 				Name:       "pathVariable3",
 				Expression: ".secret.flatMap({ $0.description })",
 				Test:       "!pathVariable3.isEmpty",
+				FieldPath:  "secret.description",
 			},
 		},
 		{

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -192,6 +192,11 @@ func TestNewPathVariable(t *testing.T) {
 				Name:  "data",
 				Typez: api.TypezBytes,
 			},
+			{
+				Name:    "oneof_field",
+				Typez:   api.TypezString,
+				IsOneOf: true,
+			},
 		},
 	}
 
@@ -241,6 +246,15 @@ func TestNewPathVariable(t *testing.T) {
 				Expression: ".displayName",
 				Test:       "!pathVariable1.isEmpty",
 			},
+		},
+		{
+			name:    "error - oneof field",
+			message: requestMessage,
+			variable: &api.PathVariable{
+				FieldPath: []string{"oneof_field"},
+			},
+			count:   6,
+			wantErr: true,
 		},
 		{
 			name:    "nested non-optional string",

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
-func TestFormatPath(t *testing.T) {
+func TestPathExpression(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		template *api.PathTemplate
@@ -39,20 +39,264 @@ func TestFormatPath(t *testing.T) {
 			template: api.NewPathTemplate().
 				WithLiteral("v1").
 				WithVariableNamed("name"),
-			want: "/v1/\\(request.name)",
+			want: "/v1/\\(pathVariable0)",
 		},
 		{
-			name: "nested variable",
+			name: "with multiple variables",
 			template: api.NewPathTemplate().
 				WithLiteral("v1").
-				WithVariableNamed("project", "name"),
-			want: "/v1/\\(request.project.name)",
+				WithVariableNamed("name").WithLiteral("separator").WithVariableNamed("second"),
+			want: "/v1/\\(pathVariable0)/separator/\\(pathVariable1)",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := formatPath(test.template)
+			got := pathExpression(test.template)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPathVariables(t *testing.T) {
+	requestMessage := &api.Message{
+		Name:    "CreateSecretRequest",
+		Package: "google.cloud.secretmanager.v1",
+		ID:      ".google.cloud.secretmanager.v1.CreateSecretRequest",
+		Fields: []*api.Field{
+			{
+				Name:  "name",
+				Typez: api.TypezString,
+			},
+			{
+				Name:  "second",
+				Typez: api.TypezString,
+			},
+		},
+	}
+	model := api.NewTestAPI([]*api.Message{requestMessage}, nil, []*api.Service{})
+	codec := newTestCodec(t, model, nil)
+
+	for _, f := range requestMessage.Fields {
+		if err := codec.annotateField(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, test := range []struct {
+		name     string
+		template *api.PathTemplate
+		want     []*pathVariable
+		wantErr  bool
+	}{
+		{
+			name:     "no variables",
+			template: api.NewPathTemplate().WithLiteral("v1"),
+			want:     nil,
+		},
+		{
+			name: "one variable",
+			template: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("name"),
+			want: []*pathVariable{
+				{
+					Name:       "pathVariable0",
+					Expression: ".name as String?",
+					Test:       "!pathVariable0.isEmpty",
+				},
+			},
+		},
+		{
+			name: "two variables",
+			template: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("name").
+				WithLiteral("sep").
+				WithVariableNamed("second"),
+			want: []*pathVariable{
+				{
+					Name:       "pathVariable0",
+					Expression: ".name as String?",
+					Test:       "!pathVariable0.isEmpty",
+				},
+				{
+					Name:       "pathVariable1",
+					Expression: ".second as String?",
+					Test:       "!pathVariable1.isEmpty",
+				},
+			},
+		},
+		{
+			name: "error - lookup field missing",
+			template: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("missing"),
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := codec.pathVariables(requestMessage, test.template)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("pathVariables() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("pathVariables() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewPathVariable(t *testing.T) {
+	secretMessage := &api.Message{
+		Name:    "Secret",
+		Package: "google.cloud.secretmanager.v1",
+		ID:      ".google.cloud.secretmanager.v1.Secret",
+		Fields: []*api.Field{
+			{
+				Name:  "name",
+				Typez: api.TypezString,
+			},
+			{
+				Name:     "description",
+				Typez:    api.TypezString,
+				Optional: true,
+			},
+		},
+	}
+
+	requestMessage := &api.Message{
+		Name:    "CreateSecretRequest",
+		Package: "google.cloud.secretmanager.v1",
+		ID:      ".google.cloud.secretmanager.v1.CreateSecretRequest",
+		Fields: []*api.Field{
+			{
+				Name:  "parent",
+				Typez: api.TypezString,
+			},
+			{
+				Name:     "display_name",
+				Typez:    api.TypezString,
+				Optional: true,
+			},
+			{
+				Name:     "secret",
+				Typez:    api.TypezMessage,
+				TypezID:  ".google.cloud.secretmanager.v1.Secret",
+				Optional: true,
+			},
+			{
+				Name:  "data",
+				Typez: api.TypezBytes,
+			},
+		},
+	}
+
+	model := api.NewTestAPI([]*api.Message{secretMessage, requestMessage}, nil, []*api.Service{})
+	model.State = &api.APIState{
+		MessageByID: map[string]*api.Message{
+			".google.cloud.secretmanager.v1.Secret":              secretMessage,
+			".google.cloud.secretmanager.v1.CreateSecretRequest": requestMessage,
+		},
+	}
+
+	codec := newTestCodec(t, model, nil)
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name     string
+		message  *api.Message
+		variable *api.PathVariable
+		count    int
+		want     *pathVariable
+		wantErr  bool
+	}{
+		{
+			name:    "non-optional string",
+			message: requestMessage,
+			variable: &api.PathVariable{
+				FieldPath: []string{"parent"},
+			},
+			count: 0,
+			want: &pathVariable{
+				Name:       "pathVariable0",
+				Expression: ".parent as String?",
+				Test:       "!pathVariable0.isEmpty",
+			},
+		},
+		{
+			name:    "optional string",
+			message: requestMessage,
+			variable: &api.PathVariable{
+				FieldPath: []string{"display_name"},
+			},
+			count: 1,
+			want: &pathVariable{
+				Name:       "pathVariable1",
+				Expression: ".displayName",
+				Test:       "!pathVariable1.isEmpty",
+			},
+		},
+		{
+			name:    "nested non-optional string",
+			message: requestMessage,
+			variable: &api.PathVariable{
+				FieldPath: []string{"secret", "name"},
+			},
+			count: 2,
+			want: &pathVariable{
+				Name:       "pathVariable2",
+				Expression: ".secret.map({ $0.name })",
+				Test:       "!pathVariable2.isEmpty",
+			},
+		},
+		{
+			name:    "nested optional string",
+			message: requestMessage,
+			variable: &api.PathVariable{
+				FieldPath: []string{"secret", "description"},
+			},
+			count: 3,
+			want: &pathVariable{
+				Name:       "pathVariable3",
+				Expression: ".secret.flatMap({ $0.description })",
+				Test:       "!pathVariable3.isEmpty",
+			},
+		},
+		{
+			name:    "error - unsupported type bytes",
+			message: requestMessage,
+			variable: &api.PathVariable{
+				FieldPath: []string{"data"},
+			},
+			count:   4,
+			wantErr: true,
+		},
+		{
+			name:    "error - lookup field missing",
+			message: requestMessage,
+			variable: &api.PathVariable{
+				FieldPath: []string{"missing"},
+			},
+			count:   5,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := codec.newPathVariable(test.message, test.variable, test.count)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("newPathVariable() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("newPathVariable() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -207,3 +207,139 @@ import GoogleCloudExternalV1`
 		t.Errorf("expected imports block not found in %s. Got content:\n%s", filename, contentStr)
 	}
 }
+
+func TestGenerateService_PathParameters(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		path      *api.PathTemplate
+		wantBlock string
+	}{
+		{
+			name: "Nested",
+			path: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("secret", "name"),
+			wantBlock: `let path = try { () throws -> String in
+      guard let pathVariable0 = request.secret.map({ $0.name }), !pathVariable0.isEmpty else {
+        throw GoogleCloudGax.RequestError.binding("'request.secret.map({ $0.name })' returns an empty binding")
+      }
+      return "/v1/\(pathVariable0)"
+    }()`,
+		},
+		{
+			name: "Plain",
+			path: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("name"),
+			wantBlock: `let path = try { () throws -> String in
+      guard let pathVariable0 = request.name as String?, !pathVariable0.isEmpty else {
+        throw GoogleCloudGax.RequestError.binding("'request.name as String?' returns an empty binding")
+      }
+      return "/v1/\(pathVariable0)"
+    }()`,
+		},
+		{
+			name: "Multiple strings",
+			path: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithLiteral("projects").
+				WithVariableNamed("project").
+				WithLiteral("locations").
+				WithVariableNamed("location"),
+			wantBlock: `let path = try { () throws -> String in
+      guard let pathVariable0 = request.project as String?, !pathVariable0.isEmpty else {
+        throw GoogleCloudGax.RequestError.binding("'request.project as String?' returns an empty binding")
+      }
+      guard let pathVariable1 = request.location, !pathVariable1.isEmpty else {
+        throw GoogleCloudGax.RequestError.binding("'request.location' returns an empty binding")
+      }
+      return "/v1/projects/\(pathVariable0)/locations/\(pathVariable1)"
+    }()`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outDir := t.TempDir()
+
+			secretMessage := &api.Message{
+				Name:    "Secret",
+				Package: "google.cloud.secretmanager.v1",
+				ID:      ".google.cloud.secretmanager.v1.Secret",
+				Fields: []*api.Field{
+					{
+						Name:  "name",
+						Typez: api.TypezString,
+					},
+				},
+			}
+
+			requestMessage := &api.Message{
+				Name:    "CreateSecretRequest",
+				Package: "google.cloud.secretmanager.v1",
+				ID:      ".google.cloud.secretmanager.v1.CreateSecretRequest",
+				Fields: []*api.Field{
+					{
+						Name:  "name",
+						Typez: api.TypezString,
+					},
+					{
+						Name:     "secret",
+						Typez:    api.TypezMessage,
+						TypezID:  ".google.cloud.secretmanager.v1.Secret",
+						Optional: true,
+					},
+					{
+						Name:  "project",
+						Typez: api.TypezString,
+					},
+					{
+						Name:     "location",
+						Typez:    api.TypezString,
+						Optional: true,
+					},
+				},
+			}
+
+			iam := &api.Service{
+				Name: "SecretManagerService",
+				Methods: []*api.Method{
+					{
+						Name:        "CreateSecret",
+						InputTypeID: requestMessage.ID,
+						InputType:   requestMessage,
+						PathInfo: &api.PathInfo{
+							Bindings: []*api.PathBinding{{
+								Verb:         "POST",
+								PathTemplate: test.path,
+							}},
+						},
+					},
+				},
+			}
+
+			model := api.NewTestAPI([]*api.Message{requestMessage, secretMessage}, nil, []*api.Service{iam})
+			model.PackageName = "google.cloud.secretmanager.v1"
+
+			cfg := &parser.ModelConfig{
+				Codec: map[string]string{
+					"copyright-year": "2038",
+				},
+			}
+
+			if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			filename := filepath.Join(outDir, "Sources", "GoogleCloudSecretmanagerV1", "SecretManagerService.swift")
+			content, err := os.ReadFile(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			contentStr := string(content)
+
+			gotBlock := extractBlock(t, contentStr, "let path = try { () throws -> String in", "    }()")
+			if diff := cmp.Diff(test.wantBlock, gotBlock); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -221,7 +221,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 				WithVariableNamed("secret", "name"),
 			wantBlock: `let path = try { () throws -> String in
       guard let pathVariable0 = request.secret.map({ $0.name }), !pathVariable0.isEmpty else {
-        throw GoogleCloudGax.RequestError.binding("'request.secret.map({ $0.name })' returns an empty binding")
+        throw GoogleCloudGax.RequestError.binding("'request.secret.name' is not set or is empty")
       }
       return "/v1/\(pathVariable0)"
     }()`,
@@ -233,7 +233,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 				WithVariableNamed("name"),
 			wantBlock: `let path = try { () throws -> String in
       guard let pathVariable0 = request.name as String?, !pathVariable0.isEmpty else {
-        throw GoogleCloudGax.RequestError.binding("'request.name as String?' returns an empty binding")
+        throw GoogleCloudGax.RequestError.binding("'request.name' is not set or is empty")
       }
       return "/v1/\(pathVariable0)"
     }()`,
@@ -248,10 +248,10 @@ func TestGenerateService_PathParameters(t *testing.T) {
 				WithVariableNamed("location"),
 			wantBlock: `let path = try { () throws -> String in
       guard let pathVariable0 = request.project as String?, !pathVariable0.isEmpty else {
-        throw GoogleCloudGax.RequestError.binding("'request.project as String?' returns an empty binding")
+        throw GoogleCloudGax.RequestError.binding("'request.project' is not set or is empty")
       }
       guard let pathVariable1 = request.location, !pathVariable1.isEmpty else {
-        throw GoogleCloudGax.RequestError.binding("'request.location' returns an empty binding")
+        throw GoogleCloudGax.RequestError.binding("'request.location' is not set or is empty")
       }
       return "/v1/projects/\(pathVariable0)/locations/\(pathVariable1)"
     }()`,

--- a/internal/sidekick/swift/lookup.go
+++ b/internal/sidekick/swift/lookup.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
@@ -36,4 +37,15 @@ func lookupEnum(model *api.API, id string) (*api.Enum, error) {
 		return nil, fmt.Errorf("unable to lookup enum %q", id)
 	}
 	return e, nil
+}
+
+// lookupField finds a field in a message.
+func lookupField(message *api.Message, name string) (*api.Field, error) {
+	idx := slices.IndexFunc(message.Fields, func(f *api.Field) bool {
+		return f.Name == name
+	})
+	if idx == -1 {
+		return nil, fmt.Errorf("consistency error: field %s not found in message %q", name, message.ID)
+	}
+	return message.Fields[idx], nil
 }

--- a/internal/sidekick/swift/lookup_test.go
+++ b/internal/sidekick/swift/lookup_test.go
@@ -64,3 +64,33 @@ func TestLookupEnum_Error(t *testing.T) {
 		t.Errorf("lookupEnum() expected error, got nil")
 	}
 }
+
+func TestLookupField(t *testing.T) {
+	field := &api.Field{Name: "name", ID: ".test.Secret.name", Typez: api.TypezString}
+	msg := &api.Message{
+		Name:   "Secret",
+		ID:     ".test.Secret",
+		Fields: []*api.Field{field},
+	}
+
+	got, err := lookupField(msg, "name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(field, got); diff != "" {
+		t.Errorf("lookupField() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLookupField_Error(t *testing.T) {
+	msg := &api.Message{
+		Name:   "Secret",
+		ID:     ".test.Secret",
+		Fields: []*api.Field{},
+	}
+
+	_, err := lookupField(msg, "missing")
+	if err == nil {
+		t.Errorf("lookupField() expected error, got nil")
+	}
+}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -63,6 +63,14 @@ public class {{Codec.Name}} {
     -> {{OutputType.Codec.Name}}
     {{/ReturnsEmpty}}
   {
+    let path = try { () throws -> String in
+      {{#Codec.PathVariables}}
+      guard let {{Name}} = request{{Expression}}{{#Test}}, {{{.}}}{{/Test}} else {
+        throw GoogleCloudGax.RequestError.binding("'request{{Expression}}' returns an empty binding")
+      }
+      {{/Codec.PathVariables}}
+      return "{{Codec.PathExpression}}"
+    }()
     {{#Codec.HasQueryParams}}
     var query = [URLQueryItem(name: "$alt", value: "json")]
     let encoder = GoogleCloudGax.QueryParameterEncoder()
@@ -77,7 +85,7 @@ public class {{Codec.Name}} {
     }}
     query.append(contentsOf: try encoder.encode(request.{{Codec.Name}}, prefix: "{{JSONName}}"))
     {{/Codec.QueryParams}}
-    var req = try await self.inner.Request(path: "{{{Codec.Path}}}", query: query)
+    var req = try await self.inner.Request(path: path, query: query)
     req.httpMethod = "{{Codec.HTTPMethod}}"
     {{#Codec.HasBody}}
     {{#Codec.IsBodyWildcard}}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -66,7 +66,7 @@ public class {{Codec.Name}} {
     let path = try { () throws -> String in
       {{#Codec.PathVariables}}
       guard let {{Name}} = request{{Expression}}{{#Test}}, {{{.}}}{{/Test}} else {
-        throw GoogleCloudGax.RequestError.binding("'request{{Expression}}' returns an empty binding")
+        throw GoogleCloudGax.RequestError.binding("'request.{{FieldPath}}' is not set or is empty")
       }
       {{/Codec.PathVariables}}
       return "{{Codec.PathExpression}}"


### PR DESCRIPTION
Sometimes the fields used to build the URL path are optional, or are nested within optional messages. The generator needs to emit code to detect if the field is not set, and if so, throw an error.

Fixes #5545 