### PR TITLE
feat(internal/librarian): add gcloud generation support

### DIFF
--- a/internal/librarian/gcloud/generate.go
+++ b/internal/librarian/gcloud/generate.go
@@ -22,6 +22,7 @@ package gcloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,6 +38,9 @@ import (
 // baseModule is the default Python base module path for generated gcloud
 // command groups.
 const baseModule = "googlecloudsdk"
+
+// ErrNoProtosFound is returned when no .proto files are found in the API directory.
+var ErrNoProtosFound = errors.New("no .proto files found")
 
 // Generate generates gcloud command YAML files for a library.
 //
@@ -107,7 +111,7 @@ func collectProtos(googleapisDir, apiPath string) ([]string, error) {
 		protos = append(protos, filepath.ToSlash(filepath.Join(apiPath, entry.Name())))
 	}
 	if len(protos) == 0 {
-		return nil, fmt.Errorf("no .proto files found in %q", apiDir)
+		return nil, fmt.Errorf("%w: %q", ErrNoProtosFound, apiDir)
 	}
 	return protos, nil
 }

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian/dart"
+	"github.com/googleapis/librarian/internal/librarian/gcloud"
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
@@ -146,6 +147,8 @@ func cleanLibraries(language string, libraries []*config.Library) error {
 			err = checkAndClean(library.Output, keep)
 		case config.LanguageSwift:
 			err = checkAndClean(library.Output, library.Keep)
+		case config.LanguageGcloud:
+			// No-op. gcloud generation does not support cleaning yet.
 		default:
 			err = fmt.Errorf("language %q does not support cleaning", language)
 		}
@@ -185,6 +188,13 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 			}
 		}
 		return fakePostGenerate()
+	case config.LanguageGcloud:
+		for _, library := range libraries {
+			if err := gcloud.Generate(ctx, library, src); err != nil {
+				return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+			}
+		}
+		return nil
 	case config.LanguageGo:
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -40,6 +40,7 @@ var (
 	errBothLibraryAndAllFlag   = errors.New("cannot specify both library name and --all flag")
 	errSkipGenerate            = errors.New("library has skip_generate set")
 	errNoPreviewVariant        = errors.New("library does not have a preview variant")
+	errUnsupportedLanguage     = errors.New("language does not support generation")
 )
 
 func generateCommand() *cli.Command {
@@ -287,7 +288,7 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		}
 		return g.Wait()
 	default:
-		return fmt.Errorf("language %q does not support generation", cfg.Language)
+		return fmt.Errorf("%w: %q", errUnsupportedLanguage, cfg.Language)
 	}
 	return nil
 }

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -189,12 +189,16 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		}
 		return fakePostGenerate()
 	case config.LanguageGcloud:
+		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {
-			if err := gcloud.Generate(ctx, library, src); err != nil {
-				return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
-			}
+			g.Go(func() error {
+				if err := gcloud.Generate(gctx, library, src); err != nil {
+					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+				}
+				return nil
+			})
 		}
-		return nil
+		return g.Wait()
 	case config.LanguageGo:
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -20,11 +20,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/librarian/gcloud"
 	"github.com/googleapis/librarian/internal/sample"
 	"github.com/googleapis/librarian/internal/yaml"
 )
@@ -386,8 +386,8 @@ libraries:
 	if errors.Is(err, errUnsupportedLanguage) {
 		t.Errorf("expected gcloud to be supported, but got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "no .proto files found") {
-		t.Errorf("expected error about missing .proto files, got: %v", err)
+	if !errors.Is(err, gcloud.ErrNoProtosFound) {
+		t.Errorf("expected error %v, got: %v", gcloud.ErrNoProtosFound, err)
 	}
 }
 

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -356,6 +356,41 @@ libraries:
 	}
 }
 
+func TestGenerate_Gcloud(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	googleapisDir := createGoogleapisServiceConfigs(t, tempDir, map[string]string{
+		"google/cloud/secretmanager/v1": "secretmanager_v1.yaml",
+	})
+
+	configContent := fmt.Sprintf(`language: gcloud
+sources:
+  googleapis:
+    dir: %s
+libraries:
+  - name: secretmanager
+    output: out
+    apis:
+      - path: google/cloud/secretmanager/v1
+`, googleapisDir)
+
+	if err := os.WriteFile(filepath.Join(tempDir, config.LibrarianYAML), []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Run(t.Context(), "librarian", "generate", "secretmanager")
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), "does not support generation") {
+		t.Errorf("expected gcloud to be supported, but got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no .proto files found") {
+		t.Errorf("expected error about missing .proto files, got: %v", err)
+	}
+}
+
 // createGoogleapisServiceConfigs creates a mock googleapis directory structure
 // with service config files for testing purposes.
 // The configs map keys are api paths (e.g., "google/cloud/speech/v1")

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -351,7 +351,7 @@ libraries:
 		return
 	}
 
-	if strings.Contains(err.Error(), "does not support generation") {
+	if errors.Is(err, errUnsupportedLanguage) {
 		t.Errorf("expected Java to be supported, but got: %v", err)
 	}
 }
@@ -383,7 +383,7 @@ libraries:
 	if err == nil {
 		return
 	}
-	if strings.Contains(err.Error(), "does not support generation") {
+	if errors.Is(err, errUnsupportedLanguage) {
 		t.Errorf("expected gcloud to be supported, but got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "no .proto files found") {


### PR DESCRIPTION
Support for generating gcloud command YAML files is added to the generate command. This allows generating libraries with language set to gcloud in librarian.yaml.

A no-op case is added to cleanLibraries for gcloud since it does not support cleaning yet. A unit test is added to verify that the gcloud case is reached in generateLibraries.

Fixes https://github.com/googleapis/librarian/issues/5597