### PR TITLE
feat(sidekick/swift): generate `Any` support code

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -15,13 +15,20 @@
 package swift
 
 import (
+	"strings"
+
 	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+const (
+	typeURLPrefix = "type.googleapis.com/"
 )
 
 type messageAnnotations struct {
 	Name     string
 	DocLines []string
 	Model    *modelAnnotations
+	TypeURL  string
 }
 
 func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
@@ -36,6 +43,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		Name:     pascalCase(message.Name),
 		DocLines: docLines,
 		Model:    model,
+		TypeURL:  typeURLPrefix + strings.TrimPrefix(message.ID, "."),
 	}
 
 	message.Codec = annotations

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -44,6 +44,7 @@ func TestAnnotateMessage(t *testing.T) {
 	want := &messageAnnotations{
 		Name:     "Secret",
 		DocLines: []string{"A secret message.", "With two lines."},
+		TypeURL:  "type.googleapis.com/test.Secret",
 	}
 
 	if diff := cmp.Diff(want, msg.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model")); diff != "" {
@@ -66,6 +67,7 @@ func TestAnnotateMessage_EscapedName(t *testing.T) {
 	want := &messageAnnotations{
 		Name:     "Protocol_",
 		DocLines: []string{"A message named Protocol."},
+		TypeURL:  "type.googleapis.com/test.Protocol",
 	}
 
 	if diff := cmp.Diff(want, msg.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model")); diff != "" {

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -107,16 +107,16 @@ func TestGenerateMessage_WithNestedMessages(t *testing.T) {
 	}
 	contentStr := string(content)
 
-	gotBlock1 := extractBlock(t, contentStr, "public struct Nested1", "Equatable {")
-	wantBlock1 := "public struct Nested1: Codable, Equatable {"
+	gotBlock1 := extractBlock(t, contentStr, "public struct Nested1", "._AnyPackable {")
+	wantBlock1 := "public struct Nested1: Codable, Equatable, GoogleCloudWkt._AnyPackable {"
 	if diff := cmp.Diff(wantBlock1, gotBlock1); diff != "" {
-		t.Errorf("mismatch in Nested1 (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	gotBlock2 := extractBlock(t, contentStr, "public struct Nested2", "Equatable {")
-	wantBlock2 := "public struct Nested2: Codable, Equatable {"
+	gotBlock2 := extractBlock(t, contentStr, "public struct Nested2", "._AnyPackable {")
+	wantBlock2 := "public struct Nested2: Codable, Equatable, GoogleCloudWkt._AnyPackable {"
 	if diff := cmp.Diff(wantBlock2, gotBlock2); diff != "" {
-		t.Errorf("mismatch in Nested2 (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -163,7 +163,7 @@ func TestGenerateMessage_WithNestedEnum(t *testing.T) {
 	gotBlock := extractBlock(t, contentStr, "public enum NestedEnum", "Equatable {")
 	wantBlock := "public enum NestedEnum: Int, Codable, Equatable {"
 	if diff := cmp.Diff(wantBlock, gotBlock); diff != "" {
-		t.Errorf("mismatch in NestedEnum (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -107,7 +107,7 @@ func TestGenerateOneOf(t *testing.T) {
 	// test.
 	//
 	// To verify the code compile, use something like: https://godbolt.org/z/EE9G7KTr8
-	want := `public struct Outer: Codable, Equatable {
+	want := `public struct Outer: Codable, Equatable, GoogleCloudWkt._AnyPackable {
 
   /// A regular field.
   public var regularInt32: Int32
@@ -135,6 +135,14 @@ func TestGenerateOneOf(t *testing.T) {
     case stringField(String)
     /// A message field that is part of the oneof.
     indirect case messageField(Inner)
+  }
+
+  public static var _anyTypeUrl: String { return "type.googleapis.com/google.cloud.test.v1.Outer" }
+  public init(fromAny any: GoogleCloudWkt.` + "`Any`" + `) throws {
+    self = try GoogleCloudWkt._slowAnyDeserialize(Self.self, from: any)
+  }
+  public func _pack() throws -> GoogleCloudWkt.Struct {
+    return try GoogleCloudWkt._slowAnySerialize(message: self)
   }
 }
 `

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -16,7 +16,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
-public struct {{Codec.Name}}: Codable, Equatable {
+public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._AnyPackable {
   {{#Fields}}
   {{^IsOneOf}}
 
@@ -81,4 +81,12 @@ public struct {{Codec.Name}}: Codable, Equatable {
 
   {{> /templates/common/oneof}}
   {{/OneOfs}}
+
+  public static var _anyTypeUrl: String { return "{{Codec.TypeURL}}" }
+  public init(fromAny any: {{Codec.Model.WktPackage}}.`Any`) throws {
+    self = try {{Codec.Model.WktPackage}}._slowAnyDeserialize(Self.self, from: any)
+  }
+  public func _pack() throws -> {{Codec.Model.WktPackage}}.Struct {
+    return try {{Codec.Model.WktPackage}}._slowAnySerialize(message: self)
+  }
 }


### PR DESCRIPTION
All generated messages need to conform to the `*Wkt._AnyPackable` protocol. Which means that any package with messages also depends on whatever package providers the `google.protobuf` source package.

Fixes #5401 