### PR TITLE
doc(librarian): rewrite CLI help

### DIFF
--- a/cmd/doc_generate.go
+++ b/cmd/doc_generate.go
@@ -25,17 +25,28 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 )
 
 const (
-	librarianDesc = `Librarian CLI runs local workflow that 
-	adds, generates, updates and publishes client libraries.
+	librarianDesc = `Librarian manages Google Cloud client libraries. It runs a local workflow
+that onboards new APIs, generates client code, bumps versions, publishes
+releases, and tags release commits. Language-specific work, such as code
+generation, building, and testing, is delegated to per-language tooling.
+
+All behavior is driven by librarian.yaml at the root of the repository,
+whose schema is documented at
+https://github.com/googleapis/librarian/blob/main/doc/config-schema.md.
 
 Usage:
 
 	librarian <command> [arguments]
+
+Global flags:
+
+	--verbose, -v    enable verbose logging
 `
 	librarianopsDesc = `Librarianops orchestrates librarian operations across multiple repositories.
 
@@ -77,31 +88,45 @@ Usage:
 //go:generate go run -tags docgen ../doc_generate.go -cmd .
 
 /*
-{{.Description}}
-
-The commands are:
-{{range .Commands}}{{template "command" .}}{{end}}
-*/
+{{.Description}}{{range .Commands}}{{template "command" .}}{{end}}*/
 package main
 
 {{define "command"}}
+# {{.Tagline}}
 
-# {{.Name}}
+Usage:
 
-{{.HelpText}}
-{{if .Commands}}
-{{range .Commands}}{{template "command" .}}{{end}}
-{{end}}
-{{end}}
+	{{.Usage}}
+{{if .Description}}
+{{.Description}}
+{{end}}{{if .Flags}}
+Flags:
+
+{{.Flags}}
+{{end}}{{if .AfterFlags}}
+{{.AfterFlags}}
+{{end}}{{if .Commands}}{{range .Commands}}{{template "command" .}}{{end}}{{end}}{{end}}
 `
 )
 
-// CommandDoc holds the documentation for a single CLI command.
+// CommandDoc holds the documentation for a single CLI command, parsed from
+// the urfave/cli "--help" output.
 type CommandDoc struct {
-	Name     string
-	HelpText string
-	Commands []CommandDoc
+	Name        string
+	Summary     string
+	Tagline     string
+	Usage       string
+	Description string
+	Flags       string
+	AfterFlags  string
+	Commands    []CommandDoc
 }
+
+// afterFlagsMarker, when it appears on its own line inside a command's
+// Description, splits the description: text above the marker stays in the
+// Description (rendered before Flags), text below moves to AfterFlags
+// (rendered after Flags). The marker itself is stripped from godoc output.
+const afterFlagsMarker = "[after-flags]"
 
 var (
 	descriptions = map[string]string{
@@ -119,6 +144,8 @@ var (
 	}
 
 	cmdPath = flag.String("cmd", "", "Path to the command to generate docs for (e.g., ../../cmd/librarian)")
+
+	sectionRE = regexp.MustCompile(`(?m)^([A-Z][A-Z ]*):\s*$`)
 )
 
 func main() {
@@ -194,7 +221,6 @@ func buildCommandDocs(parentCommand string) ([]CommandDoc, error) {
 		parentParts = strings.Fields(parentCommand)
 	}
 
-	// Get help text for parent to find subcommands.
 	args := []string{"run", "main.go"}
 	args = append(args, parentParts...)
 	cmd := exec.Command("go", args...)
@@ -206,7 +232,6 @@ func buildCommandDocs(parentCommand string) ([]CommandDoc, error) {
 
 	commandNames, err := extractCommandNames(out.Bytes())
 	if err != nil {
-		// Not an error, just means no subcommands.
 		return nil, nil
 	}
 
@@ -222,20 +247,170 @@ func buildCommandDocs(parentCommand string) ([]CommandDoc, error) {
 			return nil, fmt.Errorf("getting help text for command %s: %w", fullCommandName, err)
 		}
 
-		// Recurse.
 		subCommands, err := buildCommandDocs(fullCommandName)
 		if err != nil {
 			return nil, err
 		}
 
-		commands = append(commands, CommandDoc{
-			Name:     sanitize(fullCommandName),
-			HelpText: sanitize(helpText),
-			Commands: subCommands,
-		})
+		doc := parseHelp(helpText)
+		doc.Name = sanitize(fullCommandName)
+		doc.Commands = subCommands
+		commands = append(commands, doc)
 	}
 
 	return commands, nil
+}
+
+// parseHelp parses urfave/cli "--help" output into a CommandDoc, populating
+// Tagline, Usage, Description, and Flags. The expected input format is:
+//
+//	NAME:
+//	   <name> - <tagline>
+//
+//	USAGE:
+//	   <usage>
+//
+//	DESCRIPTION:
+//	   <description>
+//
+//	OPTIONS:
+//	   <flag>  <flag help>
+//
+//	GLOBAL OPTIONS:
+//	   <flag>  <flag help>
+//
+// GLOBAL OPTIONS are dropped (they are documented once at the package level).
+// The "--help, -h" flag is filtered out of OPTIONS.
+func parseHelp(help string) CommandDoc {
+	sections := splitSections(help)
+
+	var doc CommandDoc
+	if name, ok := sections["NAME"]; ok {
+		name = strings.TrimSpace(name)
+		if i := strings.Index(name, " - "); i >= 0 {
+			doc.Summary = strings.TrimSpace(name[i+3:])
+			doc.Tagline = sentenceCase(doc.Summary)
+		}
+	}
+	if u, ok := sections["USAGE"]; ok {
+		doc.Usage = strings.TrimSpace(u)
+	}
+	if d, ok := sections["DESCRIPTION"]; ok {
+		desc, after := splitAfterFlags(strings.TrimRight(dedent(d), "\n"))
+		doc.Description = sanitize(desc)
+		doc.AfterFlags = sanitize(after)
+	}
+	if o, ok := sections["OPTIONS"]; ok {
+		doc.Flags = filterFlags(o)
+	}
+	return doc
+}
+
+// splitSections splits urfave/cli help text into sections keyed by their
+// uppercase header (NAME, USAGE, DESCRIPTION, OPTIONS, GLOBAL OPTIONS).
+func splitSections(help string) map[string]string {
+	matches := sectionRE.FindAllStringIndex(help, -1)
+	sections := make(map[string]string, len(matches))
+	for i, m := range matches {
+		header := strings.TrimSpace(help[m[0]:m[1]])
+		header = strings.TrimSuffix(header, ":")
+		start := m[1]
+		end := len(help)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		sections[header] = help[start:end]
+	}
+	return sections
+}
+
+// splitAfterFlags splits a dedented description on a line that is exactly
+// afterFlagsMarker. Text before the marker is returned as the description;
+// text after the marker is returned as the after-flags content. If the
+// marker is absent, the whole input is returned as the description.
+func splitAfterFlags(desc string) (before, after string) {
+	lines := strings.Split(desc, "\n")
+	for i, l := range lines {
+		if strings.TrimSpace(l) == afterFlagsMarker {
+			before = strings.TrimRight(strings.Join(lines[:i], "\n"), "\n")
+			after = strings.TrimSpace(strings.Join(lines[i+1:], "\n"))
+			return
+		}
+	}
+	return desc, ""
+}
+
+// dedent strips the smallest common leading-whitespace prefix from every
+// non-blank line of s and trims surrounding blank lines.
+func dedent(s string) string {
+	lines := strings.Split(s, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	min := -1
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		i := 0
+		for i < len(l) && (l[i] == ' ' || l[i] == '\t') {
+			i++
+		}
+		if min == -1 || i < min {
+			min = i
+		}
+	}
+	if min <= 0 {
+		return strings.Join(lines, "\n")
+	}
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		if len(l) >= min {
+			out[i] = l[min:]
+		} else {
+			out[i] = l
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// filterFlags removes the help flag from an OPTIONS block, dedents, and
+// re-indents each remaining line with a single tab so godoc renders the
+// block as preformatted text.
+func filterFlags(opts string) string {
+	body := dedent(opts)
+	if body == "" {
+		return ""
+	}
+	var out []string
+	for _, l := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "--help") {
+			continue
+		}
+		out = append(out, "\t"+l)
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	return strings.Join(out, "\n")
+}
+
+// sentenceCase capitalizes the first letter of s.
+func sentenceCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 func getCommandHelpText(command string) (string, error) {
@@ -249,7 +424,6 @@ func getCommandHelpText(command string) (string, error) {
 	cmd.Stderr = &out
 	err := cmd.Run()
 	if err != nil {
-		// The help command also exits with status 1.
 		if out.Len() == 0 {
 			return "", fmt.Errorf("cmd.Run() for '%s --help' failed with %s\n%s", command, err, out.String())
 		}
@@ -260,7 +434,6 @@ func getCommandHelpText(command string) (string, error) {
 func extractCommandNames(helpText []byte) ([]string, error) {
 	ss := string(helpText)
 	var start int
-	// handle both legacy tool and urfave/cli/v3 style
 	headers := []string{"Commands:\n\n", "COMMANDS:\n"}
 	for _, header := range headers {
 		start = strings.Index(ss, header)
@@ -288,7 +461,6 @@ func extractCommandNames(helpText []byte) ([]string, error) {
 		fields := strings.Fields(line)
 		if len(fields) > 0 {
 			name := fields[0]
-			// Handle urfave/cli "help, h" style and filter out help command.
 			name = strings.TrimSuffix(name, ",")
 			if name == "help" || name == "h" {
 				continue

--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -15,213 +15,235 @@
 //go:generate go run -tags docgen ../doc_generate.go -cmd .
 
 /*
-Librarian CLI runs local workflow that
+Librarian manages Google Cloud client libraries. It runs a local workflow
+that onboards new APIs, generates client code, bumps versions, publishes
+releases, and tags release commits. Language-specific work, such as code
+generation, building, and testing, is delegated to per-language tooling.
 
-	adds, generates, updates and publishes client libraries.
+All behavior is driven by librarian.yaml at the root of the repository,
+whose schema is documented at
+https://github.com/googleapis/librarian/blob/main/doc/config-schema.md.
 
 Usage:
 
 	librarian <command> [arguments]
 
-The commands are:
+Global flags:
 
-# add
+	--verbose, -v    enable verbose logging
 
-NAME:
+# Install tool dependencies for a language
 
-	librarian add - add a new client library to librarian.yaml
-
-USAGE:
-
-	librarian add <apis...>
-
-OPTIONS:
-
-	--help, -h  show help
-
-GLOBAL OPTIONS:
-
-	--verbose, -v  enable verbose logging
-
-# generate
-
-NAME:
-
-	librarian generate - generate a client library
-
-USAGE:
-
-	librarian generate <library>
-
-OPTIONS:
-
-	--all       generate all libraries
-	--help, -h  show help
-
-GLOBAL OPTIONS:
-
-	--verbose, -v  enable verbose logging
-
-# bump
-
-NAME:
-
-	librarian bump - update versions and prepare release artifacts
-
-USAGE:
-
-	librarian bump <library>
-
-DESCRIPTION:
-
-	bump updates version numbers and prepares the files needed for a new release.
-
-	If a library name is given, only that library is updated. The --all flag updates every
-	library in the workspace. When a library is specified explicitly, the --version flag can
-	be used to override the new version.
-
-	Examples:
-	  librarian bump <library>           # update version for one library
-	  librarian bump --all               # update versions for all libraries
-
-OPTIONS:
-
-	--all             update all libraries in the workspace
-	--version string  specific version to update to; not valid with --all
-	--help, -h        show help
-
-GLOBAL OPTIONS:
-
-	--verbose, -v  enable verbose logging
-
-# install
-
-NAME:
-
-	librarian install - install tool dependencies for a language
-
-USAGE:
+Usage:
 
 	librarian install [language]
 
-DESCRIPTION:
+install installs the language-specific tools that librarian uses to
+generate and build client libraries (for example, language SDKs and code
+generators).
 
-	Install tool dependencies for the given language.
-	If no language is provided, the language is determined
-	from librarian.yaml in the current directory.
+If [language] is omitted, the language is read from librarian.yaml in the
+current directory.
 
-OPTIONS:
+Examples:
 
-	--help, -h  show help
+	librarian install              # use language from librarian.yaml
+	librarian install go           # install Go-specific tools
 
-GLOBAL OPTIONS:
+# Tidy and validate librarian.yaml
 
-	--verbose, -v  enable verbose logging
-
-# tidy
-
-NAME:
-
-	librarian tidy - format and validate librarian.yaml
-
-USAGE:
+Usage:
 
 	librarian tidy
 
-OPTIONS:
+tidy reads librarian.yaml, validates its contents, applies any
+language-specific defaults and normalization, and writes the file back
+with a canonical formatting.
 
-	--help, -h  show help
+Run tidy after editing librarian.yaml by hand, or as a quick check that
+the configuration is well-formed.
 
-GLOBAL OPTIONS:
+# Add a new client library
 
-	--verbose, -v  enable verbose logging
+Usage:
 
-# update
+	librarian add <apis...>
 
-NAME:
+add registers one or more APIs as a new client library in librarian.yaml.
 
-	librarian update - update sources to the latest version
+Each <api> is a path within the configured googleapis source, such as
+"google/cloud/secretmanager/v1". The library name and other defaults are
+derived from the first API path using language-specific rules.
 
-USAGE:
+Multiple API paths may be passed to bundle them into a single library. To
+add a preview client of an existing library, prefix every API path with
+"preview/"; preview and non-preview APIs cannot be mixed in one invocation.
+
+Examples:
+
+	librarian add google/cloud/secretmanager/v1
+	librarian add google/cloud/foo/v1 google/cloud/foo/v1beta
+	librarian add preview/google/cloud/secretmanager/v1beta
+
+A typical librarian workflow for adding a new client library is:
+
+	librarian add <api>            # onboard a new API into librarian.yaml
+	librarian generate <library>   # generate the client library
+
+# Update sources to the latest version
+
+Usage:
 
 	librarian update <sources...>
 
-DESCRIPTION:
+update refreshes the upstream source repositories declared in
+librarian.yaml to their latest commits and updates the recorded commit
+SHAs in librarian.yaml accordingly.
 
-	Supported sources are:
-	  - conformance
-	  - discovery
-	  - googleapis
-	  - protobuf
-	  - showcase
+Each <source> names an upstream repository that librarian consumes:
 
-OPTIONS:
+  - conformance: protocolbuffers/protobuf conformance tests
+  - discovery: googleapis/discovery-artifact-manager
+  - googleapis: googleapis/googleapis (the API definitions)
+  - protobuf: protocolbuffers/protobuf
+  - showcase: googleapis/gapic-showcase
 
-	--help, -h  show help
+At least one source must be specified.
 
-GLOBAL OPTIONS:
+Examples:
 
-	--verbose, -v  enable verbose logging
+	librarian update googleapis
+	librarian update googleapis protobuf
 
-# version
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
 
-NAME:
+	librarian update googleapis
+	librarian generate --all
 
-	librarian version - print the version
+# Generate a client library
 
-USAGE:
+Usage:
 
-	librarian version
+	librarian generate <library>
 
-OPTIONS:
+generate produces client library code from the APIs configured in
+librarian.yaml.
 
-	--help, -h  show help
+The library name argument selects a single library to regenerate. Use the
+--all flag to regenerate every library in the workspace instead. Exactly
+one of <library> or --all must be provided.
 
-GLOBAL OPTIONS:
+Generation is delegated to the language-specific tooling configured in
+librarian.yaml. Libraries marked with skip_generate are skipped.
 
-	--verbose, -v  enable verbose logging
+Examples:
 
-# publish
+	librarian generate <library>   # regenerate one library
+	librarian generate --all       # regenerate every library
 
-NAME:
+Flags:
 
-	librarian publish - publishes client libraries
+	--all       generate all libraries
 
-USAGE:
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
+
+	librarian update googleapis
+	librarian generate --all
+
+# Bump version numbers and prepare release artifacts
+
+Usage:
+
+	librarian bump <library>
+
+bump updates version numbers and prepares the files needed for a new release.
+
+If a library name is given, only that library is updated. The --all flag updates every
+library in the workspace. When a library is specified explicitly, the --version flag can
+be used to override the new version.
+
+Examples:
+
+	librarian bump <library>           # update version for one library
+	librarian bump --all               # update versions for all libraries
+
+Flags:
+
+	--all             update all libraries in the workspace
+	--version string  specific version to update to; not valid with --all
+
+# Publish client libraries
+
+Usage:
 
 	librarian publish
 
-OPTIONS:
+publish releases the libraries that were updated in a release commit
+prepared by librarian bump.
+
+By default, publish performs a dry run that prints the actions it would
+take. Pass --execute to actually publish. By default, the most recent
+release commit reachable from HEAD is used; --release-commit overrides
+this with a specific commit.
+
+The --dry-run, --dry-run-keep-going, and --skip-semver-checks flags are
+only honored when the workspace language is Rust; they are retained for
+backwards compatibility with the legacy Rust release jobs and will be
+removed once Rust migrates to the unified flow.
+
+Examples:
+
+	librarian publish                          # dry run
+	librarian publish --execute                # publish for real
+	librarian publish --release-commit=<sha>   # publish a specific commit
+
+Flags:
 
 	--execute                fully publish (default is to only perform a dry run)
 	--release-commit string  the release commit to publish; default finds latest release commit
 	--dry-run                print commands without executing (legacy Rust-only flag)
 	--dry-run-keep-going     print commands without executing, don't stop on error (legacy Rust-only flag)
 	--skip-semver-checks     skip semantic versioning checks (legacy Rust-only flag)
-	--help, -h               show help
 
-GLOBAL OPTIONS:
+# Tag a release commit based on the libraries published
 
-	--verbose, -v  enable verbose logging
-
-# tag
-
-NAME:
-
-	librarian tag - tags a release commit based on the libraries published
-
-USAGE:
+Usage:
 
 	librarian tag
 
-OPTIONS:
+tag creates git tags on a release commit, one tag per library that the
+commit released, using the tag_format declared for each library in
+librarian.yaml.
+
+Run tag after librarian publish has succeeded. By default, the most
+recent release commit reachable from HEAD is used; --release-commit
+overrides this with a specific commit.
+
+The --create-release-tag flag additionally creates a tag of the form
+release-<PR number>; this is used by the legacy release jobs and will be
+removed once those jobs are retired.
+
+Examples:
+
+	librarian tag
+	librarian tag --release-commit=<sha>
+	librarian tag --create-release-tag
+
+Flags:
 
 	--release-commit string  the release commit to tag; default finds latest release commit
 	--create-release-tag     whether to create a tag of the form release-{PR number}
-	--help, -h               show help
 
-GLOBAL OPTIONS:
+# Print the binary version
 
-	--verbose, -v  enable verbose logging
+Usage:
+
+	librarian version
+
+version prints the librarian binary version and exits. The version is
+embedded at build time and follows the conventions described at
+https://go.dev/ref/mod#versions.
 */
 package main

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -51,8 +51,28 @@ var (
 func addCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "add",
-		Usage:     "add a new client library to librarian.yaml",
+		Usage:     "add a new client library",
 		UsageText: "librarian add <apis...>",
+		Description: `add registers one or more APIs as a new client library in librarian.yaml.
+
+Each <api> is a path within the configured googleapis source, such as
+"google/cloud/secretmanager/v1". The library name and other defaults are
+derived from the first API path using language-specific rules.
+
+Multiple API paths may be passed to bundle them into a single library. To
+add a preview client of an existing library, prefix every API path with
+"preview/"; preview and non-preview APIs cannot be mixed in one invocation.
+
+Examples:
+
+	librarian add google/cloud/secretmanager/v1
+	librarian add google/cloud/foo/v1 google/cloud/foo/v1beta
+	librarian add preview/google/cloud/secretmanager/v1beta
+
+A typical librarian workflow for adding a new client library is:
+
+	librarian add <api>            # onboard a new API into librarian.yaml
+	librarian generate <library>   # generate the client library`,
 		Action: func(ctx context.Context, c *cli.Command) error {
 			apis := c.Args().Slice()
 			if len(apis) == 0 {

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -61,7 +61,7 @@ var (
 func bumpCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "bump",
-		Usage:     "update versions and prepare release artifacts",
+		Usage:     "bump version numbers and prepare release artifacts",
 		UsageText: "librarian bump <library>",
 		Description: `bump updates version numbers and prepares the files needed for a new release.
 
@@ -70,8 +70,9 @@ library in the workspace. When a library is specified explicitly, the --version 
 be used to override the new version.
 
 Examples:
-  librarian bump <library>           # update version for one library
-  librarian bump --all               # update versions for all libraries`,
+
+	librarian bump <library>           # update version for one library
+	librarian bump --all               # update versions for all libraries`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "all",

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -48,6 +48,27 @@ func generateCommand() *cli.Command {
 		Name:      "generate",
 		Usage:     "generate a client library",
 		UsageText: "librarian generate <library>",
+		Description: `generate produces client library code from the APIs configured in
+librarian.yaml.
+
+The library name argument selects a single library to regenerate. Use the
+--all flag to regenerate every library in the workspace instead. Exactly
+one of <library> or --all must be provided.
+
+Generation is delegated to the language-specific tooling configured in
+librarian.yaml. Libraries marked with skip_generate are skipped.
+
+Examples:
+
+	librarian generate <library>   # regenerate one library
+	librarian generate --all       # regenerate every library
+
+[after-flags]
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
+
+	librarian update googleapis
+	librarian generate --all`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "all",

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -52,15 +52,15 @@ func Run(ctx context.Context, args ...string) error {
 			return ctx, nil
 		},
 		Commands: []*cli.Command{
-			addCommand(),
-			generateCommand(),
-			bumpCommand(),
 			installCommand(),
 			tidyCommand(),
+			addCommand(),
 			updateCommand(),
-			versionCommand(),
+			generateCommand(),
+			bumpCommand(),
 			publishCommand(),
 			tagCommand(),
+			versionCommand(),
 		},
 	}
 	return cmd.Run(ctx, args)
@@ -71,9 +71,17 @@ func installCommand() *cli.Command {
 		Name:      "install",
 		Usage:     "install tool dependencies for a language",
 		UsageText: "librarian install [language]",
-		Description: `Install tool dependencies for the given language.
-If no language is provided, the language is determined
-from librarian.yaml in the current directory.`,
+		Description: `install installs the language-specific tools that librarian uses to
+generate and build client libraries (for example, language SDKs and code
+generators).
+
+If [language] is omitted, the language is read from librarian.yaml in the
+current directory.
+
+Examples:
+
+	librarian install              # use language from librarian.yaml
+	librarian install go           # install Go-specific tools`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			lang := cmd.Args().First()
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
@@ -110,8 +118,11 @@ from librarian.yaml in the current directory.`,
 func versionCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "version",
-		Usage:     "print the version",
+		Usage:     "print the binary version",
 		UsageText: "librarian version",
+		Description: `version prints the librarian binary version and exits. The version is
+embedded at build time and follows the conventions described at
+https://go.dev/ref/mod#versions.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			fmt.Printf("librarian version %s\n", Version())
 			return nil

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -29,8 +29,26 @@ import (
 func publishCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "publish",
-		Usage:     "publishes client libraries",
+		Usage:     "publish client libraries",
 		UsageText: "librarian publish",
+		Description: `publish releases the libraries that were updated in a release commit
+prepared by librarian bump.
+
+By default, publish performs a dry run that prints the actions it would
+take. Pass --execute to actually publish. By default, the most recent
+release commit reachable from HEAD is used; --release-commit overrides
+this with a specific commit.
+
+The --dry-run, --dry-run-keep-going, and --skip-semver-checks flags are
+only honored when the workspace language is Rust; they are retained for
+backwards compatibility with the legacy Rust release jobs and will be
+removed once Rust migrates to the unified flow.
+
+Examples:
+
+	librarian publish                          # dry run
+	librarian publish --execute                # publish for real
+	librarian publish --release-commit=<sha>   # publish a specific commit`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "execute",

--- a/internal/librarian/tag.go
+++ b/internal/librarian/tag.go
@@ -37,8 +37,25 @@ var (
 func tagCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "tag",
-		Usage:     "tags a release commit based on the libraries published",
+		Usage:     "tag a release commit based on the libraries published",
 		UsageText: "librarian tag",
+		Description: `tag creates git tags on a release commit, one tag per library that the
+commit released, using the tag_format declared for each library in
+librarian.yaml.
+
+Run tag after librarian publish has succeeded. By default, the most
+recent release commit reachable from HEAD is used; --release-commit
+overrides this with a specific commit.
+
+The --create-release-tag flag additionally creates a tag of the form
+release-<PR number>; this is used by the legacy release jobs and will be
+removed once those jobs are retired.
+
+Examples:
+
+	librarian tag
+	librarian tag --release-commit=<sha>
+	librarian tag --create-release-tag`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "release-commit",

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -41,8 +41,14 @@ var (
 func tidyCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "tidy",
-		Usage:     "format and validate librarian.yaml",
+		Usage:     "tidy and validate librarian.yaml",
 		UsageText: "librarian tidy",
+		Description: `tidy reads librarian.yaml, validates its contents, applies any
+language-specific defaults and normalization, and writes the file back
+with a canonical formatting.
+
+Run tidy after editing librarian.yaml by hand, or as a quick check that
+the configuration is well-formed.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {

--- a/internal/librarian/update.go
+++ b/internal/librarian/update.go
@@ -46,12 +46,30 @@ func updateCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "update",
 		Usage: "update sources to the latest version",
-		Description: `Supported sources are:
-  - conformance
-  - discovery
-  - googleapis
-  - protobuf
-  - showcase`,
+		Description: `update refreshes the upstream source repositories declared in
+librarian.yaml to their latest commits and updates the recorded commit
+SHAs in librarian.yaml accordingly.
+
+Each <source> names an upstream repository that librarian consumes:
+
+  - conformance: protocolbuffers/protobuf conformance tests
+  - discovery: googleapis/discovery-artifact-manager
+  - googleapis: googleapis/googleapis (the API definitions)
+  - protobuf: protocolbuffers/protobuf
+  - showcase: googleapis/gapic-showcase
+
+At least one source must be specified.
+
+Examples:
+
+	librarian update googleapis
+	librarian update googleapis protobuf
+
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
+
+	librarian update googleapis
+	librarian generate --all`,
 		UsageText: "librarian update <sources...>",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			args := cmd.Args().Slice()


### PR DESCRIPTION
Each librarian subcommand now has a Description with a short prose explanation, concrete examples, and pointers to related commands. The package godoc for cmd/librarian is regenerated from these.

doc_generate.go is reworked to parse urfave/cli "--help" output into structured fields (tagline, usage, description, flags) and render them directly, instead of pasting raw help text. An "[after-flags]" marker in a Description splits it so workflow examples can render after the Flags block. Commands are reordered in librarian.go to follow the typical workflow.