### PR TITLE
refactor: document doc.go generation and move docgen tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,30 @@ All documentation should live in the root of the repository or in the `doc/`
 directory. Markdown files should follow the
 [Google Style Guide](https://google.github.io/styleguide/docguide/style.html).
 
+### Generated package documentation
+
+Each binary under `cmd/` has a `doc.go` file that renders as the package's
+godoc page on pkg.go.dev. The files are produced by
+[`tool/cmd/docgen`](https://github.com/googleapis/librarian/blob/main/tool/cmd/docgen).
+If you change a command's name, usage text, description, flags, or examples,
+regenerate `doc.go` and commit it alongside your change:
+
+```
+go generate ./...
+```
+
+Then check the rendered output before sending the pull request, either with:
+
+```
+go doc ./cmd/librarian
+```
+
+or, to preview the way pkg.go.dev will display it, with pkgsite:
+
+```
+go run golang.org/x/pkgsite/cmd/pkgsite@latest .
+```
+
 ## Sending a pull request
 
 All code changes must be submitted via a pull request. If you are a first-time

--- a/cmd/legacyautomation/doc.go
+++ b/cmd/legacyautomation/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags docgen ../doc_generate.go -cmd .
+//go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
 
 /*
 Automation provides logic to trigger Cloud Build jobs that run Librarian commands for

--- a/cmd/legacylibrarian/doc.go
+++ b/cmd/legacylibrarian/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags docgen ../doc_generate.go -cmd .
+//go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
 
 /*
 Librarian manages Google API client libraries by automating onboarding,

--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags docgen ../doc_generate.go -cmd .
+//go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
 
 /*
 Librarian CLI runs local workflow that

--- a/cmd/librarianops/doc.go
+++ b/cmd/librarianops/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags docgen ../doc_generate.go -cmd .
+//go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
 
 /*
 Librarianops orchestrates librarian operations across multiple repositories.

--- a/tool/cmd/docgen/main.go
+++ b/tool/cmd/docgen/main.go
@@ -74,7 +74,7 @@ Usage:
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags docgen ../doc_generate.go -cmd .
+//go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
 
 /*
 {{.Description}}


### PR DESCRIPTION
Add a CONTRIBUTING.md section describing how doc.go files are generated.

Move cmd/doc_generate.go to tool/cmd/docgen since it’s an internal development tool and not intended to be a user-facing CLI. 