### PR TITLE
feat(tool/cmd/docgen): rewrite CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ specifications, bumping versions, and publishing releases.
 ## Usage
 
 Run `librarian -help` for a list of commands,
-or see the [command reference](https://pkg.go.dev/github.com/googleapis/librarian/cmd/librarian).
+or see the [command reference on pkg.go.dev](https://pkg.go.dev/github.com/googleapis/librarian@main/cmd/librarian).
 
 To run without installing:
 

--- a/cmd/legacyautomation/doc.go
+++ b/cmd/legacyautomation/doc.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
-
 /*
 Automation provides logic to trigger Cloud Build jobs that run Librarian commands for
 any repository listed in internal/legacylibrarian/legacyautomation/prod/repositories.yaml.

--- a/cmd/legacylibrarian/doc.go
+++ b/cmd/legacylibrarian/doc.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
-
 /*
 Librarian manages Google API client libraries by automating onboarding,
 regeneration, and release. It runs language-agnostic workflows while

--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -15,213 +15,235 @@
 //go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
 
 /*
-Librarian CLI runs local workflow that
+Librarian manages Google Cloud client libraries. It runs a local workflow
+that onboards new APIs, generates client code, bumps versions, publishes
+releases, and tags release commits. Language-specific work, such as code
+generation, building, and testing, is delegated to per-language tooling.
 
-	adds, generates, updates and publishes client libraries.
+All behavior is driven by librarian.yaml at the root of the repository,
+whose schema is documented at
+https://github.com/googleapis/librarian/blob/main/doc/config-schema.md.
 
 Usage:
 
 	librarian <command> [arguments]
 
-The commands are:
+Global flags:
 
-# add
+	--verbose, -v    enable verbose logging
 
-NAME:
+# Install tool dependencies for a language
 
-	librarian add - add a new client library to librarian.yaml
-
-USAGE:
-
-	librarian add <apis...>
-
-OPTIONS:
-
-	--help, -h  show help
-
-GLOBAL OPTIONS:
-
-	--verbose, -v  enable verbose logging
-
-# generate
-
-NAME:
-
-	librarian generate - generate a client library
-
-USAGE:
-
-	librarian generate <library>
-
-OPTIONS:
-
-	--all       generate all libraries
-	--help, -h  show help
-
-GLOBAL OPTIONS:
-
-	--verbose, -v  enable verbose logging
-
-# bump
-
-NAME:
-
-	librarian bump - update versions and prepare release artifacts
-
-USAGE:
-
-	librarian bump <library>
-
-DESCRIPTION:
-
-	bump updates version numbers and prepares the files needed for a new release.
-
-	If a library name is given, only that library is updated. The --all flag updates every
-	library in the workspace. When a library is specified explicitly, the --version flag can
-	be used to override the new version.
-
-	Examples:
-	  librarian bump <library>           # update version for one library
-	  librarian bump --all               # update versions for all libraries
-
-OPTIONS:
-
-	--all             update all libraries in the workspace
-	--version string  specific version to update to; not valid with --all
-	--help, -h        show help
-
-GLOBAL OPTIONS:
-
-	--verbose, -v  enable verbose logging
-
-# install
-
-NAME:
-
-	librarian install - install tool dependencies for a language
-
-USAGE:
+Usage:
 
 	librarian install [language]
 
-DESCRIPTION:
+install installs the language-specific tools that librarian uses to
+generate and build client libraries (for example, language SDKs and code
+generators).
 
-	Install tool dependencies for the given language.
-	If no language is provided, the language is determined
-	from librarian.yaml in the current directory.
+If [language] is omitted, the language is read from librarian.yaml in the
+current directory.
 
-OPTIONS:
+Examples:
 
-	--help, -h  show help
+	librarian install              # use language from librarian.yaml
+	librarian install go           # install Go-specific tools
 
-GLOBAL OPTIONS:
+# Tidy and validate librarian.yaml
 
-	--verbose, -v  enable verbose logging
-
-# tidy
-
-NAME:
-
-	librarian tidy - format and validate librarian.yaml
-
-USAGE:
+Usage:
 
 	librarian tidy
 
-OPTIONS:
+tidy reads librarian.yaml, validates its contents, applies any
+language-specific defaults and normalization, and writes the file back
+with a canonical formatting.
 
-	--help, -h  show help
+Run tidy after editing librarian.yaml by hand, or as a quick check that
+the configuration is well-formed.
 
-GLOBAL OPTIONS:
+# Add a new client library
 
-	--verbose, -v  enable verbose logging
+Usage:
 
-# update
+	librarian add <apis...>
 
-NAME:
+add registers one or more APIs as a new client library in librarian.yaml.
 
-	librarian update - update sources to the latest version
+Each <api> is a path within the configured googleapis source, such as
+"google/cloud/secretmanager/v1". The library name and other defaults are
+derived from the first API path using language-specific rules.
 
-USAGE:
+Multiple API paths may be passed to bundle them into a single library. To
+add a preview client of an existing library, prefix every API path with
+"preview/"; preview and non-preview APIs cannot be mixed in one invocation.
+
+Examples:
+
+	librarian add google/cloud/secretmanager/v1
+	librarian add google/cloud/foo/v1 google/cloud/foo/v1beta
+	librarian add preview/google/cloud/secretmanager/v1beta
+
+A typical librarian workflow for adding a new client library is:
+
+	librarian add <api>            # onboard a new API into librarian.yaml
+	librarian generate <library>   # generate the client library
+
+# Update sources to the latest version
+
+Usage:
 
 	librarian update <sources...>
 
-DESCRIPTION:
+update refreshes the upstream source repositories declared in
+librarian.yaml to their latest commits and updates the recorded commit
+SHAs in librarian.yaml accordingly.
 
-	Supported sources are:
-	  - conformance
-	  - discovery
-	  - googleapis
-	  - protobuf
-	  - showcase
+Each <source> names an upstream repository that librarian consumes:
 
-OPTIONS:
+  - conformance: protocolbuffers/protobuf conformance tests
+  - discovery: googleapis/discovery-artifact-manager
+  - googleapis: googleapis/googleapis (the API definitions)
+  - protobuf: protocolbuffers/protobuf
+  - showcase: googleapis/gapic-showcase
 
-	--help, -h  show help
+At least one source must be specified.
 
-GLOBAL OPTIONS:
+Examples:
 
-	--verbose, -v  enable verbose logging
+	librarian update googleapis
+	librarian update googleapis protobuf
 
-# version
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
 
-NAME:
+	librarian update googleapis
+	librarian generate --all
 
-	librarian version - print the version
+# Generate a client library
 
-USAGE:
+Usage:
 
-	librarian version
+	librarian generate <library>
 
-OPTIONS:
+generate produces client library code from the APIs configured in
+librarian.yaml.
 
-	--help, -h  show help
+The library name argument selects a single library to regenerate. Use the
+--all flag to regenerate every library in the workspace instead. Exactly
+one of <library> or --all must be provided.
 
-GLOBAL OPTIONS:
+Generation is delegated to the language-specific tooling configured in
+librarian.yaml. Libraries marked with skip_generate are skipped.
 
-	--verbose, -v  enable verbose logging
+Examples:
 
-# publish
+	librarian generate <library>   # regenerate one library
+	librarian generate --all       # regenerate every library
 
-NAME:
+Flags:
 
-	librarian publish - publishes client libraries
+	--all       generate all libraries
 
-USAGE:
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
+
+	librarian update googleapis
+	librarian generate --all
+
+# Bump version numbers and prepare release artifacts
+
+Usage:
+
+	librarian bump <library>
+
+bump updates version numbers and prepares the files needed for a new release.
+
+If a library name is given, only that library is updated. The --all flag updates every
+library in the workspace. When a library is specified explicitly, the --version flag can
+be used to override the new version.
+
+Examples:
+
+	librarian bump <library>           # update version for one library
+	librarian bump --all               # update versions for all libraries
+
+Flags:
+
+	--all             update all libraries in the workspace
+	--version string  specific version to update to; not valid with --all
+
+# Publish client libraries
+
+Usage:
 
 	librarian publish
 
-OPTIONS:
+publish releases the libraries that were updated in a release commit
+prepared by librarian bump.
+
+By default, publish performs a dry run that prints the actions it would
+take. Pass --execute to actually publish. By default, the most recent
+release commit reachable from HEAD is used; --release-commit overrides
+this with a specific commit.
+
+The --dry-run, --dry-run-keep-going, and --skip-semver-checks flags are
+only honored when the workspace language is Rust; they are retained for
+backwards compatibility with the legacy Rust release jobs and will be
+removed once Rust migrates to the unified flow.
+
+Examples:
+
+	librarian publish                          # dry run
+	librarian publish --execute                # publish for real
+	librarian publish --release-commit=<sha>   # publish a specific commit
+
+Flags:
 
 	--execute                fully publish (default is to only perform a dry run)
 	--release-commit string  the release commit to publish; default finds latest release commit
 	--dry-run                print commands without executing (legacy Rust-only flag)
 	--dry-run-keep-going     print commands without executing, don't stop on error (legacy Rust-only flag)
 	--skip-semver-checks     skip semantic versioning checks (legacy Rust-only flag)
-	--help, -h               show help
 
-GLOBAL OPTIONS:
+# Tag a release commit based on the libraries published
 
-	--verbose, -v  enable verbose logging
-
-# tag
-
-NAME:
-
-	librarian tag - tags a release commit based on the libraries published
-
-USAGE:
+Usage:
 
 	librarian tag
 
-OPTIONS:
+tag creates git tags on a release commit, one tag per library that the
+commit released, using the tag_format declared for each library in
+librarian.yaml.
+
+Run tag after librarian publish has succeeded. By default, the most
+recent release commit reachable from HEAD is used; --release-commit
+overrides this with a specific commit.
+
+The --create-release-tag flag additionally creates a tag of the form
+release-<PR number>; this is used by the legacy release jobs and will be
+removed once those jobs are retired.
+
+Examples:
+
+	librarian tag
+	librarian tag --release-commit=<sha>
+	librarian tag --create-release-tag
+
+Flags:
 
 	--release-commit string  the release commit to tag; default finds latest release commit
 	--create-release-tag     whether to create a tag of the form release-{PR number}
-	--help, -h               show help
 
-GLOBAL OPTIONS:
+# Print the binary version
 
-	--verbose, -v  enable verbose logging
+Usage:
+
+	librarian version
+
+version prints the librarian binary version and exits. The version is
+embedded at build time and follows the conventions described at
+https://go.dev/ref/mod#versions.
 */
 package main

--- a/cmd/librarianops/doc.go
+++ b/cmd/librarianops/doc.go
@@ -21,69 +21,55 @@ Usage:
 
 	librarianops <command> [arguments]
 
-The commands are:
+# Generate libraries across repositories
 
-# generate
-
-NAME:
-
-	librarianops generate - generate libraries across repositories
-
-USAGE:
+Usage:
 
 	librarianops generate [<repo> | -C <dir>]
 
-DESCRIPTION:
+Examples:
 
-	Examples:
-	  librarianops generate google-cloud-rust
-	  librarianops generate -C ~/workspace/google-cloud-rust
+	librarianops generate google-cloud-rust
+	librarianops generate -C ~/workspace/google-cloud-rust
 
-	Specify a repository name to clone and process, or use -C to work in a specific
-	directory (repo name is inferred from the directory basename).
+Specify a repository name to clone and process, or use -C to work in a specific
+directory (repo name is inferred from the directory basename).
 
-	For each repository, librarianops will:
-	  1. Clone the repository to a temporary directory (or use existing directory with -C)
-	  2. Create a branch: librarianops-generateall-YYYY-MM-DD
-	  3. Run librarian tidy
-	  4. Run librarian update for configured sources (discovery, googleapis)
-	  5. Run librarian generate --all
-	  6. Run cargo update --workspace (google-cloud-rust only)
-	  7. Commit changes
-	  8. Create a pull request
+For each repository, librarianops will:
+ 1. Clone the repository to a temporary directory (or use existing directory with -C)
+ 2. Create a branch: librarianops-generateall-YYYY-MM-DD
+ 3. Run librarian tidy
+ 4. Run librarian update for configured sources (discovery, googleapis)
+ 5. Run librarian generate --all
+ 6. Run cargo update --workspace (google-cloud-rust only)
+ 7. Commit changes
+ 8. Create a pull request
 
-OPTIONS:
+Flags:
 
 	-C directory  work in directory (repo name inferred from basename)
 	-v            run librarian with verbose output
 	--docker      run librarian in Docker
-	--help, -h    show help
 
-# upgrade
+# Upgrade librarian version in librarian.yaml
 
-NAME:
-
-	librarianops upgrade - upgrade librarian version in librarian.yaml
-
-USAGE:
+Usage:
 
 	librarianops upgrade [<repo> | -C <dir>]
 
-DESCRIPTION:
+Examples:
 
-	Examples:
-	  librarianops upgrade google-cloud-rust
-	  librarianops upgrade -C ~/workspace/google-cloud-rust
+	librarianops upgrade google-cloud-rust
+	librarianops upgrade -C ~/workspace/google-cloud-rust
 
-	For each repository, librarianops will:
-	  1. Get the latest librarian version from @main.
-	  2. Update the version field in librarian.yaml.
-	  3. Run 'librarian generate --all'.
+For each repository, librarianops will:
+ 1. Get the latest librarian version from @main.
+ 2. Update the version field in librarian.yaml.
+ 3. Run 'librarian generate --all'.
 
-OPTIONS:
+Flags:
 
 	-C directory  work in directory (repo name inferred from basename)
 	-v            run librarian with verbose output
-	--help, -h    show help
 */
 package main

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -51,8 +51,28 @@ var (
 func addCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "add",
-		Usage:     "add a new client library to librarian.yaml",
+		Usage:     "add a new client library",
 		UsageText: "librarian add <apis...>",
+		Description: `add registers one or more APIs as a new client library in librarian.yaml.
+
+Each <api> is a path within the configured googleapis source, such as
+"google/cloud/secretmanager/v1". The library name and other defaults are
+derived from the first API path using language-specific rules.
+
+Multiple API paths may be passed to bundle them into a single library. To
+add a preview client of an existing library, prefix every API path with
+"preview/"; preview and non-preview APIs cannot be mixed in one invocation.
+
+Examples:
+
+	librarian add google/cloud/secretmanager/v1
+	librarian add google/cloud/foo/v1 google/cloud/foo/v1beta
+	librarian add preview/google/cloud/secretmanager/v1beta
+
+A typical librarian workflow for adding a new client library is:
+
+	librarian add <api>            # onboard a new API into librarian.yaml
+	librarian generate <library>   # generate the client library`,
 		Action: func(ctx context.Context, c *cli.Command) error {
 			apis := c.Args().Slice()
 			if len(apis) == 0 {

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -61,7 +61,7 @@ var (
 func bumpCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "bump",
-		Usage:     "update versions and prepare release artifacts",
+		Usage:     "bump version numbers and prepare release artifacts",
 		UsageText: "librarian bump <library>",
 		Description: `bump updates version numbers and prepares the files needed for a new release.
 
@@ -70,8 +70,9 @@ library in the workspace. When a library is specified explicitly, the --version 
 be used to override the new version.
 
 Examples:
-  librarian bump <library>           # update version for one library
-  librarian bump --all               # update versions for all libraries`,
+
+	librarian bump <library>           # update version for one library
+	librarian bump --all               # update versions for all libraries`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "all",

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -48,6 +48,27 @@ func generateCommand() *cli.Command {
 		Name:      "generate",
 		Usage:     "generate a client library",
 		UsageText: "librarian generate <library>",
+		Description: `generate produces client library code from the APIs configured in
+librarian.yaml.
+
+The library name argument selects a single library to regenerate. Use the
+--all flag to regenerate every library in the workspace instead. Exactly
+one of <library> or --all must be provided.
+
+Generation is delegated to the language-specific tooling configured in
+librarian.yaml. Libraries marked with skip_generate are skipped.
+
+Examples:
+
+	librarian generate <library>   # regenerate one library
+	librarian generate --all       # regenerate every library
+
+[after-flags]
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
+
+	librarian update googleapis
+	librarian generate --all`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "all",

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -52,15 +52,15 @@ func Run(ctx context.Context, args ...string) error {
 			return ctx, nil
 		},
 		Commands: []*cli.Command{
-			addCommand(),
-			generateCommand(),
-			bumpCommand(),
 			installCommand(),
 			tidyCommand(),
+			addCommand(),
 			updateCommand(),
-			versionCommand(),
+			generateCommand(),
+			bumpCommand(),
 			publishCommand(),
 			tagCommand(),
+			versionCommand(),
 		},
 	}
 	return cmd.Run(ctx, args)
@@ -71,9 +71,17 @@ func installCommand() *cli.Command {
 		Name:      "install",
 		Usage:     "install tool dependencies for a language",
 		UsageText: "librarian install [language]",
-		Description: `Install tool dependencies for the given language.
-If no language is provided, the language is determined
-from librarian.yaml in the current directory.`,
+		Description: `install installs the language-specific tools that librarian uses to
+generate and build client libraries (for example, language SDKs and code
+generators).
+
+If [language] is omitted, the language is read from librarian.yaml in the
+current directory.
+
+Examples:
+
+	librarian install              # use language from librarian.yaml
+	librarian install go           # install Go-specific tools`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			lang := cmd.Args().First()
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
@@ -110,8 +118,11 @@ from librarian.yaml in the current directory.`,
 func versionCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "version",
-		Usage:     "print the version",
+		Usage:     "print the binary version",
 		UsageText: "librarian version",
+		Description: `version prints the librarian binary version and exits. The version is
+embedded at build time and follows the conventions described at
+https://go.dev/ref/mod#versions.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			fmt.Printf("librarian version %s\n", Version())
 			return nil

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -29,8 +29,26 @@ import (
 func publishCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "publish",
-		Usage:     "publishes client libraries",
+		Usage:     "publish client libraries",
 		UsageText: "librarian publish",
+		Description: `publish releases the libraries that were updated in a release commit
+prepared by librarian bump.
+
+By default, publish performs a dry run that prints the actions it would
+take. Pass --execute to actually publish. By default, the most recent
+release commit reachable from HEAD is used; --release-commit overrides
+this with a specific commit.
+
+The --dry-run, --dry-run-keep-going, and --skip-semver-checks flags are
+only honored when the workspace language is Rust; they are retained for
+backwards compatibility with the legacy Rust release jobs and will be
+removed once Rust migrates to the unified flow.
+
+Examples:
+
+	librarian publish                          # dry run
+	librarian publish --execute                # publish for real
+	librarian publish --release-commit=<sha>   # publish a specific commit`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "execute",

--- a/internal/librarian/tag.go
+++ b/internal/librarian/tag.go
@@ -37,8 +37,25 @@ var (
 func tagCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "tag",
-		Usage:     "tags a release commit based on the libraries published",
+		Usage:     "tag a release commit based on the libraries published",
 		UsageText: "librarian tag",
+		Description: `tag creates git tags on a release commit, one tag per library that the
+commit released, using the tag_format declared for each library in
+librarian.yaml.
+
+Run tag after librarian publish has succeeded. By default, the most
+recent release commit reachable from HEAD is used; --release-commit
+overrides this with a specific commit.
+
+The --create-release-tag flag additionally creates a tag of the form
+release-<PR number>; this is used by the legacy release jobs and will be
+removed once those jobs are retired.
+
+Examples:
+
+	librarian tag
+	librarian tag --release-commit=<sha>
+	librarian tag --create-release-tag`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "release-commit",

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -41,8 +41,14 @@ var (
 func tidyCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "tidy",
-		Usage:     "format and validate librarian.yaml",
+		Usage:     "tidy and validate librarian.yaml",
 		UsageText: "librarian tidy",
+		Description: `tidy reads librarian.yaml, validates its contents, applies any
+language-specific defaults and normalization, and writes the file back
+with a canonical formatting.
+
+Run tidy after editing librarian.yaml by hand, or as a quick check that
+the configuration is well-formed.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {

--- a/internal/librarian/update.go
+++ b/internal/librarian/update.go
@@ -46,12 +46,30 @@ func updateCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "update",
 		Usage: "update sources to the latest version",
-		Description: `Supported sources are:
-  - conformance
-  - discovery
-  - googleapis
-  - protobuf
-  - showcase`,
+		Description: `update refreshes the upstream source repositories declared in
+librarian.yaml to their latest commits and updates the recorded commit
+SHAs in librarian.yaml accordingly.
+
+Each <source> names an upstream repository that librarian consumes:
+
+  - conformance: protocolbuffers/protobuf conformance tests
+  - discovery: googleapis/discovery-artifact-manager
+  - googleapis: googleapis/googleapis (the API definitions)
+  - protobuf: protocolbuffers/protobuf
+  - showcase: googleapis/gapic-showcase
+
+At least one source must be specified.
+
+Examples:
+
+	librarian update googleapis
+	librarian update googleapis protobuf
+
+A typical librarian workflow for regenerating every library against the
+latest API definitions is:
+
+	librarian update googleapis
+	librarian generate --all`,
 		UsageText: "librarian update <sources...>",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			args := cmd.Args().Slice()

--- a/tool/cmd/docgen/main.go
+++ b/tool/cmd/docgen/main.go
@@ -28,6 +28,8 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -390,7 +392,8 @@ func sentenceCase(s string) string {
 	if s == "" {
 		return s
 	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	r, size := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + s[size:]
 }
 
 func getCommandHelpText(command string) (string, error) {

--- a/tool/cmd/docgen/main.go
+++ b/tool/cmd/docgen/main.go
@@ -25,39 +25,34 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 )
 
 const (
-	librarianDesc = `Librarian CLI runs local workflow that 
-	adds, generates, updates and publishes client libraries.
+	librarianDesc = `Librarian manages Google Cloud client libraries. It runs a local workflow
+that onboards new APIs, generates client code, bumps versions, publishes
+releases, and tags release commits. Language-specific work, such as code
+generation, building, and testing, is delegated to per-language tooling.
+
+All behavior is driven by librarian.yaml at the root of the repository,
+whose schema is documented at
+https://github.com/googleapis/librarian/blob/main/doc/config-schema.md.
 
 Usage:
 
 	librarian <command> [arguments]
+
+Global flags:
+
+	--verbose, -v    enable verbose logging
 `
 	librarianopsDesc = `Librarianops orchestrates librarian operations across multiple repositories.
 
 Usage:
 
 	librarianops <command> [arguments]
-`
-	legacyLibrarianDesc = `Librarian manages Google API client libraries by automating onboarding,
-regeneration, and release. It runs language-agnostic workflows while
-delegating language-specific tasks—such as code generation, building, and
-testing—to Docker images.
-
-Usage:
-
-	librarian <command> [arguments]
-`
-	automationDesc = `Automation provides logic to trigger Cloud Build jobs that run Librarian commands for
-any repository listed in internal/legacylibrarian/legacyautomation/prod/repositories.yaml.
-
-Usage:
-
-	automation <command> [arguments]
 `
 
 	docTemplate = `// Copyright {{.Year}} Google LLC
@@ -77,48 +72,60 @@ Usage:
 //go:generate go run -tags docgen ../../tool/cmd/docgen -cmd .
 
 /*
-{{.Description}}
-
-The commands are:
-{{range .Commands}}{{template "command" .}}{{end}}
-*/
+{{.Description}}{{range .Commands}}{{template "command" .}}{{end}}*/
 package main
 
 {{define "command"}}
+# {{.Tagline}}
 
-# {{.Name}}
+Usage:
 
-{{.HelpText}}
-{{if .Commands}}
-{{range .Commands}}{{template "command" .}}{{end}}
-{{end}}
-{{end}}
+	{{.Usage}}
+{{if .Description}}
+{{.Description}}
+{{end}}{{if .Flags}}
+Flags:
+
+{{.Flags}}
+{{end}}{{if .AfterFlags}}
+{{.AfterFlags}}
+{{end}}{{if .Commands}}{{range .Commands}}{{template "command" .}}{{end}}{{end}}{{end}}
 `
 )
 
-// CommandDoc holds the documentation for a single CLI command.
+// CommandDoc holds the documentation for a single CLI command, parsed from
+// the urfave/cli "--help" output.
 type CommandDoc struct {
-	Name     string
-	HelpText string
-	Commands []CommandDoc
+	Name        string
+	Summary     string
+	Tagline     string
+	Usage       string
+	Description string
+	Flags       string
+	AfterFlags  string
+	Commands    []CommandDoc
 }
+
+// afterFlagsMarker, when it appears on its own line inside a command's
+// Description, splits the description: text above the marker stays in the
+// Description (rendered before Flags), text below moves to AfterFlags
+// (rendered after Flags). The marker itself is stripped from godoc output.
+const afterFlagsMarker = "[after-flags]"
 
 var (
 	descriptions = map[string]string{
-		"legacyautomation": automationDesc,
-		"legacylibrarian":  legacyLibrarianDesc,
-		"librarian":        librarianDesc,
-		"librarianops":     librarianopsDesc,
+		"librarian":    librarianDesc,
+		"librarianops": librarianopsDesc,
 	}
 
 	years = map[string]string{
-		"legacyautomation": "2025",
-		"legacylibrarian":  "2025",
-		"librarian":        "2026",
-		"librarianops":     "2026",
+		"librarian":    "2026",
+		"librarianops": "2026",
 	}
 
 	cmdPath = flag.String("cmd", "", "Path to the command to generate docs for (e.g., ../../cmd/librarian)")
+
+	sectionRE = regexp.MustCompile(`(?m)^([A-Z][A-Z ]*):\s*$`)
 )
 
 func main() {
@@ -194,7 +201,6 @@ func buildCommandDocs(parentCommand string) ([]CommandDoc, error) {
 		parentParts = strings.Fields(parentCommand)
 	}
 
-	// Get help text for parent to find subcommands.
 	args := []string{"run", "main.go"}
 	args = append(args, parentParts...)
 	cmd := exec.Command("go", args...)
@@ -206,7 +212,6 @@ func buildCommandDocs(parentCommand string) ([]CommandDoc, error) {
 
 	commandNames, err := extractCommandNames(out.Bytes())
 	if err != nil {
-		// Not an error, just means no subcommands.
 		return nil, nil
 	}
 
@@ -222,20 +227,170 @@ func buildCommandDocs(parentCommand string) ([]CommandDoc, error) {
 			return nil, fmt.Errorf("getting help text for command %s: %w", fullCommandName, err)
 		}
 
-		// Recurse.
 		subCommands, err := buildCommandDocs(fullCommandName)
 		if err != nil {
 			return nil, err
 		}
 
-		commands = append(commands, CommandDoc{
-			Name:     sanitize(fullCommandName),
-			HelpText: sanitize(helpText),
-			Commands: subCommands,
-		})
+		doc := parseHelp(helpText)
+		doc.Name = sanitize(fullCommandName)
+		doc.Commands = subCommands
+		commands = append(commands, doc)
 	}
 
 	return commands, nil
+}
+
+// parseHelp parses urfave/cli "--help" output into a CommandDoc, populating
+// Tagline, Usage, Description, and Flags. The expected input format is:
+//
+//	NAME:
+//	   <name> - <tagline>
+//
+//	USAGE:
+//	   <usage>
+//
+//	DESCRIPTION:
+//	   <description>
+//
+//	OPTIONS:
+//	   <flag>  <flag help>
+//
+//	GLOBAL OPTIONS:
+//	   <flag>  <flag help>
+//
+// GLOBAL OPTIONS are dropped (they are documented once at the package level).
+// The "--help, -h" flag is filtered out of OPTIONS.
+func parseHelp(help string) CommandDoc {
+	sections := splitSections(help)
+
+	var doc CommandDoc
+	if name, ok := sections["NAME"]; ok {
+		name = strings.TrimSpace(name)
+		if i := strings.Index(name, " - "); i >= 0 {
+			doc.Summary = strings.TrimSpace(name[i+3:])
+			doc.Tagline = sentenceCase(doc.Summary)
+		}
+	}
+	if u, ok := sections["USAGE"]; ok {
+		doc.Usage = strings.TrimSpace(u)
+	}
+	if d, ok := sections["DESCRIPTION"]; ok {
+		desc, after := splitAfterFlags(strings.TrimRight(dedent(d), "\n"))
+		doc.Description = sanitize(desc)
+		doc.AfterFlags = sanitize(after)
+	}
+	if o, ok := sections["OPTIONS"]; ok {
+		doc.Flags = filterFlags(o)
+	}
+	return doc
+}
+
+// splitSections splits urfave/cli help text into sections keyed by their
+// uppercase header (NAME, USAGE, DESCRIPTION, OPTIONS, GLOBAL OPTIONS).
+func splitSections(help string) map[string]string {
+	matches := sectionRE.FindAllStringIndex(help, -1)
+	sections := make(map[string]string, len(matches))
+	for i, m := range matches {
+		header := strings.TrimSpace(help[m[0]:m[1]])
+		header = strings.TrimSuffix(header, ":")
+		start := m[1]
+		end := len(help)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		sections[header] = help[start:end]
+	}
+	return sections
+}
+
+// splitAfterFlags splits a dedented description on a line that is exactly
+// afterFlagsMarker. Text before the marker is returned as the description;
+// text after the marker is returned as the after-flags content. If the
+// marker is absent, the whole input is returned as the description.
+func splitAfterFlags(desc string) (before, after string) {
+	lines := strings.Split(desc, "\n")
+	for i, l := range lines {
+		if strings.TrimSpace(l) == afterFlagsMarker {
+			before = strings.TrimRight(strings.Join(lines[:i], "\n"), "\n")
+			after = strings.TrimSpace(strings.Join(lines[i+1:], "\n"))
+			return
+		}
+	}
+	return desc, ""
+}
+
+// dedent strips the smallest common leading-whitespace prefix from every
+// non-blank line of s and trims surrounding blank lines.
+func dedent(s string) string {
+	lines := strings.Split(s, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	min := -1
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		i := 0
+		for i < len(l) && (l[i] == ' ' || l[i] == '\t') {
+			i++
+		}
+		if min == -1 || i < min {
+			min = i
+		}
+	}
+	if min <= 0 {
+		return strings.Join(lines, "\n")
+	}
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		if len(l) >= min {
+			out[i] = l[min:]
+		} else {
+			out[i] = l
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// filterFlags removes the help flag from an OPTIONS block, dedents, and
+// re-indents each remaining line with a single tab so godoc renders the
+// block as preformatted text.
+func filterFlags(opts string) string {
+	body := dedent(opts)
+	if body == "" {
+		return ""
+	}
+	var out []string
+	for _, l := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "--help") {
+			continue
+		}
+		out = append(out, "\t"+l)
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	return strings.Join(out, "\n")
+}
+
+// sentenceCase capitalizes the first letter of s.
+func sentenceCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 func getCommandHelpText(command string) (string, error) {
@@ -249,7 +404,6 @@ func getCommandHelpText(command string) (string, error) {
 	cmd.Stderr = &out
 	err := cmd.Run()
 	if err != nil {
-		// The help command also exits with status 1.
 		if out.Len() == 0 {
 			return "", fmt.Errorf("cmd.Run() for '%s --help' failed with %s\n%s", command, err, out.String())
 		}
@@ -260,7 +414,6 @@ func getCommandHelpText(command string) (string, error) {
 func extractCommandNames(helpText []byte) ([]string, error) {
 	ss := string(helpText)
 	var start int
-	// handle both legacy tool and urfave/cli/v3 style
 	headers := []string{"Commands:\n\n", "COMMANDS:\n"}
 	for _, header := range headers {
 		start = strings.Index(ss, header)
@@ -288,7 +441,6 @@ func extractCommandNames(helpText []byte) ([]string, error) {
 		fields := strings.Fields(line)
 		if len(fields) > 0 {
 			name := fields[0]
-			// Handle urfave/cli "help, h" style and filter out help command.
 			name = strings.TrimSuffix(name, ",")
 			if name == "help" || name == "h" {
 				continue

--- a/tool/cmd/docgen/main.go
+++ b/tool/cmd/docgen/main.go
@@ -269,6 +269,8 @@ func parseHelp(help string) CommandDoc {
 	var doc CommandDoc
 	if name, ok := sections["NAME"]; ok {
 		name = strings.TrimSpace(name)
+		// urfave/cli formats NAME as "<name> - <tagline>". Skip past the
+		// 3-byte " - " separator (i+3) to extract the tagline.
 		if i := strings.Index(name, " - "); i >= 0 {
 			doc.Summary = strings.TrimSpace(name[i+3:])
 			doc.Tagline = sentenceCase(doc.Summary)
@@ -353,11 +355,11 @@ func dedent(s string) string {
 	}
 	out := make([]string, len(lines))
 	for i, l := range lines {
-		if len(l) >= min {
-			out[i] = l[min:]
-		} else {
+		if len(l) < min {
 			out[i] = l
+			continue
 		}
+		out[i] = l[min:]
 	}
 	return strings.Join(out, "\n")
 }

--- a/tool/cmd/docgen/main_test.go
+++ b/tool/cmd/docgen/main_test.go
@@ -1,0 +1,427 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build docgen
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseHelp(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		help string
+		want CommandDoc
+	}{
+		{
+			name: "full help text",
+			help: `NAME:
+   librarian generate - generate client library code
+
+USAGE:
+   librarian generate [options]
+
+DESCRIPTION:
+   Generate runs the configured generator to produce client
+   library source code from API definitions.
+
+OPTIONS:
+   --api value   path to the API definition
+   --help, -h    show help
+
+GLOBAL OPTIONS:
+   --verbose, -v   enable verbose logging
+`,
+			want: CommandDoc{
+				Summary:     "generate client library code",
+				Tagline:     "Generate client library code",
+				Usage:       "librarian generate [options]",
+				Description: "Generate runs the configured generator to produce client\nlibrary source code from API definitions.",
+				Flags:       "\t--api value   path to the API definition",
+			},
+		},
+		{
+			name: "name and usage only",
+			help: `NAME:
+   librarian version - print the version
+
+USAGE:
+   librarian version
+`,
+			want: CommandDoc{
+				Summary: "print the version",
+				Tagline: "Print the version",
+				Usage:   "librarian version",
+			},
+		},
+		{
+			name: "description with after-flags marker",
+			help: `NAME:
+   librarian release - cut a release
+
+USAGE:
+   librarian release [options]
+
+DESCRIPTION:
+   Release tags release commits and publishes artifacts.
+
+   [after-flags]
+
+   See https://example.com/release for the full release process.
+`,
+			want: CommandDoc{
+				Summary:     "cut a release",
+				Tagline:     "Cut a release",
+				Usage:       "librarian release [options]",
+				Description: "Release tags release commits and publishes artifacts.",
+				AfterFlags:  "See https://example.com/release for the full release process.",
+			},
+		},
+		{
+			name: "description containing comment terminator",
+			help: `NAME:
+   librarian onboard - onboard a new API
+
+USAGE:
+   librarian onboard [options]
+
+DESCRIPTION:
+   Onboard reads API definitions from google/cloud/*/v1 and adds
+   them to librarian.yaml.
+`,
+			want: CommandDoc{
+				Summary:     "onboard a new API",
+				Tagline:     "Onboard a new API",
+				Usage:       "librarian onboard [options]",
+				Description: "Onboard reads API definitions from google/cloud/* /v1 and adds\nthem to librarian.yaml.",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := parseHelp(test.help)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSplitSections(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		help string
+		want map[string]string
+	}{
+		{
+			name: "all sections",
+			help: `NAME:
+   librarian generate - generate client library code
+
+USAGE:
+   librarian generate [options]
+
+DESCRIPTION:
+   generates code from API definitions
+
+OPTIONS:
+   --api value  path to the API
+
+GLOBAL OPTIONS:
+   --verbose, -v  enable verbose logging
+`,
+			want: map[string]string{
+				"NAME":           "\n   librarian generate - generate client library code\n\n",
+				"USAGE":          "\n   librarian generate [options]\n\n",
+				"DESCRIPTION":    "\n   generates code from API definitions\n\n",
+				"OPTIONS":        "\n   --api value  path to the API\n\n",
+				"GLOBAL OPTIONS": "\n   --verbose, -v  enable verbose logging\n",
+			},
+		},
+		{
+			name: "no headers",
+			help: "just some text\nwith no headers\n",
+			want: map[string]string{},
+		},
+		{
+			name: "single section",
+			help: `USAGE:
+   librarian generate [options]
+`,
+			want: map[string]string{
+				"USAGE": "\n   librarian generate [options]\n",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := splitSections(test.help)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSplitAfterFlags(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		desc       string
+		wantBefore string
+		wantAfter  string
+	}{
+		{
+			name:       "marker present",
+			desc:       "before text\n\n[after-flags]\n\nafter text",
+			wantBefore: "before text",
+			wantAfter:  "after text",
+		},
+		{
+			name:       "marker absent",
+			desc:       "just description text",
+			wantBefore: "just description text",
+			wantAfter:  "",
+		},
+		{
+			name:       "marker with surrounding whitespace",
+			desc:       "above\n   [after-flags]   \nbelow",
+			wantBefore: "above",
+			wantAfter:  "below",
+		},
+		{
+			name:       "marker only",
+			desc:       "[after-flags]",
+			wantBefore: "",
+			wantAfter:  "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotBefore, gotAfter := splitAfterFlags(test.desc)
+			if diff := cmp.Diff(test.wantBefore, gotBefore); diff != "" {
+				t.Errorf("before mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantAfter, gotAfter); diff != "" {
+				t.Errorf("after mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDedent(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "common indent stripped",
+			in:   "    hello\n    world",
+			want: "hello\nworld",
+		},
+		{
+			name: "trims surrounding blank lines",
+			in:   "\n\n   foo\n   bar\n\n",
+			want: "foo\nbar",
+		},
+		{
+			name: "all blank input",
+			in:   "\n\n   \n\n",
+			want: "",
+		},
+		{
+			name: "no common indent",
+			in:   "foo\n  bar",
+			want: "foo\n  bar",
+		},
+		{
+			name: "mixed indent uses smallest",
+			in:   "  foo\n      bar\n    baz",
+			want: "foo\n    bar\n  baz",
+		},
+		{
+			name: "blank lines ignored when finding min",
+			in:   "    foo\n\n    bar",
+			want: "foo\n\nbar",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := dedent(test.in)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFilterFlags(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		opts string
+		want string
+	}{
+		{
+			name: "removes help and indents with tab",
+			opts: "   --api value  path to the API\n   --help, -h   show help\n",
+			want: "\t--api value  path to the API",
+		},
+		{
+			name: "multiple non-help flags",
+			opts: "   --api value  path to the API\n   --out value  output dir\n",
+			want: "\t--api value  path to the API\n\t--out value  output dir",
+		},
+		{
+			name: "only help flag",
+			opts: "   --help, -h  show help\n",
+			want: "",
+		},
+		{
+			name: "empty input",
+			opts: "",
+			want: "",
+		},
+		{
+			name: "skips blank lines",
+			opts: "   --api value  do api\n\n   --out value  do out\n",
+			want: "\t--api value  do api\n\t--out value  do out",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := filterFlags(test.opts)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSentenceCase(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"lowercase", "hello", "Hello"},
+		{"already capital", "Hello", "Hello"},
+		{"single letter", "a", "A"},
+		{"with spaces", "hello world", "Hello world"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := sentenceCase(test.in)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"comment terminator", "see google/cloud/*/v1 for paths", "see google/cloud/* /v1 for paths"},
+		{"multiple terminators", "google/cloud/*/v1 and google/cloud/*/v2", "google/cloud/* /v1 and google/cloud/* /v2"},
+		{"no terminator", "no special chars", "no special chars"},
+		{"empty", "", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := sanitize(test.in)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractCommandNames(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		helpText string
+		want     []string
+		wantErr  bool
+	}{
+		{
+			name: "lowercase commands header",
+			helpText: `Usage: foo [options]
+
+Commands:
+
+  generate   Generate code
+  release    Cut a release
+  help       Show help
+
+Options:
+  --verbose
+`,
+			want: []string{"generate", "release"},
+		},
+		{
+			name: "uppercase commands header",
+			helpText: `NAME:
+   foo - do stuff
+
+COMMANDS:
+   generate  Generate code
+   release   Cut a release
+   h         alias for help
+
+GLOBAL OPTIONS:
+   --verbose
+`,
+			want: []string{"generate", "release"},
+		},
+		{
+			name:     "no commands header",
+			helpText: "Usage: foo\n\nOptions:\n  --verbose\n",
+			wantErr:  true,
+		},
+		{
+			name: "filters help and h",
+			helpText: `COMMANDS:
+   help   show help
+   h      alias
+
+`,
+			want: nil,
+		},
+		{
+			name: "trims trailing comma",
+			helpText: `COMMANDS:
+   generate, gen   Generate code
+
+`,
+			want: []string{"generate"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := extractCommandNames([]byte(test.helpText))
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/tool/cmd/docgen/main_test.go
+++ b/tool/cmd/docgen/main_test.go
@@ -166,6 +166,19 @@ GLOBAL OPTIONS:
 				"USAGE": "\n   librarian generate [options]\n",
 			},
 		},
+		{
+			name: "non-consecutive sections",
+			help: `USAGE:
+   librarian generate [options]
+
+OPTIONS:
+   --api value  path to the API
+`,
+			want: map[string]string{
+				"USAGE":   "\n   librarian generate [options]\n\n",
+				"OPTIONS": "\n   --api value  path to the API\n",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := splitSections(test.help)


### PR DESCRIPTION
Rewrite the help text for each librarian subcommand. Each command now has a Description with a short explanation, concrete examples, and references to related commands. Regenerate the cmd/librarian package docs from that help text.

Refactor tool/cmd/docgen to parse `--help` output into structured fields and render a more readable document instead of embedding the raw help text.

Freeze the help text for cmd/legacylibrarian and cmd/legacyautomation, since they use the same tool but expect a different format, and those tools are getting decomissioned. 

Update the documentation cmd/librarianops with docgen as well.

Fixes https://github.com/googleapis/librarian/issues/5638