### PR TITLE
refactor(.github): set all presubmit timeouts to 5 minutes

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -20,8 +20,7 @@ jobs:
   go-generate:
     runs-on: ubuntu-24.04
     # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
-    # With a cold cache, this presubmit maybe take a little longer.
-    timeout-minutes: 6
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   addlicense:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -28,12 +29,14 @@ jobs:
         run: go test -run TestAddLicense -count=1 .
   typos:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: crate-ci/typos@v1.45.0
   yamlfmt:
     runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -18,10 +18,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
-    # TODO(https://github.com/googleapis/librarian/issues/4593):
-    # gapic-generator-typescript installation takes over 4 minutes.
-    # Improve installation speed and revert timeout to 5 minutes.
-    timeout-minutes: 6
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian

--- a/.github/workflows/sidekick.yaml
+++ b/.github/workflows/sidekick.yaml
@@ -20,8 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
-    # With a cold cache, this presubmit maybe take a little longer.
-    timeout-minutes: 6
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian


### PR DESCRIPTION
Due to recent improvements, all presubmits now complete in under 5 minutes. Set timeout-minutes to 5 for all jobs to fail on future regressions.

Fixes https://github.com/googleapis/librarian/issues/5188