### PR TITLE
refactor(.github): add Swift to Rust & Sidekick job

### DIFF
--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tests and check coverage
         run: |
           go run ./tool/cmd/coverage \
-            $(go list ./... | grep -v -E 'internal/librarian/(dart|java|nodejs|python|rust)|internal/sidekick|internal/legacylibrarian')
+            $(go list ./... | grep -v -E 'internal/librarian/(dart|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     needs: [go-generate, legacylibrarian, test]

--- a/.github/workflows/sidekick.yaml
+++ b/.github/workflows/sidekick.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: Rust & Sidekick
+name: Sidekick (Rust, Swift)
 on: [push, pull_request, merge_group]
 permissions:
   contents: read
@@ -39,7 +39,7 @@ jobs:
           git --version
           tar --version
       - name: Run tests and check coverage
-        run: go run ./tool/cmd/coverage ./internal/sidekick/... ./internal/librarian/rust
+        run: go run ./tool/cmd/coverage ./internal/sidekick/... ./internal/librarian/rust ./internal/librarian/swift
   integration:
     runs-on: ubuntu-24.04
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Move presubmit checks for./internal/librarian/swift into the Rust & Sidekick CI file, since the majority of Swift logic lives in sidekick.