### PR TITLE
refactor(internal/sidekick/gcloud): allow nil overrides in Generate

### DIFF
--- a/internal/librarian/gcloud/generate.go
+++ b/internal/librarian/gcloud/generate.go
@@ -88,7 +88,7 @@ func generateAPI(api *config.API, googleapisDir, outDir string) error {
 	if err != nil {
 		return err
 	}
-	return sidekickgcloud.Generate(model, &provider.Config{}, outDir, baseModule)
+	return sidekickgcloud.Generate(model, nil, outDir, baseModule)
 }
 
 // collectProtos returns proto file paths under apiPath, relative to

--- a/internal/sidekick/gcloud/command_builder.go
+++ b/internal/sidekick/gcloud/command_builder.go
@@ -131,7 +131,7 @@ func (b *commandBuilder) async() *Async {
 }
 
 func (b *commandBuilder) hidden() bool {
-	if len(b.overrides.APIs) > 0 {
+	if b.overrides != nil && len(b.overrides.APIs) > 0 {
 		return b.overrides.APIs[0].RootIsHidden
 	}
 	// Default to hidden if no API overrides are provided.

--- a/internal/sidekick/gcloud/provider/config.go
+++ b/internal/sidekick/gcloud/provider/config.go
@@ -263,6 +263,9 @@ func FindFieldHelpTextRule(c *Config, fieldID string) *HelpTextRule {
 
 // APIVersion extracts the API version from the configuration.
 func APIVersion(c *Config) string {
+	if c == nil {
+		return ""
+	}
 	if len(c.APIs) > 0 {
 		return c.APIs[0].APIVersion
 	}


### PR DESCRIPTION
Generate previously assumed a non-nil *provider.Config and would panic otherwise. Add nil guards in commandBuilder.hidden and provider.APIVersion so a nil config is handled safely.