### PR TITLE
refactor(internal/sidekick/api): remove NewPathTemplate and NewPathSegment

### DIFF
--- a/internal/sample/api.go
+++ b/internal/sample/api.go
@@ -83,7 +83,7 @@ func MethodCreate() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("projects").
 						WithVariableNamed("project").
@@ -108,7 +108,7 @@ func MethodUpdate() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPatch,
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithVariableNamed("secret", "name"),
 					QueryParameters: map[string]bool{
@@ -132,7 +132,7 @@ func MethodAddSecretVersion() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("projects").
 						WithVariableNamed("project").
@@ -161,7 +161,7 @@ func MethodListSecretVersions() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("projects").
 						WithVariableNamed("parent").

--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -778,11 +778,6 @@ type PathVariable struct {
 	AllowReserved bool
 }
 
-// NewPathTemplate creates a new PathTemplate.
-func NewPathTemplate() *PathTemplate {
-	return &PathTemplate{}
-}
-
 // NewPathVariable creates a new path variable.
 func NewPathVariable(fields ...string) *PathVariable {
 	return &PathVariable{FieldPath: fields}
@@ -835,11 +830,6 @@ func (v *PathVariable) WithMatch() *PathVariable {
 func (v *PathVariable) WithAllowReserved() *PathVariable {
 	v.AllowReserved = true
 	return v
-}
-
-// NewPathSegment creates a new path segment.
-func NewPathSegment() *PathSegment {
-	return &PathSegment{}
 }
 
 // WithLiteral adds a literal to the path segment.

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -196,7 +196,7 @@ func TestRoutingInfoVariantTemplateAsString(t *testing.T) {
 }
 
 func TestPathTemplateBuilder(t *testing.T) {
-	got := NewPathTemplate().
+	got := (&PathTemplate{}).
 		WithLiteral("v1").
 		WithVariable(NewPathVariable("parent", "child").
 			WithLiteral("projects").

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -57,7 +57,7 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: standard resource reference",
 			serviceID: "any.service",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project"),
 			fields: []*Field{
 				{
@@ -74,7 +74,7 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: multiple resource references",
 			serviceID: "any.service",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("locations").WithVariableNamed("location"),
 			fields: []*Field{
@@ -97,7 +97,7 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: nested field reference",
 			serviceID: "any.service",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("parent", "project"),
 			fields: []*Field{
 				{
@@ -122,7 +122,7 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: complex variable pattern treated as full name",
 			serviceID: "any.service",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("v1").
 				WithVariable(NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch()),
 			fields: []*Field{
@@ -140,7 +140,7 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: crop trailing literals (API Keys keyString case)",
 			serviceID: "apikeys.googleapis.com",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("v2").
 				WithVariable(NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch().WithLiteral("keys").WithMatch()).
 				WithLiteral("keyString"),
@@ -179,7 +179,7 @@ func TestIdentifyTargetResources_NoMatch(t *testing.T) {
 		{
 			name:      "Explicit: missing reference returns nil",
 			serviceID: "any.service",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project"),
 			fields: []*Field{
 				{Name: "project", Typez: TypezString}, // No ResourceReference
@@ -188,7 +188,7 @@ func TestIdentifyTargetResources_NoMatch(t *testing.T) {
 		{
 			name:      "Explicit: partial reference returns nil",
 			serviceID: "any.service",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("glossaries").WithVariableNamed("glossary"),
 			fields: []*Field{
@@ -231,7 +231,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: standard infrastructure tokens",
 			serviceID: ".google.cloud.compute.v1.Instances", // eligible
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("locations").WithVariableNamed("location"),
 			fields: []*Field{
@@ -246,7 +246,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: learns custom tokens from GET methods",
 			serviceID: ".google.cloud.compute.v1.Instances", // eligible
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("zones").WithVariableNamed("zone").
 				WithLiteral("instances").WithVariableNamed("instance"),
@@ -256,7 +256,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "instance", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("projects").WithVariableNamed("project").
 					WithLiteral("zones").WithVariableNamed("zone").
 					WithLiteral("instances").WithVariableNamed("instance"),
@@ -269,7 +269,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: paths with standalone literals without variables (e.g. global)",
 			serviceID: ".google.cloud.compute.v1.BackendServices",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("global").
 				WithLiteral("backendServices").WithVariableNamed("backend_service"),
@@ -278,7 +278,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "backend_service", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("projects").WithVariableNamed("project").
 					WithLiteral("global").
 					WithLiteral("backendServices").WithVariableNamed("backend_service"),
@@ -291,7 +291,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: path with non-variable standalone literal",
 			serviceID: ".google.cloud.example.v1.Service",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("projects").
 				WithLiteral("xyz").
@@ -301,7 +301,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "foo", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("v1").
 					WithLiteral("projects").
 					WithLiteral("xyz").
@@ -316,7 +316,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: paths with un-grouped variable after version string",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("v1").WithVariableNamed("resource").
 				WithLiteral("children").WithVariableNamed("child"),
 			fields: []*Field{
@@ -324,7 +324,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "child", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("v1").WithVariableNamed("resource").
 					WithLiteral("children").WithVariableNamed("child"),
 			},
@@ -336,7 +336,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: valid compute path with version string",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("locations").WithVariableNamed("location"),
@@ -352,7 +352,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: stops at trailing action",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("zones").WithVariableNamed("zone").
 				WithLiteral("instances").WithVariableNamed("instance").
@@ -364,7 +364,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "action_id", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("projects").WithVariableNamed("project").
 					WithLiteral("zones").WithVariableNamed("zone").
 					WithLiteral("instances").WithVariableNamed("instance"),
@@ -377,7 +377,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: stops at unknown segment",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("unknown").WithVariableNamed("other").
 				WithLiteral("instances").WithVariableNamed("instance"),
@@ -387,7 +387,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "instance", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("projects").WithVariableNamed("project").
 					WithLiteral("zones").WithVariableNamed("zone").
 					WithLiteral("instances").WithVariableNamed("instance"),
@@ -400,7 +400,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: skips if input field missing",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project"),
 			fields: []*Field{}, // No fields
 			want:   nil,
@@ -408,7 +408,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: skips non-collection literal without 's'",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("metadata").WithVariableNamed("data"), // does not match fallback
 			fields: []*Field{
 				{Name: "data", Typez: TypezString},
@@ -418,7 +418,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: known custom resource after standalone literal",
 			serviceID: ".google.cloud.compute.v1.CrossSiteNetworks",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("global").
 				WithLiteral("crossSiteNetworks").WithVariableNamed("cross_site_network"),
@@ -427,7 +427,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "cross_site_network", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("projects").WithVariableNamed("project").
 					WithLiteral("global").
 					WithLiteral("crossSiteNetworks").WithVariableNamed("cross_site_network"),
@@ -440,7 +440,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: unknown custom resource falls back to parent",
 			serviceID: ".google.cloud.compute.v1.CrossSiteNetworks",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("projects").WithVariableNamed("project").
 				WithLiteral("global").
 				WithLiteral("crossSiteNetworks").WithVariableNamed("cross_site_network"),
@@ -449,7 +449,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "cross_site_network", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("projects").WithVariableNamed("project"),
 			},
 			want: &TargetResource{
@@ -460,7 +460,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: multiple standalone literals before known resource",
 			serviceID: ".google.cloud.compute.v1.FirewallPolicies",
-			path: NewPathTemplate().
+			path: (&PathTemplate{}).
 				WithLiteral("locations").
 				WithLiteral("global").
 				WithLiteral("firewallPolicies").WithVariableNamed("resource"),
@@ -468,7 +468,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "resource", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				NewPathTemplate().
+				(&PathTemplate{}).
 					WithLiteral("locations").
 					WithLiteral("global").
 					WithLiteral("firewallPolicies").WithVariableNamed("resource"),
@@ -510,7 +510,7 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 func TestIdentifyTargetResources_HeuristicsDisabled(t *testing.T) {
 	// A setup that would normally match the heuristics
 	serviceID := ".google.cloud.compute.v1.Instances"
-	path := NewPathTemplate().
+	path := (&PathTemplate{}).
 		WithLiteral("projects").WithVariableNamed("project").
 		WithLiteral("locations").WithVariableNamed("location")
 	fields := []*Field{

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -37,7 +37,7 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: NewPathTemplate().
+										PathTemplate: (&PathTemplate{}).
 											WithLiteral("users").WithVariableNamed("user").
 											WithLiteral("widgets").WithVariableNamed("widget"),
 									},
@@ -68,7 +68,7 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: NewPathTemplate().
+										PathTemplate: (&PathTemplate{}).
 											WithLiteral("internal").WithVariableNamed("id"),
 									},
 								},
@@ -96,7 +96,7 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: NewPathTemplate().
+										PathTemplate: (&PathTemplate{}).
 											WithLiteral("internal").WithVariableNamed("id"),
 									},
 								},
@@ -124,7 +124,7 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: NewPathTemplate().
+										PathTemplate: (&PathTemplate{}).
 											WithLiteral("v1").
 											WithVariable(&PathVariable{
 												FieldPath: []string{"name"},

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -1788,11 +1788,11 @@ func TestFlatPath(t *testing.T) {
 		Want  string
 	}{
 		{
-			Input: NewPathTemplate(),
+			Input: (&PathTemplate{}),
 			Want:  "",
 		},
 		{
-			Input: NewPathTemplate().
+			Input: (&PathTemplate{}).
 				WithLiteral("projects").
 				WithVariableNamed("project").
 				WithLiteral("zones").
@@ -1800,7 +1800,7 @@ func TestFlatPath(t *testing.T) {
 			Want: "projects/{project}/zones/{zone}",
 		},
 		{
-			Input: NewPathTemplate().
+			Input: (&PathTemplate{}).
 				WithLiteral("projects").
 				WithVariableNamed("project").
 				WithLiteral("global").
@@ -1808,7 +1808,7 @@ func TestFlatPath(t *testing.T) {
 			Want: "projects/{project}/global/location",
 		},
 		{
-			Input: NewPathTemplate().
+			Input: (&PathTemplate{}).
 				WithLiteral("projects").
 				WithVariable(NewPathVariable("a", "b", "c").WithMatchRecursive()),
 			Want: "projects/{a.b.c}",

--- a/internal/sidekick/gcloud/argument_builder_test.go
+++ b/internal/sidekick/gcloud/argument_builder_test.go
@@ -29,7 +29,7 @@ func TestNewArgument(t *testing.T) {
 			{
 				Type: "test.googleapis.com/Network",
 				Patterns: []api.ResourcePattern{
-					{*api.NewPathSegment().WithLiteral("projects"), *api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()), *api.NewPathSegment().WithLiteral("networks"), *api.NewPathSegment().WithVariable(api.NewPathVariable("network").WithMatch())},
+					{*(&api.PathSegment{}).WithLiteral("projects"), *(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()), *(&api.PathSegment{}).WithLiteral("networks"), *(&api.PathSegment{}).WithVariable(api.NewPathVariable("network").WithMatch())},
 				},
 			},
 		},
@@ -293,10 +293,10 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 								Plural:   "things",
 								Patterns: []api.ResourcePattern{
 									{
-										*api.NewPathSegment().WithLiteral("projects"),
-										*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-										*api.NewPathSegment().WithLiteral("things"),
-										*api.NewPathSegment().WithVariable(api.NewPathVariable("thing").WithMatch()),
+										*(&api.PathSegment{}).WithLiteral("projects"),
+										*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+										*(&api.PathSegment{}).WithLiteral("things"),
+										*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
 									},
 								},
 							}),
@@ -312,10 +312,10 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 					Plural:   "things",
 					Patterns: []api.ResourcePattern{
 						{
-							*api.NewPathSegment().WithLiteral("projects"),
-							*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-							*api.NewPathSegment().WithLiteral("things"),
-							*api.NewPathSegment().WithVariable(api.NewPathVariable("thing").WithMatch()),
+							*(&api.PathSegment{}).WithLiteral("projects"),
+							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+							*(&api.PathSegment{}).WithLiteral("things"),
+							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
 						},
 					},
 				},
@@ -365,10 +365,10 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 					Plural:   "things",
 					Patterns: []api.ResourcePattern{
 						{
-							*api.NewPathSegment().WithLiteral("projects"),
-							*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-							*api.NewPathSegment().WithLiteral("things"),
-							*api.NewPathSegment().WithVariable(api.NewPathVariable("thing").WithMatch()),
+							*(&api.PathSegment{}).WithLiteral("projects"),
+							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+							*(&api.PathSegment{}).WithLiteral("things"),
+							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
 						},
 					},
 				},
@@ -418,10 +418,10 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 					Plural:   "things",
 					Patterns: []api.ResourcePattern{
 						{
-							*api.NewPathSegment().WithLiteral("projects"),
-							*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-							*api.NewPathSegment().WithLiteral("things"),
-							*api.NewPathSegment().WithVariable(api.NewPathVariable("thing").WithMatch()),
+							*(&api.PathSegment{}).WithLiteral("projects"),
+							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+							*(&api.PathSegment{}).WithLiteral("things"),
+							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
 						},
 					},
 				},
@@ -533,10 +533,10 @@ func TestNewResourceReferenceSpec(t *testing.T) {
 				Type: "test.googleapis.com/OtherThing",
 				Patterns: []api.ResourcePattern{
 					{
-						*api.NewPathSegment().WithLiteral("projects"),
-						*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-						*api.NewPathSegment().WithLiteral("otherThings"),
-						*api.NewPathSegment().WithVariable(api.NewPathVariable("other_thing").WithMatch()),
+						*(&api.PathSegment{}).WithLiteral("projects"),
+						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+						*(&api.PathSegment{}).WithLiteral("otherThings"),
+						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("other_thing").WithMatch()),
 					},
 				},
 			},

--- a/internal/sidekick/gcloud/command_builder_test.go
+++ b/internal/sidekick/gcloud/command_builder_test.go
@@ -96,21 +96,21 @@ func TestRequestMethod(t *testing.T) {
 		{
 			name: "Standard Create",
 			method: api.NewTestMethod("CreateThing").WithVerb("POST").WithPathTemplate(
-				api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
+				(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
 			),
 			want: "",
 		},
 		{
 			name: "Custom Method with Verb",
 			method: api.NewTestMethod("ImportData").WithVerb("POST").WithPathTemplate(
-				api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()).WithVerb("importData"),
+				(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()).WithVerb("importData"),
 			),
 			want: "importData",
 		},
 		{
 			name: "Custom Method without Verb (fallback to camelCase name)",
 			method: api.NewTestMethod("ExportData").WithVerb("POST").WithPathTemplate(
-				api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()),
+				(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()),
 			),
 			want: "exportData",
 		},
@@ -168,7 +168,7 @@ func TestAsync(t *testing.T) {
 			name: "Create returns Resource",
 			method: func() *api.Method {
 				m := api.NewTestMethod("CreateThing").WithVerb("POST").WithPathTemplate(
-					api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
+					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
 				).WithInput(
 					api.NewTestMessage("CreateRequest").WithFields(
 						api.NewTestField("thing").WithType(api.TypezMessage).WithMessageType(
@@ -188,7 +188,7 @@ func TestAsync(t *testing.T) {
 			name: "Delete returns Empty",
 			method: func() *api.Method {
 				m := api.NewTestMethod("DeleteThing").WithVerb("DELETE").WithPathTemplate(
-					api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("things").WithMatch()),
+					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("things").WithMatch()),
 				)
 				m.OperationInfo = &api.OperationInfo{ResponseTypeID: ".google.protobuf.Empty"}
 				return m
@@ -202,7 +202,7 @@ func TestAsync(t *testing.T) {
 			name: "Unrelated Response Type returns False",
 			method: func() *api.Method {
 				m := api.NewTestMethod("CreateThing").WithVerb("POST").WithPathTemplate(
-					api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
+					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
 				).WithInput(
 					api.NewTestMessage("CreateRequest").WithFields(
 						api.NewTestField("thing").WithType(api.TypezMessage).WithMessageType(
@@ -223,7 +223,7 @@ func TestAsync(t *testing.T) {
 			name: "Method Without Resource Returns Base Async",
 			method: func() *api.Method {
 				m := api.NewTestMethod("CustomMethod").WithVerb("POST").WithPathTemplate(
-					api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()).WithLiteral("things").WithVerb("doAction"),
+					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()).WithLiteral("things").WithVerb("doAction"),
 				)
 				m.OperationInfo = &api.OperationInfo{ResponseTypeID: "ActionResponse"}
 				m.Service = service
@@ -363,7 +363,7 @@ func TestNewCommand(t *testing.T) {
 							),
 						),
 					)).
-					WithPathTemplate(api.NewPathTemplate().
+					WithPathTemplate((&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).
 						WithLiteral("things"))
@@ -394,7 +394,7 @@ func TestNewCommand(t *testing.T) {
 						),
 						api.NewTestField("update_mask").WithType(api.TypezMessage),
 					)).
-					WithPathTemplate(api.NewPathTemplate().
+					WithPathTemplate((&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithVariable(api.NewPathVariable("thing", "name").WithLiteral("projects").WithMatch().WithLiteral("things").WithMatch()))
 				m.ID = "google.cloud.test.v1.Service.UpdateThing"
@@ -431,7 +431,7 @@ func TestNewCommand(t *testing.T) {
 					WithInput(api.NewTestMessage("CreateRequest").WithFields(
 						api.NewTestField("thing_id").WithType(api.TypezString),
 					)).
-					WithPathTemplate(api.NewPathTemplate().
+					WithPathTemplate((&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).
 						WithLiteral("things"))
@@ -554,7 +554,7 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithMatch()),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithMatch()),
 						},
 					},
 				}
@@ -588,7 +588,7 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithMatch()),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithMatch()),
 						},
 					},
 				}
@@ -627,7 +627,7 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
 						},
 					},
 					BodyFieldPath: "*",
@@ -694,7 +694,7 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
 						},
 					},
 					BodyFieldPath: "*",
@@ -724,7 +724,7 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
 						},
 					},
 					BodyFieldPath: "*",
@@ -776,7 +776,7 @@ func TestCommandBuilderNewArgumentsDuplicatesError(t *testing.T) {
 	m.PathInfo = &api.PathInfo{
 		Bindings: []*api.PathBinding{
 			{
-				PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithMatch()),
+				PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithMatch()),
 			},
 		},
 		BodyFieldPath: "*",

--- a/internal/sidekick/gcloud/provider/method_test.go
+++ b/internal/sidekick/gcloud/provider/method_test.go
@@ -236,10 +236,10 @@ func TestIsResourceMethod(t *testing.T) {
 		{"Standard Get", api.NewTestMethod("GetInstance").WithVerb("GET"), true},
 		{"Standard List", api.NewTestMethod("ListInstances").WithVerb("GET"), false},
 		{"Custom Resource", api.NewTestMethod("CustomInstance").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithVariable(api.NewPathVariable("instance"))}},
+			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance"))}},
 		), true},
 		{"Custom Collection", api.NewTestMethod("CustomCollection").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithLiteral("instances")}},
+			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithLiteral("instances")}},
 		), false},
 		{"Nil PathInfo", &api.Method{Name: "CustomMethod", PathInfo: nil}, false},
 		{"Empty Bindings", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{}}}, false},
@@ -264,10 +264,10 @@ func TestIsCollectionMethod(t *testing.T) {
 		{"Standard Get", api.NewTestMethod("GetInstance").WithVerb("GET"), false},
 		{"Standard List", api.NewTestMethod("ListInstances").WithVerb("GET"), true},
 		{"Custom Resource", api.NewTestMethod("CustomInstance").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithVariable(api.NewPathVariable("instance"))}},
+			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance"))}},
 		), false},
 		{"Custom Collection", api.NewTestMethod("CustomCollection").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*api.NewPathSegment().WithLiteral("instances")}},
+			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithLiteral("instances")}},
 		), true},
 		{"Nil PathInfo", &api.Method{Name: "CustomMethod", PathInfo: nil}, false},
 		{"Empty Bindings", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{}}}, false},
@@ -313,9 +313,9 @@ func TestIsSingletonResourceMethod(t *testing.T) {
 				Type: "test.googleapis.com/Singleton",
 				Patterns: []api.ResourcePattern{
 					[]api.PathSegment{
-						*api.NewPathSegment().WithLiteral("projects"),
-						*api.NewPathSegment().WithVariable(api.NewPathVariable("project")),
-						*api.NewPathSegment().WithLiteral("singletonConfig"),
+						*(&api.PathSegment{}).WithLiteral("projects"),
+						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
+						*(&api.PathSegment{}).WithLiteral("singletonConfig"),
 					},
 				},
 			},
@@ -323,11 +323,11 @@ func TestIsSingletonResourceMethod(t *testing.T) {
 				Type: "test.googleapis.com/AdjacentLiterals",
 				Patterns: []api.ResourcePattern{
 					[]api.PathSegment{
-						*api.NewPathSegment().WithLiteral("projects"),
-						*api.NewPathSegment().WithVariable(api.NewPathVariable("project")),
-						*api.NewPathSegment().WithLiteral("literal1"),
-						*api.NewPathSegment().WithLiteral("literal2"),
-						*api.NewPathSegment().WithVariable(api.NewPathVariable("instance")),
+						*(&api.PathSegment{}).WithLiteral("projects"),
+						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
+						*(&api.PathSegment{}).WithLiteral("literal1"),
+						*(&api.PathSegment{}).WithLiteral("literal2"),
+						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance")),
 					},
 				},
 			},
@@ -335,10 +335,10 @@ func TestIsSingletonResourceMethod(t *testing.T) {
 				Type: "test.googleapis.com/Standard",
 				Patterns: []api.ResourcePattern{
 					[]api.PathSegment{
-						*api.NewPathSegment().WithLiteral("projects"),
-						*api.NewPathSegment().WithVariable(api.NewPathVariable("project")),
-						*api.NewPathSegment().WithLiteral("instances"),
-						*api.NewPathSegment().WithVariable(api.NewPathVariable("instance")),
+						*(&api.PathSegment{}).WithLiteral("projects"),
+						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
+						*(&api.PathSegment{}).WithLiteral("instances"),
+						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance")),
 					},
 				},
 			},

--- a/internal/sidekick/gcloud/provider/resource_test.go
+++ b/internal/sidekick/gcloud/provider/resource_test.go
@@ -41,9 +41,9 @@ func TestGetPluralFromSegments(t *testing.T) {
 		{
 			name: "No Variable End",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
+				*(&api.PathSegment{}).WithLiteral("projects"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("locations"),
 			},
 			want: "",
 		},
@@ -82,16 +82,16 @@ func TestGetParentFromSegments(t *testing.T) {
 		{
 			name: "Too Short",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
+				*(&api.PathSegment{}).WithLiteral("projects"),
 			},
 			want: nil,
 		},
 		{
 			name: "Invalid Pattern (Ends in Literal)",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
+				*(&api.PathSegment{}).WithLiteral("projects"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("locations"),
 			},
 			want: nil,
 		},
@@ -130,9 +130,9 @@ func TestGetSingularFromSegments(t *testing.T) {
 		{
 			name: "No Variable End",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
-				*api.NewPathSegment().WithLiteral("locations"),
+				*(&api.PathSegment{}).WithLiteral("projects"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("locations"),
 			},
 			want: "",
 		},
@@ -208,25 +208,25 @@ func TestExtractPathFromSegments(t *testing.T) {
 		{
 			name: "Complex Variable",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("v1"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch().WithLiteral("instances").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("v1"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch().WithLiteral("instances").WithMatch()),
 			},
 			want: "projects.locations.instances",
 		},
 		{
 			name: "Trailing Literal (List)",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("v1"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch()),
-				*api.NewPathSegment().WithLiteral("instances"),
+				*(&api.PathSegment{}).WithLiteral("v1"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("instances"),
 			},
 			want: "projects.locations.instances",
 		},
 		{
 			name: "No Version",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project")),
+				*(&api.PathSegment{}).WithLiteral("projects"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
 			},
 			want: "projects",
 		},
@@ -720,9 +720,9 @@ func parseResourcePattern(pattern string) []api.PathSegment {
 	for part := range strings.SplitSeq(pattern, "/") {
 		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
 			name := part[1 : len(part)-1]
-			segments = append(segments, *api.NewPathSegment().WithVariable(api.NewPathVariable(name).WithMatch()))
+			segments = append(segments, *(&api.PathSegment{}).WithVariable(api.NewPathVariable(name).WithMatch()))
 		} else {
-			segments = append(segments, *api.NewPathSegment().WithLiteral(part))
+			segments = append(segments, *(&api.PathSegment{}).WithLiteral(part))
 		}
 	}
 	return segments
@@ -747,8 +747,8 @@ func TestGetLiteralSegments(t *testing.T) {
 		{
 			name: "With Wildcards",
 			segments: []api.PathSegment{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("name").WithLiteral("foo").WithMatch().WithLiteral("bar")),
+				*(&api.PathSegment{}).WithLiteral("projects"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("name").WithLiteral("foo").WithMatch().WithLiteral("bar")),
 			},
 			want: []string{"projects", "foo", "bar"},
 		},

--- a/internal/sidekick/parser/discovery/lro_test.go
+++ b/internal/sidekick/parser/discovery/lro_test.go
@@ -44,7 +44,7 @@ func TestLroAnnotations(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("compute").
 						WithLiteral("v1").
 						WithLiteral("projects").
@@ -83,7 +83,7 @@ func TestLroAnnotations(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("compute").
 						WithLiteral("v1").
 						WithLiteral("projects").
@@ -130,7 +130,7 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("p").
 								WithVariableNamed("project").
 								WithLiteral("l").
@@ -150,7 +150,7 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("p").
 								WithVariableNamed("project").
 								WithLiteral("l").
@@ -176,7 +176,7 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("p").
 								WithVariableNamed("project").
 								WithLiteral("l").
@@ -196,7 +196,7 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("p").
 								WithVariableNamed("project").
 								WithLiteral("l").

--- a/internal/sidekick/parser/discovery/methods_test.go
+++ b/internal/sidekick/parser/discovery/methods_test.go
@@ -42,7 +42,7 @@ func TestMakeServiceMethods(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("compute").
 						WithLiteral("v1").
 						WithLiteral("projects").
@@ -80,7 +80,7 @@ func TestMakeServiceMethodsReturnsEmpty(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("compute").
 						WithLiteral("v1").
 						WithLiteral("projects").
@@ -121,7 +121,7 @@ func TestMakeServiceMethodsDeprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("compute").
 						WithLiteral("v1").
 						WithLiteral("projects").

--- a/internal/sidekick/parser/discovery/services_test.go
+++ b/internal/sidekick/parser/discovery/services_test.go
@@ -49,7 +49,7 @@ func TestService(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("compute").
 								WithLiteral("v1").
 								WithLiteral("projects").
@@ -72,7 +72,7 @@ func TestService(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("compute").
 								WithLiteral("v1").
 								WithLiteral("projects").

--- a/internal/sidekick/parser/discovery/uritemplate_test.go
+++ b/internal/sidekick/parser/discovery/uritemplate_test.go
@@ -27,27 +27,27 @@ func TestParseUriTemplateSuccess(t *testing.T) {
 		input string
 		want  *api.PathTemplate
 	}{
-		{"locations/global/firewallPolicies", api.NewPathTemplate().
+		{"locations/global/firewallPolicies", (&api.PathTemplate{}).
 			WithLiteral("locations").
 			WithLiteral("global").
 			WithLiteral("firewallPolicies")},
-		{"locations/global/operations/{operation}", api.NewPathTemplate().
+		{"locations/global/operations/{operation}", (&api.PathTemplate{}).
 			WithLiteral("locations").
 			WithLiteral("global").
 			WithLiteral("operations").
 			WithVariableNamed("operation")},
-		{"projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks", api.NewPathTemplate().
+		{"projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks", (&api.PathTemplate{}).
 			WithLiteral("projects").
 			WithVariableNamed("project").
 			WithLiteral("zones").
 			WithVariableNamed("zone").
 			WithVariableNamed("parentName").
 			WithLiteral("reservationSubBlocks")},
-		{"v1/{+parent}/externalAccountKeys", api.NewPathTemplate().
+		{"v1/{+parent}/externalAccountKeys", (&api.PathTemplate{}).
 			WithLiteral("v1").
 			WithVariable(api.NewPathVariable("parent").WithAllowReserved().WithMatchRecursive()).
 			WithLiteral("externalAccountKeys")},
-		{"dns/v1/{+resource}:getIamPolicy", api.NewPathTemplate().
+		{"dns/v1/{+resource}:getIamPolicy", (&api.PathTemplate{}).
 			WithLiteral("dns").
 			WithLiteral("v1").
 			WithVariable(api.NewPathVariable("resource").WithAllowReserved().WithMatchRecursive()).

--- a/internal/sidekick/parser/httprule/http_rule_parser.go
+++ b/internal/sidekick/parser/httprule/http_rule_parser.go
@@ -96,10 +96,10 @@ func ParseResourcePattern(pathTemplate string) (*api.PathTemplate, error) {
 	if strings.Contains(pathTemplate, "}.{") ||
 		strings.Contains(pathTemplate, "}~{") {
 		// TODO(https://github.com/googleapis/librarian/issues/3258): support non-standard separators in resource names... somehow.
-		return api.NewPathTemplate(), nil
+		return (&api.PathTemplate{}), nil
 	}
 	if pathTemplate == api.SingleSegmentWildcard {
-		return api.NewPathTemplate(), nil
+		return (&api.PathTemplate{}), nil
 	}
 	return parsePathTemplate("/" + pathTemplate)
 }

--- a/internal/sidekick/parser/httprule/http_rule_parser_test.go
+++ b/internal/sidekick/parser/httprule/http_rule_parser_test.go
@@ -28,31 +28,31 @@ func TestParseSegments(t *testing.T) {
 		want        *api.PathTemplate
 		explanation string
 	}{
-		{"/foo", api.NewPathTemplate().WithLiteral("foo"), ""},
-		{"/foo/bar", api.NewPathTemplate().WithLiteral("foo").WithLiteral("bar"), ""},
+		{"/foo", (&api.PathTemplate{}).WithLiteral("foo"), ""},
+		{"/foo/bar", (&api.PathTemplate{}).WithLiteral("foo").WithLiteral("bar"), ""},
 		{"/v1/*/foo", nil, "matchers only exist within a variable segment"},
 		{"/v1/**/foo", nil, "matchers only exist within a variable segment"},
-		{"/foo:bar", api.NewPathTemplate().WithLiteral("foo").WithVerb("bar"), ""},
-		{"/foo/{bar}", api.NewPathTemplate().WithLiteral("foo").WithVariableNamed("bar"), ""},
-		{"/foo/{bar.baz}", api.NewPathTemplate().WithLiteral("foo").WithVariableNamed("bar", "baz"), ""},
-		{"/foo/{bar=baz}", api.NewPathTemplate().WithLiteral("foo").WithVariable(
+		{"/foo:bar", (&api.PathTemplate{}).WithLiteral("foo").WithVerb("bar"), ""},
+		{"/foo/{bar}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar"), ""},
+		{"/foo/{bar.baz}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar", "baz"), ""},
+		{"/foo/{bar=baz}", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
 			api.NewPathVariable("bar").WithLiteral("baz")), ""},
-		{"/foo/{bar=*}", api.NewPathTemplate().WithLiteral("foo").WithVariable(
+		{"/foo/{bar=*}", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
 			api.NewPathVariable("bar").WithMatch()), ""},
-		{"/foo/{bar=*}/baz", api.NewPathTemplate().WithLiteral("foo").WithVariable(
+		{"/foo/{bar=*}/baz", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
 			api.NewPathVariable("bar").WithMatch()).
 			WithLiteral("baz"), ""},
-		{"/foo/{bar=**}/baz:qux", api.NewPathTemplate().WithLiteral("foo").WithVariable(
+		{"/foo/{bar=**}/baz:qux", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
 			api.NewPathVariable("bar").WithMatchRecursive()).
 			WithLiteral("baz").WithVerb("qux"), ""},
-		{"/foo/{bar=baz/*/qux/*}", api.NewPathTemplate().WithLiteral("foo").WithVariable(
+		{"/foo/{bar=baz/*/qux/*}", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
 			api.NewPathVariable("bar").WithLiteral("baz").WithMatch().WithLiteral("qux").WithMatch()), ""},
-		{"/foo/{bar}/{baz}/{qux}", api.NewPathTemplate().WithLiteral("foo").WithVariableNamed("bar").WithVariableNamed("baz").WithVariableNamed("qux"), ""},
+		{"/foo/{bar}/{baz}/{qux}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar").WithVariableNamed("baz").WithVariableNamed("qux"), ""},
 		{"foo", nil, "path must start with slash"},
 		{"/", nil, "path cannot end with slash"},
 		{"/foo/", nil, "path cannot end with slash"},
 		{"/foo/***/bar", nil, "wildcard literal cannot exceed two *, and * isn't allowed in a LITERAL"},
-		{"/%0f", api.NewPathTemplate().WithLiteral("%0f"), ""},
+		{"/%0f", (&api.PathTemplate{}).WithLiteral("%0f"), ""},
 		{"/%0z", nil, "bad percent encoding"},
 		{"/foo//bar", nil, "segment is too short"},
 		{"/foo/:", nil, "verb is too short"},
@@ -61,7 +61,7 @@ func TestParseSegments(t *testing.T) {
 		{"/foo/{.a}/bar", nil, "var identifier too short"},
 		{"/foo/{a=}/bar", nil, "var value too short"},
 		{"/foo/{9bar}", nil, "var identifier has bad first character"},
-		{"/foo/{bar9}", api.NewPathTemplate().WithLiteral("foo").WithVariableNamed("bar9"), ""},
+		{"/foo/{bar9}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar9"), ""},
 		{"/foo/{b&r}", nil, "var identifier has bad character"},
 		{"/foo/:bar", nil, "verb cannot come after slash"},
 		{"/foo:bar/baz", nil, "verb must be the last segment, and : isn't allowed in a LITERAL"},
@@ -157,14 +157,14 @@ func TestParseResourcePattern(t *testing.T) {
 		{
 			"single wildcard",
 			api.SingleSegmentWildcard,
-			api.NewPathTemplate(),
+			(&api.PathTemplate{}),
 			false,
 			"should parse a single wildcard as a literal segment",
 		},
 		{
 			"standard hierarchical pattern",
 			"projects/{project}/serviceAccounts/{service_account}",
-			api.NewPathTemplate().
+			(&api.PathTemplate{}).
 				WithLiteral("projects").
 				WithVariableNamed("project").
 				WithLiteral("serviceAccounts").

--- a/internal/sidekick/parser/openapi_test.go
+++ b/internal/sidekick/parser/openapi_test.go
@@ -730,7 +730,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("projects").
 						WithVariableNamed("project").
@@ -968,7 +968,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithLiteral("projects").
 								WithVariableNamed("project").
@@ -1188,7 +1188,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("projects").
 						WithVariableNamed("project").
@@ -1210,7 +1210,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("projects").
 						WithVariableNamed("project").

--- a/internal/sidekick/parser/protobuf_api_version_test.go
+++ b/internal/sidekick/parser/protobuf_api_version_test.go
@@ -56,7 +56,7 @@ func TestProtobuf_ApiVersion(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v7").
 								WithLiteral("thing"),
 							QueryParameters: map[string]bool{"parent": true}},
@@ -75,7 +75,7 @@ func TestProtobuf_ApiVersion(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v7").
 								WithLiteral("thing").
 								WithVerb("make"),

--- a/internal/sidekick/parser/protobuf_mixin_test.go
+++ b/internal/sidekick/parser/protobuf_mixin_test.go
@@ -80,7 +80,7 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithVariable(api.NewPathVariable("name").
 							WithLiteral("projects").
@@ -151,7 +151,7 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithVariable(api.NewPathVariable("resource").
 							WithLiteral("services").
@@ -228,7 +228,7 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v2").
 						WithVariable(api.NewPathVariable("name").
 							WithLiteral("operations").
@@ -316,7 +316,7 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v2").
 						WithVariable(api.NewPathVariable("name").
 							WithLiteral("operations").
@@ -401,7 +401,7 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithVariable(api.NewPathVariable("name").
 							WithLiteral("operations").

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -483,7 +483,7 @@ func TestProtobuf_Comments(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -902,7 +902,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("name").
 									WithLiteral("projects").
@@ -925,7 +925,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -948,7 +948,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "DELETE",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("name").
 									WithLiteral("projects").
@@ -981,7 +981,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("name").
 									WithLiteral("projects").
@@ -1038,7 +1038,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1061,7 +1061,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1159,7 +1159,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1187,7 +1187,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1215,7 +1215,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1243,7 +1243,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1271,7 +1271,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1299,7 +1299,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1320,7 +1320,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1341,7 +1341,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1362,7 +1362,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1383,7 +1383,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1508,7 +1508,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1534,7 +1534,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithVariable(api.NewPathVariable("parent").
 									WithLiteral("projects").
@@ -1560,7 +1560,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v2").
 								WithVariable(api.NewPathVariable("name").
 									WithLiteral("operations").
@@ -1885,10 +1885,10 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 			Type: "library.googleapis.com/Shelf",
 			Patterns: []api.ResourcePattern{
 				{
-					*api.NewPathSegment().WithLiteral("publishers"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("publisher").WithMatch()),
-					*api.NewPathSegment().WithLiteral("shelves"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("shelf").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("publishers"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("shelves"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
 				},
 			},
 		}
@@ -1912,12 +1912,12 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 			Type: "library.googleapis.com/Book",
 			Patterns: []api.ResourcePattern{
 				{
-					*api.NewPathSegment().WithLiteral("publishers"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("publisher").WithMatch()),
-					*api.NewPathSegment().WithLiteral("shelves"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("shelf").WithMatch()),
-					*api.NewPathSegment().WithLiteral("books"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("book").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("publishers"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("shelves"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("books"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("book").WithMatch()),
 				},
 			},
 			Plural:   "books",
@@ -1969,12 +1969,12 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 			Type: "library.googleapis.com/Book",
 			Patterns: []api.ResourcePattern{
 				{
-					*api.NewPathSegment().WithLiteral("publishers"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("publisher").WithMatch()),
-					*api.NewPathSegment().WithLiteral("shelves"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("shelf").WithMatch()),
-					*api.NewPathSegment().WithLiteral("books"),
-					*api.NewPathSegment().WithVariable(api.NewPathVariable("book").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("publishers"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("shelves"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
+					*(&api.PathSegment{}).WithLiteral("books"),
+					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("book").WithMatch()),
 				},
 			},
 			Plural:   "books",
@@ -2169,14 +2169,14 @@ func TestParseResourcePatterns(t *testing.T) {
 		}
 		want := []api.ResourcePattern{
 			{
-				*api.NewPathSegment().WithLiteral("publishers"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("publisher").WithMatch()),
-				*api.NewPathSegment().WithLiteral("shelves"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("shelf").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("publishers"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("shelves"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
 			},
 			{
-				*api.NewPathSegment().WithLiteral("projects"),
-				*api.NewPathSegment().WithVariable(api.NewPathVariable("project").WithMatch()),
+				*(&api.PathSegment{}).WithLiteral("projects"),
+				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
 			},
 		}
 		got, err := parseResourcePatterns(patterns)

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -217,7 +217,7 @@ func annotateMethodModel(t *testing.T) *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb:         "POST",
-					PathTemplate: api.NewPathTemplate(),
+					PathTemplate: &api.PathTemplate{},
 				},
 			},
 		},
@@ -233,7 +233,7 @@ func annotateMethodModel(t *testing.T) *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("projects").
 						WithVariableNamed("project").
 						WithLiteral("zones").
@@ -259,7 +259,7 @@ func annotateMethodModel(t *testing.T) *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb:         "GET",
-					PathTemplate: api.NewPathTemplate(),
+					PathTemplate: &api.PathTemplate{},
 				},
 			},
 		},
@@ -293,7 +293,7 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 			t.Fatalf("missing method %s", methodID)
 		}
 		if m.PathInfo != nil && len(m.PathInfo.Bindings) > 0 {
-			m.PathInfo.Bindings[0].PathTemplate = api.NewPathTemplate().
+			m.PathInfo.Bindings[0].PathTemplate = (&api.PathTemplate{}).
 				WithLiteral("projects").
 				WithVariableNamed("project").
 				WithLiteral("zones").
@@ -319,7 +319,7 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 	mSelf.PathInfo.Bindings = []*api.PathBinding{
 		{
 			Verb: "GET",
-			PathTemplate: api.NewPathTemplate().
+			PathTemplate: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("name"),
 			TargetResource: &api.TargetResource{
@@ -329,7 +329,7 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 		},
 		{
 			Verb: "GET",
-			PathTemplate: api.NewPathTemplate().
+			PathTemplate: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("projects").
 				WithVariableNamed("project").
@@ -344,7 +344,7 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 		},
 		{
 			Verb:         "GET",
-			PathTemplate: api.NewPathTemplate(),
+			PathTemplate: &api.PathTemplate{},
 		},
 	}
 
@@ -476,7 +476,7 @@ func TestFormatResourceNameTemplateFromPath(t *testing.T) {
 				},
 			},
 			binding: &api.PathBinding{
-				PathTemplate: api.NewPathTemplate().
+				PathTemplate: (&api.PathTemplate{}).
 					WithLiteral("compute").
 					WithLiteral("v1").
 					WithLiteral("projects").

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -291,7 +291,7 @@ func newTestAnnotateModelAPI() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:         "GET",
-							PathTemplate: api.NewPathTemplate().WithLiteral("resource"),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("resource"),
 						},
 					},
 				},
@@ -311,7 +311,7 @@ func newTestAnnotateModelAPI() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:         "GET",
-							PathTemplate: api.NewPathTemplate().WithLiteral("resource"),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("resource"),
 						},
 					},
 				},

--- a/internal/sidekick/rust/annotate_test.go
+++ b/internal/sidekick/rust/annotate_test.go
@@ -105,7 +105,7 @@ func serviceAnnotationsModel() *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("resource"),
 				},
@@ -122,7 +122,7 @@ func serviceAnnotationsModel() *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: api.NewPathTemplate().
+					PathTemplate: (&api.PathTemplate{}).
 						WithLiteral("v1").
 						WithLiteral("resource"),
 				},
@@ -1138,7 +1138,7 @@ func TestPathInfoAnnotations(t *testing.T) {
 	binding := func(verb string) *api.PathBinding {
 		return &api.PathBinding{
 			Verb: verb,
-			PathTemplate: api.NewPathTemplate().
+			PathTemplate: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("resource"),
 		}
@@ -1270,7 +1270,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 
 	b0 := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: api.NewPathTemplate().
+		PathTemplate: (&api.PathTemplate{}).
 			WithLiteral("v2").
 			WithVariable(api.NewPathVariable("name").
 				WithLiteral("projects").
@@ -1296,7 +1296,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 
 	b1 := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: api.NewPathTemplate().
+		PathTemplate: (&api.PathTemplate{}).
 			WithLiteral("v1").
 			WithLiteral("projects").
 			WithVariableNamed("project").
@@ -1328,7 +1328,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 	}
 	b2 := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: api.NewPathTemplate().
+		PathTemplate: (&api.PathTemplate{}).
 			WithLiteral("v1").
 			WithLiteral("projects").
 			WithVariableNamed("child", "project").
@@ -1360,7 +1360,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 	}
 	b3 := &api.PathBinding{
 		Verb: "GET",
-		PathTemplate: api.NewPathTemplate().
+		PathTemplate: (&api.PathTemplate{}).
 			WithLiteral("v2").
 			WithLiteral("foos"),
 		QueryParameters: map[string]bool{
@@ -1433,7 +1433,7 @@ func TestPathBindingAnnotationsDetailedTracing(t *testing.T) {
 	}
 	binding := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: api.NewPathTemplate().
+		PathTemplate: (&api.PathTemplate{}).
 			WithLiteral("v2").
 			WithVariable(api.NewPathVariable("name").
 				WithLiteral("projects").
@@ -1502,7 +1502,7 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 		}
 		binding := &api.PathBinding{
 			Verb: "GET",
-			PathTemplate: api.NewPathTemplate().
+			PathTemplate: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("machines").
 				WithVariable(api.NewPathVariable(test.FieldName).

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -1855,7 +1855,7 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithLiteral("foo"),
 						},
@@ -1880,7 +1880,7 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithLiteral("foo"),
 						},
@@ -1901,7 +1901,7 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: api.NewPathTemplate().
+							PathTemplate: (&api.PathTemplate{}).
 								WithLiteral("v1").
 								WithLiteral("thing"),
 						},
@@ -2191,19 +2191,19 @@ func TestPathFmt(t *testing.T) {
 	}{
 		{
 			"/v1/fixed",
-			api.NewPathTemplate().
+			(&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("fixed"),
 		},
 		{
 			"/v1/{}",
-			api.NewPathTemplate().
+			(&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("parent"),
 		},
 		{
 			"/v1/{}",
-			api.NewPathTemplate().
+			(&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariable(api.NewPathVariable("parent").
 					WithLiteral("projects").
@@ -2213,14 +2213,14 @@ func TestPathFmt(t *testing.T) {
 		},
 		{
 			"/v1/{}:action",
-			api.NewPathTemplate().
+			(&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("parent").
 				WithVerb("action"),
 		},
 		{
 			"/v1/projects/{}/locations/{}/secrets/{}:action",
-			api.NewPathTemplate().
+			(&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("projects").
 				WithVariableNamed("project").

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -49,7 +49,7 @@ func TestAnnotateMethod(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:         "GET",
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithLiteral("operations"),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("operations"),
 						},
 					},
 				},
@@ -70,7 +70,7 @@ func TestAnnotateMethod(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:         "POST",
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithLiteral("keys"),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("keys"),
 						},
 					},
 					BodyFieldPath: "key",
@@ -93,7 +93,7 @@ func TestAnnotateMethod(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:         "POST",
-							PathTemplate: api.NewPathTemplate().WithLiteral("v1").WithLiteral("data"),
+							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("data"),
 						},
 					},
 					BodyFieldPath: "*",
@@ -116,7 +116,7 @@ func TestAnnotateMethod(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:            "GET",
-							PathTemplate:    api.NewPathTemplate().WithLiteral("v1").WithLiteral("things"),
+							PathTemplate:    (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("things"),
 							QueryParameters: map[string]bool{"key": true},
 						},
 					},

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -29,21 +29,21 @@ func TestPathExpression(t *testing.T) {
 	}{
 		{
 			name: "literals only",
-			template: api.NewPathTemplate().
+			template: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("operations"),
 			want: "/v1/operations",
 		},
 		{
 			name: "with variable",
-			template: api.NewPathTemplate().
+			template: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("name"),
 			want: "/v1/\\(pathVariable0)",
 		},
 		{
 			name: "with multiple variables",
-			template: api.NewPathTemplate().
+			template: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("name").WithLiteral("separator").WithVariableNamed("second"),
 			want: "/v1/\\(pathVariable0)/separator/\\(pathVariable1)",
@@ -91,12 +91,12 @@ func TestPathVariables(t *testing.T) {
 	}{
 		{
 			name:     "no variables",
-			template: api.NewPathTemplate().WithLiteral("v1"),
+			template: (&api.PathTemplate{}).WithLiteral("v1"),
 			want:     nil,
 		},
 		{
 			name: "one variable",
-			template: api.NewPathTemplate().
+			template: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("name"),
 			want: []*pathVariable{
@@ -110,7 +110,7 @@ func TestPathVariables(t *testing.T) {
 		},
 		{
 			name: "two variables",
-			template: api.NewPathTemplate().
+			template: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("name").
 				WithLiteral("sep").
@@ -132,7 +132,7 @@ func TestPathVariables(t *testing.T) {
 		},
 		{
 			name: "error - lookup field missing",
-			template: api.NewPathTemplate().
+			template: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("missing"),
 			wantErr: true,

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -212,7 +212,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 	}{
 		{
 			name: "Nested",
-			path: api.NewPathTemplate().
+			path: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("secret", "name"),
 			wantBlock: `let path = try { () throws -> String in
@@ -224,7 +224,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 		},
 		{
 			name: "Plain",
-			path: api.NewPathTemplate().
+			path: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("name"),
 			wantBlock: `let path = try { () throws -> String in
@@ -236,7 +236,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 		},
 		{
 			name: "Multiple strings",
-			path: api.NewPathTemplate().
+			path: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithLiteral("projects").
 				WithVariableNamed("project").


### PR DESCRIPTION
NewPathTemplate and NewPathSegment returned the zero value of their type and existed only as the start of a builder chain. Delete them and use &api.PathTemplate{} or &api.PathSegment{} directly. 

This is also helps setup a future refactor of the PathTemplate API to construct the structs directly instead of using builder patterns.