### PR TITLE
refactor(.github): move Go tests into its own workflow

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,12 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: Golang
+name: Go
 on: [push, pull_request, merge_group]
 permissions:
   contents: read
   issues: write
 jobs:
+  test:
+    runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-librarian
+      - name: Run tests
+        run: go run ./tool/cmd/coverage ./internal/librarian/golang
   integration:
     runs-on: ubuntu-24.04
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/librarian.yaml
+++ b/.github/workflows/librarian.yaml
@@ -53,9 +53,10 @@ jobs:
         run: |
           go run ./cmd/librarian install go
       - name: Run tests and check coverage
+        # TODO(https://github.com/googleapis/librarian/issues/4664): raise to 80.
         run: |
-          go run ./tool/cmd/coverage \
-            $(go list ./... | grep -v -E 'internal/librarian/(dart|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian')
+          go run ./tool/cmd/coverage -target=79 \
+            $(go list ./... | grep -v -E 'internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     needs: [go-generate, legacylibrarian, test]

--- a/tool/cmd/coverage/main.go
+++ b/tool/cmd/coverage/main.go
@@ -17,16 +17,18 @@
 //
 // Usage:
 //
-//	coverage <packages...>
+//	coverage [-target=N] <packages...>
 //
 // It runs "go test -race -coverprofile -covermode=atomic" on the given
 // packages, then uses "go tool cover -func" to extract the total coverage
 // percentage and compares it against the target for the component. The
 // default target is 80%. Components with a different target are listed below.
+// The -target flag overrides both the default and per-component targets.
 package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -48,11 +50,21 @@ var targets = map[string]float64{
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatalf("usage: coverage <packages...>")
+	targetFlag := flag.Float64("target", 0, "override coverage target (0 means use per-package default)")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "usage: coverage [-target=N] <packages...>\n")
+		flag.PrintDefaults()
 	}
-	pkgs := os.Args[1:]
-	target := targetFor(pkgs)
+	flag.Parse()
+	pkgs := flag.Args()
+	if len(pkgs) == 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	target := *targetFlag
+	if target == 0 {
+		target = targetFor(pkgs)
+	}
 	ctx := context.Background()
 	if err := runTests(ctx, pkgs); err != nil {
 		log.Fatalf("go test: %v", err)


### PR DESCRIPTION
Move all internal/librarian/golang tests to go.yaml so google-cloud-go related tests are consolidated in one workflow.

This lowers librarian.yaml coverage below 80%, so add a -target flag to tool/cmd/coverage and temporarily set the threshold to 79%.