### PR TITLE
feat(internal/librarian): sync new Python libs to legacylibrarian state

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -76,7 +76,7 @@ func runAdd(ctx context.Context, cfg *config.Config, apis ...string) error {
 	if err != nil {
 		return err
 	}
-	if cfg.Language == config.LanguageGo {
+	if cfg.Language == config.LanguageGo || cfg.Language == config.LanguagePython {
 		// TODO(https://github.com/googleapis/librarian/issues/5029): Remove this function after
 		// fully migrating off legacylibrarian.
 		if err := syncToStateYAML(".", cfg); err != nil {
@@ -249,7 +249,7 @@ func syncToStateYAML(repoDir string, cfg *config.Config) error {
 		legacyLib := state.LibraryByID(lib.Name)
 		if legacyLib == nil {
 			// Add a new library
-			state.Libraries = append(state.Libraries, createLegacyLibrary(lib))
+			state.Libraries = append(state.Libraries, createLegacyLibrary(cfg.Language, lib))
 			continue
 		}
 		existingAPIs := make(map[string]bool)
@@ -268,12 +268,12 @@ func syncToStateYAML(repoDir string, cfg *config.Config) error {
 	return yaml.Write(stateFile, state)
 }
 
-func createLegacyLibrary(lib *config.Library) *legacyconfig.LibraryState {
+func createLegacyLibrary(language string, lib *config.Library) *legacyconfig.LibraryState {
 	libAPIs := make([]*legacyconfig.API, 0, len(lib.APIs))
 	for _, api := range lib.APIs {
 		libAPIs = append(libAPIs, &legacyconfig.API{Path: api.Path})
 	}
-	return &legacyconfig.LibraryState{
+	legacyLib := &legacyconfig.LibraryState{
 		ID:      lib.Name,
 		Version: lib.Version,
 		APIs:    libAPIs,
@@ -286,4 +286,25 @@ func createLegacyLibrary(lib *config.Library) *legacyconfig.LibraryState {
 		},
 		TagFormat: "{id}/v{version}",
 	}
+	switch language {
+	case config.LanguageGo:
+		legacyLib.SourceRoots = []string{
+			lib.Name,
+			fmt.Sprintf("internal/generated/snippets/%s", lib.Name),
+		}
+		legacyLib.ReleaseExcludePaths = []string{
+			fmt.Sprintf("internal/generated/snippets/%s/", lib.Name),
+		}
+		legacyLib.TagFormat = "{id}/v{version}"
+	case config.LanguagePython:
+		legacyLib.SourceRoots = []string{
+			fmt.Sprintf("packages/%s", lib.Name),
+		}
+		legacyLib.ReleaseExcludePaths = []string{
+			fmt.Sprintf("packages/%s/.repo-metadata.json", lib.Name),
+			fmt.Sprintf("packages/%s/docs/README.rst", lib.Name),
+		}
+		legacyLib.TagFormat = "{id}-v{version}"
+	}
+	return legacyLib
 }

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -574,7 +574,7 @@ func TestSyncToStateYAML(t *testing.T) {
 		wantState    *legacyconfig.LibrarianState
 	}{
 		{
-			name: "sync new library",
+			name: "sync new library (go)",
 			initialState: &legacyconfig.LibrarianState{
 				Image: "gcr.io/my-image:latest",
 				Libraries: []*legacyconfig.LibraryState{
@@ -589,7 +589,7 @@ func TestSyncToStateYAML(t *testing.T) {
 				},
 			},
 			cfg: &config.Config{
-				Language: config.LanguageRust,
+				Language: config.LanguageGo,
 				Libraries: []*config.Library{
 					{
 						Name:    "existing",
@@ -632,12 +632,74 @@ func TestSyncToStateYAML(t *testing.T) {
 			},
 		},
 		{
+			name: "sync new library (python)",
+			initialState: &legacyconfig.LibrarianState{
+				Image: "gcr.io/my-image:latest",
+				Libraries: []*legacyconfig.LibraryState{
+					{
+						ID:            "google-cloud-existing",
+						Version:       "1.2.3",
+						PreserveRegex: []string{},
+						RemoveRegex:   []string{},
+						APIs:          []*legacyconfig.API{{Path: "google/cloud/existing/v1"}},
+						SourceRoots:   []string{"packages/existing"},
+					},
+				},
+			},
+			cfg: &config.Config{
+				Language: config.LanguagePython,
+				Libraries: []*config.Library{
+					{
+						Name:    "google-cloud-existing",
+						Version: "1.2.3",
+						APIs: []*config.API{
+							{Path: "google/cloud/existing/v1"},
+						},
+					},
+					{
+						Name:    "google-cloud-new",
+						Version: "0.1.0",
+						APIs: []*config.API{
+							{Path: "google/cloud/new/v1"},
+						},
+					},
+				},
+			},
+			wantState: &legacyconfig.LibrarianState{
+				Image: "gcr.io/my-image:latest",
+				Libraries: []*legacyconfig.LibraryState{
+					{
+						ID:            "google-cloud-existing",
+						Version:       "1.2.3",
+						PreserveRegex: []string{},
+						RemoveRegex:   []string{},
+						APIs:          []*legacyconfig.API{{Path: "google/cloud/existing/v1"}},
+						SourceRoots:   []string{"packages/existing"},
+					},
+					{
+						ID:            "google-cloud-new",
+						Version:       "0.1.0",
+						PreserveRegex: []string{},
+						RemoveRegex:   []string{},
+						APIs:          []*legacyconfig.API{{Path: "google/cloud/new/v1"}},
+						SourceRoots:   []string{"packages/google-cloud-new"},
+						ReleaseExcludePaths: []string{
+							"packages/google-cloud-new/.repo-metadata.json",
+							"packages/google-cloud-new/docs/README.rst",
+						},
+						TagFormat: "{id}-v{version}",
+					},
+				},
+			},
+		},
+		{
 			name: "multiple new libraries",
 			initialState: &legacyconfig.LibrarianState{
 				Image:     "gcr.io/my-image:latest",
 				Libraries: []*legacyconfig.LibraryState{},
 			},
 			cfg: &config.Config{
+				Language: config.LanguageGo,
 				Libraries: []*config.Library{
 					{Name: "lib-b", Version: "1.0.0", APIs: []*config.API{{Path: "google/cloud/lib-b/v1"}}},
 					{Name: "lib-a", Version: "2.0.0", APIs: []*config.API{{Path: "google/cloud/lib-a/v1"}}},
@@ -695,6 +757,7 @@ func TestSyncToStateYAML(t *testing.T) {
 				},
 			},
 			cfg: &config.Config{
+				Language: config.LanguageGo,
 				Libraries: []*config.Library{
 					{Name: "lib-b", Version: "1.0.0", APIs: []*config.API{{Path: "google/cloud/lib-b/v1"}}},
 					{Name: "lib-a", Version: "2.0.0", APIs: []*config.API{{Path: "google/cloud/lib-a/v1"}}},
@@ -741,6 +804,7 @@ func TestSyncToStateYAML(t *testing.T) {
 				},
 			},
 			cfg: &config.Config{
+				Language: config.LanguageGo,
 				Libraries: []*config.Library{
 					{
 						Name:    "lib-a",


### PR DESCRIPTION
Python libraries are released by legacylibrarian, so new libraries need to be persisted in the legacy .librarian/state.yaml file. This matches the Go behavior, but the individual library state for Python needs different defaults for source directory, tags etc, so the language is passed down when creating the legacy library.

Fixes #5653