### PR TITLE
feat(internal/librarian/python): enable adding API paths to a library

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -169,7 +169,7 @@ func addLibrary(cfg *config.Config, apis ...string) (string, *config.Config, err
 		return addPreviewLibrary(cfg, existingLib, paths, name)
 	}
 	if exists {
-		if cfg.Language != config.LanguageGo {
+		if cfg.Language != config.LanguageGo && cfg.Language != config.LanguagePython {
 			return "", nil, fmt.Errorf("%w: %s", errLibraryAlreadyExists, name)
 		}
 		return updateExistingLibrary(cfg, existingLib, paths)
@@ -232,6 +232,11 @@ func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, apis
 	for _, api := range apis {
 		if slices.ContainsFunc(existingLib.APIs, func(a *config.API) bool { return api.Path == a.Path }) {
 			return "", nil, fmt.Errorf("%w: %s in library %s", errAPIAlreadyExists, api.Path, existingLib.Name)
+		}
+	}
+	if cfg.Language == config.LanguagePython {
+		if err := python.ValidateNewAPIs(existingLib); err != nil {
+			return "", nil, err
 		}
 	}
 	existingLib.APIs = append(existingLib.APIs, apis...)

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -338,7 +338,7 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 							{Path: "google/cloud/kms/v1"},
 						},
 						Python: &config.PythonPackage{
-							DefaultVersion: "v1beta2",
+							DefaultVersion: "v1",
 						},
 					},
 				},
@@ -355,7 +355,7 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 							{Path: "google/cloud/kms/v1beta2"},
 						},
 						Python: &config.PythonPackage{
-							DefaultVersion: "v1beta2",
+							DefaultVersion: "v1",
 						},
 					},
 				},

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -296,7 +296,7 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 		wantCfg  *config.Config
 	}{
 		{
-			name: "update existing library",
+			name: "update existing library (go)",
 			apis: []string{"google/cloud/secretmanager/v1beta2"},
 			cfg: &config.Config{
 				Language: config.LanguageGo,
@@ -320,6 +320,42 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 						APIs: []*config.API{
 							{Path: "google/cloud/secretmanager/v1"},
 							{Path: "google/cloud/secretmanager/v1beta2"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update existing library (python)",
+			apis: []string{"google/cloud/kms/v1beta2"},
+			cfg: &config.Config{
+				Language: config.LanguagePython,
+				Libraries: []*config.Library{
+					{
+						Name:    "google-cloud-kms",
+						Version: "1.2.3",
+						APIs: []*config.API{
+							{Path: "google/cloud/kms/v1"},
+						},
+						Python: &config.PythonPackage{
+							DefaultVersion: "v1beta2",
+						},
+					},
+				},
+			},
+			wantName: "google-cloud-kms",
+			wantCfg: &config.Config{
+				Language: config.LanguagePython,
+				Libraries: []*config.Library{
+					{
+						Name:    "google-cloud-kms",
+						Version: "1.2.3",
+						APIs: []*config.API{
+							{Path: "google/cloud/kms/v1"},
+							{Path: "google/cloud/kms/v1beta2"},
+						},
+						Python: &config.PythonPackage{
+							DefaultVersion: "v1beta2",
 						},
 					},
 				},
@@ -380,13 +416,13 @@ func TestAddLibrary_ExistingLibrary_Error(t *testing.T) {
 			wantErr: errAPIDuplicate,
 		},
 		{
-			name: "python doesn't support updating existing library",
+			name: "java doesn't support updating existing library",
 			apis: []string{"google/cloud/secretmanager/v1beta2"},
 			cfg: &config.Config{
-				Language: config.LanguagePython,
+				Language: config.LanguageJava,
 				Libraries: []*config.Library{
 					{
-						Name:    "google-cloud-secretmanager",
+						Name:    "secretmanager",
 						Version: "1.2.3",
 						APIs: []*config.API{
 							{Path: "google/cloud/secretmanager/v1"},

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -61,9 +61,9 @@ func Add(lib *config.Library) (*config.Library, error) {
 }
 
 // ValidateNewAPIs validates that new APIs can be added to an existing library.
-// Currently this is just a check that no existing APIs in the library have
-// custom GAPIC options. Future checks may require details of the APIs being
-// added.
+// Currently this is just a check that there is a default version already, and
+// that no existing APIs in the library have custom GAPIC options. Future checks
+// may require details of the APIs being added.
 func ValidateNewAPIs(lib *config.Library) error {
 	if lib.Python == nil || lib.Python.DefaultVersion == "" {
 		return errExistingLibraryNoDefaultVersion

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -35,8 +35,10 @@ var (
 		"google.maps",
 		"google.shopping",
 	}
-	errNewLibraryMustHaveOneAPI = errors.New("a newly added library (in Python) must have exactly one API so that the default version can be populated")
-	errNewLibraryBadNamespace   = errors.New("derived GAPIC namespace would not match any approved namespace; consult with the Python team to determine whether the namespace should be approved, or whether GAPIC options should be specified for this API in librarian.yaml. See go/clientlibs-python-registered-namespaces for more details")
+	errNewLibraryMustHaveOneAPI          = errors.New("a newly added library (in Python) must have exactly one API so that the default version can be populated")
+	errNewLibraryBadNamespace            = errors.New("derived GAPIC namespace would not match any approved namespace; consult with the Python team to determine whether the namespace should be approved, or whether GAPIC options should be specified for this API in librarian.yaml. See go/clientlibs-python-registered-namespaces for more details")
+	errExistingLibraryNoDefaultVersion   = errors.New("new APIs cannot be automatically added to a library without a default version")
+	errExistingLibraryCustomGAPICOptions = errors.New("new APIs cannot be automatically added to a library with custom GAPIC options")
 )
 
 // Add initializes a new Python library with default values.
@@ -56,4 +58,18 @@ func Add(lib *config.Library) (*config.Library, error) {
 		return nil, fmt.Errorf("%w: unapproved namespace %s derived from API path %s", errNewLibraryBadNamespace, namespace, apiPath)
 	}
 	return lib, nil
+}
+
+// ValidateNewAPIs validates that new APIs can be added to an existing library.
+// Currently this is just a check that no existing APIs in the library have
+// custom GAPIC options. Future checks may require details of the APIs being
+// added.
+func ValidateNewAPIs(lib *config.Library) error {
+	if lib.Python == nil || lib.Python.DefaultVersion == "" {
+		return errExistingLibraryNoDefaultVersion
+	}
+	if len(lib.Python.OptArgsByAPI) != 0 {
+		return errExistingLibraryCustomGAPICOptions
+	}
+	return nil
 }

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -121,3 +121,61 @@ func TestAdd_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNewAPIs(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		lib     *config.Library
+		wantErr error
+	}{
+		{
+			name: "valid",
+			lib: &config.Library{
+				Name: "google-cloud-test",
+				APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+				Python: &config.PythonPackage{
+					DefaultVersion: "v1",
+				},
+			},
+		},
+		{
+			name: "no python configuration at all",
+			lib: &config.Library{
+				Name: "google-cloud-test",
+				APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+			},
+			wantErr: errExistingLibraryNoDefaultVersion,
+		},
+		{
+			name: "no default version",
+			lib: &config.Library{
+				Name:   "google-cloud-test",
+				APIs:   []*config.API{{Path: "google/cloud/test/v1"}},
+				Python: &config.PythonPackage{},
+			},
+			wantErr: errExistingLibraryNoDefaultVersion,
+		},
+		{
+			name: "custom GAPIC options",
+			lib: &config.Library{
+				Name: "google-cloud-test",
+				APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+				Python: &config.PythonPackage{
+					DefaultVersion: "v1",
+					OptArgsByAPI: map[string][]string{
+						"google/cloud/test/v1": []string{"x=y"},
+					},
+				},
+			},
+			wantErr: errExistingLibraryCustomGAPICOptions,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotErr := ValidateNewAPIs(test.lib)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows adding new API paths to an existing library, as long as there's already a default version specified (which should already be the case for any GAPIC-generated libraries), and as long as there are no GAPIC options explicitly specified. The latter requirement avoids us getting a mixture of GAPIC namespaces accidentally.

Fixes #5654