### PR TITLE
chore(internal/serviceconfig): add issue tracker for compute/v1beta

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -999,6 +999,7 @@
     - go
     - nodejs
     - python
+  new_issue_uri: https://issuetracker.google.com/issues/new?component=187134&template=0
   skip_rest_numeric_enums:
     - go
     - python


### PR DESCRIPTION
The sdk.yaml entry for google/cloud/compute/v1beta now has the same issue tracker as for google/cloud/compute/v1.