### PR TITLE
refactor(sidekick): use the add methods on API

### DIFF
--- a/internal/sidekick/api/well_known_types.go
+++ b/internal/sidekick/api/well_known_types.go
@@ -21,13 +21,13 @@ package api
 // protoc output.
 func (model *API) LoadWellKnownTypes() {
 	for _, message := range wellKnownMessages {
-		model.State.MessageByID[message.ID] = message
+		model.AddMessage(message)
 	}
-	model.State.EnumByID[".google.protobuf.NullValue"] = &Enum{
+	model.AddEnum(&Enum{
 		Name:    "NullValue",
 		Package: "google.protobuf",
 		ID:      ".google.protobuf.NullValue",
-	}
+	})
 }
 
 var wellKnownMessages = []*Message{

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -206,7 +206,7 @@ func TestCrossReferenceService(t *testing.T) {
 	}
 
 	model := NewTestAPI([]*Message{}, []*Enum{}, []*Service{service})
-	model.State.ServiceByID[mixin.ID] = mixin
+	model.AddService(mixin)
 	if err := CrossReference(model); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -1352,11 +1352,11 @@ func registerMissingWkt(model *api.API) {
 	} {
 		_, ok := model.State.MessageByID[message.ID]
 		if !ok {
-			model.State.MessageByID[message.ID] = &api.Message{
+			model.AddMessage(&api.Message{
 				ID:      message.ID,
 				Name:    message.Name,
 				Package: message.Package,
-			}
+			})
 		}
 	}
 }

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -712,8 +712,8 @@ func TestAnnotateMessage_OmitGeneration_Map(t *testing.T) {
 		},
 	}
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
-	model.State.MessageByID[status.ID] = status
-	model.State.MessageByID[mapMessage.ID] = mapMessage
+	model.AddMessage(status)
+	model.AddMessage(mapMessage)
 	annotate := newAnnotateModel(model)
 
 	annotate.annotateModel(map[string]string{
@@ -1925,7 +1925,7 @@ func TestAnnotateField(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enumState}, []*api.Service{})
-			model.State.MessageByID[mapMessage.ID] = mapMessage
+			model.AddMessage(mapMessage)
 			annotate := newAnnotateModel(model)
 			registerMissingWkt(annotate.model)
 

--- a/internal/sidekick/dart/dart_test.go
+++ b/internal/sidekick/dart/dart_test.go
@@ -369,7 +369,7 @@ func TestFieldType_Maps(t *testing.T) {
 		TypezID:  map1.ID,
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
-	model.State.MessageByID[map1.ID] = map1
+	model.AddMessage(map1)
 	annotate := newAnnotateModel(model)
 	annotate.annotateModel(map[string]string{})
 

--- a/internal/sidekick/parser/discovery/discovery.go
+++ b/internal/sidekick/parser/discovery/discovery.go
@@ -86,7 +86,7 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte, discoveryConf
 			return nil, err
 		}
 		result.Messages = append(result.Messages, message)
-		result.State.MessageByID[id] = message
+		result.AddMessage(message)
 	}
 	// The messages must be sorted otherwise the generated code gets different
 	// output on each run.

--- a/internal/sidekick/parser/discovery/enum.go
+++ b/internal/sidekick/parser/discovery/enum.go
@@ -56,7 +56,7 @@ func makeMessageEnum(model *api.API, message *api.Message, name string, schema *
 		enum.Values = append(enum.Values, value)
 		enum.UniqueNumberValues = append(enum.UniqueNumberValues, value)
 	}
-	model.State.EnumByID[enum.ID] = enum
+	model.AddEnum(enum)
 	message.Enums = append(message.Enums, enum)
 	return nil
 }

--- a/internal/sidekick/parser/discovery/inline_object_field.go
+++ b/internal/sidekick/parser/discovery/inline_object_field.go
@@ -37,7 +37,7 @@ func maybeInlineObjectField(model *api.API, parent *api.Message, name string, in
 		return nil, err
 	}
 	parent.Messages = append(parent.Messages, message)
-	model.State.MessageByID[id] = message
+	model.AddMessage(message)
 
 	field := &api.Field{
 		Name:          name,

--- a/internal/sidekick/parser/discovery/lro.go
+++ b/internal/sidekick/parser/discovery/lro.go
@@ -66,7 +66,7 @@ func lroAnnotations(model *api.API, discoveryConfig *api.Discovery) error {
 			SourceServiceID: svcMixin.SourceServiceID,
 		}
 		svc.Methods = append(svc.Methods, method)
-		model.State.MethodByID[method.ID] = method
+		model.AddMethod(method)
 	}
 	return nil
 }

--- a/internal/sidekick/parser/discovery/map_field.go
+++ b/internal/sidekick/parser/discovery/map_field.go
@@ -122,6 +122,6 @@ func insertMapType(model *api.API, valueTypez api.Typez, valueTypezId string) st
 		IsMap:         true,
 		Fields:        []*api.Field{key, value},
 	}
-	model.State.MessageByID[message.ID] = message
+	model.AddMessage(message)
 	return id
 }

--- a/internal/sidekick/parser/discovery/methods.go
+++ b/internal/sidekick/parser/discovery/methods.go
@@ -31,14 +31,14 @@ func makeServiceMethods(model *api.API, service *api.Service, doc *document, res
 		Documentation:      fmt.Sprintf("Synthetic messages for the [%s][%s] service", service.Name, service.ID[1:]),
 		ServicePlaceholder: true,
 	}
-	model.State.MessageByID[parent.ID] = parent
+	model.AddMessage(parent)
 	model.Messages = append(model.Messages, parent)
 	for _, input := range resource.Methods {
 		method, err := makeMethod(model, parent, doc, input)
 		if err != nil {
 			return err
 		}
-		model.State.MethodByID[method.ID] = method
+		model.AddMethod(method)
 		service.Methods = append(service.Methods, method)
 	}
 
@@ -69,7 +69,7 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 		Parent:           parent,
 		Deprecated:       input.Deprecated,
 	}
-	model.State.MessageByID[requestMessage.ID] = requestMessage
+	model.AddMessage(requestMessage)
 	parent.Messages = append(parent.Messages, requestMessage)
 
 	var uriTemplate string

--- a/internal/sidekick/parser/discovery/services.go
+++ b/internal/sidekick/parser/discovery/services.go
@@ -49,6 +49,6 @@ func addService(model *api.API, doc *document, resource *resource) error {
 		return err
 	}
 	model.Services = append(model.Services, service)
-	model.State.ServiceByID[id] = service
+	model.AddService(service)
 	return nil
 }

--- a/internal/sidekick/parser/openapi.go
+++ b/internal/sidekick/parser/openapi.go
@@ -119,7 +119,7 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 		}
 
 		result.Messages = append(result.Messages, message)
-		result.State.MessageByID[id] = message
+		result.AddMessage(message)
 	}
 
 	err := makeServices(result, model, packageName, serviceName)
@@ -150,7 +150,7 @@ func makeServices(a *api.API, model *libopenapi.DocumentModel[v3.Document], pack
 		return err
 	}
 	a.Services = append(a.Services, service)
-	a.State.ServiceByID[service.ID] = service
+	a.AddService(service)
 	return nil
 }
 
@@ -183,7 +183,7 @@ func makeMethods(a *api.API, service *api.Service, model *libopenapi.DocumentMod
 		Documentation:      fmt.Sprintf("Synthetic messages for the [%s][%s] service.", service.Name, service.ID[1:]),
 		ServicePlaceholder: true,
 	}
-	a.State.MessageByID[parent.ID] = parent
+	a.AddMessage(parent)
 	a.Messages = append(a.Messages, parent)
 
 	for pattern, item := range model.Model.Paths.PathItems.FromOldest() {
@@ -239,7 +239,7 @@ func makeMethods(a *api.API, service *api.Service, model *libopenapi.DocumentMod
 				OutputTypeID:  responseMessage.ID,
 				PathInfo:      pathInfo,
 			}
-			a.State.MethodByID[m.ID] = m
+			a.AddMethod(m)
 			service.Methods = append(service.Methods, m)
 		}
 	}
@@ -321,7 +321,7 @@ func makeRequestMessage(a *api.API, parent *api.Message, operation *v3.Operation
 	}
 	// Add the message to the symbol table and the parent.
 	parent.Messages = append(parent.Messages, message)
-	a.State.MessageByID[message.ID] = message
+	a.AddMessage(message)
 
 	return message, bodyFieldPath, nil
 }
@@ -588,7 +588,7 @@ func makeMapMessage(model *api.API, messageName, name string, schema *base.Schem
 			Parent:        nil,
 			Package:       "$",
 		}
-		model.State.MessageByID[id] = placeholder
+		model.AddMessage(placeholder)
 		message = placeholder
 	}
 	return message, nil

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -538,7 +538,7 @@ func processService(model *api.API, s *descriptorpb.ServiceDescriptorProto, sFQN
 		DefaultHost: parseDefaultHost(s.GetOptions()),
 		Deprecated:  s.GetOptions().GetDeprecated(),
 	}
-	model.State.ServiceByID[service.ID] = service
+	model.AddService(service)
 	return service
 }
 
@@ -567,7 +567,7 @@ func processMethod(model *api.API, m *descriptorpb.MethodDescriptorProto, mFQN, 
 		SourceServiceID:     serviceID,
 		APIVersion:          apiVersion,
 	}
-	model.State.MethodByID[mFQN] = method
+	model.AddMethod(method)
 	return method, nil
 }
 
@@ -579,7 +579,7 @@ func processMessage(model *api.API, m *descriptorpb.DescriptorProto, mFQN, packa
 		Package:    packagez,
 		Deprecated: m.GetOptions().GetDeprecated(),
 	}
-	model.State.MessageByID[mFQN] = message
+	model.AddMessage(message)
 
 	if opts := m.GetOptions(); opts != nil {
 		if opts.GetMapEntry() {
@@ -675,7 +675,7 @@ func processResourceAnnotation(opts *descriptorpb.MessageOptions, message *api.M
 		Self:     message,
 	}
 	message.Resource = resource
-	model.State.ResourceByType[resource.Type] = resource
+	model.AddResource(resource)
 	return nil
 }
 
@@ -750,7 +750,7 @@ func processEnum(model *api.API, e *descriptorpb.EnumDescriptorProto, eFQN, pack
 		Package:    packagez,
 		Deprecated: e.GetOptions().GetDeprecated(),
 	}
-	model.State.EnumByID[eFQN] = enum
+	model.AddEnum(enum)
 	for _, ev := range e.Value {
 		enumValue := &api.EnumValue{
 			Name:       ev.GetName(),

--- a/internal/sidekick/rust/annotate_field_test.go
+++ b/internal/sidekick/rust/annotate_field_test.go
@@ -87,7 +87,7 @@ func TestFieldAnnotations(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
-	model.State.MessageByID[map_message.ID] = map_message
+	model.AddMessage(map_message)
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
 	codec := newTestCodec(t, libconfig.SpecProtobuf, "test", map[string]string{})
@@ -258,7 +258,7 @@ func TestRecursiveFieldAnnotations(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
-	model.State.MessageByID[map_message.ID] = map_message
+	model.AddMessage(map_message)
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
 	codec := newTestCodec(t, libconfig.SpecProtobuf, "test", map[string]string{})
@@ -451,8 +451,8 @@ func TestSameTypeNameFieldAnnotations(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
-	model.State.MessageByID[map_message.ID] = map_message
-	model.State.MessageByID[inner_message.ID] = inner_message
+	model.AddMessage(map_message)
+	model.AddMessage(inner_message)
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
 	codec := newTestCodec(t, libconfig.SpecProtobuf, "test", map[string]string{})
@@ -804,7 +804,7 @@ func TestEnumFieldAnnotations(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enumz}, []*api.Service{})
-	model.State.MessageByID[map_message.ID] = map_message
+	model.AddMessage(map_message)
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
 	codec, err := newCodec(libconfig.SpecProtobuf, map[string]string{

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -715,7 +715,7 @@ func rustFieldTypesCases() *api.API {
 		},
 	}
 	model := api.NewTestAPI([]*api.Message{target, message}, []*api.Enum{}, []*api.Service{})
-	model.State.MessageByID[mapMessage.ID] = mapMessage
+	model.AddMessage(mapMessage)
 	return model
 
 }
@@ -883,7 +883,7 @@ func TestFieldMapTypeValues(t *testing.T) {
 			Fields: []*api.Field{key, value},
 		}
 		model := api.NewTestAPI([]*api.Message{message, other_message}, []*api.Enum{}, []*api.Service{})
-		model.State.MessageByID[map_thing.ID] = map_thing
+		model.AddMessage(map_thing)
 		api.LabelRecursiveFields(model)
 		c := createRustCodec()
 		got, err := c.fieldType(field, model, false, model.PackageName)
@@ -947,7 +947,7 @@ func TestFieldMapTypeKey(t *testing.T) {
 			ID:   ".test.EnumType",
 		}
 		model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enum}, []*api.Service{})
-		model.State.MessageByID[map_thing.ID] = map_thing
+		model.AddMessage(map_thing)
 		api.LabelRecursiveFields(model)
 		c := createRustCodec()
 		got, err := c.fieldType(field, model, false, model.PackageName)
@@ -1915,16 +1915,16 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 		[]*api.Enum{someEnum},
 		[]*api.Service{someService, renamedService, yellyService})
 	a.PackageName = "test.v1"
-	a.State.MessageByID[".google.iam.v1.SetIamPolicyRequest"] = &api.Message{
+	a.AddMessage(&api.Message{
 		Name:    "SetIamPolicyRequest",
 		Package: "google.iam.v1",
 		ID:      ".google.iam.v1.SetIamPolicyRequest",
-	}
-	a.State.ServiceByID[".google.iam.v1.IAMPolicy"] = &api.Service{
+	})
+	a.AddService(&api.Service{
 		Name:    "IAMPolicy",
 		Package: "google.iam.v1",
 		ID:      ".google.iam.v1.IAMPolicy",
-	}
+	})
 	return a
 }
 

--- a/internal/sidekick/rust/used_by_test.go
+++ b/internal/sidekick/rust/used_by_test.go
@@ -300,16 +300,16 @@ func TestFindUsedPackages(t *testing.T) {
 		{Name: "CreateResource", ID: ".test.Resource"},
 	}, []*api.Enum{}, []*api.Service{service})
 
-	model.State.MessageByID[".google.longrunning.Operation"] = &api.Message{
+	model.AddMessage(&api.Message{
 		Name:    "Operation",
 		ID:      ".google.longrunning.Operation",
 		Package: "google.longrunning",
-	}
-	model.State.MessageByID[".google.cloud.common.OperationMetadata"] = &api.Message{
+	})
+	model.AddMessage(&api.Message{
 		Name:    "OperationMetadata",
 		ID:      ".google.cloud.common.OperationMetadata",
 		Package: "google.cloud.common",
-	}
+	})
 
 	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
 		"package:common":      "package=google-cloud-common,source=google.cloud.common",
@@ -378,8 +378,8 @@ func TestFindUsedPackages_MapFields(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
-	model.State.MessageByID[".external.ExternalMessage"] = externalMessage
-	model.State.MessageByID[".test.Fake.FakeMapEntry"] = mapEntry
+	model.AddMessage(externalMessage)
+	model.AddMessage(mapEntry)
 
 	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
 		"package:external": "package=external-package,source=external",

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -242,8 +242,8 @@ func TestAnnotateMethod_WithExternalMessages(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{}, nil, []*api.Service{service})
 	model.PackageName = "google.cloud.test.v1"
-	model.State.MessageByID[inputMessage.ID] = inputMessage
-	model.State.MessageByID[outputMessage.ID] = outputMessage
+	model.AddMessage(inputMessage)
+	model.AddMessage(outputMessage)
 	codec := newTestCodec(t, model, nil)
 
 	if err := codec.annotateModel(); err != nil {

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -110,7 +110,7 @@ func TestModelAnnotations_WithExternalDependencies(t *testing.T) {
 
 	model := api.NewTestAPI(
 		[]*api.Message{message}, []*api.Enum{}, []*api.Service{service})
-	model.State.MessageByID[externalMessage.ID] = externalMessage
+	model.AddMessage(externalMessage)
 	codec := newTestCodec(t, model, nil)
 	codec.withExtraDependencies(t, []config.SwiftDependency{
 		{ApiPackage: "google.cloud.external.v1", Name: "GoogleCloudExternalWithOverrideV1"},

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -87,7 +87,7 @@ func TestFieldTypeName_BaseMessage(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{outer, simple}, nil, nil)
-	model.State.MessageByID[nested.ID] = nested
+	model.AddMessage(nested)
 	c := newTestCodec(t, model, map[string]string{})
 
 	for _, test := range []struct {
@@ -146,7 +146,7 @@ func TestFieldTypeName_BaseEnum(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{outer}, []*api.Enum{simple}, nil)
-	model.State.EnumByID[nested.ID] = nested
+	model.AddEnum(nested)
 	c := newTestCodec(t, model, map[string]string{})
 
 	for _, test := range []struct {
@@ -331,7 +331,7 @@ func TestFieldTypeName_Map(t *testing.T) {
 
 	model := api.NewTestAPI(nil, nil, nil)
 	model.PackageName = mapEntry.Package
-	model.State.MessageByID[mapEntry.ID] = mapEntry
+	model.AddMessage(mapEntry)
 	c := newTestCodec(t, model, map[string]string{})
 
 	field := &api.Field{
@@ -359,7 +359,7 @@ func TestFieldTypeName_ExternalMessage(t *testing.T) {
 
 	model := api.NewTestAPI(nil, nil, nil)
 	model.PackageName = "google.cloud.test.v1"
-	model.State.MessageByID[externalMessage.ID] = externalMessage
+	model.AddMessage(externalMessage)
 	c := newTestCodec(t, model, nil)
 	c.withExtraDependencies(t, []config.SwiftDependency{
 		{
@@ -404,7 +404,7 @@ func TestFieldTypeName_ExternalEnum(t *testing.T) {
 
 	model := api.NewTestAPI(nil, nil, nil)
 	model.PackageName = "google.cloud.test.v1"
-	model.State.EnumByID[externalEnum.ID] = externalEnum
+	model.AddEnum(externalEnum)
 	c := newTestCodec(t, model, nil)
 	c.withExtraDependencies(t, []config.SwiftDependency{
 		{
@@ -456,8 +456,8 @@ func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
 
 	model := api.NewTestAPI(nil, nil, nil)
 	model.PackageName = "google.cloud.test.v1"
-	model.State.MessageByID[externalNested.ID] = externalNested
-	model.State.MessageByID[externalOuter.ID] = externalOuter
+	model.AddMessage(externalNested)
+	model.AddMessage(externalOuter)
 	c := newTestCodec(t, model, nil)
 	c.withExtraDependencies(t, []config.SwiftDependency{
 		{

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -204,12 +204,8 @@ func TestNewPathVariable(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{secretMessage, requestMessage}, nil, []*api.Service{})
-	model.State = &api.APIState{
-		MessageByID: map[string]*api.Message{
-			".google.cloud.secretmanager.v1.Secret":              secretMessage,
-			".google.cloud.secretmanager.v1.CreateSecretRequest": requestMessage,
-		},
-	}
+	model.AddMessage(secretMessage)
+	model.AddMessage(requestMessage)
 
 	codec := newTestCodec(t, model, nil)
 	if err := codec.annotateModel(); err != nil {

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -191,11 +191,7 @@ func TestGenerateMessage_WithExternalImports(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
-	model.State = &api.APIState{
-		MessageByID: map[string]*api.Message{
-			".google.cloud.external.v1.ExternalMessage": externalMessage,
-		},
-	}
+	model.AddMessage(externalMessage)
 
 	cfg := &parser.ModelConfig{
 		Codec: map[string]string{

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -155,11 +155,7 @@ func TestGenerateService_WithImports(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{inputMessage}, nil, []*api.Service{iam})
 	model.PackageName = "google.cloud.test.v1"
-	model.State = &api.APIState{
-		MessageByID: map[string]*api.Message{
-			".google.cloud.external.v1.ExternalMessage": externalMessage,
-		},
-	}
+	model.AddMessage(externalMessage)
 
 	cfg := &parser.ModelConfig{
 		Codec: map[string]string{


### PR DESCRIPTION
This replaces all direct APIState assignments with the goal of hiding those maps.