### PR TITLE
feat(docker): use librarian install for pip packages

### DIFF
--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -48,12 +48,6 @@ ARG CARGO_SEMVER_CHECKS_VERSION=0.46.0
 # Python dependency versions
 ARG PYTHON_PROTOC_VERSION=25.3
 ARG PYTHON_PROTOC_CHECKSUM=5ec3474ca09df0511bb2ca66b5ca091fa8943c30aa26285f225d0b1ba60b5665b3419be4cd2322decbb55464039ca0a0405a47e86bcc11491589405d615d280e
-ARG PYTHON_GAPIC_VERSION=1.30.13
-ARG NOX_VERSION=2025.11.12
-ARG RUFF_VERSION=0.14.14
-ARG ISORT_VERSION=5.11.0
-ARG BLACK_VERSION=23.7.0
-ARG SYNTHTOOL_COMMIT=96f416c959fbe8048200b6c16000de32b352902e
 ARG PANDOC_VERSION=3.8.2
 ARG PANDOC_CHECKSUM=f5e90628b44a801ecdf812236291871607db8fb2fba0e99911a6c497b406c64a8940fd2a776d482ece7a9dac10d0228378d78da61091262b69e7276456495f5c
 
@@ -183,16 +177,13 @@ RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
 # SYNTHTOOL_TEMPLATES later.
 ENV PYTHONPATH=/python-packages
 ENV PATH=${PATH}:${PYTHONPATH}/bin
+# Specify where pip should install, and disable its cache.
+ENV PIP_TARGET=${PYTHONPATH}
+ENV PIP_NO_CACHE_DIR=1
 
 # Install Python dependencies, into /python-packages (so it's predictable).
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -t ${PYTHONPATH} --no-cache-dir \
-    gapic-generator==${PYTHON_GAPIC_VERSION} \
-    nox==${NOX_VERSION} \
-    ruff==${RUFF_VERSION} \
-    isort==${ISORT_VERSION} \
-    black[jupyter]==${BLACK_VERSION} \
-    gcp-synthtool@git+https://github.com/googleapis/synthtool@${SYNTHTOOL_COMMIT}
+    /app/librarian install python -v
 
 # Ensure we use the local synthtool templates.
 ENV SYNTHTOOL_TEMPLATES=${PYTHONPATH}/synthtool/gcp/templates

--- a/internal/librarian/python/install.go
+++ b/internal/librarian/python/install.go
@@ -33,14 +33,13 @@ func Install(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("parsing embedded librarian.yaml: %w", err)
 	}
+	args := []string{"install"}
 	for _, tool := range cfg.Tools.Pip {
 		pkg := tool.Package
 		if pkg == "" {
 			pkg = fmt.Sprintf("%s==%s", tool.Name, tool.Version)
 		}
-		if err := command.RunStreaming(ctx, "pip", "install", pkg); err != nil {
-			return err
-		}
+		args = append(args, pkg)
 	}
-	return nil
+	return command.RunStreaming(ctx, "pip", args...)
 }

--- a/internal/librarian/python/install.go
+++ b/internal/librarian/python/install.go
@@ -33,6 +33,9 @@ func Install(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("parsing embedded librarian.yaml: %w", err)
 	}
+	if len(cfg.Tools.Pip) == 0 {
+		return nil
+	}
 	args := []string{"install"}
 	for _, tool := range cfg.Tools.Pip {
 		pkg := tool.Package


### PR DESCRIPTION
The Dockerfile target for Python uses librarian install to install pip packages, so that internal/librarian/python/librarian.yaml is the single source of truth for which packages need to be installed, and at which version.

The python.Install function is modified to run pip once to install all packages, to avoid conflicts and upgrade requirements.

Fixes #5680