### PR TITLE
chore(internal/librarian/python): remove SkipReadmeCopy option

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -339,7 +339,6 @@ This document describes the schema for the librarian.yaml.
 | `issue_tracker_override` | string | Allows the issue_tracker field in .repo-metadata.json to be overridden, to reduce diffs while migrating. TODO(https://github.com/googleapis/librarian/issues/4175): remove this field. |
 | `metadata_name_override` | string | Allows the name in .repo-metadata.json (which is also used as part of the client documentation URI) to be overridden. By default, it's the package name, but older packages use the API short name instead. |
 | `default_version` | string | Is the default version of the API to use. When omitted, the version in the first API path is used. |
-| `skip_readme_copy` | bool | Prevents generation from copying README.rst from the root directory to the docs directory. TODO(https://github.com/googleapis/librarian/issues/4738): revisit whether or not this field should exist after migration. |
 
 ## RustCrate Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -377,12 +377,6 @@ type PythonPackage struct {
 	// DefaultVersion is the default version of the API to use. When omitted,
 	// the version in the first API path is used.
 	DefaultVersion string `yaml:"default_version,omitempty"`
-
-	// SkipReadmeCopy prevents generation from copying README.rst from the root
-	// directory to the docs directory.
-	// TODO(https://github.com/googleapis/librarian/issues/4738): revisit
-	// whether or not this field should exist after migration.
-	SkipReadmeCopy bool `yaml:"skip_readme_copy,omitempty"`
 }
 
 // PythonDefault contains Python-specific default configuration.

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -649,9 +649,6 @@ func mergePython(dst, src *config.PythonPackage) *config.PythonPackage {
 	if src.DefaultVersion != "" {
 		res.DefaultVersion = src.DefaultVersion
 	}
-	if src.SkipReadmeCopy {
-		res.SkipReadmeCopy = src.SkipReadmeCopy
-	}
 	return &res
 }
 

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -1236,7 +1236,6 @@ func TestMergePython(t *testing.T) {
 				IssueTrackerOverride:        "issue",
 				MetadataNameOverride:        "meta",
 				DefaultVersion:              "v1",
-				SkipReadmeCopy:              true,
 			},
 			want: &config.PythonPackage{
 				PythonDefault: config.PythonDefault{
@@ -1249,7 +1248,6 @@ func TestMergePython(t *testing.T) {
 				IssueTrackerOverride:        "issue",
 				MetadataNameOverride:        "meta",
 				DefaultVersion:              "v1",
-				SkipReadmeCopy:              true,
 			},
 		},
 	} {

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -113,10 +113,8 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		}
 	}
 
-	if library.Python == nil || !library.Python.SkipReadmeCopy {
-		if err := copyReadmeToDocsDir(outdir); err != nil {
-			return fmt.Errorf("failed to copy README to docs: %w", err)
-		}
+	if err := copyReadmeToDocsDir(library, outdir); err != nil {
+		return fmt.Errorf("failed to copy README to docs: %w", err)
 	}
 	return nil
 }
@@ -393,7 +391,9 @@ python_mono_repo.owlbot_main(%q)
 
 // copyReadmeToDocsDir copies README.rst to docs/README.rst.
 // This handles symlinks properly by reading content and writing a real file.
-func copyReadmeToDocsDir(outdir string) error {
+// This is a no-op if either the source doesn't exist, or the library is
+// handwritten and the target doesn't already exist.
+func copyReadmeToDocsDir(lib *config.Library, outdir string) error {
 	sourcePath := filepath.Join(outdir, "README.rst")
 	docsPath := filepath.Join(outdir, "docs")
 	destPath := filepath.Join(docsPath, "README.rst")
@@ -402,7 +402,13 @@ func copyReadmeToDocsDir(outdir string) error {
 	if _, err := os.Lstat(sourcePath); errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
-
+	// If the library is handwritten and the target doesn't already exist, skip
+	// copying.
+	if len(lib.APIs) == 0 {
+		if _, err := os.Lstat(destPath); errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+	}
 	// Read content from source (follows symlinks)
 	content, err := os.ReadFile(sourcePath)
 	if err != nil {

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -335,6 +335,7 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		name            string
 		setup           func(t *testing.T, outdir string)
 		expectedContent string
+		handwritten     bool
 		expectedErr     bool
 	}{
 		{
@@ -342,6 +343,31 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 			setup: func(t *testing.T, outdir string) {
 				// No setup needed
 			},
+		},
+		{
+			name: "handwritten library, target already exists",
+			setup: func(t *testing.T, outdir string) {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("after"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Join(outdir, "docs"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(outdir, "docs", "README.rst"), []byte("before"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			handwritten:     true,
+			expectedContent: "after",
+		},
+		{
+			name: "handwritten library, target doesn't already exist",
+			setup: func(t *testing.T, outdir string) {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("after"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			handwritten: true,
 		},
 		{
 			name: "readme is a regular file",
@@ -407,7 +433,14 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			outdir := t.TempDir()
 			test.setup(t, outdir)
-			err := copyReadmeToDocsDir(outdir)
+			lib := &config.Library{
+				Name: "test",
+				APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+			}
+			if test.handwritten {
+				lib.APIs = nil
+			}
+			err := copyReadmeToDocsDir(lib, outdir)
 			if (err != nil) != test.expectedErr {
 				t.Fatalf("copyReadmeToDocsDir() error = %v, wantErr %v", err, test.expectedErr)
 			}
@@ -961,91 +994,70 @@ func TestGenerate(t *testing.T) {
 	testhelper.RequireCommand(t, "ruff")
 	requireSynthtool(t)
 
-	for _, test := range []struct {
-		name           string
-		skipReadmeCopy bool
-	}{
-		{
-			name:           "copy readme",
-			skipReadmeCopy: false,
+	repoRoot := t.TempDir()
+	createReplacementScripts(t, repoRoot)
+	outdir, err := filepath.Abs(filepath.Join(repoRoot, "packages", "google-cloud-secret-manager"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Language: config.LanguagePython,
+		Repo:     "googleapis/google-cloud-python",
+	}
+
+	library := &config.Library{
+		Name:                "google-cloud-secret-manager",
+		Output:              outdir,
+		DescriptionOverride: "Stores, manages, and secures access to application secrets.",
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+			},
 		},
-		{
-			name:           "skip readme copy",
-			skipReadmeCopy: true,
+		Python: &config.PythonPackage{
+			MetadataNameOverride: "secretmanager",
+			PythonDefault: config.PythonDefault{
+				LibraryType: "GAPIC_AUTO",
+			},
+			DefaultVersion: "v1",
 		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			repoRoot := t.TempDir()
-			createReplacementScripts(t, repoRoot)
-			outdir, err := filepath.Abs(filepath.Join(repoRoot, "packages", "google-cloud-secret-manager"))
-			if err != nil {
-				t.Fatal(err)
-			}
+	}
+	srcs := &sources.Sources{
+		Googleapis: googleapisDir,
+	}
+	if err := Generate(t.Context(), cfg, library, srcs); err != nil {
+		t.Fatal(err)
+	}
+	gotMetadata, err := repometadata.Read(outdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMetadata := &repometadata.RepoMetadata{
+		// Fields set by repometadata.FromLibrary.
+		Name:                 "secretmanager",
+		NamePretty:           "Secret Manager",
+		ProductDocumentation: "https://cloud.google.com/secret-manager/",
+		IssueTracker:         "https://issuetracker.google.com/issues/new?component=784854&template=1380926",
+		ReleaseLevel:         "stable",
+		Language:             config.LanguagePython,
+		Repo:                 "googleapis/google-cloud-python",
+		DistributionName:     "google-cloud-secret-manager",
+		APIID:                "secretmanager.googleapis.com",
+		APIShortname:         "secretmanager",
+		APIDescription:       "Stores, manages, and secures access to application secrets.",
+		// Fields set by Generate.
+		LibraryType:         "GAPIC_AUTO",
+		ClientDocumentation: "https://cloud.google.com/python/docs/reference/secretmanager/latest",
+		DefaultVersion:      "v1",
+	}
+	if diff := cmp.Diff(wantMetadata, gotMetadata); diff != "" {
+		t.Errorf("mismatch in metadata (-want +got):\n%s", diff)
+	}
 
-			cfg := &config.Config{
-				Language: config.LanguagePython,
-				Repo:     "googleapis/google-cloud-python",
-			}
-
-			library := &config.Library{
-				Name:                "google-cloud-secret-manager",
-				Output:              outdir,
-				DescriptionOverride: "Stores, manages, and secures access to application secrets.",
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-					},
-				},
-				Python: &config.PythonPackage{
-					MetadataNameOverride: "secretmanager",
-					PythonDefault: config.PythonDefault{
-						LibraryType: "GAPIC_AUTO",
-					},
-					SkipReadmeCopy: test.skipReadmeCopy,
-					DefaultVersion: "v1",
-				},
-			}
-			srcs := &sources.Sources{
-				Googleapis: googleapisDir,
-			}
-			if err := Generate(t.Context(), cfg, library, srcs); err != nil {
-				t.Fatal(err)
-			}
-			gotMetadata, err := repometadata.Read(outdir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			wantMetadata := &repometadata.RepoMetadata{
-				// Fields set by repometadata.FromLibrary.
-				Name:                 "secretmanager",
-				NamePretty:           "Secret Manager",
-				ProductDocumentation: "https://cloud.google.com/secret-manager/",
-				IssueTracker:         "https://issuetracker.google.com/issues/new?component=784854&template=1380926",
-				ReleaseLevel:         "stable",
-				Language:             config.LanguagePython,
-				Repo:                 "googleapis/google-cloud-python",
-				DistributionName:     "google-cloud-secret-manager",
-				APIID:                "secretmanager.googleapis.com",
-				APIShortname:         "secretmanager",
-				APIDescription:       "Stores, manages, and secures access to application secrets.",
-				// Fields set by Generate.
-				LibraryType:         "GAPIC_AUTO",
-				ClientDocumentation: "https://cloud.google.com/python/docs/reference/secretmanager/latest",
-				DefaultVersion:      "v1",
-			}
-			if diff := cmp.Diff(wantMetadata, gotMetadata); diff != "" {
-				t.Errorf("mismatch in metadata (-want +got):\n%s", diff)
-			}
-
-			_, gotReadmeStatErr := os.Stat(filepath.Join(outdir, "docs", "README.rst"))
-			var wantReadmeStatErr error
-			if test.skipReadmeCopy {
-				wantReadmeStatErr = fs.ErrNotExist
-			}
-			if !errors.Is(gotReadmeStatErr, wantReadmeStatErr) {
-				t.Errorf("stat error on readme = %v, want %v", gotReadmeStatErr, wantReadmeStatErr)
-			}
-		})
+	_, err = os.Stat(filepath.Join(outdir, "docs", "README.rst"))
+	if err != nil {
+		t.Errorf("stat error on readme = %v", err)
 	}
 }
 


### PR DESCRIPTION
The behavior is now inferred:

- Generated libraries always have a copied README.rst
- Handwritten libraries should only copy the package-root README to the docs directory if the target file already exists.

Tested in terms of real-world impact by removing the option from librarian.yaml (for google-cloud-python) and regenerating all libraries. There are no changes.

Fixes #4738