### PR TITLE
refactor(sidekick): use number of services not number of known services

### DIFF
--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -369,7 +369,7 @@ type packagez struct {
 }
 
 func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
-	hasServices := len(model.State.ServiceByID) > 0
+	hasServices := len(model.Services) > 0
 	hasLROs := false
 	hasAutoPopulation := false
 	for _, s := range model.Services {


### PR DESCRIPTION
This changes to testing the number of services that are part of this API
rather than the number of services whose names are known when deciding if
the API has services.