### PR TITLE
feat(sidekick/swift): use `ProtoJSONDecoder`

### DIFF
--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -108,7 +108,7 @@ public class {{Codec.Name}} {
       ))
     }
     {{^ReturnsEmpty}}
-    return try JSONDecoder().decode({{OutputType.Codec.Name}}.self, from: data)
+    return try ProtoJSONDecoder().decode({{OutputType.Codec.Name}}.self, from: data)
     {{/ReturnsEmpty}}
   }
   {{/Codec.RestMethods}}


### PR DESCRIPTION
When decoding the response we want to use a custom decoder to deal with the idiosyncratic ProtoJSON encoding.

Towards #5673 #5674 #5675 #5676 and #5677 