### PR TITLE
feat(internal/librarian/java): introduce skip_pom_updates config

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -297,7 +297,7 @@ This document describes the schema for the librarian.yaml.
 | `rest_documentation` | string | Is the URL for the REST documentation. |
 | `rpc_documentation` | string | Is the URL for the RPC documentation. |
 | `transport_override` | string | Allows the "transport" field in .repo-metadata.json to be overridden. TODO(https://github.com/googleapis/librarian/issues/5561): investigate and determine if can remove |
-| `skip_pom_updates` | bool | Indicates whether to skip updating pom.xml files. |
+| `skip_pom_updates` | bool | Indicates whether to skip updating pom.xml files. TODO(https://github.com/googleapis/librarian/issues/5277): re-evaluate together with ExcludedPOMs |
 
 ## NodejsAPI Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -297,6 +297,7 @@ This document describes the schema for the librarian.yaml.
 | `rest_documentation` | string | Is the URL for the REST documentation. |
 | `rpc_documentation` | string | Is the URL for the RPC documentation. |
 | `transport_override` | string | Allows the "transport" field in .repo-metadata.json to be overridden. TODO(https://github.com/googleapis/librarian/issues/5561): investigate and determine if can remove |
+| `skip_pom_updates` | bool | Indicates whether to skip updating pom.xml files. |
 
 ## NodejsAPI Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -578,6 +578,9 @@ type JavaModule struct {
 	// TODO(https://github.com/googleapis/librarian/issues/5561):
 	// investigate and determine if can remove
 	TransportOverride string `yaml:"transport_override,omitempty"`
+
+	// SkipPOMUpdates indicates whether to skip updating pom.xml files.
+	SkipPOMUpdates bool `yaml:"skip_pom_updates,omitempty"`
 }
 
 // JavaAPI represents configuration for a single API within a Java module.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -580,6 +580,8 @@ type JavaModule struct {
 	TransportOverride string `yaml:"transport_override,omitempty"`
 
 	// SkipPOMUpdates indicates whether to skip updating pom.xml files.
+	// TODO(https://github.com/googleapis/librarian/issues/5277):
+	// re-evaluate together with ExcludedPOMs
 	SkipPOMUpdates bool `yaml:"skip_pom_updates,omitempty"`
 }
 

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -82,6 +82,9 @@ func postProcessLibrary(ctx context.Context, p libraryPostProcessParams) error {
 	if err != nil {
 		return err
 	}
+	if p.library.Java != nil && p.library.Java.SkipPOMUpdates {
+		return nil
+	}
 	if err := syncPOMs(p.library, p.outDir, monorepoVersion, p.metadata, p.transports); err != nil {
 		return fmt.Errorf("%w: %w", errSyncPOMs, err)
 	}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -402,7 +402,6 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		cfg     *config.Config
-		library *config.Library
 		setup   func(t *testing.T, outDir string)
 		wantErr error
 	}{
@@ -492,13 +491,9 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t, outDir)
 			}
-			l := library
-			if test.library != nil {
-				l = test.library
-			}
 			params := libraryPostProcessParams{
 				cfg:      test.cfg,
-				library:  l,
+				library:  library,
 				outDir:   outDir,
 				metadata: &repoMetadata{NamePretty: "Secret Manager"},
 			}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -284,6 +284,99 @@ func TestCopyProtos_ErrorCase(t *testing.T) {
 	}
 }
 
+func TestPostProcessLibrary(t *testing.T) {
+	t.Parallel()
+	testhelper.RequireCommand(t, "python3")
+
+	library := &config.Library{
+		Name:    "secretmanager",
+		Version: "1.2.3",
+		APIs: []*config.API{
+			{Path: "google/cloud/secretmanager/v1"},
+		},
+	}
+	defaultCfg := &config.Config{
+		Libraries: []*config.Library{
+			{Name: rootLibrary, Version: "1.0.0"},
+		},
+		Default: &config.Default{
+			Java: &config.JavaModule{
+				LibrariesBOMVersion: "26.35.0",
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name    string
+		cfg     *config.Config
+		library *config.Library
+		setup   func(t *testing.T, outDir string)
+	}{
+		{
+			name: "success with SkipPOMUpdates",
+			cfg:  defaultCfg,
+			library: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+				APIs:    []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Java: &config.JavaModule{
+					SkipPOMUpdates: true,
+				},
+			},
+			setup: func(t *testing.T, outDir string) {
+				writeOwlBot(t, outDir, "sys.exit(0)")
+				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "success",
+			cfg:  defaultCfg,
+			setup: func(t *testing.T, outDir string) {
+				writeOwlBot(t, outDir, "sys.exit(0)")
+				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
+					t.Fatal(err)
+				}
+				libCoords := DeriveLibraryCoordinates(library)
+				apiCoords := DeriveAPICoordinates(libCoords, "v1", &config.JavaAPI{})
+				for _, dir := range []string{
+					filepath.Join(outDir, apiCoords.Proto.ArtifactID),
+					filepath.Join(outDir, apiCoords.GRPC.ArtifactID),
+					filepath.Join(outDir, apiCoords.GAPIC.ArtifactID),
+					filepath.Join(outDir, apiCoords.Parent.ArtifactID),
+					filepath.Join(outDir, apiCoords.BOM.ArtifactID),
+				} {
+					if err := os.MkdirAll(dir, 0755); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			outDir := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, outDir)
+			}
+			l := library
+			if test.library != nil {
+				l = test.library
+			}
+			params := libraryPostProcessParams{
+				cfg:      test.cfg,
+				library:  l,
+				outDir:   outDir,
+				metadata: &repoMetadata{NamePretty: "Secret Manager"},
+			}
+			if err := postProcessLibrary(t.Context(), params); err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 	t.Parallel()
 	testhelper.RequireCommand(t, "python3")
@@ -309,6 +402,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		cfg     *config.Config
+		library *config.Library
 		setup   func(t *testing.T, outDir string)
 		wantErr error
 	}{
@@ -398,9 +492,13 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t, outDir)
 			}
+			l := library
+			if test.library != nil {
+				l = test.library
+			}
 			params := libraryPostProcessParams{
 				cfg:      test.cfg,
-				library:  library,
+				library:  l,
 				outDir:   outDir,
 				metadata: &repoMetadata{NamePretty: "Secret Manager"},
 			}

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -318,6 +318,12 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 			},
 		}
 		applyJavaLibraryOverrides(lib)
+
+		// Hardcoded configuration for grafeas special case.
+		if name == "grafeas" {
+			lib.Java.SkipPOMUpdates = true
+		}
+
 		if len(apis) > 0 {
 			derivedShortName := name
 			serviceconfig.SortAPIs(apis)


### PR DESCRIPTION
Introduce skip_pom_updates config to skip update pom.xml logics for special cases and add a hardcode assignment to grafeas in migrate script. This is needed when library has special structure or for other reasons pom.xml opts-out from managed by generate.

For https://github.com/googleapis/librarian/issues/5193