### PR TITLE
chore(tool/cmd/migrate): wrap error when tidy fails

### DIFF
--- a/tool/cmd/migrate/dotnet.go
+++ b/tool/cmd/migrate/dotnet.go
@@ -67,7 +67,7 @@ func runDotnetMigration(ctx context.Context, repoPath string) error {
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""
 	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
-		return fmt.Errorf("%w: %v", errTidyFailed, err)
+		return fmt.Errorf("%w: %w", errTidyFailed, err)
 	}
 	log.Printf("Successfully migrated %d .NET libraries", len(cfg.Libraries))
 	return nil

--- a/tool/cmd/migrate/dotnet.go
+++ b/tool/cmd/migrate/dotnet.go
@@ -67,7 +67,7 @@ func runDotnetMigration(ctx context.Context, repoPath string) error {
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""
 	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
-		return errTidyFailed
+		return fmt.Errorf("%w: %v", errTidyFailed, err)
 	}
 	log.Printf("Successfully migrated %d .NET libraries", len(cfg.Libraries))
 	return nil

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -189,7 +189,7 @@ func runJavaMigration(ctx context.Context, repoPath string, shouldInsertMarkers 
 	}
 
 	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
-		return errTidyFailed
+		return fmt.Errorf("%w: %v", errTidyFailed, err)
 	}
 	log.Printf("Successfully migrated %d Java libraries", len(cfg.Libraries))
 	return nil

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -189,7 +189,7 @@ func runJavaMigration(ctx context.Context, repoPath string, shouldInsertMarkers 
 	}
 
 	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
-		return fmt.Errorf("%w: %v", errTidyFailed, err)
+		return fmt.Errorf("%w: %w", errTidyFailed, err)
 	}
 	log.Printf("Successfully migrated %d Java libraries", len(cfg.Libraries))
 	return nil


### PR DESCRIPTION
Wrap error when tidy fails in migrate tool for debugging.