### PR TITLE
fix(internal/librarian): tidy to skip duplicate API path check for hardcoded list in java

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -36,6 +36,16 @@ var (
 	errDuplicateLibraryName  = errors.New("duplicate library name")
 	errDuplicateAPIPath      = errors.New("duplicate api path")
 	errNoGoogleapiSourceInfo = errors.New("googleapis source not configured in librarian.yaml")
+
+	// skipPaths lists special API paths that are allowed to appear in multiple
+	// libraries in Java without triggering the duplicate API path error.
+	skipPaths = map[string]bool{
+		"google/iam/v1":     true,
+		"google/iam/v2":     true,
+		"google/iam/v2beta": true,
+		"google/iam/v3":     true,
+		"google/iam/v3beta": true,
+	}
 )
 
 func tidyCommand() *cli.Command {
@@ -139,6 +149,9 @@ func validateLibraries(cfg *config.Config) error {
 		}
 		for _, ch := range lib.APIs {
 			if ch.Path != "" {
+				if cfg.Language == config.LanguageJava && skipPaths[ch.Path] {
+					continue
+				}
 				pathCount[ch.Path]++
 			}
 		}

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -37,11 +37,11 @@ var (
 	errDuplicateAPIPath      = errors.New("duplicate api path")
 	errNoGoogleapiSourceInfo = errors.New("googleapis source not configured in librarian.yaml")
 
-	// skipPaths lists special API paths that are allowed to appear in multiple
+	// javaSkipDuplicatePaths lists special API paths that are allowed to appear in multiple
 	// libraries in Java without triggering the duplicate API path error.
 	// These are paths are duplicated in java because their generated code splits
 	// between java-iam and java-iam-policy.
-	skipPaths = map[string]bool{
+	javaSkipDuplicatePaths = map[string]bool{
 		"google/iam/v1":     true,
 		"google/iam/v2":     true,
 		"google/iam/v2beta": true,
@@ -151,7 +151,7 @@ func validateLibraries(cfg *config.Config) error {
 		}
 		for _, ch := range lib.APIs {
 			if ch.Path != "" {
-				if cfg.Language == config.LanguageJava && skipPaths[ch.Path] {
+				if cfg.Language == config.LanguageJava && javaSkipDuplicatePaths[ch.Path] {
 					continue
 				}
 				pathCount[ch.Path]++

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -39,6 +39,8 @@ var (
 
 	// skipPaths lists special API paths that are allowed to appear in multiple
 	// libraries in Java without triggering the duplicate API path error.
+	// These are paths are duplicated in java because their generated code splits
+	// between java-iam and java-iam-policy.
 	skipPaths = map[string]bool{
 		"google/iam/v1":     true,
 		"google/iam/v2":     true,

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -64,6 +64,35 @@ func TestValidateLibraries(t *testing.T) {
 			language: config.LanguageJava,
 			wantErr:  java.ErrInvalidDistributionName,
 		},
+		{
+			name: "skipped duplicate api paths",
+			libraries: []*config.Library{
+				{
+					Name: "lib1",
+					APIs: []*config.API{{Path: "google/iam/v1"}},
+				},
+				{
+					Name: "lib2",
+					APIs: []*config.API{{Path: "google/iam/v1"}},
+				},
+			},
+			language: config.LanguageJava,
+		},
+		{
+			name: "duplicate api paths not skipped for non-java",
+			libraries: []*config.Library{
+				{
+					Name: "lib1",
+					APIs: []*config.API{{Path: "google/iam/v1"}},
+				},
+				{
+					Name: "lib2",
+					APIs: []*config.API{{Path: "google/iam/v1"}},
+				},
+			},
+			language: config.LanguagePython,
+			wantErr:  errDuplicateAPIPath,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := &config.Config{


### PR DESCRIPTION
Add logic in tidy to skip duplicate API path checks for this hardcoded list when language is Java.

These API paths are duplicated in java's librarian.yaml config because java geneates proto and grpc modules from these into [java-iam](https://github.com/googleapis/google-cloud-java/tree/main/java-iam) and gapic modules separately into [java-iam-policy](https://github.com/googleapis/google-cloud-java/tree/main/java-iam-policy). 

Fix #5706