### PR TITLE
feat(librarian/sidekick): support Swift modules

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -470,9 +470,17 @@ This document describes the schema for the librarian.yaml.
 | `required_by_services` | bool | Is true if this dependency is required by packages with services.<br><br>This will be set for the `gax` library and the `auth` library. Maybe more if we split the HTTP and gRPC clients into separate libraries. |
 | `api_package` | string | Is the name of the API package provided by this library.<br><br>In Swift a package contains at most one channel for one API. For packages that implement an API, this field contains the name of the package in the specification language of that API. At the moment this is only used by Protobuf-based APIs, as OpenAPI and discovery doc APIs are self-contained.<br><br>Note that some packages, for example `auth` and `gax`, do not implement APIs. This field is empty for such libraries.<br><br>Examples:<br>- The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.<br>- The `GoogleCloudLocation` package will set this to `google.cloud.location`. |
 
+## SwiftModule Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `output` | string | Is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated"). |
+| `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
+
 ## SwiftPackage Configuration
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | (embedded) | [SwiftDefault](#swiftdefault-configuration) |  |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]). |
+| `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, output location, and template to use. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -483,4 +483,4 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | (embedded) | [SwiftDefault](#swiftdefault-configuration) |  |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]). |
-| `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, output location, and template to use. |
+| `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, and output location. |

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -28,6 +28,11 @@ type SwiftPackage struct {
 
 	// IncludeList is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]).
 	IncludeList []string `yaml:"include_list,omitempty"`
+
+	// Modules specifies generation targets for veneers and test packages.
+	//
+	// Each module defines a source proto path, output location, and template to use.
+	Modules []*SwiftModule `yaml:"modules,omitempty"`
 }
 
 // SwiftDependency represents a dependency in Swift Package Manager.
@@ -82,4 +87,15 @@ type SwiftDependency struct {
 	// - The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.
 	// - The `GoogleCloudLocation` package will set this to `google.cloud.location`.
 	ApiPackage string `yaml:"api_package,omitempty"`
+}
+
+// SwiftModule defines a generation target within a larger crate. Typically a veneer, but sometimes also test targets.
+//
+// Each module specifies what proto source to use, which template to apply, and where to output the generated code.
+type SwiftModule struct {
+	// Output is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated").
+	Output string `yaml:"output"`
+
+	// APIPath is the proto path to generate from (e.g., "google/storage/v2").
+	APIPath string `yaml:"api_path"`
 }

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -91,7 +91,7 @@ type SwiftDependency struct {
 
 // SwiftModule defines a generation target within a larger crate. Typically a veneer, but sometimes also test targets.
 //
-// Each module specifies what proto source to use, which template to apply, and where to output the generated code.
+// Each module specifies what proto source to use, and where to output the generated code.
 type SwiftModule struct {
 	// Output is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated").
 	Output string `yaml:"output"`

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -31,7 +31,7 @@ type SwiftPackage struct {
 
 	// Modules specifies generation targets for veneers and test packages.
 	//
-	// Each module defines a source proto path, output location, and template to use.
+	// Each module defines a source proto path, and output location.
 	Modules []*SwiftModule `yaml:"modules,omitempty"`
 }
 

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
+	"github.com/googleapis/librarian/internal/librarian/swift"
 )
 
 // fillDefaults populates empty library fields from the provided defaults.
@@ -198,6 +199,8 @@ func isVeneer(language string, lib *config.Library) bool {
 	switch language {
 	case config.LanguageRust:
 		return rust.IsVeneer(lib)
+	case config.LanguageSwift:
+		return swift.IsModule(lib)
 	case config.LanguageNodejs:
 		return lib.Output != "" && len(lib.APIs) == 0
 	default:

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -31,6 +31,9 @@ import (
 
 // Generate generates a Swift client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
+	if IsModule(library) {
+		return generateModule(ctx, library, src)
+	}
 	if len(library.APIs) != 1 {
 		return fmt.Errorf("the Swift generator only supports a single api per library")
 	}

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -30,7 +30,7 @@ func generateModule(ctx context.Context, library *config.Library, sources *sourc
 		if err != nil {
 			return err
 		}
-		if err := sidekickswift.Generate(ctx, model, library.Output, modelConfig, library.Swift); err != nil {
+		if err := sidekickswift.Generate(ctx, model, module.Output, modelConfig, library.Swift); err != nil {
 			return err
 		}
 	}

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"context"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+	sidekickswift "github.com/googleapis/librarian/internal/sidekick/swift"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+func generateModule(ctx context.Context, library *config.Library, sources *sources.Sources) error {
+	for _, module := range library.Swift.Modules {
+		modelConfig := moduleToModelConfig(library, module, sources)
+		model, err := parser.CreateModel(modelConfig)
+		if err != nil {
+			return err
+		}
+		if err := sidekickswift.Generate(ctx, model, library.Output, modelConfig, library.Swift); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func moduleToModelConfig(library *config.Library, module *config.SwiftModule, src *sources.Sources) *parser.ModelConfig {
+	sourceConfig := sources.NewSourceConfig(src, library.Roots)
+	if library.Swift != nil && len(library.Swift.IncludeList) > 0 {
+		sourceConfig.IncludeList = library.Swift.IncludeList
+	}
+
+	return &parser.ModelConfig{
+		SpecificationFormat: config.SpecProtobuf,
+		SpecificationSource: module.APIPath,
+		Source:              sourceConfig,
+		Codec: map[string]string{
+			"module": "true",
+		},
+	}
+}

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -23,9 +23,9 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
-func generateModule(ctx context.Context, library *config.Library, sources *sources.Sources) error {
+func generateModule(ctx context.Context, library *config.Library, src *sources.Sources) error {
 	for _, module := range library.Swift.Modules {
-		modelConfig := moduleToModelConfig(library, module, sources)
+		modelConfig := moduleToModelConfig(library, module, src)
 		model, err := parser.CreateModel(modelConfig)
 		if err != nil {
 			return err

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -42,7 +42,7 @@ func TestGenerateModule(t *testing.T) {
 	library.Swift.Modules = []*config.SwiftModule{
 		{
 			APIPath: "google/type",
-			Output:  "ProtoJSON",
+			Output:  filepath.Join(outDir, "ProtoJSON"),
 		},
 	}
 	src := &sources.Sources{
@@ -54,7 +54,7 @@ func TestGenerateModule(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedFile := filepath.Join(outDir, "Expr.swift")
+	expectedFile := filepath.Join(outDir, "ProtoJSON", "Expr.swift")
 	if _, err := os.Stat(expectedFile); err != nil {
 		t.Error(err)
 	}

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+func TestGenerateModule(t *testing.T) {
+	testhelper.RequireCommand(t, "protoc")
+
+	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outDir := t.TempDir()
+	library := &config.Library{
+		Name:          "GoogleTypeModule",
+		CopyrightYear: "2038",
+		Swift:         defaultSwiftConfig(t),
+		Output:        outDir,
+	}
+	library.Swift.Modules = []*config.SwiftModule{
+		{
+			APIPath: "google/type",
+			Output:  "ProtoJSON",
+		},
+	}
+	src := &sources.Sources{
+		Googleapis: googleapisDir,
+	}
+	cfg := &config.Config{}
+
+	if err := Generate(t.Context(), cfg, library, src); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFile := filepath.Join(outDir, "Expr.swift")
+	if _, err := os.Stat(expectedFile); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestModuleToModelConfig(t *testing.T) {
+	src := &sources.Sources{}
+	for _, test := range []struct {
+		name            string
+		lib             *config.Library
+		module          *config.SwiftModule
+		wantIncludeList []string
+	}{
+		{
+			name: "no include list",
+			lib: &config.Library{
+				Swift: &config.SwiftPackage{},
+			},
+			module:          &config.SwiftModule{APIPath: "foo"},
+			wantIncludeList: nil,
+		},
+		{
+			name: "with include list",
+			lib: &config.Library{
+				Swift: &config.SwiftPackage{
+					IncludeList: []string{"a.proto", "b.proto"},
+				},
+			},
+			module:          &config.SwiftModule{APIPath: "foo"},
+			wantIncludeList: []string{"a.proto", "b.proto"},
+		},
+		{
+			name:            "nil swift",
+			lib:             &config.Library{},
+			module:          &config.SwiftModule{APIPath: "foo"},
+			wantIncludeList: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := moduleToModelConfig(test.lib, test.module, src)
+			if diff := cmp.Diff(test.wantIncludeList, got.Source.IncludeList); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/swift/is_module.go
+++ b/internal/librarian/swift/is_module.go
@@ -18,7 +18,7 @@ import "github.com/googleapis/librarian/internal/config"
 
 // IsModule reports whether the library has handwritten code wrapping generated code.
 //
-// At the moment, only libraries created for test protos are veneers. Such libraries do not have an API and have an
+// At the moment, only libraries created for test protos are modules. Such libraries do not have an API and have an
 // explicit output directory.
 func IsModule(lib *config.Library) bool {
 	return lib.Swift != nil && len(lib.Swift.Modules) > 0

--- a/internal/librarian/swift/is_module.go
+++ b/internal/librarian/swift/is_module.go
@@ -16,11 +16,10 @@ package swift
 
 import "github.com/googleapis/librarian/internal/config"
 
-// IsModule reports whether the library has handwritten code wrapping generated
-// code.
+// IsModule reports whether the library has handwritten code wrapping generated code.
 //
-// At the moment, only libraries created for test protos are veneers. Such libraries do not have a
-// an API and have an explicit output directory.
+// At the moment, only libraries created for test protos are veneers. Such libraries do not have an API and have an
+// explicit output directory.
 func IsModule(lib *config.Library) bool {
 	return lib.Swift != nil && len(lib.Swift.Modules) > 0
 }

--- a/internal/librarian/swift/is_module.go
+++ b/internal/librarian/swift/is_module.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import "github.com/googleapis/librarian/internal/config"
+
+// IsModule reports whether the library has handwritten code wrapping generated
+// code.
+//
+// At the moment, only libraries created for test protos are veneers. Such libraries do not have a
+// an API and have an explicit output directory.
+func IsModule(lib *config.Library) bool {
+	return lib.Swift != nil && len(lib.Swift.Modules) > 0
+}

--- a/internal/librarian/swift/is_module_test.go
+++ b/internal/librarian/swift/is_module_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestIsModule(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want bool
+	}{
+		{"module", &config.Library{Swift: &config.SwiftPackage{Modules: []*config.SwiftModule{{}}}}, true},
+		{"nil swift", &config.Library{}, false},
+		{"empty modules", &config.Library{Swift: &config.SwiftPackage{}}, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := IsModule(test.lib)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -99,7 +99,7 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 		case "module":
 			value, err := strconv.ParseBool(definition)
 			if err != nil {
-				return nil, fmt.Errorf("cannot convert `not-for-publication` value %q to boolean: %w", definition, err)
+				return nil, fmt.Errorf("cannot convert `module` value %q to boolean: %w", definition, err)
 			}
 			result.Module = value
 		default:

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -17,6 +17,7 @@ package swift
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -45,7 +46,9 @@ type codec struct {
 	MonorepoRoot   string
 	// Most libraries are generated from `googleapis`. Rarely, we use protobuf,
 	// gapic-showcase, or a different root.
-	RootName     string
+	RootName string
+	// Modules have a different directory structure.
+	Module       bool
 	Model        *api.API
 	Dependencies []*Dependency
 	ApiPackages  map[string]*Dependency
@@ -93,6 +96,12 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 			result.PackageName = definition
 		case "root-name":
 			result.RootName = definition
+		case "module":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `not-for-publication` value %q to boolean: %w", definition, err)
+			}
+			result.Module = value
 		default:
 			// Ignore other options.
 		}

--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -54,6 +54,10 @@ func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.Mo
 	if err := codec.generateServices(outdir, model, provider); err != nil {
 		return err
 	}
+	if codec.Module {
+		// Modules only get the top-level messages, enums, and services generated.
+		return nil
+	}
 	if err := codec.generateSnippets(outdir, model, provider); err != nil {
 		return err
 	}
@@ -61,11 +65,18 @@ func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.Mo
 	return language.GenerateFromModel(outdir, model, provider, generatedFiles)
 }
 
+func (c *codec) outputPath(name string) string {
+	if c.Module {
+		return name
+	}
+	return filepath.Join("Sources", c.PackageName, name)
+}
+
 func (c *codec) generateMessages(outdir string, model *api.API, provider language.TemplateProvider) error {
 	for _, m := range model.Messages {
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/common/message_file.swift.mustache",
-			OutputPath:   filepath.Join("Sources", c.PackageName, m.Name+".swift"),
+			OutputPath:   c.outputPath(m.Name + ".swift"),
 		}
 		if err := language.GenerateMessage(outdir, m, provider, generated); err != nil {
 			return err
@@ -78,7 +89,7 @@ func (c *codec) generateEnums(outdir string, model *api.API, provider language.T
 	for _, e := range model.Enums {
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/common/enum_file.swift.mustache",
-			OutputPath:   filepath.Join("Sources", c.PackageName, e.Name+".swift"),
+			OutputPath:   c.outputPath(e.Name + ".swift"),
 		}
 		if err := language.GenerateEnum(outdir, e, provider, generated); err != nil {
 			return err
@@ -91,7 +102,7 @@ func (c *codec) generateServices(outdir string, model *api.API, provider languag
 	for _, s := range model.Services {
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/common/service.swift.mustache",
-			OutputPath:   filepath.Join("Sources", c.PackageName, s.Name+".swift"),
+			OutputPath:   c.outputPath(s.Name + ".swift"),
 		}
 		if err := language.GenerateService(outdir, s, provider, generated); err != nil {
 			return err


### PR DESCRIPTION
Sometimes we just want to generate the code for some protos, and use them in a larger package that is hand-crafted. This is useful for tests against protos we control (the current motivation), and also for veneers when those become a thing.

Towards #5695 