### PR TITLE
fix(internal/sidekick/gcloud): omit extract_resource_result if false

### DIFF
--- a/internal/librarian/python/tidy_test.go
+++ b/internal/librarian/python/tidy_test.go
@@ -167,7 +167,7 @@ func TestTidyAPI(t *testing.T) {
 				Python: &config.PythonPackage{
 					DefaultVersion: "v1",
 					OptArgsByAPI: map[string][]string{
-						"google/cloud/derived/v1": []string{
+						"google/cloud/derived/v1": {
 							"warehouse-package-name=other-package-name",
 							"python-gapic-name=other-gapic-name",
 						},

--- a/internal/sidekick/gcloud/declarative/declarative.go
+++ b/internal/sidekick/gcloud/declarative/declarative.go
@@ -346,5 +346,5 @@ type Async struct {
 	// ExtractResourceResult unwraps the target resource from the operation's
 	// response field when the operation completes. Set when the LRO response
 	// type matches the resource being created or updated.
-	ExtractResourceResult bool `yaml:"extract_resource_result"`
+	ExtractResourceResult bool `yaml:"extract_resource_result,omitempty"`
 }

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_delete_ga.yaml
@@ -99,4 +99,3 @@
   async:
     collection:
       - developerconnect.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_delete_ga.yaml
@@ -54,4 +54,3 @@
   async:
     collection:
       - developerconnect.projects.locations.accountConnectors.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_delete_ga.yaml
@@ -88,4 +88,3 @@
   async:
     collection:
       - developerconnect.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_delete_ga.yaml
@@ -91,4 +91,3 @@
   async:
     collection:
       - developerconnect.projects.locations.connections.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_delete_ga.yaml
@@ -87,4 +87,3 @@
   async:
     collection:
       - developerconnect.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_delete_ga.yaml
@@ -83,4 +83,3 @@
       - iam.folders.locations.operations
       - iam.organizations.locations.operations
       - iam.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/principal_access_boundary_policies/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/principal_access_boundary_policies/_partials/_delete_ga.yaml
@@ -85,4 +85,3 @@
   async:
     collection:
       - iam.organizations.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/iam/expected/target/surface/iam/workforce_pools/subjects/delete.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/target/surface/iam/workforce_pools/subjects/delete.yaml
@@ -50,4 +50,3 @@
       is_positional: true
   async:
     collection: iam.locations.workforcePools.subjects.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/iam/expected/target/surface/iam/workforce_pools/subjects/revoke_sessions.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/target/surface/iam/workforce_pools/subjects/revoke_sessions.yaml
@@ -52,4 +52,3 @@
       is_positional: true
   async:
     collection: iam.locations.workforcePools.subjects.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/iam/expected/target/surface/iam/workforce_pools/subjects/undelete.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/target/surface/iam/workforce_pools/subjects/undelete.yaml
@@ -51,4 +51,3 @@
       is_positional: true
   async:
     collection: iam.locations.workforcePools.subjects.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_delete_ga.yaml
@@ -73,4 +73,3 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
@@ -155,4 +155,3 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
@@ -156,4 +156,3 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_export_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_export_data_ga.yaml
@@ -163,4 +163,3 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_import_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_import_data_ga.yaml
@@ -164,4 +164,3 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_delete_ga.yaml
@@ -75,4 +75,3 @@
   async:
     collection:
       - seclm.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_delete_ga.yaml
@@ -94,4 +94,3 @@
   async:
     collection:
       - helptext.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/method_async/expected/current/surface/method_async/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/method_async/expected/current/surface/method_async/resources/_partials/_delete_ga.yaml
@@ -94,4 +94,3 @@
   async:
     collection:
       - methodasync.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/method_operations/expected/current/surface/method_operations/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/method_operations/expected/current/surface/method_operations/resources/_partials/_delete_ga.yaml
@@ -94,4 +94,3 @@
   async:
     collection:
       - methodoperations.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/resource_ones/_partials/_delete_alpha.yaml
+++ b/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/resource_ones/_partials/_delete_alpha.yaml
@@ -53,4 +53,3 @@
   async:
     collection:
       - multiversiontrack.projects.locations.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/regional_endpoints/global_only/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/regional_endpoints/global_only/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
@@ -100,4 +100,3 @@
       - regionalendpoints.projects.operations
       - regionalendpoints.projects.regions.operations
       - regionalendpoints.projects.zones.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/regional_endpoints/regional_required/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/regional_endpoints/regional_required/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
@@ -100,4 +100,3 @@
       - regionalendpoints.projects.operations
       - regionalendpoints.projects.regions.operations
       - regionalendpoints.projects.zones.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/regional_endpoints/regional_supported/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/regional_endpoints/regional_supported/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
@@ -100,4 +100,3 @@
       - regionalendpoints.projects.operations
       - regionalendpoints.projects.regions.operations
       - regionalendpoints.projects.zones.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/deeps/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/deeps/resources/_partials/_delete_ga.yaml
@@ -94,4 +94,3 @@
   async:
     collection:
       - resourcemultitype.projects.deeps.operations
-    extract_resource_result: false

--- a/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/resources/_partials/_delete_ga.yaml
@@ -94,4 +94,3 @@
   async:
     collection:
       - resourcemultitype.organizations.locations.operations
-    extract_resource_result: false


### PR DESCRIPTION
Omit extract_resource_result from the generated async section if it is false, to match existing generated output.

This change adds omitempty to the ExtractResourceResult field in declarative.go and updates the golden files in internal/surfer.