### PR TITLE
feat(internal/sidekick/dart): make workspace resolution optional

### DIFF
--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -83,8 +83,9 @@ type modelAnnotations struct {
 	// ["export 'package:google_cloud_gax/gax.dart' show Any", "export 'package:google_cloud_gax/gax.dart' show Status"]
 	Exports []string
 	// A comma-separated list of service fakes, e.g. "FakeCacheService, FakeGenaiService".
-	FakeList    string
-	ProtoPrefix string
+	FakeList     string
+	ProtoPrefix  string
+	UseWorkspace bool
 }
 
 // HasServices returns true if the model has services.
@@ -265,6 +266,7 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 		packageVersion             string
 		partFileReference          string
 		doNotPublish               bool
+		useWorkspace               = true
 		dependencies               = []string{}
 		devDependencies            = []string{}
 		repositoryURL              string
@@ -346,6 +348,16 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 				)
 			}
 			annotate.supportsSSE = value
+		case key == "use-workspace":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return fmt.Errorf(
+					"cannot convert `use-workspace` value %q to boolean: %w",
+					definition,
+					err,
+				)
+			}
+			useWorkspace = value
 		case key == "readme-after-title-text":
 			// Markdown that will be inserted into the README.md after the title section.
 			readMeAfterTitleText = definition
@@ -478,6 +490,7 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 		Exports:                    exports,
 		FakeList:                   strings.Join(fakes, ", "),
 		ProtoPrefix:                protobufPrefix,
+		UseWorkspace:               useWorkspace,
 	}
 
 	model.Codec = ann

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -83,8 +83,9 @@ type modelAnnotations struct {
 	// ["export 'package:google_cloud_gax/gax.dart' show Any", "export 'package:google_cloud_gax/gax.dart' show Status"]
 	Exports []string
 	// A comma-separated list of service fakes, e.g. "FakeCacheService, FakeGenaiService".
-	FakeList     string
-	ProtoPrefix  string
+	FakeList    string
+	ProtoPrefix string
+	// UseWorkspace whether to include the resolution: workspace line in the generated pubspec.yaml.
 	UseWorkspace bool
 }
 

--- a/internal/sidekick/dart/templates/pubspec.yaml.mustache
+++ b/internal/sidekick/dart/templates/pubspec.yaml.mustache
@@ -34,8 +34,8 @@ publish_to: none
 {{/Codec.DoNotPublish}}
 environment:
   sdk: ^3.9.0
-
 {{#Codec.UseWorkspace}}
+
 resolution: workspace
 {{/Codec.UseWorkspace}}
 {{#Codec.HasDependencies}}

--- a/internal/sidekick/dart/templates/pubspec.yaml.mustache
+++ b/internal/sidekick/dart/templates/pubspec.yaml.mustache
@@ -35,7 +35,9 @@ publish_to: none
 environment:
   sdk: ^3.9.0
 
+{{#Codec.UseWorkspace}}
 resolution: workspace
+{{/Codec.UseWorkspace}}
 {{#Codec.HasDependencies}}
 
 dependencies:


### PR DESCRIPTION
Wraps resolution: workspace in a conditional in pubspec.yaml.mustache.

Adds use-workspace option to annotateModel in annotate.go, defaulting to true to preserve existing behavior.
