### PR TITLE
feat(internal/librarian/python): create a changelog during add

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -232,7 +232,7 @@ func addNewLibrary(cfg *config.Config, apis []*config.API, name string) (string,
 		lib = java.Add(lib)
 	case config.LanguagePython:
 		var err error
-		lib, err = python.Add(lib)
+		lib, err = python.Add(lib, python.DefaultOutput(name, cfg.Default.Output))
 		if err != nil {
 			return "", nil, err
 		}

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -17,15 +17,29 @@ package python
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
-// defaultVersion is the first version used for a new library.
-// This is set on the initial `librarian add` for a new API.
-const defaultVersion = "0.0.0"
+const (
+	// defaultVersion is the first version used for a new library.
+	// This is set on the initial `librarian add` for a new API.
+	defaultVersion = "0.0.0"
+	// changelog is the name of the changelog file to create. A regular file
+	// is created in the package root, and a symlink is created in the docs
+	// directory.
+	changelog         = "CHANGELOG.md"
+	changelogTemplate = `# Changelog
+
+[PyPI History][1]
+
+[1]: https://pypi.org/project/%s/#history
+`
+)
 
 var (
 	approvedGAPICNamespaces = []string{
@@ -42,7 +56,7 @@ var (
 )
 
 // Add initializes a new Python library with default values.
-func Add(lib *config.Library) (*config.Library, error) {
+func Add(lib *config.Library, output string) (*config.Library, error) {
 	lib.Version = defaultVersion
 	if len(lib.APIs) != 1 {
 		return nil, errNewLibraryMustHaveOneAPI
@@ -57,6 +71,9 @@ func Add(lib *config.Library) (*config.Library, error) {
 	if !slices.Contains(approvedGAPICNamespaces, namespace) {
 		return nil, fmt.Errorf("%w: unapproved namespace %s derived from API path %s", errNewLibraryBadNamespace, namespace, apiPath)
 	}
+	if err := createChangelog(lib.Name, output); err != nil {
+		return nil, err
+	}
 	return lib, nil
 }
 
@@ -70,6 +87,25 @@ func ValidateNewAPIs(lib *config.Library) error {
 	}
 	if len(lib.Python.OptArgsByAPI) != 0 {
 		return errExistingLibraryCustomGAPICOptions
+	}
+	return nil
+}
+
+// createChangelog creates a regular changelog file for the library with the
+// specified name in the given output directory, and a symlink to that from a
+// docs subdirectory.
+func createChangelog(libName, output string) error {
+	docs := filepath.Join(output, "docs")
+	if err := os.MkdirAll(docs, 0755); err != nil {
+		return err
+	}
+	content := fmt.Sprintf(changelogTemplate, libName)
+	if err := os.WriteFile(filepath.Join(output, changelog), []byte(content), 0644); err != nil {
+		return err
+	}
+	// Create a relative symlink in docs: CHANGELOG.md => ../CHANGELOG.md
+	if err := os.Symlink(filepath.Join("..", changelog), filepath.Join(docs, changelog)); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -104,7 +104,9 @@ func createChangelog(libName, output string) error {
 		return err
 	}
 	// Create a relative symlink in docs: CHANGELOG.md => ../CHANGELOG.md
-	if err := os.Symlink(filepath.Join("..", changelog), filepath.Join(docs, changelog)); err != nil {
+	// The target is created directly rather than using filepath.Join to make
+	// sure it always uses a forward-slash, even on Windows.
+	if err := os.Symlink("../"+changelog, filepath.Join(docs, changelog)); err != nil {
 		return err
 	}
 	return nil

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -118,8 +118,8 @@ func TestAdd_Error(t *testing.T) {
 			wantErr: errNewLibraryBadNamespace,
 		},
 	} {
-		output := t.TempDir()
 		t.Run(test.name, func(t *testing.T) {
+			output := t.TempDir()
 			_, gotErr := Add(test.lib, output)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("error = %v, wantErr %v", gotErr, test.wantErr)

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -211,6 +211,22 @@ func TestCreateChangelog(t *testing.T) {
 	if linkInfo.Mode()&os.ModeSymlink == 0 {
 		t.Errorf("docs file is not a symlink")
 	}
+	// Check that the target resolves to the regular file.
+	linkTarget, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absRegularFile, err := filepath.Abs(filepath.Join(output, changelog))
+	if err != nil {
+		t.Fatal(err)
+	}
+	absLinkTarget, err := filepath.Abs(filepath.Join(output, "docs", linkTarget))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if absLinkTarget != absRegularFile {
+		t.Errorf("absolute link target is %s; want %s", absLinkTarget, absRegularFile)
+	}
 }
 
 func TestCreateChangelog_Error(t *testing.T) {

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -16,6 +16,10 @@ package python
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -66,7 +70,8 @@ func TestAdd(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			gotLib, err := Add(test.lib)
+			output := t.TempDir()
+			gotLib, err := Add(test.lib, output)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -113,8 +118,9 @@ func TestAdd_Error(t *testing.T) {
 			wantErr: errNewLibraryBadNamespace,
 		},
 	} {
+		output := t.TempDir()
 		t.Run(test.name, func(t *testing.T) {
-			_, gotErr := Add(test.lib)
+			_, gotErr := Add(test.lib, output)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("error = %v, wantErr %v", gotErr, test.wantErr)
 			}
@@ -173,6 +179,79 @@ func TestValidateNewAPIs(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			gotErr := ValidateNewAPIs(test.lib)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateChangelog(t *testing.T) {
+	libName := "google-cloud-test"
+	output := t.TempDir()
+	if err := createChangelog(libName, output); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(filepath.Join(output, changelog))
+	if err != nil {
+		t.Fatal(err)
+	}
+	textContent := string(content)
+	if !strings.Contains(textContent, "pypi") {
+		t.Errorf("expected changelog to contain pypi link; was %s", textContent)
+	}
+	if !strings.Contains(textContent, libName) {
+		t.Errorf("expected changelog to contain %s; was %s", libName, textContent)
+	}
+	linkPath := filepath.Join(output, "docs", changelog)
+	linkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("docs file is not a symlink")
+	}
+}
+
+func TestCreateChangelog_Error(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		setup   func(t *testing.T, output string)
+		wantErr error
+	}{
+		{
+			name: "docs is an existing file",
+			setup: func(t *testing.T, output string) {
+				if err := os.WriteFile(filepath.Join(output, "docs"), []byte{}, 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: syscall.ENOTDIR,
+		},
+		{
+			name: "changelog is an existing directory",
+			setup: func(t *testing.T, output string) {
+				if err := os.MkdirAll(filepath.Join(output, changelog), 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: syscall.EISDIR,
+		},
+		{
+			name: "docs changelog is an existing directory",
+			setup: func(t *testing.T, output string) {
+				if err := os.MkdirAll(filepath.Join(output, "docs", changelog), 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: syscall.EEXIST,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			output := t.TempDir()
+			test.setup(t, output)
+			gotErr := createChangelog("google-cloud-test", output)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("error = %v, wantErr %v", gotErr, test.wantErr)
 			}


### PR DESCRIPTION
The python.Add function is changed to create a changelog file in the root directory of the new package, and a symlink to it from a docs directory.

Fixes #5693