### PR TITLE
chore(internal/serviceconfig): add new issue URI for storage

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -3293,6 +3293,7 @@
 - path: google/storage/v2
   languages:
     - all
+  new_issue_uri: https://issuetracker.google.com/issues/new?component=187243&template=1162869
   transports:
     go: grpc
     java: grpc


### PR DESCRIPTION
Add the same issue tracker for google/storage/v2 as is specified in the service config in google/storage/control/v2.