### PR TITLE
chore(tool/cmd/migrate): add common-protos, grafeas, iam and iam-policy to excludedSamplesLibraries

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -22,6 +22,10 @@ var (
 		"storage":           true,
 		"spanner":           true,
 		"containeranalysis": true,
+		"common-protos":     true,
+		"grafeas":           true,
+		"iam":               true,
+		"iam-policy":        true,
 	}
 
 	keepOverride = map[string][]string{


### PR DESCRIPTION
Add common-protos, grafeas, iam and iam-policy to hardcoded list in migrate tool set sample as false. These are setup as not containing generated samples in google-cloud-java by .OwlBot-hermetic.yaml not having copy rule for samples.

For #5729
For #5730
For #5193