### PR TITLE
fix(sidekick/swift): include verb in URL path

### DIFF
--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -32,7 +32,11 @@ func pathExpression(t *api.PathTemplate) string {
 			count += 1
 		}
 	}
-	return "/" + strings.Join(pathComponents, "/")
+	path := "/" + strings.Join(pathComponents, "/")
+	if t.Verb != nil {
+		path += ":" + *t.Verb
+	}
+	return path
 }
 
 func (c *codec) pathVariables(message *api.Message, t *api.PathTemplate) ([]*pathVariable, error) {

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -34,6 +34,7 @@ func pathExpression(t *api.PathTemplate) string {
 	}
 	path := "/" + strings.Join(pathComponents, "/")
 	if t.Verb != nil {
+		// t.Verb cannot be an empty string, the parsers reject empty verbs.
 		path += ":" + *t.Verb
 	}
 	return path

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -48,6 +48,14 @@ func TestPathExpression(t *testing.T) {
 				WithVariableNamed("name").WithLiteral("separator").WithVariableNamed("second"),
 			want: "/v1/\\(pathVariable0)/separator/\\(pathVariable1)",
 		},
+		{
+			name: "with verb",
+			template: (&api.PathTemplate{}).
+				WithLiteral("v1").
+				WithLiteral("operations").
+				WithVerb("cancel"),
+			want: "/v1/operations:cancel",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := pathExpression(test.template)


### PR DESCRIPTION
Some RPCs have a "verb" suffix[^1] that is part of the URL path in the request. I had forgotten to append the verb when it is present.

[^1]: Not to be confused with the HTTP method, often called the verb too.