### PR TITLE
feat(internal/librarian/python): find existing library for a new API

### DIFF
--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -80,7 +80,7 @@ func ValidateNewAPIs(lib *config.Library) error {
 // "versionless" path, which is just the path with any version removed (so the
 // versionless path of google/cloud/xyz/v1 is google/cloud/xyz/; the versionless
 // path of google/cloud/xyz/type is still google/cloud/xyz/type). A nil pointer
-// is removed if no existing library is suitable for the new API path. The
+// is returned if no existing library is suitable for the new API path. The
 // function observes the following rules:
 //
 //  1. If the versionless path of any path in the library is the same as the

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
@@ -72,4 +73,52 @@ func ValidateNewAPIs(lib *config.Library) error {
 		return errExistingLibraryCustomGAPICOptions
 	}
 	return nil
+}
+
+// FindExistingLibraryForNewAPI attempts to find an existing library that should
+// contain the given new API path. This function uses the concept of a
+// "versionless" path, which is just the path with any version removed (so the
+// versionless path of google/cloud/xyz/v1 is google/cloud/xyz/; the versionless
+// path of google/cloud/xyz/type is still google/cloud/xyz/type). A nil pointer
+// is removed if no existing library is suitable for the new API path. The
+// function observes the following rules:
+//
+//  1. If the versionless path of any path in the library is the same as the
+//     versionless apiPath, that library is returned.
+//  2. If the versionless path of any path in the library is a prefix of apiPath
+//     *and* the library contains multiple different versionless paths, that
+//     library is returned.
+//  3. Otherwise, nil is returned.
+func FindExistingLibraryForNewAPI(libraries []*config.Library, apiPath string) *config.Library {
+	versionlessApiPath := versionless(apiPath)
+	for _, lib := range libraries {
+		for _, api := range lib.APIs {
+			if versionless(api.Path) == versionlessApiPath {
+				return lib
+			}
+		}
+	}
+	for _, lib := range libraries {
+		set := make(map[string]struct{})
+		for _, api := range lib.APIs {
+			set[versionless(api.Path)] = struct{}{}
+		}
+		if len(set) <= 1 {
+			continue
+		}
+		for _, api := range lib.APIs {
+			versionlessCandidate := versionless(api.Path)
+			if strings.HasPrefix(apiPath, versionlessCandidate) {
+				return lib
+			}
+		}
+	}
+	return nil
+}
+
+// versionless trims the version (if any) from apiPath, leaving any trailing
+// slash.
+func versionless(apiPath string) string {
+	version := serviceconfig.ExtractVersion(apiPath)
+	return strings.TrimSuffix(apiPath, version)
 }

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -106,9 +106,8 @@ func FindExistingLibraryForNewAPI(libraries []*config.Library, apiPath string) *
 		if len(set) <= 1 {
 			continue
 		}
-		for _, api := range lib.APIs {
-			versionlessCandidate := versionless(api.Path)
-			if strings.HasPrefix(apiPath, versionlessCandidate) {
+		for v := range set {
+			if strings.HasPrefix(apiPath, v) {
 				return lib
 			}
 		}

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -179,3 +179,116 @@ func TestValidateNewAPIs(t *testing.T) {
 		})
 	}
 }
+
+func TestFindExistingLibraryForNewAPI(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name      string
+		libraries []*config.Library
+		apiPath   string
+		// The name of the library that should be returned, or empty if nill
+		// should be returned.
+		wantName string
+	}{
+		{
+			name:      "no libraries",
+			libraries: []*config.Library{},
+			apiPath:   "google/cloud/test/v2",
+		},
+		{
+			name: "exact match of versionless",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-other",
+					APIs: []*config.API{{Path: "google/cloud/other"}},
+				},
+				{
+					Name: "google-cloud-test",
+					APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+				},
+			},
+			apiPath:  "google/cloud/test/v2",
+			wantName: "google-cloud-test",
+		},
+		{
+			name: "prefix match of versionless with existing nested APIs",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-other",
+					APIs: []*config.API{{Path: "google/cloud/other"}},
+				},
+				{
+					Name: "google-cloud-test",
+					APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+				},
+			},
+			apiPath: "google/cloud/test/admin/v2",
+		},
+		{
+			name: "prefix match of versionless with existing nested APIs",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-other",
+					APIs: []*config.API{{Path: "google/cloud/other"}},
+				},
+				{
+					Name: "google-cloud-test",
+					APIs: []*config.API{
+						{Path: "google/cloud/test/v1"},
+						{Path: "google/cloud/test/other/v1"},
+					},
+				},
+			},
+			apiPath:  "google/cloud/test/admin/v2",
+			wantName: "google-cloud-test",
+		},
+		{
+			name: "prefix match of type library with existing nested APIs",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-other",
+					APIs: []*config.API{{Path: "google/cloud/other"}},
+				},
+				{
+					Name: "google-cloud-test",
+					APIs: []*config.API{
+						{Path: "google/cloud/test/v1"},
+						{Path: "google/cloud/test/other/v1"},
+					},
+				},
+			},
+			apiPath:  "google/cloud/test/type",
+			wantName: "google-cloud-test",
+		},
+		{
+			name: "prefix match observes slashes",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-other",
+					APIs: []*config.API{{Path: "google/cloud/other"}},
+				},
+				{
+					Name: "google-cloud-xy",
+					APIs: []*config.API{
+						// These aren't a prefix match for google/cloud/xyz/admin,
+						// even though google/cloud/xy is a prefix of it.
+						{Path: "google/cloud/xy/v1"},
+						{Path: "google/cloud/xy/other/v1"},
+					},
+				},
+			},
+			apiPath: "google/cloud/xyz/admin/v2",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := FindExistingLibraryForNewAPI(test.libraries, test.apiPath)
+			gotName := ""
+			if got != nil {
+				gotName = got.Name
+			}
+			if diff := cmp.Diff(gotName, test.wantName); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
python.FindExistingLibraryForNewAPI is added, to determine which existing library (if any) a new API should be added to. The function is not currently used, but will be used from librarian.addLibrary in a later PR.

Towards #5669