### PR TITLE
refactor(.github/workflows): move all_test.go execution to linter.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
         # TODO(https://github.com/googleapis/librarian/issues/4664): raise to 80.
         run: |
           go run ./tool/cmd/coverage -target=79 \
-            $(go list ./... | grep -v -E 'internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian')
+            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     needs: [go-generate, legacylibrarian, test]

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -45,3 +45,36 @@ jobs:
           go-version-file: "go.mod"
       - name: Run TestYAMLFormat
         run: go test -run TestYAMLFormat -count=1 .
+  goimports:
+    runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Run TestGoImports
+        run: go test -run TestGoImports -count=1 .
+  golangci-lint:
+    runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Run TestGolangCILint
+        run: go test -run TestGolangCILint -count=1 .
+  gomodtidy:
+    runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Run TestGoModTidy
+        run: go test -run TestGoModTidy -count=1 .


### PR DESCRIPTION
Execution of tests in all_test.go is moved to linter.yaml as specific jobs so that they run in parallel and fail fast.