### PR TITLE
fix(internal/librarian/java): fix apiBase in staging dir for common-protos

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -100,7 +101,7 @@ func deriveAPIBase(library *config.Library, apiPath string) string {
 	if library.Name == "common-protos" {
 		return "v1"
 	}
-	return filepath.Base(apiPath)
+	return path.Base(apiPath)
 }
 
 func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, library *config.Library, googleapisDir, outdir string, metadata *repoMetadata, apiCfg *serviceconfig.API) error {

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -94,6 +94,15 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
+func deriveAPIBase(library *config.Library, apiPath string) string {
+	// TODO(https://github.com/googleapis/librarian/issues/5728):
+	// remove this after updated owlbot.py
+	if library.Name == "common-protos" {
+		return "v1"
+	}
+	return filepath.Base(apiPath)
+}
+
 func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, library *config.Library, googleapisDir, outdir string, metadata *repoMetadata, apiCfg *serviceconfig.API) error {
 	javaAPI := ResolveJavaAPI(library, api)
 	p := postProcessParams{
@@ -102,7 +111,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		javaAPI:        javaAPI,
 		metadata:       metadata,
 		outDir:         outdir,
-		apiBase:        filepath.Base(api.Path),
+		apiBase:        deriveAPIBase(library, api.Path),
 		googleapisDir:  googleapisDir,
 		includeSamples: *javaAPI.Samples,
 	}

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -962,3 +962,38 @@ func TestDeriveAdditionalProtoPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestDeriveAPIBase(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		apiPath string
+		want    string
+	}{
+		{
+			name:    "regular library",
+			library: &config.Library{Name: "secretmanager"},
+			apiPath: "google/cloud/secretmanager/v1",
+			want:    "v1",
+		},
+		{
+			name:    "common-protos fallback to v1",
+			library: &config.Library{Name: "common-protos"},
+			apiPath: "google/cloud/audit",
+			want:    "v1",
+		},
+		{
+			name:    "common-protos with versioned path",
+			library: &config.Library{Name: "common-protos"},
+			apiPath: "google/apps/card/v1",
+			want:    "v1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := deriveAPIBase(test.library, test.apiPath)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -249,7 +249,7 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 	protoModules := make([]Coordinate, 0, len(library.APIs))
 	gRPCModules := make([]Coordinate, 0, len(library.APIs))
 	for _, api := range library.APIs {
-		apiBase := filepath.Base(api.Path)
+		apiBase := deriveAPIBase(library, api.Path)
 		javaAPI := ResolveJavaAPI(library, api)
 		apiCoord := DeriveAPICoordinates(libCoord, apiBase, javaAPI)
 


### PR DESCRIPTION
Fix apiBase for common-protos so that staging dir matches expectations in [owlbot.py](https://github.com/googleapis/google-cloud-java/blob/522e05b9112ea0160098152fee8b400fe4d0aa7d/java-common-protos/owlbot.py#L22-L33).

For general case, when API path does not end with version, the base is used to construct the staging dir (e.g., accesscontextmanager, gsuite-addons). However, common-protos does it differently and outputs generated code into staging dir "/owl-bot-staging/java-common-protos/v1/proto-google-common-protos/src".  Worth noting that without this change, the restructure done in owlbot.py is able to work out to the final output structure fine. But the special removal logic in `owlbot.py` cannot find the correct targets.

So we should be able to remove this hardcoded logic once migrated. Filed https://github.com/googleapis/librarian/issues/5728 to track.

Choose to hardcode this value instead of introducing a config in librarian.yaml because a staging_dir_base config for a intermediate structure does not provide much value.

For #5729