### PR TITLE
feat(internal/librarian/tidy): remove unused sections in tidy

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -68,11 +68,11 @@ func RunTidyOnConfig(ctx context.Context, repoDir string, cfg *config.Config) er
 	if err := validateLibraries(cfg); err != nil {
 		return err
 	}
-
 	if cfg.Sources == nil || cfg.Sources.Googleapis == nil {
 		return errNoGoogleapiSourceInfo
 	}
 	cfg.Libraries = tidyLibraries(cfg)
+	tidyConfig(cfg)
 	return yaml.Write(filepath.Join(repoDir, config.LibrarianYAML), formatConfig(cfg))
 }
 
@@ -220,6 +220,34 @@ func tidyRustConfig(lib *config.Library) *config.Library {
 	}
 
 	return lib
+}
+
+// isReleaseEmpty returns true if the release configuration is empty.
+func isReleaseEmpty(release *config.Release) bool {
+	return len(release.IgnoredChanges) == 0 && len(release.Preinstalled) == 0 && len(release.Tools) == 0
+}
+
+// isToolsEmpty returns true if the tools configuration is empty.
+func isToolsEmpty(tools *config.Tools) bool {
+	return len(tools.Cargo) == 0 && len(tools.NPM) == 0 && len(tools.Pip) == 0 && len(tools.Go) == 0
+}
+
+// isDefaultEmpty returns true if the default configuration is empty.
+func isDefaultEmpty(def *config.Default) bool {
+	return len(def.Keep) == 0 && def.Output == "" && def.TagFormat == "" && def.Dotnet == nil && def.Dart == nil && def.Java == nil && def.Nodejs == nil && def.Rust == nil && def.Python == nil && def.Swift == nil
+}
+
+// tidyConfig removes unused sections from the configuration.
+func tidyConfig(cfg *config.Config) {
+	if cfg.Release != nil && isReleaseEmpty(cfg.Release) {
+		cfg.Release = nil
+	}
+	if cfg.Tools != nil && isToolsEmpty(cfg.Tools) {
+		cfg.Tools = nil
+	}
+	if cfg.Default != nil && isDefaultEmpty(cfg.Default) {
+		cfg.Default = nil
+	}
 }
 
 func formatConfig(cfg *config.Config) *config.Config {

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -72,7 +72,7 @@ func RunTidyOnConfig(ctx context.Context, repoDir string, cfg *config.Config) er
 		return errNoGoogleapiSourceInfo
 	}
 	cfg.Libraries = tidyLibraries(cfg)
-	tidyConfig(cfg)
+	cfg = tidyConfig(cfg)
 	return yaml.Write(filepath.Join(repoDir, config.LibrarianYAML), formatConfig(cfg))
 }
 
@@ -247,7 +247,7 @@ func isDefaultEmpty(defaults *config.Default) bool {
 }
 
 // tidyConfig removes unused sections from the configuration.
-func tidyConfig(cfg *config.Config) {
+func tidyConfig(cfg *config.Config) *config.Config {
 	if cfg.Release != nil && isReleaseEmpty(cfg.Release) {
 		cfg.Release = nil
 	}
@@ -257,6 +257,7 @@ func tidyConfig(cfg *config.Config) {
 	if cfg.Default != nil && isDefaultEmpty(cfg.Default) {
 		cfg.Default = nil
 	}
+	return cfg
 }
 
 func formatConfig(cfg *config.Config) *config.Config {

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -233,8 +233,17 @@ func isToolsEmpty(tools *config.Tools) bool {
 }
 
 // isDefaultEmpty returns true if the default configuration is empty.
-func isDefaultEmpty(def *config.Default) bool {
-	return len(def.Keep) == 0 && def.Output == "" && def.TagFormat == "" && def.Dotnet == nil && def.Dart == nil && def.Java == nil && def.Nodejs == nil && def.Rust == nil && def.Python == nil && def.Swift == nil
+func isDefaultEmpty(defaults *config.Default) bool {
+	return len(defaults.Keep) == 0 &&
+		defaults.Output == "" &&
+		defaults.TagFormat == "" &&
+		defaults.Dotnet == nil &&
+		defaults.Dart == nil &&
+		defaults.Java == nil &&
+		defaults.Nodejs == nil &&
+		defaults.Rust == nil &&
+		defaults.Python == nil &&
+		defaults.Swift == nil
 }
 
 // tidyConfig removes unused sections from the configuration.

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -233,6 +233,8 @@ func isToolsEmpty(tools *config.Tools) bool {
 }
 
 // isDefaultEmpty returns true if the default configuration is empty.
+// Note that this will not remove {default: language: {}} because we have
+// not yet encountered this edge case.
 func isDefaultEmpty(defaults *config.Default) bool {
 	return len(defaults.Keep) == 0 &&
 		defaults.Output == "" &&

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -797,6 +797,67 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 	}
 }
 
+func TestTidy_UnusedSections(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		cfg         *config.Config
+		wantRelease bool
+		wantTools   bool
+		wantDefault bool
+	}{
+		{
+			name: "empty sections removed",
+			cfg: &config.Config{
+				Language: config.LanguageRust,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Commit: "commit"},
+				},
+				Release: &config.Release{},
+				Tools:   &config.Tools{},
+				Default: &config.Default{},
+			},
+			wantRelease: false,
+			wantTools:   false,
+			wantDefault: false,
+		},
+		{
+			name: "non-empty sections preserved",
+			cfg: &config.Config{
+				Language: config.LanguageRust,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Commit: "commit"},
+				},
+				Release: &config.Release{IgnoredChanges: []string{"foo"}},
+				Tools: &config.Tools{Cargo: []*config.CargoTool{{Name: "taplo", Version: "1.0"}}},
+				Default: &config.Default{Output: "output"},
+			},
+			wantRelease: true,
+			wantTools:   true,
+			wantDefault: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			if err := RunTidyOnConfig(t.Context(), tempDir, test.cfg); err != nil {
+				t.Fatal(err)
+			}
+			got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (got.Release != nil) != test.wantRelease {
+				t.Errorf("Release present = %v, want %v", got.Release != nil, test.wantRelease)
+			}
+			if (got.Tools != nil) != test.wantTools {
+				t.Errorf("Tools present = %v, want %v", got.Tools != nil, test.wantTools)
+			}
+			if (got.Default != nil) != test.wantDefault {
+				t.Errorf("Default present = %v, want %v", got.Default != nil, test.wantDefault)
+			}
+		})
+	}
+}
+
 func TestTidy_MissingGoogleApisSource(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := &config.Config{

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -828,7 +828,7 @@ func TestTidy_UnusedSections(t *testing.T) {
 					Googleapis: &config.Source{Commit: "commit"},
 				},
 				Release: &config.Release{IgnoredChanges: []string{"foo"}},
-				Tools: &config.Tools{Cargo: []*config.CargoTool{{Name: "taplo", Version: "1.0"}}},
+				Tools:   &config.Tools{Cargo: []*config.CargoTool{{Name: "taplo", Version: "1.0"}}},
 				Default: &config.Default{Output: "output"},
 			},
 			wantRelease: true,


### PR DESCRIPTION
Update librarian tidy to remove empty release, tools, and default sections from the configuration file.

Pointers to structs with all zero values were previously written back to the YAML file as empty objects (e.g., `release: {}`). This change adds explicit checks to nil out these pointers if their fields are all empty, allowing the `omitempty` tag to work as intended.

In an effort to keep the PR small and focus on actually occurring problems, I did not focus on any of [these edge cases.](https://github.com/googleapis/librarian/issues/5469#issuecomment-4347378514) If they become a problem in the future I will create a separate F/U PR.

Fixes #5469