### PR TITLE
refactor(sidekick): remove remaining references to APIState

### DIFF
--- a/internal/sidekick/parser/discovery/discovery.go
+++ b/internal/sidekick/parser/discovery/discovery.go
@@ -41,12 +41,6 @@ func NewAPI(serviceConfig *serviceconfig.Service, contents []byte, discoveryConf
 		Description: doc.Description,
 		Revision:    doc.Revision,
 		Messages:    make([]*api.Message, 0),
-		State: &api.APIState{
-			ServiceByID: make(map[string]*api.Service),
-			MethodByID:  make(map[string]*api.Method),
-			MessageByID: make(map[string]*api.Message),
-			EnumByID:    make(map[string]*api.Enum),
-		},
 	}
 	// Discovery docs use some well-known types inspired by Protobuf. With
 	// protoc these types are automatically included via `import` statements.

--- a/internal/sidekick/parser/openapi.go
+++ b/internal/sidekick/parser/openapi.go
@@ -68,12 +68,6 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 		Title:       model.Model.Info.Title,
 		Description: model.Model.Info.Description,
 		Messages:    make([]*api.Message, 0),
-		State: &api.APIState{
-			ServiceByID: make(map[string]*api.Service),
-			MethodByID:  make(map[string]*api.Method),
-			MessageByID: make(map[string]*api.Message),
-			EnumByID:    make(map[string]*api.Enum),
-		},
 	}
 	// OpenAPI (for Google) uses some well-known types inspired by Protobuf.
 	// With protoc these types are automatically included via `import`

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -263,16 +263,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		mixinFileDesc       []*descriptorpb.FileDescriptorProto
 		enabledMixinMethods mixinMethods = make(map[string]bool)
 	)
-	state := &api.APIState{
-		ServiceByID:    make(map[string]*api.Service),
-		MethodByID:     make(map[string]*api.Method),
-		MessageByID:    make(map[string]*api.Message),
-		EnumByID:       make(map[string]*api.Enum),
-		ResourceByType: make(map[string]*api.Resource),
-	}
-	result := &api.API{
-		State: state,
-	}
+	result := &api.API{}
 	if serviceConfig != nil {
 		result.Title = serviceConfig.Title
 		if serviceConfig.Documentation != nil {


### PR DESCRIPTION
This removes the last remaining refrerences to APIState from outside the api package, and will allow us to hide it.