### PR TITLE
fix(internal/sidekick/surfer): remove omitempty from ExtractResourceResult

### DIFF
--- a/internal/sidekick/surfer/declarative/declarative.go
+++ b/internal/sidekick/surfer/declarative/declarative.go
@@ -346,5 +346,5 @@ type Async struct {
 	// ExtractResourceResult unwraps the target resource from the operation's
 	// response field when the operation completes. Set when the LRO response
 	// type matches the resource being created or updated.
-	ExtractResourceResult bool `yaml:"extract_resource_result,omitempty"`
+	ExtractResourceResult bool `yaml:"extract_resource_result"`
 }

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_delete_ga.yaml
@@ -99,3 +99,4 @@
   async:
     collection:
       - developerconnect.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_delete_ga.yaml
@@ -54,3 +54,4 @@
   async:
     collection:
       - developerconnect.projects.locations.accountConnectors.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_delete_ga.yaml
@@ -88,3 +88,4 @@
   async:
     collection:
       - developerconnect.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_delete_ga.yaml
@@ -91,3 +91,4 @@
   async:
     collection:
       - developerconnect.projects.locations.connections.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_delete_ga.yaml
@@ -87,3 +87,4 @@
   async:
     collection:
       - developerconnect.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_delete_ga.yaml
@@ -83,3 +83,4 @@
       - iam.folders.locations.operations
       - iam.organizations.locations.operations
       - iam.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/principal_access_boundary_policies/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/principal_access_boundary_policies/_partials/_delete_ga.yaml
@@ -85,3 +85,4 @@
   async:
     collection:
       - iam.organizations.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_delete_ga.yaml
@@ -73,3 +73,4 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
@@ -154,3 +154,4 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
@@ -155,3 +155,4 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_export_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_export_data_ga.yaml
@@ -168,3 +168,4 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_import_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/target/surface/parallelstore/instances/_partials/_import_data_ga.yaml
@@ -169,3 +169,4 @@
   async:
     collection:
       - parallelstore.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_delete_ga.yaml
@@ -75,3 +75,4 @@
   async:
     collection:
       - seclm.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_delete_ga.yaml
@@ -94,3 +94,4 @@
   async:
     collection:
       - helptext.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/method_async/expected/current/surface/method_async/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/method_async/expected/current/surface/method_async/resources/_partials/_delete_ga.yaml
@@ -94,3 +94,4 @@
   async:
     collection:
       - methodasync.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/method_operations/expected/current/surface/method_operations/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/method_operations/expected/current/surface/method_operations/resources/_partials/_delete_ga.yaml
@@ -94,3 +94,4 @@
   async:
     collection:
       - methodoperations.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/resource_ones/_partials/_delete_alpha.yaml
+++ b/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/resource_ones/_partials/_delete_alpha.yaml
@@ -53,3 +53,4 @@
   async:
     collection:
       - multiversiontrack.projects.locations.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/regional_endpoints/global_only/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/regional_endpoints/global_only/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
@@ -100,3 +100,4 @@
       - regionalendpoints.projects.operations
       - regionalendpoints.projects.regions.operations
       - regionalendpoints.projects.zones.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/regional_endpoints/regional_required/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/regional_endpoints/regional_required/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
@@ -100,3 +100,4 @@
       - regionalendpoints.projects.operations
       - regionalendpoints.projects.regions.operations
       - regionalendpoints.projects.zones.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/regional_endpoints/regional_supported/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/regional_endpoints/regional_supported/expected/current/surface/regional_endpoints/resources/_partials/_delete_ga.yaml
@@ -100,3 +100,4 @@
       - regionalendpoints.projects.operations
       - regionalendpoints.projects.regions.operations
       - regionalendpoints.projects.zones.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/deeps/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/deeps/resources/_partials/_delete_ga.yaml
@@ -94,3 +94,4 @@
   async:
     collection:
       - resourcemultitype.projects.deeps.operations
+    extract_resource_result: false

--- a/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/resources/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/resource_multitype/expected/current/surface/resource_multitype/resources/_partials/_delete_ga.yaml
@@ -94,3 +94,4 @@
   async:
     collection:
       - resourcemultitype.organizations.locations.operations
+    extract_resource_result: false


### PR DESCRIPTION
Remove the omitempty tag from the ExtractResourceResult field in the Async struct in declarative.go. This ensures that the extract_resource_result field is explicitly emitted in the generated gcloud declarative YAML files even when it is false, which is required by the gcloud framework.

Regenerate the golden files to reflect this change, adding extract_resource_result: false to the relevant test cases.

Reverts https://github.com/googleapis/librarian/pull/5718/