### PR TITLE
feat(internal/librarian): expand exclusion list for new Python libraries

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -327,7 +327,10 @@ func createLegacyLibrary(language string, lib *config.Library) *legacyconfig.Lib
 		}
 		legacyLib.ReleaseExcludePaths = []string{
 			fmt.Sprintf("packages/%s/.repo-metadata.json", lib.Name),
-			fmt.Sprintf("packages/%s/docs/README.rst", lib.Name),
+			fmt.Sprintf("packages/%s/noxfile.py", lib.Name),
+			fmt.Sprintf("packages/%s/tests/", lib.Name),
+			fmt.Sprintf("packages/%s/README.rst", lib.Name),
+			fmt.Sprintf("packages/%s/docs/", lib.Name),
 		}
 		legacyLib.TagFormat = "{id}-v{version}"
 	}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -721,7 +721,10 @@ func TestSyncToStateYAML(t *testing.T) {
 						SourceRoots:   []string{"packages/google-cloud-new"},
 						ReleaseExcludePaths: []string{
 							"packages/google-cloud-new/.repo-metadata.json",
-							"packages/google-cloud-new/docs/README.rst",
+							"packages/google-cloud-new/noxfile.py",
+							"packages/google-cloud-new/tests/",
+							"packages/google-cloud-new/README.rst",
+							"packages/google-cloud-new/docs/",
 						},
 						TagFormat: "{id}-v{version}",
 					},


### PR DESCRIPTION
New Python libraries are populated in the legacylibrarian state.yaml file. The list of files to exclude from consideration when determining what to release is expanded to include the root package README.rst, all docs, all tests, and noxfile.py.

Towards https://github.com/googleapis/librarian/issues/5754