### PR TITLE
fix(sidekick/swift): custom message serialization

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -19,9 +19,10 @@ import (
 )
 
 type fieldAnnotations struct {
-	Name      string
-	FieldType string
-	DocLines  []string
+	Name              string
+	FieldType         string
+	DocLines          []string
+	OneOfPropertyName string
 }
 
 func (c *codec) annotateField(field *api.Field) error {
@@ -33,6 +34,11 @@ func (c *codec) annotateField(field *api.Field) error {
 		Name:      camelCase(field.Name),
 		FieldType: fieldType,
 		DocLines:  c.formatDocumentation(field.Documentation),
+	}
+	if field.IsOneOf && field.Group != nil {
+		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {
+			annotations.OneOfPropertyName = oneofAnn.PropertyName
+		}
 	}
 	field.Codec = annotations
 	return nil

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -25,10 +25,11 @@ const (
 )
 
 type messageAnnotations struct {
-	Name     string
-	DocLines []string
-	Model    *modelAnnotations
-	TypeURL  string
+	Name                string
+	DocLines            []string
+	Model               *modelAnnotations
+	TypeURL             string
+	CustomSerialization bool
 }
 
 func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {
@@ -40,10 +41,11 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	}
 	docLines := c.formatDocumentation(message.Documentation)
 	annotations := &messageAnnotations{
-		Name:     pascalCase(message.Name),
-		DocLines: docLines,
-		Model:    model,
-		TypeURL:  typeURLPrefix + strings.TrimPrefix(message.ID, "."),
+		Name:                pascalCase(message.Name),
+		DocLines:            docLines,
+		Model:               model,
+		TypeURL:             typeURLPrefix + strings.TrimPrefix(message.ID, "."),
+		CustomSerialization: len(message.OneOfs) > 0,
 	}
 
 	message.Codec = annotations
@@ -54,7 +56,11 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		if err := c.annotateField(field); err != nil {
 			return err
 		}
+		if fieldCodec, ok := field.Codec.(*fieldAnnotations); ok && fieldCodec.Name != field.JSONName {
+			annotations.CustomSerialization = true
+		}
 	}
+
 	for _, nested := range message.Messages {
 		if err := c.annotateMessage(nested, model); err != nil {
 			return err

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -23,54 +23,84 @@ import (
 )
 
 func TestAnnotateMessage(t *testing.T) {
-	msg := &api.Message{
-		Name:          "Secret",
-		Documentation: "A secret message.\nWith two lines.",
-		ID:            ".test.Secret",
-		Package:       "test",
-		Fields: []*api.Field{
-			{
-				Name:          "secret_key",
-				Documentation: "The key.",
-				Typez:         api.TypezString,
+	for _, test := range []struct {
+		name    string
+		message *api.Message
+		want    *messageAnnotations
+	}{
+		{
+			name: "simple",
+			message: &api.Message{
+				Name:          "Secret",
+				Documentation: "A secret message.\nWith two lines.",
+				ID:            ".test.Secret",
+				Package:       "test",
+				Fields: []*api.Field{
+					{Name: "secret_key", JSONName: "secretKey", Typez: api.TypezString},
+				},
+			},
+			want: &messageAnnotations{
+				Name:                "Secret",
+				DocLines:            []string{"A secret message.", "With two lines."},
+				TypeURL:             "type.googleapis.com/test.Secret",
+				CustomSerialization: false,
 			},
 		},
-	}
-	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
-		t.Fatal(err)
-	}
-	want := &messageAnnotations{
-		Name:     "Secret",
-		DocLines: []string{"A secret message.", "With two lines."},
-		TypeURL:  "type.googleapis.com/test.Secret",
-	}
-
-	if diff := cmp.Diff(want, msg.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
-	}
-}
-
-func TestAnnotateMessage_EscapedName(t *testing.T) {
-	msg := &api.Message{
-		Name:          "Protocol",
-		Documentation: "A message named Protocol.",
-		ID:            ".test.Protocol",
-		Package:       "test",
-	}
-	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
-		t.Fatal(err)
-	}
-	want := &messageAnnotations{
-		Name:     "Protocol_",
-		DocLines: []string{"A message named Protocol."},
-		TypeURL:  "type.googleapis.com/test.Protocol",
-	}
-
-	if diff := cmp.Diff(want, msg.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		{
+			name: "escaped name",
+			message: &api.Message{
+				Name:          "Protocol",
+				Documentation: "A message named Protocol.",
+				ID:            ".test.Protocol",
+				Package:       "test",
+			},
+			want: &messageAnnotations{
+				Name:                "Protocol_",
+				DocLines:            []string{"A message named Protocol."},
+				TypeURL:             "type.googleapis.com/test.Protocol",
+				CustomSerialization: false,
+			},
+		},
+		{
+			name: "with oneof",
+			message: &api.Message{
+				Name:    "WithOneof",
+				ID:      ".test.WithOneof",
+				Package: "test",
+				OneOfs:  []*api.OneOf{{Name: "choice"}},
+			},
+			want: &messageAnnotations{
+				Name:                "WithOneof",
+				TypeURL:             "type.googleapis.com/test.WithOneof",
+				CustomSerialization: true,
+			},
+		},
+		{
+			name: "with custom json name",
+			message: &api.Message{
+				Name:    "WithCustomJSON",
+				ID:      ".test.WithCustomJSON",
+				Package: "test",
+				Fields: []*api.Field{
+					{Name: "secret_key", JSONName: "specialKey", Typez: api.TypezString},
+				},
+			},
+			want: &messageAnnotations{
+				Name:                "WithCustomJSON",
+				TypeURL:             "type.googleapis.com/test.WithCustomJSON",
+				CustomSerialization: true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model := api.NewTestAPI([]*api.Message{test.message}, []*api.Enum{}, []*api.Service{})
+			codec := newTestCodec(t, model, map[string]string{})
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model")); diff != "" {
+				t.Errorf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -46,6 +46,7 @@ func TestGenerateOneOf(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "string_field",
+				JSONName:      "stringField",
 				ID:            ".google.cloud.test.v1.Outer.string_field",
 				Documentation: "A string field that is part of the oneof.",
 				Typez:         api.TypezString,
@@ -54,6 +55,7 @@ func TestGenerateOneOf(t *testing.T) {
 			},
 			{
 				Name:          "message_field",
+				JSONName:      "messageField",
 				ID:            ".google.cloud.test.v1.Outer.message_field",
 				Documentation: "A message field that is part of the oneof.",
 				Typez:         api.TypezMessage,
@@ -63,12 +65,14 @@ func TestGenerateOneOf(t *testing.T) {
 			},
 			{
 				Name:          "regular_int32",
+				JSONName:      "regularInt32",
 				ID:            ".google.cloud.test.v1.Outer.regular_int32",
 				Documentation: "A regular field.",
 				Typez:         api.TypezInt32,
 			},
 			{
 				Name:          "regular_string",
+				JSONName:      "regularStringSpecial",
 				ID:            ".google.cloud.test.v1.Outer.regular_string",
 				Documentation: "Another regular field.",
 				Typez:         api.TypezString,
@@ -128,6 +132,50 @@ func TestGenerateOneOf(t *testing.T) {
     self.regularString = regularString
     self.choice = choice
   }
+
+  private enum CodingKeys: String, CodingKey {
+    case stringField = "stringField"
+    case messageField = "messageField"
+    case regularInt32 = "regularInt32"
+    case regularString = "regularStringSpecial"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.regularInt32 = try container.decode(Int32.self, forKey: .regularInt32)
+    self.regularString = try container.decode(String.self, forKey: .regularString)
+
+    var choice: OneOf_Choice? = nil
+    let choiceCheckAndSet = { (value: OneOf_Choice) throws in
+      if choice != nil {
+        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof 'choice'"))
+      }
+      choice = value
+    }
+    if let stringField = try container.decodeIfPresent(String.self, forKey: .stringField) {
+      try choiceCheckAndSet(.stringField(stringField))
+    }
+    if let messageField = try container.decodeIfPresent(Inner.self, forKey: .messageField) {
+      try choiceCheckAndSet(.messageField(messageField))
+    }
+    self.choice = choice
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.regularInt32, forKey: .regularInt32)
+    try container.encode(self.regularString, forKey: .regularString)
+
+    if let choice = self.choice {
+      switch choice {
+      case .stringField(let value):
+        try container.encode(value, forKey: .stringField)
+      case .messageField(let value):
+        try container.encode(value, forKey: .messageField)
+      }
+    }
+  }
+
 
   /// A group of fields where only one is set.
   public enum OneOf_Choice: Codable, Equatable {

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -69,6 +69,60 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     self.{{Codec.PropertyName}} = {{Codec.PropertyName}}
     {{/OneOfs}}
   }
+
+  {{#Codec.CustomSerialization}}
+  private enum CodingKeys: String, CodingKey {
+    {{#Fields}}
+    case {{Codec.Name}} = "{{JSONName}}"
+    {{/Fields}}
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    {{#Fields}}
+    {{^IsOneOf}}
+    self.{{Codec.Name}} = try container.decode({{Codec.FieldType}}.self, forKey: .{{Codec.Name}})
+    {{/IsOneOf}}
+    {{/Fields}}
+    {{#OneOfs}}
+
+    var {{Codec.PropertyName}}: {{Codec.Name}}? = nil
+    let {{Codec.PropertyName}}CheckAndSet = { (value: {{Codec.Name}}) throws in
+      if {{Codec.PropertyName}} != nil {
+        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof '{{Codec.PropertyName}}'"))
+      }
+      {{Codec.PropertyName}} = value
+    }
+    {{#Fields}}
+    if let {{Codec.Name}} = try container.decodeIfPresent({{Codec.FieldType}}.self, forKey: .{{Codec.Name}}) {
+      try {{Codec.OneOfPropertyName}}CheckAndSet(.{{Codec.Name}}({{Codec.Name}}))
+    }
+    {{/Fields}}
+    self.{{Codec.PropertyName}} = {{Codec.PropertyName}}
+    {{/OneOfs}}
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    {{#Fields}}
+    {{^IsOneOf}}
+    try container.encode(self.{{Codec.Name}}, forKey: .{{Codec.Name}})
+    {{/IsOneOf}}
+    {{/Fields}}
+    {{#OneOfs}}
+
+    if let choice = self.{{Codec.PropertyName}} {
+      switch choice {
+      {{#Fields}}
+      case .{{Codec.Name}}(let value):
+        try container.encode(value, forKey: .{{Codec.Name}})
+      {{/Fields}}
+      }
+    }
+    {{/OneOfs}}
+  }
+  {{/Codec.CustomSerialization}}
+
   {{#Messages}}
 
   {{> /templates/common/message}}


### PR DESCRIPTION
Messages with oneofs require custom serialization: the oneof must be flattened in the JSON object.

Messages where the field names and the JSONName do not match also require custom serialization: the coding keys must have ad-hoc values.

Fixes #5695 and fixes #5732 