### PR TITLE
refactor(.github): move go generate to linter.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,21 +17,6 @@ permissions:
   contents: read
   issues: write
 jobs:
-  go-generate:
-    runs-on: ubuntu-24.04
-    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-librarian
-      - name: Check go generate
-        run: |
-          go generate ./...
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "go generate produced diffs:"
-            git diff
-            exit 1
-          fi
   legacylibrarian:
     runs-on: ubuntu-24.04
     # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
@@ -61,7 +46,7 @@ jobs:
             $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
-    needs: [go-generate, legacylibrarian, test]
+    needs: [legacylibrarian, test]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -78,3 +78,14 @@ jobs:
           go-version-file: "go.mod"
       - name: Run TestGoModTidy
         run: go test -run TestGoModTidy -count=1 .
+  gogenerate:
+    runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Run TestGoGenerate
+        run: go test -run TestGoGenerate -count=1 .

--- a/all_test.go
+++ b/all_test.go
@@ -50,6 +50,19 @@ func TestAddLicense(t *testing.T) {
 	rungo(t, "tool", "addlicense", "-check", "-c", "Google LLC", "-l", "apache", "-ignore", "**/*pom.xml", ".")
 }
 
+func TestGoGenerate(t *testing.T) {
+	rungo(t, "generate", "./...")
+	cmd := exec.Command("git", "status", "--porcelain")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if stdout.Len() > 0 {
+		t.Fatalf("go generate produced diffs:\n%s", stdout.String())
+	}
+}
+
 func rungo(t *testing.T, args ...string) string {
 	t.Helper()
 

--- a/all_test.go
+++ b/all_test.go
@@ -52,7 +52,7 @@ func TestAddLicense(t *testing.T) {
 
 func TestGoGenerate(t *testing.T) {
 	rungo(t, "generate", "./...")
-	cmd := exec.Command("git", "status", "--porcelain")
+	cmd := exec.CommandContext(t.Context(), "git", "status", "--porcelain")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {

--- a/all_test.go
+++ b/all_test.go
@@ -56,7 +56,7 @@ func TestGoGenerate(t *testing.T) {
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("git status: %v", err)
+		t.Fatal(err)
 	}
 	if stdout.Len() > 0 {
 		t.Fatalf("go generate produced diffs:\n%s", stdout.String())

--- a/tool/cmd/docgen/main.go
+++ b/tool/cmd/docgen/main.go
@@ -144,7 +144,7 @@ func run(cmdPath *string) error {
 	if err := processFile(cmdPath); err != nil {
 		return err
 	}
-	cmd := exec.Command("goimports", "-w", "doc.go")
+	cmd := exec.Command("go", "tool", "goimports", "-w", "doc.go")
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("goimports: %v", err)
 	}


### PR DESCRIPTION
Move `go generate` logic to the linter workflow since it is a lint check.