### PR TITLE
feat(sidekick/swift): request enums as ints

### DIFF
--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -72,11 +72,11 @@ public class {{Codec.Name}} {
       return "{{Codec.PathExpression}}"
     }()
     {{#Codec.HasQueryParams}}
-    var query = [URLQueryItem(name: "$alt", value: "json")]
+    var query = [URLQueryItem(name: "$alt", value: "json;enum-encoding=int")]
     let encoder = GoogleCloudGax.QueryParameterEncoder()
     {{/Codec.HasQueryParams}}
     {{^Codec.HasQueryParams}}
-    let query = [URLQueryItem(name: "$alt", value: "json")]
+    let query = [URLQueryItem(name: "$alt", value: "json;enum-encoding=int")]
     {{/Codec.HasQueryParams}}
     {{#Codec.QueryParams}}
     {{!


### PR DESCRIPTION
The generated code expects to receive enums as integers, because the enums are represented as ints. Well, it should request that the service sends the enums as integers too then.