### PR TITLE
refactor(internal/sidekick/surfer): delete surfaceBuilder

### DIFF
--- a/internal/sidekick/surfer/generate.go
+++ b/internal/sidekick/surfer/generate.go
@@ -24,7 +24,7 @@ import (
 // overrides and writes the resulting command groups into output under
 // baseModule.
 func Generate(model *api.API, overrides *provider.Config, output, baseModule string) error {
-	tree, err := newSurfaceBuilder(model, overrides).build()
+	tree, err := buildSurface(model, overrides)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/surfer/surface_builder.go
+++ b/internal/sidekick/surfer/surface_builder.go
@@ -19,35 +19,23 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/surfer/provider"
 )
 
-type surfaceBuilder struct {
-	model  *api.API
-	config *provider.Config
-}
-
-func newSurfaceBuilder(model *api.API, config *provider.Config) *surfaceBuilder {
-	return &surfaceBuilder{
-		model:  model,
-		config: config,
-	}
-}
-
-func (b *surfaceBuilder) build() (*Surface, error) {
+func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 	var root *CommandGroup
-	providerTracks := provider.Tracks(provider.APIVersionFromModel(b.model))
+	providerTracks := provider.Tracks(provider.APIVersionFromModel(model))
 	var tracks []ReleaseTrack
 	for _, t := range providerTracks {
 		tracks = append(tracks, ReleaseTrack(t))
 	}
 
-	for _, service := range b.model.Services {
-		gb := newGroupBuilder(b.model, service, b.config)
+	for _, service := range model.Services {
+		gb := newGroupBuilder(model, service, config)
 
 		if root == nil {
 			root = gb.buildRoot()
 		}
 
 		for _, method := range service.Methods {
-			if err := b.insert(root, gb, method); err != nil {
+			if err := insert(root, gb, method, model, config); err != nil {
 				return nil, err
 			}
 		}
@@ -59,8 +47,8 @@ func (b *surfaceBuilder) build() (*Surface, error) {
 // insert traverses the tree and attaches a command leaf node. It resolves the
 // literal path segments of the method and walks the tree, creating missing
 // groups if they do not yet exist.
-func (b *surfaceBuilder) insert(root *CommandGroup, gb *groupBuilder, method *api.Method) error {
-	if provider.IsSingletonResourceMethod(method, b.model) {
+func insert(root *CommandGroup, gb *groupBuilder, method *api.Method, model *api.API, config *provider.Config) error {
+	if provider.IsSingletonResourceMethod(method, model) {
 		return nil
 	}
 
@@ -76,11 +64,11 @@ func (b *surfaceBuilder) insert(root *CommandGroup, gb *groupBuilder, method *ap
 
 	curr := root
 	for i, seg := range segments {
-		if b.isTerminatedSegment(seg) {
+		if isTerminatedSegment(seg, config) {
 			return nil
 		}
 		isLeaf := i == len(segments)-1
-		if b.isFlattenedSegment(seg) && !isLeaf {
+		if flattenedSegments[seg] && !isLeaf {
 			continue
 		}
 
@@ -90,7 +78,7 @@ func (b *surfaceBuilder) insert(root *CommandGroup, gb *groupBuilder, method *ap
 		curr = curr.Groups[seg]
 	}
 
-	cmd, err := newCommandBuilder(method, b.config, b.model, gb.service).build()
+	cmd, err := newCommandBuilder(method, config, model, gb.service).build()
 	if err != nil {
 		return err
 	}
@@ -108,10 +96,6 @@ var flattenedSegments = map[string]bool{
 	"organizations": true,
 }
 
-func (b *surfaceBuilder) isFlattenedSegment(lit string) bool {
-	return flattenedSegments[lit]
-}
-
-func (b *surfaceBuilder) isTerminatedSegment(lit string) bool {
-	return lit == "operations" && !provider.ShouldGenerateOperations(b.config)
+func isTerminatedSegment(lit string, config *provider.Config) bool {
+	return lit == "operations" && !provider.ShouldGenerateOperations(config)
 }

--- a/internal/sidekick/surfer/surface_builder.go
+++ b/internal/sidekick/surfer/surface_builder.go
@@ -35,7 +35,7 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 		}
 
 		for _, method := range service.Methods {
-			if err := insert(root, gb, method, model, config); err != nil {
+			if err := insert(root, gb, method); err != nil {
 				return nil, err
 			}
 		}
@@ -47,8 +47,8 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 // insert traverses the tree and attaches a command leaf node. It resolves the
 // literal path segments of the method and walks the tree, creating missing
 // groups if they do not yet exist.
-func insert(root *CommandGroup, gb *groupBuilder, method *api.Method, model *api.API, config *provider.Config) error {
-	if provider.IsSingletonResourceMethod(method, model) {
+func insert(root *CommandGroup, gb *groupBuilder, method *api.Method) error {
+	if provider.IsSingletonResourceMethod(method, gb.model) {
 		return nil
 	}
 
@@ -64,7 +64,7 @@ func insert(root *CommandGroup, gb *groupBuilder, method *api.Method, model *api
 
 	curr := root
 	for i, seg := range segments {
-		if isTerminatedSegment(seg, config) {
+		if isTerminatedSegment(seg, gb.config) {
 			return nil
 		}
 		isLeaf := i == len(segments)-1
@@ -78,7 +78,7 @@ func insert(root *CommandGroup, gb *groupBuilder, method *api.Method, model *api
 		curr = curr.Groups[seg]
 	}
 
-	cmd, err := newCommandBuilder(method, config, model, gb.service).build()
+	cmd, err := newCommandBuilder(method, gb.config, gb.model, gb.service).build()
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/surfer/surface_builder_test.go
+++ b/internal/sidekick/surfer/surface_builder_test.go
@@ -49,7 +49,7 @@ func TestSurfaceBuilder_Build_Structure(t *testing.T) {
 		},
 	}
 
-	root, err := newSurfaceBuilder(model, config).build()
+	root, err := buildSurface(model, config)
 	if err != nil {
 		t.Fatalf("build() failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestSurfaceBuilder_Build_Operations_Disabled(t *testing.T) {
 		Services: []*api.Service{service},
 	}
 
-	root, err := newSurfaceBuilder(model, &provider.Config{GenerateOperations: boolPtr(false)}).build()
+	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(false)})
 	if err != nil {
 		t.Fatalf("build() failed: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestSurfaceBuilder_Build_Operations_Enabled(t *testing.T) {
 		Services: []*api.Service{service},
 	}
 
-	root, err := newSurfaceBuilder(model, &provider.Config{GenerateOperations: boolPtr(true)}).build()
+	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
 		t.Fatalf("build() failed: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestSurfaceBuilder_Build_MultipleServices(t *testing.T) {
 		Services: []*api.Service{serviceOne, serviceTwo},
 	}
 
-	root, err := newSurfaceBuilder(model, &provider.Config{GenerateOperations: boolPtr(true)}).build()
+	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
 		t.Fatalf("build() failed: %v", err)
 	}


### PR DESCRIPTION
Remove the surfaceBuilder struct and pass its fields (model and config) directly to the buildSurface function to remove an unnecessary layer of abstraction.

Also delete isFlattenedSegment, and use the flattenedSegments map directly to check for existence.