### PR TITLE
fix(internal/librarian/java): common-protos should not remove com/google/cloud/location classes

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -32,7 +32,10 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
-const commonResourcesProto = "google/cloud/common_resources.proto"
+const (
+	commonResourcesProto = "google/cloud/common_resources.proto"
+	commonProtosLibrary  = "common-protos"
+)
 
 // nonRecursivePaths is a set of paths where proto gathering should not be recursive.
 var nonRecursivePaths = map[string]bool{
@@ -98,7 +101,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 func deriveAPIBase(library *config.Library, apiPath string) string {
 	// TODO(https://github.com/googleapis/librarian/issues/5728):
 	// remove this after updated owlbot.py
-	if library.Name == "common-protos" {
+	if library.Name == commonProtosLibrary {
 		return "v1"
 	}
 	return path.Base(apiPath)

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -264,8 +264,10 @@ func restructure(actions []moveAction) error {
 func restructureModules(p postProcessParams, destRoot string) error {
 	coords := p.coords()
 	tempProtoSrcDir := p.protoDir()
-	if err := removeConflictingFiles(tempProtoSrcDir); err != nil {
-		return err
+	if p.library.Name != commonProtosLibrary {
+		if err := removeConflictingFiles(tempProtoSrcDir); err != nil {
+			return err
+		}
 	}
 
 	protoDest := filepath.Join(destRoot, coords.Proto.ArtifactID, "src", "main", "java")

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -225,15 +225,7 @@ func TestRestructureModules_CommonProtos(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	apiBase := "v1"
-	protoSrcDir := filepath.Join(tmpDir, apiBase, "proto")
-	locationDir := filepath.Join(protoSrcDir, "com", "google", "cloud", "location")
-	if err := os.MkdirAll(locationDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	dummyFile := filepath.Join(locationDir, "LocationsProto.java")
-	if err := os.WriteFile(dummyFile, []byte("public class LocationsProto {}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	setupLocationProtoFile(t, tmpDir, apiBase)
 	p := postProcessParams{
 		outDir:         tmpDir,
 		library:        &config.Library{Name: commonProtosLibrary},
@@ -252,6 +244,43 @@ func TestRestructureModules_CommonProtos(t *testing.T) {
 	wantPath := filepath.Join(destRoot, "proto-google-common-protos", "src", "main", "java", "com", "google", "cloud", "location", "LocationsProto.java")
 	if _, err := os.Stat(wantPath); err != nil {
 		t.Errorf("expected file at %s to exist, but it was not found: %v", wantPath, err)
+	}
+}
+
+func TestRestructureModules_ShouldRemoveClasses(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	apiBase := "v1"
+	setupLocationProtoFile(t, tmpDir, apiBase)
+	p := postProcessParams{
+		outDir:         tmpDir,
+		library:        &config.Library{Name: "secretmanager"},
+		apiBase:        apiBase,
+		googleapisDir:  googleapisDir,
+		apiProtos:      nil,
+		includeSamples: false,
+		javaAPI:        &config.JavaAPI{},
+	}
+	destRoot := filepath.Join(tmpDir, "dest")
+	if err := restructureModules(p, destRoot); err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(destRoot, "proto-google-cloud-secretmanager-v1", "src", "main", "java", "com", "google", "cloud", "location", "LocationsProto.java")
+	if _, err := os.Stat(wantPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected file at %s to be missing, but it exists", wantPath)
+	}
+}
+
+func setupLocationProtoFile(t *testing.T, tmpDir, apiBase string) {
+	t.Helper()
+	protoSrcDir := filepath.Join(tmpDir, apiBase, "proto")
+	locationDir := filepath.Join(protoSrcDir, "com", "google", "cloud", "location")
+	if err := os.MkdirAll(locationDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	dummyFile := filepath.Join(locationDir, "LocationsProto.java")
+	if err := os.WriteFile(dummyFile, []byte("public class LocationsProto {}"), 0644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -221,6 +221,40 @@ func TestRestructureModules(t *testing.T) {
 	}
 }
 
+func TestRestructureModules_CommonProtos(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	apiBase := "v1"
+	protoSrcDir := filepath.Join(tmpDir, apiBase, "proto")
+	locationDir := filepath.Join(protoSrcDir, "com", "google", "cloud", "location")
+	if err := os.MkdirAll(locationDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	dummyFile := filepath.Join(locationDir, "LocationsProto.java")
+	if err := os.WriteFile(dummyFile, []byte("public class LocationsProto {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p := postProcessParams{
+		outDir:         tmpDir,
+		library:        &config.Library{Name: commonProtosLibrary},
+		apiBase:        apiBase,
+		googleapisDir:  googleapisDir,
+		apiProtos:      nil,
+		includeSamples: false,
+		javaAPI: &config.JavaAPI{
+			ProtoArtifactIDOverride: "proto-google-common-protos",
+		},
+	}
+	destRoot := filepath.Join(tmpDir, "dest")
+	if err := restructureModules(p, destRoot); err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(destRoot, "proto-google-common-protos", "src", "main", "java", "com", "google", "cloud", "location", "LocationsProto.java")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Errorf("expected file at %s to exist, but it was not found: %v", wantPath, err)
+	}
+}
+
 func TestRestructureModules_SamplesDisabled(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
When library is `common-protos`, should not remove conflicting files. This needs to be hardcoded for `common-protos` because it is a special library, and the intention of `removeConflictingFiles` is to remove these files for libraries other than `common-protos`.

For https://github.com/googleapis/librarian/issues/5729