### PR TITLE
feat(internal/librarian/java): add skip_api_id config to allow omitting in repo-metadata

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -299,6 +299,7 @@ This document describes the schema for the librarian.yaml.
 | `rpc_documentation` | string | Is the URL for the RPC documentation. |
 | `transport_override` | string | Allows the "transport" field in .repo-metadata.json to be overridden. TODO(https://github.com/googleapis/librarian/issues/5561): investigate and determine if can remove |
 | `skip_pom_updates` | bool | Indicates whether to skip updating pom.xml files. TODO(https://github.com/googleapis/librarian/issues/5277): re-evaluate together with ExcludedPOMs |
+| `skip_api_id` | bool | Indicates whether to skip adding api_id to .repo-metadata.json. |
 
 ## NodejsAPI Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -553,6 +553,9 @@ type JavaModule struct {
 	// TODO(https://github.com/googleapis/librarian/issues/5277):
 	// re-evaluate together with ExcludedPOMs
 	SkipPOMUpdates bool `yaml:"skip_pom_updates,omitempty"`
+
+	// SkipAPIID indicates whether to skip adding api_id to .repo-metadata.json.
+	SkipAPIID bool `yaml:"skip_api_id,omitempty"`
 }
 
 // JavaAPI represents configuration for a single API within a Java module.

--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -119,6 +119,9 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		if library.Java.APIIDOverride != "" {
 			metadata.APIID = library.Java.APIIDOverride
 		}
+		if library.Java.SkipAPIID {
+			metadata.APIID = ""
+		}
 		if library.Java.APIDescriptionOverride != "" {
 			metadata.APIDescription = library.Java.APIDescriptionOverride
 		}

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -453,6 +453,9 @@ func applyJavaLibraryOverrides(lib *config.Library) {
 	if skipPOMUpdates[lib.Name] {
 		lib.Java.SkipPOMUpdates = true
 	}
+	if skipAPIID[lib.Name] {
+		lib.Java.SkipAPIID = true
+	}
 	for _, ja := range lib.Java.JavaAPIs {
 		if monolithicJavaAPIs[ja.Path] {
 			ja.Monolithic = true

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -163,6 +163,16 @@ var (
 		"common-protos": "common-protos",
 	}
 
+	skipAPIID = map[string]bool{
+		"google-auth-library": true,
+		"showcase":            true,
+		"iam":                 true,
+		"api-common":          true,
+		"common-protos":       true,
+		"gax":                 true,
+		"core":                true,
+	}
+
 	skipPOMUpdates = map[string]bool{
 		"grafeas":       true,
 		"common-protos": true,

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -131,6 +131,7 @@ func TestApplyJavaLibraryOverrides(t *testing.T) {
 				Java: &config.JavaModule{
 					APIShortnameOverride: "common-protos",
 					SkipPOMUpdates:       true,
+					SkipAPIID:            true,
 				},
 			},
 		},


### PR DESCRIPTION
Add `skip_api_id` config to allow omitting in repo-metadata, update migrate script to hardcode libraries. This was originally hardcoded in hermetic build script [here]( https://github.com/googleapis/google-cloud-java/blob/d690333e4ffe8dda982d61723387ecda971d7d21/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py#L30-L38).

For https://github.com/googleapis/librarian/issues/5729