### PR TITLE
chore(python): move changelog consts to generate

### DIFF
--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -23,21 +23,9 @@ import (
 	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
-const (
-	// defaultVersion is the first version used for a new library.
-	// This is set on the initial `librarian add` for a new API.
-	defaultVersion = "0.0.0"
-	// changelog is the name of the changelog file to create. A regular file
-	// is created in the package root, and a symlink is created in the docs
-	// directory.
-	changelog         = "CHANGELOG.md"
-	changelogTemplate = `# Changelog
-
-[PyPI History][1]
-
-[1]: https://pypi.org/project/%s/#history
-`
-)
+// defaultVersion is the first version used for a new library.
+// This is set on the initial `librarian add` for a new API.
+const defaultVersion = "0.0.0"
 
 var (
 	approvedGAPICNamespaces = []string{

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -40,6 +40,17 @@ const (
 	gapicNamespaceOption                = "python-gapic-namespace"
 	gapicNameOption                     = "python-gapic-name"
 	warehousePackageNameOption          = "warehouse-package-name"
+
+	// changelog is the name of the changelog file to create. A regular file
+	// is created in the package root, and a symlink is created in the docs
+	// directory.
+	changelog         = "CHANGELOG.md"
+	changelogTemplate = `# Changelog
+
+[PyPI History][1]
+
+[1]: https://pypi.org/project/%s/#history
+`
 )
 
 var (


### PR DESCRIPTION
#5756 added new consts for changelog initialization to `python/add.go`, but this logic exists in `python/generate.go`. Merged the PR for velocity purposes, consolidating with this PR.