### PR TITLE
refactor(internal/sidekick/surfer): default help text

### DIFF
--- a/internal/librarian/surfer/testdata/publicca/publicca/external_account_keys/_partials/_create_ga.yaml
+++ b/internal/librarian/surfer/testdata/publicca/publicca/external_account_keys/_partials/_create_ga.yaml
@@ -20,7 +20,7 @@
   hidden: true
   help_text:
     brief: Create externalAccountKeys
-    description: Create a external_account_key
+    description: Create an external_account_key
     examples: |-
       To create the external_account_key, run:
 

--- a/internal/sidekick/surfer/provider/method.go
+++ b/internal/sidekick/surfer/provider/method.go
@@ -246,10 +246,18 @@ func GetMethodHelpText(overrides *Config, method *api.Method, model *api.API) He
 	description := ""
 	examples := ""
 
+	aOrAn := "a"
+	if len(singular) > 0 {
+		c := strings.ToLower(string(singular[0]))
+		if strings.Contains("aeiou", c) {
+			aOrAn = "an"
+		}
+	}
+
 	switch commandName {
 	case "describe":
 		brief = fmt.Sprintf("Describe %s", plural)
-		description = fmt.Sprintf("Describe a %s", singular)
+		description = fmt.Sprintf("Describe %s %s", aOrAn, singular)
 		examples = fmt.Sprintf("To describe the %s, run:\n\n    $ {command}", singular)
 	case "list":
 		brief = fmt.Sprintf("List %s", plural)
@@ -257,16 +265,28 @@ func GetMethodHelpText(overrides *Config, method *api.Method, model *api.API) He
 		examples = fmt.Sprintf("To list all %s, run:\n\n    $ {command}", plural)
 	case "create":
 		brief = fmt.Sprintf("Create %s", plural)
-		description = fmt.Sprintf("Create a %s", singular)
+		description = fmt.Sprintf("Create %s %s", aOrAn, singular)
 		examples = fmt.Sprintf("To create the %s, run:\n\n    $ {command}", singular)
 	case "delete":
 		brief = fmt.Sprintf("Delete %s", plural)
-		description = fmt.Sprintf("Delete a %s", singular)
+		description = fmt.Sprintf("Delete %s %s", aOrAn, singular)
 		examples = fmt.Sprintf("To delete the %s, run:\n\n    $ {command}", singular)
 	case "update":
 		brief = fmt.Sprintf("Update %s", plural)
-		description = fmt.Sprintf("Update a %s", singular)
+		description = fmt.Sprintf("Update %s %s", aOrAn, singular)
 		examples = fmt.Sprintf("To update the %s, run:\n\n    $ {command}", singular)
+	default:
+		verb := commandName
+		if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 {
+			binding := method.PathInfo.Bindings[0]
+			if binding.PathTemplate != nil && binding.PathTemplate.Verb != nil {
+				verb = *binding.PathTemplate.Verb
+			}
+		}
+		sentenceCaseVerb := ToSentenceCase(verb)
+		brief = fmt.Sprintf("%s %s", sentenceCaseVerb, plural)
+		description = fmt.Sprintf("%s %s %s", sentenceCaseVerb, aOrAn, singular)
+		examples = fmt.Sprintf("To %s the %s, run:\n\n    $ {command}", strings.ToLower(sentenceCaseVerb), singular)
 	}
 
 	return HelpText{
@@ -274,6 +294,21 @@ func GetMethodHelpText(overrides *Config, method *api.Method, model *api.API) He
 		Description: description,
 		Examples:    examples,
 	}
+}
+
+// ToSentenceCase converts a string to sentence case (e.g., "exportData" -> "Export data").
+func ToSentenceCase(s string) string {
+	camel := strcase.ToCamel(s)
+	var sb strings.Builder
+	for i, r := range camel {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			sb.WriteByte(' ')
+			sb.WriteString(strings.ToLower(string(r)))
+		} else {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
 }
 
 // APIVersionFromMethod extracts the API version from the method's service package name.

--- a/internal/sidekick/surfer/provider/method_test.go
+++ b/internal/sidekick/surfer/provider/method_test.go
@@ -439,6 +439,11 @@ func TestGetMethodHelpText(t *testing.T) {
 				Plural:   "instances",
 				Singular: "instance",
 			},
+			{
+				Type:     "test.googleapis.com/Book",
+				Plural:   "books",
+				Singular: "book",
+			},
 		},
 	}
 
@@ -486,8 +491,28 @@ func TestGetMethodHelpText(t *testing.T) {
 			method: methodMock("GetInstance"),
 			want: HelpText{
 				Brief:       "Describe instances",
-				Description: "Describe a instance",
+				Description: "Describe an instance",
 				Examples:    "To describe the instance, run:\n\n    $ {command}",
+			},
+		},
+		{
+			name: "Describe Fallback with A",
+			method: &api.Method{
+				Name: "GetBook",
+				ID:   ".GetBook",
+				InputType: &api.Message{
+					Fields: []*api.Field{{
+						Name: "name",
+						ResourceReference: &api.ResourceReference{
+							Type: "test.googleapis.com/Book",
+						},
+					}},
+				},
+			},
+			want: HelpText{
+				Brief:       "Describe books",
+				Description: "Describe a book",
+				Examples:    "To describe the book, run:\n\n    $ {command}",
 			},
 		},
 		{
@@ -504,7 +529,7 @@ func TestGetMethodHelpText(t *testing.T) {
 			method: methodMock("CreateInstance"),
 			want: HelpText{
 				Brief:       "Create instances",
-				Description: "Create a instance",
+				Description: "Create an instance",
 				Examples:    "To create the instance, run:\n\n    $ {command}",
 			},
 		},
@@ -513,7 +538,7 @@ func TestGetMethodHelpText(t *testing.T) {
 			method: methodMock("DeleteInstance"),
 			want: HelpText{
 				Brief:       "Delete instances",
-				Description: "Delete a instance",
+				Description: "Delete an instance",
 				Examples:    "To delete the instance, run:\n\n    $ {command}",
 			},
 		},
@@ -522,8 +547,39 @@ func TestGetMethodHelpText(t *testing.T) {
 			method: methodMock("UpdateInstance"),
 			want: HelpText{
 				Brief:       "Update instances",
-				Description: "Update a instance",
+				Description: "Update an instance",
 				Examples:    "To update the instance, run:\n\n    $ {command}",
+			},
+		},
+		{
+			name: "Custom Verb Fallback",
+			method: func() *api.Method {
+				v := "exportData"
+				m := api.NewTestMethod("ExportData")
+				m.ID = ".ExportData"
+				m.InputType = &api.Message{
+					Fields: []*api.Field{{
+						Name: "name",
+						ResourceReference: &api.ResourceReference{
+							Type: "test.googleapis.com/Instance",
+						},
+					}},
+				}
+				m.PathInfo = &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							PathTemplate: &api.PathTemplate{
+								Verb: &v,
+							},
+						},
+					},
+				}
+				return m
+			}(),
+			want: HelpText{
+				Brief:       "Export data instances",
+				Description: "Export data an instance",
+				Examples:    "To export data the instance, run:\n\n    $ {command}",
 			},
 		},
 		{

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_create_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Create accountConnectors
-    description: Create a accountConnector
+    description: Create an accountConnector
     examples: |-
       To create the accountConnector, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_delete_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Delete accountConnectors
-    description: Delete a accountConnector
+    description: Delete an accountConnector
     examples: |-
       To delete the accountConnector, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_describe_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_describe_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Describe accountConnectors
-    description: Describe a accountConnector
+    description: Describe an accountConnector
     examples: |-
       To describe the accountConnector, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_update_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/_partials/_update_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Update accountConnectors
-    description: Update a accountConnector
+    description: Update an accountConnector
     examples: |-
       To update the accountConnector, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_delete_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Delete accountConnectors
-    description: Delete a accountConnector
+    description: Delete an accountConnector
     examples: |-
       To delete the accountConnector, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_fetch_access_token_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_fetch_access_token_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Fetch access token resources
+    description: Fetch access token a resource
+    examples: |-
+      To fetch access token the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: account-connector

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_fetch_self_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_fetch_self_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Fetch self accountConnectors
+    description: Fetch self an accountConnector
+    examples: |-
+      To fetch self the accountConnector, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: name

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_finish_o_auth_flow_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_finish_o_auth_flow_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Finish oauth flow resources
+    description: Finish oauth flow a resource
+    examples: |-
+      To finish oauth flow the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: oauth-params

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_start_o_auth_flow_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/account_connectors/users/_partials/_start_o_auth_flow_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Start oauth flow resources
+    description: Start oauth flow a resource
+    examples: |-
+      To start oauth flow the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: account-connector

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_fetch_git_hub_installations_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_fetch_git_hub_installations_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Fetch git hub installations resources
+    description: Fetch git hub installations a resource
+    examples: |-
+      To fetch git hub installations the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: connection

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_fetch_linkable_git_repositories_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_fetch_linkable_git_repositories_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Fetch linkable git repositories resources
+    description: Fetch linkable git repositories a resource
+    examples: |-
+      To fetch linkable git repositories the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: connection

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_git_refs_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_git_refs_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Fetch git refs resources
+    description: Fetch git refs a resource
+    examples: |-
+      To fetch git refs the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: git-repository-link

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_read_token_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_read_token_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Fetch read token resources
+    description: Fetch read token a resource
+    examples: |-
+      To fetch read token the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: git-repository-link

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_read_write_token_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_read_write_token_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Fetch read write token resources
+    description: Fetch read write token a resource
+    examples: |-
+      To fetch read write token the resource, run:
+
+          $ {command}
   arguments:
     params:
       - arg_name: git-repository-link

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_create_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Create insightsConfigs
-    description: Create a insightsConfig
+    description: Create an insightsConfig
     examples: |-
       To create the insightsConfig, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_delete_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_delete_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Delete insightsConfigs
-    description: Delete a insightsConfig
+    description: Delete an insightsConfig
     examples: |-
       To delete the insightsConfig, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_describe_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_describe_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Describe insightsConfigs
-    description: Describe a insightsConfig
+    description: Describe an insightsConfig
     examples: |-
       To describe the insightsConfig, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_update_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_update_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Update insightsConfigs
-    description: Update a insightsConfig
+    description: Update an insightsConfig
     examples: |-
       To update the insightsConfig, run:
 

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/operations/_partials/_cancel_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/operations/_partials/_cancel_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Cancel resources
+    description: Cancel a resource
+    examples: |-
+      To cancel the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: ""

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/operations/_partials/_cancel_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/operations/_partials/_cancel_ga.yaml
@@ -19,8 +19,12 @@
   auto_generated: true
   hidden: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Cancel resources
+    description: Cancel a resource
+    examples: |-
+      To cancel the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: ""

--- a/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/operations/_partials/_cancel_ga.yaml
+++ b/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/operations/_partials/_cancel_ga.yaml
@@ -19,8 +19,12 @@
   auto_generated: true
   hidden: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Cancel resources
+    description: Cancel a resource
+    examples: |-
+      To cancel the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: ""

--- a/internal/surfer/testdata/field_flag_names/expected/current/surface/field_flag_names/resources/_partials/_archive_ga.yaml
+++ b/internal/surfer/testdata/field_flag_names/expected/current/surface/field_flag_names/resources/_partials/_archive_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Archive resources
+    description: Archive a resource
+    examples: |-
+      To archive the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: Resource name.

--- a/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_archive_ga.yaml
+++ b/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_archive_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Archive resources
+    description: Archive a resource
+    examples: |-
+      To archive the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: The resource name of the resource within a service.

--- a/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_export_ga.yaml
+++ b/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_export_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Export resources
+    description: Export a resource
+    examples: |-
+      To export the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: The resource name of the resource within a service.

--- a/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_search_ga.yaml
+++ b/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_search_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Search resources
+    description: Search a resource
+    examples: |-
+      To search the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: The parent of the resource.

--- a/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_undelete_ga.yaml
+++ b/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/_partials/_undelete_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Undelete resources
+    description: Undelete a resource
+    examples: |-
+      To undelete the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: |-

--- a/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/revisions/_partials/_search_ga.yaml
+++ b/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/resources/revisions/_partials/_search_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Search revisions
+    description: Search a revision
+    examples: |-
+      To search the revision, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: The parent of the resource.

--- a/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/revisions/_partials/_archive_ga.yaml
+++ b/internal/surfer/testdata/method_custom/expected/current/surface/method_custom/revisions/_partials/_archive_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Archive revisions
+    description: Archive a revision
+    examples: |-
+      To archive the revision, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: The resource name of the resource within a service.

--- a/internal/surfer/testdata/method_operations/expected/current/surface/method_operations/operations/_partials/_cancel_ga.yaml
+++ b/internal/surfer/testdata/method_operations/expected/current/surface/method_operations/operations/_partials/_cancel_ga.yaml
@@ -18,8 +18,12 @@
     - GA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Cancel resources
+    description: Cancel a resource
+    examples: |-
+      To cancel the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: ""

--- a/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/operations/_partials/_cancel_alpha.yaml
+++ b/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/operations/_partials/_cancel_alpha.yaml
@@ -18,8 +18,12 @@
     - ALPHA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Cancel resources
+    description: Cancel a resource
+    examples: |-
+      To cancel the resource, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: ""

--- a/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/resource_ones/_partials/_archive_alpha.yaml
+++ b/internal/surfer/testdata/multi_version_multi_track/expected/current/surface/multi_version_multi_track/resource_ones/_partials/_archive_alpha.yaml
@@ -18,8 +18,12 @@
     - ALPHA
   auto_generated: true
   help_text:
-    brief: ""
-    description: ""
+    brief: Archive resourceOnes
+    description: Archive a resourceOne
+    examples: |-
+      To archive the resourceOne, run:
+
+          $ {command}
   arguments:
     params:
       - help_text: The name of the resource.

--- a/internal/surfer/testdata/resource_non_standard/expected/current/surface/resource_non_standard/apis/_partials/_describe_ga.yaml
+++ b/internal/surfer/testdata/resource_non_standard/expected/current/surface/resource_non_standard/apis/_partials/_describe_ga.yaml
@@ -19,7 +19,7 @@
   auto_generated: true
   help_text:
     brief: Describe apis
-    description: Describe a api
+    description: Describe an api
     examples: |-
       To describe the api, run:
 


### PR DESCRIPTION
Fix grammar of default help text. Additionally, add default help text for non CRUDL commands

For #5485