### PR TITLE
feat(too/cmd/migrate): add showcase source to librarian.yaml

### DIFF
--- a/tool/cmd/migrate/fetch.go
+++ b/tool/cmd/migrate/fetch.go
@@ -34,9 +34,17 @@ func fetchGoogleapis(ctx context.Context) (*config.Source, error) {
 }
 
 func fetchGoogleapisWithCommit(ctx context.Context, endpoints *fetch.Endpoints, commitish string) (*config.Source, error) {
+	return fetchRepoWithCommit(ctx, endpoints, "googleapis", "googleapis", googleapisRepo, commitish)
+}
+
+func fetchShowcaseWithCommit(ctx context.Context, endpoints *fetch.Endpoints, commitish string) (*config.Source, error) {
+	return fetchRepoWithCommit(ctx, endpoints, "googleapis", "gapic-showcase", "github.com/googleapis/gapic-showcase", commitish)
+}
+
+func fetchRepoWithCommit(ctx context.Context, endpoints *fetch.Endpoints, org, name, repoURL, commitish string) (*config.Source, error) {
 	repo := &fetch.RepoRef{
-		Org:    "googleapis",
-		Name:   "googleapis",
+		Org:    org,
+		Name:   name,
 		Branch: commitish,
 	}
 	commit, sha256, err := fetch.LatestCommitAndChecksum(endpoints, repo)
@@ -44,7 +52,7 @@ func fetchGoogleapisWithCommit(ctx context.Context, endpoints *fetch.Endpoints, 
 		return nil, err
 	}
 
-	dir, err := fetch.Repo(ctx, googleapisRepo, commit, sha256)
+	dir, err := fetch.Repo(ctx, repoURL, commit, sha256)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -167,11 +167,20 @@ func runJavaMigration(ctx context.Context, repoPath string, shouldInsertMarkers 
 	if err != nil {
 		return errFetchSource
 	}
+	showcaseVersion, err := getShowcaseVersion(repoPath)
+	if err != nil {
+		return fmt.Errorf("failed to get showcase version: %w", err)
+	}
+	showcaseSrc, err := fetchShowcaseWithCommit(ctx, githubEndpoints, "v"+showcaseVersion)
+	if err != nil {
+		return errFetchSource
+	}
+
 	versions, err := readVersions(filepath.Join(repoPath, "versions.txt"))
 	if err != nil {
 		return err
 	}
-	cfg, err := buildConfig(gen, repoPath, src, versions)
+	cfg, err := buildConfig(gen, repoPath, src, showcaseSrc, versions)
 	if err != nil {
 		return err
 	}
@@ -181,6 +190,7 @@ func runJavaMigration(ctx context.Context, repoPath string, shouldInsertMarkers 
 	// The directory name in Googleapis is present for migration code to look
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""
+	cfg.Sources.Showcase.Dir = ""
 
 	if shouldInsertMarkers {
 		if err := insertMarkers(repoPath, cfg); err != nil {
@@ -223,7 +233,7 @@ func readVersions(path string) (map[string]string, error) {
 }
 
 // buildConfig converts a GenerationConfig to a Librarian Config.
-func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, versions map[string]string) (*config.Config, error) {
+func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *config.Source, versions map[string]string) (*config.Config, error) {
 	var libs []*config.Library
 	if v, ok := versions["google-cloud-java"]; ok {
 		libs = append(libs, &config.Library{
@@ -353,6 +363,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src *config.Source, ver
 		},
 		Sources: &config.Sources{
 			Googleapis: src,
+			Showcase:   showcaseSrc,
 		},
 		Libraries: libs,
 		Repo:      "googleapis/google-cloud-java",
@@ -768,4 +779,22 @@ func extractStrings(expr build.Expr) []string {
 		}
 	})
 	return res
+}
+
+func getShowcaseVersion(repoPath string) (string, error) {
+	showcaseDir := filepath.Join(repoPath, "java-showcase")
+	return extractVersionFromPOM(filepath.Join(showcaseDir, "gapic-showcase", "pom.xml"))
+}
+
+func extractVersionFromPOM(pomPath string) (string, error) {
+	content, err := os.ReadFile(pomPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", pomPath, err)
+	}
+	re := regexp.MustCompile(`<gapic-showcase\.version>(.*?)</gapic-showcase\.version>`)
+	match := re.FindSubmatch(content)
+	if len(match) < 2 {
+		return "", fmt.Errorf("failed to find gapic-showcase.version in %s", pomPath)
+	}
+	return string(match[1]), nil
 }

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -49,7 +49,8 @@ const (
 )
 
 var (
-	fetchSourceWithCommit = fetchGoogleapisWithCommit
+	fetchGoogleapisWithCommitVar = fetchGoogleapisWithCommit
+	fetchShowcaseWithCommitVar   = fetchShowcaseWithCommit
 )
 
 type javaGAPICInfo struct {
@@ -163,17 +164,17 @@ func runJavaMigration(ctx context.Context, repoPath string, shouldInsertMarkers 
 	if commit == "" {
 		commit = "master"
 	}
-	src, err := fetchSourceWithCommit(ctx, githubEndpoints, commit)
+	src, err := fetchGoogleapisWithCommitVar(ctx, githubEndpoints, commit)
 	if err != nil {
-		return errFetchSource
+		return fmt.Errorf("failed to fetch googleapis source: %w", err)
 	}
 	showcaseVersion, err := getShowcaseVersion(repoPath)
 	if err != nil {
 		return fmt.Errorf("failed to get showcase version: %w", err)
 	}
-	showcaseSrc, err := fetchShowcaseWithCommit(ctx, githubEndpoints, "v"+showcaseVersion)
+	showcaseSrc, err := fetchShowcaseWithCommitVar(ctx, githubEndpoints, "v"+showcaseVersion)
 	if err != nil {
-		return errFetchSource
+		return fmt.Errorf("failed to fetch showcase source: %w", err)
 	}
 
 	versions, err := readVersions(filepath.Join(repoPath, "versions.txt"))
@@ -782,7 +783,7 @@ func extractStrings(expr build.Expr) []string {
 }
 
 func getShowcaseVersion(repoPath string) (string, error) {
-	showcaseDir := filepath.Join(repoPath, "java-showcase")
+	showcaseDir := filepath.Join(repoPath, "sdk-platform-java", "java-showcase")
 	return extractVersionFromPOM(filepath.Join(showcaseDir, "gapic-showcase", "pom.xml"))
 }
 

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -193,11 +193,18 @@ func TestApplyJavaLibraryOverrides(t *testing.T) {
 }
 
 func TestRunJavaMigration(t *testing.T) {
-	fetchSourceWithCommit = func(ctx context.Context, endpoints *fetch.Endpoints, commitish string) (*config.Source, error) {
+	fetchGoogleapisWithCommitVar = func(ctx context.Context, endpoints *fetch.Endpoints, commitish string) (*config.Source, error) {
 		return &config.Source{
 			Commit: commitish,
 			SHA256: "sha123",
 			Dir:    "../../../internal/testdata/googleapis",
+		}, nil
+	}
+	fetchShowcaseWithCommitVar = func(ctx context.Context, endpoints *fetch.Endpoints, commitish string) (*config.Source, error) {
+		return &config.Source{
+			Commit: commitish,
+			SHA256: "sha456",
+			Dir:    "../../../internal/testdata/gapic-showcase",
 		}, nil
 	}
 	for _, test := range []struct {
@@ -232,6 +239,17 @@ func TestRunJavaMigration(t *testing.T) {
 				t.Fatal(err)
 			}
 			writeVersionsFile(t, dir, "")
+
+			// Create dummy showcase pom.xml to avoid failure in runJavaMigration
+			showcaseDir := filepath.Join(dir, "sdk-platform-java", "java-showcase", "gapic-showcase")
+			if err := os.MkdirAll(showcaseDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			pomPath := filepath.Join(showcaseDir, "pom.xml")
+			if err := os.WriteFile(pomPath, []byte("<gapic-showcase.version>0.39.0</gapic-showcase.version>"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
 			if test.insert {
 				// Create dummy pom.xml to be updated
 				libDir := filepath.Join(dir, "java-language-v1")

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -708,7 +708,7 @@ func TestBuildConfig(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := buildConfig(test.gen, ".", test.src, test.versions)
+			got, err := buildConfig(test.gen, ".", test.src, nil, test.versions)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -866,7 +866,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 				},
 			}
 
-			got, err := buildConfig(gen, ".", &config.Source{Dir: srcDir}, nil)
+			got, err := buildConfig(gen, ".", &config.Source{Dir: srcDir}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -966,6 +966,47 @@ func TestReadVersions_MissingFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "non-existent")
 	if _, err := readVersions(path); err == nil {
 		t.Error("readVersions() error = nil, want error")
+	}
+}
+
+func TestExtractVersionFromPOM(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name        string
+		content     string
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "success",
+			content:     "<project><properties><gapic-showcase.version>0.39.0</gapic-showcase.version></properties></project>",
+			wantVersion: "0.39.0",
+		},
+		{
+			name:    "missing version",
+			content: "<project><properties></properties></project>",
+			wantErr: true,
+		},
+		{
+			name:    "malformed tag",
+			content: "<gapic-showcase.version>0.39.0",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			pomPath := filepath.Join(tmpDir, "pom.xml")
+			if err := os.WriteFile(pomPath, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := extractVersionFromPOM(pomPath)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("extractVersionFromPOM() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if !test.wantErr && got != test.wantVersion {
+				t.Errorf("extractVersionFromPOM() = %v, want %v", got, test.wantVersion)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Add showcase source to migrated librarian.yaml, version is sourced from gapic-showcase.version  property directly from the file  java-showcase/gapic-showcase/pom.xml.
Migrated librarian.yaml with this code [here](https://paste.googleplex.com/6109015173103616).

For #5731