### PR TITLE
refactor(internal/sidekick/api): replace path template builders

### DIFF
--- a/internal/sample/api.go
+++ b/internal/sample/api.go
@@ -83,11 +83,17 @@ func MethodCreate() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("secrets"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "secrets"},
+						},
+					},
 					QueryParameters: map[string]bool{"secretId": true},
 				},
 			},
@@ -108,9 +114,15 @@ func MethodUpdate() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPatch,
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithVariableNamed("secret", "name"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"secret", "name"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{
 						"field_mask": true,
 					},
@@ -132,13 +144,22 @@ func MethodAddSecretVersion() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("secrets").
-						WithVariableNamed("secret").
-						WithVerb("addVersion"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "secrets"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"secret"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+						},
+						Verb: "addVersion",
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -161,13 +182,22 @@ func MethodListSecretVersions() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("parent").
-						WithLiteral("secrets").
-						WithVariableNamed("secret").
-						WithVerb("listSecretVersions"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"parent"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "secrets"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"secret"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+						},
+						Verb: "listSecretVersions",
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},

--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -749,7 +749,7 @@ const (
 // PathTemplate is a template for a path.
 type PathTemplate struct {
 	Segments []PathSegment
-	Verb     *string
+	Verb     string
 }
 
 // FlatPath returns a simplified representation of the path template as a string.
@@ -763,8 +763,8 @@ func (template *PathTemplate) FlatPath() string {
 	sep := ""
 	for _, segment := range template.Segments {
 		buffer.WriteString(sep)
-		if segment.Literal != nil {
-			buffer.WriteString(*segment.Literal)
+		if segment.Literal != "" {
+			buffer.WriteString(segment.Literal)
 		} else if segment.Variable != nil {
 			fmt.Fprintf(&buffer, "{%s}", strings.Join(segment.Variable.FieldPath, "."))
 		}
@@ -775,7 +775,7 @@ func (template *PathTemplate) FlatPath() string {
 
 // PathSegment is a segment of a path.
 type PathSegment struct {
-	Literal  *string
+	Literal  string
 	Variable *PathVariable
 }
 
@@ -791,67 +791,6 @@ type PathVariable struct {
 // NewPathVariable creates a new path variable.
 func NewPathVariable(fields ...string) *PathVariable {
 	return &PathVariable{FieldPath: fields}
-}
-
-// WithLiteral adds a literal to the path template.
-func (p *PathTemplate) WithLiteral(l string) *PathTemplate {
-	p.Segments = append(p.Segments, PathSegment{Literal: &l})
-	return p
-}
-
-// WithVariable adds a variable to the path template.
-func (p *PathTemplate) WithVariable(v *PathVariable) *PathTemplate {
-	p.Segments = append(p.Segments, PathSegment{Variable: v})
-	return p
-}
-
-// WithVariableNamed adds a variable with the given name to the path template.
-func (p *PathTemplate) WithVariableNamed(fields ...string) *PathTemplate {
-	v := PathVariable{FieldPath: fields}
-	p.Segments = append(p.Segments, PathSegment{Variable: v.WithMatch()})
-	return p
-}
-
-// WithVerb adds a verb to the path template.
-func (p *PathTemplate) WithVerb(v string) *PathTemplate {
-	p.Verb = &v
-	return p
-}
-
-// WithLiteral adds a literal to the path variable.
-func (v *PathVariable) WithLiteral(l string) *PathVariable {
-	v.Segments = append(v.Segments, l)
-	return v
-}
-
-// WithMatchRecursive adds a recursive match to the path variable.
-func (v *PathVariable) WithMatchRecursive() *PathVariable {
-	v.Segments = append(v.Segments, MultiSegmentWildcard)
-	return v
-}
-
-// WithMatch adds a match to the path variable.
-func (v *PathVariable) WithMatch() *PathVariable {
-	v.Segments = append(v.Segments, SingleSegmentWildcard)
-	return v
-}
-
-// WithAllowReserved marks the variable as allowing reserved characters to remain unescaped.
-func (v *PathVariable) WithAllowReserved() *PathVariable {
-	v.AllowReserved = true
-	return v
-}
-
-// WithLiteral adds a literal to the path segment.
-func (s *PathSegment) WithLiteral(l string) *PathSegment {
-	s.Literal = &l
-	return s
-}
-
-// WithVariable adds a variable to the path segment.
-func (s *PathSegment) WithVariable(v *PathVariable) *PathSegment {
-	s.Variable = v
-	return s
 }
 
 // Message defines a message used in request/response handling.

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -195,45 +195,6 @@ func TestRoutingInfoVariantTemplateAsString(t *testing.T) {
 	}
 }
 
-func TestPathTemplateBuilder(t *testing.T) {
-	got := (&PathTemplate{}).
-		WithLiteral("v1").
-		WithVariable(NewPathVariable("parent", "child").
-			WithLiteral("projects").
-			WithMatch().
-			WithAllowReserved().
-			WithLiteral("locations").
-			WithMatchRecursive()).
-		WithVariableNamed("v2", "field").
-		WithVerb("verb")
-	name := "v1"
-	verb := "verb"
-	want := &PathTemplate{
-		Segments: []PathSegment{
-			{
-				Literal: &name,
-			},
-			{
-				Variable: &PathVariable{
-					FieldPath:     []string{"parent", "child"},
-					Segments:      []string{"projects", "*", "locations", "**"},
-					AllowReserved: true,
-				},
-			},
-			{
-				Variable: &PathVariable{
-					FieldPath: []string{"v2", "field"},
-					Segments:  []string{"*"},
-				},
-			},
-		},
-		Verb: &verb,
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("bad builder result (-want, +got):\n%s", diff)
-	}
-}
-
 func TestPathBindingHeuristic(t *testing.T) {
 	heuristic := &TargetResource{
 		FieldPaths: [][]string{{"project"}, {"zone"}, {"instance"}},

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -85,11 +85,11 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 	// Iterate backwards over segments
 	for i := len(tmpl.Segments) - 1; i >= 0; i-- {
 		seg := tmpl.Segments[i]
-		if seg.Variable == nil || i == 0 || tmpl.Segments[i-1].Literal == nil {
+		if seg.Variable == nil || i == 0 || tmpl.Segments[i-1].Literal == "" {
 			continue
 		}
 
-		token := *tmpl.Segments[i-1].Literal
+		token := tmpl.Segments[i-1].Literal
 		if !vocabulary[token] && !isVersionString(token) {
 			continue // continue scanning backward if not in vocabulary
 		}
@@ -105,8 +105,8 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 				prevSeg := tmpl.Segments[firstIndex-1]
 
 				// Case 1: The preceding segment is a standalone literal (e.g., "global")
-				if prevSeg.Literal != nil {
-					if isVersionString(*prevSeg.Literal) {
+				if prevSeg.Literal != "" {
+					if isVersionString(prevSeg.Literal) {
 						break // Stop at version strings (e.g., "v1")
 					}
 					firstIndex--
@@ -115,11 +115,11 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 
 				// Case 2: The preceding segment is a variable. It must be paired with a literal.
 				if prevSeg.Variable != nil {
-					if firstIndex < 2 || tmpl.Segments[firstIndex-2].Literal == nil {
+					if firstIndex < 2 || tmpl.Segments[firstIndex-2].Literal == "" {
 						break // Variable near the beginning, cannot form a pair
 					}
 
-					prevLiteralVal := *tmpl.Segments[firstIndex-2].Literal
+					prevLiteralVal := tmpl.Segments[firstIndex-2].Literal
 
 					// If the literal is a known collection, include the pair and continue
 					if vocabulary[prevLiteralVal] {
@@ -257,15 +257,15 @@ func constructTemplate(method *Method, segments []PathSegment) ([]PathSegment, e
 
 	var result []PathSegment
 	h := "//" + host
-	result = append(result, PathSegment{Literal: &h})
+	result = append(result, PathSegment{Literal: h})
 
 	for _, seg := range segments {
-		if seg.Literal != nil {
-			l := *seg.Literal
+		if seg.Literal != "" {
+			l := seg.Literal
 			if isVersionString(l) {
 				continue
 			}
-			result = append(result, PathSegment{Literal: &l})
+			result = append(result, PathSegment{Literal: l})
 		} else if seg.Variable != nil {
 			result = append(result, PathSegment{Variable: &PathVariable{
 				FieldPath: seg.Variable.FieldPath,

--- a/internal/sidekick/api/resource_identification_test.go
+++ b/internal/sidekick/api/resource_identification_test.go
@@ -57,8 +57,15 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: standard resource reference",
 			serviceID: "any.service",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{
 					Name:              "project",
@@ -74,9 +81,20 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: multiple resource references",
 			serviceID: "any.service",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("locations").WithVariableNamed("location"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "locations"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"location"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{
 					Name:              "project",
@@ -97,8 +115,15 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: nested field reference",
 			serviceID: "any.service",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("parent", "project"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"parent", "project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{
 					Name:  "parent",
@@ -122,9 +147,15 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: complex variable pattern treated as full name",
 			serviceID: "any.service",
-			path: (&PathTemplate{}).
-				WithLiteral("v1").
-				WithVariable(NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch()),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "v1"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{"projects", SingleSegmentWildcard, "locations", SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{
 					Name:              "name",
@@ -140,10 +171,16 @@ func TestIdentifyTargetResources(t *testing.T) {
 		{
 			name:      "explicit: crop trailing literals (API Keys keyString case)",
 			serviceID: "apikeys.googleapis.com",
-			path: (&PathTemplate{}).
-				WithLiteral("v2").
-				WithVariable(NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch().WithLiteral("keys").WithMatch()).
-				WithLiteral("keyString"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "v2"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{"projects", SingleSegmentWildcard, "locations", SingleSegmentWildcard, "keys", SingleSegmentWildcard},
+					}},
+					{Literal: "keyString"},
+				},
+			},
 			fields: []*Field{
 				{
 					Name:              "name",
@@ -179,8 +216,15 @@ func TestIdentifyTargetResources_NoMatch(t *testing.T) {
 		{
 			name:      "Explicit: missing reference returns nil",
 			serviceID: "any.service",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString}, // No ResourceReference
 			},
@@ -188,9 +232,20 @@ func TestIdentifyTargetResources_NoMatch(t *testing.T) {
 		{
 			name:      "Explicit: partial reference returns nil",
 			serviceID: "any.service",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("glossaries").WithVariableNamed("glossary"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "glossaries"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"glossary"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{
 					Name:              "project",
@@ -231,9 +286,20 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: standard infrastructure tokens",
 			serviceID: ".google.cloud.compute.v1.Instances", // eligible
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("locations").WithVariableNamed("location"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "locations"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"location"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "location", Typez: TypezString},
@@ -246,20 +312,50 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: learns custom tokens from GET methods",
 			serviceID: ".google.cloud.compute.v1.Instances", // eligible
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("zones").WithVariableNamed("zone").
-				WithLiteral("instances").WithVariableNamed("instance"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "zones"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"zone"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "instances"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"instance"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "zone", Typez: TypezString},
 				{Name: "instance", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("projects").WithVariableNamed("project").
-					WithLiteral("zones").WithVariableNamed("zone").
-					WithLiteral("instances").WithVariableNamed("instance"),
+				{
+					Segments: []PathSegment{
+						{Literal: "projects"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "zones"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"zone"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "instances"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"instance"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"project"}, {"zone"}, {"instance"}},
@@ -269,19 +365,41 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: paths with standalone literals without variables (e.g. global)",
 			serviceID: ".google.cloud.compute.v1.BackendServices",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("global").
-				WithLiteral("backendServices").WithVariableNamed("backend_service"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "global"},
+					{Literal: "backendServices"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"backend_service"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "backend_service", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("projects").WithVariableNamed("project").
-					WithLiteral("global").
-					WithLiteral("backendServices").WithVariableNamed("backend_service"),
+				{
+					Segments: []PathSegment{
+						{Literal: "projects"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "global"},
+						{Literal: "backendServices"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"backend_service"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"project"}, {"backend_service"}},
@@ -291,22 +409,36 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: path with non-variable standalone literal",
 			serviceID: ".google.cloud.example.v1.Service",
-			path: (&PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("projects").
-				WithLiteral("xyz").
-				WithLiteral("global").
-				WithLiteral("foos").WithVariableNamed("foo"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "v1"},
+					{Literal: "projects"},
+					{Literal: "xyz"},
+					{Literal: "global"},
+					{Literal: "foos"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"foo"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "foo", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("v1").
-					WithLiteral("projects").
-					WithLiteral("xyz").
-					WithLiteral("global").
-					WithLiteral("foos").WithVariableNamed("foo"),
+				{
+					Segments: []PathSegment{
+						{Literal: "v1"},
+						{Literal: "projects"},
+						{Literal: "xyz"},
+						{Literal: "global"},
+						{Literal: "foos"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"foo"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"foo"}},
@@ -316,17 +448,39 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: paths with un-grouped variable after version string",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: (&PathTemplate{}).
-				WithLiteral("v1").WithVariableNamed("resource").
-				WithLiteral("children").WithVariableNamed("child"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "v1"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"resource"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "children"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"child"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "resource", Typez: TypezString},
 				{Name: "child", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("v1").WithVariableNamed("resource").
-					WithLiteral("children").WithVariableNamed("child"),
+				{
+					Segments: []PathSegment{
+						{Literal: "v1"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"resource"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "children"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"child"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"resource"}, {"child"}},
@@ -336,10 +490,21 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: valid compute path with version string",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: (&PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("locations").WithVariableNamed("location"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "v1"},
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "locations"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"location"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "location", Typez: TypezString},
@@ -352,11 +517,30 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: stops at trailing action",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("zones").WithVariableNamed("zone").
-				WithLiteral("instances").WithVariableNamed("instance").
-				WithLiteral("start").WithVariableNamed("action_id"), // "start" is not a collection
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "zones"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"zone"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "instances"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"instance"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "start"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"action_id"},
+						Segments:  []string{SingleSegmentWildcard},
+					}}, // "start" is not a collection
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "zone", Typez: TypezString},
@@ -364,10 +548,25 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 				{Name: "action_id", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("projects").WithVariableNamed("project").
-					WithLiteral("zones").WithVariableNamed("zone").
-					WithLiteral("instances").WithVariableNamed("instance"),
+				{
+					Segments: []PathSegment{
+						{Literal: "projects"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "zones"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"zone"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "instances"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"instance"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"project"}, {"zone"}, {"instance"}},
@@ -377,20 +576,50 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: stops at unknown segment",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("unknown").WithVariableNamed("other").
-				WithLiteral("instances").WithVariableNamed("instance"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "unknown"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"other"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "instances"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"instance"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "other", Typez: TypezString},
 				{Name: "instance", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("projects").WithVariableNamed("project").
-					WithLiteral("zones").WithVariableNamed("zone").
-					WithLiteral("instances").WithVariableNamed("instance"),
+				{
+					Segments: []PathSegment{
+						{Literal: "projects"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "zones"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"zone"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "instances"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"instance"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"project"}},
@@ -400,16 +629,30 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: skips if input field missing",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{}, // No fields
 			want:   nil,
 		},
 		{
 			name:      "heuristic: skips non-collection literal without 's'",
 			serviceID: ".google.cloud.compute.v1.Instances",
-			path: (&PathTemplate{}).
-				WithLiteral("metadata").WithVariableNamed("data"), // does not match fallback
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "metadata"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"data"},
+						Segments:  []string{SingleSegmentWildcard},
+					}}, // does not match fallback
+				},
+			},
 			fields: []*Field{
 				{Name: "data", Typez: TypezString},
 			},
@@ -418,19 +661,41 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: known custom resource after standalone literal",
 			serviceID: ".google.cloud.compute.v1.CrossSiteNetworks",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("global").
-				WithLiteral("crossSiteNetworks").WithVariableNamed("cross_site_network"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "global"},
+					{Literal: "crossSiteNetworks"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"cross_site_network"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "cross_site_network", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("projects").WithVariableNamed("project").
-					WithLiteral("global").
-					WithLiteral("crossSiteNetworks").WithVariableNamed("cross_site_network"),
+				{
+					Segments: []PathSegment{
+						{Literal: "projects"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+						{Literal: "global"},
+						{Literal: "crossSiteNetworks"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"cross_site_network"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"project"}, {"cross_site_network"}},
@@ -440,17 +705,35 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: unknown custom resource falls back to parent",
 			serviceID: ".google.cloud.compute.v1.CrossSiteNetworks",
-			path: (&PathTemplate{}).
-				WithLiteral("projects").WithVariableNamed("project").
-				WithLiteral("global").
-				WithLiteral("crossSiteNetworks").WithVariableNamed("cross_site_network"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "global"},
+					{Literal: "crossSiteNetworks"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"cross_site_network"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "project", Typez: TypezString},
 				{Name: "cross_site_network", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("projects").WithVariableNamed("project"),
+				{
+					Segments: []PathSegment{
+						{Literal: "projects"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"project"}},
@@ -460,18 +743,32 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 		{
 			name:      "heuristic: multiple standalone literals before known resource",
 			serviceID: ".google.cloud.compute.v1.FirewallPolicies",
-			path: (&PathTemplate{}).
-				WithLiteral("locations").
-				WithLiteral("global").
-				WithLiteral("firewallPolicies").WithVariableNamed("resource"),
+			path: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "locations"},
+					{Literal: "global"},
+					{Literal: "firewallPolicies"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"resource"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			fields: []*Field{
 				{Name: "resource", Typez: TypezString},
 			},
 			getPaths: []*PathTemplate{
-				(&PathTemplate{}).
-					WithLiteral("locations").
-					WithLiteral("global").
-					WithLiteral("firewallPolicies").WithVariableNamed("resource"),
+				{
+					Segments: []PathSegment{
+						{Literal: "locations"},
+						{Literal: "global"},
+						{Literal: "firewallPolicies"},
+						{Variable: &PathVariable{
+							FieldPath: []string{"resource"},
+							Segments:  []string{SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 			want: &TargetResource{
 				FieldPaths: [][]string{{"resource"}},
@@ -510,9 +807,20 @@ func TestIdentifyTargetResources_Heuristic(t *testing.T) {
 func TestIdentifyTargetResources_HeuristicsDisabled(t *testing.T) {
 	// A setup that would normally match the heuristics
 	serviceID := ".google.cloud.compute.v1.Instances"
-	path := (&PathTemplate{}).
-		WithLiteral("projects").WithVariableNamed("project").
-		WithLiteral("locations").WithVariableNamed("location")
+	path := &PathTemplate{
+		Segments: []PathSegment{
+			{Literal: "projects"},
+			{Variable: &PathVariable{
+				FieldPath: []string{"project"},
+				Segments:  []string{SingleSegmentWildcard},
+			}},
+			{Literal: "locations"},
+			{Variable: &PathVariable{
+				FieldPath: []string{"location"},
+				Segments:  []string{SingleSegmentWildcard},
+			}},
+		},
+	}
 	fields := []*Field{
 		{Name: "project", Typez: TypezString},
 		{Name: "location", Typez: TypezString},

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -88,8 +88,8 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 			for i := len(tmpl.Segments) - 1; i >= 0; i-- {
 				seg := tmpl.Segments[i]
 				if seg.Variable != nil {
-					if i > 0 && tmpl.Segments[i-1].Literal != nil {
-						token := *tmpl.Segments[i-1].Literal
+					if i > 0 && tmpl.Segments[i-1].Literal != "" {
+						token := tmpl.Segments[i-1].Literal
 						// Do not add API version strings (e.g., v1, v1beta1) to the vocabulary
 						if isVersionString(token) {
 							continue

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -37,9 +37,20 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: (&PathTemplate{}).
-											WithLiteral("users").WithVariableNamed("user").
-											WithLiteral("widgets").WithVariableNamed("widget"),
+										PathTemplate: &PathTemplate{
+											Segments: []PathSegment{
+												{Literal: "users"},
+												{Variable: &PathVariable{
+													FieldPath: []string{"user"},
+													Segments:  []string{SingleSegmentWildcard},
+												}},
+												{Literal: "widgets"},
+												{Variable: &PathVariable{
+													FieldPath: []string{"widget"},
+													Segments:  []string{SingleSegmentWildcard},
+												}},
+											},
+										},
 									},
 								},
 							},
@@ -68,8 +79,15 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: (&PathTemplate{}).
-											WithLiteral("internal").WithVariableNamed("id"),
+										PathTemplate: &PathTemplate{
+											Segments: []PathSegment{
+												{Literal: "internal"},
+												{Variable: &PathVariable{
+													FieldPath: []string{"id"},
+													Segments:  []string{SingleSegmentWildcard},
+												}},
+											},
+										},
 									},
 								},
 							},
@@ -96,8 +114,15 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: (&PathTemplate{}).
-											WithLiteral("internal").WithVariableNamed("id"),
+										PathTemplate: &PathTemplate{
+											Segments: []PathSegment{
+												{Literal: "internal"},
+												{Variable: &PathVariable{
+													FieldPath: []string{"id"},
+													Segments:  []string{SingleSegmentWildcard},
+												}},
+											},
+										},
 									},
 								},
 							},
@@ -124,12 +149,15 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 							PathInfo: &PathInfo{
 								Bindings: []*PathBinding{
 									{
-										PathTemplate: (&PathTemplate{}).
-											WithLiteral("v1").
-											WithVariable(&PathVariable{
-												FieldPath: []string{"name"},
-												Segments:  []string{"projects", SingleSegmentWildcard, "instances", MultiSegmentWildcard},
-											}),
+										PathTemplate: &PathTemplate{
+											Segments: []PathSegment{
+												{Literal: "v1"},
+												{Variable: &PathVariable{
+													FieldPath: []string{"name"},
+													Segments:  []string{"projects", SingleSegmentWildcard, "instances", MultiSegmentWildcard},
+												}},
+											},
+										},
 									},
 								},
 							},

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -288,15 +288,14 @@ func ParseTemplateForTest(template string) []PathSegment {
 	if strings.HasPrefix(template, "//") {
 		host = "//" + parts[0]
 	}
-	segments = append(segments, PathSegment{Literal: &host})
+	segments = append(segments, PathSegment{Literal: host})
 
 	for _, part := range parts[1:] {
 		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
 			fieldPath := strings.Split(part[1:len(part)-1], ".")
 			segments = append(segments, PathSegment{Variable: &PathVariable{FieldPath: fieldPath}})
 		} else {
-			l := part
-			segments = append(segments, PathSegment{Literal: &l})
+			segments = append(segments, PathSegment{Literal: part})
 		}
 	}
 	return segments

--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -411,12 +411,12 @@ func toResourceNamePattern(pattern ResourcePattern, skipLast bool) *ResourceName
 	var segments []ResourceNameSegment
 	for i := 0; i < len(pattern); i++ {
 		s := pattern[i]
-		if s.Literal != nil && strings.HasPrefix(*s.Literal, "//") {
+		if s.Literal != "" && strings.HasPrefix(s.Literal, "//") {
 			continue
 		}
 		seg := ResourceNameSegment{}
-		if s.Literal != nil {
-			seg.Literal = *s.Literal
+		if s.Literal != "" {
+			seg.Literal = s.Literal
 		}
 		if s.Variable != nil && len(s.Variable.FieldPath) > 0 {
 			// The parser used for parsing resource name patterns is the same used for
@@ -429,7 +429,7 @@ func toResourceNamePattern(pattern ResourcePattern, skipLast bool) *ResourceName
 		}
 
 		// Try to combine with next segment if this is a literal and next is variable
-		if s.Literal != nil && i+1 < len(pattern) && pattern[i+1].Variable != nil {
+		if s.Literal != "" && i+1 < len(pattern) && pattern[i+1].Variable != nil {
 			if len(pattern[i+1].Variable.FieldPath) > 0 {
 				seg.Variable = pattern[i+1].Variable.FieldPath[0]
 			}

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -425,8 +425,11 @@ func TestEnrichSamplesWithResourceNamePattern(t *testing.T) {
 			Type: "test.googleapis.com/Resource",
 			Patterns: []ResourcePattern{
 				{
-					*(&PathSegment{}).WithLiteral("resources"),
-					*(&PathSegment{}).WithVariable(NewPathVariable("resource").WithMatch()),
+					{Literal: "resources"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"resource"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
 				},
 			},
 		}
@@ -466,10 +469,16 @@ func TestEnrichSamplesWithResourceNamePattern(t *testing.T) {
 			Type: "test.googleapis.com/Child",
 			Patterns: []ResourcePattern{
 				{
-					*(&PathSegment{}).WithLiteral("parents"),
-					*(&PathSegment{}).WithVariable(NewPathVariable("parent").WithMatch()),
-					*(&PathSegment{}).WithLiteral("children"),
-					*(&PathSegment{}).WithVariable(NewPathVariable("child").WithMatch()),
+					{Literal: "parents"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"parent"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "children"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"child"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
 				},
 			},
 		}
@@ -509,8 +518,11 @@ func TestEnrichSamplesWithResourceNamePattern(t *testing.T) {
 			Type: "test.googleapis.com/Resource",
 			Patterns: []ResourcePattern{
 				{
-					*(&PathSegment{}).WithLiteral("resources"),
-					*(&PathSegment{}).WithVariable(NewPathVariable("resource").WithMatch()),
+					{Literal: "resources"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"resource"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
 				},
 			},
 		}
@@ -554,8 +566,11 @@ func TestToResourceNamePattern(t *testing.T) {
 		{
 			name: "simple",
 			pattern: ResourcePattern{
-				*(&PathSegment{}).WithLiteral("projects"),
-				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
+				{Literal: "projects"},
+				{Variable: &PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{SingleSegmentWildcard},
+				}},
 			},
 			skipLast: false,
 			want: &ResourceNamePattern{
@@ -567,10 +582,16 @@ func TestToResourceNamePattern(t *testing.T) {
 		{
 			name: "multi-segment",
 			pattern: ResourcePattern{
-				*(&PathSegment{}).WithLiteral("projects"),
-				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
-				*(&PathSegment{}).WithLiteral("secrets"),
-				*(&PathSegment{}).WithVariable(NewPathVariable("secret").WithMatch()),
+				{Literal: "projects"},
+				{Variable: &PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{SingleSegmentWildcard},
+				}},
+				{Literal: "secrets"},
+				{Variable: &PathVariable{
+					FieldPath: []string{"secret"},
+					Segments:  []string{SingleSegmentWildcard},
+				}},
 			},
 			skipLast: false,
 			want: &ResourceNamePattern{
@@ -583,10 +604,16 @@ func TestToResourceNamePattern(t *testing.T) {
 		{
 			name: "multi-segment-skip-last",
 			pattern: ResourcePattern{
-				*(&PathSegment{}).WithLiteral("projects"),
-				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
-				*(&PathSegment{}).WithLiteral("secrets"),
-				*(&PathSegment{}).WithVariable(NewPathVariable("secret").WithMatch()),
+				{Literal: "projects"},
+				{Variable: &PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{SingleSegmentWildcard},
+				}},
+				{Literal: "secrets"},
+				{Variable: &PathVariable{
+					FieldPath: []string{"secret"},
+					Segments:  []string{SingleSegmentWildcard},
+				}},
 			},
 			skipLast: true,
 			want: &ResourceNamePattern{
@@ -598,9 +625,12 @@ func TestToResourceNamePattern(t *testing.T) {
 		{
 			name: "with trailing literal",
 			pattern: ResourcePattern{
-				*(&PathSegment{}).WithLiteral("projects"),
-				*(&PathSegment{}).WithVariable(NewPathVariable("project").WithMatch()),
-				*(&PathSegment{}).WithLiteral("config"),
+				{Literal: "projects"},
+				{Variable: &PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{SingleSegmentWildcard},
+				}},
+				{Literal: "config"},
 			},
 			skipLast: false,
 			want: &ResourceNamePattern{
@@ -2021,25 +2051,46 @@ func TestFlatPath(t *testing.T) {
 			Want:  "",
 		},
 		{
-			Input: (&PathTemplate{}).
-				WithLiteral("projects").
-				WithVariableNamed("project").
-				WithLiteral("zones").
-				WithVariableNamed("zone"),
+			Input: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "zones"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"zone"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+				},
+			},
 			Want: "projects/{project}/zones/{zone}",
 		},
 		{
-			Input: (&PathTemplate{}).
-				WithLiteral("projects").
-				WithVariableNamed("project").
-				WithLiteral("global").
-				WithLiteral("location"),
+			Input: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{SingleSegmentWildcard},
+					}},
+					{Literal: "global"},
+					{Literal: "location"},
+				},
+			},
 			Want: "projects/{project}/global/location",
 		},
 		{
-			Input: (&PathTemplate{}).
-				WithLiteral("projects").
-				WithVariable(NewPathVariable("a", "b", "c").WithMatchRecursive()),
+			Input: &PathTemplate{
+				Segments: []PathSegment{
+					{Literal: "projects"},
+					{Variable: &PathVariable{
+						FieldPath: []string{"a", "b", "c"},
+						Segments:  []string{MultiSegmentWildcard},
+					}},
+				},
+			},
 			Want: "projects/{a.b.c}",
 		},
 	} {

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -170,9 +170,9 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 	t := pathInfo.Bindings[0].PathTemplate
 	for _, segment := range t.Segments {
 		switch {
-		case segment.Literal != nil:
+		case segment.Literal != "":
 			builder.WriteString("/")
-			builder.WriteString(*segment.Literal)
+			builder.WriteString(segment.Literal)
 		case segment.Variable != nil:
 			// Form '${request.foo!.bar!.baz}'.
 			builder.WriteString("/${request")
@@ -185,9 +185,9 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 			builder.WriteString("}")
 		}
 	}
-	if t.Verb != nil {
+	if t.Verb != "" {
 		builder.WriteString(":")
-		builder.WriteString(*t.Verb)
+		builder.WriteString(t.Verb)
 	}
 
 	return builder.String()

--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -74,13 +74,22 @@ func TestParallelstoreMock(t *testing.T) {
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("locations").
-						WithVariableNamed("location").
-						WithLiteral("instances"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "locations"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"location"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "instances"},
+						},
+					},
 				},
 			},
 		},

--- a/internal/sidekick/parser/discovery/lro_test.go
+++ b/internal/sidekick/parser/discovery/lro_test.go
@@ -44,14 +44,23 @@ func TestLroAnnotations(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("compute").
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("zones").
-						WithVariableNamed("zone").
-						WithLiteral("instances"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "compute"},
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "zones"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"zone"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "instances"},
+						},
+					},
 					QueryParameters: map[string]bool{
 						"requestId":              true,
 						"sourceInstanceTemplate": true,
@@ -83,15 +92,27 @@ func TestLroAnnotations(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("compute").
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("zones").
-						WithVariableNamed("zone").
-						WithLiteral("operations").
-						WithVariableNamed("operation"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "compute"},
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "zones"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"zone"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "operations"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"operation"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -130,13 +151,25 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("p").
-								WithVariableNamed("project").
-								WithLiteral("l").
-								WithVariableNamed("zone").
-								WithLiteral("foo").
-								WithVariableNamed("id"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "p"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"project"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "l"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"zone"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "foo"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"id"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -150,13 +183,25 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("p").
-								WithVariableNamed("project").
-								WithLiteral("l").
-								WithVariableNamed("region").
-								WithLiteral("foo").
-								WithVariableNamed("id"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "p"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"project"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "l"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"region"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "foo"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"id"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -176,13 +221,25 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("p").
-								WithVariableNamed("project").
-								WithLiteral("l").
-								WithVariableNamed("zone").
-								WithLiteral("operations").
-								WithVariableNamed("operation"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "p"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"project"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "l"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"zone"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "operations"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"operation"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -196,13 +253,25 @@ func TestLroAnnotationsError(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("p").
-								WithVariableNamed("project").
-								WithLiteral("l").
-								WithVariableNamed("region").
-								WithLiteral("operations").
-								WithVariableNamed("operation"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "p"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"project"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "l"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"region"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "operations"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"operation"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{},
 						},
 					},

--- a/internal/sidekick/parser/discovery/methods_test.go
+++ b/internal/sidekick/parser/discovery/methods_test.go
@@ -42,13 +42,22 @@ func TestMakeServiceMethods(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("compute").
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("zones").
-						WithVariableNamed("zone"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "compute"},
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "zones"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"zone"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -80,15 +89,27 @@ func TestMakeServiceMethodsReturnsEmpty(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("compute").
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("zones").
-						WithVariableNamed("zone").
-						WithLiteral("operations").
-						WithVariableNamed("operation"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "compute"},
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "zones"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"zone"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "operations"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"operation"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -121,12 +142,18 @@ func TestMakeServiceMethodsDeprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("compute").
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("moveInstance"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "compute"},
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "moveInstance"},
+						},
+					},
 					QueryParameters: map[string]bool{"requestId": true},
 				},
 			},

--- a/internal/sidekick/parser/discovery/services_test.go
+++ b/internal/sidekick/parser/discovery/services_test.go
@@ -49,13 +49,22 @@ func TestService(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("compute").
-								WithLiteral("v1").
-								WithLiteral("projects").
-								WithVariableNamed("project").
-								WithLiteral("zones").
-								WithVariableNamed("zone"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "compute"},
+									{Literal: "v1"},
+									{Literal: "projects"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"project"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "zones"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"zone"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -72,12 +81,18 @@ func TestService(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("compute").
-								WithLiteral("v1").
-								WithLiteral("projects").
-								WithVariableNamed("project").
-								WithLiteral("zones"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "compute"},
+									{Literal: "v1"},
+									{Literal: "projects"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"project"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "zones"},
+								},
+							},
 							QueryParameters: map[string]bool{
 								"filter":               true,
 								"maxResults":           true,

--- a/internal/sidekick/parser/discovery/uritemplate.go
+++ b/internal/sidekick/parser/discovery/uritemplate.go
@@ -114,10 +114,10 @@ func parseExpression(input string) (*api.PathSegment, int, error) {
 	}
 	variable := api.NewPathVariable(tail)
 	if allowReserved {
-		variable.WithAllowReserved()
-		variable.WithMatchRecursive()
+		variable.AllowReserved = true
+		variable.Segments = append(variable.Segments, api.MultiSegmentWildcard)
 	} else {
-		variable.WithMatch()
+		variable.Segments = append(variable.Segments, api.SingleSegmentWildcard)
 	}
 	return &api.PathSegment{Variable: variable}, end + 2, nil
 }
@@ -150,5 +150,5 @@ func parseLiteral(input string) (*api.PathSegment, int, error) {
 	if tail != "" && tail[0] != slash {
 		return nil, index, fmt.Errorf("found unexpected character %v in literal %q, stopped at position %v", tail[0], input, index)
 	}
-	return &api.PathSegment{Literal: &literal}, width, nil
+	return &api.PathSegment{Literal: literal}, width, nil
 }

--- a/internal/sidekick/parser/discovery/uritemplate_test.go
+++ b/internal/sidekick/parser/discovery/uritemplate_test.go
@@ -27,31 +27,81 @@ func TestParseUriTemplateSuccess(t *testing.T) {
 		input string
 		want  *api.PathTemplate
 	}{
-		{"locations/global/firewallPolicies", (&api.PathTemplate{}).
-			WithLiteral("locations").
-			WithLiteral("global").
-			WithLiteral("firewallPolicies")},
-		{"locations/global/operations/{operation}", (&api.PathTemplate{}).
-			WithLiteral("locations").
-			WithLiteral("global").
-			WithLiteral("operations").
-			WithVariableNamed("operation")},
-		{"projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks", (&api.PathTemplate{}).
-			WithLiteral("projects").
-			WithVariableNamed("project").
-			WithLiteral("zones").
-			WithVariableNamed("zone").
-			WithVariableNamed("parentName").
-			WithLiteral("reservationSubBlocks")},
-		{"v1/{+parent}/externalAccountKeys", (&api.PathTemplate{}).
-			WithLiteral("v1").
-			WithVariable(api.NewPathVariable("parent").WithAllowReserved().WithMatchRecursive()).
-			WithLiteral("externalAccountKeys")},
-		{"dns/v1/{+resource}:getIamPolicy", (&api.PathTemplate{}).
-			WithLiteral("dns").
-			WithLiteral("v1").
-			WithVariable(api.NewPathVariable("resource").WithAllowReserved().WithMatchRecursive()).
-			WithVerb("getIamPolicy")},
+		{
+			"locations/global/firewallPolicies",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "locations"},
+					{Literal: "global"},
+					{Literal: "firewallPolicies"},
+				},
+			},
+		},
+		{
+			"locations/global/operations/{operation}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "locations"},
+					{Literal: "global"},
+					{Literal: "operations"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"operation"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
+		},
+		{
+			"projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "projects"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "zones"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"zone"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"parentName"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "reservationSubBlocks"},
+				},
+			},
+		},
+		{
+			"v1/{+parent}/externalAccountKeys",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath:     []string{"parent"},
+						Segments:      []string{api.MultiSegmentWildcard},
+						AllowReserved: true,
+					}},
+					{Literal: "externalAccountKeys"},
+				},
+			},
+		},
+		{
+			"dns/v1/{+resource}:getIamPolicy",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "dns"},
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath:     []string{"resource"},
+						Segments:      []string{api.MultiSegmentWildcard},
+						AllowReserved: true,
+					}},
+				},
+				Verb: "getIamPolicy",
+			},
+		},
 	} {
 		got, err := ParseUriTemplate(test.input)
 		if err != nil {
@@ -100,7 +150,11 @@ func TestParseExpression(t *testing.T) {
 			t.Errorf("expected a successful parse with input=%s, err=%v", test.input, err)
 			continue
 		}
-		if diff := cmp.Diff(&api.PathSegment{Variable: api.NewPathVariable(test.want).WithMatch()}, gotSegment); diff != "" {
+		want := &api.PathSegment{Variable: &api.PathVariable{
+			FieldPath: []string{test.want},
+			Segments:  []string{api.SingleSegmentWildcard},
+		}}
+		if diff := cmp.Diff(want, gotSegment); diff != "" {
 			t.Errorf("mismatch [%s] (-want, +got):\n%s", test.input, diff)
 		}
 		if len(test.want)+2 != gotWidth {
@@ -141,7 +195,7 @@ func TestParseLiteral(t *testing.T) {
 			t.Errorf("expected a successful parse with input=%s, err=%v", test.input, err)
 			continue
 		}
-		if diff := cmp.Diff(&api.PathSegment{Literal: &test.want}, gotSegment); diff != "" {
+		if diff := cmp.Diff(&api.PathSegment{Literal: test.want}, gotSegment); diff != "" {
 			t.Errorf("mismatch [%s] (-want, +got):\n%s", test.input, diff)
 		}
 		if len(test.want) != gotWidth {

--- a/internal/sidekick/parser/httprule/http_rule_parser.go
+++ b/internal/sidekick/parser/httprule/http_rule_parser.go
@@ -165,6 +165,9 @@ func parseVerb(verbString string) (string, int, error) {
 		return "", 0, err
 	}
 	pos += width
+	if verb == nil {
+		return "", pos, nil
+	}
 	return string(*verb), pos, nil
 }
 

--- a/internal/sidekick/parser/httprule/http_rule_parser.go
+++ b/internal/sidekick/parser/httprule/http_rule_parser.go
@@ -124,7 +124,7 @@ const (
 func parsePathTemplate(pathTemplate string) (*api.PathTemplate, error) {
 	var pos int
 	var segments []api.PathSegment
-	var verb *string
+	var verb string
 	if len(pathTemplate) < 2 {
 		return nil, fmt.Errorf("invalid path template, expected at least two characters: %s", pathTemplate)
 	} else if pathTemplate[0] != slash {
@@ -151,21 +151,21 @@ func parsePathTemplate(pathTemplate string) (*api.PathTemplate, error) {
 
 }
 
-func parseVerb(verbString string) (*string, int, error) {
+func parseVerb(verbString string) (string, int, error) {
 	if len(verbString) == 0 {
-		return nil, 0, nil
+		return "", 0, nil
 	}
 	var pos int
 	if verbString[pos] != verbSep {
-		return nil, 0, fmt.Errorf("invalid verb, must start with '%q': %s", verbSep, verbString)
+		return "", 0, fmt.Errorf("invalid verb, must start with '%q': %s", verbSep, verbString)
 	}
 	pos++ // Skip verbSep
 	verb, width, err := parseLiteral(verbString[pos:])
 	if err != nil {
-		return nil, 0, err
+		return "", 0, err
 	}
 	pos += width
-	return (*string)(verb), pos, nil
+	return string(*verb), pos, nil
 }
 
 // parseSegments parses a sequence of variable and/or plain segments starting at the beginning of the provided string.
@@ -204,7 +204,7 @@ func parseLiteralSegment(literalSegment string) (*api.PathSegment, int, error) {
 		return nil, 0, err
 	}
 	return &api.PathSegment{
-		Literal: (*string)(literal),
+		Literal: string(*literal),
 	}, width, nil
 }
 

--- a/internal/sidekick/parser/httprule/http_rule_parser_test.go
+++ b/internal/sidekick/parser/httprule/http_rule_parser_test.go
@@ -28,45 +28,272 @@ func TestParseSegments(t *testing.T) {
 		want        *api.PathTemplate
 		explanation string
 	}{
-		{"/foo", (&api.PathTemplate{}).WithLiteral("foo"), ""},
-		{"/foo/bar", (&api.PathTemplate{}).WithLiteral("foo").WithLiteral("bar"), ""},
-		{"/v1/*/foo", nil, "matchers only exist within a variable segment"},
-		{"/v1/**/foo", nil, "matchers only exist within a variable segment"},
-		{"/foo:bar", (&api.PathTemplate{}).WithLiteral("foo").WithVerb("bar"), ""},
-		{"/foo/{bar}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar"), ""},
-		{"/foo/{bar.baz}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar", "baz"), ""},
-		{"/foo/{bar=baz}", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
-			api.NewPathVariable("bar").WithLiteral("baz")), ""},
-		{"/foo/{bar=*}", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
-			api.NewPathVariable("bar").WithMatch()), ""},
-		{"/foo/{bar=*}/baz", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
-			api.NewPathVariable("bar").WithMatch()).
-			WithLiteral("baz"), ""},
-		{"/foo/{bar=**}/baz:qux", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
-			api.NewPathVariable("bar").WithMatchRecursive()).
-			WithLiteral("baz").WithVerb("qux"), ""},
-		{"/foo/{bar=baz/*/qux/*}", (&api.PathTemplate{}).WithLiteral("foo").WithVariable(
-			api.NewPathVariable("bar").WithLiteral("baz").WithMatch().WithLiteral("qux").WithMatch()), ""},
-		{"/foo/{bar}/{baz}/{qux}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar").WithVariableNamed("baz").WithVariableNamed("qux"), ""},
-		{"foo", nil, "path must start with slash"},
-		{"/", nil, "path cannot end with slash"},
-		{"/foo/", nil, "path cannot end with slash"},
-		{"/foo/***/bar", nil, "wildcard literal cannot exceed two *, and * isn't allowed in a LITERAL"},
-		{"/%0f", (&api.PathTemplate{}).WithLiteral("%0f"), ""},
-		{"/%0z", nil, "bad percent encoding"},
-		{"/foo//bar", nil, "segment is too short"},
-		{"/foo/:", nil, "verb is too short"},
-		{"/foo/{}/bar", nil, "var too short"},
-		{"/foo/{a.}/bar", nil, "var identifier too short"},
-		{"/foo/{.a}/bar", nil, "var identifier too short"},
-		{"/foo/{a=}/bar", nil, "var value too short"},
-		{"/foo/{9bar}", nil, "var identifier has bad first character"},
-		{"/foo/{bar9}", (&api.PathTemplate{}).WithLiteral("foo").WithVariableNamed("bar9"), ""},
-		{"/foo/{b&r}", nil, "var identifier has bad character"},
-		{"/foo/:bar", nil, "verb cannot come after slash"},
-		{"/foo:bar/baz", nil, "verb must be the last segment, and : isn't allowed in a LITERAL"},
-		{":foo", nil, "verb cannot be the first segment"},
-		{"/foo/{bar={baz}}", nil, "variables cannot be nested"},
+		{
+			"/foo",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/bar",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Literal: "bar"},
+				},
+			},
+			"",
+		},
+		{
+			"/v1/*/foo",
+			nil,
+			"matchers only exist within a variable segment",
+		},
+		{
+			"/v1/**/foo",
+			nil,
+			"matchers only exist within a variable segment",
+		},
+		{
+			"/foo:bar",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+				},
+				Verb: "bar",
+			},
+			"",
+		},
+		{
+			"/foo/{bar}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/{bar.baz}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar", "baz"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/{bar=baz}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar"},
+						Segments:  []string{"baz"},
+					}},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/{bar=*}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/{bar=*}/baz",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "baz"},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/{bar=**}/baz:qux",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar"},
+						Segments:  []string{api.MultiSegmentWildcard},
+					}},
+					{Literal: "baz"},
+				},
+				Verb: "qux",
+			},
+			"",
+		},
+		{
+			"/foo/{bar=baz/*/qux/*}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar"},
+						Segments: []string{
+							"baz",
+							api.SingleSegmentWildcard,
+							"qux",
+							api.SingleSegmentWildcard,
+						},
+					}},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/{bar}/{baz}/{qux}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"baz"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"qux"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
+			"",
+		},
+		{
+			"foo",
+			nil,
+			"path must start with slash",
+		},
+		{
+			"/",
+			nil,
+			"path cannot end with slash",
+		},
+		{
+			"/foo/",
+			nil,
+			"path cannot end with slash",
+		},
+		{
+			"/foo/***/bar",
+			nil,
+			"wildcard literal cannot exceed two *, and * isn't allowed in a LITERAL",
+		},
+		{
+			"/%0f",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "%0f"},
+				},
+			},
+			"",
+		},
+		{
+			"/%0z",
+			nil,
+			"bad percent encoding",
+		},
+		{
+			"/foo//bar",
+			nil,
+			"segment is too short",
+		},
+		{
+			"/foo/:",
+			nil,
+			"verb is too short",
+		},
+		{
+			"/foo/{}/bar",
+			nil,
+			"var too short",
+		},
+		{
+			"/foo/{a.}/bar",
+			nil,
+			"var identifier too short",
+		},
+		{
+			"/foo/{.a}/bar",
+			nil,
+			"var identifier too short",
+		},
+		{
+			"/foo/{a=}/bar",
+			nil,
+			"var value too short",
+		},
+		{
+			"/foo/{9bar}",
+			nil,
+			"var identifier has bad first character",
+		},
+		{
+			"/foo/{bar9}",
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "foo"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"bar9"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
+			"",
+		},
+		{
+			"/foo/{b&r}",
+			nil,
+			"var identifier has bad character",
+		},
+		{
+			"/foo/:bar",
+			nil,
+			"verb cannot come after slash",
+		},
+		{
+			"/foo:bar/baz",
+			nil,
+			"verb must be the last segment, and : isn't allowed in a LITERAL",
+		},
+		{
+			":foo",
+			nil,
+			"verb cannot be the first segment",
+		},
+		{
+			"/foo/{bar={baz}}",
+			nil,
+			"variables cannot be nested",
+		},
 	} {
 		t.Run(test.path, func(t *testing.T) {
 			got, err := ParseSegments(test.path)
@@ -164,11 +391,20 @@ func TestParseResourcePattern(t *testing.T) {
 		{
 			"standard hierarchical pattern",
 			"projects/{project}/serviceAccounts/{service_account}",
-			(&api.PathTemplate{}).
-				WithLiteral("projects").
-				WithVariableNamed("project").
-				WithLiteral("serviceAccounts").
-				WithVariableNamed("service_account"),
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "projects"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "serviceAccounts"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"service_account"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			false,
 			"should parse a standard hierarchical resource pattern correctly",
 		},

--- a/internal/sidekick/parser/openapi_test.go
+++ b/internal/sidekick/parser/openapi_test.go
@@ -730,11 +730,17 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("locations"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "locations"},
+						},
+					},
 					QueryParameters: map[string]bool{
 						"filter":    true,
 						"pageSize":  true,
@@ -968,11 +974,17 @@ func TestOpenAPI_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithLiteral("projects").
-								WithVariableNamed("project").
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "projects"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"project"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"pageSize": true, "pageToken": true},
 						},
 					},
@@ -1188,12 +1200,18 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("rpc").
-						WithLiteral("a"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "rpc"},
+							{Literal: "a"},
+						},
+					},
 					QueryParameters: map[string]bool{"filter": true},
 				},
 			},
@@ -1210,12 +1228,18 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("rpc").
-						WithLiteral("b"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "rpc"},
+							{Literal: "b"},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},

--- a/internal/sidekick/parser/protobuf_api_version_test.go
+++ b/internal/sidekick/parser/protobuf_api_version_test.go
@@ -56,9 +56,12 @@ func TestProtobuf_ApiVersion(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v7").
-								WithLiteral("thing"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v7"},
+									{Literal: "thing"},
+								},
+							},
 							QueryParameters: map[string]bool{"parent": true}},
 					},
 				},
@@ -75,10 +78,13 @@ func TestProtobuf_ApiVersion(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v7").
-								WithLiteral("thing").
-								WithVerb("make"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v7"},
+									{Literal: "thing"},
+								},
+								Verb: "make",
+							},
 							QueryParameters: map[string]bool{"parent": true}},
 					},
 				},

--- a/internal/sidekick/parser/protobuf_mixin_test.go
+++ b/internal/sidekick/parser/protobuf_mixin_test.go
@@ -80,13 +80,15 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithVariable(api.NewPathVariable("name").
-							WithLiteral("projects").
-							WithMatch().
-							WithLiteral("locations").
-							WithMatch()),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"name"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard, "locations", api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -151,12 +153,16 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithVariable(api.NewPathVariable("resource").
-							WithLiteral("services").
-							WithMatch()).
-						WithVerb("getIamPolicy"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"resource"},
+								Segments:  []string{"services", api.SingleSegmentWildcard},
+							}},
+						},
+						Verb: "getIamPolicy",
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -228,11 +234,15 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v2").
-						WithVariable(api.NewPathVariable("name").
-							WithLiteral("operations").
-							WithMatch()),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v2"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"name"},
+								Segments:  []string{"operations", api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -316,11 +326,15 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v2").
-						WithVariable(api.NewPathVariable("name").
-							WithLiteral("operations").
-							WithMatch()),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v2"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"name"},
+								Segments:  []string{"operations", api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -401,11 +415,15 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithVariable(api.NewPathVariable("name").
-							WithLiteral("operations").
-							WithMatch()),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"name"},
+								Segments:  []string{"operations", api.SingleSegmentWildcard},
+							}},
+						},
+					},
 					QueryParameters: map[string]bool{},
 				},
 			},

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -483,12 +483,16 @@ func TestProtobuf_Comments(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{}},
 					},
 					BodyFieldPath: "*",
@@ -902,13 +906,15 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("name").
-									WithLiteral("projects").
-									WithMatch().
-									WithLiteral("foos").
-									WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"name"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard, "foos", api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{}},
 					},
 					BodyFieldPath: "",
@@ -925,12 +931,16 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"foo_id": true},
 						},
 					},
@@ -948,13 +958,15 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "DELETE",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("name").
-									WithLiteral("projects").
-									WithMatch().
-									WithLiteral("foos").
-									WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"name"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard, "foos", api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{}},
 					},
 				},
@@ -981,14 +993,16 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("name").
-									WithLiteral("projects").
-									WithMatch().
-									WithLiteral("foos").
-									WithMatch()).
-								WithVerb("Download"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"name"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard, "foos", api.SingleSegmentWildcard},
+									}},
+								},
+								Verb: "Download",
+							},
 							QueryParameters: map[string]bool{}},
 					},
 					BodyFieldPath: "",
@@ -1038,12 +1052,16 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"foo_id": true},
 						},
 					},
@@ -1061,14 +1079,16 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch().
-									WithLiteral("foos").
-									WithMatch()).
-								WithVerb("addFoo"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard, "foos", api.SingleSegmentWildcard},
+									}},
+								},
+								Verb: "addFoo",
+							},
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -1159,12 +1179,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 						},
 					},
@@ -1187,12 +1211,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"max_results": true, "page_token": true},
 						},
 					},
@@ -1215,12 +1243,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"max_results": true, "page_token": true},
 						},
 					},
@@ -1243,12 +1275,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"max_results": true, "page_token": true},
 						},
 					},
@@ -1271,12 +1307,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"max_results": true, "page_token": true},
 						},
 					},
@@ -1299,12 +1339,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"max_results": true, "page_token": true},
 						},
 					},
@@ -1320,12 +1364,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 						},
 					},
@@ -1341,12 +1389,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"page_token": true},
 						},
 					},
@@ -1362,12 +1414,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"page_size": true},
 						},
 					},
@@ -1383,12 +1439,16 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 						},
 					},
@@ -1508,12 +1568,16 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{}},
 					},
 					BodyFieldPath: "foo",
@@ -1534,12 +1598,16 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithVariable(api.NewPathVariable("parent").
-									WithLiteral("projects").
-									WithMatch()).
-								WithLiteral("foos"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{"projects", api.SingleSegmentWildcard},
+									}},
+									{Literal: "foos"},
+								},
+							},
 							QueryParameters: map[string]bool{}},
 					},
 					BodyFieldPath: "foo",
@@ -1560,11 +1628,15 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v2").
-								WithVariable(api.NewPathVariable("name").
-									WithLiteral("operations").
-									WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v2"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"name"},
+										Segments:  []string{"operations", api.SingleSegmentWildcard},
+									}},
+								},
+							},
 							QueryParameters: map[string]bool{}},
 					},
 					BodyFieldPath: "*",
@@ -1885,10 +1957,16 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 			Type: "library.googleapis.com/Shelf",
 			Patterns: []api.ResourcePattern{
 				{
-					*(&api.PathSegment{}).WithLiteral("publishers"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
-					*(&api.PathSegment{}).WithLiteral("shelves"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
+					{Literal: "publishers"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"publisher"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "shelves"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"shelf"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
 				},
 			},
 		}
@@ -1912,12 +1990,21 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 			Type: "library.googleapis.com/Book",
 			Patterns: []api.ResourcePattern{
 				{
-					*(&api.PathSegment{}).WithLiteral("publishers"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
-					*(&api.PathSegment{}).WithLiteral("shelves"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
-					*(&api.PathSegment{}).WithLiteral("books"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("book").WithMatch()),
+					{Literal: "publishers"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"publisher"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "shelves"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"shelf"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "books"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"book"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
 				},
 			},
 			Plural:   "books",
@@ -1969,12 +2056,21 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 			Type: "library.googleapis.com/Book",
 			Patterns: []api.ResourcePattern{
 				{
-					*(&api.PathSegment{}).WithLiteral("publishers"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
-					*(&api.PathSegment{}).WithLiteral("shelves"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
-					*(&api.PathSegment{}).WithLiteral("books"),
-					*(&api.PathSegment{}).WithVariable(api.NewPathVariable("book").WithMatch()),
+					{Literal: "publishers"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"publisher"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "shelves"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"shelf"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "books"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"book"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
 				},
 			},
 			Plural:   "books",
@@ -2169,14 +2265,23 @@ func TestParseResourcePatterns(t *testing.T) {
 		}
 		want := []api.ResourcePattern{
 			{
-				*(&api.PathSegment{}).WithLiteral("publishers"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("publisher").WithMatch()),
-				*(&api.PathSegment{}).WithLiteral("shelves"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("shelf").WithMatch()),
+				{Literal: "publishers"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"publisher"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "shelves"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"shelf"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
 			},
 			{
-				*(&api.PathSegment{}).WithLiteral("projects"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
 			},
 		}
 		got, err := parseResourcePatterns(patterns)

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -593,8 +593,8 @@ func formatResourceNameTemplateFromPath(m *api.Method, b *api.PathBinding) (stri
 		if i > 0 {
 			sb.WriteString("/")
 		}
-		if seg.Literal != nil {
-			sb.WriteString(*seg.Literal)
+		if seg.Literal != "" {
+			sb.WriteString(seg.Literal)
 		} else if seg.Variable != nil {
 			sb.WriteString("{}")
 		}

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -233,15 +233,27 @@ func annotateMethodModel(t *testing.T) *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("zones").
-						WithVariableNamed("zone").
-						// This is unlikely, but want to test variables that
-						// are reserved words.
-						WithLiteral("types").
-						WithVariableNamed("type"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "zones"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"zone"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							// This is unlikely, but want to test variables that
+							// are reserved words.
+							{Literal: "types"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"type"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+						},
+					},
 				},
 			},
 		},
@@ -293,13 +305,25 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 			t.Fatalf("missing method %s", methodID)
 		}
 		if m.PathInfo != nil && len(m.PathInfo.Bindings) > 0 {
-			m.PathInfo.Bindings[0].PathTemplate = (&api.PathTemplate{}).
-				WithLiteral("projects").
-				WithVariableNamed("project").
-				WithLiteral("zones").
-				WithVariableNamed("zone").
-				WithLiteral("types").
-				WithVariableNamed("type")
+			m.PathInfo.Bindings[0].PathTemplate = &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "projects"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "zones"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"zone"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "types"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"type"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			}
 			m.PathInfo.Bindings[0].TargetResource = &api.TargetResource{
 				Template:   api.ParseTemplateForTest(template),
 				FieldPaths: fields,
@@ -319,9 +343,15 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 	mSelf.PathInfo.Bindings = []*api.PathBinding{
 		{
 			Verb: "GET",
-			PathTemplate: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("name"),
+			PathTemplate: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			TargetResource: &api.TargetResource{
 				Template:   api.ParseTemplateForTest("//Test.googleapis.com/projects/{project}/locations/{location}/clusters/{cluster}"),
 				FieldPaths: [][]string{{"name"}},
@@ -329,14 +359,26 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 		},
 		{
 			Verb: "GET",
-			PathTemplate: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("projects").
-				WithVariableNamed("project").
-				WithLiteral("locations").
-				WithVariableNamed("location").
-				WithLiteral("clusters").
-				WithVariableNamed("cluster"),
+			PathTemplate: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "projects"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "locations"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"location"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "clusters"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"cluster"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			TargetResource: &api.TargetResource{
 				Template:   api.ParseTemplateForTest("//Test.googleapis.com/projects/{project}/locations/{location}/clusters/{cluster}"),
 				FieldPaths: [][]string{{"project"}, {"location"}, {"cluster"}},
@@ -476,13 +518,22 @@ func TestFormatResourceNameTemplateFromPath(t *testing.T) {
 				},
 			},
 			binding: &api.PathBinding{
-				PathTemplate: (&api.PathTemplate{}).
-					WithLiteral("compute").
-					WithLiteral("v1").
-					WithLiteral("projects").
-					WithVariableNamed("project").
-					WithLiteral("zones").
-					WithVariableNamed("zone"),
+				PathTemplate: &api.PathTemplate{
+					Segments: []api.PathSegment{
+						{Literal: "compute"},
+						{Literal: "v1"},
+						{Literal: "projects"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{api.SingleSegmentWildcard},
+						}},
+						{Literal: "zones"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"zone"},
+							Segments:  []string{api.SingleSegmentWildcard},
+						}},
+					},
+				},
 				TargetResource: &api.TargetResource{
 					// Notice that constructTemplate already stripped out "compute/v1"
 					Template: api.ParseTemplateForTest("//compute.googleapis.com/projects/{project}/zones/{zone}"),

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -292,7 +292,7 @@ func newTestAnnotateModelAPI() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:         "GET",
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("resource"),
+							PathTemplate: &api.PathTemplate{Segments: []api.PathSegment{{Literal: "resource"}}},
 						},
 					},
 				},
@@ -312,7 +312,7 @@ func newTestAnnotateModelAPI() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb:         "GET",
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("resource"),
+							PathTemplate: &api.PathTemplate{Segments: []api.PathSegment{{Literal: "resource"}}},
 						},
 					},
 				},

--- a/internal/sidekick/rust/annotate_path_info_test.go
+++ b/internal/sidekick/rust/annotate_path_info_test.go
@@ -52,9 +52,12 @@ func serviceAnnotationsModel() *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("resource"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "resource"},
+						},
+					},
 				},
 			},
 		},
@@ -69,9 +72,12 @@ func serviceAnnotationsModel() *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("resource"),
+					PathTemplate: &api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Literal: "resource"},
+						},
+					},
 				},
 			},
 		},
@@ -113,9 +119,12 @@ func TestPathInfoAnnotations(t *testing.T) {
 	binding := func(verb string) *api.PathBinding {
 		return &api.PathBinding{
 			Verb: verb,
-			PathTemplate: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("resource"),
+			PathTemplate: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "resource"},
+				},
+			},
 		}
 	}
 
@@ -245,14 +254,21 @@ func TestPathBindingAnnotations(t *testing.T) {
 
 	b0 := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: (&api.PathTemplate{}).
-			WithLiteral("v2").
-			WithVariable(api.NewPathVariable("name").
-				WithLiteral("projects").
-				WithMatch().
-				WithLiteral("locations").
-				WithMatch()).
-			WithVerb("create"),
+		PathTemplate: &api.PathTemplate{
+			Segments: []api.PathSegment{
+				{Literal: "v2"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"name"},
+					Segments: []string{
+						"projects",
+						api.SingleSegmentWildcard,
+						"locations",
+						api.SingleSegmentWildcard,
+					},
+				}},
+			},
+			Verb: "create",
+		},
 		QueryParameters: map[string]bool{
 			"id": true,
 		},
@@ -271,15 +287,27 @@ func TestPathBindingAnnotations(t *testing.T) {
 
 	b1 := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: (&api.PathTemplate{}).
-			WithLiteral("v1").
-			WithLiteral("projects").
-			WithVariableNamed("project").
-			WithLiteral("locations").
-			WithVariableNamed("location").
-			WithLiteral("ids").
-			WithVariableNamed("id").
-			WithVerb("action"),
+		PathTemplate: &api.PathTemplate{
+			Segments: []api.PathSegment{
+				{Literal: "v1"},
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "locations"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"location"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "ids"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"id"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+			},
+			Verb: "action",
+		},
 	}
 	want_b1 := &pathBindingAnnotation{
 		PathFmt: "/v1/projects/{}/locations/{}/ids/{}:action",
@@ -303,15 +331,27 @@ func TestPathBindingAnnotations(t *testing.T) {
 	}
 	b2 := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: (&api.PathTemplate{}).
-			WithLiteral("v1").
-			WithLiteral("projects").
-			WithVariableNamed("child", "project").
-			WithLiteral("locations").
-			WithVariableNamed("child", "location").
-			WithLiteral("ids").
-			WithVariableNamed("child", "id").
-			WithVerb("actionOnChild"),
+		PathTemplate: &api.PathTemplate{
+			Segments: []api.PathSegment{
+				{Literal: "v1"},
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"child", "project"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "locations"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"child", "location"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "ids"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"child", "id"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+			},
+			Verb: "actionOnChild",
+		},
 	}
 	want_b2 := &pathBindingAnnotation{
 		PathFmt: "/v1/projects/{}/locations/{}/ids/{}:actionOnChild",
@@ -335,9 +375,12 @@ func TestPathBindingAnnotations(t *testing.T) {
 	}
 	b3 := &api.PathBinding{
 		Verb: "GET",
-		PathTemplate: (&api.PathTemplate{}).
-			WithLiteral("v2").
-			WithLiteral("foos"),
+		PathTemplate: &api.PathTemplate{
+			Segments: []api.PathSegment{
+				{Literal: "v2"},
+				{Literal: "foos"},
+			},
+		},
 		QueryParameters: map[string]bool{
 			"name":     true,
 			"optional": true,
@@ -408,12 +451,19 @@ func TestPathBindingAnnotationsDetailedTracing(t *testing.T) {
 	}
 	binding := &api.PathBinding{
 		Verb: "POST",
-		PathTemplate: (&api.PathTemplate{}).
-			WithLiteral("v2").
-			WithVariable(api.NewPathVariable("name").
-				WithLiteral("projects").
-				WithMatch()).
-			WithVerb("create"),
+		PathTemplate: &api.PathTemplate{
+			Segments: []api.PathSegment{
+				{Literal: "v2"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"name"},
+					Segments: []string{
+						"projects",
+						api.SingleSegmentWildcard,
+					},
+				}},
+			},
+			Verb: "create",
+		},
 	}
 	method := &api.Method{
 		Name:         "DoFoo",
@@ -477,12 +527,17 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 		}
 		binding := &api.PathBinding{
 			Verb: "GET",
-			PathTemplate: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("machines").
-				WithVariable(api.NewPathVariable(test.FieldName).
-					WithMatch()).
-				WithVerb("create"),
+			PathTemplate: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "machines"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{test.FieldName},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+				Verb: "create",
+			},
 			QueryParameters: map[string]bool{},
 		}
 		wantBinding := &pathBindingAnnotation{

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -759,14 +759,14 @@ func bodyAccessor(m *api.Method) string {
 func httpPathFmt(t *api.PathTemplate) string {
 	fmt := ""
 	for _, segment := range t.Segments {
-		if segment.Literal != nil {
-			fmt = fmt + "/" + *segment.Literal
+		if segment.Literal != "" {
+			fmt = fmt + "/" + segment.Literal
 		} else if segment.Variable != nil {
 			fmt = fmt + "/{}"
 		}
 	}
-	if t.Verb != nil {
-		fmt = fmt + ":" + *t.Verb
+	if t.Verb != "" {
+		fmt = fmt + ":" + t.Verb
 	}
 	return fmt
 }

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -1855,9 +1855,12 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithLiteral("foo"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "foo"},
+								},
+							},
 						},
 					},
 				},
@@ -1880,9 +1883,12 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithLiteral("foo"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "foo"},
+								},
+							},
 						},
 					},
 				},
@@ -1901,9 +1907,12 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: (&api.PathTemplate{}).
-								WithLiteral("v1").
-								WithLiteral("thing"),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "thing"},
+								},
+							},
 						},
 					},
 				},
@@ -2191,44 +2200,73 @@ func TestPathFmt(t *testing.T) {
 	}{
 		{
 			"/v1/fixed",
-			(&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("fixed"),
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "fixed"},
+				},
+			},
 		},
 		{
 			"/v1/{}",
-			(&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("parent"),
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"parent"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 		},
 		{
 			"/v1/{}",
-			(&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariable(api.NewPathVariable("parent").
-					WithLiteral("projects").
-					WithMatch().
-					WithLiteral("locations").
-					WithMatch()),
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"parent"},
+						Segments:  []string{"projects", api.SingleSegmentWildcard, "locations", api.SingleSegmentWildcard},
+					}},
+				},
+			},
 		},
 		{
 			"/v1/{}:action",
-			(&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("parent").
-				WithVerb("action"),
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"parent"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+				Verb: "action",
+			},
 		},
 		{
 			"/v1/projects/{}/locations/{}/secrets/{}:action",
-			(&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("projects").
-				WithVariableNamed("project").
-				WithLiteral("locations").
-				WithVariableNamed("location").
-				WithLiteral("secrets").
-				WithVariableNamed("secret").
-				WithVerb("action"),
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "projects"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "locations"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"location"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "secrets"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"secret"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+				Verb: "action",
+			},
 		},
 	} {
 		got := httpPathFmt(test.template)

--- a/internal/sidekick/surfer/argument_builder.go
+++ b/internal/sidekick/surfer/argument_builder.go
@@ -242,8 +242,8 @@ func newAttributesFromSegments(segments []api.PathSegment) []Attribute {
 
 		// The `parameter_name` is derived from the preceding literal segment
 		// (e.g., "projects" -> "projectsId"). This is a gcloud convention.
-		if i > 0 && segments[i-1].Literal != nil {
-			parameterName = *segments[i-1].Literal + "Id"
+		if i > 0 && segments[i-1].Literal != "" {
+			parameterName = segments[i-1].Literal + "Id"
 		} else {
 			parameterName = name + "sId"
 		}

--- a/internal/sidekick/surfer/argument_builder_test.go
+++ b/internal/sidekick/surfer/argument_builder_test.go
@@ -29,7 +29,18 @@ func TestNewArgument(t *testing.T) {
 			{
 				Type: "test.googleapis.com/Network",
 				Patterns: []api.ResourcePattern{
-					{*(&api.PathSegment{}).WithLiteral("projects"), *(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()), *(&api.PathSegment{}).WithLiteral("networks"), *(&api.PathSegment{}).WithVariable(api.NewPathVariable("network").WithMatch())},
+					{
+						{Literal: "projects"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{api.SingleSegmentWildcard},
+						}},
+						{Literal: "networks"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"network"},
+							Segments:  []string{api.SingleSegmentWildcard},
+						}},
+					},
 				},
 			},
 		},
@@ -292,10 +303,16 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 								Plural:   "things",
 								Patterns: []api.ResourcePattern{
 									{
-										*(&api.PathSegment{}).WithLiteral("projects"),
-										*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-										*(&api.PathSegment{}).WithLiteral("things"),
-										*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
+										{Literal: "projects"},
+										{Variable: &api.PathVariable{
+											FieldPath: []string{"project"},
+											Segments:  []string{api.SingleSegmentWildcard},
+										}},
+										{Literal: "things"},
+										{Variable: &api.PathVariable{
+											FieldPath: []string{"thing"},
+											Segments:  []string{api.SingleSegmentWildcard},
+										}},
 									},
 								},
 							}),
@@ -311,10 +328,16 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 					Plural:   "things",
 					Patterns: []api.ResourcePattern{
 						{
-							*(&api.PathSegment{}).WithLiteral("projects"),
-							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-							*(&api.PathSegment{}).WithLiteral("things"),
-							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"thing"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
 						},
 					},
 				},
@@ -364,10 +387,16 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 					Plural:   "things",
 					Patterns: []api.ResourcePattern{
 						{
-							*(&api.PathSegment{}).WithLiteral("projects"),
-							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-							*(&api.PathSegment{}).WithLiteral("things"),
-							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"thing"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
 						},
 					},
 				},
@@ -417,10 +446,16 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 					Plural:   "things",
 					Patterns: []api.ResourcePattern{
 						{
-							*(&api.PathSegment{}).WithLiteral("projects"),
-							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-							*(&api.PathSegment{}).WithLiteral("things"),
-							*(&api.PathSegment{}).WithVariable(api.NewPathVariable("thing").WithMatch()),
+							{Literal: "projects"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"project"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"thing"},
+								Segments:  []string{api.SingleSegmentWildcard},
+							}},
 						},
 					},
 				},
@@ -532,10 +567,16 @@ func TestNewResourceReferenceSpec(t *testing.T) {
 				Type: "test.googleapis.com/OtherThing",
 				Patterns: []api.ResourcePattern{
 					{
-						*(&api.PathSegment{}).WithLiteral("projects"),
-						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-						*(&api.PathSegment{}).WithLiteral("otherThings"),
-						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("other_thing").WithMatch()),
+						{Literal: "projects"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"project"},
+							Segments:  []string{api.SingleSegmentWildcard},
+						}},
+						{Literal: "otherThings"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"other_thing"},
+							Segments:  []string{api.SingleSegmentWildcard},
+						}},
 					},
 				},
 			},

--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -131,8 +131,8 @@ func helpText(overrides *provider.Config, method *api.Method, model *api.API) He
 func requestMethod(method *api.Method) string {
 	// For custom methods (AIP-136), the `method` field in the request configuration
 	// MUST match the custom verb defined in the HTTP binding (e.g., ":exportData" -> "exportData").
-	if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 && method.PathInfo.Bindings[0].PathTemplate.Verb != nil {
-		return *method.PathInfo.Bindings[0].PathTemplate.Verb
+	if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 && method.PathInfo.Bindings[0].PathTemplate.Verb != "" {
+		return method.PathInfo.Bindings[0].PathTemplate.Verb
 	} else if !provider.IsStandardMethod(method) {
 		commandName, _ := provider.GetCommandName(method)
 		// GetCommandName returns snake_case (e.g. "export_data"), but request.method expects camelCase (e.g. "exportData").

--- a/internal/sidekick/surfer/command_builder_test.go
+++ b/internal/sidekick/surfer/command_builder_test.go
@@ -96,21 +96,47 @@ func TestRequestMethod(t *testing.T) {
 		{
 			name: "Standard Create",
 			method: api.NewTestMethod("CreateThing").WithVerb("POST").WithPathTemplate(
-				(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
+				&api.PathTemplate{
+					Segments: []api.PathSegment{
+						{Literal: "v1"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"parent"},
+							Segments:  []string{"projects", api.SingleSegmentWildcard},
+						}},
+						{Literal: "things"},
+					},
+				},
 			),
 			want: "",
 		},
 		{
 			name: "Custom Method with Verb",
 			method: api.NewTestMethod("ImportData").WithVerb("POST").WithPathTemplate(
-				(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()).WithVerb("importData"),
+				&api.PathTemplate{
+					Segments: []api.PathSegment{
+						{Literal: "v1"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"name"},
+							Segments:  []string{"projects", api.SingleSegmentWildcard},
+						}},
+					},
+					Verb: "importData",
+				},
 			),
 			want: "importData",
 		},
 		{
 			name: "Custom Method without Verb (fallback to camelCase name)",
 			method: api.NewTestMethod("ExportData").WithVerb("POST").WithPathTemplate(
-				(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()),
+				&api.PathTemplate{
+					Segments: []api.PathSegment{
+						{Literal: "v1"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"name"},
+							Segments:  []string{"projects", api.SingleSegmentWildcard},
+						}},
+					},
+				},
 			),
 			want: "exportData",
 		},
@@ -168,7 +194,16 @@ func TestAsync(t *testing.T) {
 			name: "Create returns Resource",
 			method: func() *api.Method {
 				m := api.NewTestMethod("CreateThing").WithVerb("POST").WithPathTemplate(
-					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
+					&api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"parent"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+						},
+					},
 				).WithInput(
 					api.NewTestMessage("CreateRequest").WithFields(
 						api.NewTestField("thing").WithType(api.TypezMessage).WithMessageType(
@@ -188,7 +223,15 @@ func TestAsync(t *testing.T) {
 			name: "Delete returns Empty",
 			method: func() *api.Method {
 				m := api.NewTestMethod("DeleteThing").WithVerb("DELETE").WithPathTemplate(
-					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("things").WithMatch()),
+					&api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"name"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard, "things", api.SingleSegmentWildcard},
+							}},
+						},
+					},
 				)
 				m.OperationInfo = &api.OperationInfo{ResponseTypeID: ".google.protobuf.Empty"}
 				return m
@@ -202,7 +245,16 @@ func TestAsync(t *testing.T) {
 			name: "Unrelated Response Type returns False",
 			method: func() *api.Method {
 				m := api.NewTestMethod("CreateThing").WithVerb("POST").WithPathTemplate(
-					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).WithLiteral("things"),
+					&api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"parent"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+						},
+					},
 				).WithInput(
 					api.NewTestMessage("CreateRequest").WithFields(
 						api.NewTestField("thing").WithType(api.TypezMessage).WithMessageType(
@@ -223,7 +275,17 @@ func TestAsync(t *testing.T) {
 			name: "Method Without Resource Returns Base Async",
 			method: func() *api.Method {
 				m := api.NewTestMethod("CustomMethod").WithVerb("POST").WithPathTemplate(
-					(&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch()).WithLiteral("things").WithVerb("doAction"),
+					&api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"name"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+						},
+						Verb: "doAction",
+					},
 				)
 				m.OperationInfo = &api.OperationInfo{ResponseTypeID: "ActionResponse"}
 				m.Service = service
@@ -255,8 +317,6 @@ func TestCollectionPath(t *testing.T) {
 		DefaultHost: "test.googleapis.com",
 	}
 
-	stringPtr := func(s string) *string { return &s }
-
 	for _, test := range []struct {
 		name    string
 		method  *api.Method
@@ -271,12 +331,12 @@ func TestCollectionPath(t *testing.T) {
 						{
 							PathTemplate: &api.PathTemplate{
 								Segments: []api.PathSegment{
-									{Literal: stringPtr("v1")},
-									{Literal: stringPtr("projects")},
+									{Literal: "v1"},
+									{Literal: "projects"},
 									{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
-									{Literal: stringPtr("locations")},
+									{Literal: "locations"},
 									{Variable: &api.PathVariable{FieldPath: []string{"location"}}},
-									{Literal: stringPtr("instances")},
+									{Literal: "instances"},
 									{Variable: &api.PathVariable{FieldPath: []string{"instance"}}},
 								},
 							},
@@ -295,12 +355,12 @@ func TestCollectionPath(t *testing.T) {
 						{
 							PathTemplate: &api.PathTemplate{
 								Segments: []api.PathSegment{
-									{Literal: stringPtr("v1")},
-									{Literal: stringPtr("projects")},
+									{Literal: "v1"},
+									{Literal: "projects"},
 									{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
-									{Literal: stringPtr("locations")},
+									{Literal: "locations"},
 									{Variable: &api.PathVariable{FieldPath: []string{"location"}}},
-									{Literal: stringPtr("instances")},
+									{Literal: "instances"},
 									{Variable: &api.PathVariable{FieldPath: []string{"instance"}}},
 								},
 							},
@@ -319,8 +379,8 @@ func TestCollectionPath(t *testing.T) {
 						{
 							PathTemplate: &api.PathTemplate{
 								Segments: []api.PathSegment{
-									{Literal: stringPtr("v1")},
-									{Literal: stringPtr("instances")},
+									{Literal: "v1"},
+									{Literal: "instances"},
 								},
 							},
 						},
@@ -363,10 +423,16 @@ func TestNewCommand(t *testing.T) {
 							),
 						),
 					)).
-					WithPathTemplate((&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).
-						WithLiteral("things"))
+					WithPathTemplate(&api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"parent"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+						},
+					})
 				m.OutputType.Pagination = &api.PaginationInfo{PageableItem: m.OutputType.Fields[0]}
 				return m
 			}(),
@@ -395,9 +461,15 @@ func TestNewCommand(t *testing.T) {
 						),
 						api.NewTestField("update_mask").WithType(api.TypezMessage),
 					)).
-					WithPathTemplate((&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithVariable(api.NewPathVariable("thing", "name").WithLiteral("projects").WithMatch().WithLiteral("things").WithMatch()))
+					WithPathTemplate(&api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"thing", "name"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard, "things", api.SingleSegmentWildcard},
+							}},
+						},
+					})
 				m.ID = "google.cloud.test.v1.Service.UpdateThing"
 				return m
 			}(),
@@ -433,10 +505,16 @@ func TestNewCommand(t *testing.T) {
 					WithInput(api.NewTestMessage("CreateRequest").WithFields(
 						api.NewTestField("thing_id").WithType(api.TypezString),
 					)).
-					WithPathTemplate((&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithVariable(api.NewPathVariable("parent").WithLiteral("projects").WithMatch()).
-						WithLiteral("things"))
+					WithPathTemplate(&api.PathTemplate{
+						Segments: []api.PathSegment{
+							{Literal: "v1"},
+							{Variable: &api.PathVariable{
+								FieldPath: []string{"parent"},
+								Segments:  []string{"projects", api.SingleSegmentWildcard},
+							}},
+							{Literal: "things"},
+						},
+					})
 				m.ID = "google.cloud.test.v1.Service.CreateThing"
 				m.OperationInfo = &api.OperationInfo{ResponseTypeID: "Thing", MetadataTypeID: "Metadata"}
 				return m
@@ -571,7 +649,15 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"name"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 						},
 					},
 				}
@@ -605,7 +691,15 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("parent").WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"parent"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 						},
 					},
 				}
@@ -644,7 +738,15 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"resource.name"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 						},
 					},
 					BodyFieldPath: "*",
@@ -711,7 +813,15 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"resource.name"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 						},
 					},
 					BodyFieldPath: "*",
@@ -741,7 +851,15 @@ func TestCommandBuilderNewArguments(t *testing.T) {
 				m.PathInfo = &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("resource.name").WithMatch()),
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Variable: &api.PathVariable{
+										FieldPath: []string{"resource.name"},
+										Segments:  []string{api.SingleSegmentWildcard},
+									}},
+								},
+							},
 						},
 					},
 					BodyFieldPath: "*",
@@ -787,7 +905,15 @@ func TestCommandBuilderNewArgumentsDuplicatesError(t *testing.T) {
 	m.PathInfo = &api.PathInfo{
 		Bindings: []*api.PathBinding{
 			{
-				PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithVariable(api.NewPathVariable("name").WithMatch()),
+				PathTemplate: &api.PathTemplate{
+					Segments: []api.PathSegment{
+						{Literal: "v1"},
+						{Variable: &api.PathVariable{
+							FieldPath: []string{"name"},
+							Segments:  []string{api.SingleSegmentWildcard},
+						}},
+					},
+				},
 			},
 		},
 		BodyFieldPath: "*",

--- a/internal/sidekick/surfer/provider/method.go
+++ b/internal/sidekick/surfer/provider/method.go
@@ -44,8 +44,8 @@ func GetCommandName(method *api.Method) (string, error) {
 		// The custom verb is the part after the colon (e.g., .../instances/*:exportData).
 		if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 {
 			binding := method.PathInfo.Bindings[0]
-			if binding.PathTemplate != nil && binding.PathTemplate.Verb != nil {
-				return strcase.ToSnake(*binding.PathTemplate.Verb), nil
+			if binding.PathTemplate != nil && binding.PathTemplate.Verb != "" {
+				return strcase.ToSnake(binding.PathTemplate.Verb), nil
 			}
 		}
 		// Fallback: use the method name converted to snake_case.
@@ -184,7 +184,7 @@ func IsCollectionMethod(m *api.Method) bool {
 		}
 		lastSegment := template.Segments[len(template.Segments)-1]
 		// If the path ends with a literal, it's a collection method.
-		return lastSegment.Literal != nil
+		return lastSegment.Literal != ""
 	}
 }
 
@@ -279,8 +279,8 @@ func GetMethodHelpText(overrides *Config, method *api.Method, model *api.API) He
 		verb := commandName
 		if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 {
 			binding := method.PathInfo.Bindings[0]
-			if binding.PathTemplate != nil && binding.PathTemplate.Verb != nil {
-				verb = *binding.PathTemplate.Verb
+			if binding.PathTemplate != nil && binding.PathTemplate.Verb != "" {
+				verb = binding.PathTemplate.Verb
 			}
 		}
 		sentenceCaseVerb := ToSentenceCase(verb)

--- a/internal/sidekick/surfer/provider/method_test.go
+++ b/internal/sidekick/surfer/provider/method_test.go
@@ -129,7 +129,6 @@ func TestIsDelete(t *testing.T) {
 }
 
 func TestGetCommandName(t *testing.T) {
-	v := "exportData"
 	for _, test := range []struct {
 		name   string
 		method *api.Method
@@ -138,7 +137,7 @@ func TestGetCommandName(t *testing.T) {
 		{"Standard Create", &api.Method{Name: "CreateInstance"}, "create"},
 		{"Standard List", &api.Method{Name: "ListInstances"}, "list"},
 		{"Standard Get", &api.Method{Name: "GetInstance"}, "describe"},
-		{"Custom Verb in Path", api.NewTestMethod("ExportData").WithPathTemplate(&api.PathTemplate{Verb: &v}), "export_data"},
+		{"Custom Verb in Path", api.NewTestMethod("ExportData").WithPathTemplate(&api.PathTemplate{Verb: "exportData"}), "export_data"},
 		{"Fallback to Name", &api.Method{Name: "ExportData"}, "export_data"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -236,10 +235,16 @@ func TestIsResourceMethod(t *testing.T) {
 		{"Standard Get", api.NewTestMethod("GetInstance").WithVerb("GET"), true},
 		{"Standard List", api.NewTestMethod("ListInstances").WithVerb("GET"), false},
 		{"Custom Resource", api.NewTestMethod("CustomInstance").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance"))}},
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"instance"},
+					}},
+				},
+			},
 		), true},
 		{"Custom Collection", api.NewTestMethod("CustomCollection").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithLiteral("instances")}},
+			&api.PathTemplate{Segments: []api.PathSegment{{Literal: "instances"}}},
 		), false},
 		{"Nil PathInfo", &api.Method{Name: "CustomMethod", PathInfo: nil}, false},
 		{"Empty Bindings", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{}}}, false},
@@ -264,10 +269,16 @@ func TestIsCollectionMethod(t *testing.T) {
 		{"Standard Get", api.NewTestMethod("GetInstance").WithVerb("GET"), false},
 		{"Standard List", api.NewTestMethod("ListInstances").WithVerb("GET"), true},
 		{"Custom Resource", api.NewTestMethod("CustomInstance").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance"))}},
+			&api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"instance"},
+					}},
+				},
+			},
 		), false},
 		{"Custom Collection", api.NewTestMethod("CustomCollection").WithPathTemplate(
-			&api.PathTemplate{Segments: []api.PathSegment{*(&api.PathSegment{}).WithLiteral("instances")}},
+			&api.PathTemplate{Segments: []api.PathSegment{{Literal: "instances"}}},
 		), true},
 		{"Nil PathInfo", &api.Method{Name: "CustomMethod", PathInfo: nil}, false},
 		{"Empty Bindings", &api.Method{Name: "CustomMethod", PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{}}}, false},
@@ -313,9 +324,9 @@ func TestIsSingletonResourceMethod(t *testing.T) {
 				Type: "test.googleapis.com/Singleton",
 				Patterns: []api.ResourcePattern{
 					[]api.PathSegment{
-						*(&api.PathSegment{}).WithLiteral("projects"),
-						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
-						*(&api.PathSegment{}).WithLiteral("singletonConfig"),
+						{Literal: "projects"},
+						{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
+						{Literal: "singletonConfig"},
 					},
 				},
 			},
@@ -323,11 +334,11 @@ func TestIsSingletonResourceMethod(t *testing.T) {
 				Type: "test.googleapis.com/AdjacentLiterals",
 				Patterns: []api.ResourcePattern{
 					[]api.PathSegment{
-						*(&api.PathSegment{}).WithLiteral("projects"),
-						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
-						*(&api.PathSegment{}).WithLiteral("literal1"),
-						*(&api.PathSegment{}).WithLiteral("literal2"),
-						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance")),
+						{Literal: "projects"},
+						{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
+						{Literal: "literal1"},
+						{Literal: "literal2"},
+						{Variable: &api.PathVariable{FieldPath: []string{"instance"}}},
 					},
 				},
 			},
@@ -335,10 +346,10 @@ func TestIsSingletonResourceMethod(t *testing.T) {
 				Type: "test.googleapis.com/Standard",
 				Patterns: []api.ResourcePattern{
 					[]api.PathSegment{
-						*(&api.PathSegment{}).WithLiteral("projects"),
-						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
-						*(&api.PathSegment{}).WithLiteral("instances"),
-						*(&api.PathSegment{}).WithVariable(api.NewPathVariable("instance")),
+						{Literal: "projects"},
+						{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
+						{Literal: "instances"},
+						{Variable: &api.PathVariable{FieldPath: []string{"instance"}}},
 					},
 				},
 			},
@@ -554,7 +565,6 @@ func TestGetMethodHelpText(t *testing.T) {
 		{
 			name: "Custom Verb Fallback",
 			method: func() *api.Method {
-				v := "exportData"
 				m := api.NewTestMethod("ExportData")
 				m.ID = ".ExportData"
 				m.InputType = &api.Message{
@@ -569,7 +579,7 @@ func TestGetMethodHelpText(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							PathTemplate: &api.PathTemplate{
-								Verb: &v,
+								Verb: "exportData",
 							},
 						},
 					},

--- a/internal/sidekick/surfer/provider/resource.go
+++ b/internal/sidekick/surfer/provider/resource.go
@@ -35,10 +35,10 @@ func GetPluralFromSegments(segments []api.PathSegment) string {
 	}
 	// The second to last segment should be the literal plural name
 	secondLastSegment := segments[len(segments)-2]
-	if secondLastSegment.Literal == nil {
+	if secondLastSegment.Literal == "" {
 		return ""
 	}
-	return *secondLastSegment.Literal
+	return secondLastSegment.Literal
 }
 
 // GetParentFromSegments extracts the pattern segments for the parent resource.
@@ -51,7 +51,7 @@ func GetParentFromSegments(segments []api.PathSegment) []api.PathSegment {
 	}
 	// We verify that the last segment is a variable and the second to last is a literal,
 	// consistent with standard AIP-122 patterns.
-	if segments[len(segments)-1].Variable != nil && segments[len(segments)-2].Literal != nil {
+	if segments[len(segments)-1].Variable != nil && segments[len(segments)-2].Literal != "" {
 		return segments[:len(segments)-2]
 	}
 	return nil
@@ -81,10 +81,10 @@ func GetCollectionPathFromSegments(segments []api.PathSegment) string {
 	var collectionParts []string
 	for i := 0; i < len(segments)-1; i++ {
 		// A collection identifier is a literal segment followed by a variable segment.
-		if segments[i].Literal == nil || segments[i+1].Variable == nil {
+		if segments[i].Literal == "" || segments[i+1].Variable == nil {
 			continue
 		}
-		collectionParts = append(collectionParts, *segments[i].Literal)
+		collectionParts = append(collectionParts, segments[i].Literal)
 	}
 	return strings.Join(collectionParts, ".")
 }
@@ -211,13 +211,13 @@ func isSingletonResource(resource *api.Resource) bool {
 		}
 
 		// A pattern ending in a literal is a singleton (e.g., projects/{project}/singletonConfig).
-		if pattern[len(pattern)-1].Literal != nil {
+		if pattern[len(pattern)-1].Literal != "" {
 			return true
 		}
 
 		// Adjacent literals anywhere in the pattern signify a singleton (e.g., .../literal1/literal2/...).
 		for i := 0; i < len(pattern)-1; i++ {
-			if pattern[i].Literal != nil && pattern[i+1].Literal != nil {
+			if pattern[i].Literal != "" && pattern[i+1].Literal != "" {
 				return true
 			}
 		}
@@ -270,8 +270,8 @@ func GetSingularResourceNameForMethod(method *api.Method, model *api.API) string
 func ExtractPathFromSegments(segments []api.PathSegment) string {
 	var parts []string
 	for i, seg := range segments {
-		if seg.Literal != nil {
-			val := *seg.Literal
+		if seg.Literal != "" {
+			val := seg.Literal
 			// Heuristic: Skip API version at the start.
 			if i == 0 && len(val) >= 2 && val[0] == 'v' && val[1] >= '0' && val[1] <= '9' {
 				continue
@@ -315,8 +315,8 @@ func ExtractCollectionFromStrings(parts []string) string {
 func GetLiteralSegments(raw []api.PathSegment) []string {
 	var literals []string
 	for _, seg := range raw {
-		if seg.Literal != nil {
-			literals = append(literals, *seg.Literal)
+		if seg.Literal != "" {
+			literals = append(literals, seg.Literal)
 		} else if seg.Variable != nil {
 			for _, vSeg := range seg.Variable.Segments {
 				if vSeg != "*" && vSeg != "**" {

--- a/internal/sidekick/surfer/provider/resource_test.go
+++ b/internal/sidekick/surfer/provider/resource_test.go
@@ -41,9 +41,12 @@ func TestGetPluralFromSegments(t *testing.T) {
 		{
 			name: "No Variable End",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("projects"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-				*(&api.PathSegment{}).WithLiteral("locations"),
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "locations"},
 			},
 			want: "",
 		},
@@ -82,16 +85,19 @@ func TestGetParentFromSegments(t *testing.T) {
 		{
 			name: "Too Short",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("projects"),
+				{Literal: "projects"},
 			},
 			want: nil,
 		},
 		{
 			name: "Invalid Pattern (Ends in Literal)",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("projects"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-				*(&api.PathSegment{}).WithLiteral("locations"),
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "locations"},
 			},
 			want: nil,
 		},
@@ -130,9 +136,12 @@ func TestGetSingularFromSegments(t *testing.T) {
 		{
 			name: "No Variable End",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("projects"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project").WithMatch()),
-				*(&api.PathSegment{}).WithLiteral("locations"),
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"project"},
+					Segments:  []string{api.SingleSegmentWildcard},
+				}},
+				{Literal: "locations"},
 			},
 			want: "",
 		},
@@ -208,25 +217,31 @@ func TestExtractPathFromSegments(t *testing.T) {
 		{
 			name: "Complex Variable",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("v1"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch().WithLiteral("instances").WithMatch()),
+				{Literal: "v1"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"name"},
+					Segments:  []string{"projects", api.SingleSegmentWildcard, "locations", api.SingleSegmentWildcard, "instances", api.SingleSegmentWildcard},
+				}},
 			},
 			want: "projects.locations.instances",
 		},
 		{
 			name: "Trailing Literal (List)",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("v1"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("name").WithLiteral("projects").WithMatch().WithLiteral("locations").WithMatch()),
-				*(&api.PathSegment{}).WithLiteral("instances"),
+				{Literal: "v1"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"name"},
+					Segments:  []string{"projects", api.SingleSegmentWildcard, "locations", api.SingleSegmentWildcard},
+				}},
+				{Literal: "instances"},
 			},
 			want: "projects.locations.instances",
 		},
 		{
 			name: "No Version",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("projects"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("project")),
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
 			},
 			want: "projects",
 		},
@@ -720,9 +735,12 @@ func parseResourcePattern(pattern string) []api.PathSegment {
 	for part := range strings.SplitSeq(pattern, "/") {
 		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
 			name := part[1 : len(part)-1]
-			segments = append(segments, *(&api.PathSegment{}).WithVariable(api.NewPathVariable(name).WithMatch()))
+			segments = append(segments, api.PathSegment{Variable: &api.PathVariable{
+				FieldPath: []string{name},
+				Segments:  []string{api.SingleSegmentWildcard},
+			}})
 		} else {
-			segments = append(segments, *(&api.PathSegment{}).WithLiteral(part))
+			segments = append(segments, api.PathSegment{Literal: part})
 		}
 	}
 	return segments
@@ -747,8 +765,11 @@ func TestGetLiteralSegments(t *testing.T) {
 		{
 			name: "With Wildcards",
 			segments: []api.PathSegment{
-				*(&api.PathSegment{}).WithLiteral("projects"),
-				*(&api.PathSegment{}).WithVariable(api.NewPathVariable("name").WithLiteral("foo").WithMatch().WithLiteral("bar")),
+				{Literal: "projects"},
+				{Variable: &api.PathVariable{
+					FieldPath: []string{"name"},
+					Segments:  []string{"foo", api.SingleSegmentWildcard, "bar"},
+				}},
 			},
 			want: []string{"projects", "foo", "bar"},
 		},

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -48,8 +48,13 @@ func TestAnnotateMethod(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:         "GET",
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("operations"),
+							Verb: "GET",
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "operations"},
+								},
+							},
 						},
 					},
 				},
@@ -69,8 +74,13 @@ func TestAnnotateMethod(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:         "POST",
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("keys"),
+							Verb: "POST",
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "keys"},
+								},
+							},
 						},
 					},
 					BodyFieldPath: "key",
@@ -92,8 +102,13 @@ func TestAnnotateMethod(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:         "POST",
-							PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("data"),
+							Verb: "POST",
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "data"},
+								},
+							},
 						},
 					},
 					BodyFieldPath: "*",
@@ -115,8 +130,13 @@ func TestAnnotateMethod(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:            "GET",
-							PathTemplate:    (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("things"),
+							Verb: "GET",
+							PathTemplate: &api.PathTemplate{
+								Segments: []api.PathSegment{
+									{Literal: "v1"},
+									{Literal: "things"},
+								},
+							},
 							QueryParameters: map[string]bool{"key": true},
 						},
 					},

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -25,17 +25,17 @@ func pathExpression(t *api.PathTemplate) string {
 	count := 0
 	var pathComponents []string
 	for _, segment := range t.Segments {
-		if segment.Literal != nil {
-			pathComponents = append(pathComponents, *segment.Literal)
+		if segment.Literal != "" {
+			pathComponents = append(pathComponents, segment.Literal)
 		} else if segment.Variable != nil {
 			pathComponents = append(pathComponents, fmt.Sprintf(`\(pathVariable%d)`, count))
 			count += 1
 		}
 	}
 	path := "/" + strings.Join(pathComponents, "/")
-	if t.Verb != nil {
+	if t.Verb != "" {
 		// t.Verb cannot be an empty string, the parsers reject empty verbs.
-		path += ":" + *t.Verb
+		path += ":" + t.Verb
 	}
 	return path
 }

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -29,31 +29,54 @@ func TestPathExpression(t *testing.T) {
 	}{
 		{
 			name: "literals only",
-			template: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("operations"),
+			template: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "operations"},
+				},
+			},
 			want: "/v1/operations",
 		},
 		{
 			name: "with variable",
-			template: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("name"),
+			template: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			want: "/v1/\\(pathVariable0)",
 		},
 		{
 			name: "with multiple variables",
-			template: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("name").WithLiteral("separator").WithVariableNamed("second"),
+			template: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "separator"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"second"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			want: "/v1/\\(pathVariable0)/separator/\\(pathVariable1)",
 		},
 		{
 			name: "with verb",
-			template: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("operations").
-				WithVerb("cancel"),
+			template: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "operations"},
+				},
+				Verb: "cancel",
+			},
 			want: "/v1/operations:cancel",
 		},
 	} {
@@ -99,14 +122,20 @@ func TestPathVariables(t *testing.T) {
 	}{
 		{
 			name:     "no variables",
-			template: (&api.PathTemplate{}).WithLiteral("v1"),
+			template: &api.PathTemplate{Segments: []api.PathSegment{{Literal: "v1"}}},
 			want:     nil,
 		},
 		{
 			name: "one variable",
-			template: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("name"),
+			template: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			want: []*pathVariable{
 				{
 					Name:       "pathVariable0",
@@ -118,11 +147,20 @@ func TestPathVariables(t *testing.T) {
 		},
 		{
 			name: "two variables",
-			template: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("name").
-				WithLiteral("sep").
-				WithVariableNamed("second"),
+			template: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "sep"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"second"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			want: []*pathVariable{
 				{
 					Name:       "pathVariable0",
@@ -140,9 +178,15 @@ func TestPathVariables(t *testing.T) {
 		},
 		{
 			name: "error - lookup field missing",
-			template: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("missing"),
+			template: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"missing"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			wantErr: true,
 		},
 	} {

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -208,9 +208,15 @@ func TestGenerateService_PathParameters(t *testing.T) {
 	}{
 		{
 			name: "Nested",
-			path: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("secret", "name"),
+			path: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"secret", "name"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			wantBlock: `let path = try { () throws -> String in
       guard let pathVariable0 = request.secret.map({ $0.name }), !pathVariable0.isEmpty else {
         throw GoogleCloudGax.RequestError.binding("'request.secret.name' is not set or is empty")
@@ -220,9 +226,15 @@ func TestGenerateService_PathParameters(t *testing.T) {
 		},
 		{
 			name: "Plain",
-			path: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithVariableNamed("name"),
+			path: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"name"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			wantBlock: `let path = try { () throws -> String in
       guard let pathVariable0 = request.name as String?, !pathVariable0.isEmpty else {
         throw GoogleCloudGax.RequestError.binding("'request.name' is not set or is empty")
@@ -232,12 +244,21 @@ func TestGenerateService_PathParameters(t *testing.T) {
 		},
 		{
 			name: "Multiple strings",
-			path: (&api.PathTemplate{}).
-				WithLiteral("v1").
-				WithLiteral("projects").
-				WithVariableNamed("project").
-				WithLiteral("locations").
-				WithVariableNamed("location"),
+			path: &api.PathTemplate{
+				Segments: []api.PathSegment{
+					{Literal: "v1"},
+					{Literal: "projects"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"project"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+					{Literal: "locations"},
+					{Variable: &api.PathVariable{
+						FieldPath: []string{"location"},
+						Segments:  []string{api.SingleSegmentWildcard},
+					}},
+				},
+			},
 			wantBlock: `let path = try { () throws -> String in
       guard let pathVariable0 = request.project as String?, !pathVariable0.isEmpty else {
         throw GoogleCloudGax.RequestError.binding("'request.project' is not set or is empty")


### PR DESCRIPTION
Change PathSegment.Literal and PathTemplate.Verb from `*string` to `string`, where the empty string means the field is unset.

Delete the builder methods on PathTemplate, PathVariable, and PathSegment and rewrite all call sites using plain struct literals instead. Once the pointer fields were removed, the builder chain no longer provided any meaningful benefit over directly constructing the structs.