### PR TITLE
test(internal/sidekick/gcloud): use testdata/googleapis/parallelstore

### DIFF
--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -64,7 +64,7 @@ func TestFromProtobuf(t *testing.T) {
 	}
 }
 
-func TestParallelstoreMock(t *testing.T) {
+func TestParallelstore(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 	testdataDir, err := filepath.Abs("../../testdata")
 	if err != nil {

--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/testhelper"
@@ -66,43 +65,31 @@ func TestFromProtobuf(t *testing.T) {
 }
 
 func TestParallelstoreMock(t *testing.T) {
-	// TODO(https://github.com/googleapis/librarian/issues/5769): once we
-	// implement the model building, we should remove the hardcoded data and
-	// construct it from internal/testdata/googleapis instead.
-	method := &api.Method{
-		Name: "CreateInstance",
-		PathInfo: &api.PathInfo{
-			Bindings: []*api.PathBinding{
-				{
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("locations").
-						WithVariableNamed("location").
-						WithLiteral("instances"),
-				},
-			},
-		},
-		InputType: &api.Message{
-			Fields: []*api.Field{},
-		},
+	testhelper.RequireCommand(t, "protoc")
+	testdataDir, err := filepath.Abs("../../testdata")
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	service := &api.Service{
-		Name:        "Parallelstore",
-		DefaultHost: "parallelstore.googleapis.com",
-		Methods:     []*api.Method{method},
-	}
-	method.Service = service
-
-	model := &api.API{
-		Name:     "parallelstore",
-		Title:    "Parallelstore API",
-		Services: []*api.Service{service},
-	}
-
 	outDir := t.TempDir()
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: config.SpecProtobuf,
+		ServiceConfig:       "google/cloud/parallelstore/v1/service.yaml",
+		SpecificationSource: "google/cloud/parallelstore/v1",
+		Source: &sources.SourceConfig{
+			Sources: &sources.Sources{
+				Googleapis: filepath.Join(testdataDir, "googleapis"),
+			},
+			ActiveRoots: []string{"googleapis"},
+		},
+		Codec: map[string]string{
+			"copyright-year": "2026",
+		},
+	}
+	model, err := parser.CreateModel(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := Generate(model, outDir); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
+++ b/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
@@ -22,10 +22,118 @@ func main() {
 						Usage: "Manage instances resources",
 						Commands: []*cli.Command{
 							{
+								Name:  "list",
+								Usage: "list instances",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing list...")
+									return nil
+								},
+							},
+							{
+								Name:  "describe",
+								Usage: "describe instances",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing describe...")
+									return nil
+								},
+							},
+							{
 								Name:  "create",
 								Usage: "create instances",
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing create...")
+									return nil
+								},
+							},
+							{
+								Name:  "update",
+								Usage: "update instances",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing update...")
+									return nil
+								},
+							},
+							{
+								Name:  "delete",
+								Usage: "delete instances",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing delete...")
+									return nil
+								},
+							},
+							{
+								Name:  "import-data",
+								Usage: "import-data instances",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing import-data...")
+									return nil
+								},
+							},
+							{
+								Name:  "export-data",
+								Usage: "export-data instances",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing export-data...")
+									return nil
+								},
+							},
+						},
+					},
+					{
+						Name:  "locations",
+						Usage: "Manage locations resources",
+						Commands: []*cli.Command{
+							{
+								Name:  "list",
+								Usage: "list locations",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing list...")
+									return nil
+								},
+							},
+							{
+								Name:  "describe",
+								Usage: "describe locations",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing describe...")
+									return nil
+								},
+							},
+						},
+					},
+					{
+						Name:  "operations",
+						Usage: "Manage operations resources",
+						Commands: []*cli.Command{
+							{
+								Name:  "list",
+								Usage: "list operations",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing list...")
+									return nil
+								},
+							},
+							{
+								Name:  "describe",
+								Usage: "describe operations",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing describe...")
+									return nil
+								},
+							},
+							{
+								Name:  "delete",
+								Usage: "delete operations",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing delete...")
+									return nil
+								},
+							},
+							{
+								Name:  "cancel",
+								Usage: "cancel operations",
+								Action: func(ctx context.Context, cmd *cli.Command) error {
+									fmt.Println("Executing cancel...")
 									return nil
 								},
 							},


### PR DESCRIPTION
Replace the hardcoded api.Method in TestParallelstoreMock with a model built through parser.CreateModel against the parallelstore proto and service config in internal/testdata/googleapis, so that the golden file reflects the full command tree.

For https://github.com/googleapis/librarian/issues/5769