### PR TITLE
fix(sidekick/swift): use `decodeIfPresent` for `T?`

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -19,9 +19,22 @@ import (
 )
 
 type fieldAnnotations struct {
-	Name              string
-	FieldType         string
-	DocLines          []string
+	// Name is the name of the field in the generated `struct`.
+	//
+	// The naming convention in Swift is to use camelCase, same as OpenAPI and discovery doc. However, most of the
+	// Google Cloud services use Protobuf where the conventiion is `snake_case`.
+	Name string
+	// FieldType is name type of the field in the generated `struct`.
+	//
+	// This includes the optional (`T?`), repeated (`[T]`), and map (`[K: V]`) decorators.
+	FieldType string
+	// BaseFieldType is `FieldType` without optional/repeated decorations. Sometimes the mustache templates need to
+	BaseFieldType string
+	// DocLines is the field documentation broken by lines with any filtering / corrections for Swift.
+	DocLines []string
+	// OneOfPropertyName is the name of the oneof property containing this field.
+	//
+	// This is empty for fields that are not part of a oneof group.
 	OneOfPropertyName string
 }
 
@@ -30,10 +43,15 @@ func (c *codec) annotateField(field *api.Field) error {
 	if err != nil {
 		return err
 	}
+	baseFieldType, err := c.baseFieldTypeName(field)
+	if err != nil {
+		return err
+	}
 	annotations := &fieldAnnotations{
-		Name:      camelCase(field.Name),
-		FieldType: fieldType,
-		DocLines:  c.formatDocumentation(field.Documentation),
+		Name:          camelCase(field.Name),
+		FieldType:     fieldType,
+		BaseFieldType: baseFieldType,
+		DocLines:      c.formatDocumentation(field.Documentation),
 	}
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -22,13 +22,15 @@ type fieldAnnotations struct {
 	// Name is the name of the field in the generated `struct`.
 	//
 	// The naming convention in Swift is to use camelCase, same as OpenAPI and discovery doc. However, most of the
-	// Google Cloud services use Protobuf where the conventiion is `snake_case`.
+	// Google Cloud services use Protobuf where the convention is `snake_case`.
 	Name string
 	// FieldType is name type of the field in the generated `struct`.
 	//
 	// This includes the optional (`T?`), repeated (`[T]`), and map (`[K: V]`) decorators.
 	FieldType string
-	// BaseFieldType is `FieldType` without optional/repeated decorations. Sometimes the mustache templates need to
+	// BaseFieldType is `FieldType` without optional/repeated decorations.
+	//
+	// This is used in the mustache templates, which sometimes need to refer to the underlying type.
 	BaseFieldType string
 	// DocLines is the field documentation broken by lines with any filtering / corrections for Swift.
 	DocLines []string

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -24,16 +24,20 @@ type fieldAnnotations struct {
 	// The naming convention in Swift is to use camelCase, same as OpenAPI and discovery doc. However, most of the
 	// Google Cloud services use Protobuf where the convention is `snake_case`.
 	Name string
+
 	// FieldType is name type of the field in the generated `struct`.
 	//
 	// This includes the optional (`T?`), repeated (`[T]`), and map (`[K: V]`) decorators.
 	FieldType string
+
 	// BaseFieldType is `FieldType` without optional/repeated decorations.
 	//
 	// This is used in the mustache templates, which sometimes need to refer to the underlying type.
 	BaseFieldType string
+
 	// DocLines is the field documentation broken by lines with any filtering / corrections for Swift.
 	DocLines []string
+
 	// OneOfPropertyName is the name of the oneof property containing this field.
 	//
 	// This is empty for fields that are not part of a oneof group.

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -22,31 +22,66 @@ import (
 )
 
 func TestAnnotateField(t *testing.T) {
-	field := &api.Field{
-		Name:          "secret_payload",
-		Documentation: "The secret version payload.",
-		ID:            ".test.SecretVersion.secret_payload",
-		Typez:         api.TypezString,
-	}
-	msg := &api.Message{
-		Name:    "Secret",
-		ID:      ".test.SecretVersion",
-		Package: "test",
-		Fields:  []*api.Field{field},
-	}
-	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{})
-	if err := codec.annotateModel(); err != nil {
-		t.Fatal(err)
-	}
-	want := &fieldAnnotations{
-		Name:      "secretPayload",
-		DocLines:  []string{"The secret version payload."},
-		FieldType: "String",
-	}
+	for _, test := range []struct {
+		name         string
+		optional     bool
+		repeated     bool
+		wantType     string
+		wantBaseType string
+	}{
+		{
+			name:         "regular",
+			optional:     false,
+			repeated:     false,
+			wantType:     "String",
+			wantBaseType: "String",
+		},
+		{
+			name:         "optional",
+			optional:     true,
+			repeated:     false,
+			wantType:     "String?",
+			wantBaseType: "String",
+		},
+		{
+			name:         "repeated",
+			optional:     false,
+			repeated:     true,
+			wantType:     "[String]",
+			wantBaseType: "String",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			field := &api.Field{
+				Name:          "secret_payload",
+				Documentation: "The secret version payload.",
+				ID:            ".test.SecretVersion.secret_payload",
+				Typez:         api.TypezString,
+				Optional:      test.optional,
+				Repeated:      test.repeated,
+			}
+			msg := &api.Message{
+				Name:    "Secret",
+				ID:      ".test.SecretVersion",
+				Package: "test",
+				Fields:  []*api.Field{field},
+			}
+			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+			codec := newTestCodec(t, model, map[string]string{})
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			want := &fieldAnnotations{
+				Name:          "secretPayload",
+				DocLines:      []string{"The secret version payload."},
+				FieldType:     test.wantType,
+				BaseFieldType: test.wantBaseType,
+			}
 
-	if diff := cmp.Diff(want, field.Codec); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(want, field.Codec); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -79,9 +114,10 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 				t.Fatal(err)
 			}
 			want := &fieldAnnotations{
-				Name:      "testField",
-				FieldType: test.wantType,
-				DocLines:  []string{"Test documentation."},
+				Name:          "testField",
+				FieldType:     test.wantType,
+				BaseFieldType: test.wantType,
+				DocLines:      []string{"Test documentation."},
 			}
 			if diff := cmp.Diff(want, field.Codec); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/generate_field_swift_test.go
+++ b/internal/sidekick/swift/generate_field_swift_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerateField_InitFromDecoder(t *testing.T) {
+	outDir := t.TempDir()
+
+	// Field 1: Normal field with JSONName override to trigger CustomSerialization
+	field1 := &api.Field{
+		Name:          "normal_field",
+		Documentation: "A normal field.",
+		ID:            ".test.TestMessage.normal_field",
+		Typez:         api.TypezString,
+		JSONName:      "normal_field", // Differs from camelCase "normalField"
+	}
+
+	// Field 2: Optional field with JSONName override
+	field2 := &api.Field{
+		Name:          "optional_field",
+		Documentation: "An optional field.",
+		ID:            ".test.TestMessage.optional_field",
+		Typez:         api.TypezString,
+		Optional:      true,
+		JSONName:      "optional_field", // Differs from camelCase "optionalField"
+	}
+
+	msg := &api.Message{
+		Name:    "TestMessage",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.TestMessage",
+		Fields:  []*api.Field{field1, field2},
+	}
+
+	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+
+	cfg := &parser.ModelConfig{
+		Codec: map[string]string{
+			"copyright-year": "2038",
+		},
+	}
+
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	filename := filepath.Join(expectedDir, "TestMessage.swift")
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+
+	// Verify init(from decoder: Decoder) content
+	gotBlock := extractBlock(t, contentStr, "  public init(from decoder: Decoder) throws {", "\n  }")
+	wantBlock := `  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.normalField = try container.decode(String.self, forKey: .normalField)
+    self.optionalField = try container.decodeIfPresent(String.self, forKey: .optionalField)
+  }`
+
+	if diff := cmp.Diff(wantBlock, gotBlock); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -81,7 +81,12 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     let container = try decoder.container(keyedBy: CodingKeys.self)
     {{#Fields}}
     {{^IsOneOf}}
+    {{#Optional}}
+    self.{{Codec.Name}} = try container.decodeIfPresent({{Codec.BaseFieldType}}.self, forKey: .{{Codec.Name}})
+    {{/Optional}}
+    {{^Optional}}
     self.{{Codec.Name}} = try container.decode({{Codec.FieldType}}.self, forKey: .{{Codec.Name}})
+    {{/Optional}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}


### PR DESCRIPTION
To correctly decode optionals we need to use `decodeIfPresent()`. Otherwise, the decoder does not recurse properly and skips the interceptor to decode numeric scalars as numbers or strings.

Fixes #5732 (for realsies)
