### PR TITLE
feat(librarian/gcloud): wire up gcloud generation end-to-end

### DIFF
--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -31,8 +31,8 @@ const (
 	LanguageDotnet = "dotnet"
 	// LanguageFake is the language identifier for Fakes.
 	LanguageFake = "fake"
-	// LanguageSurfer is the language identifier for gcloud command surfaces.
-	LanguageSurfer = "gcloud"
+	// LanguageGcloud is the language identifier for gcloud command binaries.
+	LanguageGcloud = "gcloud"
 	// LanguageGo is the language identifier for Go.
 	LanguageGo = "go"
 	// LanguageJava is the language identifier for Java.
@@ -47,6 +47,8 @@ const (
 	LanguageRuby = "ruby"
 	// LanguageRust is the language identifier for Rust.
 	LanguageRust = "rust"
+	// LanguageSurfer is the language identifier for gcloud command surfaces.
+	LanguageSurfer = "surfer"
 	// LanguageSwift is the language identifier for Swift.
 	LanguageSwift = "swift"
 )

--- a/internal/librarian/gcloud/generate.go
+++ b/internal/librarian/gcloud/generate.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gcloud provides gcloud command binary generation for librarian.
+package gcloud
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+	sidekickgcloud "github.com/googleapis/librarian/internal/sidekick/gcloud"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+// Generate generates a gcloud command binary for a library.
+//
+// For each API in the library, it parses the protos and service config via
+// the sidekick parser and invokes the sidekick gcloud generator, writing the
+// results to the library's output directory.
+func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources) error {
+	googleapisDir, err := filepath.Abs(srcs.Googleapis)
+	if err != nil {
+		return fmt.Errorf("failed to resolve googleapis directory path: %w", err)
+	}
+	outDir, err := filepath.Abs(library.Output)
+	if err != nil {
+		return fmt.Errorf("failed to resolve output directory path: %w", err)
+	}
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	resolvedSrcs := &sources.Sources{Googleapis: googleapisDir}
+	for _, api := range library.APIs {
+		if err := generateAPI(api, resolvedSrcs, googleapisDir, outDir); err != nil {
+			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
+		}
+	}
+	return nil
+}
+
+func generateAPI(api *config.API, srcs *sources.Sources, googleapisDir, outDir string) error {
+	sc, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageGcloud)
+	if err != nil {
+		return err
+	}
+	if sc.ServiceConfig == "" {
+		return fmt.Errorf("no service config found for api %q", api.Path)
+	}
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: config.SpecProtobuf,
+		SpecificationSource: api.Path,
+		ServiceConfig:       sc.ServiceConfig,
+		Source: &sources.SourceConfig{
+			Sources:     srcs,
+			ActiveRoots: []string{"googleapis"},
+		},
+		Codec: map[string]string{
+			"copyright-year": "2026",
+		},
+	}
+	model, err := parser.CreateModel(cfg)
+	if err != nil {
+		return err
+	}
+	return sidekickgcloud.Generate(model, outDir)
+}

--- a/internal/librarian/gcloud/generate_test.go
+++ b/internal/librarian/gcloud/generate_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+const testGoogleapisDir = "../../testdata/googleapis"
+
+func TestGenerate(t *testing.T) {
+	testhelper.RequireCommand(t, "protoc")
+
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+	}{
+		{
+			name: "parallelstore",
+			library: &config.Library{
+				Name: "parallelstore",
+				APIs: []*config.API{{Path: "google/cloud/parallelstore/v1"}},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			out := t.TempDir()
+			test.library.Output = out
+			if err := Generate(t.Context(), test.library,
+				&sources.Sources{Googleapis: testGoogleapisDir}); err != nil {
+				t.Fatal(err)
+			}
+			for _, name := range []string{"main.go", "README.md"} {
+				if _, err := os.Stat(filepath.Join(out, name)); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerate_Errors(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		googleapis string
+		apiPath    string
+	}{
+		{
+			name:       "missing googleapis dir",
+			googleapis: "nonexistent_googleapis_dir",
+			apiPath:    "google/cloud/parallelstore/v1",
+		},
+		{
+			name:       "missing api path",
+			googleapis: testGoogleapisDir,
+			apiPath:    "google/cloud/does/not/exist/v1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			library := &config.Library{
+				Name:   "parallelstore",
+				Output: t.TempDir(),
+				APIs:   []*config.API{{Path: test.apiPath}},
+			}
+			if err := Generate(t.Context(), library,
+				&sources.Sources{Googleapis: test.googleapis}); err == nil {
+				t.Error("Generate() error = nil, want error")
+			}
+		})
+	}
+}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian/dart"
+	"github.com/googleapis/librarian/internal/librarian/gcloud"
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
@@ -169,6 +170,8 @@ func cleanLibraries(language string, libraries []*config.Library) error {
 			err = checkAndClean(library.Output, keep)
 		case config.LanguageSwift:
 			err = checkAndClean(library.Output, library.Keep)
+		case config.LanguageGcloud:
+			// No-op. gcloud generation does not support cleaning yet.
 		case config.LanguageSurfer:
 			// No-op. surfer generation does not support cleaning yet.
 		default:
@@ -210,6 +213,13 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 			}
 		}
 		return fakePostGenerate()
+	case config.LanguageGcloud:
+		for _, library := range libraries {
+			if err := gcloud.Generate(ctx, library, src); err != nil {
+				return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+			}
+		}
+		return nil
 	case config.LanguageSurfer:
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -364,7 +364,7 @@ func TestGenerate_Surfer(t *testing.T) {
 		"google/cloud/secretmanager/v1": "secretmanager_v1.yaml",
 	})
 
-	configContent := fmt.Sprintf(`language: gcloud
+	configContent := fmt.Sprintf(`language: surfer
 sources:
   googleapis:
     dir: %s
@@ -384,7 +384,7 @@ libraries:
 		return
 	}
 	if errors.Is(err, errUnsupportedLanguage) {
-		t.Errorf("expected gcloud to be supported, but got: %v", err)
+		t.Errorf("expected surfer to be supported, but got: %v", err)
 	}
 	if !errors.Is(err, surfer.ErrNoProtosFound) {
 		t.Errorf("expected error %v, got: %v", surfer.ErrNoProtosFound, err)


### PR DESCRIPTION
Add a new gcloud language and setup Sidekick gcloud command generation through librarian.

Rename LanguageSurfer to use the language "surfer", and add LanguageGcloud for the "gcloud" language.

For https://github.com/googleapis/librarian/issues/5769