### PR TITLE
refactor(internal/sidekick/gcloud): simplify Generate

### DIFF
--- a/internal/sidekick/gcloud/generate.go
+++ b/internal/sidekick/gcloud/generate.go
@@ -59,28 +59,40 @@ type Command struct {
 	Usage string
 }
 
-// Generate generates code from the model.
+// Generate is the package entry point. It builds the model, renders main.go,
+// writes it, then renders any other generated files via
+// language.GenerateFromModel.
 func Generate(model *api.API, outdir string) error {
 	cliModel := constructCLIModel(model)
+	contents, err := renderMain(cliModel)
+	if err != nil {
+		return err
+	}
+	if err := writeMain(outdir, contents); err != nil {
+		return err
+	}
+	return renderReadme(outdir, model)
+}
 
+// renderMain renders the main.go contents from the CLI model.
+func renderMain(model CLIModel) (string, error) {
 	templateContents, err := templates.ReadFile("templates/package/cli.go.mustache")
 	if err != nil {
-		return err
+		return "", err
 	}
+	return mustache.Render(string(templateContents), model)
+}
 
-	s, err := mustache.Render(string(templateContents), cliModel)
-	if err != nil {
-		return err
-	}
-
+func writeMain(outdir, contents string) error {
 	destination := filepath.Join(outdir, "main.go")
 	if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
 		return err
 	}
-	if err := os.WriteFile(destination, []byte(s), 0666); err != nil {
-		return err
-	}
+	return os.WriteFile(destination, []byte(contents), 0666)
+}
 
+// renderReadme renders README.md via language.GenerateFromModel.
+func renderReadme(outdir string, model *api.API) error {
 	provider := func(name string) (string, error) {
 		contents, err := templates.ReadFile(name)
 		if err != nil {
@@ -113,10 +125,7 @@ func constructCLIModel(model *api.API) CLIModel {
 				continue
 			}
 
-			subgroupName := "default"
-			if len(segments) >= 1 {
-				subgroupName = strcase.ToKebab(segments[len(segments)-1])
-			}
+			subgroupName := strcase.ToKebab(segments[len(segments)-1])
 
 			commandName, _ := provider.GetCommandName(method)
 			commandName = strcase.ToKebab(commandName)

--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -17,10 +17,12 @@ package gcloud
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/testhelper"
@@ -118,5 +120,157 @@ func TestParallelstore(t *testing.T) {
 	}
 	if diff := cmp.Diff(string(wantReadme), string(gotReadme)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderMain(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		model CLIModel
+		wants []string
+	}{
+		{
+			name: "empty",
+			model: CLIModel{
+				Groups: []Group{{
+					Name:  "gcloud",
+					Usage: "Google Cloud CLI",
+				}},
+			},
+			wants: []string{
+				`Name:  "gcloud"`,
+				`Usage: "Google Cloud CLI"`,
+			},
+		},
+		{
+			name: "subgroup with command",
+			model: CLIModel{
+				Groups: []Group{{
+					Name:  "gcloud",
+					Usage: "Google Cloud CLI",
+					Subgroups: []Subgroup{{
+						Name:  "compute",
+						Usage: "Manage compute resources",
+						Commands: []Command{{
+							Name:  "list",
+							Usage: "list compute",
+						}},
+					}},
+				}},
+			},
+			wants: []string{
+				`Name:  "compute"`,
+				`Name:  "list"`,
+				`fmt.Println("Executing list...")`,
+			},
+		},
+		{
+			name: "top-level command",
+			model: CLIModel{
+				Groups: []Group{{
+					Name:  "gcloud",
+					Usage: "Google Cloud CLI",
+					Commands: []Command{{
+						Name:  "version",
+						Usage: "show version",
+					}},
+				}},
+			},
+			wants: []string{
+				`Name:  "version"`,
+				`fmt.Println("Executing version...")`,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := renderMain(test.model)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(got, "package main") {
+				t.Errorf("rendered output does not start with %q\n%s", "package main", got)
+			}
+			for _, want := range test.wants {
+				if !strings.Contains(got, want) {
+					t.Errorf("rendered output missing %q\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteMain(t *testing.T) {
+	const contents = "package main\n"
+	for _, test := range []struct {
+		name   string
+		outdir func(t *testing.T) string
+	}{
+		{
+			name: "existing dir",
+			outdir: func(t *testing.T) string {
+				return t.TempDir()
+			},
+		},
+		{
+			name: "nested dir creation",
+			outdir: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "nested", "deep")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outdir := test.outdir(t)
+			if err := writeMain(outdir, contents); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(filepath.Join(outdir, "main.go"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(contents, string(got)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRenderReadme(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		model *api.API
+		wants []string
+	}{
+		{
+			name:  "title only",
+			model: &api.API{Title: "Parallelstore API"},
+			wants: []string{
+				"# Google Cloud CLI (gcloud)",
+				"Parallelstore API",
+			},
+		},
+		{
+			name:  "title and description",
+			model: &api.API{Title: "Parallelstore API", Description: "Manages parallelstore instances."},
+			wants: []string{
+				"Parallelstore API",
+				"Manages parallelstore instances.",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outdir := t.TempDir()
+			if err := renderReadme(outdir, test.model); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(filepath.Join(outdir, "README.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range test.wants {
+				if !strings.Contains(string(got), want) {
+					t.Errorf("README missing %q\n%s", want, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Split Generate into renderMain, writeMain, and renderReadme, and add unit tests.