### PR TITLE
chore(internal/serviceconfig): add java to skip_rest_numeric_enums for schema/google/showcase/v1beta1

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -3327,6 +3327,8 @@
   languages:
     - all
   service_config: schema/google/showcase/v1beta1/showcase_v1beta1.yaml
+  skip_rest_numeric_enums:
+    - java
 - path: src/google/protobuf
   languages:
     - all


### PR DESCRIPTION
Specify API path schema/google/showcase/v1beta1 to skip_rest_numeric_enums for Java. This is to match current generation setup with hermetic build. 
Hermetic build parses BUILD.bazel in runtime to find out if `rest_numeric_enums` is explicitly set to true inside `java_gapic_library` target. For showcase where BUILD.bazel does not have `java_gapic_library` target, the build injections use [BUILD.partial.bazel](https://github.com/googleapis/google-cloud-java/blob/2cecd0caf4f15da2d894a70077ccb0d0fd69d296/java-showcase/scripts/resources/BUILD.partial.bazel#L7-L16) to define one.

For #5731