### PR TITLE
fix(tool/cmd/migrate): fix path to showcase module

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -783,7 +783,7 @@ func extractStrings(expr build.Expr) []string {
 }
 
 func getShowcaseVersion(repoPath string) (string, error) {
-	showcaseDir := filepath.Join(repoPath, "sdk-platform-java", "java-showcase")
+	showcaseDir := filepath.Join(repoPath, "java-showcase")
 	return extractVersionFromPOM(filepath.Join(showcaseDir, "gapic-showcase", "pom.xml"))
 }
 

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -241,7 +241,7 @@ func TestRunJavaMigration(t *testing.T) {
 			writeVersionsFile(t, dir, "")
 
 			// Create dummy showcase pom.xml to avoid failure in runJavaMigration
-			showcaseDir := filepath.Join(dir, "sdk-platform-java", "java-showcase", "gapic-showcase")
+			showcaseDir := filepath.Join(dir, "java-showcase", "gapic-showcase")
 			if err := os.MkdirAll(showcaseDir, 0755); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Update path to java-showcase module. It was moved from google-cloud-java/sdk-platform-java/java-showcase to google-cloud-java/java-showcase.
This is a fix for #5783, as I was working on an outdated google-cloud-java clone.


For https://github.com/googleapis/librarian/issues/5731