### PR TITLE
feat(internal/librarian/java): support showcase as source in generate

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -103,7 +103,7 @@ type librarySources struct {
 
 	// googleapisDir is the absolute path to the googleapis source directory.
 	// This is always needed (even for showcase) because common proto resources always reside in
-	//  the googleapis repository.
+	// the googleapis repository.
 	googleapisDir string
 
 	// includeDirs contains the ordered list of import directories to pass to protoc via -I flags.

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -78,7 +78,15 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		}
 		transports[api.Path] = apiCfg.Transport(config.LanguageJava)
 		// metadata is needed for pom.xml generation in post process
-		if err := generateAPI(ctx, cfg, api, library, libSrcs, outdir, metadata, apiCfg); err != nil {
+		if err := generateAPI(ctx, generateAPIParams{
+			cfg:      cfg,
+			api:      api,
+			library:  library,
+			libSrcs:  libSrcs,
+			outdir:   outdir,
+			metadata: metadata,
+			apiCfg:   apiCfg,
+		}); err != nil {
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
@@ -145,46 +153,56 @@ func deriveAPIBase(library *config.Library, apiPath string) string {
 	return path.Base(apiPath)
 }
 
-func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, library *config.Library, libSrcs *librarySources, outdir string, metadata *repoMetadata, apiCfg *serviceconfig.API) error {
-	javaAPI := ResolveJavaAPI(library, api)
-	p := postProcessParams{
-		cfg:            cfg,
-		library:        library,
+type generateAPIParams struct {
+	cfg      *config.Config
+	api      *config.API
+	library  *config.Library
+	libSrcs  *librarySources
+	outdir   string
+	metadata *repoMetadata
+	apiCfg   *serviceconfig.API
+}
+
+func generateAPI(ctx context.Context, params generateAPIParams) error {
+	javaAPI := ResolveJavaAPI(params.library, params.api)
+	postParams := postProcessParams{
+		cfg:            params.cfg,
+		library:        params.library,
 		javaAPI:        javaAPI,
-		metadata:       metadata,
-		outDir:         outdir,
-		apiBase:        deriveAPIBase(library, api.Path),
-		protoSourceDir: libSrcs.primaryDir,
+		metadata:       params.metadata,
+		outDir:         params.outdir,
+		apiBase:        deriveAPIBase(params.library, params.api.Path),
+		protoSourceDir: params.libSrcs.primaryDir,
 		includeSamples: *javaAPI.Samples,
 	}
-	gapicDir := p.gapicDir()
-	gRPCDir := p.gRPCDir()
-	protoDir := p.protoDir()
+	gapicDir := postParams.gapicDir()
+	gRPCDir := postParams.gRPCDir()
+	protoDir := postParams.protoDir()
 	for _, dir := range []string{gapicDir, gRPCDir, protoDir} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %q: %w", dir, err)
 		}
 	}
 
-	apiDir := filepath.Join(libSrcs.primaryDir, api.Path)
-	apiProtos, err := gatherProtos(apiDir, api.Path)
+	apiDir := filepath.Join(params.libSrcs.primaryDir, params.api.Path)
+	apiProtos, err := gatherProtos(apiDir, params.api.Path)
 	if err != nil {
 		return fmt.Errorf("failed to find protos: %w", err)
 	}
-	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos, libSrcs.primaryDir)
+	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos, params.libSrcs.primaryDir)
 	if len(apiProtos) == 0 {
-		return fmt.Errorf("%s: %w", api.Path, errNoProtos)
+		return fmt.Errorf("%s: %w", params.api.Path, errNoProtos)
 	}
-	p.apiProtos = apiProtos
+	postParams.apiProtos = apiProtos
 
 	// 1. Generate standard Protocol Buffer Java classes.
-	protoProtos := filterProtos(apiProtos, javaAPI.SkipProtoClassGeneration, libSrcs.primaryDir)
-	includeDirs := libSrcs.includeDirs
+	protoProtos := filterProtos(apiProtos, javaAPI.SkipProtoClassGeneration, params.libSrcs.primaryDir)
+	includeDirs := params.libSrcs.includeDirs
 	if err := runProtoc(ctx, protoProtocArgs(protoProtos, includeDirs, protoDir)); err != nil {
 		return fmt.Errorf("failed to generate proto: %w", err)
 	}
 	// 2. Generate gRPC service stubs (skipped if transport is rest).
-	transport := apiCfg.Transport(config.LanguageJava)
+	transport := params.apiCfg.Transport(config.LanguageJava)
 	if transport != "rest" {
 		if err := runProtoc(ctx, gRPCProtocArgs(apiProtos, includeDirs, gRPCDir)); err != nil {
 			return fmt.Errorf("failed to generate gRPC module: %w", err)
@@ -192,17 +210,17 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 	}
 	// 3. Generate GAPIC library.
 	if !javaAPI.ProtoGRPCOnly {
-		gapicOpts, err := resolveGAPICOptions(cfg, library, api, libSrcs.primaryDir, apiCfg)
+		gapicOpts, err := resolveGAPICOptions(params.cfg, params.library, params.api, params.libSrcs.primaryDir, params.apiCfg)
 		if err != nil {
 			return fmt.Errorf("failed to resolve gapic options: %w", err)
 		}
-		additionalProtos := deriveAdditionalProtoPaths(javaAPI, libSrcs.googleapisDir)
+		additionalProtos := deriveAdditionalProtoPaths(javaAPI, params.libSrcs.googleapisDir)
 		if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, includeDirs, gapicDir, gapicOpts)); err != nil {
 			return fmt.Errorf("failed to generate gapic: %w", err)
 		}
 	}
 
-	if err := postProcessAPI(ctx, p); err != nil {
+	if err := postProcessAPI(ctx, postParams); err != nil {
 		return fmt.Errorf("failed to post process: %w", err)
 	}
 	return nil

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -59,26 +59,26 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory %q: %w", outdir, err)
 	}
-	// generate repo metadata prior to client because info is needed for
-	// owlbot.py to generate README.md
-	sourceDir, err := getAbsSourceDir(library, srcs)
+	libSrcs, err := getLibrarySources(library, srcs)
 	if err != nil {
 		return err
 	}
-	metadata, err := generateRepoMetadata(cfg, library, outdir, sourceDir)
+	// generate repo metadata prior to client because info is needed for
+	// owlbot.py to generate README.md
+	metadata, err := generateRepoMetadata(cfg, library, outdir, libSrcs.primaryDir)
 	if err != nil {
 		return fmt.Errorf("failed to generate .repo-metadata.json: %w", err)
 	}
 
 	transports := make(map[string]serviceconfig.Transport)
 	for _, api := range library.APIs {
-		apiCfg, err := serviceconfig.Find(sourceDir, api.Path, config.LanguageJava)
+		apiCfg, err := serviceconfig.Find(libSrcs.primaryDir, api.Path, config.LanguageJava)
 		if err != nil {
 			return fmt.Errorf("failed to find api config for %s: %w", api.Path, err)
 		}
 		transports[api.Path] = apiCfg.Transport(config.LanguageJava)
 		// metadata is needed for pom.xml generation in post process
-		if err := generateAPI(ctx, cfg, api, library, sourceDir, outdir, metadata, apiCfg); err != nil {
+		if err := generateAPI(ctx, cfg, api, library, libSrcs, outdir, metadata, apiCfg); err != nil {
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
@@ -104,7 +104,7 @@ func deriveAPIBase(library *config.Library, apiPath string) string {
 	return path.Base(apiPath)
 }
 
-func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, library *config.Library, googleapisDir, outdir string, metadata *repoMetadata, apiCfg *serviceconfig.API) error {
+func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, library *config.Library, libSrcs *librarySources, outdir string, metadata *repoMetadata, apiCfg *serviceconfig.API) error {
 	javaAPI := ResolveJavaAPI(library, api)
 	p := postProcessParams{
 		cfg:            cfg,
@@ -113,7 +113,7 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		metadata:       metadata,
 		outDir:         outdir,
 		apiBase:        deriveAPIBase(library, api.Path),
-		googleapisDir:  googleapisDir,
+		protoSourceDir: libSrcs.primaryDir,
 		includeSamples: *javaAPI.Samples,
 	}
 	gapicDir := p.gapicDir()
@@ -125,37 +125,38 @@ func generateAPI(ctx context.Context, cfg *config.Config, api *config.API, libra
 		}
 	}
 
-	apiDir := filepath.Join(googleapisDir, api.Path)
+	apiDir := filepath.Join(libSrcs.primaryDir, api.Path)
 	apiProtos, err := gatherProtos(apiDir, api.Path)
 	if err != nil {
 		return fmt.Errorf("failed to find protos: %w", err)
 	}
-	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos, googleapisDir)
+	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos, libSrcs.primaryDir)
 	if len(apiProtos) == 0 {
 		return fmt.Errorf("%s: %w", api.Path, errNoProtos)
 	}
 	p.apiProtos = apiProtos
 
 	// 1. Generate standard Protocol Buffer Java classes.
-	protoProtos := filterProtos(apiProtos, javaAPI.SkipProtoClassGeneration, googleapisDir)
-	if err := runProtoc(ctx, protoProtocArgs(protoProtos, googleapisDir, protoDir)); err != nil {
+	protoProtos := filterProtos(apiProtos, javaAPI.SkipProtoClassGeneration, libSrcs.primaryDir)
+	includeDirs := libSrcs.includeDirs
+	if err := runProtoc(ctx, protoProtocArgs(protoProtos, includeDirs, protoDir)); err != nil {
 		return fmt.Errorf("failed to generate proto: %w", err)
 	}
 	// 2. Generate gRPC service stubs (skipped if transport is rest).
 	transport := apiCfg.Transport(config.LanguageJava)
 	if transport != "rest" {
-		if err := runProtoc(ctx, gRPCProtocArgs(apiProtos, googleapisDir, gRPCDir)); err != nil {
+		if err := runProtoc(ctx, gRPCProtocArgs(apiProtos, includeDirs, gRPCDir)); err != nil {
 			return fmt.Errorf("failed to generate gRPC module: %w", err)
 		}
 	}
 	// 3. Generate GAPIC library.
 	if !javaAPI.ProtoGRPCOnly {
-		gapicOpts, err := resolveGAPICOptions(cfg, library, api, googleapisDir, apiCfg)
+		gapicOpts, err := resolveGAPICOptions(cfg, library, api, libSrcs.primaryDir, apiCfg)
 		if err != nil {
 			return fmt.Errorf("failed to resolve gapic options: %w", err)
 		}
-		additionalProtos := deriveAdditionalProtoPaths(javaAPI, googleapisDir)
-		if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, googleapisDir, gapicDir, gapicOpts)); err != nil {
+		additionalProtos := deriveAdditionalProtoPaths(javaAPI, libSrcs.googleapisDir)
+		if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, includeDirs, gapicDir, gapicOpts)); err != nil {
 			return fmt.Errorf("failed to generate gapic: %w", err)
 		}
 	}
@@ -187,29 +188,32 @@ var runProtoc = func(ctx context.Context, args []string) error {
 	return command.Run(ctx, "protoc", args...)
 }
 
-func baseProtocArgs(googleapisDir string) []string {
-	return []string{
+func baseProtocArgs(includeDirs ...string) []string {
+	args := []string{
 		"--experimental_allow_proto3_optional",
-		"-I=" + googleapisDir,
 	}
+	for _, dir := range includeDirs {
+		args = append(args, "-I="+dir)
+	}
+	return args
 }
 
-func protoProtocArgs(apiProtos []string, googleapisDir, protoDir string) []string {
-	args := baseProtocArgs(googleapisDir)
+func protoProtocArgs(apiProtos []string, includeDirs []string, protoDir string) []string {
+	args := baseProtocArgs(includeDirs...)
 	args = append(args, fmt.Sprintf("--java_out=%s", protoDir))
 	args = append(args, apiProtos...)
 	return args
 }
 
-func gRPCProtocArgs(apiProtos []string, googleapisDir, gRPCDir string) []string {
-	args := baseProtocArgs(googleapisDir)
+func gRPCProtocArgs(apiProtos []string, includeDirs []string, gRPCDir string) []string {
+	args := baseProtocArgs(includeDirs...)
 	args = append(args, fmt.Sprintf("--java_grpc_out=%s", gRPCDir))
 	args = append(args, apiProtos...)
 	return args
 }
 
-func gapicProtocArgs(apiProtos, additionalProtos []string, googleapisDir, gapicDir string, gapicOpts []string) []string {
-	args := baseProtocArgs(googleapisDir)
+func gapicProtocArgs(apiProtos, additionalProtos []string, includeDirs []string, gapicDir string, gapicOpts []string) []string {
+	args := baseProtocArgs(includeDirs...)
 	args = append(args, fmt.Sprintf("--java_gapic_out=metadata:%s", gapicDir))
 	args = append(args, "--java_gapic_opt="+strings.Join(gapicOpts, ","))
 	args = append(args, apiProtos...)
@@ -387,12 +391,44 @@ func filterProtos(fullPaths []string, relExcludes []string, root string) []strin
 	return filtered
 }
 
-// getAbsSourceDir returns the absolute path of the source directory for the library,
-// resolving either the Googleapis or Showcase source path depending on the library name.
-// Use absolute path to avoid issues with relative paths in protoc.
-func getAbsSourceDir(library *config.Library, srcs *sources.Sources) (string, error) {
-	if library.Name == "showcase" {
-		return filepath.Abs(srcs.Showcase)
+type librarySources struct {
+	// primaryDir is the main source directory for the library being generated.
+	// It maps to srcs.Showcase for the showcase library, and srcs.Googleapis for all others.
+	// Used for finding the library's protos, service configs, and defining the proto source root.
+	primaryDir string
+
+	// googleapisDir is the absolute path to the googleapis source directory.
+	// This is always needed (even for showcase) because common proto resources
+	// (like google/cloud/common_resources.proto) always reside in the googleapis repository.
+	googleapisDir string
+
+	// includeDirs contains the ordered list of import directories to pass to protoc via -I flags.
+	// Pre-calculated to keep generateAPI simple: includes [Showcase, Googleapis] for showcase,
+	// and just [Googleapis] for others.
+	includeDirs []string
+}
+
+func getLibrarySources(library *config.Library, srcs *sources.Sources) (*librarySources, error) {
+	absGoogleapis, err := filepath.Abs(srcs.Googleapis)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve absolute path for googleapis: %w", err)
 	}
-	return filepath.Abs(srcs.Googleapis)
+
+	if library.Name == "showcase" {
+		absShowcase, err := filepath.Abs(srcs.Showcase)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve absolute path for showcase: %w", err)
+		}
+		return &librarySources{
+			primaryDir:    absShowcase,
+			googleapisDir: absGoogleapis,
+			includeDirs:   []string{absShowcase, absGoogleapis},
+		}, nil
+	}
+
+	return &librarySources{
+		primaryDir:    absGoogleapis,
+		googleapisDir: absGoogleapis,
+		includeDirs:   []string{absGoogleapis},
+	}, nil
 }

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -56,31 +56,29 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
-	// Ensure googleapisDir is absolute to avoid issues with relative paths in protoc.
-	var googleapisDir string
-	googleapisDir, err = filepath.Abs(srcs.Googleapis)
-	if err != nil {
-		return fmt.Errorf("failed to resolve googleapis directory path: %w", err)
-	}
 	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory %q: %w", outdir, err)
 	}
 	// generate repo metadata prior to client because info is needed for
 	// owlbot.py to generate README.md
-	metadata, err := generateRepoMetadata(cfg, library, outdir, googleapisDir)
+	sourceDir, err := getAbsSourceDir(library, srcs)
+	if err != nil {
+		return err
+	}
+	metadata, err := generateRepoMetadata(cfg, library, outdir, sourceDir)
 	if err != nil {
 		return fmt.Errorf("failed to generate .repo-metadata.json: %w", err)
 	}
 
 	transports := make(map[string]serviceconfig.Transport)
 	for _, api := range library.APIs {
-		apiCfg, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageJava)
+		apiCfg, err := serviceconfig.Find(sourceDir, api.Path, config.LanguageJava)
 		if err != nil {
 			return fmt.Errorf("failed to find api config for %s: %w", api.Path, err)
 		}
 		transports[api.Path] = apiCfg.Transport(config.LanguageJava)
 		// metadata is needed for pom.xml generation in post process
-		if err := generateAPI(ctx, cfg, api, library, googleapisDir, outdir, metadata, apiCfg); err != nil {
+		if err := generateAPI(ctx, cfg, api, library, sourceDir, outdir, metadata, apiCfg); err != nil {
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
@@ -94,7 +92,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -388,4 +385,14 @@ func filterProtos(fullPaths []string, relExcludes []string, root string) []strin
 		filtered = append(filtered, p)
 	}
 	return filtered
+}
+
+// getAbsSourceDir returns the absolute path of the source directory for the library,
+// resolving either the Googleapis or Showcase source path depending on the library name.
+// Use absolute path to avoid issues with relative paths in protoc.
+func getAbsSourceDir(library *config.Library, srcs *sources.Sources) (string, error) {
+	if library.Name == "showcase" {
+		return filepath.Abs(srcs.Showcase)
+	}
+	return filepath.Abs(srcs.Googleapis)
 }

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -262,7 +262,7 @@ func gapicProtocArgs(apiProtos, additionalProtos []string, includeDirs []string,
 	return args
 }
 
-func resolveGAPICOptions(cfg *config.Config, library *config.Library, api *config.API, googleapisDir string, apiCfg *serviceconfig.API) ([]string, error) {
+func resolveGAPICOptions(cfg *config.Config, library *config.Library, api *config.API, sourceDir string, apiCfg *serviceconfig.API) ([]string, error) {
 	// gapicOpts are passed to the GAPIC generator via --java_gapic_opt.
 	// "metadata" enables the generation of gapic_metadata.json and GraalVM reflect-config.json.
 	gapicOpts := []string{"metadata"}
@@ -273,26 +273,26 @@ func resolveGAPICOptions(cfg *config.Config, library *config.Library, api *confi
 	if apiCfg.ServiceConfig != "" {
 		// api-service-config specifies the service YAML (e.g., logging_v2.yaml) which
 		// contains documentation, HTTP rules, and other API-level configuration.
-		gapicOpts = append(gapicOpts, gapicOpt("api-service-config", filepath.Join(googleapisDir, apiCfg.ServiceConfig)))
+		gapicOpts = append(gapicOpts, gapicOpt("api-service-config", filepath.Join(sourceDir, apiCfg.ServiceConfig)))
 	}
 
-	gapicConfig, err := serviceconfig.FindGAPICConfig(googleapisDir, api.Path)
+	gapicConfig, err := serviceconfig.FindGAPICConfig(sourceDir, api.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find gapic config: %w", err)
 	}
 	if gapicConfig != "" {
 		// gapic-config specifies the GAPIC configuration (e.g., logging_gapic.yaml) which
 		// contains batching, LRO retries, and language settings.
-		gapicOpts = append(gapicOpts, gapicOpt("gapic-config", filepath.Join(googleapisDir, gapicConfig)))
+		gapicOpts = append(gapicOpts, gapicOpt("gapic-config", filepath.Join(sourceDir, gapicConfig)))
 	}
 
-	gRPCServiceConfig, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
+	gRPCServiceConfig, err := serviceconfig.FindGRPCServiceConfig(sourceDir, api.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find gRPC service config: %w", err)
 	}
 	if gRPCServiceConfig != "" {
 		// grpc-service-config specifies the retry and timeout settings for the gRPC client.
-		gapicOpts = append(gapicOpts, gapicOpt("grpc-service-config", filepath.Join(googleapisDir, gRPCServiceConfig)))
+		gapicOpts = append(gapicOpts, gapicOpt("grpc-service-config", filepath.Join(sourceDir, gRPCServiceConfig)))
 	}
 
 	// transport specifies whether to generate gRPC, REST, or both types of clients.

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -95,6 +95,47 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
+type librarySources struct {
+	// primaryDir is the main source directory for the library being generated.
+	// It maps to srcs.Showcase for the showcase library, and srcs.Googleapis for all others.
+	// Used for finding the library's protos, service configs, and defining the proto source root.
+	primaryDir string
+
+	// googleapisDir is the absolute path to the googleapis source directory.
+	// This is always needed (even for showcase) because common proto resources always reside in
+	//  the googleapis repository.
+	googleapisDir string
+
+	// includeDirs contains the ordered list of import directories to pass to protoc via -I flags.
+	// Pre-calculated to keep generateAPI simple: includes [Showcase, Googleapis] for showcase,
+	// and just [Googleapis] for others.
+	includeDirs []string
+}
+
+func getLibrarySources(library *config.Library, srcs *sources.Sources) (*librarySources, error) {
+	// Ensure source dir is absolute to avoid issues with relative paths in protoc.
+	absGoogleapis, err := filepath.Abs(srcs.Googleapis)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve absolute path for googleapis: %w", err)
+	}
+	if library.Name == "showcase" {
+		absShowcase, err := filepath.Abs(srcs.Showcase)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve absolute path for showcase: %w", err)
+		}
+		return &librarySources{
+			primaryDir:    absShowcase,
+			googleapisDir: absGoogleapis,
+			includeDirs:   []string{absShowcase, absGoogleapis},
+		}, nil
+	}
+	return &librarySources{
+		primaryDir:    absGoogleapis,
+		googleapisDir: absGoogleapis,
+		includeDirs:   []string{absGoogleapis},
+	}, nil
+}
+
 func deriveAPIBase(library *config.Library, apiPath string) string {
 	// TODO(https://github.com/googleapis/librarian/issues/5728):
 	// remove this after updated owlbot.py
@@ -389,46 +430,4 @@ func filterProtos(fullPaths []string, relExcludes []string, root string) []strin
 		filtered = append(filtered, p)
 	}
 	return filtered
-}
-
-type librarySources struct {
-	// primaryDir is the main source directory for the library being generated.
-	// It maps to srcs.Showcase for the showcase library, and srcs.Googleapis for all others.
-	// Used for finding the library's protos, service configs, and defining the proto source root.
-	primaryDir string
-
-	// googleapisDir is the absolute path to the googleapis source directory.
-	// This is always needed (even for showcase) because common proto resources
-	// (like google/cloud/common_resources.proto) always reside in the googleapis repository.
-	googleapisDir string
-
-	// includeDirs contains the ordered list of import directories to pass to protoc via -I flags.
-	// Pre-calculated to keep generateAPI simple: includes [Showcase, Googleapis] for showcase,
-	// and just [Googleapis] for others.
-	includeDirs []string
-}
-
-func getLibrarySources(library *config.Library, srcs *sources.Sources) (*librarySources, error) {
-	absGoogleapis, err := filepath.Abs(srcs.Googleapis)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve absolute path for googleapis: %w", err)
-	}
-
-	if library.Name == "showcase" {
-		absShowcase, err := filepath.Abs(srcs.Showcase)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve absolute path for showcase: %w", err)
-		}
-		return &librarySources{
-			primaryDir:    absShowcase,
-			googleapisDir: absGoogleapis,
-			includeDirs:   []string{absShowcase, absGoogleapis},
-		}, nil
-	}
-
-	return &librarySources{
-		primaryDir:    absGoogleapis,
-		googleapisDir: absGoogleapis,
-		includeDirs:   []string{absGoogleapis},
-	}, nil
 }

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -59,20 +59,19 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory %q: %w", outdir, err)
 	}
-	libSrcs, err := getLibrarySources(library, srcs)
-	if err != nil {
-		return err
-	}
+	srcCfg := sources.NewSourceConfig(srcs, library.Roots)
+	primaryDir := srcCfg.Root(srcCfg.ActiveRoots[0])
+
 	// generate repo metadata prior to client because info is needed for
 	// owlbot.py to generate README.md
-	metadata, err := generateRepoMetadata(cfg, library, outdir, libSrcs.primaryDir)
+	metadata, err := generateRepoMetadata(cfg, library, outdir, primaryDir)
 	if err != nil {
 		return fmt.Errorf("failed to generate .repo-metadata.json: %w", err)
 	}
 
 	transports := make(map[string]serviceconfig.Transport)
 	for _, api := range library.APIs {
-		apiCfg, err := serviceconfig.Find(libSrcs.primaryDir, api.Path, config.LanguageJava)
+		apiCfg, err := serviceconfig.Find(primaryDir, api.Path, config.LanguageJava)
 		if err != nil {
 			return fmt.Errorf("failed to find api config for %s: %w", api.Path, err)
 		}
@@ -82,7 +81,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			cfg:      cfg,
 			api:      api,
 			library:  library,
-			libSrcs:  libSrcs,
+			srcCfg:   srcCfg,
 			outdir:   outdir,
 			metadata: metadata,
 			apiCfg:   apiCfg,
@@ -103,47 +102,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
-type librarySources struct {
-	// primaryDir is the main source directory for the library being generated.
-	// It maps to srcs.Showcase for the showcase library, and srcs.Googleapis for all others.
-	// Used for finding the library's protos, service configs, and defining the proto source root.
-	primaryDir string
-
-	// googleapisDir is the absolute path to the googleapis source directory.
-	// This is always needed (even for showcase) because common proto resources always reside in
-	// the googleapis repository.
-	googleapisDir string
-
-	// includeDirs contains the ordered list of import directories to pass to protoc via -I flags.
-	// Pre-calculated to keep generateAPI simple: includes [Showcase, Googleapis] for showcase,
-	// and just [Googleapis] for others.
-	includeDirs []string
-}
-
-func getLibrarySources(library *config.Library, srcs *sources.Sources) (*librarySources, error) {
-	// Ensure source dir is absolute to avoid issues with relative paths in protoc.
-	absGoogleapis, err := filepath.Abs(srcs.Googleapis)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve absolute path for googleapis: %w", err)
-	}
-	if library.Name == "showcase" {
-		absShowcase, err := filepath.Abs(srcs.Showcase)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve absolute path for showcase: %w", err)
-		}
-		return &librarySources{
-			primaryDir:    absShowcase,
-			googleapisDir: absGoogleapis,
-			includeDirs:   []string{absShowcase, absGoogleapis},
-		}, nil
-	}
-	return &librarySources{
-		primaryDir:    absGoogleapis,
-		googleapisDir: absGoogleapis,
-		includeDirs:   []string{absGoogleapis},
-	}, nil
-}
-
 func deriveAPIBase(library *config.Library, apiPath string) string {
 	// TODO(https://github.com/googleapis/librarian/issues/5728):
 	// remove this after updated owlbot.py
@@ -157,7 +115,7 @@ type generateAPIParams struct {
 	cfg      *config.Config
 	api      *config.API
 	library  *config.Library
-	libSrcs  *librarySources
+	srcCfg   *sources.SourceConfig
 	outdir   string
 	metadata *repoMetadata
 	apiCfg   *serviceconfig.API
@@ -165,6 +123,9 @@ type generateAPIParams struct {
 
 func generateAPI(ctx context.Context, params generateAPIParams) error {
 	javaAPI := ResolveJavaAPI(params.library, params.api)
+	primaryDir := params.srcCfg.Root(params.srcCfg.ActiveRoots[0])
+	googleapisDir := params.srcCfg.Root("googleapis")
+
 	postParams := postProcessParams{
 		cfg:            params.cfg,
 		library:        params.library,
@@ -172,7 +133,7 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 		metadata:       params.metadata,
 		outDir:         params.outdir,
 		apiBase:        deriveAPIBase(params.library, params.api.Path),
-		protoSourceDir: params.libSrcs.primaryDir,
+		protoSourceDir: primaryDir,
 		includeSamples: *javaAPI.Samples,
 	}
 	gapicDir := postParams.gapicDir()
@@ -184,38 +145,37 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 		}
 	}
 
-	apiDir := filepath.Join(params.libSrcs.primaryDir, params.api.Path)
+	apiDir := filepath.Join(primaryDir, params.api.Path)
 	apiProtos, err := gatherProtos(apiDir, params.api.Path)
 	if err != nil {
 		return fmt.Errorf("failed to find protos: %w", err)
 	}
-	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos, params.libSrcs.primaryDir)
+	apiProtos = filterProtos(apiProtos, javaAPI.ExcludedProtos, primaryDir)
 	if len(apiProtos) == 0 {
 		return fmt.Errorf("%s: %w", params.api.Path, errNoProtos)
 	}
 	postParams.apiProtos = apiProtos
 
 	// 1. Generate standard Protocol Buffer Java classes.
-	protoProtos := filterProtos(apiProtos, javaAPI.SkipProtoClassGeneration, params.libSrcs.primaryDir)
-	includeDirs := params.libSrcs.includeDirs
-	if err := runProtoc(ctx, protoProtocArgs(protoProtos, includeDirs, protoDir)); err != nil {
+	protoProtos := filterProtos(apiProtos, javaAPI.SkipProtoClassGeneration, primaryDir)
+	if err := runProtoc(ctx, protoProtocArgs(protoProtos, params.srcCfg, protoDir)); err != nil {
 		return fmt.Errorf("failed to generate proto: %w", err)
 	}
 	// 2. Generate gRPC service stubs (skipped if transport is rest).
 	transport := params.apiCfg.Transport(config.LanguageJava)
 	if transport != "rest" {
-		if err := runProtoc(ctx, gRPCProtocArgs(apiProtos, includeDirs, gRPCDir)); err != nil {
+		if err := runProtoc(ctx, gRPCProtocArgs(apiProtos, params.srcCfg, gRPCDir)); err != nil {
 			return fmt.Errorf("failed to generate gRPC module: %w", err)
 		}
 	}
 	// 3. Generate GAPIC library.
 	if !javaAPI.ProtoGRPCOnly {
-		gapicOpts, err := resolveGAPICOptions(params.cfg, params.library, params.api, params.libSrcs.primaryDir, params.apiCfg)
+		gapicOpts, err := resolveGAPICOptions(params.cfg, params.library, params.api, primaryDir, params.apiCfg)
 		if err != nil {
 			return fmt.Errorf("failed to resolve gapic options: %w", err)
 		}
-		additionalProtos := deriveAdditionalProtoPaths(javaAPI, params.libSrcs.googleapisDir)
-		if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, includeDirs, gapicDir, gapicOpts)); err != nil {
+		additionalProtos := deriveAdditionalProtoPaths(javaAPI, googleapisDir)
+		if err := runProtoc(ctx, gapicProtocArgs(apiProtos, additionalProtos, params.srcCfg, gapicDir, gapicOpts)); err != nil {
 			return fmt.Errorf("failed to generate gapic: %w", err)
 		}
 	}
@@ -247,32 +207,32 @@ var runProtoc = func(ctx context.Context, args []string) error {
 	return command.Run(ctx, "protoc", args...)
 }
 
-func baseProtocArgs(includeDirs ...string) []string {
+func baseProtocArgs(srcCfg *sources.SourceConfig) []string {
 	args := []string{
 		"--experimental_allow_proto3_optional",
 	}
-	for _, dir := range includeDirs {
-		args = append(args, "-I="+dir)
+	for _, root := range srcCfg.ActiveRoots {
+		args = append(args, "-I="+srcCfg.Root(root))
 	}
 	return args
 }
 
-func protoProtocArgs(apiProtos []string, includeDirs []string, protoDir string) []string {
-	args := baseProtocArgs(includeDirs...)
+func protoProtocArgs(apiProtos []string, srcCfg *sources.SourceConfig, protoDir string) []string {
+	args := baseProtocArgs(srcCfg)
 	args = append(args, fmt.Sprintf("--java_out=%s", protoDir))
 	args = append(args, apiProtos...)
 	return args
 }
 
-func gRPCProtocArgs(apiProtos []string, includeDirs []string, gRPCDir string) []string {
-	args := baseProtocArgs(includeDirs...)
+func gRPCProtocArgs(apiProtos []string, srcCfg *sources.SourceConfig, gRPCDir string) []string {
+	args := baseProtocArgs(srcCfg)
 	args = append(args, fmt.Sprintf("--java_grpc_out=%s", gRPCDir))
 	args = append(args, apiProtos...)
 	return args
 }
 
-func gapicProtocArgs(apiProtos, additionalProtos []string, includeDirs []string, gapicDir string, gapicOpts []string) []string {
-	args := baseProtocArgs(includeDirs...)
+func gapicProtocArgs(apiProtos, additionalProtos []string, srcCfg *sources.SourceConfig, gapicDir string, gapicOpts []string) []string {
+	args := baseProtocArgs(srcCfg)
 	args = append(args, fmt.Sprintf("--java_gapic_out=metadata:%s", gapicDir))
 	args = append(args, "--java_gapic_opt="+strings.Join(gapicOpts, ","))
 	args = append(args, apiProtos...)

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -997,3 +997,46 @@ func TestDeriveAPIBase(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAbsSourceDir(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		srcs    *sources.Sources
+		want    string
+	}{
+		{
+			name:    "default to googleapis",
+			library: &config.Library{Name: "secretmanager"},
+			srcs: &sources.Sources{
+				Googleapis: "/path/to/googleapis",
+				Showcase:   "/path/to/showcase",
+			},
+			want: "/path/to/googleapis",
+		},
+		{
+			name:    "showcase library with showcase dir",
+			library: &config.Library{Name: "showcase"},
+			srcs: &sources.Sources{
+				Googleapis: "/path/to/googleapis",
+				Showcase:   "/path/to/showcase",
+			},
+			want: "/path/to/showcase",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := getAbsSourceDir(test.library, test.srcs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := test.want
+			if test.srcs.Showcase == "" && test.library.Name == "showcase" {
+				want, _ = filepath.Abs("")
+			}
+			if got != want {
+				t.Errorf("getAbsSourceDir() = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -179,7 +179,7 @@ func TestProtoProtocArgs(t *testing.T) {
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/resources.proto"),
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/service.proto"),
 	}
-	got := protoProtocArgs(apiProtos, googleapisDir, "proto-out")
+	got := protoProtocArgs(apiProtos, []string{googleapisDir}, "proto-out")
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
@@ -197,7 +197,7 @@ func TestGRPCProtocArgs(t *testing.T) {
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/resources.proto"),
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/service.proto"),
 	}
-	got := gRPCProtocArgs(apiProtos, googleapisDir, "grpc-out")
+	got := gRPCProtocArgs(apiProtos, []string{googleapisDir}, "grpc-out")
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
@@ -218,7 +218,7 @@ func TestGAPICProtocArgs(t *testing.T) {
 	additionalProtos := []string{
 		filepath.Join(googleapisDir, "google/cloud/common_resources.proto"),
 	}
-	got := gapicProtocArgs(apiProtos, additionalProtos, googleapisDir, "gapic-out", []string{"opt1", "opt2"})
+	got := gapicProtocArgs(apiProtos, additionalProtos, []string{googleapisDir}, "gapic-out", []string{"opt1", "opt2"})
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
@@ -341,7 +341,11 @@ func TestGenerateAPI(t *testing.T) {
 		cfg,
 		&config.API{Path: "google/cloud/secretmanager/v1"},
 		library,
-		googleapisDir,
+		&librarySources{
+			primaryDir:    googleapisDir,
+			googleapisDir: googleapisDir,
+			includeDirs:   []string{googleapisDir},
+		},
 		outdir,
 		&repoMetadata{
 			NamePretty:     "Secret Manager",
@@ -406,7 +410,11 @@ func TestGenerateAPI_ProtoOnly(t *testing.T) {
 		cfg,
 		&config.API{Path: "google/cloud/gkehub/policycontroller/v1beta"},
 		library,
-		googleapisDir,
+		&librarySources{
+			primaryDir:    googleapisDir,
+			googleapisDir: googleapisDir,
+			includeDirs:   []string{googleapisDir},
+		},
 		outdir,
 		&repoMetadata{
 			NamePretty: "GKE Hub API",
@@ -462,7 +470,11 @@ func TestGenerateAPI_NoTools(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = generateAPI(t.Context(), cfg, api, library, googleapisDir, outdir, &repoMetadata{
+	err = generateAPI(t.Context(), cfg, api, library, &librarySources{
+		primaryDir:    googleapisDir,
+		googleapisDir: googleapisDir,
+		includeDirs:   []string{googleapisDir},
+	}, outdir, &repoMetadata{
 		NamePretty:     "Secret Manager",
 		APIDescription: "Secret Manager API",
 	}, apiCfg)
@@ -998,13 +1010,13 @@ func TestDeriveAPIBase(t *testing.T) {
 	}
 }
 
-func TestGetAbsSourceDir(t *testing.T) {
+func TestGetLibrarySources(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
 		name    string
 		library *config.Library
 		srcs    *sources.Sources
-		want    string
+		want    *librarySources
 	}{
 		{
 			name:    "default to googleapis",
@@ -1013,7 +1025,11 @@ func TestGetAbsSourceDir(t *testing.T) {
 				Googleapis: "/path/to/googleapis",
 				Showcase:   "/path/to/showcase",
 			},
-			want: "/path/to/googleapis",
+			want: &librarySources{
+				primaryDir:    "/path/to/googleapis",
+				googleapisDir: "/path/to/googleapis",
+				includeDirs:   []string{"/path/to/googleapis"},
+			},
 		},
 		{
 			name:    "showcase library with showcase dir",
@@ -1022,20 +1038,20 @@ func TestGetAbsSourceDir(t *testing.T) {
 				Googleapis: "/path/to/googleapis",
 				Showcase:   "/path/to/showcase",
 			},
-			want: "/path/to/showcase",
+			want: &librarySources{
+				primaryDir:    "/path/to/showcase",
+				googleapisDir: "/path/to/googleapis",
+				includeDirs:   []string{"/path/to/showcase", "/path/to/googleapis"},
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := getAbsSourceDir(test.library, test.srcs)
+			got, err := getLibrarySources(test.library, test.srcs)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := test.want
-			if test.srcs.Showcase == "" && test.library.Name == "showcase" {
-				want, _ = filepath.Abs("")
-			}
-			if got != want {
-				t.Errorf("getAbsSourceDir() = %v, want %v", got, want)
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(librarySources{})); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -179,7 +179,8 @@ func TestProtoProtocArgs(t *testing.T) {
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/resources.proto"),
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/service.proto"),
 	}
-	got := protoProtocArgs(apiProtos, []string{googleapisDir}, "proto-out")
+	srcCfg := sources.NewSourceConfig(&sources.Sources{Googleapis: googleapisDir}, nil)
+	got := protoProtocArgs(apiProtos, srcCfg, "proto-out")
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
@@ -197,7 +198,8 @@ func TestGRPCProtocArgs(t *testing.T) {
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/resources.proto"),
 		filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/service.proto"),
 	}
-	got := gRPCProtocArgs(apiProtos, []string{googleapisDir}, "grpc-out")
+	srcCfg := sources.NewSourceConfig(&sources.Sources{Googleapis: googleapisDir}, nil)
+	got := gRPCProtocArgs(apiProtos, srcCfg, "grpc-out")
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
@@ -218,7 +220,8 @@ func TestGAPICProtocArgs(t *testing.T) {
 	additionalProtos := []string{
 		filepath.Join(googleapisDir, "google/cloud/common_resources.proto"),
 	}
-	got := gapicProtocArgs(apiProtos, additionalProtos, []string{googleapisDir}, "gapic-out", []string{"opt1", "opt2"})
+	srcCfg := sources.NewSourceConfig(&sources.Sources{Googleapis: googleapisDir}, nil)
+	got := gapicProtocArgs(apiProtos, additionalProtos, srcCfg, "gapic-out", []string{"opt1", "opt2"})
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
@@ -340,12 +343,8 @@ func TestGenerateAPI(t *testing.T) {
 		cfg:     cfg,
 		api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 		library: library,
-		libSrcs: &librarySources{
-			primaryDir:    googleapisDir,
-			googleapisDir: googleapisDir,
-			includeDirs:   []string{googleapisDir},
-		},
-		outdir: outdir,
+		srcCfg:  sources.NewSourceConfig(&sources.Sources{Googleapis: googleapisDir}, nil),
+		outdir:  outdir,
 		metadata: &repoMetadata{
 			NamePretty:     "Secret Manager",
 			APIDescription: "Secret Manager API",
@@ -408,12 +407,8 @@ func TestGenerateAPI_ProtoOnly(t *testing.T) {
 		cfg:     cfg,
 		api:     &config.API{Path: "google/cloud/gkehub/policycontroller/v1beta"},
 		library: library,
-		libSrcs: &librarySources{
-			primaryDir:    googleapisDir,
-			googleapisDir: googleapisDir,
-			includeDirs:   []string{googleapisDir},
-		},
-		outdir: outdir,
+		srcCfg:  sources.NewSourceConfig(&sources.Sources{Googleapis: googleapisDir}, nil),
+		outdir:  outdir,
 		metadata: &repoMetadata{
 			NamePretty: "GKE Hub API",
 		},
@@ -472,12 +467,8 @@ func TestGenerateAPI_NoTools(t *testing.T) {
 		cfg:     cfg,
 		api:     api,
 		library: library,
-		libSrcs: &librarySources{
-			primaryDir:    googleapisDir,
-			googleapisDir: googleapisDir,
-			includeDirs:   []string{googleapisDir},
-		},
-		outdir: outdir,
+		srcCfg:  sources.NewSourceConfig(&sources.Sources{Googleapis: googleapisDir}, nil),
+		outdir:  outdir,
 		metadata: &repoMetadata{
 			NamePretty:     "Secret Manager",
 			APIDescription: "Secret Manager API",
@@ -1010,53 +1001,6 @@ func TestDeriveAPIBase(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := deriveAPIBase(test.library, test.apiPath)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGetLibrarySources(t *testing.T) {
-	t.Parallel()
-	for _, test := range []struct {
-		name    string
-		library *config.Library
-		srcs    *sources.Sources
-		want    *librarySources
-	}{
-		{
-			name:    "default to googleapis",
-			library: &config.Library{Name: "secretmanager"},
-			srcs: &sources.Sources{
-				Googleapis: "/path/to/googleapis",
-				Showcase:   "/path/to/showcase",
-			},
-			want: &librarySources{
-				primaryDir:    "/path/to/googleapis",
-				googleapisDir: "/path/to/googleapis",
-				includeDirs:   []string{"/path/to/googleapis"},
-			},
-		},
-		{
-			name:    "showcase library with showcase dir",
-			library: &config.Library{Name: "showcase"},
-			srcs: &sources.Sources{
-				Googleapis: "/path/to/googleapis",
-				Showcase:   "/path/to/showcase",
-			},
-			want: &librarySources{
-				primaryDir:    "/path/to/showcase",
-				googleapisDir: "/path/to/googleapis",
-				includeDirs:   []string{"/path/to/showcase", "/path/to/googleapis"},
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := getLibrarySources(test.library, test.srcs)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(librarySources{})); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -336,23 +336,22 @@ func TestGenerateAPI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = generateAPI(
-		t.Context(),
-		cfg,
-		&config.API{Path: "google/cloud/secretmanager/v1"},
-		library,
-		&librarySources{
+	err = generateAPI(t.Context(), generateAPIParams{
+		cfg:     cfg,
+		api:     &config.API{Path: "google/cloud/secretmanager/v1"},
+		library: library,
+		libSrcs: &librarySources{
 			primaryDir:    googleapisDir,
 			googleapisDir: googleapisDir,
 			includeDirs:   []string{googleapisDir},
 		},
-		outdir,
-		&repoMetadata{
+		outdir: outdir,
+		metadata: &repoMetadata{
 			NamePretty:     "Secret Manager",
 			APIDescription: "Secret Manager API",
 		},
-		apiCfg,
-	)
+		apiCfg: apiCfg,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,22 +404,21 @@ func TestGenerateAPI_ProtoOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = generateAPI(
-		t.Context(),
-		cfg,
-		&config.API{Path: "google/cloud/gkehub/policycontroller/v1beta"},
-		library,
-		&librarySources{
+	err = generateAPI(t.Context(), generateAPIParams{
+		cfg:     cfg,
+		api:     &config.API{Path: "google/cloud/gkehub/policycontroller/v1beta"},
+		library: library,
+		libSrcs: &librarySources{
 			primaryDir:    googleapisDir,
 			googleapisDir: googleapisDir,
 			includeDirs:   []string{googleapisDir},
 		},
-		outdir,
-		&repoMetadata{
+		outdir: outdir,
+		metadata: &repoMetadata{
 			NamePretty: "GKE Hub API",
 		},
-		apiCfg,
-	)
+		apiCfg: apiCfg,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,14 +468,22 @@ func TestGenerateAPI_NoTools(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = generateAPI(t.Context(), cfg, api, library, &librarySources{
-		primaryDir:    googleapisDir,
-		googleapisDir: googleapisDir,
-		includeDirs:   []string{googleapisDir},
-	}, outdir, &repoMetadata{
-		NamePretty:     "Secret Manager",
-		APIDescription: "Secret Manager API",
-	}, apiCfg)
+	err = generateAPI(t.Context(), generateAPIParams{
+		cfg:     cfg,
+		api:     api,
+		library: library,
+		libSrcs: &librarySources{
+			primaryDir:    googleapisDir,
+			googleapisDir: googleapisDir,
+			includeDirs:   []string{googleapisDir},
+		},
+		outdir: outdir,
+		metadata: &repoMetadata{
+			NamePretty:     "Secret Manager",
+			APIDescription: "Secret Manager API",
+		},
+		apiCfg: apiCfg,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -50,7 +50,7 @@ type postProcessParams struct {
 	metadata       *repoMetadata
 	outDir         string
 	apiBase        string
-	googleapisDir  string
+	protoSourceDir string
 	apiProtos      []string
 	includeSamples bool
 }
@@ -322,7 +322,7 @@ func restructureModules(p postProcessParams, destRoot string) error {
 		return err
 	}
 	// Copy proto files to proto-*/src/main/proto
-	if err := copyProtos(p.googleapisDir, p.apiProtos, protoFilesDestDir); err != nil {
+	if err := copyProtos(p.protoSourceDir, p.apiProtos, protoFilesDestDir); err != nil {
 		return fmt.Errorf("failed to copy proto files: %w", err)
 	}
 	return nil
@@ -384,10 +384,10 @@ func deriveLastReleasedVersion(v string) (string, error) {
 	return sv.String(), nil
 }
 
-func copyProtos(googleapisDir string, protos []string, destDir string) error {
+func copyProtos(protoSourceDir string, protos []string, destDir string) error {
 	for _, proto := range protos {
-		// Calculate relative path from googleapisDir to preserve directory structure
-		rel, err := filepath.Rel(googleapisDir, proto)
+		// Calculate relative path from protoSourceDir to preserve directory structure
+		rel, err := filepath.Rel(protoSourceDir, proto)
 		if err != nil {
 			return fmt.Errorf("failed to calculate relative path for %s: %w", proto, err)
 		}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -114,7 +114,7 @@ func TestPostProcessAPI(t *testing.T) {
 			APIs: []*config.API{api},
 		},
 		apiBase:        apiBase,
-		googleapisDir:  googleapisDir,
+		protoSourceDir: googleapisDir,
 		apiProtos:      apiProtos,
 		includeSamples: true,
 		javaAPI:        &config.JavaAPI{},
@@ -194,7 +194,7 @@ func TestRestructureModules(t *testing.T) {
 		outDir:         tmpDir,
 		library:        &config.Library{Name: libraryID},
 		apiBase:        apiBase,
-		googleapisDir:  googleapisDir,
+		protoSourceDir: googleapisDir,
 		apiProtos:      []string{protoPath},
 		includeSamples: true,
 		javaAPI:        &config.JavaAPI{},
@@ -230,7 +230,7 @@ func TestRestructureModules_CommonProtos(t *testing.T) {
 		outDir:         tmpDir,
 		library:        &config.Library{Name: commonProtosLibrary},
 		apiBase:        apiBase,
-		googleapisDir:  googleapisDir,
+		protoSourceDir: googleapisDir,
 		apiProtos:      nil,
 		includeSamples: false,
 		javaAPI: &config.JavaAPI{
@@ -256,7 +256,7 @@ func TestRestructureModules_ShouldRemoveClasses(t *testing.T) {
 		outDir:         tmpDir,
 		library:        &config.Library{Name: "secretmanager"},
 		apiBase:        apiBase,
-		googleapisDir:  googleapisDir,
+		protoSourceDir: googleapisDir,
 		apiProtos:      nil,
 		includeSamples: false,
 		javaAPI:        &config.JavaAPI{},
@@ -309,7 +309,7 @@ func TestRestructureModules_SamplesDisabled(t *testing.T) {
 		outDir:         tmpDir,
 		library:        &config.Library{Name: libraryID},
 		apiBase:        apiBase,
-		googleapisDir:  googleapisDir,
+		protoSourceDir: googleapisDir,
 		apiProtos:      nil,
 		includeSamples: false,
 		javaAPI:        &config.JavaAPI{},
@@ -359,7 +359,7 @@ func TestRestructureModules_Monolithic(t *testing.T) {
 		outDir:         tmpDir,
 		library:        &config.Library{Name: libraryID, Java: &config.JavaModule{}},
 		apiBase:        apiBase,
-		googleapisDir:  t.TempDir(), // dummy
+		protoSourceDir: t.TempDir(), // dummy
 		apiProtos:      nil,
 		includeSamples: false,
 		javaAPI: &config.JavaAPI{

--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -75,8 +75,8 @@ func (metadata *repoMetadata) write(libraryOutputDir string) error {
 
 // generateRepoMetadata coordinates all library-level post-processing tasks,
 // such as generating .repo-metadata.json.
-func generateRepoMetadata(cfg *config.Config, library *config.Library, outDir, googleapisDir string) (*repoMetadata, error) {
-	metadata, err := deriveRepoMetadata(cfg, library, googleapisDir)
+func generateRepoMetadata(cfg *config.Config, library *config.Library, outDir, sourceDir string) (*repoMetadata, error) {
+	metadata, err := deriveRepoMetadata(cfg, library, sourceDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive repo metadata: %w", err)
 	}
@@ -88,9 +88,9 @@ func generateRepoMetadata(cfg *config.Config, library *config.Library, outDir, g
 
 // deriveRepoMetadata constructs the repoMetadata for a Java library using
 // information from the primary service configuration and library-level overrides.
-func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisDir string) (*repoMetadata, error) {
+func deriveRepoMetadata(cfg *config.Config, library *config.Library, sourceDir string) (*repoMetadata, error) {
 	serviceconfig.SortAPIs(library.APIs)
-	sharedMetadata, err := repometadata.FromLibrary(cfg, library, googleapisDir)
+	sharedMetadata, err := repometadata.FromLibrary(cfg, library, sourceDir)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, googleapisD
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/java/docs/reference/%s/latest/overview", artifactID)
 	}
 	// transport
-	apiCfg, err := serviceconfig.Find(googleapisDir, library.APIs[0].Path, config.LanguageJava)
+	apiCfg, err := serviceconfig.Find(sourceDir, library.APIs[0].Path, config.LanguageJava)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find api config: %w", err)
 	}

--- a/internal/librarian/source.go
+++ b/internal/librarian/source.go
@@ -100,7 +100,12 @@ func fetchSource(ctx context.Context, source *config.Source, repo string) (strin
 		return "", nil
 	}
 	if source.Dir != "" {
-		return source.Dir, nil
+		// use absolute dir to avoid issues with relative paths in protoc.
+		absDir, err := filepath.Abs(source.Dir)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve absolute path for %s: %w", source.Dir, err)
+		}
+		return absDir, nil
 	}
 	dir, err := fetch.Repo(ctx, repo, source.Commit, source.SHA256)
 	if err != nil {

--- a/internal/librarian/source_test.go
+++ b/internal/librarian/source_test.go
@@ -16,6 +16,7 @@ package librarian
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -75,6 +76,18 @@ func TestLoadSources(t *testing.T) {
 			want: &sources.Sources{
 				Googleapis: "/tmp/googleapis",
 				Discovery:  "/tmp/discovery",
+			},
+		},
+		{
+			name: "relative paths are resolved to absolute",
+			src: &config.Sources{
+				Googleapis: &config.Source{Dir: "relative/path/to/googleapis"},
+			},
+			want: &sources.Sources{
+				Googleapis: func() string {
+					p, _ := filepath.Abs("relative/path/to/googleapis")
+					return p
+				}(),
 			},
 		},
 	} {

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -299,9 +299,14 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 			}
 			javaAPIs = append(javaAPIs, javaAPI)
 		}
+		var roots []string
+		if name == "showcase" {
+			roots = []string{"showcase", "googleapis"}
+		}
 		lib := &config.Library{
 			Name:    name,
 			Version: version,
+			Roots:   roots,
 			APIs:    apis,
 			Java: &config.JavaModule{
 				APIIDOverride:                l.APIID,

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -331,6 +331,41 @@ func TestBuildConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "showcase library gets roots",
+			gen: &GenerationConfig{
+				Libraries: []LibraryConfig{
+					{
+						LibraryName:  "showcase",
+						APIShortName: "showcase",
+						GAPICs: []GAPICConfig{
+							{ProtoPath: "schema/google/showcase/v1beta1"},
+						},
+					},
+				},
+			},
+			src: &config.Source{},
+			want: &config.Config{
+				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
+				Default: &config.Default{
+					Java: &config.JavaModule{},
+				},
+				Sources: &config.Sources{
+					Googleapis: &config.Source{},
+				},
+				Libraries: []*config.Library{
+					{
+						Name:  "showcase",
+						Roots: []string{"showcase", "googleapis"},
+						APIs: []*config.API{
+							{Path: "schema/google/showcase/v1beta1"},
+						},
+						Java: &config.JavaModule{SkipAPIID: true},
+					},
+				},
+			},
+		},
+		{
 			name: "fallback to api_shortname",
 			gen: &GenerationConfig{
 				Libraries: []LibraryConfig{


### PR DESCRIPTION
Support showcase as source in generate, pass both showcase dir and googleapis dir to protoc via -I flags, use only showcase dir for copy protos, and finding service configs. Also renaming variables related to googleapisDir for clarity.

For https://github.com/googleapis/librarian/issues/5731