### PR TITLE
chore(tool/cmd/migrate): add hardcoded configs for showcase

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -478,6 +478,11 @@ func applyJavaLibraryOverrides(lib *config.Library) {
 // applyJavaProtoOverrides sets hardcoded proto inclusions and exclusions
 // for specific APIs, mirroring logic in sdk-platform-java.
 func applyJavaProtoOverrides(api *config.JavaAPI) {
+	for prefix, protos := range javaAdditionalProtosOverrides {
+		if strings.HasPrefix(api.Path, prefix) {
+			api.AdditionalProtos = append(api.AdditionalProtos, protos...)
+		}
+	}
 	switch {
 	case api.Path == "google/cloud":
 		api.ExcludedProtos = append(api.ExcludedProtos, "google/cloud/common_resources.proto")
@@ -492,10 +497,6 @@ func applyJavaProtoOverrides(api *config.JavaAPI) {
 			"google/cloud/aiplatform/v1beta1/schema/dataset_metadata.proto",
 			"google/cloud/aiplatform/v1beta1/schema/geometry.proto",
 		)
-	case strings.HasPrefix(api.Path, "google/cloud/filestore"):
-		api.AdditionalProtos = append(api.AdditionalProtos, "google/cloud/common/operation_metadata.proto")
-	case strings.HasPrefix(api.Path, "google/cloud/oslogin"):
-		api.AdditionalProtos = append(api.AdditionalProtos, "google/cloud/oslogin/common/common.proto")
 	case api.Path == "google/rpc":
 		api.ExcludedProtos = append(api.ExcludedProtos, "google/rpc/http.proto")
 	}

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -151,6 +151,10 @@ var (
 			grpcArtifactID:  "grpc-google-cloud-storage-control-v2",
 			gapicArtifactID: "google-cloud-storage-control",
 		},
+		"schema/google/showcase/v1beta1": {
+			protoArtifactID: "proto-gapic-showcase-v1beta1",
+			grpcArtifactID:  "grpc-gapic-showcase-v1beta1",
+		},
 	}
 
 	javaTransportOverrides = map[string]string{
@@ -181,6 +185,19 @@ var (
 
 	monolithicJavaAPIs = map[string]bool{
 		"grafeas/v1": true,
+	}
+
+	javaAdditionalProtosOverrides = map[string][]string{
+		"schema/google/showcase/v1beta1": {
+			"google/cloud/location/locations.proto",
+			"google/iam/v1/iam_policy.proto",
+		},
+		"google/cloud/filestore": {
+			"google/cloud/common/operation_metadata.proto",
+		},
+		"google/cloud/oslogin": {
+			"google/cloud/oslogin/common/common.proto",
+		},
 	}
 )
 

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -90,6 +90,17 @@ func TestApplyJavaProtoOverrides(t *testing.T) {
 				Path: "google/cloud/language/v1",
 			},
 		},
+		{
+			name: "showcase",
+			path: "schema/google/showcase/v1beta1",
+			want: &config.JavaAPI{
+				Path: "schema/google/showcase/v1beta1",
+				AdditionalProtos: []string{
+					"google/cloud/location/locations.proto",
+					"google/iam/v1/iam_policy.proto",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := &config.JavaAPI{Path: test.path}


### PR DESCRIPTION
Adds hardcoded additional protos and artifact id overrides configs for showcase. 
`AdditionalProtos` needs to be hardcoded for showcase because it is usually parsed from BUILD.bazel, but showcase uses [BUILD.partial.bazel](https://github.com/googleapis/google-cloud-java/blob/2cecd0caf4f15da2d894a70077ccb0d0fd69d296/java-showcase/scripts/resources/BUILD.partial.bazel#L18-L24) to define it.
Artifact overrides are needed because showcase does not follow general deriving logic. 

For #5731