### PR TITLE
feature(internal/sidekick/surfer): add standard resource inflection map

### DIFF
--- a/internal/sidekick/surfer/provider/resource.go
+++ b/internal/sidekick/surfer/provider/resource.go
@@ -373,3 +373,46 @@ func GetPluralResourceTypeName(model *api.API, methodPath []string) string {
 	}
 	return res.Plural
 }
+
+// BuildInflectionMap pre-computes a lookup map from plural literal collection segments to their singular variable names.
+// This is extracted from the model's standard resource definitions and message patterns.
+// Example: "projects" -> "project", "locations" -> "location".
+func BuildInflectionMap(model *api.API) map[string]string {
+	m := make(map[string]string)
+	if model == nil {
+		return m
+	}
+
+	for _, res := range model.ResourceDefinitions {
+		for _, pattern := range res.Patterns {
+			for k, v := range inflectionsFromPattern(pattern) {
+				m[k] = v
+			}
+		}
+	}
+	for _, msg := range model.Messages {
+		if msg.Resource == nil {
+			continue
+		}
+		for _, pattern := range msg.Resource.Patterns {
+			for k, v := range inflectionsFromPattern(pattern) {
+				m[k] = v
+			}
+		}
+	}
+	return m
+}
+
+// inflectionsFromPattern extracts collection segment inflections from a single structured path pattern.
+func inflectionsFromPattern(pattern []api.PathSegment) map[string]string {
+	m := make(map[string]string)
+	for j := 0; j < len(pattern)-1; j++ {
+		if pattern[j].Literal != nil && pattern[j+1].Variable != nil {
+			vars := pattern[j+1].Variable.FieldPath
+			if len(vars) > 0 {
+				m[*pattern[j].Literal] = vars[len(vars)-1]
+			}
+		}
+	}
+	return m
+}

--- a/internal/sidekick/surfer/provider/resource_test.go
+++ b/internal/sidekick/surfer/provider/resource_test.go
@@ -886,3 +886,94 @@ func TestGetPluralResourceTypeName(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildInflectionMap(t *testing.T) {
+	tests := []struct {
+		name  string
+		model *api.API
+		want  map[string]string
+	}{
+		{
+			name: "Inflections from resource definitions and messages",
+			model: &api.API{
+				ResourceDefinitions: []*api.Resource{
+					{
+						Patterns: []api.ResourcePattern{
+							parseResourcePattern("projects/{project}/locations/{location}/instances/{instance}"),
+						},
+					},
+				},
+				Messages: []*api.Message{
+					{
+						Resource: &api.Resource{
+							Patterns: []api.ResourcePattern{
+								parseResourcePattern("organizations/{organization}/locations/{location}/nodes/{node}"),
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"projects":      "project",
+				"locations":     "location",
+				"instances":     "instance",
+				"organizations": "organization",
+				"nodes":         "node",
+			},
+		},
+		{
+			name:  "Nil Model",
+			model: nil,
+			want:  map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildInflectionMap(tt.model)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("BuildInflectionMap() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestInflectionsFromPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern []api.PathSegment
+		want    map[string]string
+	}{
+		{
+			name:    "Valid Pattern",
+			pattern: parseResourcePattern("projects/{project}/locations/{location}"),
+			want: map[string]string{
+				"projects":  "project",
+				"locations": "location",
+			},
+		},
+		{
+			name:    "Ending With Wildcard Variable",
+			pattern: parseResourcePattern("projects/{project}/*"),
+			want: map[string]string{
+				"projects": "project",
+			},
+		},
+		{
+			name:    "Short Pattern",
+			pattern: parseResourcePattern("projects"),
+			want:    map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := inflectionsFromPattern(tt.pattern)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("inflectionsFromPattern() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Create inflection map so that you can get the singular version of a resource. For example, `projects/{project}/locations/{location}/resources/{resource}` will generate map {projects: project, ...}. This assists for generating a fake operations resources like `projects/{project}/libraries/{library}/operations{operation}`

For #5485