### PR TITLE
feat(sidekick/surfer): prefix nested message flag names with parent names

### DIFF
--- a/internal/sidekick/surfer/argument_builder.go
+++ b/internal/sidekick/surfer/argument_builder.go
@@ -31,7 +31,7 @@ type argumentParams struct {
 	model     *api.API
 	service   *api.Service
 	field     *api.Field
-	apiField  []string
+	fieldPath []*api.Field
 }
 
 // newArgument creates a single command-line argument (an `Argument` struct) from the parameters.
@@ -40,11 +40,13 @@ func newArgument(ap *argumentParams) (*Argument, error) {
 	if isArgIgnored(ap.field, ap.method) {
 		return nil, nil
 	}
+	if len(ap.fieldPath) == 0 {
+		return nil, fmt.Errorf("field %q has empty field path", ap.field.Name)
+	}
 
-	// TODO(https://github.com/googleapis/librarian/issues/3414): Abstract away casing logic in the model.
 	arg := &Argument{
-		ArgName:   ap.field.Name,
-		APIField:  ap.apiField,
+		ArgName:   argName(ap),
+		APIField:  apiField(ap),
 		Required:  ap.field.DocumentAsRequired(),
 		Repeated:  repeated(ap.field),
 		Clearable: clearable(ap.field, ap.method),
@@ -258,4 +260,38 @@ func newAttributesFromSegments(segments []api.PathSegment) []Attribute {
 		attributes = append(attributes, attr)
 	}
 	return attributes
+}
+
+func argName(ap *argumentParams) string {
+	parts := ap.fieldPath
+	// Strip explicit body field name (e.g., "instance" when body: "instance").
+	// The explicit body message represents the main resource being acted upon,
+	// so its fields should appear as top-level flags without redundant prefixes.
+	if ap.method.PathInfo != nil && !isBodyWildcard(ap) {
+		if len(parts) > 0 && parts[0].Name == ap.method.PathInfo.BodyFieldPath {
+			parts = parts[1:]
+		}
+	}
+
+	var names []string
+	for _, f := range parts {
+		names = append(names, f.Name)
+	}
+	return strings.Join(names, "_")
+}
+
+// apiField constructs the path segments to the field in the API request message.
+func apiField(ap *argumentParams) []string {
+	var apiFields []string
+	if isBodyWildcard(ap) && ap.method.InputType != nil {
+		apiFields = append(apiFields, ap.method.InputType.Name)
+	}
+	for _, f := range ap.fieldPath {
+		apiFields = append(apiFields, f.JSONName)
+	}
+	return apiFields
+}
+
+func isBodyWildcard(ap *argumentParams) bool {
+	return ap.method.PathInfo != nil && ap.method.PathInfo.BodyFieldPath == "*"
 }

--- a/internal/sidekick/surfer/argument_builder_test.go
+++ b/internal/sidekick/surfer/argument_builder_test.go
@@ -39,16 +39,14 @@ func TestNewArgument(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		field     *api.Field
-		apiField  []string
 		method    *api.Method
 		overrides *provider.Config
 		want      Argument
 	}{
 		{
-			name:     "String Field",
-			field:    api.NewTestField("description").WithType(api.TypezString).WithBehavior(api.FieldBehaviorOptional),
-			apiField: []string{"description"},
-			method:   api.NewTestMethod("CreateInstance"),
+			name:   "String Field",
+			field:  api.NewTestField("description").WithType(api.TypezString).WithBehavior(api.FieldBehaviorOptional),
+			method: api.NewTestMethod("CreateInstance"),
 			want: Argument{
 				ArgName:  "description",
 				APIField: []string{"description"},
@@ -65,8 +63,7 @@ func TestNewArgument(t *testing.T) {
 				f.Documentation = "My proto comment"
 				return f
 			}(),
-			apiField: []string{"description"},
-			method:   api.NewTestMethod("CreateInstance"),
+			method: api.NewTestMethod("CreateInstance"),
 			want: Argument{
 				ArgName:  "description",
 				APIField: []string{"description"},
@@ -77,10 +74,9 @@ func TestNewArgument(t *testing.T) {
 			},
 		},
 		{
-			name:     "Resource Reference Field",
-			field:    api.NewTestField("network").WithResourceReference("test.googleapis.com/Network"),
-			apiField: []string{"network"},
-			method:   api.NewTestMethod("CreateInstance"),
+			name:   "Resource Reference Field",
+			field:  api.NewTestField("network").WithResourceReference("test.googleapis.com/Network"),
+			method: api.NewTestMethod("CreateInstance"),
 			want: Argument{
 				ArgName:  "network",
 				APIField: []string{"network"},
@@ -98,10 +94,9 @@ func TestNewArgument(t *testing.T) {
 			},
 		},
 		{
-			name:     "Boolean Field in Create Command",
-			field:    api.NewTestField("validateOnly").WithType(api.TypezBool),
-			apiField: []string{"validateOnly"},
-			method:   api.NewTestMethod("CreateInstance").WithVerb("POST"),
+			name:   "Boolean Field in Create Command",
+			field:  api.NewTestField("validateOnly").WithType(api.TypezBool),
+			method: api.NewTestMethod("CreateInstance").WithVerb("POST"),
 			want: Argument{
 				ArgName:  "validateOnly",
 				APIField: []string{"validateOnly"},
@@ -111,10 +106,9 @@ func TestNewArgument(t *testing.T) {
 			},
 		},
 		{
-			name:     "Boolean Field in Update Command",
-			field:    api.NewTestField("validateOnly").WithType(api.TypezBool),
-			apiField: []string{"validateOnly"},
-			method:   api.NewTestMethod("UpdateInstance").WithVerb("PATCH"),
+			name:   "Boolean Field in Update Command",
+			field:  api.NewTestField("validateOnly").WithType(api.TypezBool),
+			method: api.NewTestMethod("UpdateInstance").WithVerb("PATCH"),
 			want: Argument{
 				ArgName:  "validateOnly",
 				APIField: []string{"validateOnly"},
@@ -141,8 +135,7 @@ func TestNewArgument(t *testing.T) {
 					},
 				},
 			},
-			apiField: []string{"foo"},
-			method:   api.NewTestMethod("CreateInstance"),
+			method: api.NewTestMethod("CreateInstance"),
 			want: Argument{
 				ArgName:  "foo",
 				APIField: []string{"foo"},
@@ -157,13 +150,14 @@ func TestNewArgument(t *testing.T) {
 			if overrides == nil {
 				overrides = &provider.Config{}
 			}
+			path := []*api.Field{test.field}
 			got, err := newArgument(&argumentParams{
 				method:    test.method,
 				overrides: overrides,
 				model:     model,
 				service:   service,
 				field:     test.field,
-				apiField:  test.apiField,
+				fieldPath: path,
 			})
 			if err != nil {
 				t.Errorf("newArgument(%s) unexpected error: %v", test.name, err)
@@ -563,26 +557,70 @@ func TestArgumentBuilder_Build(t *testing.T) {
 	createMethod.Service = service
 	createMethod.Model = model
 
+	// Method with body: "*" to test wildcard prepending
+	wildcardMethod := api.NewTestMethod("CreateThingWildcard").WithVerb("POST").WithInput(
+		api.NewTestMessage("CreateRequest").WithFields(
+			api.NewTestField("thing_id").WithType(api.TypezString),
+		),
+	)
+	wildcardMethod.Service = service
+	wildcardMethod.Model = model
+	wildcardMethod.PathInfo = &api.PathInfo{BodyFieldPath: "*"}
+
+	displayNameField := api.NewTestField("display_name").WithType(api.TypezString)
+	instanceField := api.NewTestField("instance").WithType(api.TypezMessage)
+
 	for _, test := range []struct {
 		name    string
+		method  *api.Method
 		field   *api.Field
-		prefix  []string
+		path    []*api.Field
 		want    *Argument
 		wantErr bool
 	}{
 		{
 			name:   "Skips skipped fields",
+			method: createMethod,
 			field:  api.NewTestField("update_mask").WithType(api.TypezMessage),
-			prefix: []string{"update_mask"},
+			path:   []*api.Field{api.NewTestField("update_mask")},
 			want:   nil,
 		},
 		{
 			name:   "Handles Simple String Field",
-			field:  api.NewTestField("display_name").WithType(api.TypezString),
-			prefix: []string{"displayName"},
+			method: createMethod,
+			field:  displayNameField,
+			path:   []*api.Field{displayNameField},
 			want: &Argument{
 				ArgName:  "display_name",
 				APIField: []string{"displayName"},
+				HelpText: "Value for the `display-name` field.",
+				Required: false,
+				Repeated: false,
+				Type:     "str",
+			},
+		},
+		{
+			name:   "Handles Nested String Field",
+			method: createMethod,
+			field:  displayNameField,
+			path:   []*api.Field{instanceField, displayNameField},
+			want: &Argument{
+				ArgName:  "instance_display_name",
+				APIField: []string{"instance", "displayName"},
+				HelpText: "Value for the `display-name` field.",
+				Required: false,
+				Repeated: false,
+				Type:     "str",
+			},
+		},
+		{
+			name:   "Handles Nested String Field with InputType prefix (body *)",
+			method: wildcardMethod,
+			field:  displayNameField,
+			path:   []*api.Field{instanceField, displayNameField},
+			want: &Argument{
+				ArgName:  "instance_display_name",
+				APIField: []string{"CreateRequest", "instance", "displayName"},
 				HelpText: "Value for the `display-name` field.",
 				Required: false,
 				Repeated: false,
@@ -593,12 +631,12 @@ func TestArgumentBuilder_Build(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := newArgument(&argumentParams{
-				method:    createMethod,
+				method:    test.method,
 				overrides: &provider.Config{},
 				model:     model,
 				service:   service,
 				field:     test.field,
-				apiField:  test.prefix,
+				fieldPath: test.path,
 			})
 			if (err != nil) != test.wantErr {
 				t.Fatalf("build() error = %v, wantErr %v", err, test.wantErr)

--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -179,15 +179,10 @@ func requestMethod(method *api.Method) string {
 	return ""
 }
 
-type fieldWithPrefix struct {
-	field  *api.Field
-	prefix []string
-}
-
 type classifiedFields struct {
-	primaryField    *fieldWithPrefix
-	resourceIdField *fieldWithPrefix
-	other           []fieldWithPrefix
+	primaryField    []*api.Field
+	resourceIdField []*api.Field
+	other           [][]*api.Field
 }
 
 // newArguments generates the set of arguments for a command by parsing the
@@ -206,27 +201,28 @@ func newArguments(method *api.Method, overrides *provider.Config, model *api.API
 	if cf.primaryField != nil {
 		var idField *api.Field
 		if cf.resourceIdField != nil {
-			idField = cf.resourceIdField.field
+			idField = cf.resourceIdField[len(cf.resourceIdField)-1]
 		}
 		arg := newPrimaryResourceArgument(&argumentParams{
 			method:    method,
 			overrides: overrides,
 			model:     model,
 			service:   service,
-			field:     cf.primaryField.field,
-			apiField:  cf.primaryField.prefix,
+			field:     cf.primaryField[len(cf.primaryField)-1],
+			fieldPath: cf.primaryField,
 		}, idField)
 		args = append(args, arg)
 	}
 
-	for _, fwp := range cf.other {
+	for _, path := range cf.other {
+		field := path[len(path)-1]
 		arg, err := newArgument(&argumentParams{
 			method:    method,
 			overrides: overrides,
 			model:     model,
 			service:   service,
-			field:     fwp.field,
-			apiField:  fwp.prefix,
+			field:     field,
+			fieldPath: path,
 		})
 		if err != nil {
 			return nil, err
@@ -252,7 +248,7 @@ func positionalResourceArg(method *api.Method, overrides *provider.Config, model
 
 	var idField *api.Field
 	if cf.resourceIdField != nil {
-		idField = cf.resourceIdField.field
+		idField = cf.resourceIdField[len(cf.resourceIdField)-1]
 	}
 
 	arg := newPrimaryResourceArgument(&argumentParams{
@@ -260,8 +256,8 @@ func positionalResourceArg(method *api.Method, overrides *provider.Config, model
 		overrides: overrides,
 		model:     model,
 		service:   service,
-		field:     cf.primaryField.field,
-		apiField:  cf.primaryField.prefix,
+		field:     cf.primaryField[len(cf.primaryField)-1],
+		fieldPath: cf.primaryField,
 	}, idField)
 	return &arg, nil
 }
@@ -276,50 +272,42 @@ func categorizeFields(method *api.Method, model *api.API) (classifiedFields, err
 		bodyFieldPath = method.PathInfo.BodyFieldPath
 	}
 
-	var collected []fieldWithPrefix
+	var collected [][]*api.Field
 	for _, field := range method.InputType.Fields {
 		isExpandableMessage := field.MessageType != nil && !field.Map
 		isBodyWildcard := bodyFieldPath == "*"
 		isBodyField := bodyFieldPath == field.Name || isBodyWildcard
 
-		var prefix []string
-		if isBodyWildcard {
-			prefix = append(prefix, method.InputType.Name)
-		}
+		var path []*api.Field
 
 		if isExpandableMessage && isBodyField {
-			prefix = append(prefix, field.JSONName)
+			path = append(path, field)
 			for _, f := range field.MessageType.Fields {
-				collected = append(collected, fieldWithPrefix{
-					field:  f,
-					prefix: append(append([]string{}, prefix...), f.JSONName),
-				})
+				collected = append(collected, append(slices.Clone(path), f))
 			}
 			continue
 		}
 
-		collected = append(collected, fieldWithPrefix{
-			field:  field,
-			prefix: append(prefix, field.JSONName),
-		})
+		collected = append(collected, append(path, field))
 	}
 
-	for _, fwp := range collected {
+	for _, path := range collected {
+		field := path[len(path)-1]
 		switch {
-		case provider.IsPrimaryResourceField(fwp.field, method):
+		case provider.IsPrimaryResourceField(field, method):
 			if cf.primaryField != nil {
-				return cf, fmt.Errorf("method %q has multiple primary resource fields: %q and %q", method.Name, cf.primaryField.field.Name, fwp.field.Name)
+				return cf, fmt.Errorf("method %q has multiple primary resource fields: %q and %q", method.Name, cf.primaryField[len(cf.primaryField)-1].Name, field.Name)
 			}
-			cf.primaryField = &fieldWithPrefix{field: fwp.field, prefix: fwp.prefix}
-		case provider.IsResourceIdField(fwp.field, method, model):
+			cf.primaryField = path
+		case provider.IsResourceIdField(field, method, model):
 			if cf.resourceIdField != nil {
-				return cf, fmt.Errorf("method %q has multiple resource ID fields: %q and %q", method.Name, cf.resourceIdField.field.Name, fwp.field.Name)
+				return cf, fmt.Errorf("method %q has multiple resource ID fields: %q and %q", method.Name, cf.resourceIdField[len(cf.resourceIdField)-1].Name, field.Name)
 			}
-			cf.resourceIdField = &fieldWithPrefix{field: fwp.field, prefix: fwp.prefix}
-		case provider.IsCreate(method) && fwp.field.Name == "name":
+			cf.resourceIdField = path
+		case provider.IsCreate(method) && field.Name == "name":
 			// Ignore name field in Create methods as it's redundant with resource_id
 		default:
-			cf.other = append(cf.other, fwp)
+			cf.other = append(cf.other, path)
 		}
 	}
 

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
@@ -48,14 +48,14 @@
           name: instance
           plural_name: instances
         required: true
-      - arg_name: path
+      - arg_name: source-parallelstore-path
         api_field: exportDataRequest.sourceParallelstore.path
         help_text: |-
           Root directory path to the Paralellstore filesystem, starting
           with `/`. Defaults to `/` if unset.
         is_positional: false
         required: false
-      - arg_name: uri
+      - arg_name: destination-gcs-bucket-uri
         api_field: exportDataRequest.destinationGcsBucket.uri
         help_text: |-
           URI to a Cloud Storage bucket in the format:
@@ -110,7 +110,7 @@
         required: false
         resource_method_params:
           exportDataRequest.serviceAccount: '{__relative_name__}'
-      - arg_name: uid
+      - arg_name: metadata-options-uid
         api_field: exportDataRequest.metadataOptions.uid
         help_text: The UID preservation behavior.
         is_positional: false
@@ -122,7 +122,7 @@
           - arg_value: uid-number-preserve
             enum_value: UID_NUMBER_PRESERVE
             help_text: Value for the `uid-number-preserve` field.
-      - arg_name: gid
+      - arg_name: metadata-options-gid
         api_field: exportDataRequest.metadataOptions.gid
         help_text: The GID preservation behavior.
         is_positional: false
@@ -134,7 +134,7 @@
           - arg_value: gid-number-preserve
             enum_value: GID_NUMBER_PRESERVE
             help_text: Value for the `gid-number-preserve` field.
-      - arg_name: mode
+      - arg_name: metadata-options-mode
         api_field: exportDataRequest.metadataOptions.mode
         help_text: The mode preservation behavior.
         is_positional: false

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
@@ -48,7 +48,7 @@
           name: instance
           plural_name: instances
         required: true
-      - arg_name: uri
+      - arg_name: source-gcs-bucket-uri
         api_field: importDataRequest.sourceGcsBucket.uri
         help_text: |-
           URI to a Cloud Storage bucket in the format:
@@ -56,7 +56,7 @@
           optional.
         is_positional: false
         required: true
-      - arg_name: path
+      - arg_name: destination-parallelstore-path
         api_field: importDataRequest.destinationParallelstore.path
         help_text: |-
           Root directory path to the Paralellstore filesystem, starting
@@ -111,7 +111,7 @@
         required: false
         resource_method_params:
           importDataRequest.serviceAccount: '{__relative_name__}'
-      - arg_name: uid
+      - arg_name: metadata-options-uid
         api_field: importDataRequest.metadataOptions.uid
         help_text: The UID preservation behavior.
         is_positional: false
@@ -123,7 +123,7 @@
           - arg_value: uid-number-preserve
             enum_value: UID_NUMBER_PRESERVE
             help_text: Value for the `uid-number-preserve` field.
-      - arg_name: gid
+      - arg_name: metadata-options-gid
         api_field: importDataRequest.metadataOptions.gid
         help_text: The GID preservation behavior.
         is_positional: false
@@ -135,7 +135,7 @@
           - arg_value: gid-number-preserve
             enum_value: GID_NUMBER_PRESERVE
             help_text: Value for the `gid-number-preserve` field.
-      - arg_name: mode
+      - arg_name: metadata-options-mode
         api_field: importDataRequest.metadataOptions.mode
         help_text: The mode preservation behavior.
         is_positional: false

--- a/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_query_ga.yaml
+++ b/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_query_ga.yaml
@@ -53,7 +53,7 @@
           name: workbench
           plural_name: workbenches
         required: true
-      - arg_name: role
+      - arg_name: contents-role
         api_field: workbenchQueryRequest.contents.role
         help_text: |-
           The producer of the content. Must be either 'user' or 'model'.
@@ -62,7 +62,7 @@
           or unset.
         is_positional: false
         required: false
-      - arg_name: parts
+      - arg_name: contents-parts
         api_field: workbenchQueryRequest.contents.parts
         help_text: |-
           Ordered `Parts` that constitute a single message. Parts may have
@@ -71,7 +71,7 @@
         required: true
         repeated: true
         type: arg_object
-      - arg_name: category
+      - arg_name: safety-settings-category
         api_field: workbenchQueryRequest.safetySettings.category
         help_text: The category for this setting.
         is_positional: false
@@ -89,7 +89,7 @@
           - arg_value: harm-category-sexually-explicit
             enum_value: HARM_CATEGORY_SEXUALLY_EXPLICIT
             help_text: Value for the `harm-category-sexually-explicit` field.
-      - arg_name: threshold
+      - arg_name: safety-settings-threshold
         api_field: workbenchQueryRequest.safetySettings.threshold
         help_text: Controls the probability threshold at which harm is blocked.
         is_positional: false

--- a/internal/surfer/testdata/field_flag_names/expected/current/surface/field_flag_names/resources/_partials/_archive_ga.yaml
+++ b/internal/surfer/testdata/field_flag_names/expected/current/surface/field_flag_names/resources/_partials/_archive_ga.yaml
@@ -46,29 +46,29 @@
           name: resource
           plural_name: resources
         required: true
-      - arg_name: field-with-no-parent
+      - arg_name: resource-field-with-no-parent
         api_field: archiveResourceRequest.resource.fieldWithNoParent
         help_text: Field with no parent
         is_positional: false
         required: false
-      - arg_name: msg
+      - arg_name: resource-msg
         api_field: archiveResourceRequest.resource.msg
         help_text: Message Field.
         is_positional: false
         required: false
         type: arg_object
-      - arg_name: quiet
+      - arg_name: resource-quiet
         api_field: archiveResourceRequest.resource.quiet
         help_text: Field that conflicts with quiet global flag.
         is_positional: false
         required: false
-      - arg_name: billing-info
+      - arg_name: resource-billing-info
         api_field: archiveResourceRequest.resource.billingInfo
         help_text: Field that indirectly conflicts with billing-project global flag.
         is_positional: false
         required: false
         type: arg_object
-      - arg_name: labels
+      - arg_name: resource-labels
         api_field: archiveResourceRequest.resource.labels
         help_text: |-
           The labels on the resource, which can be used for categorization.


### PR DESCRIPTION
Surfer now prepends parent field names to generated gcloud flag names for fields inside nested messages, preventing collisions and matching gen_sfc behavior.

The new logic derives the flag name from the API field path and applies rules to strip request message names and explicit body field names, avoiding redundant prefixes. This logic is encapsulated in a new deriveArgName helper function.

Fixes https://github.com/googleapis/librarian/issues/5511