### PR TITLE
feat(sidekick/swift): generate `Sendable` types

### DIFF
--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -107,14 +107,14 @@ func TestGenerateMessage_WithNestedMessages(t *testing.T) {
 	}
 	contentStr := string(content)
 
-	gotBlock1 := extractBlock(t, contentStr, "public struct Nested1", "._AnyPackable {")
-	wantBlock1 := "public struct Nested1: Codable, Equatable, GoogleCloudWkt._AnyPackable {"
+	gotBlock1 := extractBlock(t, contentStr, "public struct Nested1", ", Sendable {")
+	wantBlock1 := "public struct Nested1: Codable, Equatable, GoogleCloudWkt._AnyPackable, Sendable {"
 	if diff := cmp.Diff(wantBlock1, gotBlock1); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	gotBlock2 := extractBlock(t, contentStr, "public struct Nested2", "._AnyPackable {")
-	wantBlock2 := "public struct Nested2: Codable, Equatable, GoogleCloudWkt._AnyPackable {"
+	gotBlock2 := extractBlock(t, contentStr, "public struct Nested2", ", Sendable {")
+	wantBlock2 := "public struct Nested2: Codable, Equatable, GoogleCloudWkt._AnyPackable, Sendable {"
 	if diff := cmp.Diff(wantBlock2, gotBlock2); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -160,8 +160,8 @@ func TestGenerateMessage_WithNestedEnum(t *testing.T) {
 	}
 	contentStr := string(content)
 
-	gotBlock := extractBlock(t, contentStr, "public enum NestedEnum", "Equatable {")
-	wantBlock := "public enum NestedEnum: Int, Codable, Equatable {"
+	gotBlock := extractBlock(t, contentStr, "public enum NestedEnum", ", Sendable {")
+	wantBlock := "public enum NestedEnum: Int, Codable, Equatable, Sendable {"
 	if diff := cmp.Diff(wantBlock, gotBlock); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -111,7 +111,7 @@ func TestGenerateOneOf(t *testing.T) {
 	// test.
 	//
 	// To verify the code compile, use something like: https://godbolt.org/z/EE9G7KTr8
-	want := `public struct Outer: Codable, Equatable, GoogleCloudWkt._AnyPackable {
+	want := `public struct Outer: Codable, Equatable, GoogleCloudWkt._AnyPackable, Sendable {
 
   /// A regular field.
   public var regularInt32: Int32
@@ -178,7 +178,7 @@ func TestGenerateOneOf(t *testing.T) {
 
 
   /// A group of fields where only one is set.
-  public enum OneOf_Choice: Codable, Equatable {
+  public enum OneOf_Choice: Codable, Equatable, Sendable {
     /// A string field that is part of the oneof.
     case stringField(String)
     /// A message field that is part of the oneof.

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -16,7 +16,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
-public enum {{Codec.Name}}: Int, Codable, Equatable {
+public enum {{Codec.Name}}: Int, Codable, Equatable, Sendable {
     {{#UniqueNumberValues}}
     {{#DocLines}}
     /// {{{.}}}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -16,7 +16,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
-public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._AnyPackable {
+public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._AnyPackable, Sendable {
   {{#Fields}}
   {{^IsOneOf}}
 

--- a/internal/sidekick/swift/templates/common/oneof.mustache
+++ b/internal/sidekick/swift/templates/common/oneof.mustache
@@ -16,7 +16,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
-public enum {{Codec.Name}}: Codable, Equatable {
+public enum {{Codec.Name}}: Codable, Equatable, Sendable {
   {{#Fields}}
   {{#Codec.DocLines}}
   /// {{{.}}}


### PR DESCRIPTION
The structs, and enums, generated from messages, enums, and oneofs are intended to be value types, and therefore should be `Sendable`. That is, they can be moved from one thread to another without any problems.

In Swift this is a long-term committment about our types, and one we need to make.