### PR TITLE
feat(internal/sidekick/gcloud): generate required flags

### DIFF
--- a/internal/sidekick/gcloud/flag.go
+++ b/internal/sidekick/gcloud/flag.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Flag represents a single CLI flag.
+type Flag struct {
+	// Name is the long flag name without leading dashes (e.g. "project").
+	Name string
+
+	// Kind is the urfave/cli flag type (e.g. "String", "Bool").
+	Kind string
+
+	// Required reports whether the flag must be set on the command line.
+	Required bool
+
+	// Usage is the help text shown next to the flag.
+	//
+	// TODO(https://github.com/googleapis/librarian/issues/5769):
+	// Usage is currently a generic "The <name>." string. Source it from
+	// the proto field's documentation when we wire that through.
+	Usage string
+}
+
+// flag returns a Flag with canonical Usage derived from name.
+func flag(name, kind string, required bool) Flag {
+	return Flag{
+		Name:     name,
+		Kind:     kind,
+		Required: required,
+		Usage:    fmt.Sprintf("The %s.", strings.ReplaceAll(name, "-", " ")),
+	}
+}
+
+// pathFlag returns the canonical required-string Flag for a path-derived name.
+func pathFlag(name string) Flag {
+	return flag(name, "String", true)
+}

--- a/internal/sidekick/gcloud/flag_test.go
+++ b/internal/sidekick/gcloud/flag_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFlag(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		flagName string
+		kind     string
+		required bool
+		want     Flag
+	}{
+		{
+			name:     "required project",
+			flagName: "project",
+			kind:     "String",
+			required: true,
+			want:     Flag{Name: "project", Kind: "String", Required: true, Usage: "The project."},
+		},
+		{
+			name:     "optional page-token",
+			flagName: "page-token",
+			kind:     "String",
+			required: false,
+			want:     Flag{Name: "page-token", Kind: "String", Required: false, Usage: "The page token."},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := flag(test.flagName, test.kind, test.required)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPathFlag(t *testing.T) {
+	got := pathFlag("location")
+	want := Flag{Name: "location", Kind: "String", Required: true, Usage: "The location."}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/gcloud/generate.go
+++ b/internal/sidekick/gcloud/generate.go
@@ -55,9 +55,13 @@ type Subgroup struct {
 
 // Command represents a leaf command.
 type Command struct {
+	Flags []Flag
 	Name  string
 	Usage string
 }
+
+// HasFlags reports whether the command has any flags.
+func (c Command) HasFlags() bool { return len(c.Flags) > 0 }
 
 // Generate is the package entry point. It builds the model, renders main.go,
 // writes it, then renders any other generated files via
@@ -137,10 +141,8 @@ func constructCLIModel(model *api.API) CLIModel {
 				}
 			}
 
-			subgroups[subgroupName].Commands = append(subgroups[subgroupName].Commands, Command{
-				Name:  commandName,
-				Usage: fmt.Sprintf("%s %s", commandName, subgroupName),
-			})
+			cmd := buildCommand(method, model, commandName, subgroupName)
+			subgroups[subgroupName].Commands = append(subgroups[subgroupName].Commands, cmd)
 		}
 	}
 
@@ -156,4 +158,56 @@ func constructCLIModel(model *api.API) CLIModel {
 	return CLIModel{
 		Groups: []Group{rootGroup},
 	}
+}
+
+// buildCommand constructs a Command for a method. The command's flags name
+// each component of the resource the method operates on.
+func buildCommand(method *api.Method, model *api.API, commandName, subgroupName string) Command {
+	return Command{
+		Name:  commandName,
+		Usage: fmt.Sprintf("%s %s", commandName, subgroupName),
+		Flags: pathFlagsForMethod(method, model),
+	}
+}
+
+// pathFlagsForMethod returns the required flags that name each component of
+// the resource the method operates on. For collection methods (List,
+// Create, custom collection) it walks up to the parent of the resource
+// pattern; for resource methods it uses the resource pattern directly.
+//
+// The flag name is the last component of each variable segment's
+// FieldPath, per AIP-123. Resources without a pattern, or methods whose
+// resource cannot be resolved, contribute no flags.
+func pathFlagsForMethod(method *api.Method, model *api.API) []Flag {
+	resource := provider.GetResourceForMethod(method, model)
+	if resource == nil || len(resource.Patterns) == 0 {
+		return nil
+	}
+	segments := resource.Patterns[0]
+	if provider.IsCollectionMethod(method) {
+		if parent := provider.GetParentFromSegments(segments); parent != nil {
+			segments = parent
+		}
+	}
+	return pathFlagsFromSegments(segments)
+}
+
+// pathFlagsFromSegments returns one required string flag for each variable
+// segment in the pattern, named after the variable's last FieldPath
+// component. Duplicates (same FieldPath) are skipped.
+func pathFlagsFromSegments(segments []api.PathSegment) []Flag {
+	var flags []Flag
+	seen := map[string]bool{}
+	for _, seg := range segments {
+		if seg.Variable == nil || len(seg.Variable.FieldPath) == 0 {
+			continue
+		}
+		name := seg.Variable.FieldPath[len(seg.Variable.FieldPath)-1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		flags = append(flags, pathFlag(name))
+	}
+	return flags
 }

--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -274,3 +274,74 @@ func TestRenderReadme(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandHasFlags(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cmd  Command
+		want bool
+	}{
+		{"empty", Command{}, false},
+		{"with-flag", Command{Flags: []Flag{{Name: "x"}}}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.cmd.HasFlags()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPathFlagsFromSegments(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		segments []api.PathSegment
+		want     []Flag
+	}{
+		{"nil", nil, nil},
+		{
+			"single",
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				Segments,
+			[]Flag{{Name: "project", Kind: "String", Required: true, Usage: "The project."}},
+		},
+		{
+			"multi",
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+				WithLiteral("instances").WithVariable(api.NewPathVariable("instance")).
+				Segments,
+			[]Flag{
+				{Name: "project", Kind: "String", Required: true, Usage: "The project."},
+				{Name: "location", Kind: "String", Required: true, Usage: "The location."},
+				{Name: "instance", Kind: "String", Required: true, Usage: "The instance."},
+			},
+		},
+		{
+			"dedup",
+			(&api.PathTemplate{}).
+				WithLiteral("users").WithVariable(api.NewPathVariable("user")).
+				WithLiteral("users").WithVariable(api.NewPathVariable("user")).
+				Segments,
+			[]Flag{{Name: "user", Kind: "String", Required: true, Usage: "The user."}},
+		},
+		{
+			"trailing-literal",
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				WithLiteral("config").
+				Segments,
+			[]Flag{{Name: "project", Kind: "String", Required: true, Usage: "The project."}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := pathFlagsFromSegments(test.segments)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/gcloud/templates/package/cli.go.mustache
+++ b/internal/sidekick/gcloud/templates/package/cli.go.mustache
@@ -42,6 +42,13 @@ func main() {
 							{
 								Name:  "{{Name}}",
 								Usage: "{{Usage}}",
+								{{#HasFlags}}
+								Flags: []cli.Flag{
+									{{#Flags}}
+									&cli.{{Kind}}Flag{Name: "{{Name}}", Usage: "{{Usage}}", Required: {{Required}}},
+									{{/Flags}}
+								},
+								{{/HasFlags}}
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing {{Name}}...")
 									return nil
@@ -55,6 +62,13 @@ func main() {
 					{
 						Name:  "{{Name}}",
 						Usage: "{{Usage}}",
+						{{#HasFlags}}
+						Flags: []cli.Flag{
+							{{#Flags}}
+							&cli.{{Kind}}Flag{Name: "{{Name}}", Usage: "{{Usage}}", Required: {{Required}}},
+							{{/Flags}}
+						},
+						{{/HasFlags}}
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							fmt.Println("Executing {{Name}}...")
 							return nil

--- a/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
+++ b/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
@@ -24,6 +24,10 @@ func main() {
 							{
 								Name:  "list",
 								Usage: "list instances",
+								Flags: []cli.Flag{
+									&cli.StringFlag{Name: "project", Usage: "The project.", Required: true},
+									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing list...")
 									return nil
@@ -32,6 +36,11 @@ func main() {
 							{
 								Name:  "describe",
 								Usage: "describe instances",
+								Flags: []cli.Flag{
+									&cli.StringFlag{Name: "project", Usage: "The project.", Required: true},
+									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing describe...")
 									return nil
@@ -40,6 +49,10 @@ func main() {
 							{
 								Name:  "create",
 								Usage: "create instances",
+								Flags: []cli.Flag{
+									&cli.StringFlag{Name: "project", Usage: "The project.", Required: true},
+									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing create...")
 									return nil
@@ -48,6 +61,11 @@ func main() {
 							{
 								Name:  "update",
 								Usage: "update instances",
+								Flags: []cli.Flag{
+									&cli.StringFlag{Name: "project", Usage: "The project.", Required: true},
+									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing update...")
 									return nil
@@ -56,6 +74,11 @@ func main() {
 							{
 								Name:  "delete",
 								Usage: "delete instances",
+								Flags: []cli.Flag{
+									&cli.StringFlag{Name: "project", Usage: "The project.", Required: true},
+									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing delete...")
 									return nil
@@ -64,6 +87,11 @@ func main() {
 							{
 								Name:  "import-data",
 								Usage: "import-data instances",
+								Flags: []cli.Flag{
+									&cli.StringFlag{Name: "project", Usage: "The project.", Required: true},
+									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing import-data...")
 									return nil
@@ -72,6 +100,11 @@ func main() {
 							{
 								Name:  "export-data",
 								Usage: "export-data instances",
+								Flags: []cli.Flag{
+									&cli.StringFlag{Name: "project", Usage: "The project.", Required: true},
+									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									fmt.Println("Executing export-data...")
 									return nil


### PR DESCRIPTION
Each generated command now requires one flag per variable in the resource it operates on. For example, a command on an instance gets --project, --location, and --instance. The flag names come from the resource's pattern in the proto annotation.

For https://github.com/googleapis/librarian/issues/5769