### PR TITLE
test(librarianops): force goproxy fallback

### DIFF
--- a/internal/librarianops/upgrade_test.go
+++ b/internal/librarianops/upgrade_test.go
@@ -76,6 +76,8 @@ func TestRunUpgrade(t *testing.T) {
 }
 
 func TestRunUpgrade_Error(t *testing.T) {
+	t.Setenv("GOPROXY", testGoProxyValue)
+
 	for _, test := range []struct {
 		name           string
 		setup          func(t *testing.T) (repoDir string)
@@ -93,7 +95,6 @@ func TestRunUpgrade_Error(t *testing.T) {
 		{
 			name: "UpdateLibrarianVersion error",
 			setup: func(t *testing.T) string {
-				t.Setenv("GOPROXY", testGoProxyValue)
 				// Make writing the config file fail by creating a directory at its path.
 				repoDir := t.TempDir()
 				configPath := generateLibrarianConfigPath(t, repoDir)
@@ -107,7 +108,6 @@ func TestRunUpgrade_Error(t *testing.T) {
 		{
 			name: "runLibrarianWithVersion error",
 			setup: func(t *testing.T) string {
-				t.Setenv("GOPROXY", testGoProxyValue)
 				repoDir := t.TempDir()
 				configPath := generateLibrarianConfigPath(t, repoDir)
 				// Use an invalid config that will cause `librarian generate` to fail.

--- a/internal/librarianops/upgrade_test.go
+++ b/internal/librarianops/upgrade_test.go
@@ -27,7 +27,15 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+// Force Go commands to first consult the official proxy, but fallback to and
+// retry with direct-to-source-control mode if that fails for any reason.
+// This differs from the default value with the same proxies, but which uses
+// a selective fallback mode that only retries on certain 4xx errors.
+// See https://golang.org/cl/226460 for more information.
+const testGoProxyValue = "https://proxy.golang.org|direct"
+
 func TestRunUpgrade(t *testing.T) {
+	t.Setenv("GOPROXY", testGoProxyValue)
 	wantVersion, err := getLibrarianVersionAtMain(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -85,6 +93,7 @@ func TestRunUpgrade_Error(t *testing.T) {
 		{
 			name: "UpdateLibrarianVersion error",
 			setup: func(t *testing.T) string {
+				t.Setenv("GOPROXY", testGoProxyValue)
 				// Make writing the config file fail by creating a directory at its path.
 				repoDir := t.TempDir()
 				configPath := generateLibrarianConfigPath(t, repoDir)
@@ -98,6 +107,7 @@ func TestRunUpgrade_Error(t *testing.T) {
 		{
 			name: "runLibrarianWithVersion error",
 			setup: func(t *testing.T) string {
+				t.Setenv("GOPROXY", testGoProxyValue)
 				repoDir := t.TempDir()
 				configPath := generateLibrarianConfigPath(t, repoDir)
 				// Use an invalid config that will cause `librarian generate` to fail.
@@ -129,6 +139,7 @@ func TestUpgradeCommand(t *testing.T) {
 	// current working directory.
 	repoDir := t.TempDir()
 	t.Chdir(repoDir)
+	t.Setenv("GOPROXY", testGoProxyValue)
 
 	configPath := generateLibrarianConfigPath(t, ".")
 	initialConfig := sample.Config()

--- a/internal/librarianops/upgrade_test.go
+++ b/internal/librarianops/upgrade_test.go
@@ -32,10 +32,10 @@ import (
 // This differs from the default value with the same proxies, but which uses
 // a selective fallback mode that only retries on certain 4xx errors.
 // See https://golang.org/cl/226460 for more information.
-const testGoProxyValue = "https://proxy.golang.org|direct"
+const testRetryingGoProxy = "https://proxy.golang.org|direct"
 
 func TestRunUpgrade(t *testing.T) {
-	t.Setenv("GOPROXY", testGoProxyValue)
+	t.Setenv("GOPROXY", testRetryingGoProxy)
 	wantVersion, err := getLibrarianVersionAtMain(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -76,7 +76,7 @@ func TestRunUpgrade(t *testing.T) {
 }
 
 func TestRunUpgrade_Error(t *testing.T) {
-	t.Setenv("GOPROXY", testGoProxyValue)
+	t.Setenv("GOPROXY", testRetryingGoProxy)
 
 	for _, test := range []struct {
 		name           string
@@ -139,7 +139,7 @@ func TestUpgradeCommand(t *testing.T) {
 	// current working directory.
 	repoDir := t.TempDir()
 	t.Chdir(repoDir)
-	t.Setenv("GOPROXY", testGoProxyValue)
+	t.Setenv("GOPROXY", testRetryingGoProxy)
 
 	configPath := generateLibrarianConfigPath(t, ".")
 	initialConfig := sample.Config()


### PR DESCRIPTION
In `librarianops upgrade` tests, force `GOPROXY` to retry on any error by setting it as documented  in https://golang.org/cl/226460.

The default `GOPROXY` will only fallback & retry when faced with `4xx` errors, but we want it to retry  with `direct` in the face of _any_ error, before exiting.

This doesn't actually fix the integration test dependency on `go` and running a real `librarian` version, but should reduce flakes due to Go proxy/HTTP instability. We'd need to refactor the code and tests to fake the `upgrade` steps. We can explore that if we encounter another flake even after enabling the more expansive fallback/retry mode.

Fixes #5311