### PR TITLE
feat(internal/sidekick/gcloud): compose resource paths in command actions

### DIFF
--- a/internal/sidekick/gcloud/command.go
+++ b/internal/sidekick/gcloud/command.go
@@ -19,6 +19,29 @@ import (
 	"strings"
 )
 
+// Command represents a leaf command.
+type Command struct {
+	Args       []string
+	Flags      []Flag
+	Name       string
+	PathFormat string
+	PathLabel  string
+	Usage      string
+}
+
+// HasPath reports whether the command composes a resource path.
+func (c Command) HasPath() bool { return c.PathFormat != "" }
+
+// PathFormatArgs returns the comma-separated cmd.String("X") arguments
+// passed to the generated [fmt.Sprintf] call.
+func (c Command) PathFormatArgs() string {
+	parts := make([]string, len(c.Args))
+	for i, a := range c.Args {
+		parts[i] = fmt.Sprintf("cmd.String(%q)", a)
+	}
+	return strings.Join(parts, ", ")
+}
+
 // Flag represents a single CLI flag.
 type Flag struct {
 	// Name is the long flag name without leading dashes (e.g. "project").

--- a/internal/sidekick/gcloud/generate.go
+++ b/internal/sidekick/gcloud/generate.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"text/template"
 
 	"github.com/iancoleman/strcase"
@@ -53,13 +54,6 @@ type Subgroup struct {
 	Name     string
 	Usage    string
 	Commands []Command
-}
-
-// Command represents a leaf command.
-type Command struct {
-	Flags []Flag
-	Name  string
-	Usage string
 }
 
 // Generate is the package entry point. It builds the model, renders main.go,
@@ -125,23 +119,19 @@ func constructCLIModel(model *api.API) CLIModel {
 	}
 
 	subgroups := make(map[string]*Subgroup)
-
 	for _, service := range model.Services {
 		for _, method := range service.Methods {
 			binding := provider.PrimaryBinding(method)
 			if binding == nil {
 				continue
 			}
+
 			segments := provider.GetLiteralSegments(binding.PathTemplate.Segments)
 			if len(segments) == 0 {
 				continue
 			}
 
 			subgroupName := strcase.ToKebab(segments[len(segments)-1])
-
-			commandName, _ := provider.GetCommandName(method)
-			commandName = strcase.ToKebab(commandName)
-
 			if subgroups[subgroupName] == nil {
 				subgroups[subgroupName] = &Subgroup{
 					Name:  subgroupName,
@@ -149,6 +139,8 @@ func constructCLIModel(model *api.API) CLIModel {
 				}
 			}
 
+			commandName, _ := provider.GetCommandName(method)
+			commandName = strcase.ToKebab(commandName)
 			cmd := buildCommand(method, model, commandName, subgroupName)
 			subgroups[subgroupName].Commands = append(subgroups[subgroupName].Commands, cmd)
 		}
@@ -158,35 +150,40 @@ func constructCLIModel(model *api.API) CLIModel {
 	for k := range subgroups {
 		keys = append(keys, k)
 	}
+
 	sort.Strings(keys)
 	for _, k := range keys {
 		rootGroup.Subgroups = append(rootGroup.Subgroups, *subgroups[k])
 	}
-
 	return CLIModel{
 		Groups: []Group{rootGroup},
 	}
 }
 
 // buildCommand constructs a Command for a method. The command's flags name
-// each component of the resource the method operates on.
+// each component of the resource the method operates on, and (when the
+// resource has any variables) the path is composed at runtime via
+// [fmt.Sprintf].
 func buildCommand(method *api.Method, model *api.API, commandName, subgroupName string) Command {
-	return Command{
+	segments := resourceSegments(method, model)
+	cmd := Command{
 		Name:  commandName,
 		Usage: fmt.Sprintf("%s %s", commandName, subgroupName),
-		Flags: pathFlagsForMethod(method, model),
+		Flags: pathFlagsFromSegments(segments),
 	}
+	if format := pathFormatFromSegments(segments); format != "" {
+		cmd.PathFormat = format
+		cmd.Args = pathArgsFromSegments(segments)
+		cmd.PathLabel = pathLabel(method)
+	}
+	return cmd
 }
 
-// pathFlagsForMethod returns the required flags that name each component of
-// the resource the method operates on. For collection methods (List,
-// Create, custom collection) it walks up to the parent of the resource
-// pattern; for resource methods it uses the resource pattern directly.
-//
-// The flag name is the last component of each variable segment's
-// FieldPath, per AIP-123. Resources without a pattern, or methods whose
-// resource cannot be resolved, contribute no flags.
-func pathFlagsForMethod(method *api.Method, model *api.API) []Flag {
+// resourceSegments returns the resource pattern segments for a method, or
+// nil when the method's resource cannot be resolved or has no pattern. For
+// collection methods (List, Create, custom collection) the pattern is
+// trimmed to the parent.
+func resourceSegments(method *api.Method, model *api.API) []api.PathSegment {
 	resource := provider.GetResourceForMethod(method, model)
 	if resource == nil || len(resource.Patterns) == 0 {
 		return nil
@@ -197,7 +194,7 @@ func pathFlagsForMethod(method *api.Method, model *api.API) []Flag {
 			segments = parent
 		}
 	}
-	return pathFlagsFromSegments(segments)
+	return segments
 }
 
 // pathFlagsFromSegments returns one required string flag for each variable
@@ -218,4 +215,47 @@ func pathFlagsFromSegments(segments []api.PathSegment) []Flag {
 		flags = append(flags, pathFlag(name))
 	}
 	return flags
+}
+
+// pathFormatFromSegments returns a "/"-joined format string with literals
+// as themselves and variables as "%s", or "" if there are no variables.
+func pathFormatFromSegments(segments []api.PathSegment) string {
+	hasVar := false
+	var parts []string
+	for _, seg := range segments {
+		switch {
+		case seg.Literal != nil:
+			parts = append(parts, *seg.Literal)
+		case seg.Variable != nil && len(seg.Variable.FieldPath) > 0:
+			parts = append(parts, "%s")
+			hasVar = true
+		}
+	}
+	if !hasVar {
+		return ""
+	}
+	return strings.Join(parts, "/")
+}
+
+// pathArgsFromSegments returns the variable names in segment order, one
+// per "%s" position in the format string from pathFormatFromSegments.
+func pathArgsFromSegments(segments []api.PathSegment) []string {
+	var args []string
+	for _, seg := range segments {
+		if seg.Variable == nil || len(seg.Variable.FieldPath) == 0 {
+			continue
+		}
+		args = append(args, seg.Variable.FieldPath[len(seg.Variable.FieldPath)-1])
+	}
+	return args
+}
+
+// pathLabel returns the local variable name used in the generated action
+// to hold the composed path. Collection methods compose the parent path,
+// so the label is "parent"; resource methods compose the resource name.
+func pathLabel(method *api.Method) string {
+	if provider.IsCollectionMethod(method) {
+		return "parent"
+	}
+	return "name"
 }

--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -327,3 +327,121 @@ func TestPathFlagsFromSegments(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandHasPath(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cmd  Command
+		want bool
+	}{
+		{"empty", Command{}, false},
+		{"with-path", Command{PathFormat: "projects/%s"}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.cmd.HasPath()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCommandPathFormatArgs(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cmd  Command
+		want string
+	}{
+		{"empty", Command{}, ""},
+		{"single", Command{Args: []string{"project"}}, `cmd.String("project")`},
+		{
+			"multi",
+			Command{Args: []string{"project", "location", "instance"}},
+			`cmd.String("project"), cmd.String("location"), cmd.String("instance")`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.cmd.PathFormatArgs()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPathFormatFromSegments(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		segments []api.PathSegment
+		want     string
+	}{
+		{"nil", nil, ""},
+		{
+			"no-variable",
+			(&api.PathTemplate{}).WithLiteral("projects").Segments,
+			"",
+		},
+		{
+			"single",
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				Segments,
+			"projects/%s",
+		},
+		{
+			"multi",
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+				WithLiteral("instances").WithVariable(api.NewPathVariable("instance")).
+				Segments,
+			"projects/%s/locations/%s/instances/%s",
+		},
+		{
+			"trailing-literal",
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				WithLiteral("config").
+				Segments,
+			"projects/%s/config",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := pathFormatFromSegments(test.segments)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPathArgsFromSegments(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		segments []api.PathSegment
+		want     []string
+	}{
+		{"nil", nil, nil},
+		{
+			"no-variable",
+			(&api.PathTemplate{}).WithLiteral("projects").Segments,
+			nil,
+		},
+		{
+			"multi",
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+				WithLiteral("instances").WithVariable(api.NewPathVariable("instance")).
+				Segments,
+			[]string{"project", "location", "instance"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := pathArgsFromSegments(test.segments)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/gcloud/templates/package/cli.go.tmpl
+++ b/internal/sidekick/gcloud/templates/package/cli.go.tmpl
@@ -71,7 +71,12 @@ func main() {
 	},
 	{{- end}}
 	Action: func(ctx context.Context, cmd *cli.Command) error {
+		{{- if .HasPath}}
+		{{.PathLabel}} := fmt.Sprintf("{{.PathFormat}}", {{.PathFormatArgs}})
+		fmt.Printf("Executing {{.Name}} on %s\n", {{.PathLabel}})
+		{{- else}}
 		fmt.Println("Executing {{.Name}}...")
+		{{- end}}
 		return nil
 	},
 }

--- a/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
+++ b/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
@@ -29,7 +29,8 @@ func main() {
 									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
-									fmt.Println("Executing list...")
+									parent := fmt.Sprintf("projects/%s/locations/%s", cmd.String("project"), cmd.String("location"))
+									fmt.Printf("Executing list on %s\n", parent)
 									return nil
 								},
 							},
@@ -42,7 +43,8 @@ func main() {
 									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
-									fmt.Println("Executing describe...")
+									name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", cmd.String("project"), cmd.String("location"), cmd.String("instance"))
+									fmt.Printf("Executing describe on %s\n", name)
 									return nil
 								},
 							},
@@ -54,7 +56,8 @@ func main() {
 									&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
-									fmt.Println("Executing create...")
+									parent := fmt.Sprintf("projects/%s/locations/%s", cmd.String("project"), cmd.String("location"))
+									fmt.Printf("Executing create on %s\n", parent)
 									return nil
 								},
 							},
@@ -67,7 +70,8 @@ func main() {
 									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
-									fmt.Println("Executing update...")
+									name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", cmd.String("project"), cmd.String("location"), cmd.String("instance"))
+									fmt.Printf("Executing update on %s\n", name)
 									return nil
 								},
 							},
@@ -80,7 +84,8 @@ func main() {
 									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
-									fmt.Println("Executing delete...")
+									name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", cmd.String("project"), cmd.String("location"), cmd.String("instance"))
+									fmt.Printf("Executing delete on %s\n", name)
 									return nil
 								},
 							},
@@ -93,7 +98,8 @@ func main() {
 									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
-									fmt.Println("Executing import-data...")
+									name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", cmd.String("project"), cmd.String("location"), cmd.String("instance"))
+									fmt.Printf("Executing import-data on %s\n", name)
 									return nil
 								},
 							},
@@ -106,7 +112,8 @@ func main() {
 									&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
-									fmt.Println("Executing export-data...")
+									name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", cmd.String("project"), cmd.String("location"), cmd.String("instance"))
+									fmt.Printf("Executing export-data on %s\n", name)
 									return nil
 								},
 							},


### PR DESCRIPTION
Each generated command that operates on a resource now builds its resource path at runtime and prints it. For example, `describe instances` now reads `--project`, `--location`, and `--instance` and prints "Executing describe on projects/X/locations/Y/instances/Z". Commands without a resolvable resource continue printing the plain "Executing X..." line

For https://github.com/googleapis/librarian/issues/5769