### PR TITLE
feat(internal/librarian): use Python-specific existing library detection in add

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -147,46 +147,55 @@ func deriveLibraryName(language string, api string) string {
 }
 
 // addLibrary adds a new library to the config based on the provided API.
-// It returns the name of the new library, the updated config, and an error
-// if the library already exists.
+// It returns the name of the new or updated library, the updated config, and an
+// error if the API cannot be added (e.g. because it already exists, or the new
+// API is a preview and there is no corresponding stable library).
 func addLibrary(cfg *config.Config, apiPath string) (string, *config.Config, error) {
 	isPreview := strings.HasPrefix(apiPath, "preview/")
-
 	stablePath := apiPath
 	if isPreview {
 		stablePath = strings.TrimPrefix(apiPath, "preview/")
 	}
-	name := deriveLibraryName(cfg.Language, stablePath)
 	api := &config.API{Path: stablePath}
-	existingLib, err := FindLibrary(cfg, name)
-	var exists bool
-	switch {
-	case err == nil:
-		exists = true
-	case errors.Is(err, ErrLibraryNotFound):
-		exists = false
-	default:
-		return "", nil, err
-	}
+	existingLib := findExistingLibraryForNewAPI(cfg, stablePath)
 	if isPreview {
-		if !exists {
-			return "", nil, fmt.Errorf("%s: %w", name, errPreviewRequiresLibrary)
+		if existingLib == nil {
+			return "", nil, fmt.Errorf("%w: API path %s", errPreviewRequiresLibrary, apiPath)
 		}
-		return addPreviewLibrary(cfg, existingLib, api, name)
+		return addPreviewLibrary(cfg, existingLib, api)
 	}
-	if exists {
-		if cfg.Language != config.LanguageGo && cfg.Language != config.LanguagePython {
-			return "", nil, fmt.Errorf("%w: %s", errLibraryAlreadyExists, name)
-		}
+	if existingLib != nil {
 		return updateExistingLibrary(cfg, existingLib, api)
 	}
-	return addNewLibrary(cfg, api, name)
+	return addNewLibrary(cfg, api)
+}
+
+// findExistingLibraryForNewAPI determines if an existing library in cfg is
+// the natural library to contain apiPath, and returns it if so. If no existing
+// library is found, nil is returned. In most languages this check is performed
+// by deriving the library name from the API path and seeing if that library
+// already exists. In Python the mapping from API path to library name isn't
+// always as simple for historical reasons.
+func findExistingLibraryForNewAPI(cfg *config.Config, apiPath string) *config.Library {
+	switch cfg.Language {
+	case config.LanguagePython:
+		return python.FindExistingLibraryForNewAPI(cfg.Libraries, apiPath)
+	default:
+		name := deriveLibraryName(cfg.Language, apiPath)
+		// Not using FindLibrary as the error handling becomes awkward.
+		for _, library := range cfg.Libraries {
+			if library.Name == name {
+				return library
+			}
+		}
+		return nil
+	}
 }
 
 // addPreviewLibrary adds a new preview library to the config.
-func addPreviewLibrary(cfg *config.Config, lib *config.Library, api *config.API, name string) (string, *config.Config, error) {
+func addPreviewLibrary(cfg *config.Config, lib *config.Library, api *config.API) (string, *config.Config, error) {
 	if lib.Preview != nil {
-		return "", nil, fmt.Errorf("%s: %w", name, errPreviewAlreadyExists)
+		return "", nil, fmt.Errorf("%w: %s", errPreviewAlreadyExists, lib.Name)
 	}
 	// Derive an initial version for the preview client, starting from the
 	// containing stable client's version as if it were a preview, then
@@ -201,11 +210,12 @@ func addPreviewLibrary(cfg *config.Config, lib *config.Library, api *config.API,
 		Version: v,
 		APIs:    []*config.API{api},
 	}
-	return name, cfg, nil
+	return lib.Name, cfg, nil
 }
 
 // addNewLibrary adds a new library to the config.
-func addNewLibrary(cfg *config.Config, api *config.API, name string) (string, *config.Config, error) {
+func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config, error) {
+	name := deriveLibraryName(cfg.Language, api.Path)
 	lib := &config.Library{
 		Name:          name,
 		CopyrightYear: strconv.Itoa(time.Now().Year()),
@@ -238,12 +248,17 @@ func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api 
 	if slices.ContainsFunc(existingLib.APIs, func(a *config.API) bool { return api.Path == a.Path }) {
 		return "", nil, fmt.Errorf("%w: %s in library %s", errAPIAlreadyExists, api.Path, existingLib.Name)
 	}
-	if cfg.Language == config.LanguagePython {
+	switch cfg.Language {
+	case config.LanguagePython:
 		if err := python.ValidateNewAPIs(existingLib); err != nil {
 			return "", nil, err
 		}
+		existingLib.APIs = append(existingLib.APIs, api)
+	case config.LanguageGo:
+		existingLib.APIs = append(existingLib.APIs, api)
+	default:
+		return "", nil, fmt.Errorf("%w: %s", errLibraryAlreadyExists, existingLib.Name)
 	}
-	existingLib.APIs = append(existingLib.APIs, api)
 	return existingLib.Name, cfg, nil
 }
 

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -299,16 +299,20 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 			},
 		},
 		{
-			name:    "update existing library (python)",
-			apiPath: "google/cloud/kms/v1beta2",
+			name: "update existing library (python)",
+			// The API path here deliberately doesn't match the library name,
+			// to demonstrate that we're finding the right library based on
+			// existing API paths.
+			apiPath: "google/firestore/queries/v1beta2",
 			cfg: &config.Config{
 				Language: config.LanguagePython,
 				Libraries: []*config.Library{
 					{
-						Name:    "google-cloud-kms",
+						Name:    "google-cloud-firestore",
 						Version: "1.2.3",
 						APIs: []*config.API{
-							{Path: "google/cloud/kms/v1"},
+							{Path: "google/firestore/admin/v2"},
+							{Path: "google/firestore/v1"},
 						},
 						Python: &config.PythonPackage{
 							DefaultVersion: "v1",
@@ -316,16 +320,17 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 					},
 				},
 			},
-			wantName: "google-cloud-kms",
+			wantName: "google-cloud-firestore",
 			wantCfg: &config.Config{
 				Language: config.LanguagePython,
 				Libraries: []*config.Library{
 					{
-						Name:    "google-cloud-kms",
+						Name:    "google-cloud-firestore",
 						Version: "1.2.3",
 						APIs: []*config.API{
-							{Path: "google/cloud/kms/v1"},
-							{Path: "google/cloud/kms/v1beta2"},
+							{Path: "google/firestore/admin/v2"},
+							{Path: "google/firestore/v1"},
+							{Path: "google/firestore/queries/v1beta2"},
 						},
 						Python: &config.PythonPackage{
 							DefaultVersion: "v1",
@@ -391,7 +396,6 @@ func TestAddLibrary_ExistingLibrary_Error(t *testing.T) {
 						Version: "1.2.3",
 						APIs: []*config.API{
 							{Path: "google/cloud/secretmanager/v1"},
-							{Path: "google/cloud/secretmanager/v1beta2"},
 						},
 					},
 				},


### PR DESCRIPTION
The addLibrary function is refactored for simplicity, so that it only performs high-level operations. It delegates to a new findExistingLibraryForNewAPI function to find an existing library that should include a new API. The new function uses the existing "derive the library name and find an existing library with that name" logic for most languages, but delegates to a dedicated function for Python, which uses the existing API paths.

Additionally, error formatting is updated to follow the style guide so that sentinel errors are always wrapped at the start of error messages. The error message when a preview library is being added without an existing library is modified to specfy the API path rather than the expected library name.

Fixes #5669