### PR TITLE
feat(sidekick/rust): gate generated doc samples with run_all_samples

### DIFF
--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -223,6 +223,46 @@ func TestRustFromProtobuf(t *testing.T) {
 	importsModelModules(t, path.Join(outDir, "src", "model.rs"))
 }
 
+func TestRustSamplesUseRunAllSamplesFeature(t *testing.T) {
+	requireProtoc(t)
+	outDir := t.TempDir()
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: libconfig.SpecProtobuf,
+		ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+		SpecificationSource: "google/cloud/secretmanager/v1",
+		Source: &sources.SourceConfig{
+			Sources: &sources.Sources{
+				Googleapis: path.Join(testdataDir, "googleapis"),
+			},
+			ActiveRoots: []string{"googleapis"},
+		},
+		Codec: map[string]string{
+			"package:wkt":                 "source=google.protobuf,package=google-cloud-wkt",
+			"package:google-cloud-api":    "source=google.api,package=google-cloud-api",
+			"generate-setter-samples":     "true",
+			"generate-rpc-samples":        "true",
+			"quickstart-service-override": "SecretManagerService",
+		},
+	}
+	model, err := parser.CreateModel(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !generatedTreeContains(t, outDir, `run_all_samples = []`) {
+		t.Fatalf("generated files in %s do not declare run_all_samples feature", outDir)
+	}
+	if !generatedTreeContains(t, outDir, `#[cfg(feature = "run_all_samples")]`) {
+		t.Fatalf("generated files in %s do not feature-gate samples with run_all_samples", outDir)
+	}
+	if generatedTreeContains(t, outDir, "```ignore,no_run") {
+		t.Fatalf("generated files in %s still contain ignore,no_run samples", outDir)
+	}
+}
+
 func TestRustClient(t *testing.T) {
 	requireProtoc(t)
 	for _, override := range []string{"http-client", "grpc-client"} {
@@ -472,4 +512,30 @@ func requireProtoc(t *testing.T) {
 	if _, err := exec.LookPath("protoc"); err != nil {
 		t.Skip("skipping test because protoc is not installed")
 	}
+}
+
+func generatedTreeContains(t *testing.T, root, needle string) bool {
+	t.Helper()
+	found := false
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		contents, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(contents), needle) {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil && err != fs.SkipAll {
+		t.Fatal(err)
+	}
+	return found
 }

--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -37,9 +37,9 @@ publish                = false
 [lints]
 workspace = true
 {{/Codec.DetailedTracingAttributes}}
-{{#Codec.HasServices}}
-
 [features]
+run_all_samples = []
+{{#Codec.HasServices}}
 default = [
     "default-rustls-provider",
     {{#Codec.DefaultFeatures}}
@@ -57,7 +57,6 @@ default-rustls-provider = ["gaxi/_default-rustls-provider"]
 {{Codec.FeatureName}} = []
 {{/Codec.Services}}
 {{/Codec.PerServiceFeatures}}
-
 {{! We want docs for all features, not just the default features. }}
 [package.metadata.docs.rs]
 all-features = true

--- a/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
@@ -21,12 +21,13 @@ limitations under the License.
 /// # use {{Service.Model.Codec.PackageNamespace}}::client::{{Service.Codec.Name}};
 {{> /templates/common/client_method_samples/use_statements}}
 /// use {{Service.Model.Codec.PackageNamespace}}::Result;
-/// async fn sample(
+/// # #[cfg(feature = "run_all_samples")]
+/// # async fn sample(
 {{> /templates/common/client_method_samples/parameters}}
 /// ) -> Result<()> {
 {{> /templates/common/client_method_samples/method_call}}
-///     Ok(())
-/// }
+/// #     Ok(())
+/// # }
 /// ```
 {{/IsStreaming}}
 {{/ModelCodec.GenerateRpcSamples}}

--- a/internal/sidekick/rust/templates/common/quickstart.mustache
+++ b/internal/sidekick/rust/templates/common/quickstart.mustache
@@ -23,7 +23,8 @@ limitations under the License.
 {{> /templates/common/client_method_samples/use_statements}}
 {{/QuickstartMethod}}
 {{/Model.Codec.GenerateRpcSamples}}
-/// async fn sample(
+/// # #[cfg(feature = "run_all_samples")]
+/// # async fn sample(
 {{#Model.Codec.GenerateRpcSamples}}
 {{#QuickstartMethod}}
 {{#SampleInfo}}
@@ -46,7 +47,7 @@ limitations under the License.
 {{^Model.Codec.GenerateRpcSamples}}
 ///     // use `client` to make requests to the {{Codec.APITitle}}.
 {{/Model.Codec.GenerateRpcSamples}}
-///     Ok(())
-/// }
+/// #     Ok(())
+/// # }
 /// ```
 {{/Model.Codec.InternalBuilders}}

--- a/internal/sidekick/rust/templates/common/setter_preamble/map.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/map.mustache
@@ -17,8 +17,11 @@ limitations under the License.
 {{#ModelCodec.GenerateSetterSamples}}
 ///
 /// # Example
-/// ```ignore,no_run
+/// ```
+/// # #[cfg(feature = "run_all_samples")]
+/// # fn sample() {
 {{> /templates/common/setter_preamble/map_samples}}
+/// # }
 /// ```
 {{/ModelCodec.GenerateSetterSamples}}
 {{#Deprecated}}

--- a/internal/sidekick/rust/templates/common/setter_preamble/oneof.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/oneof.mustache
@@ -20,7 +20,9 @@ limitations under the License.
 {{#ModelCodec.GenerateSetterSamples}}
 ///
 /// # Example
-/// ```ignore,no_run
+/// ```
+/// # #[cfg(feature = "run_all_samples")]
+/// # fn sample() {
 {{#ExampleField}}
 {{#IsString}}
 /// # use {{Parent.Codec.NameInExamples}};
@@ -77,5 +79,6 @@ limitations under the License.
 ///     {{{Group.Codec.NameInExamples}}}::{{Codec.BranchName}}({{Codec.MessageNameInExamples}}::default().into())));
 {{/IsObject}}
 {{/ExampleField}}
+/// # }
 /// ```
 {{/ModelCodec.GenerateSetterSamples}}

--- a/internal/sidekick/rust/templates/common/setter_preamble/oneof_variants.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/oneof_variants.mustache
@@ -22,7 +22,9 @@ limitations under the License.
 {{#Singular}}
 ///
 /// # Example
-/// ```ignore,no_run
+/// ```
+/// # #[cfg(feature = "run_all_samples")]
+/// # fn sample() {
 {{> /templates/common/setter_preamble/singular_value_samples}}
 {{#IsEnum}}
 {{#Codec.IsWktNullValue}}
@@ -46,6 +48,7 @@ limitations under the License.
 /// assert!(x.{{Codec.FieldName}}().is_none());
 {{/Codec.OtherFieldsInGroup}}
 {{/IsEnum}}
+/// # }
 /// ```
 {{/Singular}}
 {{/ModelCodec.GenerateSetterSamples}}

--- a/internal/sidekick/rust/templates/common/setter_preamble/repeated.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/repeated.mustache
@@ -17,8 +17,11 @@ limitations under the License.
 {{#ModelCodec.GenerateSetterSamples}}
 ///
 /// # Example
-/// ```ignore,no_run
+/// ```
+/// # #[cfg(feature = "run_all_samples")]
+/// # fn sample() {
 {{> /templates/common/setter_preamble/repeated_samples}}
+/// # }
 /// ```
 {{/ModelCodec.GenerateSetterSamples}}
 {{#Deprecated}}

--- a/internal/sidekick/rust/templates/common/setter_preamble/singular_option.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/singular_option.mustache
@@ -17,7 +17,9 @@ limitations under the License.
 {{#ModelCodec.GenerateSetterSamples}}
 ///
 /// # Example
-/// ```ignore,no_run
+/// ```
+/// # #[cfg(feature = "run_all_samples")]
+/// # fn sample() {
 {{#IsString}}
 /// # use {{Parent.Codec.NameInExamples}};
 /// let x = {{Parent.Codec.Name}}::new().set_or_clear_{{Codec.SetterName}}(Some("example"));
@@ -72,6 +74,7 @@ limitations under the License.
 /// let x = {{Parent.Codec.Name}}::new().set_or_clear_{{Codec.SetterName}}(Some({{Codec.MessageNameInExamples}}::default()/* use setters */));
 /// let x = {{Parent.Codec.Name}}::new().set_or_clear_{{Codec.SetterName}}(None::<{{Codec.MessageNameInExamples}}>);
 {{/IsObject}}
+/// # }
 /// ```
 {{/ModelCodec.GenerateSetterSamples}}
 {{#Deprecated}}

--- a/internal/sidekick/rust/templates/common/setter_preamble/singular_value.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/singular_value.mustache
@@ -17,8 +17,11 @@ limitations under the License.
 {{#ModelCodec.GenerateSetterSamples}}
 ///
 /// # Example
-/// ```ignore,no_run
+/// ```
+/// # #[cfg(feature = "run_all_samples")]
+/// # fn sample() {
 {{> /templates/common/setter_preamble/singular_value_samples}}
+/// # }
 /// ```
 {{/ModelCodec.GenerateSetterSamples}}
 {{#Deprecated}}


### PR DESCRIPTION
This updates the Rust generator to emit feature-gated doc samples using
`run_all_samples` instead of `ignore,no_run`.

Changes:
- add `run_all_samples` to generated Rust crate features
- gate generated RPC and quickstart samples with `#[cfg(feature = "run_all_samples")]`
- gate generated setter samples with the same pattern
- add generator coverage to verify generated output contains the new pattern and no longer emits `ignore,no_run`

Related:
- https://github.com/googleapis/google-cloud-rust/issues/5500

Testing:
- `gofmt -s -w .`
- `go tool goimports -w .`
- `go tool golangci-lint run`
- `go test -race ./internal/sidekick/rust`

Notes:
- Full repo-wide `go test -short ./...` / `go test -race ./...` were not clean in this environment because the root `TestGoGenerate` rejects a dirty worktree after `go generate`, and the full race run later hit local disk-space limits.