### PR TITLE
feat(internal/sidekick/gcloud): call the Go client in describe command

### DIFF
--- a/internal/sidekick/gcloud/command.go
+++ b/internal/sidekick/gcloud/command.go
@@ -22,11 +22,36 @@ import (
 // Command represents a leaf command.
 type Command struct {
 	Args       []string
+	ClientCall *ClientCall
 	Flags      []Flag
 	Name       string
 	PathFormat string
 	PathLabel  string
 	Usage      string
+}
+
+// ClientCall describes a Go client method invocation that should replace the
+// default print-only action for a generated command.
+type ClientCall struct {
+	// Method is the unqualified client method to call on the constructed
+	// client, for example "GetInstance". The template invokes it as
+	// `client.<Method>(ctx, &<RequestType>{...})`.
+	Method string
+
+	// NameField is the field on the request message that takes the
+	// composed resource path, for example "Name" for AIP-131 Get requests.
+	// The template assigns it from the local path variable.
+	NameField string
+
+	// Package is the import alias of the Go client package, for example
+	// "parallelstore". The template invokes the constructor as
+	// `client, err := <Package>.NewClient(ctx)`.
+	Package string
+
+	// RequestType is the qualified request message type, for example
+	// "parallelstorepb.GetInstanceRequest". The template composites a
+	// literal of this type and passes its address to the method.
+	RequestType string
 }
 
 // HasPath reports whether the command composes a resource path.

--- a/internal/sidekick/gcloud/generate.go
+++ b/internal/sidekick/gcloud/generate.go
@@ -38,7 +38,24 @@ var templates embed.FS
 
 // CLIModel represents the data structure for the template.
 type CLIModel struct {
+	// Imports holds the Go imports rendered into the generated main.go.
+	Imports []Import
+
+	// Groups holds the top-level gcloud command groups rendered into main.go.
 	Groups []Group
+}
+
+// Import represents a Go import line in the generated main.go.
+type Import struct {
+	// Alias is the optional package alias; empty when the import has no
+	// alias. For example, "parallelstore" in:
+	//
+	//	parallelstore "cloud.google.com/go/parallelstore/apiv1"
+	Alias string
+
+	// Path is the import path of the package, for example
+	// "cloud.google.com/go/parallelstore/apiv1".
+	Path string
 }
 
 // Group represents a gcloud command group.
@@ -118,7 +135,12 @@ func constructCLIModel(model *api.API) CLIModel {
 		Usage: fmt.Sprintf("manage %s resources", model.Title),
 	}
 
-	subgroups := make(map[string]*Subgroup)
+	var (
+		cliModel      CLIModel
+		goClient      = goClientPackage(model.PackageName)
+		hasClientCall = false
+		subgroups     = make(map[string]*Subgroup)
+	)
 	for _, service := range model.Services {
 		for _, method := range service.Methods {
 			binding := provider.PrimaryBinding(method)
@@ -142,7 +164,19 @@ func constructCLIModel(model *api.API) CLIModel {
 			commandName, _ := provider.GetCommandName(method)
 			commandName = strcase.ToKebab(commandName)
 			cmd := buildCommand(method, model, commandName, subgroupName)
+
+			if call := buildClientCall(method, goClient, cmd.HasPath()); call != nil {
+				cmd.ClientCall = call
+				hasClientCall = true
+			}
 			subgroups[subgroupName].Commands = append(subgroups[subgroupName].Commands, cmd)
+		}
+	}
+
+	if hasClientCall {
+		cliModel.Imports = []Import{
+			{Alias: goClient.Alias, Path: goClient.ClientPath},
+			{Path: goClient.PbPath},
 		}
 	}
 
@@ -155,9 +189,98 @@ func constructCLIModel(model *api.API) CLIModel {
 	for _, k := range keys {
 		rootGroup.Subgroups = append(rootGroup.Subgroups, *subgroups[k])
 	}
-	return CLIModel{
-		Groups: []Group{rootGroup},
+	cliModel.Groups = []Group{rootGroup}
+	return cliModel
+}
+
+// buildClientCall returns a ClientCall for an AIP-131 Get method when the
+// model maps to a standard GAPIC Go package and the command composes a
+// resource path. It returns nil otherwise so the command keeps its
+// print-only action.
+func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *ClientCall {
+	if goClient == nil || !hasPath {
+		return nil
 	}
+	if !provider.IsGet(method) {
+		return nil
+	}
+	if method.InputType == nil {
+		return nil
+	}
+	return &ClientCall{
+		Method:      method.Name,
+		NameField:   "Name",
+		Package:     goClient.Alias,
+		RequestType: goClient.Alias + "pb." + method.InputType.Name,
+	}
+}
+
+// goClientInfo describes the Go client and proto-Go packages for a proto
+// package like "google.cloud.parallelstore.v1".
+type goClientInfo struct {
+	// Alias is the short name used as the import alias for the client
+	// package, for example "parallelstore". The proto-Go package is
+	// imported as Alias+"pb" (e.g. "parallelstorepb").
+	Alias string
+
+	// ClientPath is the import path of the GAPIC Go client package, for
+	// example "cloud.google.com/go/parallelstore/apiv1".
+	ClientPath string
+
+	// PbPath is the import path of the proto-Go package, for example
+	// "cloud.google.com/go/parallelstore/apiv1/parallelstorepb".
+	PbPath string
+}
+
+// goClientPackage maps a proto package name like "google.cloud.parallelstore.v1"
+// to its Go client (apiv1) and proto-Go (apiv1/parallelstorepb) packages.
+// It returns nil when the proto package does not have the shape
+// google.cloud.<short>.v<N>. Beta and alpha suffixes (e.g. v1beta1) are
+// intentionally excluded for now.
+func goClientPackage(protoPkg string) *goClientInfo {
+	rest, ok := strings.CutPrefix(protoPkg, "google.cloud.")
+	if !ok {
+		return nil
+	}
+	short, version, ok := strings.Cut(rest, ".")
+	if !ok || !isLowerAlphanum(short) || !isStableVersion(version) {
+		return nil
+	}
+	return &goClientInfo{
+		Alias:      short,
+		ClientPath: fmt.Sprintf("cloud.google.com/go/%s/api%s", short, version),
+		PbPath:     fmt.Sprintf("cloud.google.com/go/%s/api%s/%spb", short, version, short),
+	}
+}
+
+// isLowerAlphanum reports whether s starts with a lowercase letter and
+// contains only lowercase letters and digits.
+func isLowerAlphanum(s string) bool {
+	if s == "" || s[0] < 'a' || s[0] > 'z' {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+// isStableVersion reports whether s is a stable proto version like "v1" or
+// "v2": a "v" followed by one or more digits, with no alpha/beta suffix.
+func isStableVersion(s string) bool {
+	digits, ok := strings.CutPrefix(s, "v")
+	if !ok || digits == "" {
+		return false
+	}
+	for i := 0; i < len(digits); i++ {
+		if digits[i] < '0' || digits[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // buildCommand constructs a Command for a method. The command's flags name

--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -415,6 +415,44 @@ func TestPathFormatFromSegments(t *testing.T) {
 	}
 }
 
+func TestGoClientPackage(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		protoPkg string
+		want     *goClientInfo
+	}{
+		{
+			name:     "parallelstore",
+			protoPkg: "google.cloud.parallelstore.v1",
+			want: &goClientInfo{
+				Alias:      "parallelstore",
+				ClientPath: "cloud.google.com/go/parallelstore/apiv1",
+				PbPath:     "cloud.google.com/go/parallelstore/apiv1/parallelstorepb",
+			},
+		},
+		{
+			name:     "secretmanager",
+			protoPkg: "google.cloud.secretmanager.v1",
+			want: &goClientInfo{
+				Alias:      "secretmanager",
+				ClientPath: "cloud.google.com/go/secretmanager/apiv1",
+				PbPath:     "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb",
+			},
+		},
+		{name: "empty", protoPkg: ""},
+		{name: "three-segments", protoPkg: "google.cloud.parallelstore"},
+		{name: "beta-version", protoPkg: "google.cloud.parallelstore.v1beta1"},
+		{name: "not-google-cloud", protoPkg: "google.api.X.v1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := goClientPackage(test.protoPkg)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestPathArgsFromSegments(t *testing.T) {
 	for _, test := range []struct {
 		name     string

--- a/internal/sidekick/gcloud/templates/package/cli.go.tmpl
+++ b/internal/sidekick/gcloud/templates/package/cli.go.tmpl
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli/v3"
+{{range .Imports}}	{{if .Alias}}{{.Alias}} {{end}}"{{.Path}}"
+{{end}}	"github.com/urfave/cli/v3"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func main() {
@@ -71,13 +73,31 @@ func main() {
 	},
 	{{- end}}
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		{{- if .HasPath}}
+		{{- if .ClientCall}}
+		{{.PathLabel}} := fmt.Sprintf("{{.PathFormat}}", {{.PathFormatArgs}})
+		client, err := {{.ClientCall.Package}}.NewClient(ctx)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+		resp, err := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })
+		if err != nil {
+			return err
+		}
+		out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(resp)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+		return nil
+		{{- else if .HasPath}}
 		{{.PathLabel}} := fmt.Sprintf("{{.PathFormat}}", {{.PathFormatArgs}})
 		fmt.Printf("Executing {{.Name}} on %s\n", {{.PathLabel}})
+		return nil
 		{{- else}}
 		fmt.Println("Executing {{.Name}}...")
-		{{- end}}
 		return nil
+		{{- end}}
 	},
 }
 {{- end}}

--- a/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
+++ b/internal/sidekick/gcloud/testdata/parallelstore/main.go.golden
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"os"
 
+	parallelstore "cloud.google.com/go/parallelstore/apiv1"
+	"cloud.google.com/go/parallelstore/apiv1/parallelstorepb"
 	"github.com/urfave/cli/v3"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func main() {
@@ -44,7 +47,20 @@ func main() {
 								},
 								Action: func(ctx context.Context, cmd *cli.Command) error {
 									name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", cmd.String("project"), cmd.String("location"), cmd.String("instance"))
-									fmt.Printf("Executing describe on %s\n", name)
+									client, err := parallelstore.NewClient(ctx)
+									if err != nil {
+										return err
+									}
+									defer client.Close()
+									resp, err := client.GetInstance(ctx, &parallelstorepb.GetInstanceRequest{Name: name})
+									if err != nil {
+										return err
+									}
+									out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(resp)
+									if err != nil {
+										return err
+									}
+									fmt.Println(string(out))
 									return nil
 								},
 							},


### PR DESCRIPTION
A generated describe command used to print the resource path and return. It now creates the Go client for the API, fetches the resource, and prints the response. The generator picks the Go client package and request type from the proto package name. 