### PR TITLE
refactor(internal/sidekick/surfer): remove writer object oriented boiler plate

### DIFF
--- a/internal/sidekick/surfer/surface_writer.go
+++ b/internal/sidekick/surfer/surface_writer.go
@@ -25,22 +25,23 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-type surfaceWriter struct {
-	outputDir  string
-	baseModule string
-	tracks     []ReleaseTrack
+// SurfaceWriterConfig contains the configuration required to write a command surface.
+type SurfaceWriterConfig struct {
+	OutputDir  string
+	BaseModule string
+	Tracks     []ReleaseTrack
 }
 
 func writeSurface(outputDir string, baseModule string, surface *Surface) error {
-	w := &surfaceWriter{
-		outputDir:  outputDir,
-		baseModule: baseModule,
-		tracks:     surface.Tracks,
+	cfg := &SurfaceWriterConfig{
+		OutputDir:  outputDir,
+		BaseModule: baseModule,
+		Tracks:     surface.Tracks,
 	}
-	return w.writeGroup(surface.Root, nil)
+	return writeGroup(cfg, surface.Root, nil)
 }
 
-func (w *surfaceWriter) writeGroup(g *CommandGroup, parentPath []string) error {
+func writeGroup(cfg *SurfaceWriterConfig, g *CommandGroup, parentPath []string) error {
 	if g == nil {
 		return nil
 	}
@@ -49,44 +50,44 @@ func (w *surfaceWriter) writeGroup(g *CommandGroup, parentPath []string) error {
 	copy(path, parentPath)
 	path = append(path, strcase.ToSnake(g.FileName))
 
-	groupDir := filepath.Join(w.outputDir, filepath.Join(path...))
+	groupDir := filepath.Join(cfg.OutputDir, filepath.Join(path...))
 	if err := os.MkdirAll(groupDir, 0755); err != nil {
 		return err
 	}
 
-	if err := w.writeCommandGroupFile(g, path); err != nil {
+	if err := writeCommandGroupFile(cfg, g, path); err != nil {
 		return err
 	}
 
-	if err := w.writeGroupCommands(g, path); err != nil {
+	if err := writeGroupCommands(cfg, g, path); err != nil {
 		return err
 	}
 
-	return w.writeGroupSubgroups(g, path)
+	return writeGroupSubgroups(cfg, g, path)
 }
 
-func (w *surfaceWriter) writeGroupCommands(g *CommandGroup, path []string) error {
-	groupDir := filepath.Join(w.outputDir, filepath.Join(path...))
+func writeGroupCommands(cfg *SurfaceWriterConfig, g *CommandGroup, path []string) error {
+	groupDir := filepath.Join(cfg.OutputDir, filepath.Join(path...))
 
 	for verb, cmd := range g.Commands {
-		if err := writeCommandFiles(groupDir, verb, cmd, w.tracks); err != nil {
+		if err := writeCommandFiles(groupDir, verb, cmd, cfg.Tracks); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *surfaceWriter) writeGroupSubgroups(g *CommandGroup, path []string) error {
+func writeGroupSubgroups(cfg *SurfaceWriterConfig, g *CommandGroup, path []string) error {
 	for _, subGroup := range g.Groups {
-		if err := w.writeGroup(subGroup, path); err != nil {
+		if err := writeGroup(cfg, subGroup, path); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *surfaceWriter) writeCommandGroupFile(g *CommandGroup, path []string) error {
-	groupDir := filepath.Join(w.outputDir, filepath.Join(path...))
+func writeCommandGroupFile(cfg *SurfaceWriterConfig, g *CommandGroup, path []string) error {
+	groupDir := filepath.Join(cfg.OutputDir, filepath.Join(path...))
 	if err := os.MkdirAll(groupDir, 0755); err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (w *surfaceWriter) writeCommandGroupFile(g *CommandGroup, path []string) er
 
 	primaryHelpText := g.HelpText
 	var trackViews []trackView
-	for _, t := range w.tracks {
+	for _, t := range cfg.Tracks {
 		var suffix string
 		switch t {
 		case GA:
@@ -109,8 +110,8 @@ func (w *surfaceWriter) writeCommandGroupFile(g *CommandGroup, path []string) er
 	}
 
 	modulePathParts := make([]string, 0, 2+len(path))
-	if w.baseModule != "" {
-		modulePathParts = append(modulePathParts, w.baseModule)
+	if cfg.BaseModule != "" {
+		modulePathParts = append(modulePathParts, cfg.BaseModule)
 		modulePathParts = append(modulePathParts, "surface")
 	}
 	modulePathParts = append(modulePathParts, path...)

--- a/internal/sidekick/surfer/surface_writer.go
+++ b/internal/sidekick/surfer/surface_writer.go
@@ -25,23 +25,23 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// SurfaceWriterConfig contains the configuration required to write a command surface.
-type SurfaceWriterConfig struct {
-	OutputDir  string
-	BaseModule string
-	Tracks     []ReleaseTrack
+// surfaceWriterConfig contains the configuration required to write a command surface.
+type surfaceWriterConfig struct {
+	outputDir  string
+	baseModule string
+	tracks     []ReleaseTrack
 }
 
 func writeSurface(outputDir string, baseModule string, surface *Surface) error {
-	cfg := &SurfaceWriterConfig{
-		OutputDir:  outputDir,
-		BaseModule: baseModule,
-		Tracks:     surface.Tracks,
+	cfg := &surfaceWriterConfig{
+		outputDir:  outputDir,
+		baseModule: baseModule,
+		tracks:     surface.Tracks,
 	}
 	return writeGroup(cfg, surface.Root, nil)
 }
 
-func writeGroup(cfg *SurfaceWriterConfig, g *CommandGroup, parentPath []string) error {
+func writeGroup(cfg *surfaceWriterConfig, g *CommandGroup, parentPath []string) error {
 	if g == nil {
 		return nil
 	}
@@ -50,7 +50,7 @@ func writeGroup(cfg *SurfaceWriterConfig, g *CommandGroup, parentPath []string) 
 	copy(path, parentPath)
 	path = append(path, strcase.ToSnake(g.FileName))
 
-	groupDir := filepath.Join(cfg.OutputDir, filepath.Join(path...))
+	groupDir := filepath.Join(cfg.outputDir, filepath.Join(path...))
 	if err := os.MkdirAll(groupDir, 0755); err != nil {
 		return err
 	}
@@ -66,18 +66,18 @@ func writeGroup(cfg *SurfaceWriterConfig, g *CommandGroup, parentPath []string) 
 	return writeGroupSubgroups(cfg, g, path)
 }
 
-func writeGroupCommands(cfg *SurfaceWriterConfig, g *CommandGroup, path []string) error {
-	groupDir := filepath.Join(cfg.OutputDir, filepath.Join(path...))
+func writeGroupCommands(cfg *surfaceWriterConfig, g *CommandGroup, path []string) error {
+	groupDir := filepath.Join(cfg.outputDir, filepath.Join(path...))
 
 	for verb, cmd := range g.Commands {
-		if err := writeCommandFiles(groupDir, verb, cmd, cfg.Tracks); err != nil {
+		if err := writeCommandFiles(groupDir, verb, cmd, cfg.tracks); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func writeGroupSubgroups(cfg *SurfaceWriterConfig, g *CommandGroup, path []string) error {
+func writeGroupSubgroups(cfg *surfaceWriterConfig, g *CommandGroup, path []string) error {
 	for _, subGroup := range g.Groups {
 		if err := writeGroup(cfg, subGroup, path); err != nil {
 			return err
@@ -86,8 +86,8 @@ func writeGroupSubgroups(cfg *SurfaceWriterConfig, g *CommandGroup, path []strin
 	return nil
 }
 
-func writeCommandGroupFile(cfg *SurfaceWriterConfig, g *CommandGroup, path []string) error {
-	groupDir := filepath.Join(cfg.OutputDir, filepath.Join(path...))
+func writeCommandGroupFile(cfg *surfaceWriterConfig, g *CommandGroup, path []string) error {
+	groupDir := filepath.Join(cfg.outputDir, filepath.Join(path...))
 	if err := os.MkdirAll(groupDir, 0755); err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func writeCommandGroupFile(cfg *SurfaceWriterConfig, g *CommandGroup, path []str
 
 	primaryHelpText := g.HelpText
 	var trackViews []trackView
-	for _, t := range cfg.Tracks {
+	for _, t := range cfg.tracks {
 		var suffix string
 		switch t {
 		case GA:
@@ -110,8 +110,8 @@ func writeCommandGroupFile(cfg *SurfaceWriterConfig, g *CommandGroup, path []str
 	}
 
 	modulePathParts := make([]string, 0, 2+len(path))
-	if cfg.BaseModule != "" {
-		modulePathParts = append(modulePathParts, cfg.BaseModule)
+	if cfg.baseModule != "" {
+		modulePathParts = append(modulePathParts, cfg.baseModule)
 		modulePathParts = append(modulePathParts, "surface")
 	}
 	modulePathParts = append(modulePathParts, path...)

--- a/internal/sidekick/surfer/surface_writer_test.go
+++ b/internal/sidekick/surfer/surface_writer_test.go
@@ -138,7 +138,7 @@ class InstancesGa(base.Group):
 func TestWriteCommandGroupFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	ga := &CommandGroup{ClassName: "instances", FileName: "instances", HelpText: "Manage instances"}
-	cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk.instances", Tracks: []ReleaseTrack{GA}}
+	cfg := &surfaceWriterConfig{outputDir: tmpDir, baseModule: "googlecloudsdk.instances", tracks: []ReleaseTrack{GA}}
 	if err := writeCommandGroupFile(cfg, ga, []string{"instances"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestWriteCommandGroupFile(t *testing.T) {
 
 func TestWriteCommandGroupFile_Error(t *testing.T) {
 	ga := &CommandGroup{ClassName: "instances", FileName: "instances", HelpText: "Manage instances"}
-	cfg := &SurfaceWriterConfig{OutputDir: "/dev/null/invalid/path", BaseModule: "googlecloudsdk.instances", Tracks: []ReleaseTrack{GA}}
+	cfg := &surfaceWriterConfig{outputDir: "/dev/null/invalid/path", baseModule: "googlecloudsdk.instances", tracks: []ReleaseTrack{GA}}
 	err := writeCommandGroupFile(cfg, ga, []string{"instances"})
 	if err == nil {
 		t.Error("expected error writing to invalid path, got nil")
@@ -251,7 +251,7 @@ func TestWriteCommandGroupFile_TrackCombinations(t *testing.T) {
 				tracks = append(tracks, Alpha)
 			}
 
-			cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk.instances", Tracks: tracks}
+			cfg := &surfaceWriterConfig{outputDir: tmpDir, baseModule: "googlecloudsdk.instances", tracks: tracks}
 			if err := writeCommandGroupFile(cfg, g, []string{"instances"}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -286,7 +286,7 @@ func TestWriteGroup_DirError(t *testing.T) {
 	}
 
 	ga := &CommandGroup{ClassName: "instances", FileName: "instances"}
-	cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk", Tracks: []ReleaseTrack{GA}}
+	cfg := &surfaceWriterConfig{outputDir: tmpDir, baseModule: "googlecloudsdk", tracks: []ReleaseTrack{GA}}
 	err := writeGroup(cfg, ga, nil)
 	if err == nil {
 		t.Error("expected error when creating directory over an existing file, got nil")
@@ -295,7 +295,7 @@ func TestWriteGroup_DirError(t *testing.T) {
 
 func TestWriteGroup_NoName(t *testing.T) {
 	tmpDir := t.TempDir()
-	cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk", Tracks: []ReleaseTrack{}}
+	cfg := &surfaceWriterConfig{outputDir: tmpDir, baseModule: "googlecloudsdk", tracks: []ReleaseTrack{}}
 	err := writeGroup(cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/sidekick/surfer/surface_writer_test.go
+++ b/internal/sidekick/surfer/surface_writer_test.go
@@ -138,8 +138,8 @@ class InstancesGa(base.Group):
 func TestWriteCommandGroupFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	ga := &CommandGroup{ClassName: "instances", FileName: "instances", HelpText: "Manage instances"}
-	w := &surfaceWriter{outputDir: tmpDir, baseModule: "googlecloudsdk.instances", tracks: []ReleaseTrack{GA}}
-	if err := w.writeCommandGroupFile(ga, []string{"instances"}); err != nil {
+	cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk.instances", Tracks: []ReleaseTrack{GA}}
+	if err := writeCommandGroupFile(cfg, ga, []string{"instances"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -151,8 +151,8 @@ func TestWriteCommandGroupFile(t *testing.T) {
 
 func TestWriteCommandGroupFile_Error(t *testing.T) {
 	ga := &CommandGroup{ClassName: "instances", FileName: "instances", HelpText: "Manage instances"}
-	w := &surfaceWriter{outputDir: "/dev/null/invalid/path", baseModule: "googlecloudsdk.instances", tracks: []ReleaseTrack{GA}}
-	err := w.writeCommandGroupFile(ga, []string{"instances"})
+	cfg := &SurfaceWriterConfig{OutputDir: "/dev/null/invalid/path", BaseModule: "googlecloudsdk.instances", Tracks: []ReleaseTrack{GA}}
+	err := writeCommandGroupFile(cfg, ga, []string{"instances"})
 	if err == nil {
 		t.Error("expected error writing to invalid path, got nil")
 	}
@@ -251,8 +251,8 @@ func TestWriteCommandGroupFile_TrackCombinations(t *testing.T) {
 				tracks = append(tracks, Alpha)
 			}
 
-			w := &surfaceWriter{outputDir: tmpDir, baseModule: "googlecloudsdk.instances", tracks: tracks}
-			if err := w.writeCommandGroupFile(g, []string{"instances"}); err != nil {
+			cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk.instances", Tracks: tracks}
+			if err := writeCommandGroupFile(cfg, g, []string{"instances"}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -286,8 +286,8 @@ func TestWriteGroup_DirError(t *testing.T) {
 	}
 
 	ga := &CommandGroup{ClassName: "instances", FileName: "instances"}
-	w := &surfaceWriter{outputDir: tmpDir, baseModule: "googlecloudsdk", tracks: []ReleaseTrack{GA}}
-	err := w.writeGroup(ga, nil)
+	cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk", Tracks: []ReleaseTrack{GA}}
+	err := writeGroup(cfg, ga, nil)
 	if err == nil {
 		t.Error("expected error when creating directory over an existing file, got nil")
 	}
@@ -295,8 +295,8 @@ func TestWriteGroup_DirError(t *testing.T) {
 
 func TestWriteGroup_NoName(t *testing.T) {
 	tmpDir := t.TempDir()
-	w := &surfaceWriter{outputDir: tmpDir, baseModule: "googlecloudsdk", tracks: []ReleaseTrack{}}
-	err := w.writeGroup(nil, nil)
+	cfg := &SurfaceWriterConfig{OutputDir: tmpDir, BaseModule: "googlecloudsdk", Tracks: []ReleaseTrack{}}
+	err := writeGroup(cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Remove the object oriented writer and pass around stateless config. This keeps the code consistent and removes confusion around state. Context is passed in as config struct to reduce parameter explosion and help with type safety