### PR TITLE
fix(internal/librarian/java): deriveLastReleasedVersion support patch snapshot version

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -363,10 +363,10 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 }
 
 // deriveLastReleasedVersion derives the last released version from a snapshot version
-// (e.g., x.y.0-SNAPSHOT) by decrementing the minor version.
+// (e.g., x.y.z-SNAPSHOT) by decrementing the patch or minor version.
 //
-// It returns an error if the snapshot version has a non-zero patch or a zero
-// minor version, as this repository is assumed to always bump the minor version.
+// It returns an error if both minor and patch versions are zero, as it's
+// ambiguous what the last released version was in that case.
 func deriveLastReleasedVersion(v string) (string, error) {
 	sv, err := semver.Parse(v)
 	if err != nil {
@@ -375,11 +375,14 @@ func deriveLastReleasedVersion(v string) (string, error) {
 	if sv.Prerelease != "SNAPSHOT" {
 		return sv.String(), nil
 	}
-	if sv.Patch > 0 || sv.Minor == 0 {
+	if sv.Patch > 0 {
+		sv.Patch--
+	} else if sv.Minor > 0 {
+		sv.Minor--
+		sv.Patch = 0
+	} else {
 		return "", errInvalidVersion
 	}
-	sv.Minor--
-	sv.Patch = 0
 	sv.Prerelease = ""
 	return sv.String(), nil
 }

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -657,6 +657,8 @@ func TestDeriveLastReleasedVersion(t *testing.T) {
 		{input: "1.2.0-SNAPSHOT", want: "1.1.0"},
 		{input: "1.10.0-SNAPSHOT", want: "1.9.0"},
 		{input: "0.87.0-SNAPSHOT", want: "0.86.0"},
+		{input: "0.0.1-SNAPSHOT", want: "0.0.0"},
+		{input: "1.10.1-SNAPSHOT", want: "1.10.0"},
 		{input: "1.2.3", want: "1.2.3"},
 	} {
 		t.Run(test.input, func(t *testing.T) {
@@ -685,11 +687,6 @@ func TestDeriveLastReleasedVersion_Error(t *testing.T) {
 		{
 			name:    "v1.0.0 snapshot",
 			input:   "1.0.0-SNAPSHOT",
-			wantErr: errInvalidVersion,
-		},
-		{
-			name:    "patch version snapshot",
-			input:   "1.10.1-SNAPSHOT",
 			wantErr: errInvalidVersion,
 		},
 	} {


### PR DESCRIPTION
Update deriveLastReleasedVersion to support patch snapshot version instead of return error.
`java-showcase` module is not released and version pinned to `0.0.1-SNAPSHOT`. Newly added libraries are also created with `0.0.1-SNAPSHOT` in hermetic build (see [here](https://github.com/googleapis/google-cloud-java/blob/814cb1aee49884c9bce59708c4d1751f2d9ec654/versions.txt#L1029-L1034)).  This change allows librarian to work out version for these to use for readme generation via owlbot.py.

For https://github.com/googleapis/librarian/issues/5731
