### PR TITLE
chore(tool/cmd/migrate): remove hardcoded excluded_protos for google/rpc

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -502,8 +502,6 @@ func applyJavaProtoOverrides(api *config.JavaAPI) {
 			"google/cloud/aiplatform/v1beta1/schema/dataset_metadata.proto",
 			"google/cloud/aiplatform/v1beta1/schema/geometry.proto",
 		)
-	case api.Path == "google/rpc":
-		api.ExcludedProtos = append(api.ExcludedProtos, "google/rpc/http.proto")
 	}
 }
 

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -76,14 +76,6 @@ func TestApplyJavaProtoOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "google/rpc",
-			path: "google/rpc",
-			want: &config.JavaAPI{
-				Path:           "google/rpc",
-				ExcludedProtos: []string{"google/rpc/http.proto"},
-			},
-		},
-		{
 			name: "no override",
 			path: "google/cloud/language/v1",
 			want: &config.JavaAPI{


### PR DESCRIPTION
Remove hardcoded exclusion for `google/rpc` to keep in sync with recent changes in google-cloud-java. See https://github.com/googleapis/google-cloud-java/pull/12992 and https://github.com/googleapis/google-cloud-java/pull/13005

Fix #5803