### PR TITLE
refactor(internal/sidekick/surfer): remove group builder object oriented boiler plate

### DIFF
--- a/internal/sidekick/surfer/group_builder.go
+++ b/internal/sidekick/surfer/group_builder.go
@@ -23,24 +23,17 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-type groupBuilder struct {
-	model   *api.API
-	config  *provider.Config
-	service *api.Service
+// GroupContext contains the context required to build a command group.
+type GroupContext struct {
+	Model   *api.API
+	Service *api.Service
+	Config  *provider.Config
 }
 
-func newGroupBuilder(model *api.API, service *api.Service, config *provider.Config) *groupBuilder {
-	return &groupBuilder{
-		model:   model,
-		config:  config,
-		service: service,
-	}
-}
-
-func (b *groupBuilder) buildRoot() *CommandGroup {
+func buildRootGroup(ctx *GroupContext) *CommandGroup {
 	// TODO (https://github.com/googleapis/librarian/issues/3033): Use service selector
 	// to look up the help text from the gcloud config.
-	rootName := provider.ResolveRootPackage(b.model)
+	rootName := provider.ResolveRootPackage(ctx.Model)
 	return &CommandGroup{
 		ClassName: rootName,
 		FileName:  rootName,
@@ -50,9 +43,9 @@ func (b *groupBuilder) buildRoot() *CommandGroup {
 	}
 }
 
-func (b *groupBuilder) build(methodPath []string) *CommandGroup {
+func buildGroup(ctx *GroupContext, methodPath []string) *CommandGroup {
 	collectionName := methodPath[len(methodPath)-1]
-	resourceTypeName := provider.GetResourceTypeName(b.model, methodPath)
+	resourceTypeName := provider.GetResourceTypeName(ctx.Model, methodPath)
 
 	helpText := fmt.Sprintf("Manage %s resources.", toTitleCase(resourceTypeName))
 	if resourceTypeName == "" {

--- a/internal/sidekick/surfer/group_builder.go
+++ b/internal/sidekick/surfer/group_builder.go
@@ -23,17 +23,17 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// GroupContext contains the context required to build a command group.
-type GroupContext struct {
-	Model   *api.API
-	Service *api.Service
-	Config  *provider.Config
+// groupContext contains the context required to build a command group.
+type groupContext struct {
+	model   *api.API
+	service *api.Service
+	config  *provider.Config
 }
 
-func buildRootGroup(ctx *GroupContext) *CommandGroup {
+func buildRootGroup(ctx *groupContext) *CommandGroup {
 	// TODO (https://github.com/googleapis/librarian/issues/3033): Use service selector
 	// to look up the help text from the gcloud config.
-	rootName := provider.ResolveRootPackage(ctx.Model)
+	rootName := provider.ResolveRootPackage(ctx.model)
 	return &CommandGroup{
 		ClassName: rootName,
 		FileName:  rootName,
@@ -43,9 +43,9 @@ func buildRootGroup(ctx *GroupContext) *CommandGroup {
 	}
 }
 
-func buildGroup(ctx *GroupContext, methodPath []string) *CommandGroup {
+func buildGroup(ctx *groupContext, methodPath []string) *CommandGroup {
 	collectionName := methodPath[len(methodPath)-1]
-	resourceTypeName := provider.GetResourceTypeName(ctx.Model, methodPath)
+	resourceTypeName := provider.GetResourceTypeName(ctx.model, methodPath)
 
 	helpText := fmt.Sprintf("Manage %s resources.", toTitleCase(resourceTypeName))
 	if resourceTypeName == "" {

--- a/internal/sidekick/surfer/group_builder.go
+++ b/internal/sidekick/surfer/group_builder.go
@@ -23,17 +23,17 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// groupContext contains the context required to build a command group.
-type groupContext struct {
+// groupParams contains the parameters required to build a command group.
+type groupParams struct {
 	model   *api.API
 	service *api.Service
 	config  *provider.Config
 }
 
-func buildRootGroup(ctx *groupContext) *CommandGroup {
+func buildRootGroup(params *groupParams) *CommandGroup {
 	// TODO (https://github.com/googleapis/librarian/issues/3033): Use service selector
 	// to look up the help text from the gcloud config.
-	rootName := provider.ResolveRootPackage(ctx.model)
+	rootName := provider.ResolveRootPackage(params.model)
 	return &CommandGroup{
 		ClassName: rootName,
 		FileName:  rootName,
@@ -43,9 +43,9 @@ func buildRootGroup(ctx *groupContext) *CommandGroup {
 	}
 }
 
-func buildGroup(ctx *groupContext, methodPath []string) *CommandGroup {
+func buildGroup(params *groupParams, methodPath []string) *CommandGroup {
 	collectionName := methodPath[len(methodPath)-1]
-	resourceTypeName := provider.GetResourceTypeName(ctx.model, methodPath)
+	resourceTypeName := provider.GetResourceTypeName(params.model, methodPath)
 
 	helpText := fmt.Sprintf("Manage %s resources.", toTitleCase(resourceTypeName))
 	if resourceTypeName == "" {

--- a/internal/sidekick/surfer/group_builder_test.go
+++ b/internal/sidekick/surfer/group_builder_test.go
@@ -33,10 +33,10 @@ func TestGroupBuilder_BuildRoot(t *testing.T) {
 		},
 	}
 
-	group := buildRootGroup(&GroupContext{
-		Model:   model,
-		Service: model.Services[0],
-		Config:  &provider.Config{},
+	group := buildRootGroup(&groupContext{
+		model:   model,
+		service: model.Services[0],
+		config:  &provider.Config{},
 	})
 
 	if group.ClassName != "parallelstore" {
@@ -66,10 +66,10 @@ func TestGroupBuilder_BuildGroup(t *testing.T) {
 		},
 	}
 
-	group := buildGroup(&GroupContext{
-		Model:   model,
-		Service: model.Services[0],
-		Config:  &provider.Config{},
+	group := buildGroup(&groupContext{
+		model:   model,
+		service: model.Services[0],
+		config:  &provider.Config{},
 	}, []string{"instances"})
 
 	if group.ClassName != "instances" {

--- a/internal/sidekick/surfer/group_builder_test.go
+++ b/internal/sidekick/surfer/group_builder_test.go
@@ -33,8 +33,11 @@ func TestGroupBuilder_BuildRoot(t *testing.T) {
 		},
 	}
 
-	builder := newGroupBuilder(model, model.Services[0], &provider.Config{})
-	group := builder.buildRoot()
+	group := buildRootGroup(&GroupContext{
+		Model:   model,
+		Service: model.Services[0],
+		Config:  &provider.Config{},
+	})
 
 	if group.ClassName != "parallelstore" {
 		t.Errorf("group.ClassName = %q, want %q", group.ClassName, "parallelstore")
@@ -63,8 +66,11 @@ func TestGroupBuilder_BuildGroup(t *testing.T) {
 		},
 	}
 
-	builder := newGroupBuilder(model, model.Services[0], &provider.Config{})
-	group := builder.build([]string{"instances"})
+	group := buildGroup(&GroupContext{
+		Model:   model,
+		Service: model.Services[0],
+		Config:  &provider.Config{},
+	}, []string{"instances"})
 
 	if group.ClassName != "instances" {
 		t.Errorf("group.ClassName = %q, want %q", group.ClassName, "instances")

--- a/internal/sidekick/surfer/group_builder_test.go
+++ b/internal/sidekick/surfer/group_builder_test.go
@@ -33,7 +33,7 @@ func TestGroupBuilder_BuildRoot(t *testing.T) {
 		},
 	}
 
-	group := buildRootGroup(&groupContext{
+	group := buildRootGroup(&groupParams{
 		model:   model,
 		service: model.Services[0],
 		config:  &provider.Config{},
@@ -66,7 +66,7 @@ func TestGroupBuilder_BuildGroup(t *testing.T) {
 		},
 	}
 
-	group := buildGroup(&groupContext{
+	group := buildGroup(&groupParams{
 		model:   model,
 		service: model.Services[0],
 		config:  &provider.Config{},

--- a/internal/sidekick/surfer/surface_builder.go
+++ b/internal/sidekick/surfer/surface_builder.go
@@ -28,18 +28,18 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 	}
 
 	for _, service := range model.Services {
-		ctx := &groupContext{
+		params := &groupParams{
 			model:   model,
 			service: service,
 			config:  config,
 		}
 
 		if root == nil {
-			root = buildRootGroup(ctx)
+			root = buildRootGroup(params)
 		}
 
 		for _, method := range service.Methods {
-			if err := insert(root, ctx, method); err != nil {
+			if err := insert(root, params, method); err != nil {
 				return nil, err
 			}
 		}
@@ -51,8 +51,8 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 // insert traverses the tree and attaches a command leaf node. It resolves the
 // literal path segments of the method and walks the tree, creating missing
 // groups if they do not yet exist.
-func insert(root *CommandGroup, ctx *groupContext, method *api.Method) error {
-	if provider.IsSingletonResourceMethod(method, ctx.model) {
+func insert(root *CommandGroup, params *groupParams, method *api.Method) error {
+	if provider.IsSingletonResourceMethod(method, params.model) {
 		return nil
 	}
 
@@ -68,7 +68,7 @@ func insert(root *CommandGroup, ctx *groupContext, method *api.Method) error {
 
 	curr := root
 	for i, seg := range segments {
-		if isTerminatedSegment(seg, ctx.config) {
+		if isTerminatedSegment(seg, params.config) {
 			return nil
 		}
 		isLeaf := i == len(segments)-1
@@ -77,12 +77,12 @@ func insert(root *CommandGroup, ctx *groupContext, method *api.Method) error {
 		}
 
 		if curr.Groups[seg] == nil {
-			curr.Groups[seg] = buildGroup(ctx, segments[:i+1])
+			curr.Groups[seg] = buildGroup(params, segments[:i+1])
 		}
 		curr = curr.Groups[seg]
 	}
 
-	cmd, err := buildCommand(method, ctx.config, ctx.model, ctx.service)
+	cmd, err := buildCommand(method, params.config, params.model, params.service)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/surfer/surface_builder.go
+++ b/internal/sidekick/surfer/surface_builder.go
@@ -28,10 +28,10 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 	}
 
 	for _, service := range model.Services {
-		ctx := &GroupContext{
-			Model:   model,
-			Service: service,
-			Config:  config,
+		ctx := &groupContext{
+			model:   model,
+			service: service,
+			config:  config,
 		}
 
 		if root == nil {
@@ -51,8 +51,8 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 // insert traverses the tree and attaches a command leaf node. It resolves the
 // literal path segments of the method and walks the tree, creating missing
 // groups if they do not yet exist.
-func insert(root *CommandGroup, ctx *GroupContext, method *api.Method) error {
-	if provider.IsSingletonResourceMethod(method, ctx.Model) {
+func insert(root *CommandGroup, ctx *groupContext, method *api.Method) error {
+	if provider.IsSingletonResourceMethod(method, ctx.model) {
 		return nil
 	}
 
@@ -68,7 +68,7 @@ func insert(root *CommandGroup, ctx *GroupContext, method *api.Method) error {
 
 	curr := root
 	for i, seg := range segments {
-		if isTerminatedSegment(seg, ctx.Config) {
+		if isTerminatedSegment(seg, ctx.config) {
 			return nil
 		}
 		isLeaf := i == len(segments)-1
@@ -82,7 +82,7 @@ func insert(root *CommandGroup, ctx *GroupContext, method *api.Method) error {
 		curr = curr.Groups[seg]
 	}
 
-	cmd, err := buildCommand(method, ctx.Config, ctx.Model, ctx.Service)
+	cmd, err := buildCommand(method, ctx.config, ctx.model, ctx.service)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/surfer/surface_builder.go
+++ b/internal/sidekick/surfer/surface_builder.go
@@ -28,14 +28,18 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 	}
 
 	for _, service := range model.Services {
-		gb := newGroupBuilder(model, service, config)
+		ctx := &GroupContext{
+			Model:   model,
+			Service: service,
+			Config:  config,
+		}
 
 		if root == nil {
-			root = gb.buildRoot()
+			root = buildRootGroup(ctx)
 		}
 
 		for _, method := range service.Methods {
-			if err := insert(root, gb, method); err != nil {
+			if err := insert(root, ctx, method); err != nil {
 				return nil, err
 			}
 		}
@@ -47,8 +51,8 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 // insert traverses the tree and attaches a command leaf node. It resolves the
 // literal path segments of the method and walks the tree, creating missing
 // groups if they do not yet exist.
-func insert(root *CommandGroup, gb *groupBuilder, method *api.Method) error {
-	if provider.IsSingletonResourceMethod(method, gb.model) {
+func insert(root *CommandGroup, ctx *GroupContext, method *api.Method) error {
+	if provider.IsSingletonResourceMethod(method, ctx.Model) {
 		return nil
 	}
 
@@ -64,7 +68,7 @@ func insert(root *CommandGroup, gb *groupBuilder, method *api.Method) error {
 
 	curr := root
 	for i, seg := range segments {
-		if isTerminatedSegment(seg, gb.config) {
+		if isTerminatedSegment(seg, ctx.Config) {
 			return nil
 		}
 		isLeaf := i == len(segments)-1
@@ -73,12 +77,12 @@ func insert(root *CommandGroup, gb *groupBuilder, method *api.Method) error {
 		}
 
 		if curr.Groups[seg] == nil {
-			curr.Groups[seg] = gb.build(segments[:i+1])
+			curr.Groups[seg] = buildGroup(ctx, segments[:i+1])
 		}
 		curr = curr.Groups[seg]
 	}
 
-	cmd, err := buildCommand(method, gb.config, gb.model, gb.service)
+	cmd, err := buildCommand(method, ctx.Config, ctx.Model, ctx.Service)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Remove the object-oriented group builder and pass around stateless group context. This keeps the codebase consistent withe surface_builder and eliminates confusion about internal state.