### PR TITLE
feat(internal/librarian/golang): support GOTOOLCHAIN

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -97,8 +97,9 @@ This document describes the schema for the librarian.yaml.
 | `keep` | list of string | Lists files and directories to preserve during regeneration. |
 | `output` | string | Is the directory where code is written. For example, for Rust this is src/generated. |
 | `tag_format` | string | Is the template for git tags, such as "{name}/v{version}". |
-| `dotnet` | [DotnetPackage](#dotnetpackage-configuration) (optional) | Contains .NET-specific default configuration. |
 | `dart` | [DartPackage](#dartpackage-configuration) (optional) | Contains Dart-specific default configuration. |
+| `dotnet` | [DotnetPackage](#dotnetpackage-configuration) (optional) | Contains .NET-specific default configuration. |
+| `go` | [GoDefault](#godefault-configuration) (optional) | Contains Go-specific default configuration. |
 | `java` | [JavaModule](#javamodule-configuration) (optional) | Contains Java-specific default configuration. |
 | `nodejs` | [NodejsPackage](#nodejspackage-configuration) (optional) | Contains Node.js-specific default configuration. |
 | `rust` | [RustDefault](#rustdefault-configuration) (optional) | Contains Rust-specific default configuration. |
@@ -137,6 +138,12 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `path` | string | Specifies which googleapis Path to generate from (for generated libraries). |
+
+## GoDefault Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `toolchain` | string | Is the desired Go toolchain version (e.g., "go1.25.0"). |
 
 ## DartPackage Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,11 +198,14 @@ type Default struct {
 
 	// Language-specific fields are below.
 
+	// Dart contains Dart-specific default configuration.
+	Dart *DartPackage `yaml:"dart,omitempty"`
+
 	// Dotnet contains .NET-specific default configuration.
 	Dotnet *DotnetPackage `yaml:"dotnet,omitempty"`
 
-	// Dart contains Dart-specific default configuration.
-	Dart *DartPackage `yaml:"dart,omitempty"`
+	// Go contains Go-specific default configuration.
+	Go *GoDefault `yaml:"go,omitempty"`
 
 	// Java contains Java-specific default configuration.
 	Java *JavaModule `yaml:"java,omitempty"`
@@ -319,4 +322,10 @@ type API struct {
 	// Path specifies which googleapis Path to generate from (for generated
 	// libraries).
 	Path string `yaml:"path,omitempty"`
+}
+
+// GoDefault defines Go-specific default configuration.
+type GoDefault struct {
+	// Toolchain is the desired Go toolchain version (e.g., "go1.25.0").
+	Toolchain string `yaml:"toolchain,omitempty"`
 }

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -232,11 +232,14 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		}
 		return g.Wait()
 	case config.LanguageGo:
-		goCmd := golang.GoCommand(cfg.Tools)
+		var toolchain string
+		if cfg.Default != nil && cfg.Default.Go != nil {
+			toolchain = cfg.Default.Go.Toolchain
+		}
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {
 			g.Go(func() error {
-				if err := golang.Generate(gctx, library, src, goCmd); err != nil {
+				if err := golang.Generate(gctx, library, src, toolchain); err != nil {
 					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
 				}
 				return nil

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -42,7 +42,7 @@ var (
 )
 
 // Generate generates a Go client library.
-func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources, goCmd string) (err error) {
+func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources, toolchain string) (err error) {
 	outDir, err := filepath.Abs(library.Output)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path of output directory: %w", err)
@@ -112,19 +112,26 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 	}
 	if _, err := os.Stat(filepath.Join(outDir, "go.mod")); errors.Is(err, fs.ErrNotExist) {
 		// New client, init the module.
-		if err := initModule(ctx, outDir, modulePath(library), goCmd); err != nil {
+		if err := initModule(ctx, outDir, modulePath(library), toolchain); err != nil {
 			return err
 		}
-		return updateSnippetsModule(ctx, library, outDir, goCmd)
+		return updateSnippetsModule(ctx, library, outDir, toolchain)
 	} else if err != nil {
 		return fmt.Errorf("failed to stat go.mod: %w", err)
 	}
-	return nil
+
+	// If go.mod exists, still run go mod tidy with the specified toolchain
+	// to ensure it stays in sync with the configured Go version.
+	var env map[string]string
+	if toolchain != "" {
+		env = map[string]string{"GOTOOLCHAIN": toolchain}
+	}
+	return command.RunInDirWithEnv(ctx, outDir, env, command.Go, "mod", "tidy")
 }
 
 // updateSnippetsModule updates the snippets module's go.mod file with a requirement
 // and a local replacement for the newly generated library.
-func updateSnippetsModule(ctx context.Context, library *config.Library, outDir, goCmd string) error {
+func updateSnippetsModule(ctx context.Context, library *config.Library, outDir string, toolchain string) error {
 	if library.Go == nil {
 		return nil
 	}
@@ -142,26 +149,13 @@ func updateSnippetsModule(ctx context.Context, library *config.Library, outDir, 
 		return fmt.Errorf("failed to get relative path of module: %w", err)
 	}
 	modPath := modulePath(library)
-	return command.RunInDir(ctx, snippetsDir, goCmd, "mod", "edit",
+	var env map[string]string
+	if toolchain != "" {
+		env = map[string]string{"GOTOOLCHAIN": toolchain}
+	}
+	return command.RunInDirWithEnv(ctx, snippetsDir, env, command.Go, "mod", "edit",
 		"-require="+modPath+"@v0.0.0",
 		"-replace="+modPath+"="+filepath.Join("../../..", modDir))
-}
-
-// GoCommand returns the name of the Go executable to use.
-// It checks the tools list for any compiler package like "golang.org/dl/goVERSION".
-// If found, it returns the base name (e.g. "go1.22.3").
-// Otherwise, it falls back to "go".
-func GoCommand(tools *config.Tools) string {
-	if tools == nil {
-		return command.Go
-	}
-	for _, tool := range tools.Go {
-		if strings.HasPrefix(tool.Name, "golang.org/dl/go") {
-			parts := strings.Split(tool.Name, "/")
-			return parts[len(parts)-1]
-		}
-	}
-	return command.Go
 }
 
 func generateAPI(ctx context.Context, goAPI *config.GoAPI, googleapisDir, version, outDir string) error {

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -113,7 +113,7 @@ func TestGenerate(t *testing.T) {
 		library.Output = filepath.Join(repoRoot, library.Output, library.Name)
 	}
 	for _, library := range libraries {
-		if err := Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir}, "go"); err != nil {
+		if err := Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir}, ""); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -173,7 +173,7 @@ func TestGenerate_Error(t *testing.T) {
 			outdir := t.TempDir()
 			test.library.Output = outdir
 
-			gotErr := Generate(t.Context(), test.library, &sources.Sources{Googleapis: googleapisDir}, "go")
+			gotErr := Generate(t.Context(), test.library, &sources.Sources{Googleapis: googleapisDir}, "")
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("Generate error = %v, wantErr %v", gotErr, test.wantErr)
 			}
@@ -207,7 +207,7 @@ func TestGenerate_MkdirAllError(t *testing.T) {
 		},
 	}
 
-	gotErr := Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir}, "go")
+	gotErr := Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir}, "")
 	if !errors.Is(gotErr, syscall.ENOTDIR) {
 		t.Errorf("Generate error = %v, want %v", gotErr, syscall.ENOTDIR)
 	}
@@ -451,7 +451,7 @@ func TestGenerateLibrary(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if err := Generate(t.Context(), test.library, &sources.Sources{Googleapis: googleapisDir}, "go"); err != nil {
+			if err := Generate(t.Context(), test.library, &sources.Sources{Googleapis: googleapisDir}, ""); err != nil {
 				t.Fatal(err)
 			}
 			for _, path := range test.want {
@@ -1032,7 +1032,7 @@ func TestUpdateSnippetsModule(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := updateSnippetsModule(t.Context(), library, outDir, "go"); err != nil {
+	if err := updateSnippetsModule(t.Context(), library, outDir, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1077,7 +1077,7 @@ func TestUpdateSnippetsModule_NoSnippets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := updateSnippetsModule(t.Context(), library, outDir, "go"); err != nil {
+	if err := updateSnippetsModule(t.Context(), library, outDir, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1100,49 +1100,5 @@ func setupSnippets(t *testing.T, repoRoot string) {
 	snippetsGoMod := filepath.Join(snippetsDir, "go.mod")
 	if err := os.WriteFile(snippetsGoMod, []byte("module cloud.google.com/go/internal/generated/snippets\n\ngo 1.22\n"), 0644); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestGoCommand(t *testing.T) {
-	for _, test := range []struct {
-		name  string
-		tools *config.Tools
-		want  string
-	}{
-		{
-			name:  "nil tools",
-			tools: nil,
-			want:  "go",
-		},
-		{
-			name:  "empty tools",
-			tools: &config.Tools{},
-			want:  "go",
-		},
-		{
-			name: "go tools but no compiler",
-			tools: &config.Tools{
-				Go: []*config.GoTool{
-					{Name: "golang.org/x/tools/cmd/goimports", Version: "v0.1.0"},
-				},
-			},
-			want: "go",
-		},
-		{
-			name: "custom Go compiler wrapper version",
-			tools: &config.Tools{
-				Go: []*config.GoTool{
-					{Name: "golang.org/dl/go1.22.3", Version: "v0.1.0"},
-				},
-			},
-			want: "go1.22.3",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := GoCommand(test.tools)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
 	}
 }

--- a/internal/librarian/golang/module.go
+++ b/internal/librarian/golang/module.go
@@ -195,11 +195,15 @@ func modulePath(library *config.Library) string {
 }
 
 // initModule initializes and tidies a Go module in the given directory.
-func initModule(ctx context.Context, dir, modPath, goCmd string) error {
-	if err := command.RunInDir(ctx, dir, goCmd, "mod", "init", modPath); err != nil {
+func initModule(ctx context.Context, dir, modPath, toolchain string) error {
+	var env map[string]string
+	if toolchain != "" {
+		env = map[string]string{"GOTOOLCHAIN": toolchain}
+	}
+	if err := command.RunInDirWithEnv(ctx, dir, env, command.Go, "mod", "init", modPath); err != nil {
 		return err
 	}
-	return command.RunInDir(ctx, dir, goCmd, "mod", "tidy")
+	return command.RunInDirWithEnv(ctx, dir, env, command.Go, "mod", "tidy")
 }
 
 // defaultImportPathAndClientPkg returns the default Go import path and client package name

--- a/internal/librarian/golang/module_test.go
+++ b/internal/librarian/golang/module_test.go
@@ -639,7 +639,7 @@ func TestInitModule(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(outDir, "main.go"), content, 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := initModule(t.Context(), outDir, "example.com/testmod", command.Go); err != nil {
+	if err := initModule(t.Context(), outDir, "example.com/testmod", ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(outDir, "go.mod")); err != nil {


### PR DESCRIPTION
Support for specifying a Go toolchain version is added to librarian.yaml under default.go.toolchain. This allows specifying a specific Go version when initializing module by leveraging the GOTOOLCHAIN environment variable (https://go.dev/blog/toolchain), as opposed to downloading a separate binary via golang.org/dl/goVERSION. 

This ensures that the generated go.mod has the requested version and that the correct toolchain is used during generation.

For https://github.com/googleapis/librarian/issues/5201
For https://github.com/googleapis/librarian/issues/5246
Fixes https://github.com/googleapis/librarian/issues/5519