### PR TITLE
refactor(internal/sidekick/surfer): remove argument builder

### DIFF
--- a/internal/sidekick/surfer/argument_builder.go
+++ b/internal/sidekick/surfer/argument_builder.go
@@ -24,9 +24,8 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// argumentBuilder encapsulates the state required to generate the set of
-// arguments for a gcloud command.
-type argumentBuilder struct {
+// argumentParams contains the parameters required to build a command-line argument.
+type argumentParams struct {
 	method    *api.Method
 	overrides *provider.Config
 	model     *api.API
@@ -35,49 +34,37 @@ type argumentBuilder struct {
 	apiField  []string
 }
 
-// newArgumentBuilder constructs a new argumentBuilder.
-func newArgumentBuilder(method *api.Method, overrides *provider.Config, model *api.API, service *api.Service, field *api.Field, apiField []string) *argumentBuilder {
-	return &argumentBuilder{
-		method:    method,
-		overrides: overrides,
-		model:     model,
-		service:   service,
-		field:     field,
-		apiField:  apiField,
-	}
-}
-
-// build creates a single command-line argument (a `Argument` struct) from the builder's state.
+// buildArgument creates a single command-line argument (an `Argument` struct) from the parameters.
 // It returns nil if the field should be ignored.
-func (b *argumentBuilder) build() (*Argument, error) {
-	if b.isIgnored() {
+func buildArgument(ap *argumentParams) (*Argument, error) {
+	if isArgIgnored(ap.field, ap.method) {
 		return nil, nil
 	}
 
 	// TODO(https://github.com/googleapis/librarian/issues/3414): Abstract away casing logic in the model.
 	arg := &Argument{
-		ArgName:   b.field.Name,
-		APIField:  b.apiField,
-		Required:  b.field.DocumentAsRequired(),
-		Repeated:  b.repeated(),
-		Clearable: b.clearable(),
-		HelpText:  b.helpText(),
+		ArgName:   ap.field.Name,
+		APIField:  ap.apiField,
+		Required:  ap.field.DocumentAsRequired(),
+		Repeated:  repeated(ap.field),
+		Clearable: clearable(ap.field, ap.method),
+		HelpText:  argumentHelpText(ap.overrides, ap.field),
 	}
 
-	if b.field.ResourceReference != nil {
-		spec, err := b.resourceReferenceSpec()
+	if ap.field.ResourceReference != nil {
+		spec, err := resourceReferenceSpec(ap)
 		if err != nil {
 			return nil, err
 		}
 		arg.ResourceSpec = spec
-	} else if b.field.Map {
-		arg.Spec = b.mapSpec()
-	} else if b.field.EnumType != nil {
-		arg.Choices = b.choices()
+	} else if ap.field.Map {
+		arg.Spec = mapSpec()
+	} else if ap.field.EnumType != nil {
+		arg.Choices = choices(ap.field)
 	} else {
-		arg.Type = provider.GetGcloudType(b.field.Typez)
-		if b.field.Typez == api.TypezBool {
-			if provider.IsUpdate(b.method) {
+		arg.Type = provider.GetGcloudType(ap.field.Typez)
+		if ap.field.Typez == api.TypezBool {
+			if provider.IsUpdate(ap.method) {
 				arg.Action = "store_true_false"
 			} else {
 				arg.Action = "store_true"
@@ -88,44 +75,44 @@ func (b *argumentBuilder) build() (*Argument, error) {
 	return arg, nil
 }
 
-func (b *argumentBuilder) isIgnored() bool {
-	if b.field.Name == "update_mask" {
+func isArgIgnored(field *api.Field, method *api.Method) bool {
+	if field.Name == "update_mask" {
 		return true
 	}
-	if provider.IsList(b.method) {
-		switch b.field.Name {
+	if provider.IsList(method) {
+		switch field.Name {
 		case "page_size", "page_token", "filter", "order_by":
 			return true
 		case "return_partial_success":
 			// Field is available in all APIs due to operations mixin but not all APIs actually
 			// support it. Omitting for now.
-			return b.method.Name == provider.ListOperations
+			return method.Name == provider.ListOperations
 		}
 	}
-	if slices.Contains(b.field.Behavior, api.FieldBehaviorOutputOnly) {
+	if slices.Contains(field.Behavior, api.FieldBehaviorOutputOnly) {
 		return true
 	}
-	if provider.IsUpdate(b.method) && slices.Contains(b.field.Behavior, api.FieldBehaviorImmutable) {
+	if provider.IsUpdate(method) && slices.Contains(field.Behavior, api.FieldBehaviorImmutable) {
 		return true
 	}
 	return false
 }
 
-func (b *argumentBuilder) repeated() bool {
-	return b.field.Repeated || b.field.Map
+func repeated(field *api.Field) bool {
+	return field.Repeated || field.Map
 }
 
-func (b *argumentBuilder) clearable() bool {
-	return provider.IsUpdate(b.method) && b.repeated()
+func clearable(field *api.Field, method *api.Method) bool {
+	return provider.IsUpdate(method) && repeated(field)
 }
 
-func (b *argumentBuilder) helpText() string {
-	return provider.GetFieldHelpText(b.overrides, b.field)
+func argumentHelpText(overrides *provider.Config, field *api.Field) string {
+	return provider.GetFieldHelpText(overrides, field)
 }
 
-func (b *argumentBuilder) choices() []Choice {
+func choices(field *api.Field) []Choice {
 	var choices []Choice
-	for _, v := range b.field.EnumType.Values {
+	for _, v := range field.EnumType.Values {
 		// Skip the default "UNSPECIFIED" value.
 		if !strings.HasSuffix(v.Name, "_UNSPECIFIED") {
 			choices = append(choices, Choice{
@@ -138,14 +125,14 @@ func (b *argumentBuilder) choices() []Choice {
 	return choices
 }
 
-func (b *argumentBuilder) mapSpec() []ArgSpec {
+func mapSpec() []ArgSpec {
 	return []ArgSpec{{APIField: "key"}, {APIField: "value"}}
 }
 
-// BuildPrimaryResource creates the main positional resource argument for a command.
+// buildPrimaryResourceArgument creates the main positional resource argument for a command.
 // This is the argument that represents the resource being acted upon (e.g., the instance name).
-func (b *argumentBuilder) buildPrimaryResource(idField *api.Field) Argument {
-	resource := provider.GetResourceForMethod(b.method, b.model)
+func buildPrimaryResourceArgument(ap *argumentParams, idField *api.Field) Argument {
+	resource := provider.GetResourceForMethod(ap.method, ap.model)
 	var segments []api.PathSegment
 	// TODO(https://github.com/googleapis/librarian/issues/3415): Support multiple resource patterns and multitype resources.
 	if resource != nil && len(resource.Patterns) > 0 {
@@ -153,7 +140,7 @@ func (b *argumentBuilder) buildPrimaryResource(idField *api.Field) Argument {
 	}
 
 	// Grab the parent if it is collection based method unless you have a resource id field.
-	if provider.IsCollectionMethod(b.method) && idField == nil {
+	if provider.IsCollectionMethod(ap.method) && idField == nil {
 		segments = provider.GetParentFromSegments(segments)
 	}
 
@@ -162,30 +149,30 @@ func (b *argumentBuilder) buildPrimaryResource(idField *api.Field) Argument {
 
 	// Help text should be documentation of builder.field name.
 	// However, if you have resource id, then you actually want resource.name field.
-	fieldHelpText := b.field.Documentation
+	fieldHelpText := ap.field.Documentation
 	if nameField := provider.FindNameField(resource); idField != nil && nameField != nil {
 		fieldHelpText = nameField.Documentation
 	}
 
 	// documentation for LRO service is stripped. Provide fallback.
-	if provider.IsOperationsServiceMethod(b.method) && fieldHelpText == "" {
-		fieldHelpText = provider.OperationMethodDocumentation(b.method.Name)
+	if provider.IsOperationsServiceMethod(ap.method) && fieldHelpText == "" {
+		fieldHelpText = provider.OperationMethodDocumentation(ap.method.Name)
 	}
 
 	collectionPath := provider.GetCollectionPathFromSegments(segments)
-	hostParts := strings.Split(b.service.DefaultHost, ".")
+	hostParts := strings.Split(ap.service.DefaultHost, ".")
 	shortServiceName := hostParts[0]
 
 	param := Argument{
 		HelpText:          provider.CleanDocumentation(fieldHelpText),
-		IsPositional:      !provider.IsList(b.method),
+		IsPositional:      !provider.IsList(ap.method),
 		IsPrimaryResource: true,
 		Required:          true,
 		ResourceSpec: &ResourceSpec{
 			Name:                  resourceName,
 			PluralName:            provider.GetPluralFromSegments(segments),
 			Collection:            fmt.Sprintf("%s.%s", shortServiceName, collectionPath),
-			DisableAutoCompleters: provider.IsList(b.method),
+			DisableAutoCompleters: provider.IsList(ap.method),
 			Attributes:            newAttributesFromSegments(segments),
 		},
 	}
@@ -199,9 +186,9 @@ func (b *argumentBuilder) buildPrimaryResource(idField *api.Field) Argument {
 
 // resourceReferenceSpec creates a ResourceSpec for a field that references
 // another resource type (e.g., a `--network` flag).
-func (b *argumentBuilder) resourceReferenceSpec() (*ResourceSpec, error) {
-	for _, def := range b.model.ResourceDefinitions {
-		if def.Type == b.field.ResourceReference.Type {
+func resourceReferenceSpec(ap *argumentParams) (*ResourceSpec, error) {
+	for _, def := range ap.model.ResourceDefinitions {
+		if def.Type == ap.field.ResourceReference.Type {
 			if len(def.Patterns) == 0 {
 				return nil, fmt.Errorf("resource definition for %q has no patterns", def.Type)
 			}
@@ -215,7 +202,7 @@ func (b *argumentBuilder) resourceReferenceSpec() (*ResourceSpec, error) {
 
 			name := provider.GetSingularFromSegments(segments)
 
-			hostParts := strings.Split(b.service.DefaultHost, ".")
+			hostParts := strings.Split(ap.service.DefaultHost, ".")
 			shortServiceName := hostParts[0]
 			baseCollectionPath := provider.GetCollectionPathFromSegments(segments)
 			fullCollectionPath := fmt.Sprintf("%s.%s", shortServiceName, baseCollectionPath)
@@ -230,7 +217,7 @@ func (b *argumentBuilder) resourceReferenceSpec() (*ResourceSpec, error) {
 			}, nil
 		}
 	}
-	return nil, fmt.Errorf("resource definition not found for type %q", b.field.ResourceReference.Type)
+	return nil, fmt.Errorf("resource definition not found for type %q", ap.field.ResourceReference.Type)
 }
 
 // newAttributesFromSegments parses a structured resource pattern and extracts the attributes

--- a/internal/sidekick/surfer/argument_builder_test.go
+++ b/internal/sidekick/surfer/argument_builder_test.go
@@ -157,7 +157,14 @@ func TestNewArgument(t *testing.T) {
 			if overrides == nil {
 				overrides = &provider.Config{}
 			}
-			got, err := newArgumentBuilder(test.method, overrides, model, service, test.field, test.apiField).build()
+			got, err := buildArgument(&argumentParams{
+				method:    test.method,
+				overrides: overrides,
+				model:     model,
+				service:   service,
+				field:     test.field,
+				apiField:  test.apiField,
+			})
 			if err != nil {
 				t.Errorf("newArgument(%s) unexpected error: %v", test.name, err)
 				return
@@ -272,8 +279,7 @@ func TestIsIgnored(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			builder := newArgumentBuilder(test.method, nil, nil, nil, test.field, nil)
-			got := builder.isIgnored()
+			got := isArgIgnored(test.field, test.method)
 			if got != test.want {
 				t.Errorf("isIgnored() = %v, want %v", got, test.want)
 			}
@@ -532,7 +538,12 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 			if provider.IsCreate(test.method) {
 				idField = test.field
 			}
-			got := newArgumentBuilder(test.method, nil, model, service, test.field, nil).buildPrimaryResource(idField)
+			got := buildPrimaryResourceArgument(&argumentParams{
+				method:  test.method,
+				model:   model,
+				service: service,
+				field:   test.field,
+			}, idField)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("newPrimaryResourceArgument() mismatch (-want +got):\n%s", diff)
 			}
@@ -581,8 +592,14 @@ func TestArgumentBuilder_Build(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			builder := newArgumentBuilder(createMethod, &provider.Config{}, model, service, test.field, test.prefix)
-			got, err := builder.build()
+			got, err := buildArgument(&argumentParams{
+				method:    createMethod,
+				overrides: &provider.Config{},
+				model:     model,
+				service:   service,
+				field:     test.field,
+				apiField:  test.prefix,
+			})
 			if (err != nil) != test.wantErr {
 				t.Fatalf("build() error = %v, wantErr %v", err, test.wantErr)
 			}
@@ -635,7 +652,11 @@ func TestNewResourceReferenceSpec(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := newArgumentBuilder(nil, nil, model, service, test.field, nil).resourceReferenceSpec()
+			got, err := resourceReferenceSpec(&argumentParams{
+				model:   model,
+				service: service,
+				field:   test.field,
+			})
 			if err != nil {
 				t.Fatalf("newResourceReferenceSpec() unexpected error = %v", err)
 			}
@@ -660,7 +681,11 @@ func TestNewResourceReferenceSpec_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := newArgumentBuilder(nil, nil, &api.API{}, service, test.field, nil).resourceReferenceSpec()
+			_, err := resourceReferenceSpec(&argumentParams{
+				model:   &api.API{},
+				service: service,
+				field:   test.field,
+			})
 			if err == nil {
 				t.Fatalf("newResourceReferenceSpec() expected error, got nil")
 			}

--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -171,12 +171,26 @@ func newArguments(method *api.Method, overrides *provider.Config, model *api.API
 		if cf.resourceIdField != nil {
 			idField = cf.resourceIdField.field
 		}
-		arg := newArgumentBuilder(method, overrides, model, service, cf.primaryField.field, cf.primaryField.prefix).buildPrimaryResource(idField)
+		arg := buildPrimaryResourceArgument(&argumentParams{
+			method:    method,
+			overrides: overrides,
+			model:     model,
+			service:   service,
+			field:     cf.primaryField.field,
+			apiField:  cf.primaryField.prefix,
+		}, idField)
 		args = append(args, arg)
 	}
 
 	for _, fwp := range cf.other {
-		arg, err := newArgumentBuilder(method, overrides, model, service, fwp.field, fwp.prefix).build()
+		arg, err := buildArgument(&argumentParams{
+			method:    method,
+			overrides: overrides,
+			model:     model,
+			service:   service,
+			field:     fwp.field,
+			apiField:  fwp.prefix,
+		})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Remove argument builder state to be more inline with rest of builders. Functions receives context (params) to make it clear the builder is stateless. If more than 3 arguments are needed, context is passed in to prevent parameter explosion / improve type safety.