### PR TITLE
refactor(surfer): configure surfer overrides per API and abstract config converter

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -486,7 +486,14 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `help_text` | [GcloudHelpTextRules](#gcloudhelptextrules-configuration) (optional) | Contains help text overrides for the surface. |
+| `surfer_apis` | list of [SurferAPI](#surferapi-configuration) (optional) | Is a list of gcloud-specific API configurations. |
+
+## SurferAPI Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `path` | string | Is the source path (e.g., "google/cloud/security/publicca/v1"). |
+| `help_text` | [GcloudHelpTextRules](#gcloudhelptextrules-configuration) (optional) | Contains help text overrides for this API. |
 
 ## SwiftDefault Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -769,7 +769,16 @@ type GcloudCommand struct {
 
 // Surfer contains gcloud-specific library configuration. Surfer is related to gcloud command generation.
 type Surfer struct {
-	// HelpText contains help text overrides for the surface.
+	// SurferAPIs is a list of gcloud-specific API configurations.
+	SurferAPIs []*SurferAPI `yaml:"surfer_apis,omitempty"`
+}
+
+// SurferAPI represents configuration for a single API within a gcloud surface.
+type SurferAPI struct {
+	// Path is the source path (e.g., "google/cloud/security/publicca/v1").
+	Path string `yaml:"path,omitempty"`
+
+	// HelpText contains help text overrides for this API.
 	HelpText *GcloudHelpTextRules `yaml:"help_text,omitempty"`
 }
 

--- a/internal/librarian/surfer/generate.go
+++ b/internal/librarian/surfer/generate.go
@@ -61,14 +61,14 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 	}
 
 	for _, api := range library.APIs {
-		if err := generateAPI(api, library.Surfer, googleapisDir, outDir); err != nil {
+		if err := generateAPI(api, library, googleapisDir, outDir); err != nil {
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
 	return nil
 }
 
-func generateAPI(api *config.API, gcloudCfg *config.Surfer, googleapisDir, outDir string) error {
+func generateAPI(api *config.API, library *config.Library, googleapisDir, outDir string) error {
 	protos, err := collectProtos(googleapisDir, api.Path)
 	if err != nil {
 		return err
@@ -88,42 +88,8 @@ func generateAPI(api *config.API, gcloudCfg *config.Surfer, googleapisDir, outDi
 	if err != nil {
 		return err
 	}
-	providerCfg := &provider.Config{}
-	if gcloudCfg != nil && gcloudCfg.HelpText != nil {
-		providerCfg.APIs = []provider.API{{
-			Name:     model.Name,
-			HelpText: mapHelpText(gcloudCfg.HelpText),
-		}}
-	}
+	providerCfg := provider.FromLibrarianConfig(library, api, model.Name)
 	return sidekicksurfer.Generate(model, providerCfg, outDir, baseModule)
-}
-
-func mapHelpText(ht *config.GcloudHelpTextRules) *provider.HelpTextRules {
-	if ht == nil {
-		return nil
-	}
-	rules := &provider.HelpTextRules{}
-	for _, r := range ht.MethodRules {
-		rules.MethodRules = append(rules.MethodRules, &provider.HelpTextRule{
-			Selector: r.Selector,
-			HelpText: &provider.HelpTextElement{
-				Brief:       r.Brief,
-				Description: r.Description,
-				Examples:    r.Examples,
-			},
-		})
-	}
-	for _, r := range ht.FieldRules {
-		rules.FieldRules = append(rules.FieldRules, &provider.HelpTextRule{
-			Selector: r.Selector,
-			HelpText: &provider.HelpTextElement{
-				Brief:       r.Brief,
-				Description: r.Description,
-				Examples:    r.Examples,
-			},
-		})
-	}
-	return rules
 }
 
 // collectProtos returns proto file paths under apiPath, relative to

--- a/internal/sidekick/surfer/provider/config.go
+++ b/internal/sidekick/surfer/provider/config.go
@@ -322,12 +322,12 @@ func mapHelpText(ht *libconfig.GcloudHelpTextRules) *HelpTextRules {
 		return nil
 	}
 	return &HelpTextRules{
-		MethodRules: mapRules(ht.MethodRules),
-		FieldRules:  mapRules(ht.FieldRules),
+		MethodRules: mapHelpTextRules(ht.MethodRules),
+		FieldRules:  mapHelpTextRules(ht.FieldRules),
 	}
 }
 
-func mapRules(src []*libconfig.GcloudHelpTextRule) []*HelpTextRule {
+func mapHelpTextRules(src []*libconfig.GcloudHelpTextRule) []*HelpTextRule {
 	var dst []*HelpTextRule
 	for _, r := range src {
 		dst = append(dst, &HelpTextRule{

--- a/internal/sidekick/surfer/provider/config.go
+++ b/internal/sidekick/surfer/provider/config.go
@@ -287,7 +287,7 @@ func ShouldGenerateOperations(c *Config) bool {
 
 // FromLibrarianConfig builds a provider.Config for a specific API from Librarian's Library config.
 func FromLibrarianConfig(library *libconfig.Library, api *libconfig.API, modelName string) *Config {
-	surferAPI := findSurferAPI(library, api)
+	surferAPI := surferAPIFor(library, api)
 	if surferAPI == nil {
 		return &Config{}
 	}
@@ -305,7 +305,7 @@ func FromLibrarianConfig(library *libconfig.Library, api *libconfig.API, modelNa
 	}
 }
 
-func findSurferAPI(library *libconfig.Library, api *libconfig.API) *libconfig.SurferAPI {
+func surferAPIFor(library *libconfig.Library, api *libconfig.API) *libconfig.SurferAPI {
 	if library.Surfer == nil {
 		return nil
 	}

--- a/internal/sidekick/surfer/provider/config.go
+++ b/internal/sidekick/surfer/provider/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,10 @@
 
 // Package provider contains configuration types and helpers for surfer tools.
 package provider
+
+import (
+	libconfig "github.com/googleapis/librarian/internal/config"
+)
 
 //go:generate go run -tags configdocgen ../../../../cmd/config_doc_generate.go -input . -output ../../../../doc/gcloud/gcloud-yaml-schema.md -title "gcloud.yaml"
 
@@ -279,4 +283,61 @@ func ShouldGenerateOperations(c *Config) bool {
 		return true
 	}
 	return *c.GenerateOperations
+}
+
+// FromLibrarianConfig builds a provider.Config for a specific API from Librarian's Library config.
+func FromLibrarianConfig(library *libconfig.Library, api *libconfig.API, modelName string) *Config {
+	surferAPI := findSurferAPI(library, api)
+	if surferAPI == nil {
+		return &Config{}
+	}
+
+	var helpText *HelpTextRules
+	if surferAPI.HelpText != nil {
+		helpText = mapHelpText(surferAPI.HelpText)
+	}
+
+	return &Config{
+		APIs: []API{{
+			Name:     modelName,
+			HelpText: helpText,
+		}},
+	}
+}
+
+func findSurferAPI(library *libconfig.Library, api *libconfig.API) *libconfig.SurferAPI {
+	if library.Surfer == nil {
+		return nil
+	}
+	for _, s := range library.Surfer.SurferAPIs {
+		if s.Path == api.Path {
+			return s
+		}
+	}
+	return nil
+}
+
+func mapHelpText(ht *libconfig.GcloudHelpTextRules) *HelpTextRules {
+	if ht == nil {
+		return nil
+	}
+	return &HelpTextRules{
+		MethodRules: mapRules(ht.MethodRules),
+		FieldRules:  mapRules(ht.FieldRules),
+	}
+}
+
+func mapRules(src []*libconfig.GcloudHelpTextRule) []*HelpTextRule {
+	var dst []*HelpTextRule
+	for _, r := range src {
+		dst = append(dst, &HelpTextRule{
+			Selector: r.Selector,
+			HelpText: &HelpTextElement{
+				Brief:       r.Brief,
+				Description: r.Description,
+				Examples:    r.Examples,
+			},
+		})
+	}
+	return dst
 }

--- a/internal/sidekick/surfer/provider/config_test.go
+++ b/internal/sidekick/surfer/provider/config_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	libconfig "github.com/googleapis/librarian/internal/config"
 )
 
 func TestFindHelpTextRule(t *testing.T) {
@@ -146,6 +147,99 @@ func TestAPIVersion(t *testing.T) {
 			got := APIVersion(test.overrides)
 			if got != test.want {
 				t.Errorf("APIVersion() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFromLibrarianConfig(t *testing.T) {
+	library := &libconfig.Library{
+		Surfer: &libconfig.Surfer{
+			SurferAPIs: []*libconfig.SurferAPI{
+				{
+					Path: "google/cloud/test/v1",
+					HelpText: &libconfig.GcloudHelpTextRules{
+						MethodRules: []*libconfig.GcloudHelpTextRule{
+							{
+								Selector:    "google.cloud.test.v1.Service.CreateInstance",
+								Brief:       "Override Brief",
+								Description: "Override Desc",
+								Examples:    []string{"Override Ex"},
+							},
+						},
+						FieldRules: []*libconfig.GcloudHelpTextRule{
+							{
+								Selector:    ".google.cloud.test.v1.Request.instance_id",
+								Brief:       "Override Field Brief",
+								Description: "Override Field Desc",
+								Examples:    []string{"Override Field Ex"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name    string
+		library *libconfig.Library
+		api     *libconfig.API
+		want    *Config
+	}{
+		{
+			name:    "Library has no Surfer config",
+			library: &libconfig.Library{},
+			api:     &libconfig.API{Path: "google/cloud/test/v1"},
+			want:    &Config{},
+		},
+		{
+			name:    "API Path not found in overrides",
+			library: library,
+			api:     &libconfig.API{Path: "google/cloud/unrelated/v1"},
+			want:    &Config{},
+		},
+
+		{
+			name:    "API Path found with HelpText overrides",
+			library: library,
+			api:     &libconfig.API{Path: "google/cloud/test/v1"},
+			want: &Config{
+				APIs: []API{
+					{
+						Name: "parallelstore",
+						HelpText: &HelpTextRules{
+							MethodRules: []*HelpTextRule{
+								{
+									Selector: "google.cloud.test.v1.Service.CreateInstance",
+									HelpText: &HelpTextElement{
+										Brief:       "Override Brief",
+										Description: "Override Desc",
+										Examples:    []string{"Override Ex"},
+									},
+								},
+							},
+							FieldRules: []*HelpTextRule{
+								{
+									Selector: ".google.cloud.test.v1.Request.instance_id",
+									HelpText: &HelpTextElement{
+										Brief:       "Override Field Brief",
+										Description: "Override Field Desc",
+										Examples:    []string{"Override Field Ex"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := FromLibrarianConfig(test.library, test.api, "parallelstore")
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("FromLibrarianConfig() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This change migrates gcloud surfer overrides in librarian.yaml to be configured per-API rather than globally, allowing fine-grained help text control in libraries with multiple APIs.

Specifically:
- Updates config.Surfer schema in language.go to support a SurferAPIs slice and moves GcloudHelpTextRules entirely into SurferAPI (removing global HelpText).
- Implements provider.FromLibrarianConfig inside the sidekick/surfer/provider package to abstract the conversion and mapping of Librarian configs into provider.Config, keeping the provider decoupled from Librarian.
- Refactors Librarian's generate.go to delegate configuration generation directly to provider.FromLibrarianConfig, simplifying generation logic.
- Adds targeted unit test TestFromLibrarianConfig to config_test.go to verify the conversion and override mapping logic.

For https://github.com/googleapis/librarian/issues/5511