### PR TITLE
feat(internal/librarian/gcloud): derive API path and output

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/legacylibrarian/legacyconfig"
 	"github.com/googleapis/librarian/internal/librarian/dart"
+	"github.com/googleapis/librarian/internal/librarian/gcloud"
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/python"
@@ -131,6 +132,8 @@ func deriveLibraryName(language string, api string) string {
 		return dart.DefaultLibraryName(api)
 	case config.LanguageFake:
 		return fakeDefaultLibraryName(api)
+	case config.LanguageGcloud:
+		return gcloud.DefaultLibraryName(api)
 	case config.LanguageGo:
 		return golang.DefaultLibraryName(api)
 	case config.LanguageJava:

--- a/internal/librarian/gcloud/default.go
+++ b/internal/librarian/gcloud/default.go
@@ -22,6 +22,10 @@ import (
 // DeriveAPIPath returns the canonical API path for a gcloud library name. For
 // example: accessapproval -> google/cloud/accessapproval/v1.
 func DeriveAPIPath(name string) string {
+	// TODO(https://github.com/googleapis/librarian/issues/5862): use the
+	// actual API version from the service configuration or the library's
+	// metadata rather than hardcoding "v1". At the moment we override this
+	// with apis.path in librarian.yaml.
 	return "google/cloud/" + name + "/v1"
 }
 

--- a/internal/librarian/gcloud/default.go
+++ b/internal/librarian/gcloud/default.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// DeriveAPIPath returns the canonical API path for a gcloud library name. For
+// example: accessapproval -> google/cloud/accessapproval/v1.
+func DeriveAPIPath(name string) string {
+	return "google/cloud/" + name + "/v1"
+}
+
+// DefaultLibraryName returns the gcloud library name for an API path. For
+// example: google/cloud/accessapproval/v1 -> accessapproval.
+//
+// The library name is the segment after the leading google/cloud/ (or
+// google/) prefix and before the trailing version. APIs that do not match
+// the expected shape fall through to a "/"-replaced fallback.
+func DefaultLibraryName(api string) string {
+	trimmed := strings.TrimPrefix(api, "google/cloud/")
+	if trimmed == api {
+		trimmed = strings.TrimPrefix(api, "google/")
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return strings.ReplaceAll(api, "/", "-")
+	}
+	return parts[0]
+}
+
+// DefaultOutput returns the output directory for a gcloud library. The
+// directory is a subdirectory of defaultOutput named after the library. When
+// defaultOutput is empty, "generated" is used so that a fresh librarian.yaml
+// without an explicit default.output still produces sensible paths.
+func DefaultOutput(name, defaultOutput string) string {
+	if defaultOutput == "" {
+		defaultOutput = "generated"
+	}
+	return filepath.Join(defaultOutput, name)
+}

--- a/internal/librarian/gcloud/default_test.go
+++ b/internal/librarian/gcloud/default_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDeriveAPIPath(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want string
+	}{
+		{"accessapproval", "google/cloud/accessapproval/v1"},
+		{"secretmanager", "google/cloud/secretmanager/v1"},
+		{"parallelstore", "google/cloud/parallelstore/v1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DeriveAPIPath(test.name)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDefaultLibraryName(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		api  string
+		want string
+	}{
+		{"google-cloud-v1", "google/cloud/accessapproval/v1", "accessapproval"},
+		{"google-cloud-v1beta", "google/cloud/secretmanager/v1beta2", "secretmanager"},
+		{"google-no-cloud", "google/longrunning/v1", "longrunning"},
+		{"unknown-shape", "foo/bar/baz", "foo"},
+		{"empty", "", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultLibraryName(test.api)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDefaultOutput(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		libName       string
+		defaultOutput string
+		want          string
+	}{
+		{"empty default falls back to generated", "accessapproval", "", "generated/accessapproval"},
+		{"explicit default", "accessapproval", "out", "out/accessapproval"},
+		{"explicit default same as fallback", "accessapproval", "generated", "generated/accessapproval"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultOutput(test.libName, test.defaultOutput)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -332,6 +332,8 @@ func defaultOutput(language string, name, api, defaultOut string) string {
 	switch language {
 	case config.LanguageDart:
 		return dart.DefaultOutput(name, defaultOut)
+	case config.LanguageGcloud:
+		return gcloud.DefaultOutput(name, defaultOut)
 	case config.LanguageGo:
 		return golang.DefaultOutput(name, defaultOut)
 	case config.LanguageNodejs:
@@ -351,6 +353,8 @@ func deriveAPIPath(language string, name string) string {
 	switch language {
 	case config.LanguageDart:
 		return dart.DeriveAPIPath(name)
+	case config.LanguageGcloud:
+		return gcloud.DeriveAPIPath(name)
 	case config.LanguageRust:
 		return rust.DeriveAPIPath(name)
 	default:


### PR DESCRIPTION
librarian add, generate and tidy now supports deriving the API path and output based on the name.

For https://github.com/googleapis/librarian/issues/5769