### PR TITLE
feat(internal/librarian/python): install pandoc via librarian install

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -26,15 +26,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - name: Install pandoc
-        run: |
-          set -e
-          curl -fsSL --retry 5 --retry-delay 15 -o /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/$VERSION/pandoc-$VERSION-linux-amd64.tar.gz
-          sudo tar -xvf /tmp/pandoc.tar.gz -C /usr/local --strip-components=1
-          pandoc --version
-        env:
-          VERSION: 3.8.2
       - name: Install Python dependencies
         run: librarian install python
+      - name: Add librarian cache bin to PATH
+        run: echo "$HOME/.cache/librarian/bin" >> $GITHUB_PATH
       - name: Run tests
         run: go run ./tool/cmd/coverage ./internal/librarian/python

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -57,6 +57,7 @@ This document describes the schema for the librarian.yaml.
 | `npm` | list of [NPMTool](#npmtool-configuration) (optional) | Defines tools to install via npm. |
 | `pip` | list of [PipTool](#piptool-configuration) (optional) | Defines tools to install via pip. |
 | `go` | list of [GoTool](#gotool-configuration) (optional) | Defines tools to install via go. |
+| `pandoc` | string | Is the version of pandoc to install (e.g. "3.8.2"). Empty means pandoc is not installed. |
 
 ## CargoTool Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,10 @@ type Tools struct {
 
 	// Go defines tools to install via go.
 	Go []*GoTool `yaml:"go,omitempty"`
+
+	// Pandoc is the version of pandoc to install (e.g. "3.8.2"). Empty means
+	// pandoc is not installed.
+	Pandoc string `yaml:"pandoc,omitempty"`
 }
 
 // CargoTool defines a tool to install via cargo.

--- a/internal/librarian/python/install.go
+++ b/internal/librarian/python/install.go
@@ -15,9 +15,20 @@
 package python
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
@@ -27,22 +38,216 @@ import (
 //go:embed librarian.yaml
 var librarianYAML []byte
 
+// pandocBaseURL is the base URL for downloading pandoc release archives. It is
+// a variable so tests can override it.
+var pandocBaseURL = "https://github.com/jgm/pandoc/releases/download"
+
+// pandocArtifactFn resolves the archive file name for the given version,
+// runtime.GOOS, and runtime.GOARCH. It is a variable so tests can override
+// platform detection.
+var pandocArtifactFn = pandocArtifact
+
 // Install installs Python pip tool dependencies.
 func Install(ctx context.Context) error {
 	cfg, err := yaml.Unmarshal[config.Config](librarianYAML)
 	if err != nil {
 		return fmt.Errorf("parsing embedded librarian.yaml: %w", err)
 	}
-	if len(cfg.Tools.Pip) == 0 {
+	if cfg.Tools == nil {
 		return nil
 	}
-	args := []string{"install"}
-	for _, tool := range cfg.Tools.Pip {
-		pkg := tool.Package
-		if pkg == "" {
-			pkg = fmt.Sprintf("%s==%s", tool.Name, tool.Version)
+	if len(cfg.Tools.Pip) > 0 {
+		args := []string{"install"}
+		for _, tool := range cfg.Tools.Pip {
+			pkg := tool.Package
+			if pkg == "" {
+				pkg = fmt.Sprintf("%s==%s", tool.Name, tool.Version)
+			}
+			args = append(args, pkg)
 		}
-		args = append(args, pkg)
+		if err := command.RunStreaming(ctx, "pip", args...); err != nil {
+			return err
+		}
 	}
-	return command.RunStreaming(ctx, "pip", args...)
+	if cfg.Tools.Pandoc != "" {
+		if err := installPandoc(ctx, cfg.Tools.Pandoc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// installPandoc downloads pandoc at the given version into the librarian
+// cache bin directory. It is a no-op if the right version is already present.
+func installPandoc(ctx context.Context, version string) error {
+	cache, err := librarianCacheDir()
+	if err != nil {
+		return err
+	}
+	binDir := filepath.Join(cache, "bin")
+	target := filepath.Join(binDir, "pandoc")
+
+	if installed, err := pandocVersion(ctx, target); err == nil && installed == version {
+		return nil
+	}
+
+	artifact, err := pandocArtifactFn(version, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/%s/%s", pandocBaseURL, version, artifact)
+
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("creating %q: %w", binDir, err)
+	}
+	tmp, err := os.CreateTemp("", "pandoc-*"+filepath.Ext(artifact))
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if err := downloadPandoc(ctx, url, tmp); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing %q: %w", tmpPath, err)
+	}
+
+	if strings.HasSuffix(artifact, ".tar.gz") {
+		return extractPandocTarGz(tmpPath, target)
+	}
+	return extractPandocZip(tmpPath, target)
+}
+
+func librarianCacheDir() (string, error) {
+	if cache := os.Getenv("LIBRARIAN_CACHE"); cache != "" {
+		return cache, nil
+	}
+	home, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("getting user cache directory: %w", err)
+	}
+	return filepath.Join(home, "librarian"), nil
+}
+
+func pandocVersion(ctx context.Context, bin string) (string, error) {
+	if _, err := os.Stat(bin); err != nil {
+		return "", err
+	}
+	out, err := exec.CommandContext(ctx, bin, "--version").Output()
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 2 || fields[0] != "pandoc" {
+		return "", fmt.Errorf("unexpected pandoc --version output: %q", string(out))
+	}
+	return fields[1], nil
+}
+
+func pandocArtifact(version, goos, goarch string) (string, error) {
+	switch goos + "/" + goarch {
+	case "linux/amd64":
+		return fmt.Sprintf("pandoc-%s-linux-amd64.tar.gz", version), nil
+	case "linux/arm64":
+		return fmt.Sprintf("pandoc-%s-linux-arm64.tar.gz", version), nil
+	case "darwin/amd64":
+		return fmt.Sprintf("pandoc-%s-x86_64-macOS.zip", version), nil
+	case "darwin/arm64":
+		return fmt.Sprintf("pandoc-%s-arm64-macOS.zip", version), nil
+	}
+	return "", fmt.Errorf("unsupported platform for pandoc install: %s/%s", goos, goarch)
+}
+
+func downloadPandoc(ctx context.Context, url string, w io.Writer) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("building request for %s: %w", url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading %s: status %s", url, resp.Status)
+	}
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		return fmt.Errorf("reading response from %s: %w", url, err)
+	}
+	return nil
+}
+
+func extractPandocTarGz(archive, target string) error {
+	f, err := os.Open(archive)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("reading gzip %q: %w", archive, err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return fmt.Errorf("pandoc binary not found in %q", archive)
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar %q: %w", archive, err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if path.Base(hdr.Name) != "pandoc" {
+			continue
+		}
+		return writePandoc(target, tr)
+	}
+}
+
+func extractPandocZip(archive, target string) error {
+	zr, err := zip.OpenReader(archive)
+	if err != nil {
+		return fmt.Errorf("reading zip %q: %w", archive, err)
+	}
+	defer zr.Close()
+	for _, entry := range zr.File {
+		if entry.FileInfo().IsDir() {
+			continue
+		}
+		if path.Base(entry.Name) != "pandoc" {
+			continue
+		}
+		rc, err := entry.Open()
+		if err != nil {
+			return fmt.Errorf("opening %q in %q: %w", entry.Name, archive, err)
+		}
+		err = writePandoc(target, rc)
+		rc.Close()
+		return err
+	}
+	return fmt.Errorf("pandoc binary not found in %q", archive)
+}
+
+func writePandoc(target string, src io.Reader) error {
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("creating %q: %w", target, err)
+	}
+	if _, err := io.Copy(out, src); err != nil {
+		out.Close()
+		return fmt.Errorf("writing %q: %w", target, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing %q: %w", target, err)
+	}
+	if err := os.Chmod(target, 0755); err != nil {
+		return fmt.Errorf("chmod %q: %w", target, err)
+	}
+	return nil
 }

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -15,8 +15,17 @@
 package python
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -27,7 +36,123 @@ func TestInstall(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
+	cache := t.TempDir()
+	t.Setenv("LIBRARIAN_CACHE", cache)
+	cacheBin := filepath.Join(cache, "bin")
+	if err := os.MkdirAll(cacheBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheBin, "pandoc"), []byte("#!/bin/sh\necho \"pandoc 3.8.2\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := Install(t.Context()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestInstallPandoc(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake pandoc is a shell script; not runnable on Windows")
+	}
+
+	const version = "3.8.2"
+	archive, err := buildFakePandocTarGz(version)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	artifactName, err := pandocArtifact(version, "linux", "amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPath := "/" + version + "/" + artifactName
+
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Path != expectedPath {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(archive)
+	}))
+	t.Cleanup(srv.Close)
+
+	originalBaseURL := pandocBaseURL
+	originalArtifact := pandocArtifactFn
+	pandocBaseURL = srv.URL
+	pandocArtifactFn = func(v, _, _ string) (string, error) {
+		return pandocArtifact(v, "linux", "amd64")
+	}
+	t.Cleanup(func() {
+		pandocBaseURL = originalBaseURL
+		pandocArtifactFn = originalArtifact
+	})
+
+	cache := t.TempDir()
+	t.Setenv("LIBRARIAN_CACHE", cache)
+
+	if err := installPandoc(t.Context(), version); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(cache, "bin", "pandoc")
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o755 {
+		t.Errorf("mode = %o, want 0755", mode)
+	}
+	out, err := exec.Command(target, "--version").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "pandoc "+version) {
+		t.Errorf("--version output = %q, want to contain %q", string(out), "pandoc "+version)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("server requests = %d, want 1", got)
+	}
+
+	t.Run("idempotent", func(t *testing.T) {
+		if err := installPandoc(t.Context(), version); err != nil {
+			t.Fatal(err)
+		}
+		if got := requests.Load(); got != 1 {
+			t.Errorf("server requests after second call = %d, want 1", got)
+		}
+	})
+}
+
+// buildFakePandocTarGz creates an in-memory tar.gz archive whose only entry
+// is a tiny shell script at pandoc-<version>/bin/pandoc that prints the
+// version string.
+func buildFakePandocTarGz(version string) ([]byte, error) {
+	script := []byte("#!/bin/sh\necho \"pandoc " + version + "\"\n")
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     "pandoc-" + version + "/bin/pandoc",
+		Mode:     0o755,
+		Size:     int64(len(script)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(script); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -17,6 +17,7 @@
 # librarian.
 language: python
 tools:
+  pandoc: "3.8.2"
   pip:
     - name: gapic-generator
       version: "1.30.13"


### PR DESCRIPTION
librarian install for Python now downloads the matching pandoc release from github.com/jgm/pandoc and writes the binary to $LIBRARIAN_CACHE/bin/pandoc. Subsequent runs are a no-op when the installed binary already reports the configured version.

