### PR TITLE
feat(internal/config): add gcloud.client_path override for Library

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -125,6 +125,7 @@ This document describes the schema for the librarian.yaml.
 | `specification_format` | string | Specifies the API specification format. Valid values are "protobuf" (default) or "discovery". |
 | `dart` | [DartPackage](#dartpackage-configuration) (optional) | Contains Dart-specific library configuration. |
 | `dotnet` | [DotnetPackage](#dotnetpackage-configuration) (optional) | Contains .NET-specific library configuration. |
+| `gcloud` | [GcloudCommand](#gcloudcommand-configuration) (optional) | Contains gcloud-specific library configuration. |
 | `go` | [GoModule](#gomodule-configuration) (optional) | Contains Go-specific library configuration. |
 | `java` | [JavaModule](#javamodule-configuration) (optional) | Contains Java-specific library configuration. |
 | `nodejs` | [NodejsPackage](#nodejspackage-configuration) (optional) | Contains Node.js-specific library configuration. |
@@ -229,6 +230,12 @@ This document describes the schema for the librarian.yaml.
 | `from` | string |  |
 | `to` | string |  |
 | `wire_name` | string |  |
+
+## GcloudCommand Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `client_import_path` | string | Overrides the GAPIC Go client import path that would otherwise be derived from the proto package. Set this when the proto package and the published Go GAPIC location diverge. For example, the proto package google.cloud.recaptchaenterprise.v1 publishes its Go client at "cloud.google.com/go/recaptchaenterprise/v2/apiv1". |
 
 ## GcloudHelpTextRule Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,6 +295,9 @@ type Library struct {
 	// Dotnet contains .NET-specific library configuration.
 	Dotnet *DotnetPackage `yaml:"dotnet,omitempty"`
 
+	// Gcloud contains gcloud-specific library configuration.
+	Gcloud *GcloudCommand `yaml:"gcloud,omitempty"`
+
 	// Go contains Go-specific library configuration.
 	Go *GoModule `yaml:"go,omitempty"`
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -756,6 +756,17 @@ type NodejsAPI struct {
 	Path string `yaml:"path,omitempty"`
 }
 
+// GcloudCommand contains gcloud-specific library configuration.
+type GcloudCommand struct {
+	// ClientImportPath overrides the GAPIC Go client import path that
+	// would otherwise be derived from the proto package. Set this when
+	// the proto package and the published Go GAPIC location diverge.
+	// For example, the proto package google.cloud.recaptchaenterprise.v1
+	// publishes its Go client at
+	// "cloud.google.com/go/recaptchaenterprise/v2/apiv1".
+	ClientImportPath string `yaml:"client_import_path,omitempty"`
+}
+
 // Surfer contains gcloud-specific library configuration. Surfer is related to gcloud command generation.
 type Surfer struct {
 	// HelpText contains help text overrides for the surface.

--- a/internal/librarian/gcloud/generate.go
+++ b/internal/librarian/gcloud/generate.go
@@ -49,6 +49,11 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
+	var clientImportPath string
+	if library.Gcloud != nil {
+		clientImportPath = library.Gcloud.ClientImportPath
+	}
+
 	resolvedSrcs := &sources.Sources{Googleapis: googleapisDir}
 	models := make([]*api.API, 0, len(library.APIs))
 	for _, a := range library.APIs {
@@ -58,7 +63,7 @@ func Generate(ctx context.Context, library *config.Library, srcs *sources.Source
 		}
 		models = append(models, model)
 	}
-	return sidekickgcloud.Generate(models, outDir)
+	return sidekickgcloud.Generate(models, outDir, clientImportPath)
 }
 
 func buildModel(a *config.API, srcs *sources.Sources, googleapisDir string) (*api.API, error) {

--- a/internal/librarian/gcloud/generate_test.go
+++ b/internal/librarian/gcloud/generate_test.go
@@ -17,6 +17,7 @@ package gcloud
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -50,6 +51,30 @@ func TestGenerate(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(out, name)); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestGenerate_GcloudClientImportPath(t *testing.T) {
+	testhelper.RequireCommand(t, "protoc")
+
+	const clientImportPath = "cloud.google.com/go/parallelstore/apiv1"
+	out := t.TempDir()
+	library := &config.Library{
+		Name:   "parallelstore",
+		Output: out,
+		APIs:   []*config.API{{Path: "google/cloud/parallelstore/v1"}},
+		Gcloud: &config.GcloudCommand{ClientImportPath: clientImportPath},
+	}
+	if err := Generate(t.Context(), library,
+		&sources.Sources{Googleapis: testGoogleapisDir}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(out, "internal", "generated", "parallelstore", "commands.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), clientImportPath) {
+		t.Errorf("commands.go missing override path %q\n%s", clientImportPath, got)
 	}
 }
 

--- a/internal/sidekick/gcloud/client.go
+++ b/internal/sidekick/gcloud/client.go
@@ -73,10 +73,12 @@ func clientInfoFromPath(clientImportPath string) *goClientInfo {
 	if !strings.HasPrefix(last, "api") || len(last) == len("api") {
 		return nil
 	}
+
 	var alias string
 	for i := len(segments) - 2; i >= 0; i-- {
 		s := segments[i]
-		if isStableVersion(s) {
+		// Skip any segment that looks like a version (e.g., v1, v2, v1beta1).
+		if strings.HasPrefix(s, "v") && len(s) > 1 && s[1] >= '0' && s[1] <= '9' {
 			continue
 		}
 		alias = s

--- a/internal/sidekick/gcloud/client.go
+++ b/internal/sidekick/gcloud/client.go
@@ -43,8 +43,12 @@ type goClientInfo struct {
 // to its Go client (apiv1) and proto-Go (apiv1/parallelstorepb) packages.
 // It returns nil when the proto package does not have the shape
 // google.cloud.<short>.v<N>. Beta and alpha suffixes (e.g. v1beta1) are
-// intentionally excluded for now.
-func goClientPackage(protoPkg string) *goClientInfo {
+// intentionally excluded for now. If clientImportPath is non-empty it
+// overrides the proto-derived path.
+func goClientPackage(protoPkg, clientImportPath string) *goClientInfo {
+	if clientImportPath != "" {
+		return clientInfoFromPath(clientImportPath)
+	}
 	rest, ok := strings.CutPrefix(protoPkg, "google.cloud.")
 	if !ok {
 		return nil
@@ -57,6 +61,34 @@ func goClientPackage(protoPkg string) *goClientInfo {
 		Alias:      short,
 		ClientPath: fmt.Sprintf("cloud.google.com/go/%s/api%s", short, version),
 		PbPath:     fmt.Sprintf("cloud.google.com/go/%s/api%s/%spb", short, version, short),
+	}
+}
+
+// clientInfoFromPath derives a goClientInfo from an explicit GAPIC Go client
+// import path. It returns nil when the path's final segment is not an
+// "api<version>" segment or when no usable alias can be found.
+func clientInfoFromPath(clientImportPath string) *goClientInfo {
+	segments := strings.Split(clientImportPath, "/")
+	last := segments[len(segments)-1]
+	if !strings.HasPrefix(last, "api") || len(last) == len("api") {
+		return nil
+	}
+	var alias string
+	for i := len(segments) - 2; i >= 0; i-- {
+		s := segments[i]
+		if isStableVersion(s) {
+			continue
+		}
+		alias = s
+		break
+	}
+	if !isLowerAlphanum(alias) {
+		return nil
+	}
+	return &goClientInfo{
+		Alias:      alias,
+		ClientPath: clientImportPath,
+		PbPath:     clientImportPath + "/" + alias + "pb",
 	}
 }
 

--- a/internal/sidekick/gcloud/generate.go
+++ b/internal/sidekick/gcloud/generate.go
@@ -40,13 +40,13 @@ const modulePath = "cloud.google.com/go/gcloud"
 // each model it emits internal/generated/<name>/commands.go exposing a
 // Command() function, then writes cmd/gcloud/main.go that registers each
 // surface under the gcloud root.
-func Generate(models []*api.API, outdir string) error {
+func Generate(models []*api.API, outdir string, clientImportPath string) error {
 	if len(models) == 0 {
 		return errors.New("gcloud: Generate requires at least one model")
 	}
 	main := CLIModel{ModulePath: modulePath}
 	for _, model := range models {
-		surface := constructSurfaceModel(model)
+		surface := constructSurfaceModel(model, clientImportPath)
 		if err := writeSurface(outdir, surface); err != nil {
 			return err
 		}

--- a/internal/sidekick/gcloud/generate_test.go
+++ b/internal/sidekick/gcloud/generate_test.go
@@ -62,7 +62,7 @@ func TestFromProtobuf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate([]*api.API{model}, outDir); err != nil {
+	if err := Generate([]*api.API{model}, outDir, ""); err != nil {
 		t.Fatal(err)
 	}
 	mainFile := filepath.Join(outDir, "cmd", "gcloud", "main.go")
@@ -101,11 +101,10 @@ func TestGenerate(t *testing.T) {
 		}
 		return m
 	}
-
 	parallelstoreModel := makeModel("google/cloud/parallelstore/v1/service.yaml", "google/cloud/parallelstore/v1")
 	publiccaModel := makeModel("google/cloud/security/publicca/v1/publicca_v1.yaml", "google/cloud/security/publicca/v1")
 
-	if err := Generate([]*api.API{parallelstoreModel, publiccaModel}, outDir); err != nil {
+	if err := Generate([]*api.API{parallelstoreModel, publiccaModel}, outDir, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -430,6 +429,7 @@ func TestGoClientPackage(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		protoPkg string
+		override string
 		want     *goClientInfo
 	}{
 		{
@@ -454,9 +454,53 @@ func TestGoClientPackage(t *testing.T) {
 		{name: "three-segments", protoPkg: "google.cloud.parallelstore"},
 		{name: "beta-version", protoPkg: "google.cloud.parallelstore.v1beta1"},
 		{name: "not-google-cloud", protoPkg: "google.api.X.v1"},
+		{
+			name:     "override-major-version",
+			protoPkg: "google.cloud.recaptchaenterprise.v1",
+			override: "cloud.google.com/go/recaptchaenterprise/v2/apiv1",
+			want: &goClientInfo{
+				Alias:      "recaptchaenterprise",
+				ClientPath: "cloud.google.com/go/recaptchaenterprise/v2/apiv1",
+				PbPath:     "cloud.google.com/go/recaptchaenterprise/v2/apiv1/recaptchaenterprisepb",
+			},
+		},
+		{
+			name:     "override-renamed-module",
+			protoPkg: "google.cloud.tasks.v2",
+			override: "cloud.google.com/go/cloudtasks/apiv2",
+			want: &goClientInfo{
+				Alias:      "cloudtasks",
+				ClientPath: "cloud.google.com/go/cloudtasks/apiv2",
+				PbPath:     "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb",
+			},
+		},
+		{
+			name:     "override-translate-apiv3",
+			protoPkg: "google.cloud.translation.v3",
+			override: "cloud.google.com/go/translate/apiv3",
+			want: &goClientInfo{
+				Alias:      "translate",
+				ClientPath: "cloud.google.com/go/translate/apiv3",
+				PbPath:     "cloud.google.com/go/translate/apiv3/translatepb",
+			},
+		},
+		{
+			name:     "override-ignores-proto-pkg",
+			protoPkg: "ignored.totally",
+			override: "cloud.google.com/go/translate/apiv3",
+			want: &goClientInfo{
+				Alias:      "translate",
+				ClientPath: "cloud.google.com/go/translate/apiv3",
+				PbPath:     "cloud.google.com/go/translate/apiv3/translatepb",
+			},
+		},
+		{
+			name:     "override-malformed-no-api",
+			override: "cloud.google.com/go/parallelstore",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := goClientPackage(test.protoPkg)
+			got := goClientPackage(test.protoPkg, test.override)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/sidekick/gcloud/model.go
+++ b/internal/sidekick/gcloud/model.go
@@ -94,7 +94,7 @@ type Subgroup struct {
 // from the given API model. The returned model's PackageName matches the
 // API's short name (e.g. "parallelstore"), which is also used as the
 // directory name under internal/generated/.
-func constructSurfaceModel(model *api.API) SurfaceModel {
+func constructSurfaceModel(model *api.API, clientImportPath string) SurfaceModel {
 	rootGroup := Group{
 		Name:  model.Name,
 		Usage: fmt.Sprintf("manage %s resources", model.Title),
@@ -102,7 +102,7 @@ func constructSurfaceModel(model *api.API) SurfaceModel {
 
 	var (
 		imports       []Import
-		goClient      = goClientPackage(model.PackageName)
+		goClient      = goClientPackage(model.PackageName, clientImportPath)
 		hasClientCall = false
 		subgroups     = make(map[string]*Subgroup)
 	)

--- a/internal/sidekick/gcloud/model_test.go
+++ b/internal/sidekick/gcloud/model_test.go
@@ -124,7 +124,7 @@ func TestConstructSurfaceModel(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := constructSurfaceModel(test.model)
+			got := constructSurfaceModel(test.model, "")
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
The gcloud generator derives the GAPIC Go client import path from the proto package using the format cloud.google.com/go/<short>/api<version>. Some surfaces do not follow that shape, so add an option for an override. 