### PR TITLE
refactor(internal/sidekick/surfer): rename build constructors to use new prefix

### DIFF
--- a/internal/sidekick/surfer/argument_builder.go
+++ b/internal/sidekick/surfer/argument_builder.go
@@ -34,9 +34,9 @@ type argumentParams struct {
 	apiField  []string
 }
 
-// buildArgument creates a single command-line argument (an `Argument` struct) from the parameters.
+// newArgument creates a single command-line argument (an `Argument` struct) from the parameters.
 // It returns nil if the field should be ignored.
-func buildArgument(ap *argumentParams) (*Argument, error) {
+func newArgument(ap *argumentParams) (*Argument, error) {
 	if isArgIgnored(ap.field, ap.method) {
 		return nil, nil
 	}
@@ -129,9 +129,9 @@ func mapSpec() []ArgSpec {
 	return []ArgSpec{{APIField: "key"}, {APIField: "value"}}
 }
 
-// buildPrimaryResourceArgument creates the main positional resource argument for a command.
+// newPrimaryResourceArgument creates the main positional resource argument for a command.
 // This is the argument that represents the resource being acted upon (e.g., the instance name).
-func buildPrimaryResourceArgument(ap *argumentParams, idField *api.Field) Argument {
+func newPrimaryResourceArgument(ap *argumentParams, idField *api.Field) Argument {
 	resource := provider.GetResourceForMethod(ap.method, ap.model)
 	var segments []api.PathSegment
 	// TODO(https://github.com/googleapis/librarian/issues/3415): Support multiple resource patterns and multitype resources.

--- a/internal/sidekick/surfer/argument_builder_test.go
+++ b/internal/sidekick/surfer/argument_builder_test.go
@@ -157,7 +157,7 @@ func TestNewArgument(t *testing.T) {
 			if overrides == nil {
 				overrides = &provider.Config{}
 			}
-			got, err := buildArgument(&argumentParams{
+			got, err := newArgument(&argumentParams{
 				method:    test.method,
 				overrides: overrides,
 				model:     model,
@@ -538,7 +538,7 @@ func TestNewPrimaryResourceArgument(t *testing.T) {
 			if provider.IsCreate(test.method) {
 				idField = test.field
 			}
-			got := buildPrimaryResourceArgument(&argumentParams{
+			got := newPrimaryResourceArgument(&argumentParams{
 				method:  test.method,
 				model:   model,
 				service: service,
@@ -592,7 +592,7 @@ func TestArgumentBuilder_Build(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := buildArgument(&argumentParams{
+			got, err := newArgument(&argumentParams{
 				method:    createMethod,
 				overrides: &provider.Config{},
 				model:     model,

--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -53,8 +53,8 @@ func newCommand(method *api.Method, overrides *provider.Config, model *api.API, 
 	}, nil
 }
 
-// buildWaitCommand synthesizes a 'wait' command for operations based on GetOperation method.
-func buildWaitCommand(getMethod *api.Method, overrides *provider.Config, model *api.API, service *api.Service) (*Command, error) {
+// newWaitCommand synthesizes a 'wait' command for operations based on GetOperation method.
+func newWaitCommand(getMethod *api.Method, overrides *provider.Config, model *api.API, service *api.Service) (*Command, error) {
 	arg, err := positionalResourceArg(getMethod, overrides, model, service)
 	if err != nil {
 		return nil, err
@@ -255,7 +255,7 @@ func positionalResourceArg(method *api.Method, overrides *provider.Config, model
 		idField = cf.resourceIdField.field
 	}
 
-	arg := buildPrimaryResourceArgument(&argumentParams{
+	arg := newPrimaryResourceArgument(&argumentParams{
 		method:    method,
 		overrides: overrides,
 		model:     model,

--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -24,7 +24,7 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-func buildCommand(method *api.Method, overrides *provider.Config, model *api.API, service *api.Service) (*Command, error) {
+func newCommand(method *api.Method, overrides *provider.Config, model *api.API, service *api.Service) (*Command, error) {
 	args, err := newArguments(method, overrides, model, service)
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func newArguments(method *api.Method, overrides *provider.Config, model *api.API
 		if cf.resourceIdField != nil {
 			idField = cf.resourceIdField.field
 		}
-		arg := buildPrimaryResourceArgument(&argumentParams{
+		arg := newPrimaryResourceArgument(&argumentParams{
 			method:    method,
 			overrides: overrides,
 			model:     model,
@@ -220,7 +220,7 @@ func newArguments(method *api.Method, overrides *provider.Config, model *api.API
 	}
 
 	for _, fwp := range cf.other {
-		arg, err := buildArgument(&argumentParams{
+		arg, err := newArgument(&argumentParams{
 			method:    method,
 			overrides: overrides,
 			model:     model,

--- a/internal/sidekick/surfer/command_builder_test.go
+++ b/internal/sidekick/surfer/command_builder_test.go
@@ -469,7 +469,7 @@ func TestNewCommand(t *testing.T) {
 
 			got, err := newCommand(test.method, test.overrides, model, service)
 			if err != nil {
-				t.Fatalf("newCommand() unexpected error: %v", err)
+				t.Fatal(err)
 			}
 
 			opts := cmpopts.IgnoreFields(Command{}, "Arguments", "Collection", "Method", "HelpText")

--- a/internal/sidekick/surfer/command_builder_test.go
+++ b/internal/sidekick/surfer/command_builder_test.go
@@ -467,9 +467,9 @@ func TestNewCommand(t *testing.T) {
 			test.method.Service = service
 			test.method.Model = model
 
-			got, err := buildCommand(test.method, test.overrides, model, service)
+			got, err := newCommand(test.method, test.overrides, model, service)
 			if err != nil {
-				t.Fatalf("buildCommand() unexpected error: %v", err)
+				t.Fatalf("newCommand() unexpected error: %v", err)
 			}
 
 			opts := cmpopts.IgnoreFields(Command{}, "Arguments", "Collection", "Method", "HelpText")
@@ -488,9 +488,9 @@ func TestNewCommand_Error(t *testing.T) {
 	service.DefaultHost = "test.googleapis.com"
 	model := api.NewTestAPI([]*api.Message{}, nil, []*api.Service{service})
 
-	_, err := buildCommand(m, &provider.Config{}, model, service)
+	_, err := newCommand(m, &provider.Config{}, model, service)
 	if err == nil {
-		t.Errorf("build() expected error for nil Service, got nil")
+		t.Errorf("newCommand() expected error for nil Service, got nil")
 	}
 }
 

--- a/internal/sidekick/surfer/command_builder_test.go
+++ b/internal/sidekick/surfer/command_builder_test.go
@@ -823,7 +823,7 @@ func TestCommandBuilderNewArgumentsResourceError(t *testing.T) {
 	}
 }
 
-func TestBuildWaitCommand(t *testing.T) {
+func TestNewWaitCommand(t *testing.T) {
 	service := api.NewTestService("TestService").WithPackage("google.cloud.test.v1")
 	service.DefaultHost = "test.googleapis.com"
 
@@ -857,9 +857,9 @@ func TestBuildWaitCommand(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, nil, []*api.Service{service})
 	m.Model = model
 
-	got, err := buildWaitCommand(m, &provider.Config{}, model, service)
+	got, err := newWaitCommand(m, &provider.Config{}, model, service)
 	if err != nil {
-		t.Fatalf("buildWaitCommand() unexpected error: %v", err)
+		t.Fatalf("newWaitCommand() unexpected error: %v", err)
 	}
 
 	want := &Command{
@@ -883,22 +883,22 @@ func TestBuildWaitCommand(t *testing.T) {
 	}
 
 	if got.Name != want.Name {
-		t.Errorf("buildWaitCommand().Name = %q, want %q", got.Name, want.Name)
+		t.Errorf("newWaitCommand().Name = %q, want %q", got.Name, want.Name)
 	}
 	if got.APIVersion != want.APIVersion {
-		t.Errorf("buildWaitCommand().APIVersion = %q, want %q", got.APIVersion, want.APIVersion)
+		t.Errorf("newWaitCommand().APIVersion = %q, want %q", got.APIVersion, want.APIVersion)
 	}
 	if diff := cmp.Diff(want.HelpText, got.HelpText); diff != "" {
-		t.Errorf("buildWaitCommand().HelpText mismatch (-want +got):\n%s", diff)
+		t.Errorf("newWaitCommand().HelpText mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(want.Collection, got.Collection); diff != "" {
-		t.Errorf("buildWaitCommand().Collection mismatch (-want +got):\n%s", diff)
+		t.Errorf("newWaitCommand().Collection mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(want.Async, got.Async); diff != "" {
-		t.Errorf("buildWaitCommand().Async mismatch (-want +got):\n%s", diff)
+		t.Errorf("newWaitCommand().Async mismatch (-want +got):\n%s", diff)
 	}
 	if len(got.Arguments) == 0 || got.Arguments[0].HelpText != want.Arguments[0].HelpText {
-		t.Errorf("buildWaitCommand().Arguments[0].HelpText = %q, want %q",
+		t.Errorf("newWaitCommand().Arguments[0].HelpText = %q, want %q",
 			func() string {
 				if len(got.Arguments) > 0 {
 					return got.Arguments[0].HelpText
@@ -909,7 +909,7 @@ func TestBuildWaitCommand(t *testing.T) {
 	}
 }
 
-func TestBuildWaitCommand_Error(t *testing.T) {
+func TestNewWaitCommand_Error(t *testing.T) {
 	service := api.NewTestService("TestService").WithPackage("google.cloud.test.v1")
 	service.DefaultHost = "test.googleapis.com"
 
@@ -941,11 +941,11 @@ func TestBuildWaitCommand_Error(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, nil, []*api.Service{service})
 	m.Model = model
 
-	_, err := buildWaitCommand(m, &provider.Config{}, model, service)
+	_, err := newWaitCommand(m, &provider.Config{}, model, service)
 	if err == nil {
-		t.Fatal("buildWaitCommand() expected error, got nil")
+		t.Fatal("newWaitCommand() expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "missing positional resource argument for wait command") {
-		t.Errorf("buildWaitCommand() error = %q, want error containing %q", err, "missing positional resource argument for wait command")
+		t.Errorf("newWaitCommand() error = %q, want error containing %q", err, "missing positional resource argument for wait command")
 	}
 }

--- a/internal/sidekick/surfer/generate.go
+++ b/internal/sidekick/surfer/generate.go
@@ -24,7 +24,7 @@ import (
 // overrides and writes the resulting command groups into output under
 // baseModule.
 func Generate(model *api.API, overrides *provider.Config, output, baseModule string) error {
-	tree, err := buildSurface(model, overrides)
+	tree, err := newSurface(model, overrides)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/surfer/group_builder.go
+++ b/internal/sidekick/surfer/group_builder.go
@@ -30,7 +30,7 @@ type groupParams struct {
 	config  *provider.Config
 }
 
-func buildRootGroup(params *groupParams) *CommandGroup {
+func newRootGroup(params *groupParams) *CommandGroup {
 	// TODO (https://github.com/googleapis/librarian/issues/3033): Use service selector
 	// to look up the help text from the gcloud config.
 	rootName := provider.ResolveRootPackage(params.model)
@@ -43,7 +43,7 @@ func buildRootGroup(params *groupParams) *CommandGroup {
 	}
 }
 
-func buildGroup(params *groupParams, methodPath []string) *CommandGroup {
+func newGroup(params *groupParams, methodPath []string) *CommandGroup {
 	collectionName := methodPath[len(methodPath)-1]
 	resourceTypeName := provider.GetResourceTypeName(params.model, methodPath)
 

--- a/internal/sidekick/surfer/group_builder_test.go
+++ b/internal/sidekick/surfer/group_builder_test.go
@@ -33,7 +33,7 @@ func TestGroupBuilder_BuildRoot(t *testing.T) {
 		},
 	}
 
-	group := buildRootGroup(&groupParams{
+	group := newRootGroup(&groupParams{
 		model:   model,
 		service: model.Services[0],
 		config:  &provider.Config{},
@@ -66,7 +66,7 @@ func TestGroupBuilder_BuildGroup(t *testing.T) {
 		},
 	}
 
-	group := buildGroup(&groupParams{
+	group := newGroup(&groupParams{
 		model:   model,
 		service: model.Services[0],
 		config:  &provider.Config{},

--- a/internal/sidekick/surfer/surface_builder.go
+++ b/internal/sidekick/surfer/surface_builder.go
@@ -21,7 +21,7 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/surfer/provider"
 )
 
-func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
+func newSurface(model *api.API, config *provider.Config) (*Surface, error) {
 	var root *CommandGroup
 	providerTracks := provider.Tracks(provider.APIVersionFromModel(model))
 	var tracks []ReleaseTrack
@@ -37,7 +37,7 @@ func buildSurface(model *api.API, config *provider.Config) (*Surface, error) {
 		}
 
 		if root == nil {
-			root = buildRootGroup(params)
+			root = newRootGroup(params)
 		}
 
 		for _, method := range service.Methods {
@@ -79,12 +79,12 @@ func insert(root *CommandGroup, params *groupParams, method *api.Method) error {
 		}
 
 		if curr.Groups[seg] == nil {
-			curr.Groups[seg] = buildGroup(params, segments[:i+1])
+			curr.Groups[seg] = newGroup(params, segments[:i+1])
 		}
 		curr = curr.Groups[seg]
 	}
 
-	cmd, err := buildCommand(method, params.config, params.model, params.service)
+	cmd, err := newCommand(method, params.config, params.model, params.service)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/surfer/surface_builder.go
+++ b/internal/sidekick/surfer/surface_builder.go
@@ -93,7 +93,7 @@ func insert(root *CommandGroup, params *groupParams, method *api.Method) error {
 
 	// Synthesize a 'wait' command for operations.
 	if provider.IsOperationsServiceMethod(method) && method.Name == provider.GetOperation {
-		waitCmd, err := buildWaitCommand(method, params.config, params.model, params.service)
+		waitCmd, err := newWaitCommand(method, params.config, params.model, params.service)
 		if err != nil {
 			slog.Warn("failed to build wait command for operations", "method", method.ID, "error", err)
 		} else {

--- a/internal/sidekick/surfer/surface_builder_test.go
+++ b/internal/sidekick/surfer/surface_builder_test.go
@@ -52,9 +52,9 @@ func TestSurfaceBuilder_Build_Structure(t *testing.T) {
 		},
 	}
 
-	root, err := buildSurface(model, config)
+	root, err := newSurface(model, config)
 	if err != nil {
-		t.Fatalf("build() failed: %v", err)
+		t.Fatalf("newSurface() failed: %v", err)
 	}
 
 	got := flattenTree(root.Root)
@@ -78,9 +78,9 @@ func TestSurfaceBuilder_Build_Operations_Disabled(t *testing.T) {
 		Services: []*api.Service{service},
 	}
 
-	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(false)})
+	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(false)})
 	if err != nil {
-		t.Fatalf("build() failed: %v", err)
+		t.Fatalf("newSurface() failed: %v", err)
 	}
 
 	got := flattenTree(root.Root)
@@ -98,9 +98,9 @@ func TestSurfaceBuilder_Build_Operations_Enabled(t *testing.T) {
 		Services: []*api.Service{service},
 	}
 
-	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
+	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
-		t.Fatalf("build() failed: %v", err)
+		t.Fatalf("newSurface() failed: %v", err)
 	}
 
 	got := flattenTree(root.Root)
@@ -123,9 +123,9 @@ func TestSurfaceBuilder_Build_MultipleServices(t *testing.T) {
 		Services: []*api.Service{serviceOne, serviceTwo},
 	}
 
-	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
+	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
-		t.Fatalf("build() failed: %v", err)
+		t.Fatalf("newSurface() failed: %v", err)
 	}
 
 	got := flattenTree(root.Root)
@@ -169,9 +169,9 @@ func TestSurfaceBuilder_Build_HelpTextOverride(t *testing.T) {
 		},
 	}
 
-	root, err := buildSurface(model, config)
+	root, err := newSurface(model, config)
 	if err != nil {
-		t.Fatalf("build() failed: %v", err)
+		t.Fatalf("newSurface() failed: %v", err)
 	}
 
 	instancesGroup, ok := root.Root.Groups["instances"]

--- a/internal/sidekick/surfer/surface_builder_test.go
+++ b/internal/sidekick/surfer/surface_builder_test.go
@@ -54,7 +54,7 @@ func TestSurfaceBuilder_Build_Structure(t *testing.T) {
 
 	root, err := newSurface(model, config)
 	if err != nil {
-		t.Fatalf("newSurface() failed: %v", err)
+		t.Fatal(err)
 	}
 
 	got := flattenTree(root.Root)
@@ -80,7 +80,7 @@ func TestSurfaceBuilder_Build_Operations_Disabled(t *testing.T) {
 
 	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(false)})
 	if err != nil {
-		t.Fatalf("newSurface() failed: %v", err)
+		t.Fatal(err)
 	}
 
 	got := flattenTree(root.Root)
@@ -100,7 +100,7 @@ func TestSurfaceBuilder_Build_Operations_Enabled(t *testing.T) {
 
 	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
-		t.Fatalf("newSurface() failed: %v", err)
+		t.Fatal(err)
 	}
 
 	got := flattenTree(root.Root)
@@ -125,7 +125,7 @@ func TestSurfaceBuilder_Build_MultipleServices(t *testing.T) {
 
 	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
-		t.Fatalf("newSurface() failed: %v", err)
+		t.Fatal(err)
 	}
 
 	got := flattenTree(root.Root)
@@ -171,7 +171,7 @@ func TestSurfaceBuilder_Build_HelpTextOverride(t *testing.T) {
 
 	root, err := newSurface(model, config)
 	if err != nil {
-		t.Fatalf("newSurface() failed: %v", err)
+		t.Fatal(err)
 	}
 
 	instancesGroup, ok := root.Root.Groups["instances"]

--- a/internal/sidekick/surfer/surface_builder_test.go
+++ b/internal/sidekick/surfer/surface_builder_test.go
@@ -255,7 +255,7 @@ func TestSurfaceBuilder_Build_SynthesizeWaitCommand(t *testing.T) {
 		Services: []*api.Service{service},
 	}
 
-	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
+	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
 		t.Fatalf("build() failed: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestSurfaceBuilder_Build_SynthesizeWaitCommand(t *testing.T) {
 func TestSurfaceBuilder_Build_SynthesizeWaitCommand_Warning(t *testing.T) {
 	opMethod := mockMethod("GetOperation", "v1/{name=projects/*/locations/*/operations/*}")
 	opMethod.SourceServiceID = ".google.longrunning.Operations"
-	// Do not add the "name" field to opMethod.InputType.Fields so buildWaitCommand fails.
+	// Do not add the "name" field to opMethod.InputType.Fields so newWaitCommand fails.
 	service := mockService("parallelstore.googleapis.com", opMethod)
 
 	model := &api.API{
@@ -290,7 +290,7 @@ func TestSurfaceBuilder_Build_SynthesizeWaitCommand_Warning(t *testing.T) {
 	slog.SetDefault(slog.New(h))
 	defer slog.SetDefault(oldLogger)
 
-	root, err := buildSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
+	root, err := newSurface(model, &provider.Config{GenerateOperations: boolPtr(true)})
 	if err != nil {
 		t.Fatalf("build() failed: %v", err)
 	}


### PR DESCRIPTION
This change renames constructor functions across the surfer package from using the build prefix to the more Go-idiomatic new prefix:
- buildCommand -> newCommand
- buildWaitCommand -> newWaitCommand
- buildArgument -> newArgument
- buildPrimaryResourceArgument -> newPrimaryResourceArgument
- buildSurface -> newSurface
- buildRootGroup -> newRootGroup
- buildGroup -> newGroup

This ensures (1) consistency across the package (2) eliminates confusion that we are using complex stateful builders (3) aligns with standard Go constructor and factory conventions.