### PR TITLE
refactor(sidekick): common `ExtractCrossReferenceLinks`

### DIFF
--- a/internal/sidekick/language/extract_xref_links.go
+++ b/internal/sidekick/language/extract_xref_links.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package language
+
+import (
+	"bytes"
+	"regexp"
+	"sort"
+
+	"github.com/yuin/goldmark/ast"
+)
+
+// ExtractCrossReferenceLinks returns the cross-reference links found in `doc` and `source`.
+//
+// Google Cloud documentation comments include cross-reference links:
+//
+// https://google.aip.dev/192#cross-references
+//
+// That is, markdown reference-style links in the form `[Title][Definition]` where `Title` is the text that should
+// appear in the documentation and `Definition` is the name of a Protobuf entity, e.g., `google.longrunning.Operation`.
+//
+// The cross reference links can be of the form `[Title][]` when both the title and definitions match. And may also
+// be relative to the current entity (e.g. `Operation` instead of the fully qualified `google.longrunning.Operation`).
+func ExtractCrossReferenceLinks(doc ast.Node, source []byte) []string {
+	protobufLinks := map[string]bool{}
+	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		switch node.Kind() {
+		case ast.KindParagraph:
+			text := node.Lines().Value(source)
+			extractProtoLinks(text, protobufLinks)
+			return ast.WalkContinue, nil
+		case ast.KindTextBlock:
+			text := node.Lines().Value(source)
+			extractProtoLinks(text, protobufLinks)
+			return ast.WalkContinue, nil
+		default:
+			return ast.WalkContinue, nil
+		}
+	})
+	var sortedLinks []string
+	for link := range protobufLinks {
+		sortedLinks = append(sortedLinks, link)
+	}
+	sort.Strings(sortedLinks)
+	return sortedLinks
+}
+
+var commentCrossReferenceLink = regexp.MustCompile(
+	`` + // `go fmt` is annoying
+		`\]` + // The closing bracket for the `[Thing]`
+		`\[` + // The opening bracket for the code element.
+		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
+		`(\.` + // Followed by (maybe a dot)
+		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
+		`)*` + // zero or more times
+		`\]`) // The closing bracket
+
+var commentImpliedCrossReferenceLink = regexp.MustCompile(
+	`` + // `go fmt` is annoying
+		`\[` +
+		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
+		`(\.[A-Za-z][A-Za-z0-9_]*)*` + // Followed by more identifiers
+		`\]\[\]`) // The closing bracket followed by an empty link label
+
+func extractProtoLinks(paragraph []byte, links map[string]bool) {
+	for _, match := range commentCrossReferenceLink.FindAll(paragraph, -1) {
+		match = bytes.TrimSuffix(bytes.TrimPrefix(match, []byte("][")), []byte("]"))
+		links[string(match)] = true
+	}
+	for _, match := range commentImpliedCrossReferenceLink.FindAll(paragraph, -1) {
+		match = bytes.TrimSuffix(bytes.TrimPrefix(match, []byte("[")), []byte("][]"))
+		links[string(match)] = true
+	}
+}

--- a/internal/sidekick/language/extract_xref_links.go
+++ b/internal/sidekick/language/extract_xref_links.go
@@ -36,6 +36,9 @@ import (
 func ExtractCrossReferenceLinks(doc ast.Node, source []byte) []string {
 	protobufLinks := map[string]bool{}
 	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
 		switch node.Kind() {
 		case ast.KindParagraph:
 			text := node.Lines().Value(source)

--- a/internal/sidekick/language/extract_xref_links.go
+++ b/internal/sidekick/language/extract_xref_links.go
@@ -88,7 +88,7 @@ func validProtoName(b []byte) bool {
 	return len(parts) != 0
 }
 
-// isProtoIdent returns true if the id looks like a valid protobuf identifier
+// isProtoIdent returns true if the id looks like a valid identifier.
 func isIdent(id []byte) bool {
 	if len(id) == 0 {
 		return false

--- a/internal/sidekick/language/extract_xref_links.go
+++ b/internal/sidekick/language/extract_xref_links.go
@@ -60,30 +60,54 @@ func ExtractCrossReferenceLinks(doc ast.Node, source []byte) []string {
 	return sortedLinks
 }
 
-var commentCrossReferenceLink = regexp.MustCompile(
-	`` + // `go fmt` is annoying
-		`\]` + // The closing bracket for the `[Thing]`
-		`\[` + // The opening bracket for the code element.
-		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
-		`(\.` + // Followed by (maybe a dot)
-		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
-		`)*` + // zero or more times
-		`\]`) // The closing bracket
+var (
+	explicitLink = regexp.MustCompile(`\]\[([^.][^]]*)\]`)
+	impliedLink  = regexp.MustCompile(`\[([^.][^]]*)\]\[\]`)
+)
 
-var commentImpliedCrossReferenceLink = regexp.MustCompile(
-	`` + // `go fmt` is annoying
-		`\[` +
-		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
-		`(\.[A-Za-z][A-Za-z0-9_]*)*` + // Followed by more identifiers
-		`\]\[\]`) // The closing bracket followed by an empty link label
+func extractProtoLinks(p []byte, links map[string]bool) {
+	for _, m := range explicitLink.FindAllSubmatch(p, -1) {
+		if validProtoName(m[1]) {
+			links[string(m[1])] = true
+		}
+	}
+	for _, m := range impliedLink.FindAllSubmatch(p, -1) {
+		if validProtoName(m[1]) {
+			links[string(m[1])] = true
+		}
+	}
+}
 
-func extractProtoLinks(paragraph []byte, links map[string]bool) {
-	for _, match := range commentCrossReferenceLink.FindAll(paragraph, -1) {
-		match = bytes.TrimSuffix(bytes.TrimPrefix(match, []byte("][")), []byte("]"))
-		links[string(match)] = true
+func validProtoName(b []byte) bool {
+	parts := bytes.Split(b, []byte("."))
+	for _, p := range parts {
+		if !isIdent(p) {
+			return false
+		}
 	}
-	for _, match := range commentImpliedCrossReferenceLink.FindAll(paragraph, -1) {
-		match = bytes.TrimSuffix(bytes.TrimPrefix(match, []byte("[")), []byte("][]"))
-		links[string(match)] = true
+	return len(parts) != 0
+}
+
+// isProtoIdent returns true if the id looks like a valid protobuf identifier
+func isIdent(id []byte) bool {
+	if len(id) == 0 {
+		return false
 	}
+	if !isIdStartingChar(id[0]) {
+		return false
+	}
+	for _, b := range id[1:] {
+		if !isIdChar(b) {
+			return false
+		}
+	}
+	return true
+}
+
+func isIdStartingChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isIdChar(b byte) bool {
+	return isIdStartingChar(b) || (b >= '0' && b <= '9') || b == '_'
 }

--- a/internal/sidekick/language/extract_xref_links_test.go
+++ b/internal/sidekick/language/extract_xref_links_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package language
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+func TestExtractCrossReferenceLinks(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name: "standard links",
+			input: `
+[Any][google.protobuf.Any]
+[Message][test.v1.SomeMessage]
+`,
+			want: []string{"google.protobuf.Any", "test.v1.SomeMessage"},
+		},
+		{
+			name: "implied links",
+			input: `
+implied service reference [SomeService][]
+implied method reference [SomeService.CreateFoo][]
+`,
+			want: []string{"SomeService", "SomeService.CreateFoo"},
+		},
+		{
+			name:  "no links",
+			input: `Just some text without links.`,
+			want:  nil,
+		},
+		{
+			name:  "multiple links on one line",
+			input: `[Service][test.v1.SomeService] [field][test.v1.SomeMessage.field]`,
+			want:  []string{"test.v1.SomeMessage.field", "test.v1.SomeService"},
+		},
+		{
+			name: "link definitions",
+			input: `Link definitions should be added when collapsed links are used.
+For example, [google][].
+Second [example][].
+[Third] example.
+[google]: https://www.google.com
+[example]: https://www.example.com
+[Third]: https://www.third.com`,
+			want: []string{"example", "google"},
+		},
+		{
+			name: "explicit cross links",
+			input: `
+[Any][google.protobuf.Any]
+[Message][test.v1.SomeMessage]
+[Enum][test.v1.SomeMessage.SomeEnum]
+[Message][test.v1.SomeMessage] repeated
+[Service][test.v1.SomeService] [field][test.v1.SomeMessage.field]
+[oneof group][test.v1.SomeMessage.result]
+[oneof field][test.v1.SomeMessage.error]
+[unmangled field][test.v1.SomeMessage.type] - normally r#type, but not in links
+[SomeMessage.error][test.v1.SomeMessage.error]
+[ExternalMessage][google.iam.v1.SetIamPolicyRequest]
+[ExternalService][google.iam.v1.IAMPolicy]
+[ENUM_VALUE][test.v1.SomeMessage.SomeEnum.ENUM_VALUE]
+[SomeService.CreateFoo][test.v1.SomeService.CreateFoo]
+[SomeService.CreateBar][test.v1.SomeService.CreateBar]
+[a method][test.v1.YELL.CreateThing]
+[the service name][test.v1.YELL]
+[renamed service][test.v1.RenamedService]
+[method of renamed service][test.v1.RenamedService.CreateFoo]
+`,
+			want: []string{
+				"google.iam.v1.IAMPolicy",
+				"google.iam.v1.SetIamPolicyRequest",
+				"google.protobuf.Any",
+				"test.v1.RenamedService",
+				"test.v1.RenamedService.CreateFoo",
+				"test.v1.SomeMessage",
+				"test.v1.SomeMessage.SomeEnum",
+				"test.v1.SomeMessage.SomeEnum.ENUM_VALUE",
+				"test.v1.SomeMessage.error",
+				"test.v1.SomeMessage.field",
+				"test.v1.SomeMessage.result",
+				"test.v1.SomeMessage.type",
+				"test.v1.SomeService",
+				"test.v1.SomeService.CreateBar",
+				"test.v1.SomeService.CreateFoo",
+				"test.v1.YELL",
+				"test.v1.YELL.CreateThing",
+			},
+		},
+		{
+			name: "relative cross links",
+			input: `
+[relative link to service][SomeService]
+[relative link to method][SomeService.CreateFoo]
+[relative link to message][SomeMessage]
+[relative link to message field][SomeMessage.field]
+[relative link to message oneof group][SomeMessage.result]
+[relative link to message oneof field][SomeMessage.error]
+[relative link to unmangled field][SomeMessage.type]
+[relative link to enum][SomeMessage.SomeEnum]
+[relative link to enum value][SomeMessage.SomeEnum.ENUM_VALUE]
+`,
+			want: []string{
+				"SomeMessage",
+				"SomeMessage.SomeEnum",
+				"SomeMessage.SomeEnum.ENUM_VALUE",
+				"SomeMessage.error",
+				"SomeMessage.field",
+				"SomeMessage.result",
+				"SomeMessage.type",
+				"SomeService",
+				"SomeService.CreateFoo",
+			},
+		},
+		{
+			name: "implied cross links",
+			input: `
+implied service reference [SomeService][]
+implied method reference [SomeService.CreateFoo][]
+implied message reference [SomeMessage][]
+implied message field reference [SomeMessage.field][]
+implied message oneof group reference [SomeMessage.result][]
+implied message oneof field reference [SomeMessage.error][]
+implied message unmangled field reference [SomeMessage.type][]
+implied enum reference [SomeMessage.SomeEnum][]
+implied enum value reference [SomeMessage.SomeEnum.ENUM_VALUE][]
+`,
+			want: []string{
+				"SomeMessage",
+				"SomeMessage.SomeEnum",
+				"SomeMessage.SomeEnum.ENUM_VALUE",
+				"SomeMessage.error",
+				"SomeMessage.field",
+				"SomeMessage.result",
+				"SomeMessage.type",
+				"SomeService",
+				"SomeService.CreateFoo",
+			},
+		},
+		{
+			name:  "text block in list item",
+			input: `- [ListMessage][test.v1.ListMessage]`,
+			want:  []string{"test.v1.ListMessage"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			md := goldmark.New(
+				goldmark.WithParserOptions(
+					parser.WithAutoHeadingID(),
+				),
+			)
+			doc := md.Parser().Parse(text.NewReader([]byte(test.input)))
+			got := ExtractCrossReferenceLinks(doc, []byte(test.input))
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -15,7 +15,6 @@
 package rust
 
 import (
-	"bytes"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -942,7 +941,7 @@ func (c *codec) formatDocComments(
 		return ast.WalkContinue, nil
 	})
 
-	for _, link := range protobufLinkMapping(doc, documentationBytes) {
+	for _, link := range language.ExtractCrossReferenceLinks(doc, documentationBytes) {
 		rusty, err := c.docLink(link, model, scopes)
 		if err != nil {
 			return nil, err
@@ -960,79 +959,6 @@ func (c *codec) formatDocComments(
 		results[i] = strings.TrimRightFunc(fmt.Sprintf("/// %s", line), unicode.IsSpace)
 	}
 	return results, nil
-}
-
-// protobufLinkMapping returns additional comment lines to map protobuf links
-// to Rustdoc links.
-//
-// Protobuf comments include links in the form `[Title][Definition]` where
-// `Title` is the text that should appear in the documentation and `Definition`
-// is the name of a Protobuf entity, e.g., `google.longrunning.Operation`.
-//
-// We need to map these references from Protobuf names to the corresponding
-// entity in the generated code. We do this by appending a number of link
-// definitions to the comments, e.g.
-//
-//	//// [google.longrunning.Operation]: google_cloud_longrunning::model::Operation
-func protobufLinkMapping(doc ast.Node, source []byte) []string {
-	protobufLinks := map[string]bool{}
-	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
-		switch node.Kind() {
-		case ast.KindParagraph:
-			text := node.Lines().Value(source)
-			extractProtoLinks(text, protobufLinks)
-			return ast.WalkContinue, nil
-		case ast.KindTextBlock:
-			text := node.Lines().Value(source)
-			extractProtoLinks(text, protobufLinks)
-			return ast.WalkContinue, nil
-		default:
-			return ast.WalkContinue, nil
-		}
-	})
-	var sortedLinks []string
-	for link := range protobufLinks {
-		sortedLinks = append(sortedLinks, link)
-	}
-	sort.Strings(sortedLinks)
-	return sortedLinks
-}
-
-// commentCrossReferenceLink  is a regular expression to find cross links in
-// comments.
-//
-// The Google API documentation (typically in protos) include links to code
-// elements in the form `[Thing][google.package.blah.v1.Thing.SubThing]`.
-// This regular expression captures the `][...]` part. There is a lot of scaping
-// because the brackets are metacharacters in regex.
-var commentCrossReferenceLink = regexp.MustCompile(
-	`` + // `go fmt` is annoying
-		`\]` + // The closing bracket for the `[Thing]`
-		`\[` + // The opening bracket for the code element.
-		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
-		`(\.` + // Followed by (maybe a dot)
-		`[A-Za-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
-		`)*` + // zero or more times
-		`\]`) // The closing bracket
-
-// commentImpliedCrossReferenceLink is a regular expression to find implied
-// cross reference links.
-var commentImpliedCrossReferenceLink = regexp.MustCompile(
-	`` + // `go fmt` is annoying
-		`\[` +
-		`[A-Z-a-z][A-Za-z0-9_]*` + // A thing that looks like a Protobuf identifier
-		`(\.[A-Za-z][A-Za-z0-9_]*)*` + // Followed by more identifiers
-		`\]\[\]`) // The closing bracket followed by an empty link label
-
-func extractProtoLinks(paragraph []byte, links map[string]bool) {
-	for _, match := range commentCrossReferenceLink.FindAll(paragraph, -1) {
-		match = bytes.TrimSuffix(bytes.TrimPrefix(match, []byte("][")), []byte("]"))
-		links[string(match)] = true
-	}
-	for _, match := range commentImpliedCrossReferenceLink.FindAll(paragraph, -1) {
-		match = bytes.TrimSuffix(bytes.TrimPrefix(match, []byte("[")), []byte("][]"))
-		links[string(match)] = true
-	}
 }
 
 func processCommentLine(node ast.Node, line text.Segment, documentationBytes []byte) string {


### PR DESCRIPTION
Swift is going to need the cross-reference links found in the service specification comments (see aip.dev/192), and then will use these cross reference links to create proper Swifty links to the right things.

This refactors some of the code to a common place.

Towards #5072 
