### PR TITLE
cleanup(sidekick): use `Scopes()` method

### DIFF
--- a/internal/sidekick/api/scopes.go
+++ b/internal/sidekick/api/scopes.go
@@ -53,7 +53,7 @@ func (x *Service) Scopes() []string {
 func (x *Message) Scopes() []string {
 	localScope := strings.TrimPrefix(x.ID, ".")
 	if x.Parent == nil {
-		return []string{localScope, x.Package}
+		return []string{localScope, x.Package} // simplify some test set-up
 	}
 	return append([]string{localScope}, x.Parent.Scopes()...)
 }
@@ -62,7 +62,7 @@ func (x *Message) Scopes() []string {
 func (x *Enum) Scopes() []string {
 	localScope := strings.TrimPrefix(x.ID, ".")
 	if x.Parent == nil {
-		return []string{localScope, x.Package}
+		return []string{localScope, x.Package} // simplify some test set-up
 	}
 	return append([]string{localScope}, x.Parent.Scopes()...)
 }
@@ -70,7 +70,35 @@ func (x *Enum) Scopes() []string {
 // Scopes returns the scopes for an enum value.
 func (x *EnumValue) Scopes() []string {
 	if x.Parent == nil {
-		return []string{}
+		return []string{} // simplify some test set-up
 	}
 	return x.Parent.Scopes()
+}
+
+// Scopes returns the scopes for a field.
+func (x *Field) Scopes() []string {
+	if x.Parent == nil {
+		return []string{} // simplify some test set-up
+	}
+	return x.Parent.Scopes()
+}
+
+// Scopes returns the scopes for a method.
+func (x *Method) Scopes() []string {
+	if x.SourceService == nil {
+		return []string{} // simplify some test set-up
+	}
+	return x.SourceService.Scopes()
+}
+
+// Scopes returns the scopes for a oneof.
+func (x *OneOf) Scopes() []string {
+	if len(x.Fields) > 0 {
+		return x.Fields[0].Scopes()
+	}
+	idx := strings.LastIndex(x.ID, ".")
+	if idx == -1 {
+		return []string{strings.TrimPrefix(x.ID, ".")}
+	}
+	return []string{strings.TrimPrefix(x.ID[:idx], ".")}
 }

--- a/internal/sidekick/api/scopes.go
+++ b/internal/sidekick/api/scopes.go
@@ -96,9 +96,14 @@ func (x *OneOf) Scopes() []string {
 	if len(x.Fields) > 0 {
 		return x.Fields[0].Scopes()
 	}
-	idx := strings.LastIndex(x.ID, ".")
-	if idx == -1 {
-		return []string{strings.TrimPrefix(x.ID, ".")}
+	parts := strings.Split(strings.TrimPrefix(x.ID, "."), ".")
+	if len(parts) <= 1 {
+		return []string{}
 	}
-	return []string{strings.TrimPrefix(x.ID[:idx], ".")}
+	parts = parts[:len(parts)-1]
+	res := make([]string, 0, len(parts))
+	for i := len(parts); i > 0; i-- {
+		res = append(res, strings.Join(parts[:i], "."))
+	}
+	return res
 }

--- a/internal/sidekick/api/scopes.go
+++ b/internal/sidekick/api/scopes.go
@@ -69,26 +69,30 @@ func (x *Enum) Scopes() []string {
 
 // Scopes returns the scopes for an enum value.
 func (x *EnumValue) Scopes() []string {
-	if x.Parent == nil {
-		return []string{} // simplify some test set-up
+	if x.Parent != nil {
+		return x.Parent.Scopes()
 	}
-	return x.Parent.Scopes()
+	return fallbackScopes(x.ID)
 }
 
 // Scopes returns the scopes for a field.
 func (x *Field) Scopes() []string {
-	if x.Parent == nil {
-		return []string{} // simplify some test set-up
+	if x.Parent != nil {
+		return x.Parent.Scopes()
 	}
-	return x.Parent.Scopes()
+	return fallbackScopes(x.ID)
 }
 
 // Scopes returns the scopes for a method.
 func (x *Method) Scopes() []string {
-	if x.SourceService == nil {
-		return []string{} // simplify some test set-up
+	if x.SourceService != nil {
+		// For mixing methods, the local names probably refer to symbols in the source service.
+		return x.SourceService.Scopes()
 	}
-	return x.SourceService.Scopes()
+	if x.Service != nil {
+		return x.Service.Scopes()
+	}
+	return fallbackScopes(x.ID)
 }
 
 // Scopes returns the scopes for a oneof.
@@ -96,7 +100,12 @@ func (x *OneOf) Scopes() []string {
 	if len(x.Fields) > 0 {
 		return x.Fields[0].Scopes()
 	}
-	parts := strings.Split(strings.TrimPrefix(x.ID, "."), ".")
+	return fallbackScopes(x.ID)
+}
+
+// A fallback so we can be lazy in test set-up.
+func fallbackScopes(id string) []string {
+	parts := strings.Split(strings.TrimPrefix(id, "."), ".")
 	if len(parts) <= 1 {
 		return []string{}
 	}

--- a/internal/sidekick/api/scopes_test.go
+++ b/internal/sidekick/api/scopes_test.go
@@ -168,7 +168,7 @@ func TestScopesField(t *testing.T) {
 				Name: "field",
 				ID:   ".test.Parent.field",
 			},
-			want: []string{},
+			want: []string{"test.Parent", "test"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -194,19 +194,29 @@ func TestScopesMethod(t *testing.T) {
 		{
 			name: "standard",
 			method: &Method{
-				Name:          "Method",
-				ID:            ".test.Service.Method",
-				SourceService: service,
+				Name:    "Method",
+				ID:      ".test.Service.Method",
+				Service: service,
 			},
 			want: []string{"test.Service", "test"},
 		},
 		{
-			name: "nil source service",
+			name: "both set",
+			method: &Method{
+				Name:          "Method",
+				ID:            ".test.Service.Method",
+				Service:       service,
+				SourceService: &Service{Name: "Other", Package: "other", ID: ".other.Other"},
+			},
+			want: []string{"other.Other", "other"},
+		},
+		{
+			name: "nil both",
 			method: &Method{
 				Name: "Method",
 				ID:   ".test.Service.Method",
 			},
-			want: []string{},
+			want: []string{"test.Service", "test"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -255,6 +265,52 @@ func TestScopesOneOf(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.oneof.Scopes()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFallbackScopes(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		id   string
+		want []string
+	}{
+		{
+			name: "empty",
+			id:   "",
+			want: []string{},
+		},
+		{
+			name: "no dot",
+			id:   "foo",
+			want: []string{},
+		},
+		{
+			name: "single dot",
+			id:   ".foo",
+			want: []string{},
+		},
+		{
+			name: "two parts with dot",
+			id:   ".foo.bar",
+			want: []string{"foo"},
+		},
+		{
+			name: "three parts with dot",
+			id:   ".foo.bar.baz",
+			want: []string{"foo.bar", "foo"},
+		},
+		{
+			name: "two parts no dot",
+			id:   "foo.bar",
+			want: []string{"foo"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := fallbackScopes(test.id)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/sidekick/api/scopes_test.go
+++ b/internal/sidekick/api/scopes_test.go
@@ -250,7 +250,7 @@ func TestScopesOneOf(t *testing.T) {
 				Name: "empty_oneof",
 				ID:   ".test.Parent.empty_oneof",
 			},
-			want: []string{"test.Parent"},
+			want: []string{"test.Parent", "test"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/sidekick/api/scopes_test.go
+++ b/internal/sidekick/api/scopes_test.go
@@ -141,3 +141,123 @@ func TestScopesEnumValueInMessage(t *testing.T) {
 		t.Errorf("mismatched child.Scopes() (-want, +got):\n%s", diff)
 	}
 }
+
+func TestScopesField(t *testing.T) {
+	parent := &Message{
+		Name:    "Parent",
+		Package: "test",
+		ID:      ".test.Parent",
+	}
+	for _, test := range []struct {
+		name  string
+		field *Field
+		want  []string
+	}{
+		{
+			name: "standard",
+			field: &Field{
+				Name:   "field",
+				ID:     ".test.Parent.field",
+				Parent: parent,
+			},
+			want: []string{"test.Parent", "test"},
+		},
+		{
+			name: "nil parent",
+			field: &Field{
+				Name: "field",
+				ID:   ".test.Parent.field",
+			},
+			want: []string{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.field.Scopes()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestScopesMethod(t *testing.T) {
+	service := &Service{
+		Name:    "Service",
+		Package: "test",
+		ID:      ".test.Service",
+	}
+	for _, test := range []struct {
+		name   string
+		method *Method
+		want   []string
+	}{
+		{
+			name: "standard",
+			method: &Method{
+				Name:          "Method",
+				ID:            ".test.Service.Method",
+				SourceService: service,
+			},
+			want: []string{"test.Service", "test"},
+		},
+		{
+			name: "nil source service",
+			method: &Method{
+				Name: "Method",
+				ID:   ".test.Service.Method",
+			},
+			want: []string{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.method.Scopes()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestScopesOneOf(t *testing.T) {
+	parent := &Message{
+		Name:    "Parent",
+		Package: "test",
+		ID:      ".test.Parent",
+	}
+	field := &Field{
+		Name:   "field",
+		ID:     ".test.Parent.field",
+		Parent: parent,
+	}
+
+	for _, test := range []struct {
+		name  string
+		oneof *OneOf
+		want  []string
+	}{
+		{
+			name: "with fields",
+			oneof: &OneOf{
+				Name:   "oneof",
+				ID:     ".test.Parent.oneof",
+				Fields: []*Field{field},
+			},
+			want: []string{"test.Parent", "test"},
+		},
+		{
+			name: "empty",
+			oneof: &OneOf{
+				Name: "empty_oneof",
+				ID:   ".test.Parent.empty_oneof",
+			},
+			want: []string{"test.Parent"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.oneof.Scopes()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/annotate_field.go
+++ b/internal/sidekick/rust/annotate_field.go
@@ -183,7 +183,7 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 	if err != nil {
 		return nil, err
 	}
-	docLines, err := c.formatDocComments(field.Documentation, field.ID, model, message.Scopes())
+	docLines, err := c.formatDocComments(field.Documentation, field.ID, model, field.Scopes())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -291,7 +291,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 			Value: m.APIVersion,
 		})
 	}
-	docLines, err := c.formatDocComments(m.Documentation, m.ID, m.Model, m.Service.Scopes())
+	docLines, err := c.formatDocComments(m.Documentation, m.ID, m.Model, m.Scopes())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sidekick/rust/annotate_oneof.go
+++ b/internal/sidekick/rust/annotate_oneof.go
@@ -77,7 +77,7 @@ func (c *codec) annotateOneOf(oneof *api.OneOf, message *api.Message, model *api
 		return nil, err
 	}
 	nameInExamples := c.nameInExamplesFromQualifiedName(qualifiedName, model)
-	docLines, err := c.formatDocComments(oneof.Documentation, oneof.ID, model, message.Scopes())
+	docLines, err := c.formatDocComments(oneof.Documentation, oneof.ID, model, oneof.Scopes())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add a `Scopes()` method to the elements that lacked them, and then use the new method. This will be more useful when we start using these methods for the Swift codec.

Towards #5072 