### PR TITLE
fix(tool/cmd/migrate): add artifact overrides for iam case in java

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -278,7 +278,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 			if shouldExcludeSamples(name, info) {
 				javaAPI.Samples = new(false)
 			}
-			applyJavaArtifactOverrides(javaAPI)
+			applyJavaArtifactOverrides(javaAPI, name)
 			applyJavaProtoOverrides(javaAPI)
 
 			if name == "storage" && g.ProtoPath == "google/storage/v2" {
@@ -445,8 +445,12 @@ func parseArtifactID(distributionName, name string) string {
 
 // applyJavaArtifactOverrides sets artifact ID overrides for specific cases where
 // they don't follow the standard pattern.
-func applyJavaArtifactOverrides(api *config.JavaAPI) {
-	if override, ok := javaArtifactIDOverrides[api.Path]; ok {
+func applyJavaArtifactOverrides(api *config.JavaAPI, libraryName string) {
+	override, ok := javaArtifactIDOverrides[overrideKey{libraryName: libraryName, apiPath: api.Path}]
+	if !ok {
+		override, ok = javaArtifactIDOverrides[overrideKey{apiPath: api.Path}]
+	}
+	if ok {
 		if override.protoArtifactID != "" {
 			api.ProtoArtifactIDOverride = override.protoArtifactID
 		}

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -14,6 +14,11 @@
 
 package main
 
+type overrideKey struct {
+	libraryName string
+	apiPath     string
+}
+
 var (
 	excludedSamplesLibraries = map[string]bool{
 		"bigquerystorage":   true,
@@ -64,94 +69,114 @@ var (
 		},
 	}
 
-	javaArtifactIDOverrides = map[string]javaArtifactOverrides{
-		"google/datastore/admin/v1": {
+	javaArtifactIDOverrides = map[overrideKey]javaArtifactOverrides{
+		{apiPath: "google/datastore/admin/v1"}: {
 			protoArtifactID: "proto-google-cloud-datastore-admin-v1",
 			grpcArtifactID:  "grpc-google-cloud-datastore-admin-v1",
 		},
-		"google/api": {
+		{apiPath: "google/api"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/apps/card/v1": {
+		{apiPath: "google/apps/card/v1"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/apps/script/type": {
+		{apiPath: "google/apps/script/type"}: {
 			protoArtifactID: "proto-google-apps-script-type-protos",
 		},
-		"google/apps/script/type/docs": {
+		{apiPath: "google/apps/script/type/docs"}: {
 			protoArtifactID: "proto-google-apps-script-type-protos",
 		},
-		"google/apps/script/type/drive": {
+		{apiPath: "google/apps/script/type/drive"}: {
 			protoArtifactID: "proto-google-apps-script-type-protos",
 		},
-		"google/apps/script/type/gmail": {
+		{apiPath: "google/apps/script/type/gmail"}: {
 			protoArtifactID: "proto-google-apps-script-type-protos",
 		},
-		"google/apps/script/type/sheets": {
+		{apiPath: "google/apps/script/type/sheets"}: {
 			protoArtifactID: "proto-google-apps-script-type-protos",
 		},
-		"google/apps/script/type/slides": {
+		{apiPath: "google/apps/script/type/slides"}: {
 			protoArtifactID: "proto-google-apps-script-type-protos",
 		},
-		"google/cloud": {
+		{libraryName: "iam", apiPath: "google/iam/v1"}: {
+			protoArtifactID: "proto-google-iam-v1",
+			grpcArtifactID:  "grpc-google-iam-v1",
+		},
+		{libraryName: "iam", apiPath: "google/iam/v2"}: {
+			protoArtifactID: "proto-google-iam-v2",
+			grpcArtifactID:  "grpc-google-iam-v2",
+		},
+		{libraryName: "iam", apiPath: "google/iam/v3"}: {
+			protoArtifactID: "proto-google-iam-v3",
+			grpcArtifactID:  "grpc-google-iam-v3",
+		},
+		{libraryName: "iam", apiPath: "google/iam/v2beta"}: {
+			protoArtifactID: "proto-google-iam-v2beta",
+			grpcArtifactID:  "grpc-google-iam-v2beta",
+		},
+		{libraryName: "iam", apiPath: "google/iam/v3beta"}: {
+			protoArtifactID: "proto-google-iam-v3beta",
+			grpcArtifactID:  "grpc-google-iam-v3beta",
+		},
+		{apiPath: "google/cloud"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/cloud/audit": {
+		{apiPath: "google/cloud/audit"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/cloud/location": {
+		{apiPath: "google/cloud/location"}: {
 			protoArtifactID: "proto-google-common-protos",
 			grpcArtifactID:  "grpc-google-common-protos",
 		},
-		"google/geo/type": {
+		{apiPath: "google/geo/type"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/logging/type": {
+		{apiPath: "google/logging/type"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/longrunning": {
+		{apiPath: "google/longrunning"}: {
 			protoArtifactID: "proto-google-common-protos",
 			grpcArtifactID:  "grpc-google-common-protos",
 		},
-		"google/rpc": {
+		{apiPath: "google/rpc"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/rpc/context": {
+		{apiPath: "google/rpc/context"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/shopping/type": {
+		{apiPath: "google/shopping/type"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/type": {
+		{apiPath: "google/type"}: {
 			protoArtifactID: "proto-google-common-protos",
 		},
-		"google/spanner/admin/database/v1": {
+		{apiPath: "google/spanner/admin/database/v1"}: {
 			protoArtifactID: "proto-google-cloud-spanner-admin-database-v1",
 			grpcArtifactID:  "grpc-google-cloud-spanner-admin-database-v1",
 		},
-		"google/spanner/admin/instance/v1": {
+		{apiPath: "google/spanner/admin/instance/v1"}: {
 			protoArtifactID: "proto-google-cloud-spanner-admin-instance-v1",
 			grpcArtifactID:  "grpc-google-cloud-spanner-admin-instance-v1",
 		},
-		"google/spanner/executor/v1": {
+		{apiPath: "google/spanner/executor/v1"}: {
 			protoArtifactID: "proto-google-cloud-spanner-executor-v1",
 			grpcArtifactID:  "grpc-google-cloud-spanner-executor-v1",
 		},
-		"google/devtools/clouderrorreporting/v1beta1": {
+		{apiPath: "google/devtools/clouderrorreporting/v1beta1"}: {
 			protoArtifactID: "proto-google-cloud-error-reporting-v1beta1",
 			grpcArtifactID:  "grpc-google-cloud-error-reporting-v1beta1",
 		},
-		"google/storage/v2": {
+		{apiPath: "google/storage/v2"}: {
 			protoArtifactID: "proto-google-cloud-storage-v2",
 			grpcArtifactID:  "grpc-google-cloud-storage-v2",
 			gapicArtifactID: "gapic-google-cloud-storage-v2",
 		},
-		"google/storage/control/v2": {
+		{apiPath: "google/storage/control/v2"}: {
 			protoArtifactID: "proto-google-cloud-storage-control-v2",
 			grpcArtifactID:  "grpc-google-cloud-storage-control-v2",
 			gapicArtifactID: "google-cloud-storage-control",
 		},
-		"schema/google/showcase/v1beta1": {
+		{apiPath: "schema/google/showcase/v1beta1"}: {
 			protoArtifactID: "proto-gapic-showcase-v1beta1",
 			grpcArtifactID:  "grpc-gapic-showcase-v1beta1",
 		},

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -104,6 +104,69 @@ func TestApplyJavaProtoOverrides(t *testing.T) {
 	}
 }
 
+func TestApplyJavaArtifactOverrides(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		libraryName string
+		path        string
+		want        *config.JavaAPI
+	}{
+		{
+			name:        "iam v1 overrides",
+			libraryName: "iam",
+			path:        "google/iam/v1",
+			want: &config.JavaAPI{
+				Path:                    "google/iam/v1",
+				ProtoArtifactIDOverride: "proto-google-iam-v1",
+				GRPCArtifactIDOverride:  "grpc-google-iam-v1",
+			},
+		},
+		{
+			name:        "iam v2 overrides",
+			libraryName: "iam",
+			path:        "google/iam/v2",
+			want: &config.JavaAPI{
+				Path:                    "google/iam/v2",
+				ProtoArtifactIDOverride: "proto-google-iam-v2",
+				GRPCArtifactIDOverride:  "grpc-google-iam-v2",
+			},
+		},
+		{
+			name:        "iam-policy v1 no overrides",
+			libraryName: "iam-policy",
+			path:        "google/iam/v1",
+			want: &config.JavaAPI{
+				Path: "google/iam/v1",
+			},
+		},
+		{
+			name:        "iam-policy v2 no overrides",
+			libraryName: "iam-policy",
+			path:        "google/iam/v2",
+			want: &config.JavaAPI{
+				Path: "google/iam/v2",
+			},
+		},
+		{
+			name:        "global override applies to any library",
+			libraryName: "any-library",
+			path:        "google/api",
+			want: &config.JavaAPI{
+				Path:                    "google/api",
+				ProtoArtifactIDOverride: "proto-google-common-protos",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := &config.JavaAPI{Path: test.path}
+			applyJavaArtifactOverrides(got, test.libraryName)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestApplyJavaLibraryOverrides(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
Add artifact id overrides needed for `iam` library. The refactor to match on API path plus library name is needed because these overrides are intended for `iam` library, these paths are shared with `iam-policy` library.

For #5730