### PR TITLE
feat(internal/sidekick/gcloud): support list methods in generator

### DIFF
--- a/internal/sidekick/gcloud/client.go
+++ b/internal/sidekick/gcloud/client.go
@@ -94,25 +94,36 @@ func clientInfoFromPath(clientImportPath string) *goClientInfo {
 	}
 }
 
-// buildClientCall returns a ClientCall for an AIP-131 Get method when the
-// model maps to a standard GAPIC Go package and the command composes a
-// resource path. It returns nil otherwise so the command keeps its
-// print-only action.
+// buildClientCall returns a ClientCall for an AIP-131 Get or AIP-132 List
+// method when the model maps to a standard GAPIC Go package and the command
+// composes a resource path. It returns nil otherwise so the command keeps
+// its print-only action.
 func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *ClientCall {
 	if goClient == nil || !hasPath {
-		return nil
-	}
-	if !provider.IsGet(method) {
 		return nil
 	}
 	if method.InputType == nil {
 		return nil
 	}
-	return &ClientCall{
-		Method:      method.Name,
-		NameField:   "Name",
-		Package:     goClient.Alias,
-		RequestType: goClient.Alias + "pb." + method.InputType.Name,
+
+	switch {
+	case provider.IsGet(method):
+		return &ClientCall{
+			Method:      method.Name,
+			NameField:   "Name",
+			Package:     goClient.Alias,
+			RequestType: goClient.Alias + "pb." + method.InputType.Name,
+		}
+	case provider.IsList(method):
+		return &ClientCall{
+			Method:      method.Name,
+			NameField:   "Parent",
+			Package:     goClient.Alias,
+			RequestType: goClient.Alias + "pb." + method.InputType.Name,
+			IsList:      true,
+		}
+	default:
+		return nil
 	}
 }
 

--- a/internal/sidekick/gcloud/client_test.go
+++ b/internal/sidekick/gcloud/client_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func TestBuildClientCall(t *testing.T) {
+	goClient := &goClientInfo{
+		Alias:      "parallelstore",
+		ClientPath: "cloud.google.com/go/parallelstore/apiv1",
+		PbPath:     "cloud.google.com/go/parallelstore/apiv1/parallelstorepb",
+	}
+
+	for _, test := range []struct {
+		name     string
+		method   *api.Method
+		goClient *goClientInfo
+		hasPath  bool
+		want     *ClientCall
+	}{
+		{
+			name: "Get method",
+			method: &api.Method{
+				Name:      "GetInstance",
+				InputType: &api.Message{Name: "GetInstanceRequest"},
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want: &ClientCall{
+				Method:      "GetInstance",
+				NameField:   "Name",
+				Package:     "parallelstore",
+				RequestType: "parallelstorepb.GetInstanceRequest",
+			},
+		},
+		{
+			name: "List method",
+			method: &api.Method{
+				Name:      "ListInstances",
+				InputType: &api.Message{Name: "ListInstancesRequest"},
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want: &ClientCall{
+				Method:      "ListInstances",
+				NameField:   "Parent",
+				Package:     "parallelstore",
+				RequestType: "parallelstorepb.ListInstancesRequest",
+				IsList:      true,
+			},
+		},
+		{
+			name: "nil goClient",
+			method: &api.Method{
+				Name:      "GetInstance",
+				InputType: &api.Message{Name: "GetInstanceRequest"},
+			},
+			goClient: nil,
+			hasPath:  true,
+			want:     nil,
+		},
+		{
+			name: "no path",
+			method: &api.Method{
+				Name:      "GetInstance",
+				InputType: &api.Message{Name: "GetInstanceRequest"},
+			},
+			goClient: goClient,
+			hasPath:  false,
+			want:     nil,
+		},
+		{
+			name: "nil InputType",
+			method: &api.Method{
+				Name: "GetInstance",
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want:     nil,
+		},
+		{
+			name: "not get or list",
+			method: &api.Method{
+				Name:      "CreateInstance",
+				InputType: &api.Message{Name: "CreateInstanceRequest"},
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want:     nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildClientCall(test.method, test.goClient, test.hasPath)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/gcloud/command.go
+++ b/internal/sidekick/gcloud/command.go
@@ -33,6 +33,9 @@ type Command struct {
 // ClientCall describes a Go client method invocation that should replace the
 // default print-only action for a generated command.
 type ClientCall struct {
+	// IsList reports whether the method is a standard List method.
+	IsList bool
+
 	// Method is the unqualified client method to call on the constructed
 	// client, for example "GetInstance". The template invokes it as
 	// `client.<Method>(ctx, &<RequestType>{...})`.

--- a/internal/sidekick/gcloud/model.go
+++ b/internal/sidekick/gcloud/model.go
@@ -104,6 +104,7 @@ func constructSurfaceModel(model *api.API, clientImportPath string) SurfaceModel
 		imports       []Import
 		goClient      = goClientPackage(model.PackageName, clientImportPath)
 		hasClientCall = false
+		hasListCall   = false
 		subgroups     = make(map[string]*Subgroup)
 	)
 
@@ -119,6 +120,9 @@ func constructSurfaceModel(model *api.API, clientImportPath string) SurfaceModel
 			if call := buildClientCall(method, goClient, cmd.HasPath()); call != nil {
 				cmd.ClientCall = call
 				hasClientCall = true
+				if call.IsList {
+					hasListCall = true
+				}
 			}
 
 			sg, ok := subgroups[subName]
@@ -137,6 +141,9 @@ func constructSurfaceModel(model *api.API, clientImportPath string) SurfaceModel
 		imports = []Import{
 			{Alias: goClient.Alias, Path: goClient.ClientPath},
 			{Path: goClient.PbPath},
+		}
+		if hasListCall {
+			imports = append(imports, Import{Path: "google.golang.org/api/iterator"})
 		}
 	}
 

--- a/internal/sidekick/gcloud/model_test.go
+++ b/internal/sidekick/gcloud/model_test.go
@@ -131,22 +131,47 @@ func TestConstructSurfaceModel(t *testing.T) {
 				Services: []*api.Service{{
 					Name: "InstanceService",
 					Methods: []*api.Method{{
-						Name:      "ListInstances",
-						InputType: &api.Message{Name: "ListInstancesRequest"},
+						Name:              "ListInstances",
+						IsAIPStandardList: true,
+						InputType: &api.Message{
+							Name: "ListInstancesRequest",
+							Fields: []*api.Field{
+								{
+									Name:              "parent",
+									ResourceReference: &api.ResourceReference{ChildType: "parallelstore.googleapis.com/Instance"},
+								},
+							},
+						},
 						PathInfo: &api.PathInfo{
 							Bindings: []*api.PathBinding{{
 								Verb: "GET",
 								PathTemplate: (&api.PathTemplate{}).
 									WithLiteral("v1").
+									WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+									WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
 									WithLiteral("instances"),
 							}},
 						},
 					}},
 				}},
+				ResourceDefinitions: []*api.Resource{{
+					Type: "parallelstore.googleapis.com/Instance",
+					Patterns: []api.ResourcePattern{
+						(&api.PathTemplate{}).
+							WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+							WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+							WithLiteral("instances").WithVariable(api.NewPathVariable("instance")).
+							Segments,
+					},
+				}},
 			},
 			want: SurfaceModel{
 				PackageName: "parallelstore",
-				Imports:     nil,
+				Imports: []Import{
+					{Alias: "parallelstore", Path: "cloud.google.com/go/parallelstore/apiv1"},
+					{Path: "cloud.google.com/go/parallelstore/apiv1/parallelstorepb"},
+					{Path: "google.golang.org/api/iterator"},
+				},
 				Group: Group{
 					Name:  "parallelstore",
 					Usage: "manage Parallelstore resources",
@@ -154,8 +179,22 @@ func TestConstructSurfaceModel(t *testing.T) {
 						Name:  "instances",
 						Usage: "manage instances resources",
 						Commands: []Command{{
-							Name:  "list",
-							Usage: "list instances",
+							Name:       "list",
+							Usage:      "list instances",
+							PathFormat: "projects/%s/locations/%s",
+							Args:       []string{"project", "location"},
+							PathLabel:  "parent",
+							Flags: []Flag{
+								{Name: "project", Kind: "String", Required: true, Usage: "The project."},
+								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
+							},
+							ClientCall: &ClientCall{
+								Method:      "ListInstances",
+								NameField:   "Parent",
+								Package:     "parallelstore",
+								RequestType: "parallelstorepb.ListInstancesRequest",
+								IsList:      true,
+							},
 						}},
 					}},
 				},

--- a/internal/sidekick/gcloud/model_test.go
+++ b/internal/sidekick/gcloud/model_test.go
@@ -122,6 +122,45 @@ func TestConstructSurfaceModel(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "list method adds iterator import",
+			model: &api.API{
+				Name:        "parallelstore",
+				Title:       "Parallelstore",
+				PackageName: "google.cloud.parallelstore.v1",
+				Services: []*api.Service{{
+					Name: "InstanceService",
+					Methods: []*api.Method{{
+						Name:      "ListInstances",
+						InputType: &api.Message{Name: "ListInstancesRequest"},
+						PathInfo: &api.PathInfo{
+							Bindings: []*api.PathBinding{{
+								Verb: "GET",
+								PathTemplate: (&api.PathTemplate{}).
+									WithLiteral("v1").
+									WithLiteral("instances"),
+							}},
+						},
+					}},
+				}},
+			},
+			want: SurfaceModel{
+				PackageName: "parallelstore",
+				Imports:     nil,
+				Group: Group{
+					Name:  "parallelstore",
+					Usage: "manage Parallelstore resources",
+					Subgroups: []Subgroup{{
+						Name:  "instances",
+						Usage: "manage instances resources",
+						Commands: []Command{{
+							Name:  "list",
+							Usage: "list instances",
+						}},
+					}},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := constructSurfaceModel(test.model, "")

--- a/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
+++ b/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
@@ -67,6 +67,24 @@ func Command() *cli.Command {
 			return err
 		}
 		defer client.Close()
+		{{- if .ClientCall.IsList}}
+		it := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })
+		for {
+			resp, err := it.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(resp)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+		}
+		return nil
+		{{- else}}
 		resp, err := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })
 		if err != nil {
 			return err
@@ -77,6 +95,7 @@ func Command() *cli.Command {
 		}
 		fmt.Println(string(out))
 		return nil
+		{{- end}}
 		{{- else if .HasPath}}
 		{{.PathLabel}} := fmt.Sprintf("{{.PathFormat}}", {{.PathFormatArgs}})
 		fmt.Printf("Executing {{.Name}} on %s\n", {{.PathLabel}})

--- a/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
+++ b/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
@@ -7,6 +7,7 @@ import (
 	parallelstore "cloud.google.com/go/parallelstore/apiv1"
 	"cloud.google.com/go/parallelstore/apiv1/parallelstorepb"
 	"github.com/urfave/cli/v3"
+	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -29,7 +30,26 @@ func Command() *cli.Command {
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							parent := fmt.Sprintf("projects/%s/locations/%s", cmd.String("project"), cmd.String("location"))
-							fmt.Printf("Executing list on %s\n", parent)
+							client, err := parallelstore.NewClient(ctx)
+							if err != nil {
+								return err
+							}
+							defer client.Close()
+							it := client.ListInstances(ctx, &parallelstorepb.ListInstancesRequest{Parent: parent})
+							for {
+								resp, err := it.Next()
+								if err == iterator.Done {
+									break
+								}
+								if err != nil {
+									return err
+								}
+								out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(resp)
+								if err != nil {
+									return err
+								}
+								fmt.Println(string(out))
+							}
 							return nil
 						},
 					},
@@ -166,7 +186,26 @@ func Command() *cli.Command {
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							parent := fmt.Sprintf("projects/%s/locations/%s", cmd.String("project"), cmd.String("location"))
-							fmt.Printf("Executing list on %s\n", parent)
+							client, err := parallelstore.NewClient(ctx)
+							if err != nil {
+								return err
+							}
+							defer client.Close()
+							it := client.ListOperations(ctx, &parallelstorepb.ListOperationsRequest{Parent: parent})
+							for {
+								resp, err := it.Next()
+								if err == iterator.Done {
+									break
+								}
+								if err != nil {
+									return err
+								}
+								out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(resp)
+								if err != nil {
+									return err
+								}
+								fmt.Println(string(out))
+							}
 							return nil
 						},
 					},


### PR DESCRIPTION
The gcloud CLI generator is updated to support List methods. This enables generated commands to invoke the API and iterate through results rather than displaying a placeholder message.