### PR TITLE
refactor(sidekick): use string for PathSegment.Literal

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -741,8 +741,8 @@ func (template *PathTemplate) FlatPath() string {
 	sep := ""
 	for _, segment := range template.Segments {
 		buffer.WriteString(sep)
-		if segment.Literal != nil {
-			buffer.WriteString(*segment.Literal)
+		if segment.Literal != "" {
+			buffer.WriteString(segment.Literal)
 		} else if segment.Variable != nil {
 			fmt.Fprintf(&buffer, "{%s}", strings.Join(segment.Variable.FieldPath, "."))
 		}
@@ -753,7 +753,7 @@ func (template *PathTemplate) FlatPath() string {
 
 // PathSegment is a segment of a path.
 type PathSegment struct {
-	Literal  *string
+	Literal  string
 	Variable *PathVariable
 }
 
@@ -773,7 +773,7 @@ func NewPathVariable(fields ...string) *PathVariable {
 
 // WithLiteral adds a literal to the path template.
 func (p *PathTemplate) WithLiteral(l string) *PathTemplate {
-	p.Segments = append(p.Segments, PathSegment{Literal: &l})
+	p.Segments = append(p.Segments, PathSegment{Literal: l})
 	return p
 }
 
@@ -822,7 +822,7 @@ func (v *PathVariable) WithAllowReserved() *PathVariable {
 
 // WithLiteral adds a literal to the path segment.
 func (s *PathSegment) WithLiteral(l string) *PathSegment {
-	s.Literal = &l
+	s.Literal = l
 	return s
 }
 

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -206,12 +206,11 @@ func TestPathTemplateBuilder(t *testing.T) {
 			WithMatchRecursive()).
 		WithVariableNamed("v2", "field").
 		WithVerb("verb")
-	name := "v1"
 	verb := "verb"
 	want := &PathTemplate{
 		Segments: []PathSegment{
 			{
-				Literal: &name,
+				Literal: "v1",
 			},
 			{
 				Variable: &PathVariable{

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -85,11 +85,11 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 	// Iterate backwards over segments
 	for i := len(tmpl.Segments) - 1; i >= 0; i-- {
 		seg := tmpl.Segments[i]
-		if seg.Variable == nil || i == 0 || tmpl.Segments[i-1].Literal == nil {
+		if seg.Variable == nil || i == 0 || tmpl.Segments[i-1].Literal == "" {
 			continue
 		}
 
-		token := *tmpl.Segments[i-1].Literal
+		token := tmpl.Segments[i-1].Literal
 		if !vocabulary[token] && !isVersionString(token) {
 			continue // continue scanning backward if not in vocabulary
 		}
@@ -105,8 +105,8 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 				prevSeg := tmpl.Segments[firstIndex-1]
 
 				// Case 1: The preceding segment is a standalone literal (e.g., "global")
-				if prevSeg.Literal != nil {
-					if isVersionString(*prevSeg.Literal) {
+				if prevSeg.Literal != "" {
+					if isVersionString(prevSeg.Literal) {
 						break // Stop at version strings (e.g., "v1")
 					}
 					firstIndex--
@@ -115,11 +115,11 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 
 				// Case 2: The preceding segment is a variable. It must be paired with a literal.
 				if prevSeg.Variable != nil {
-					if firstIndex < 2 || tmpl.Segments[firstIndex-2].Literal == nil {
+					if firstIndex < 2 || tmpl.Segments[firstIndex-2].Literal == "" {
 						break // Variable near the beginning, cannot form a pair
 					}
 
-					prevLiteralVal := *tmpl.Segments[firstIndex-2].Literal
+					prevLiteralVal := tmpl.Segments[firstIndex-2].Literal
 
 					// If the literal is a known collection, include the pair and continue
 					if vocabulary[prevLiteralVal] {
@@ -257,15 +257,15 @@ func constructTemplate(method *Method, segments []PathSegment) ([]PathSegment, e
 
 	var result []PathSegment
 	h := "//" + host
-	result = append(result, PathSegment{Literal: &h})
+	result = append(result, PathSegment{Literal: h})
 
 	for _, seg := range segments {
-		if seg.Literal != nil {
-			l := *seg.Literal
+		if seg.Literal != "" {
+			l := seg.Literal
 			if isVersionString(l) {
 				continue
 			}
-			result = append(result, PathSegment{Literal: &l})
+			result = append(result, PathSegment{Literal: l})
 		} else if seg.Variable != nil {
 			result = append(result, PathSegment{Variable: &PathVariable{
 				FieldPath: seg.Variable.FieldPath,

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -88,8 +88,8 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 			for i := len(tmpl.Segments) - 1; i >= 0; i-- {
 				seg := tmpl.Segments[i]
 				if seg.Variable != nil {
-					if i > 0 && tmpl.Segments[i-1].Literal != nil {
-						token := *tmpl.Segments[i-1].Literal
+					if i > 0 && tmpl.Segments[i-1].Literal != "" {
+						token := tmpl.Segments[i-1].Literal
 						// Do not add API version strings (e.g., v1, v1beta1) to the vocabulary
 						if isVersionString(token) {
 							continue

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -284,15 +284,14 @@ func ParseTemplateForTest(template string) []PathSegment {
 	if strings.HasPrefix(template, "//") {
 		host = "//" + parts[0]
 	}
-	segments = append(segments, PathSegment{Literal: &host})
+	segments = append(segments, PathSegment{Literal: host})
 
 	for _, part := range parts[1:] {
 		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
 			fieldPath := strings.Split(part[1:len(part)-1], ".")
 			segments = append(segments, PathSegment{Variable: &PathVariable{FieldPath: fieldPath}})
 		} else {
-			l := part
-			segments = append(segments, PathSegment{Literal: &l})
+			segments = append(segments, PathSegment{Literal: part})
 		}
 	}
 	return segments

--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -411,12 +411,11 @@ func toResourceNamePattern(pattern ResourcePattern, skipLast bool) *ResourceName
 	var segments []ResourceNameSegment
 	for i := 0; i < len(pattern); i++ {
 		s := pattern[i]
-		if s.Literal != nil && strings.HasPrefix(*s.Literal, "//") {
+		if strings.HasPrefix(s.Literal, "//") {
 			continue
 		}
-		seg := ResourceNameSegment{}
-		if s.Literal != nil {
-			seg.Literal = *s.Literal
+		seg := ResourceNameSegment{
+			Literal: s.Literal,
 		}
 		if s.Variable != nil && len(s.Variable.FieldPath) > 0 {
 			// The parser used for parsing resource name patterns is the same used for
@@ -429,7 +428,7 @@ func toResourceNamePattern(pattern ResourcePattern, skipLast bool) *ResourceName
 		}
 
 		// Try to combine with next segment if this is a literal and next is variable
-		if s.Literal != nil && i+1 < len(pattern) && pattern[i+1].Variable != nil {
+		if s.Literal != "" && i+1 < len(pattern) && pattern[i+1].Variable != nil {
 			if len(pattern[i+1].Variable.FieldPath) > 0 {
 				seg.Variable = pattern[i+1].Variable.FieldPath[0]
 			}

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -170,9 +170,9 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 	t := pathInfo.Bindings[0].PathTemplate
 	for _, segment := range t.Segments {
 		switch {
-		case segment.Literal != nil:
+		case segment.Literal != "":
 			builder.WriteString("/")
-			builder.WriteString(*segment.Literal)
+			builder.WriteString(segment.Literal)
 		case segment.Variable != nil:
 			// Form '${request.foo!.bar!.baz}'.
 			builder.WriteString("/${request")

--- a/internal/sidekick/gcloud/path.go
+++ b/internal/sidekick/gcloud/path.go
@@ -108,8 +108,8 @@ func pathFormatFromSegments(segments []api.PathSegment) string {
 	var parts []string
 	for _, seg := range segments {
 		switch {
-		case seg.Literal != nil:
-			parts = append(parts, *seg.Literal)
+		case seg.Literal != "":
+			parts = append(parts, seg.Literal)
 		case seg.Variable != nil && len(seg.Variable.FieldPath) > 0:
 			parts = append(parts, "%s")
 			hasVar = true

--- a/internal/sidekick/parser/discovery/uritemplate.go
+++ b/internal/sidekick/parser/discovery/uritemplate.go
@@ -70,7 +70,7 @@ func ParseUriTemplate(uriTemplate string) (*api.PathTemplate, error) {
 			return nil, err
 		}
 		pos += width
-		template.Verb = literal.Literal
+		template.Verb = &literal.Literal
 	}
 	if pos != len(uriTemplate) {
 		return nil, fmt.Errorf("trailing data (%q) cannot be parsed as a URI template", uriTemplate[pos:])
@@ -150,5 +150,5 @@ func parseLiteral(input string) (*api.PathSegment, int, error) {
 	if tail != "" && tail[0] != slash {
 		return nil, index, fmt.Errorf("found unexpected character %v in literal %q, stopped at position %v", tail[0], input, index)
 	}
-	return &api.PathSegment{Literal: &literal}, width, nil
+	return &api.PathSegment{Literal: literal}, width, nil
 }

--- a/internal/sidekick/parser/discovery/uritemplate_test.go
+++ b/internal/sidekick/parser/discovery/uritemplate_test.go
@@ -141,7 +141,7 @@ func TestParseLiteral(t *testing.T) {
 			t.Errorf("expected a successful parse with input=%s, err=%v", test.input, err)
 			continue
 		}
-		if diff := cmp.Diff(&api.PathSegment{Literal: &test.want}, gotSegment); diff != "" {
+		if diff := cmp.Diff(&api.PathSegment{Literal: test.want}, gotSegment); diff != "" {
 			t.Errorf("mismatch [%s] (-want, +got):\n%s", test.input, diff)
 		}
 		if len(test.want) != gotWidth {

--- a/internal/sidekick/parser/httprule/http_rule_parser.go
+++ b/internal/sidekick/parser/httprule/http_rule_parser.go
@@ -204,7 +204,7 @@ func parseLiteralSegment(literalSegment string) (*api.PathSegment, int, error) {
 		return nil, 0, err
 	}
 	return &api.PathSegment{
-		Literal: (*string)(literal),
+		Literal: string(*literal),
 	}, width, nil
 }
 

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -593,8 +593,8 @@ func formatResourceNameTemplateFromPath(m *api.Method, b *api.PathBinding) (stri
 		if i > 0 {
 			sb.WriteString("/")
 		}
-		if seg.Literal != nil {
-			sb.WriteString(*seg.Literal)
+		if seg.Literal != "" {
+			sb.WriteString(seg.Literal)
 		} else if seg.Variable != nil {
 			sb.WriteString("{}")
 		}

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -758,8 +758,8 @@ func bodyAccessor(m *api.Method) string {
 func httpPathFmt(t *api.PathTemplate) string {
 	fmt := ""
 	for _, segment := range t.Segments {
-		if segment.Literal != nil {
-			fmt = fmt + "/" + *segment.Literal
+		if segment.Literal != "" {
+			fmt = fmt + "/" + segment.Literal
 		} else if segment.Variable != nil {
 			fmt = fmt + "/{}"
 		}

--- a/internal/sidekick/surfer/argument_builder.go
+++ b/internal/sidekick/surfer/argument_builder.go
@@ -247,8 +247,8 @@ func newAttributesFromSegments(segments []api.PathSegment) []Attribute {
 
 		// The `parameter_name` is derived from the preceding literal segment
 		// (e.g., "projects" -> "projectsId"). This is a gcloud convention.
-		if i > 0 && segments[i-1].Literal != nil {
-			parameterName = *segments[i-1].Literal + "Id"
+		if i > 0 && segments[i-1].Literal != "" {
+			parameterName = segments[i-1].Literal + "Id"
 		} else {
 			parameterName = name + "sId"
 		}

--- a/internal/sidekick/surfer/command_builder_test.go
+++ b/internal/sidekick/surfer/command_builder_test.go
@@ -318,8 +318,6 @@ func TestCollectionPath(t *testing.T) {
 		DefaultHost: "test.googleapis.com",
 	}
 
-	stringPtr := func(s string) *string { return &s }
-
 	for _, test := range []struct {
 		name    string
 		method  *api.Method
@@ -334,12 +332,12 @@ func TestCollectionPath(t *testing.T) {
 						{
 							PathTemplate: &api.PathTemplate{
 								Segments: []api.PathSegment{
-									{Literal: stringPtr("v1")},
-									{Literal: stringPtr("projects")},
+									{Literal: "v1"},
+									{Literal: "projects"},
 									{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
-									{Literal: stringPtr("locations")},
+									{Literal: "locations"},
 									{Variable: &api.PathVariable{FieldPath: []string{"location"}}},
-									{Literal: stringPtr("instances")},
+									{Literal: "instances"},
 									{Variable: &api.PathVariable{FieldPath: []string{"instance"}}},
 								},
 							},
@@ -358,12 +356,12 @@ func TestCollectionPath(t *testing.T) {
 						{
 							PathTemplate: &api.PathTemplate{
 								Segments: []api.PathSegment{
-									{Literal: stringPtr("v1")},
-									{Literal: stringPtr("projects")},
+									{Literal: "v1"},
+									{Literal: "projects"},
 									{Variable: &api.PathVariable{FieldPath: []string{"project"}}},
-									{Literal: stringPtr("locations")},
+									{Literal: "locations"},
 									{Variable: &api.PathVariable{FieldPath: []string{"location"}}},
-									{Literal: stringPtr("instances")},
+									{Literal: "instances"},
 									{Variable: &api.PathVariable{FieldPath: []string{"instance"}}},
 								},
 							},
@@ -382,8 +380,8 @@ func TestCollectionPath(t *testing.T) {
 						{
 							PathTemplate: &api.PathTemplate{
 								Segments: []api.PathSegment{
-									{Literal: stringPtr("v1")},
-									{Literal: stringPtr("instances")},
+									{Literal: "v1"},
+									{Literal: "instances"},
 								},
 							},
 						},

--- a/internal/sidekick/surfer/provider/method.go
+++ b/internal/sidekick/surfer/provider/method.go
@@ -184,7 +184,7 @@ func IsCollectionMethod(m *api.Method) bool {
 		}
 		lastSegment := template.Segments[len(template.Segments)-1]
 		// If the path ends with a literal, it's a collection method.
-		return lastSegment.Literal != nil
+		return lastSegment.Literal != ""
 	}
 }
 

--- a/internal/sidekick/surfer/provider/mixin.go
+++ b/internal/sidekick/surfer/provider/mixin.go
@@ -144,10 +144,9 @@ func resourcePatterns(m *api.Method) ([]api.ResourcePattern, error) {
 func expandBinding(binding *api.PathBinding) ([]api.PathSegment, error) {
 	var expandedSegments []api.PathSegment
 	for _, seg := range binding.PathTemplate.Segments {
-		if seg.Literal != nil {
-			lit := *seg.Literal
+		if seg.Literal != "" {
 			// Skip version prefix segments (e.g. "v1", "v2", "v1beta1")
-			if len(lit) > 1 && lit[0] == 'v' && lit[1] >= '0' && lit[1] <= '9' {
+			if len(seg.Literal) > 1 && seg.Literal[0] == 'v' && seg.Literal[1] >= '0' && seg.Literal[1] <= '9' {
 				continue
 			}
 			// Literal segments represent static collection nouns or resource verbs (e.g., "projects", "locations").
@@ -187,9 +186,8 @@ func expandNestedVariable(v *api.PathVariable) ([]api.PathSegment, error) {
 				},
 			})
 		} else {
-			lit := part
 			expanded = append(expanded, api.PathSegment{
-				Literal: &lit,
+				Literal: part,
 			})
 		}
 	}

--- a/internal/sidekick/surfer/provider/resource.go
+++ b/internal/sidekick/surfer/provider/resource.go
@@ -36,11 +36,7 @@ func GetPluralFromSegments(segments []api.PathSegment) string {
 		return ""
 	}
 	// The second to last segment should be the literal plural name
-	secondLastSegment := segments[len(segments)-2]
-	if secondLastSegment.Literal == nil {
-		return ""
-	}
-	return *secondLastSegment.Literal
+	return segments[len(segments)-2].Literal
 }
 
 // GetParentFromSegments extracts the pattern segments for the parent resource.
@@ -53,7 +49,7 @@ func GetParentFromSegments(segments []api.PathSegment) []api.PathSegment {
 	}
 	// We verify that the last segment is a variable and the second to last is a literal,
 	// consistent with standard AIP-122 patterns.
-	if segments[len(segments)-1].Variable != nil && segments[len(segments)-2].Literal != nil {
+	if segments[len(segments)-1].Variable != nil && segments[len(segments)-2].Literal != "" {
 		return segments[:len(segments)-2]
 	}
 	return nil
@@ -83,10 +79,10 @@ func GetCollectionPathFromSegments(segments []api.PathSegment) string {
 	var collectionParts []string
 	for i := 0; i < len(segments)-1; i++ {
 		// A collection identifier is a literal segment followed by a variable segment.
-		if segments[i].Literal == nil || segments[i+1].Variable == nil {
+		if segments[i].Literal == "" || segments[i+1].Variable == nil {
 			continue
 		}
-		collectionParts = append(collectionParts, *segments[i].Literal)
+		collectionParts = append(collectionParts, segments[i].Literal)
 	}
 	return strings.Join(collectionParts, ".")
 }
@@ -223,13 +219,13 @@ func isSingletonResource(resource *api.Resource) bool {
 		}
 
 		// A pattern ending in a literal is a singleton (e.g., projects/{project}/singletonConfig).
-		if pattern[len(pattern)-1].Literal != nil {
+		if pattern[len(pattern)-1].Literal != "" {
 			return true
 		}
 
 		// Adjacent literals anywhere in the pattern signify a singleton (e.g., .../literal1/literal2/...).
 		for i := 0; i < len(pattern)-1; i++ {
-			if pattern[i].Literal != nil && pattern[i+1].Literal != nil {
+			if pattern[i].Literal != "" && pattern[i+1].Literal != "" {
 				return true
 			}
 		}
@@ -282,13 +278,12 @@ func GetSingularResourceNameForMethod(method *api.Method, model *api.API) string
 func ExtractPathFromSegments(segments []api.PathSegment) string {
 	var parts []string
 	for i, seg := range segments {
-		if seg.Literal != nil {
-			val := *seg.Literal
+		if seg.Literal != "" {
 			// Heuristic: Skip API version at the start.
-			if i == 0 && len(val) >= 2 && val[0] == 'v' && val[1] >= '0' && val[1] <= '9' {
+			if i == 0 && len(seg.Literal) >= 2 && seg.Literal[0] == 'v' && seg.Literal[1] >= '0' && seg.Literal[1] <= '9' {
 				continue
 			}
-			parts = append(parts, val)
+			parts = append(parts, seg.Literal)
 		} else if seg.Variable != nil && len(seg.Variable.Segments) > 1 {
 			internal := ExtractCollectionFromStrings(seg.Variable.Segments)
 			if internal != "" {
@@ -327,8 +322,8 @@ func ExtractCollectionFromStrings(parts []string) string {
 func GetLiteralSegments(raw []api.PathSegment) []string {
 	var literals []string
 	for _, seg := range raw {
-		if seg.Literal != nil {
-			literals = append(literals, *seg.Literal)
+		if seg.Literal != "" {
+			literals = append(literals, seg.Literal)
 		} else if seg.Variable != nil {
 			for _, vSeg := range seg.Variable.Segments {
 				if vSeg != "*" && vSeg != "**" {

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -25,8 +25,8 @@ func pathExpression(t *api.PathTemplate) string {
 	count := 0
 	var pathComponents []string
 	for _, segment := range t.Segments {
-		if segment.Literal != nil {
-			pathComponents = append(pathComponents, *segment.Literal)
+		if segment.Literal != "" {
+			pathComponents = append(pathComponents, segment.Literal)
 		} else if segment.Variable != nil {
 			pathComponents = append(pathComponents, fmt.Sprintf(`\(pathVariable%d)`, count))
 			count += 1


### PR DESCRIPTION
This change converts the Literal field in the PathSegment struct from `*string` to just `string`. This simplifies object construction and eliminates the need for safe pointer handling (nil checks and dereferences) throughout the codebase.