### PR TITLE
fix(tool/cmd/migrate): fix and override for showcase for java

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -46,6 +46,8 @@ const (
 
 	managedModulesStartMarker = "<!-- {x-generated-modules-start} -->"
 	managedModulesEndMarker   = "<!-- {x-generated-modules-end} -->"
+
+	showcaseLibraryName = "showcase"
 )
 
 var (
@@ -254,8 +256,8 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 		var apis []*config.API
 		var javaAPIs []*config.JavaAPI
 		var roots []string
-		if name == "showcase" {
-			roots = []string{"showcase", "googleapis"}
+		if name == showcaseLibraryName {
+			roots = []string{showcaseLibraryName, "googleapis"}
 		}
 		for _, g := range l.GAPICs {
 			if g.ProtoPath == "" {
@@ -264,7 +266,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 			apis = append(apis, &config.API{Path: g.ProtoPath})
 
 			var info *javaGAPICInfo
-			if name == "showcase" {
+			if name == showcaseLibraryName {
 				// Skip parsing BUILD.bazel for showcase as it doesn't contain standard java rules.
 				info = &javaGAPICInfo{Samples: true, OmitCommonResources: true}
 			} else {

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -276,6 +276,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 				}
 			}
 			if info == nil {
+				log.Printf("Warning: skipping API %s for library %s because no Java build info was found", g.ProtoPath, name)
 				continue
 			}
 			javaAPI := &config.JavaAPI{

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -253,16 +253,27 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 		version := versions[artifactID]
 		var apis []*config.API
 		var javaAPIs []*config.JavaAPI
+		var roots []string
+		if name == "showcase" {
+			roots = []string{"showcase", "googleapis"}
+		}
 		for _, g := range l.GAPICs {
 			if g.ProtoPath == "" {
 				continue
 			}
 			apis = append(apis, &config.API{Path: g.ProtoPath})
 
-			info, err := parseJavaBazel(src.Dir, g.ProtoPath)
-			if err != nil {
-				log.Printf("Warning: failed to parse BUILD.bazel for %s: %v", g.ProtoPath, err)
-				continue
+			var info *javaGAPICInfo
+			if name == "showcase" {
+				// Skip parsing BUILD.bazel for showcase as it doesn't contain standard java rules.
+				info = &javaGAPICInfo{Samples: true, OmitCommonResources: true}
+			} else {
+				var err error
+				info, err = parseJavaBazel(src.Dir, g.ProtoPath)
+				if err != nil {
+					log.Printf("Warning: failed to parse BUILD.bazel for %s: %v", g.ProtoPath, err)
+					continue
+				}
 			}
 			if info == nil {
 				continue
@@ -298,10 +309,6 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 				}
 			}
 			javaAPIs = append(javaAPIs, javaAPI)
-		}
-		var roots []string
-		if name == "showcase" {
-			roots = []string{"showcase", "googleapis"}
 		}
 		lib := &config.Library{
 			Name:    name,

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -62,6 +62,10 @@ var (
 			"google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicy.java",
 			"google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicyImpl.java",
 		},
+		"showcase": {
+			"gapic-showcase/src/test",
+			"gapic-showcase/src/main/java/com/google/showcase/v1beta1/Version.java",
+		},
 	}
 
 	javaArtifactIDOverrides = map[string]javaArtifactOverrides{

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -363,7 +363,22 @@ func TestBuildConfig(t *testing.T) {
 						APIs: []*config.API{
 							{Path: "schema/google/showcase/v1beta1"},
 						},
-						Java: &config.JavaModule{SkipAPIID: true},
+						Keep: []string{
+							"gapic-showcase/src/test",
+							"gapic-showcase/src/main/java/com/google/showcase/v1beta1/Version.java",
+						},
+						Java: &config.JavaModule{
+							SkipAPIID: true,
+							JavaAPIs: []*config.JavaAPI{
+								{
+									Path:                    "schema/google/showcase/v1beta1",
+									AdditionalProtos:        []string{"google/cloud/location/locations.proto", "google/iam/v1/iam_policy.proto"},
+									GRPCArtifactIDOverride:  "grpc-gapic-showcase-v1beta1",
+									ProtoArtifactIDOverride: "proto-gapic-showcase-v1beta1",
+									OmitCommonResources:     true,
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
The hardcoded overrides added in https://github.com/googleapis/librarian/pull/5801 was never reached because showcase BUILD.bazel does not contain standard java rules. Add logic to hardcode relevant configs according to [BUILD.partial.bazel](https://github.com/googleapis/google-cloud-java/blob/2cecd0caf4f15da2d894a70077ccb0d0fd69d296/java-showcase/scripts/resources/BUILD.partial.bazel#L18-L24).
Also added a warning in case similar situation happens (this is the only one).

For #5731