### PR TITLE
fix(sidekick/rust): bad comment block in template

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -48,7 +48,7 @@ limitations under the License.
 /// * [with_endpoint()]: by default this client uses the global default endpoint
 ///   (`https://{{Model.Codec.DefaultHost}}`). Applications using regional
 ///   endpoints or running in restricted networks (e.g. a network configured
-//    with [Private Google Access with VPC Service Controls]) may want to
+///   with [Private Google Access with VPC Service Controls]) may want to
 ///   override this default.
 /// * [with_credentials()]: by default this client uses
 ///   [Application Default Credentials]. Applications using custom


### PR DESCRIPTION
We had a `//` comment in the middle of a `///` block. That is a grevious sin in the Rust formatting world.