### PR TITLE
feat(internal/sidekick/gcloud): support delete methods in generator

### DIFF
--- a/internal/sidekick/gcloud/client.go
+++ b/internal/sidekick/gcloud/client.go
@@ -94,10 +94,10 @@ func clientInfoFromPath(clientImportPath string) *goClientInfo {
 	}
 }
 
-// buildClientCall returns a ClientCall for an AIP-131 Get or AIP-132 List
-// method when the model maps to a standard GAPIC Go package and the command
-// composes a resource path. It returns nil otherwise so the command keeps
-// its print-only action.
+// buildClientCall returns a ClientCall for an AIP-131 Get, AIP-132 List, or
+// AIP-135 Delete method when the model maps to a standard GAPIC Go package
+// and the command composes a resource path. It returns nil otherwise so the
+// command keeps its print-only action.
 func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *ClientCall {
 	if goClient == nil || !hasPath {
 		return nil
@@ -121,6 +121,15 @@ func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *
 			Package:     goClient.Alias,
 			RequestType: goClient.Alias + "pb." + method.InputType.Name,
 			IsList:      true,
+		}
+	case provider.IsDelete(method):
+		return &ClientCall{
+			Method:      method.Name,
+			NameField:   "Name",
+			Package:     goClient.Alias,
+			RequestType: goClient.Alias + "pb." + method.InputType.Name,
+			IsDelete:    true,
+			IsLRO:       method.IsLRO,
 		}
 	default:
 		return nil

--- a/internal/sidekick/gcloud/client_test.go
+++ b/internal/sidekick/gcloud/client_test.go
@@ -67,6 +67,40 @@ func TestBuildClientCall(t *testing.T) {
 			},
 		},
 		{
+			name: "Delete LRO method",
+			method: &api.Method{
+				Name:      "DeleteInstance",
+				InputType: &api.Message{Name: "DeleteInstanceRequest"},
+				IsLRO:     true,
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want: &ClientCall{
+				Method:      "DeleteInstance",
+				NameField:   "Name",
+				Package:     "parallelstore",
+				RequestType: "parallelstorepb.DeleteInstanceRequest",
+				IsDelete:    true,
+				IsLRO:       true,
+			},
+		},
+		{
+			name: "Delete non-LRO method",
+			method: &api.Method{
+				Name:      "DeleteOperation",
+				InputType: &api.Message{Name: "DeleteOperationRequest"},
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want: &ClientCall{
+				Method:      "DeleteOperation",
+				NameField:   "Name",
+				Package:     "parallelstore",
+				RequestType: "parallelstorepb.DeleteOperationRequest",
+				IsDelete:    true,
+			},
+		},
+		{
 			name: "nil goClient",
 			method: &api.Method{
 				Name:      "GetInstance",
@@ -96,10 +130,10 @@ func TestBuildClientCall(t *testing.T) {
 			want:     nil,
 		},
 		{
-			name: "not get or list",
+			name: "not get list or delete",
 			method: &api.Method{
-				Name:      "CreateInstance",
-				InputType: &api.Message{Name: "CreateInstanceRequest"},
+				Name:      "ImportData",
+				InputType: &api.Message{Name: "ImportDataRequest"},
 			},
 			goClient: goClient,
 			hasPath:  true,

--- a/internal/sidekick/gcloud/command.go
+++ b/internal/sidekick/gcloud/command.go
@@ -33,8 +33,14 @@ type Command struct {
 // ClientCall describes a Go client method invocation that should replace the
 // default print-only action for a generated command.
 type ClientCall struct {
+	// IsDelete reports whether the method is a standard Delete method.
+	IsDelete bool
+
 	// IsList reports whether the method is a standard List method.
 	IsList bool
+
+	// IsLRO reports whether the call returns a long-running operation.
+	IsLRO bool
 
 	// Method is the unqualified client method to call on the constructed
 	// client, for example "GetInstance". The template invokes it as

--- a/internal/sidekick/gcloud/model_test.go
+++ b/internal/sidekick/gcloud/model_test.go
@@ -199,6 +199,85 @@ func TestConstructSurfaceModel(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "delete method",
+			model: &api.API{
+				Name:        "parallelstore",
+				Title:       "Parallelstore",
+				PackageName: "google.cloud.parallelstore.v1",
+				Services: []*api.Service{{
+					Name: "InstanceService",
+					Methods: []*api.Method{{
+						Name:                "DeleteInstance",
+						IsAIPStandardDelete: true,
+						IsLRO:               true,
+						InputType: &api.Message{
+							Name: "DeleteInstanceRequest",
+							Fields: []*api.Field{
+								{
+									Name:              "name",
+									ResourceReference: &api.ResourceReference{Type: "parallelstore.googleapis.com/Instance"},
+								},
+							},
+						},
+						PathInfo: &api.PathInfo{
+							Bindings: []*api.PathBinding{{
+								Verb: "DELETE",
+								PathTemplate: (&api.PathTemplate{}).
+									WithLiteral("v1").
+									WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+									WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+									WithLiteral("instances").WithVariable(api.NewPathVariable("instance")),
+							}},
+						},
+					}},
+				}},
+				ResourceDefinitions: []*api.Resource{{
+					Type: "parallelstore.googleapis.com/Instance",
+					Patterns: []api.ResourcePattern{
+						(&api.PathTemplate{}).
+							WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+							WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+							WithLiteral("instances").WithVariable(api.NewPathVariable("instance")).
+							Segments,
+					},
+				}},
+			},
+			want: SurfaceModel{
+				PackageName: "parallelstore",
+				Imports: []Import{
+					{Alias: "parallelstore", Path: "cloud.google.com/go/parallelstore/apiv1"},
+					{Path: "cloud.google.com/go/parallelstore/apiv1/parallelstorepb"},
+				},
+				Group: Group{
+					Name:  "parallelstore",
+					Usage: "manage Parallelstore resources",
+					Subgroups: []Subgroup{{
+						Name:  "instances",
+						Usage: "manage instances resources",
+						Commands: []Command{{
+							Name:       "delete",
+							Usage:      "delete instances",
+							PathFormat: "projects/%s/locations/%s/instances/%s",
+							Args:       []string{"project", "location", "instance"},
+							PathLabel:  "name",
+							Flags: []Flag{
+								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
+								{Name: "instance", Kind: "String", Required: true, Usage: "The instance."},
+							},
+							ClientCall: &ClientCall{
+								Method:      "DeleteInstance",
+								NameField:   "Name",
+								Package:     "parallelstore",
+								RequestType: "parallelstorepb.DeleteInstanceRequest",
+								IsDelete:    true,
+								IsLRO:       true,
+							},
+						}},
+					}},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := constructSurfaceModel(test.model, "")

--- a/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
+++ b/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
@@ -89,6 +89,22 @@ func Command() *cli.Command {
 			fmt.Println(string(out))
 		}
 		return nil
+		{{- else if .ClientCall.IsDelete}}
+		{{- if .ClientCall.IsLRO}}
+		op, err := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })
+		if err != nil {
+			return err
+		}
+		if err := op.Wait(ctx); err != nil {
+			return err
+		}
+		{{- else}}
+		if err := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} }); err != nil {
+			return err
+		}
+		{{- end}}
+		fmt.Printf("Deleted %s\n", {{.PathLabel}})
+		return nil
 		{{- else}}
 		resp, err := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })
 		if err != nil {

--- a/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
+++ b/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
@@ -127,7 +127,19 @@ func Command() *cli.Command {
 								return fmt.Errorf("--project is required")
 							}
 							name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", cmd.String("project"), cmd.String("location"), cmd.String("instance"))
-							fmt.Printf("Executing delete on %s\n", name)
+							client, err := parallelstore.NewClient(ctx)
+							if err != nil {
+								return err
+							}
+							defer client.Close()
+							op, err := client.DeleteInstance(ctx, &parallelstorepb.DeleteInstanceRequest{Name: name})
+							if err != nil {
+								return err
+							}
+							if err := op.Wait(ctx); err != nil {
+								return err
+							}
+							fmt.Printf("Deleted %s\n", name)
 							return nil
 						},
 					},
@@ -266,7 +278,15 @@ func Command() *cli.Command {
 								return fmt.Errorf("--project is required")
 							}
 							name := fmt.Sprintf("projects/%s/locations/%s/operations/%s", cmd.String("project"), cmd.String("location"), cmd.String("operation"))
-							fmt.Printf("Executing delete on %s\n", name)
+							client, err := parallelstore.NewClient(ctx)
+							if err != nil {
+								return err
+							}
+							defer client.Close()
+							if err := client.DeleteOperation(ctx, &parallelstorepb.DeleteOperationRequest{Name: name}); err != nil {
+								return err
+							}
+							fmt.Printf("Deleted %s\n", name)
 							return nil
 						},
 					},


### PR DESCRIPTION
The gcloud CLI generator is updated to support Delete methods. Generated delete commands now invoke the client's Delete method instead of printing a placeholder. 