### PR TITLE
fix(sidekick/surfer): strip immutable prefix from help text

### DIFF
--- a/internal/sidekick/surfer/provider/field.go
+++ b/internal/sidekick/surfer/provider/field.go
@@ -29,6 +29,7 @@ func CleanDocumentation(s string) string {
 		s = strings.TrimPrefix(s, "Required. ")
 		s = strings.TrimPrefix(s, "Identifier. ")
 		s = strings.TrimPrefix(s, "Optional. ")
+		s = strings.TrimPrefix(s, "Immutable. ")
 		if s == original {
 			break
 		}

--- a/internal/sidekick/surfer/provider/field_test.go
+++ b/internal/sidekick/surfer/provider/field_test.go
@@ -86,6 +86,9 @@ func TestCleanDocumentation(t *testing.T) {
 		{"Both_IdentifierFirst", "Identifier. Required. This is help text.", "This is help text."},
 		{"OptionalAndRequired", "Optional. Required. This is help text.", "This is help text."},
 		{"Repeated", "Required. Required. This is help text.", "This is help text."},
+		{"Immutable", "Immutable. This is help text.", "This is help text."},
+		{"RequiredAndImmutable", "Required. Immutable. This is help text.", "This is help text."},
+		{"ImmutableAndRequired", "Immutable. Required. This is help text.", "This is help text."},
 		{"Empty", "", ""},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_create_ga.yaml
@@ -91,7 +91,7 @@
       - arg_name: target
         api_field: policyBinding.target
         help_text: |-
-          Immutable. Target is the full resource name of the resource to
+          Target is the full resource name of the resource to
           which the policy will be bound. Immutable once set.
         is_positional: false
         required: true
@@ -99,7 +99,7 @@
       - arg_name: policy-kind
         api_field: policyBinding.policyKind
         help_text: |-
-          Immutable. The kind of the policy to attach in this binding. This field
+          The kind of the policy to attach in this binding. This field
           must be one of the following:
 
           - Left empty (will be automatically set to the policy kind)
@@ -113,7 +113,7 @@
       - arg_name: policy
         api_field: policyBinding.policy
         help_text: |-
-          Immutable. The resource name of the policy to be bound. The
+          The resource name of the policy to be bound. The
           binding parent and policy must belong to the same organization.
         is_positional: false
         required: true

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_create_ga.yaml
@@ -72,7 +72,7 @@
       - arg_name: capacity-gib
         api_field: instance.capacityGib
         help_text: |-
-          Immutable. The instance's storage capacity in Gibibytes (GiB).
+          The instance's storage capacity in Gibibytes (GiB).
           Allowed values are between 12000 and 100000, in multiples of 4000; e.g.,
           12000, 16000, 20000, ...
         is_positional: false
@@ -80,7 +80,7 @@
         type: long
       - arg_name: network
         help_text: |-
-          Immutable. The name of the Compute Engine
+          The name of the Compute Engine
           [VPC network](https://cloud.google.com/vpc/docs/vpc) to which the
           instance is connected.
         is_positional: false
@@ -102,7 +102,7 @@
           instance.network: '{__relative_name__}'
       - arg_name: reserved-ip-range
         help_text: |-
-          Immutable. The ID of the IP address range being used by the
+          The ID of the IP address range being used by the
           instance's VPC network. See [Configure a VPC
           network](https://cloud.google.com/parallelstore/docs/vpc#create_and_configure_the_vpc).
           If no ID is provided, all ranges are considered.
@@ -129,7 +129,7 @@
       - arg_name: file-stripe-level
         api_field: instance.fileStripeLevel
         help_text: |-
-          Immutable. Stripe level for files. Allowed values are:
+          Stripe level for files. Allowed values are:
 
           * `FILE_STRIPE_LEVEL_MIN`: offers the best performance for small size
             files.
@@ -151,7 +151,7 @@
       - arg_name: directory-stripe-level
         api_field: instance.directoryStripeLevel
         help_text: |-
-          Immutable. Stripe level for directories. Allowed values are:
+          Stripe level for directories. Allowed values are:
 
           * `DIRECTORY_STRIPE_LEVEL_MIN`: recommended when directories contain a
             small number of files.
@@ -174,7 +174,7 @@
       - arg_name: deployment-type
         api_field: instance.deploymentType
         help_text: |-
-          Immutable. The deployment type of the instance. Allowed values
+          The deployment type of the instance. Allowed values
           are:
 
           * `SCRATCH`: the instance is a scratch instance.

--- a/internal/surfer/testdata/field_attributes/expected/current/surface/field_attributes/resources/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/field_attributes/expected/current/surface/field_attributes/resources/_partials/_create_ga.yaml
@@ -54,7 +54,7 @@
         required: true
       - arg_name: immutable-field
         api_field: resource.immutableField
-        help_text: Immutable. Immutable field.
+        help_text: Immutable field.
         is_positional: false
         required: false
       - arg_name: labels


### PR DESCRIPTION
The "Immutable. " prefix is stripped from field documentation when generating help text for CLI arguments. This prefix is redundant in the context of CLI help text.

The CleanDocumentation function is updated to handle "Immutable. " in addition to other common prefixes like "Required. " and "Optional. ". Golden files are updated to reflect the change.

Fixes https://github.com/googleapis/librarian/issues/5874