### PR TITLE
fix(internal/sidekick/surfer): derive enum help text from proto

### DIFF
--- a/internal/sidekick/surfer/argument_builder.go
+++ b/internal/sidekick/surfer/argument_builder.go
@@ -117,10 +117,14 @@ func choices(field *api.Field) []Choice {
 	for _, v := range field.EnumType.Values {
 		// Skip the default "UNSPECIFIED" value.
 		if !strings.HasSuffix(v.Name, "_UNSPECIFIED") {
+			helpText := provider.CleanDocumentation(strings.TrimSpace(v.Documentation))
+			if helpText == "" {
+				helpText = fmt.Sprintf("Value for the `%s` field.", strcase.ToKebab(v.Name))
+			}
 			choices = append(choices, Choice{
 				ArgValue:  strcase.ToKebab(v.Name),
 				EnumValue: v.Name,
-				HelpText:  fmt.Sprintf("Value for the `%s` field.", strcase.ToKebab(v.Name)),
+				HelpText:  helpText,
 			})
 		}
 	}

--- a/internal/sidekick/surfer/argument_builder_test.go
+++ b/internal/sidekick/surfer/argument_builder_test.go
@@ -143,6 +143,56 @@ func TestNewArgument(t *testing.T) {
 				HelpText: "Override Foo",
 			},
 		},
+		{
+			name: "Enum Field with Documentation",
+			field: func() *api.Field {
+				f := api.NewTestField("state").WithType(api.TypezEnum)
+				f.EnumType = &api.Enum{
+					Name: "State",
+					Values: []*api.EnumValue{
+						{Name: "STATE_UNSPECIFIED"},
+						{Name: "ACTIVE", Documentation: "The active state."},
+						{Name: "SUSPENDED", Documentation: "The suspended state."},
+					},
+				}
+				return f
+			}(),
+			method: api.NewTestMethod("CreateInstance"),
+			want: Argument{
+				ArgName:  "state",
+				APIField: []string{"state"},
+				HelpText: "Value for the `state` field.",
+				Choices: []Choice{
+					{ArgValue: "active", EnumValue: "ACTIVE", HelpText: "The active state."},
+					{ArgValue: "suspended", EnumValue: "SUSPENDED", HelpText: "The suspended state."},
+				},
+			},
+		},
+		{
+			name: "Enum Field without Documentation (Fallback)",
+			field: func() *api.Field {
+				f := api.NewTestField("state").WithType(api.TypezEnum)
+				f.EnumType = &api.Enum{
+					Name: "State",
+					Values: []*api.EnumValue{
+						{Name: "STATE_UNSPECIFIED"},
+						{Name: "ACTIVE"},
+						{Name: "SUSPENDED"},
+					},
+				}
+				return f
+			}(),
+			method: api.NewTestMethod("CreateInstance"),
+			want: Argument{
+				ArgName:  "state",
+				APIField: []string{"state"},
+				HelpText: "Value for the `state` field.",
+				Choices: []Choice{
+					{ArgValue: "active", EnumValue: "ACTIVE", HelpText: "Value for the `active` field."},
+					{ArgValue: "suspended", EnumValue: "SUSPENDED", HelpText: "Value for the `suspended` field."},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_git_refs_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/git_repository_links/_partials/_fetch_git_refs_ga.yaml
@@ -61,10 +61,10 @@
         choices:
           - arg_value: tag
             enum_value: TAG
-            help_text: Value for the `tag` field.
+            help_text: To fetch tags.
           - arg_value: branch
             enum_value: BRANCH
-            help_text: Value for the `branch` field.
+            help_text: To fetch branches.
       - arg_name: page-size
         api_field: pageSize
         help_text: Number of results to return in the list. Default to 20.

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_create_ga.yaml
@@ -79,13 +79,13 @@
         choices:
           - arg_value: pending
             enum_value: PENDING
-            help_text: Value for the `pending` field.
+            help_text: The InsightsConfig is pending application discovery/runtime discovery.
           - arg_value: complete
             enum_value: COMPLETE
-            help_text: Value for the `complete` field.
+            help_text: The initial discovery process is complete.
           - arg_value: error
             enum_value: ERROR
-            help_text: Value for the `error` field.
+            help_text: The InsightsConfig is in an error state.
       - arg_name: annotations
         api_field: insightsConfig.annotations
         help_text: |-

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_update_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/insights_configs/_partials/_update_ga.yaml
@@ -79,13 +79,13 @@
         choices:
           - arg_value: pending
             enum_value: PENDING
-            help_text: Value for the `pending` field.
+            help_text: The InsightsConfig is pending application discovery/runtime discovery.
           - arg_value: complete
             enum_value: COMPLETE
-            help_text: Value for the `complete` field.
+            help_text: The initial discovery process is complete.
           - arg_value: error
             enum_value: ERROR
-            help_text: Value for the `error` field.
+            help_text: The InsightsConfig is in an error state.
       - arg_name: annotations
         api_field: insightsConfig.annotations
         help_text: |-

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_create_ga.yaml
@@ -109,7 +109,7 @@
         choices:
           - arg_value: principal-access-boundary
             enum_value: PRINCIPAL_ACCESS_BOUNDARY
-            help_text: Value for the `principal-access-boundary` field.
+            help_text: Principal access boundary policy kind
       - arg_name: policy
         api_field: policyBinding.policy
         help_text: |-

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_create_ga.yaml
@@ -141,13 +141,13 @@
         choices:
           - arg_value: file-stripe-level-min
             enum_value: FILE_STRIPE_LEVEL_MIN
-            help_text: Value for the `file-stripe-level-min` field.
+            help_text: Minimum file striping
           - arg_value: file-stripe-level-balanced
             enum_value: FILE_STRIPE_LEVEL_BALANCED
-            help_text: Value for the `file-stripe-level-balanced` field.
+            help_text: Medium file striping
           - arg_value: file-stripe-level-max
             enum_value: FILE_STRIPE_LEVEL_MAX
-            help_text: Value for the `file-stripe-level-max` field.
+            help_text: Maximum file striping
       - arg_name: directory-stripe-level
         api_field: instance.directoryStripeLevel
         help_text: |-
@@ -164,13 +164,13 @@
         choices:
           - arg_value: directory-stripe-level-min
             enum_value: DIRECTORY_STRIPE_LEVEL_MIN
-            help_text: Value for the `directory-stripe-level-min` field.
+            help_text: Minimum directory striping
           - arg_value: directory-stripe-level-balanced
             enum_value: DIRECTORY_STRIPE_LEVEL_BALANCED
-            help_text: Value for the `directory-stripe-level-balanced` field.
+            help_text: Medium directory striping
           - arg_value: directory-stripe-level-max
             enum_value: DIRECTORY_STRIPE_LEVEL_MAX
-            help_text: Value for the `directory-stripe-level-max` field.
+            help_text: Maximum directory striping
       - arg_name: deployment-type
         api_field: instance.deploymentType
         help_text: |-
@@ -184,10 +184,10 @@
         choices:
           - arg_value: scratch
             enum_value: SCRATCH
-            help_text: Value for the `scratch` field.
+            help_text: Scratch
           - arg_value: persistent
             enum_value: PERSISTENT
-            help_text: Value for the `persistent` field.
+            help_text: Persistent
       - arg_name: request-id
         api_field: requestId
         help_text: |-

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_export_data_ga.yaml
@@ -118,10 +118,10 @@
         choices:
           - arg_value: uid-skip
             enum_value: UID_SKIP
-            help_text: Value for the `uid-skip` field.
+            help_text: Do not preserve UID during a transfer job.
           - arg_value: uid-number-preserve
             enum_value: UID_NUMBER_PRESERVE
-            help_text: Value for the `uid-number-preserve` field.
+            help_text: Preserve UID that is in number format during a transfer job.
       - arg_name: metadata-options-gid
         api_field: exportDataRequest.metadataOptions.gid
         help_text: The GID preservation behavior.
@@ -130,10 +130,10 @@
         choices:
           - arg_value: gid-skip
             enum_value: GID_SKIP
-            help_text: Value for the `gid-skip` field.
+            help_text: Do not preserve GID during a transfer job.
           - arg_value: gid-number-preserve
             enum_value: GID_NUMBER_PRESERVE
-            help_text: Value for the `gid-number-preserve` field.
+            help_text: Preserve GID that is in number format during a transfer job.
       - arg_name: metadata-options-mode
         api_field: exportDataRequest.metadataOptions.mode
         help_text: The mode preservation behavior.
@@ -142,10 +142,10 @@
         choices:
           - arg_value: mode-skip
             enum_value: MODE_SKIP
-            help_text: Value for the `mode-skip` field.
+            help_text: Do not preserve mode during a transfer job.
           - arg_value: mode-preserve
             enum_value: MODE_PRESERVE
-            help_text: Value for the `mode-preserve` field.
+            help_text: Preserve mode during a transfer job.
   request:
     api_version: v1
     collection:

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_import_data_ga.yaml
@@ -119,10 +119,10 @@
         choices:
           - arg_value: uid-skip
             enum_value: UID_SKIP
-            help_text: Value for the `uid-skip` field.
+            help_text: Do not preserve UID during a transfer job.
           - arg_value: uid-number-preserve
             enum_value: UID_NUMBER_PRESERVE
-            help_text: Value for the `uid-number-preserve` field.
+            help_text: Preserve UID that is in number format during a transfer job.
       - arg_name: metadata-options-gid
         api_field: importDataRequest.metadataOptions.gid
         help_text: The GID preservation behavior.
@@ -131,10 +131,10 @@
         choices:
           - arg_value: gid-skip
             enum_value: GID_SKIP
-            help_text: Value for the `gid-skip` field.
+            help_text: Do not preserve GID during a transfer job.
           - arg_value: gid-number-preserve
             enum_value: GID_NUMBER_PRESERVE
-            help_text: Value for the `gid-number-preserve` field.
+            help_text: Preserve GID that is in number format during a transfer job.
       - arg_name: metadata-options-mode
         api_field: importDataRequest.metadataOptions.mode
         help_text: The mode preservation behavior.
@@ -143,10 +143,10 @@
         choices:
           - arg_value: mode-skip
             enum_value: MODE_SKIP
-            help_text: Value for the `mode-skip` field.
+            help_text: Do not preserve mode during a transfer job.
           - arg_value: mode-preserve
             enum_value: MODE_PRESERVE
-            help_text: Value for the `mode-preserve` field.
+            help_text: Preserve mode during a transfer job.
   request:
     api_version: v1
     collection:

--- a/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_query_ga.yaml
+++ b/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_query_ga.yaml
@@ -79,16 +79,16 @@
         choices:
           - arg_value: harm-category-hate-speech
             enum_value: HARM_CATEGORY_HATE_SPEECH
-            help_text: Value for the `harm-category-hate-speech` field.
+            help_text: The harm category is hate speech.
           - arg_value: harm-category-dangerous-content
             enum_value: HARM_CATEGORY_DANGEROUS_CONTENT
-            help_text: Value for the `harm-category-dangerous-content` field.
+            help_text: The harm category is dangerous content.
           - arg_value: harm-category-harassment
             enum_value: HARM_CATEGORY_HARASSMENT
-            help_text: Value for the `harm-category-harassment` field.
+            help_text: The harm category is harassment.
           - arg_value: harm-category-sexually-explicit
             enum_value: HARM_CATEGORY_SEXUALLY_EXPLICIT
-            help_text: Value for the `harm-category-sexually-explicit` field.
+            help_text: The harm category is sexually explicit content.
       - arg_name: safety-settings-threshold
         api_field: workbenchQueryRequest.safetySettings.threshold
         help_text: Controls the probability threshold at which harm is blocked.
@@ -97,16 +97,16 @@
         choices:
           - arg_value: block-low-and-above
             enum_value: BLOCK_LOW_AND_ABOVE
-            help_text: Value for the `block-low-and-above` field.
+            help_text: Content with NEGLIGIBLE will be allowed.
           - arg_value: block-medium-and-above
             enum_value: BLOCK_MEDIUM_AND_ABOVE
-            help_text: Value for the `block-medium-and-above` field.
+            help_text: Content with NEGLIGIBLE and LOW will be allowed.
           - arg_value: block-only-high
             enum_value: BLOCK_ONLY_HIGH
-            help_text: Value for the `block-only-high` field.
+            help_text: Content with NEGLIGIBLE, LOW, and MEDIUM will be allowed.
           - arg_value: block-none
             enum_value: BLOCK_NONE
-            help_text: Value for the `block-none` field.
+            help_text: All content will be allowed.
   request:
     api_version: v1
     collection:

--- a/internal/surfer/testdata/field_complex_types/expected/current/surface/field_complex_types/resources/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/field_complex_types/expected/current/surface/field_complex_types/resources/_partials/_create_ga.yaml
@@ -55,13 +55,13 @@
         choices:
           - arg_value: default
             enum_value: DEFAULT
-            help_text: Value for the `default` field.
+            help_text: Default.
           - arg_value: one
             enum_value: ONE
-            help_text: Value for the `one` field.
+            help_text: Enum One.
           - arg_value: two
             enum_value: TWO
-            help_text: Value for the `two` field.
+            help_text: Enum Two.
       - arg_name: my-message
         api_field: resource.myMessage
         help_text: Message field.

--- a/internal/surfer/testdata/field_complex_types/expected/current/surface/field_complex_types/resources/_partials/_update_ga.yaml
+++ b/internal/surfer/testdata/field_complex_types/expected/current/surface/field_complex_types/resources/_partials/_update_ga.yaml
@@ -54,13 +54,13 @@
         choices:
           - arg_value: default
             enum_value: DEFAULT
-            help_text: Value for the `default` field.
+            help_text: Default.
           - arg_value: one
             enum_value: ONE
-            help_text: Value for the `one` field.
+            help_text: Enum One.
           - arg_value: two
             enum_value: TWO
-            help_text: Value for the `two` field.
+            help_text: Enum Two.
       - arg_name: my-message
         api_field: resource.myMessage
         help_text: Message field.

--- a/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_create_ga.yaml
@@ -79,10 +79,10 @@
         choices:
           - arg_value: option-a
             enum_value: OPTION_A
-            help_text: Value for the `option-a` field.
+            help_text: Option A.
           - arg_value: option-b
             enum_value: OPTION_B
-            help_text: Value for the `option-b` field.
+            help_text: Option B.
       - arg_name: integer-field
         api_field: resource.integerField
         help_text: An integer field.

--- a/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_update_ga.yaml
+++ b/internal/surfer/testdata/help_text/expected/current/surface/help_text/resources/_partials/_update_ga.yaml
@@ -78,10 +78,10 @@
         choices:
           - arg_value: option-a
             enum_value: OPTION_A
-            help_text: Value for the `option-a` field.
+            help_text: Option A.
           - arg_value: option-b
             enum_value: OPTION_B
-            help_text: Value for the `option-b` field.
+            help_text: Option B.
       - arg_name: integer-field
         api_field: resource.integerField
         help_text: An integer field.


### PR DESCRIPTION
The surfer tool is modified to derive enum choices help text from proto comments when available, instead of using a default placeholder.

This brings surfer closer to parity with the legacy generator gen_sfc, which already supported this feature. When no proto comments are available, surfer falls back to the existing default help text behavior.

Fixes https://github.com/googleapis/librarian/issues/5876