### PR TITLE
feat(sidekick/swift): support xref links

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -32,7 +32,9 @@ func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
 	existing := map[int32]*enumValueAnnotations{}
 	var defaultCaseName string
 	for _, ev := range enum.UniqueNumberValues {
-		c.annotateUniqueEnumValue(ev)
+		if err := c.annotateUniqueEnumValue(ev); err != nil {
+			return err
+		}
 		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
 		if ev.Number == 0 {
 			defaultCaseName = ev.Codec.(*enumValueAnnotations).CaseName
@@ -53,7 +55,10 @@ func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
 		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
 	}
 
-	docLines := c.formatDocumentation(enum.Documentation)
+	docLines, err := c.formatDocumentation(enum.Documentation, enum.Scopes())
+	if err != nil {
+		return err
+	}
 	annotations := &enumAnnotations{
 		CopyrightYear:   model.CopyrightYear,
 		BoilerPlate:     model.BoilerPlate,

--- a/internal/sidekick/swift/annotate_enum_value.go
+++ b/internal/sidekick/swift/annotate_enum_value.go
@@ -27,8 +27,11 @@ type enumValueAnnotations struct {
 	DocLines    []string
 }
 
-func (c *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
-	docLines := c.formatDocumentation(ev.Documentation)
+func (c *codec) annotateUniqueEnumValue(ev *api.EnumValue) error {
+	docLines, err := c.formatDocumentation(ev.Documentation, ev.Scopes())
+	if err != nil {
+		return err
+	}
 	ann := &enumValueAnnotations{
 		CaseName:    enumValueCaseName(ev),
 		Number:      ev.Number,
@@ -36,6 +39,7 @@ func (c *codec) annotateUniqueEnumValue(ev *api.EnumValue) {
 		DocLines:    docLines,
 	}
 	ev.Codec = ann
+	return nil
 }
 
 func (c *codec) annotateEnumValue(ev *api.EnumValue, unique map[int32]*enumValueAnnotations) error {

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -53,11 +53,15 @@ func (c *codec) annotateField(field *api.Field) error {
 	if err != nil {
 		return err
 	}
+	docLines, err := c.formatDocumentation(field.Documentation, field.Scopes())
+	if err != nil {
+		return err
+	}
 	annotations := &fieldAnnotations{
 		Name:          camelCase(field.Name),
 		FieldType:     fieldType,
 		BaseFieldType: baseFieldType,
-		DocLines:      c.formatDocumentation(field.Documentation),
+		DocLines:      docLines,
 	}
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -66,6 +66,7 @@ func TestAnnotateField(t *testing.T) {
 				Package: "test",
 				Fields:  []*api.Field{field},
 			}
+			field.Parent = msg
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 			codec := newTestCodec(t, model, map[string]string{})
 			if err := codec.annotateModel(); err != nil {
@@ -108,6 +109,7 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 				Package: "test",
 				Fields:  []*api.Field{field},
 			}
+			field.Parent = msg
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 			codec := newTestCodec(t, model, map[string]string{})
 			if err := codec.annotateModel(); err != nil {

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -39,7 +39,10 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if message.Codec != nil {
 		return nil
 	}
-	docLines := c.formatDocumentation(message.Documentation)
+	docLines, err := c.formatDocumentation(message.Documentation, message.Scopes())
+	if err != nil {
+		return err
+	}
 	annotations := &messageAnnotations{
 		Name:                pascalCase(message.Name),
 		DocLines:            docLines,
@@ -50,7 +53,9 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 
 	message.Codec = annotations
 	for _, oneof := range message.OneOfs {
-		c.annotateOneOf(oneof)
+		if err := c.annotateOneOf(oneof); err != nil {
+			return err
+		}
 	}
 	for _, field := range message.Fields {
 		if err := c.annotateField(field); err != nil {

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -93,6 +93,9 @@ func TestAnnotateMessage(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			for _, f := range test.message.Fields {
+				f.Parent = test.message
+			}
 			model := api.NewTestAPI([]*api.Message{test.message}, []*api.Enum{}, []*api.Service{})
 			codec := newTestCodec(t, model, map[string]string{})
 			if err := codec.annotateModel(); err != nil {

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -72,7 +72,10 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 			return err
 		}
 	}
-	docLines := c.formatDocumentation(method.Documentation)
+	docLines, err := c.formatDocumentation(method.Documentation, method.Scopes())
+	if err != nil {
+		return err
+	}
 	binding := method.PathInfo.Bindings[0]
 	hasBody := method.PathInfo.BodyFieldPath != ""
 	isBodyWildcard := method.PathInfo.BodyFieldPath == "*"

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -28,6 +28,7 @@ func TestAnnotateMethod(t *testing.T) {
 		ID:     ".test.Request",
 		Fields: []*api.Field{keyField},
 	}
+	keyField.Parent = inputType
 	outputType := &api.Message{
 		Name: "Response",
 		ID:   ".test.Response",
@@ -35,6 +36,7 @@ func TestAnnotateMethod(t *testing.T) {
 			{Name: "value", ID: ".test.Request.value", Typez: api.TypezString},
 		},
 	}
+	outputType.Fields[0].Parent = outputType
 	for _, test := range []struct {
 		name   string
 		method *api.Method
@@ -143,7 +145,10 @@ func TestAnnotateMethod(t *testing.T) {
 				Package: "test",
 				Methods: []*api.Method{test.method},
 			}
-			model := api.NewTestAPI(nil, nil, []*api.Service{service})
+			model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
 			codec := newTestCodec(t, model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
@@ -196,7 +201,10 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 				Name:    "TestService",
 				Methods: []*api.Method{method},
 			}
-			model := api.NewTestAPI(nil, nil, []*api.Service{service})
+			model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
 			codec := newTestCodec(t, model, nil)
 
 			if err := codec.annotateModel(); err != nil {
@@ -229,9 +237,11 @@ func TestAnnotateMethod_WithExternalMessages(t *testing.T) {
 		ID:      ".google.cloud.external.v1.OutputMessage",
 	}
 	method := &api.Method{
-		Name:       "TestMethod",
-		InputType:  inputMessage,
-		OutputType: outputMessage,
+		Name:         "TestMethod",
+		InputType:    inputMessage,
+		InputTypeID:  inputMessage.ID,
+		OutputType:   outputMessage,
+		OutputTypeID: outputMessage.ID,
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{{Verb: "POST", PathTemplate: &api.PathTemplate{}}},
 		},
@@ -244,6 +254,9 @@ func TestAnnotateMethod_WithExternalMessages(t *testing.T) {
 	model.PackageName = "google.cloud.test.v1"
 	model.AddMessage(inputMessage)
 	model.AddMessage(outputMessage)
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
 	codec := newTestCodec(t, model, nil)
 
 	if err := codec.annotateModel(); err != nil {

--- a/internal/sidekick/swift/annotate_oneof.go
+++ b/internal/sidekick/swift/annotate_oneof.go
@@ -24,12 +24,16 @@ type oneOfAnnotations struct {
 	DocLines     []string
 }
 
-func (c *codec) annotateOneOf(oneof *api.OneOf) {
-	docLines := c.formatDocumentation(oneof.Documentation)
+func (c *codec) annotateOneOf(oneof *api.OneOf) error {
+	docLines, err := c.formatDocumentation(oneof.Documentation, oneof.Scopes())
+	if err != nil {
+		return err
+	}
 	annotations := &oneOfAnnotations{
 		Name:         "OneOf_" + pascalCase(oneof.Name),
 		PropertyName: camelCase(oneof.Name),
 		DocLines:     docLines,
 	}
 	oneof.Codec = annotations
+	return nil
 }

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -28,7 +28,10 @@ type serviceAnnotations struct {
 }
 
 func (c *codec) annotateService(service *api.Service, model *modelAnnotations) error {
-	docLines := c.formatDocumentation(service.Documentation)
+	docLines, err := c.formatDocumentation(service.Documentation, service.Scopes())
+	if err != nil {
+		return err
+	}
 	var restMethods []*api.Method
 	for _, method := range service.Methods {
 		if isGeneratedMethod(method) {

--- a/internal/sidekick/swift/doc_link.go
+++ b/internal/sidekick/swift/doc_link.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func (c *codec) docLink(link string, scopes []string) (string, error) {
+	for _, s := range scopes {
+		localId := fmt.Sprintf(".%s.%s", s, link)
+		result, err := c.tryDocLinkWithId(localId)
+		if err != nil {
+			return "", err
+		}
+		if result != "" {
+			return result, nil
+		}
+	}
+	localId := fmt.Sprintf(".%s", link)
+	return c.tryDocLinkWithId(localId)
+}
+
+// swiftDocLink returns the documentation link for a symbol.
+func (c *codec) swiftDocLink(packageName, name string) string {
+	if packageName != c.Model.PackageName {
+		// TODO(#5072) - we have not implemented cross-reference links to external packages.
+		return fmt.Sprintf("https://www.google.com/search?q=Swift+%s+%s", packageName, name)
+	}
+	swiftyName := strings.ReplaceAll(name, ".", "/")
+	return fmt.Sprintf("<doc:%s>", swiftyName)
+}
+
+func (c *codec) tryDocLinkWithId(id string) (string, error) {
+	if m := c.Model.Message(id); m != nil {
+		name, err := c.messageTypeName(m)
+		if err != nil {
+			return "", err
+		}
+		return c.swiftDocLink(m.Package, name), nil
+	}
+	if e := c.Model.Enum(id); e != nil {
+		name, err := c.enumTypeName(e)
+		if err != nil {
+			return "", err
+		}
+		return c.swiftDocLink(e.Package, name), nil
+	}
+	if me := c.Model.Method(id); me != nil {
+		return c.methodSwiftDocLink(me)
+	}
+	if s := c.Model.Service(id); s != nil {
+		return c.serviceSwiftDocLink(s), nil
+	}
+	rdLink, err := c.tryFieldswiftDocLink(id)
+	if err != nil {
+		return "", err
+	}
+	if rdLink != "" {
+		return rdLink, nil
+	}
+	rdLink, err = c.tryEnumValueSwiftDocLink(id)
+	if err != nil {
+		return "", err
+	}
+	return rdLink, nil
+}
+
+func (c *codec) tryFieldswiftDocLink(id string) (string, error) {
+	idx := strings.LastIndex(id, ".")
+	if idx == -1 {
+		return "", nil
+	}
+	messageId := id[0:idx]
+	fieldName := id[idx+1:]
+	m := c.Model.Message(messageId)
+	if m == nil {
+		return "", nil
+	}
+	for _, f := range m.Fields {
+		if f.Name == fieldName {
+			p, err := c.messageTypeName(m)
+			if err != nil {
+				return "", err
+			}
+			return c.swiftDocLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(f.Name))), nil
+		}
+	}
+	for _, o := range m.OneOfs {
+		if o.Name == fieldName {
+			p, err := c.messageTypeName(m)
+			if err != nil {
+				return "", err
+			}
+			return c.swiftDocLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(o.Name))), nil
+		}
+	}
+	return "", nil
+}
+
+func (c *codec) tryEnumValueSwiftDocLink(id string) (string, error) {
+	idx := strings.LastIndex(id, ".")
+	if idx == -1 {
+		return "", nil
+	}
+	enumId := id[0:idx]
+	valueName := id[idx+1:]
+	e := c.Model.Enum(enumId)
+	if e == nil {
+		return "", nil
+	}
+	for _, v := range e.Values {
+		if v.Name == valueName {
+			p, err := c.enumTypeName(e)
+			if err != nil {
+				return "", err
+			}
+			return c.swiftDocLink(e.Package, fmt.Sprintf("%s/%s", p, enumValueCaseName(v))), nil
+		}
+	}
+	return "", nil
+}
+
+func (c *codec) methodSwiftDocLink(m *api.Method) (string, error) {
+	idx := strings.LastIndex(m.ID, ".")
+	if idx == -1 {
+		return "", nil
+	}
+	serviceId := m.ID[0:idx]
+	s := c.Model.Service(serviceId)
+	if s == nil {
+		return "", nil
+	}
+	return c.swiftDocLink(s.Package, fmt.Sprintf("%s/%s(request:)", pascalCase(s.Name), camelCase(m.Name))), nil
+}
+
+func (c *codec) serviceSwiftDocLink(s *api.Service) string {
+	return c.swiftDocLink(s.Package, pascalCase(s.Name))
+}

--- a/internal/sidekick/swift/doc_link.go
+++ b/internal/sidekick/swift/doc_link.go
@@ -21,7 +21,7 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
-func (c *codec) docLink(link string, scopes []string) (string, error) {
+func (c *codec) linkDefinition(link string, scopes []string) (string, error) {
 	for _, s := range scopes {
 		localId := fmt.Sprintf(".%s.%s", s, link)
 		result, err := c.tryDocLinkWithId(localId)
@@ -36,8 +36,8 @@ func (c *codec) docLink(link string, scopes []string) (string, error) {
 	return c.tryDocLinkWithId(localId)
 }
 
-// swiftDocLink returns the documentation link for a symbol.
-func (c *codec) swiftDocLink(packageName, name string) string {
+// docLink returns the documentation link for a symbol.
+func (c *codec) docLink(packageName, name string) string {
 	if packageName != c.Model.PackageName {
 		// TODO(#5072) - we have not implemented cross-reference links to external packages.
 		return fmt.Sprintf("https://www.google.com/search?q=Swift+%s+%s", packageName, name)
@@ -52,36 +52,36 @@ func (c *codec) tryDocLinkWithId(id string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return c.swiftDocLink(m.Package, name), nil
+		return c.docLink(m.Package, name), nil
 	}
 	if e := c.Model.Enum(id); e != nil {
 		name, err := c.enumTypeName(e)
 		if err != nil {
 			return "", err
 		}
-		return c.swiftDocLink(e.Package, name), nil
+		return c.docLink(e.Package, name), nil
 	}
 	if me := c.Model.Method(id); me != nil {
-		return c.methodSwiftDocLink(me)
+		return c.methodDocLink(me)
 	}
 	if s := c.Model.Service(id); s != nil {
-		return c.serviceSwiftDocLink(s), nil
+		return c.serviceDocLink(s), nil
 	}
-	rdLink, err := c.tryFieldswiftDocLink(id)
+	rdLink, err := c.tryFieldDocLink(id)
 	if err != nil {
 		return "", err
 	}
 	if rdLink != "" {
 		return rdLink, nil
 	}
-	rdLink, err = c.tryEnumValueSwiftDocLink(id)
+	rdLink, err = c.tryEnumValueDocLink(id)
 	if err != nil {
 		return "", err
 	}
 	return rdLink, nil
 }
 
-func (c *codec) tryFieldswiftDocLink(id string) (string, error) {
+func (c *codec) tryFieldDocLink(id string) (string, error) {
 	idx := strings.LastIndex(id, ".")
 	if idx == -1 {
 		return "", nil
@@ -98,7 +98,7 @@ func (c *codec) tryFieldswiftDocLink(id string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return c.swiftDocLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(f.Name))), nil
+			return c.docLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(f.Name))), nil
 		}
 	}
 	for _, o := range m.OneOfs {
@@ -107,13 +107,13 @@ func (c *codec) tryFieldswiftDocLink(id string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return c.swiftDocLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(o.Name))), nil
+			return c.docLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(o.Name))), nil
 		}
 	}
 	return "", nil
 }
 
-func (c *codec) tryEnumValueSwiftDocLink(id string) (string, error) {
+func (c *codec) tryEnumValueDocLink(id string) (string, error) {
 	idx := strings.LastIndex(id, ".")
 	if idx == -1 {
 		return "", nil
@@ -130,13 +130,13 @@ func (c *codec) tryEnumValueSwiftDocLink(id string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return c.swiftDocLink(e.Package, fmt.Sprintf("%s/%s", p, enumValueCaseName(v))), nil
+			return c.docLink(e.Package, fmt.Sprintf("%s/%s", p, enumValueCaseName(v))), nil
 		}
 	}
 	return "", nil
 }
 
-func (c *codec) methodSwiftDocLink(m *api.Method) (string, error) {
+func (c *codec) methodDocLink(m *api.Method) (string, error) {
 	idx := strings.LastIndex(m.ID, ".")
 	if idx == -1 {
 		return "", nil
@@ -146,9 +146,9 @@ func (c *codec) methodSwiftDocLink(m *api.Method) (string, error) {
 	if s == nil {
 		return "", nil
 	}
-	return c.swiftDocLink(s.Package, fmt.Sprintf("%s/%s(request:)", pascalCase(s.Name), camelCase(m.Name))), nil
+	return c.docLink(s.Package, fmt.Sprintf("%s/%s(request:)", pascalCase(s.Name), camelCase(m.Name))), nil
 }
 
-func (c *codec) serviceSwiftDocLink(s *api.Service) string {
-	return c.swiftDocLink(s.Package, pascalCase(s.Name))
+func (c *codec) serviceDocLink(s *api.Service) string {
+	return c.docLink(s.Package, pascalCase(s.Name))
 }

--- a/internal/sidekick/swift/doc_link.go
+++ b/internal/sidekick/swift/doc_link.go
@@ -67,18 +67,13 @@ func (c *codec) tryDocLinkWithId(id string) (string, error) {
 	if s := c.Model.Service(id); s != nil {
 		return c.serviceDocLink(s), nil
 	}
-	rdLink, err := c.tryFieldDocLink(id)
-	if err != nil {
-		return "", err
+	if rdLink, err := c.tryFieldDocLink(id); err != nil || rdLink != "" {
+		return rdLink, err
 	}
-	if rdLink != "" {
-		return rdLink, nil
+	if rdLink, err := c.tryEnumValueDocLink(id); err != nil || rdLink != "" {
+		return rdLink, err
 	}
-	rdLink, err = c.tryEnumValueDocLink(id)
-	if err != nil {
-		return "", err
-	}
-	return rdLink, nil
+	return "", nil
 }
 
 func (c *codec) tryFieldDocLink(id string) (string, error) {

--- a/internal/sidekick/swift/doc_link_test.go
+++ b/internal/sidekick/swift/doc_link_test.go
@@ -148,7 +148,7 @@ func TestDocLink(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.docLink(tt.link, tt.scopes)
+			got, err := c.linkDefinition(tt.link, tt.scopes)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -216,7 +216,7 @@ func TestDocLinkAmbiguity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.docLink(tt.link, tt.scopes)
+			got, err := c.linkDefinition(tt.link, tt.scopes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/sidekick/swift/doc_link_test.go
+++ b/internal/sidekick/swift/doc_link_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func TestDocLink(t *testing.T) {
+	enumValue := &api.EnumValue{
+		Name: "ENUM_VALUE",
+		ID:   ".test.v1.SomeMessage.SomeEnum.ENUM_VALUE",
+	}
+	someEnum := &api.Enum{
+		Name:    "SomeEnum",
+		ID:      ".test.v1.SomeMessage.SomeEnum",
+		Values:  []*api.EnumValue{enumValue},
+		Package: "test.v1",
+	}
+	enumValue.Parent = someEnum
+	response := &api.Field{
+		Name:    "response",
+		ID:      ".test.v1.SomeMessage.response",
+		IsOneOf: true,
+	}
+	errorz := &api.Field{
+		Name:    "error",
+		ID:      ".test.v1.SomeMessage.error",
+		IsOneOf: true,
+	}
+	typez := &api.Field{
+		Name: "type",
+		ID:   ".test.v1.SomeMessage.type",
+	}
+	someMessage := &api.Message{
+		Name:    "SomeMessage",
+		ID:      ".test.v1.SomeMessage",
+		Package: "test.v1",
+		Enums:   []*api.Enum{someEnum},
+		Fields: []*api.Field{
+			{Name: "unused"}, {Name: "field"}, response, errorz, typez,
+		},
+		OneOfs: []*api.OneOf{
+			{
+				Name:   "result",
+				ID:     ".test.v1.SomeMessage.result",
+				Fields: []*api.Field{response, errorz},
+			},
+		},
+	}
+	otherMessage := &api.Message{
+		Name:    "OtherMessage",
+		ID:      ".other.v1.OtherMessage",
+		Package: "other.v1",
+	}
+	someService := &api.Service{
+		Name:    "SomeService",
+		ID:      ".test.v1.SomeService",
+		Package: "test.v1",
+		Methods: []*api.Method{
+			{
+				Name: "CreateFoo",
+				ID:   ".test.v1.SomeService.CreateFoo",
+			},
+		},
+	}
+
+	model := api.NewTestAPI(
+		[]*api.Message{otherMessage, someMessage},
+		[]*api.Enum{someEnum},
+		[]*api.Service{someService})
+
+	c := newTestCodec(t, model, nil)
+	c.withExtraDependencies(t, []config.SwiftDependency{
+		{Name: "OtherPrefix", ApiPackage: "other.v1"},
+	})
+
+	tests := []struct {
+		name   string
+		link   string
+		scopes []string
+		want   string
+	}{
+		{
+			name:   "message link",
+			link:   "SomeMessage",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeMessage>",
+		},
+		{
+			name:   "enum link",
+			link:   "SomeMessage.SomeEnum",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeMessage/SomeEnum>",
+		},
+		{
+			name:   "field link",
+			link:   "SomeMessage.field",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeMessage/field>",
+		},
+		{
+			name:   "enum value link",
+			link:   "SomeMessage.SomeEnum.ENUM_VALUE",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeMessage/SomeEnum/enumValue>",
+		},
+		{
+			name:   "method link",
+			link:   "SomeService.CreateFoo",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeService/createFoo(request:)>",
+		},
+		{
+			name:   "service link",
+			link:   "SomeService",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeService>",
+		},
+		{
+			name:   "fully qualified message link",
+			link:   "test.v1.SomeMessage",
+			scopes: []string{},
+			want:   "<doc:SomeMessage>",
+		},
+		{
+			name:   "different package link",
+			link:   "other.v1.OtherMessage",
+			scopes: []string{},
+			want:   "https://www.google.com/search?q=Swift+other.v1+OtherPrefix.OtherMessage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.docLink(tt.link, tt.scopes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("docLink() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDocLinkAmbiguity(t *testing.T) {
+	globalAmbiguous2 := &api.Message{
+		Name:    "Ambiguous2",
+		ID:      ".test.v1.Ambiguous2",
+		Package: "test.v1",
+	}
+	nestedAmbiguous1 := &api.Message{
+		Name:    "Ambiguous1",
+		ID:      ".test.v1.Parent.Ambiguous1",
+		Package: "test.v1",
+	}
+	nestedAmbiguous2 := &api.Message{
+		Name:    "Ambiguous2",
+		ID:      ".test.v1.Parent.Ambiguous2",
+		Package: "test.v1",
+		Fields: []*api.Field{
+			{Name: "field_name"},
+		},
+	}
+	parent := &api.Message{
+		Name:     "Parent",
+		ID:       ".test.v1.Parent",
+		Package:  "test.v1",
+		Messages: []*api.Message{nestedAmbiguous1, nestedAmbiguous2},
+	}
+	nestedAmbiguous1.Parent = parent
+	nestedAmbiguous2.Parent = parent
+
+	model := api.NewTestAPI(
+		[]*api.Message{globalAmbiguous2, parent, nestedAmbiguous1, nestedAmbiguous2},
+		[]*api.Enum{},
+		[]*api.Service{})
+
+	c := newTestCodec(t, model, nil)
+
+	tests := []struct {
+		name   string
+		link   string
+		scopes []string
+		want   string
+	}{
+		{
+			name:   "resolve to sibling inside parent",
+			link:   "Ambiguous2.field_name",
+			scopes: []string{"test.v1.Parent", "test.v1"},
+			want:   "<doc:Parent/Ambiguous2/fieldName>",
+		},
+		{
+			name:   "resolve to global outside parent",
+			link:   "Ambiguous2",
+			scopes: []string{"test.v1"},
+			want:   "<doc:Ambiguous2>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.docLink(tt.link, tt.scopes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("docLink() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/format_documentation.go
+++ b/internal/sidekick/swift/format_documentation.go
@@ -48,7 +48,7 @@ func (c *codec) formatDocumentation(doc string, scopes []string) ([]string, erro
 		results = append(results, "") // Add a blank line before link definitions
 	}
 	for _, link := range links {
-		resolved, err := c.docLink(link, scopes)
+		resolved, err := c.linkDefinition(link, scopes)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sidekick/swift/format_documentation.go
+++ b/internal/sidekick/swift/format_documentation.go
@@ -44,17 +44,19 @@ func (c *codec) formatDocumentation(doc string, scopes []string) ([]string, erro
 	node := md.Parser().Parse(text.NewReader(docBytes))
 	links := language.ExtractCrossReferenceLinks(node, docBytes)
 
-	if len(links) > 0 {
-		results = append(results, "") // Add a blank line before link definitions
-	}
+	var definitions []string
 	for _, link := range links {
 		resolved, err := c.linkDefinition(link, scopes)
 		if err != nil {
 			return nil, err
 		}
 		if resolved != "" {
-			results = append(results, fmt.Sprintf("[%s]: %s", link, resolved))
+			definitions = append(definitions, fmt.Sprintf("[%s]: %s", link, resolved))
 		}
+	}
+	if len(definitions) != 0 {
+		results = append(results, "") // Add a blank line before link definitions, if any
+		results = append(results, definitions...)
 	}
 
 	return results, nil

--- a/internal/sidekick/swift/format_documentation.go
+++ b/internal/sidekick/swift/format_documentation.go
@@ -14,16 +14,48 @@
 
 package swift
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/sidekick/language"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
 
 // formatDocumentation converts a documentation string from the source (typically Protobuf
 // comments) into a sequence of lines suitable for Swift documentation comments.
 //
 // Both Swift and the Protobuf comments use markdown, but our markdown includes cross-reference
 // links and sometimes needs cleaning up work correctly on a different markdown engine.
-func (c *codec) formatDocumentation(doc string) []string {
+func (c *codec) formatDocumentation(doc string, scopes []string) ([]string, error) {
 	if doc == "" {
-		return nil
+		return nil, nil
 	}
-	return strings.Split(doc, "\n")
+	results := strings.Split(doc, "\n")
+
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+	)
+	docBytes := []byte(doc)
+	node := md.Parser().Parse(text.NewReader(docBytes))
+	links := language.ExtractCrossReferenceLinks(node, docBytes)
+
+	if len(links) > 0 {
+		results = append(results, "") // Add a blank line before link definitions
+	}
+	for _, link := range links {
+		resolved, err := c.docLink(link, scopes)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != "" {
+			results = append(results, fmt.Sprintf("[%s]: %s", link, resolved))
+		}
+	}
+
+	return results, nil
 }

--- a/internal/sidekick/swift/format_documentation_test.go
+++ b/internal/sidekick/swift/format_documentation_test.go
@@ -18,10 +18,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
 func TestFormatDocumentation(t *testing.T) {
-	codec := &codec{}
+	codec := newTestCodec(t, api.NewTestAPI(nil, nil, nil), nil)
 
 	for _, test := range []struct {
 		name string
@@ -50,10 +51,38 @@ func TestFormatDocumentation(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := codec.formatDocumentation(test.doc)
+			got, err := codec.formatDocumentation(test.doc, []string{})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("formatDocumentation() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestFormatDocumentationWithLinks(t *testing.T) {
+	someMessage := &api.Message{
+		Name:    "SomeMessage",
+		ID:      ".test.v1.SomeMessage",
+		Package: "test.v1",
+	}
+	model := api.NewTestAPI([]*api.Message{someMessage}, []*api.Enum{}, []*api.Service{})
+	c := newTestCodec(t, model, nil)
+
+	input := `Refer to [SomeMessage][] for details.`
+	want := []string{
+		"Refer to [SomeMessage][] for details.",
+		"",
+		"[SomeMessage]: <doc:SomeMessage>",
+	}
+
+	got, err := c.formatDocumentation(input, []string{"test.v1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("formatDocumentation() mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
The service and message documentation has cross-reference links, these need to be converted to links that Swift DocC understands. With this change the comments gain additional link definitions.

Towards #5072 support for external references may need a more complex design, but we don't run into many of those anyway.