### PR TITLE
feat(internal/sidekick/gcloud): add --limit flag to list commands

### DIFF
--- a/internal/sidekick/gcloud/client.go
+++ b/internal/sidekick/gcloud/client.go
@@ -120,7 +120,7 @@ func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *
 			NameField:   "Parent",
 			Package:     goClient.Alias,
 			RequestType: goClient.Alias + "pb." + method.InputType.Name,
-			IsList:      true,
+			Paged:       true,
 		}
 	case provider.IsDelete(method):
 		return &ClientCall{

--- a/internal/sidekick/gcloud/client_test.go
+++ b/internal/sidekick/gcloud/client_test.go
@@ -63,7 +63,7 @@ func TestBuildClientCall(t *testing.T) {
 				NameField:   "Parent",
 				Package:     "parallelstore",
 				RequestType: "parallelstorepb.ListInstancesRequest",
-				IsList:      true,
+				Paged:       true,
 			},
 		},
 		{

--- a/internal/sidekick/gcloud/command.go
+++ b/internal/sidekick/gcloud/command.go
@@ -36,9 +36,6 @@ type ClientCall struct {
 	// IsDelete reports whether the method is a standard Delete method.
 	IsDelete bool
 
-	// IsList reports whether the method is a standard List method.
-	IsList bool
-
 	// IsLRO reports whether the call returns a long-running operation.
 	IsLRO bool
 
@@ -56,6 +53,10 @@ type ClientCall struct {
 	// "parallelstore". The template invokes the constructor as
 	// `client, err := <Package>.NewClient(ctx)`.
 	Package string
+
+	// Paged reports whether the method returns a paginated iterator (e.g.,
+	// AIP-132 List).
+	Paged bool
 
 	// RequestType is the qualified request message type, for example
 	// "parallelstorepb.GetInstanceRequest". The template composites a

--- a/internal/sidekick/gcloud/model.go
+++ b/internal/sidekick/gcloud/model.go
@@ -120,8 +120,9 @@ func constructSurfaceModel(model *api.API, clientImportPath string) SurfaceModel
 			if call := buildClientCall(method, goClient, cmd.HasPath()); call != nil {
 				cmd.ClientCall = call
 				hasClientCall = true
-				if call.IsList {
+				if call.Paged {
 					hasListCall = true
+					cmd.Flags = append(cmd.Flags, flag("limit", "Int", false))
 				}
 			}
 

--- a/internal/sidekick/gcloud/model_test.go
+++ b/internal/sidekick/gcloud/model_test.go
@@ -186,13 +186,14 @@ func TestConstructSurfaceModel(t *testing.T) {
 							PathLabel:  "parent",
 							Flags: []Flag{
 								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
+								{Name: "limit", Kind: "Int", Required: false, Usage: "The limit."},
 							},
 							ClientCall: &ClientCall{
 								Method:      "ListInstances",
 								NameField:   "Parent",
 								Package:     "parallelstore",
 								RequestType: "parallelstorepb.ListInstancesRequest",
-								IsList:      true,
+								Paged:       true,
 							},
 						}},
 					}},

--- a/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
+++ b/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
@@ -72,7 +72,9 @@ func Command() *cli.Command {
 			return err
 		}
 		defer client.Close()
-		{{- if .ClientCall.IsList}}
+		{{- if .ClientCall.Paged}}
+		limit := cmd.Int("limit")
+		count := 0
 		it := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })
 		for {
 			resp, err := it.Next()
@@ -87,6 +89,10 @@ func Command() *cli.Command {
 				return err
 			}
 			fmt.Println(string(out))
+			count++
+			if limit > 0 && count >= limit {
+				break
+			}
 		}
 		return nil
 		{{- else if .ClientCall.IsDelete}}

--- a/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
+++ b/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
@@ -74,7 +74,7 @@ func Command() *cli.Command {
 		defer client.Close()
 		{{- if .ClientCall.Paged}}
 		limit := cmd.Int("limit")
-		count := 0
+		count := int64(0)
 		it := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })
 		for {
 			resp, err := it.Next()

--- a/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
+++ b/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
@@ -26,6 +26,7 @@ func Command() *cli.Command {
 						Usage: "list instances",
 						Flags: []cli.Flag{
 							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+							&cli.IntFlag{Name: "limit", Usage: "The limit.", Required: false},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -37,6 +38,8 @@ func Command() *cli.Command {
 								return err
 							}
 							defer client.Close()
+							limit := cmd.Int("limit")
+							count := 0
 							it := client.ListInstances(ctx, &parallelstorepb.ListInstancesRequest{Parent: parent})
 							for {
 								resp, err := it.Next()
@@ -51,6 +54,10 @@ func Command() *cli.Command {
 									return err
 								}
 								fmt.Println(string(out))
+								count++
+								if limit > 0 && count >= limit {
+									break
+								}
 							}
 							return nil
 						},
@@ -208,6 +215,7 @@ func Command() *cli.Command {
 						Usage: "list operations",
 						Flags: []cli.Flag{
 							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+							&cli.IntFlag{Name: "limit", Usage: "The limit.", Required: false},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -219,6 +227,8 @@ func Command() *cli.Command {
 								return err
 							}
 							defer client.Close()
+							limit := cmd.Int("limit")
+							count := 0
 							it := client.ListOperations(ctx, &parallelstorepb.ListOperationsRequest{Parent: parent})
 							for {
 								resp, err := it.Next()
@@ -233,6 +243,10 @@ func Command() *cli.Command {
 									return err
 								}
 								fmt.Println(string(out))
+								count++
+								if limit > 0 && count >= limit {
+									break
+								}
 							}
 							return nil
 						},

--- a/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
+++ b/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
@@ -39,7 +39,7 @@ func Command() *cli.Command {
 							}
 							defer client.Close()
 							limit := cmd.Int("limit")
-							count := 0
+							count := int64(0)
 							it := client.ListInstances(ctx, &parallelstorepb.ListInstancesRequest{Parent: parent})
 							for {
 								resp, err := it.Next()
@@ -228,7 +228,7 @@ func Command() *cli.Command {
 							}
 							defer client.Close()
 							limit := cmd.Int("limit")
-							count := 0
+							count := int64(0)
 							it := client.ListOperations(ctx, &parallelstorepb.ListOperationsRequest{Parent: parent})
 							for {
 								resp, err := it.Next()


### PR DESCRIPTION
Add support for `--limit=N` for list commands. The flag is added only to commands whose ClientCall has Paged set, and the iterator loop in the generated action breaks once the count reaches the limit. The default zero value means unlimited, which matches gcloud's behavior.

For https://github.com/googleapis/librarian/issues/5769