### PR TITLE
feat(internal/sidekick/gcloud): add support for create commands

### DIFF
--- a/internal/sidekick/gcloud/client.go
+++ b/internal/sidekick/gcloud/client.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/iancoleman/strcase"
+
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/surfer/provider"
 )
@@ -94,16 +96,19 @@ func clientInfoFromPath(clientImportPath string) *goClientInfo {
 	}
 }
 
-// buildClientCall returns a ClientCall for an AIP-131 Get, AIP-132 List, or
-// AIP-135 Delete method when the model maps to a standard GAPIC Go package
-// and the command composes a resource path. It returns nil otherwise so the
-// command keeps its print-only action.
-func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *ClientCall {
+// buildClientCall returns a ClientCall for an AIP-131 Get, AIP-132 List,
+// AIP-133 Create, or AIP-135 Delete method when the model maps to a
+// standard GAPIC Go package and the command composes a resource path.
+// Create may produce additional CLI flags for the resource id and the
+// body's scalar fields; those are returned as the second result. It
+// returns (nil, nil) otherwise so the command keeps its print-only
+// action.
+func buildClientCall(method *api.Method, model *api.API, goClient *goClientInfo, hasPath bool) (*ClientCall, []Flag) {
 	if goClient == nil || !hasPath {
-		return nil
+		return nil, nil
 	}
 	if method.InputType == nil {
-		return nil
+		return nil, nil
 	}
 
 	switch {
@@ -113,7 +118,7 @@ func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *
 			NameField:   "Name",
 			Package:     goClient.Alias,
 			RequestType: goClient.Alias + "pb." + method.InputType.Name,
-		}
+		}, nil
 	case provider.IsList(method):
 		return &ClientCall{
 			Method:      method.Name,
@@ -121,7 +126,9 @@ func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *
 			Package:     goClient.Alias,
 			RequestType: goClient.Alias + "pb." + method.InputType.Name,
 			Paged:       true,
-		}
+		}, nil
+	case provider.IsCreate(method):
+		return buildCreateClientCall(method, model, goClient)
 	case provider.IsDelete(method):
 		return &ClientCall{
 			Method:      method.Name,
@@ -130,9 +137,129 @@ func buildClientCall(method *api.Method, goClient *goClientInfo, hasPath bool) *
 			RequestType: goClient.Alias + "pb." + method.InputType.Name,
 			IsDelete:    true,
 			IsLRO:       method.IsLRO,
-		}
+		}, nil
 	default:
-		return nil
+		return nil, nil
+	}
+}
+
+// buildCreateClientCall returns the ClientCall and extra flags for an
+// AIP-133 Create method. Body-field walking descends into the request's
+// resource body field; scalar fields become CLI flags; everything else
+// is recorded as a TODO so the generated code documents what's missing.
+func buildCreateClientCall(method *api.Method, model *api.API, goClient *goClientInfo) (*ClientCall, []Flag) {
+	resource := provider.GetResourceForMethod(method, model)
+	if resource == nil || resource.Self == nil {
+		return nil, nil
+	}
+
+	var bodyField *api.Field
+	for _, f := range method.InputType.Fields {
+		if f.TypezID == resource.Self.ID {
+			bodyField = f
+			break
+		}
+	}
+	if bodyField == nil || bodyField.MessageType == nil {
+		return nil, nil
+	}
+
+	idFieldName := resource.Singular + "_id"
+	var idField *api.Field
+	for _, f := range method.InputType.Fields {
+		if f.Name == idFieldName && f.Typez == api.TypezString {
+			idField = f
+			break
+		}
+	}
+
+	call := &ClientCall{
+		IsCreate:    true,
+		IsLRO:       method.IsLRO,
+		Method:      method.Name,
+		NameField:   "Parent",
+		Package:     goClient.Alias,
+		RequestType: goClient.Alias + "pb." + method.InputType.Name,
+		BodyField:   strcase.ToCamel(bodyField.Name),
+		BodyType:    goClient.Alias + "pb." + bodyField.MessageType.Name,
+	}
+	if idField != nil {
+		call.IDField = strcase.ToCamel(idField.Name)
+		call.IDFlag = strcase.ToKebab(idField.Name)
+	}
+
+	var extraFlags []Flag
+	if idField != nil {
+		extraFlags = append(extraFlags, pathFlag(call.IDFlag))
+	}
+
+	for _, f := range bodyField.MessageType.Fields {
+		if hasBehavior(f, api.FieldBehaviorOutputOnly) {
+			continue
+		}
+		if hasBehavior(f, api.FieldBehaviorIdentifier) {
+			continue
+		}
+		if f.Map {
+			call.BodySkippedFields = append(call.BodySkippedFields,
+				fmt.Sprintf("map field %q", f.Name))
+			continue
+		}
+		if f.Repeated {
+			call.BodySkippedFields = append(call.BodySkippedFields,
+				fmt.Sprintf("repeated field %q", f.Name))
+			continue
+		}
+		switch f.Typez {
+		case api.TypezEnum:
+			call.BodySkippedFields = append(call.BodySkippedFields,
+				fmt.Sprintf("enum field %q", f.Name))
+			continue
+		case api.TypezMessage:
+			call.BodySkippedFields = append(call.BodySkippedFields,
+				fmt.Sprintf("message field %q", f.Name))
+			continue
+		}
+		kind, ok := scalarKind(f.Typez)
+		if !ok {
+			call.BodySkippedFields = append(call.BodySkippedFields,
+				fmt.Sprintf("unsupported scalar field %q", f.Name))
+			continue
+		}
+		call.BodyAssignments = append(call.BodyAssignments, BodyAssignment{
+			Name: strcase.ToCamel(f.Name),
+			Flag: strcase.ToKebab(f.Name),
+			Kind: kind,
+		})
+		extraFlags = append(extraFlags, flag(strcase.ToKebab(f.Name), kind, hasBehavior(f, api.FieldBehaviorRequired)))
+	}
+	return call, extraFlags
+}
+
+// hasBehavior reports whether f's Behavior list contains b.
+func hasBehavior(f *api.Field, b api.FieldBehavior) bool {
+	for _, x := range f.Behavior {
+		if x == b {
+			return true
+		}
+	}
+	return false
+}
+
+// scalarKind maps a scalar Typez to the urfave/cli flag accessor name.
+// It returns ("", false) for non-scalar or unsupported types.
+func scalarKind(t api.Typez) (string, bool) {
+	switch t {
+	case api.TypezString:
+		return "String", true
+	case api.TypezInt32:
+		return "Int32", true
+	case api.TypezInt64:
+		return "Int64", true
+	case api.TypezBool:
+		return "Bool", true
+	default:
+		return "", false
 	}
 }
 

--- a/internal/sidekick/gcloud/client_test.go
+++ b/internal/sidekick/gcloud/client_test.go
@@ -28,12 +28,54 @@ func TestBuildClientCall(t *testing.T) {
 		PbPath:     "cloud.google.com/go/parallelstore/apiv1/parallelstorepb",
 	}
 
+	// createModel is a minimal model with an Instance resource definition
+	// whose body has a couple of scalar fields plus one of every kind that
+	// must be skipped with a TODO.
+	createInstance := &api.Message{
+		Name: "Instance",
+		ID:   ".google.cloud.parallelstore.v1.Instance",
+		Fields: []*api.Field{
+			{Name: "name", Typez: api.TypezString, Behavior: []api.FieldBehavior{api.FieldBehaviorIdentifier}},
+			{Name: "description", Typez: api.TypezString},
+			{Name: "state", Typez: api.TypezEnum},
+			{Name: "labels", Typez: api.TypezMessage, Map: true},
+			{Name: "capacity_gib", Typez: api.TypezInt64, Behavior: []api.FieldBehavior{api.FieldBehaviorRequired}},
+			{Name: "access_points", Typez: api.TypezString, Repeated: true, Behavior: []api.FieldBehavior{api.FieldBehaviorOutputOnly}},
+			{Name: "create_time", Typez: api.TypezMessage, Behavior: []api.FieldBehavior{api.FieldBehaviorOutputOnly}},
+		},
+	}
+	createInstance.Resource = &api.Resource{
+		Type:     "parallelstore.googleapis.com/Instance",
+		Singular: "instance",
+		Self:     createInstance,
+	}
+	createModel := &api.API{
+		Name:        "parallelstore",
+		PackageName: "google.cloud.parallelstore.v1",
+		Messages:    []*api.Message{createInstance},
+	}
+	createMethod := &api.Method{
+		Name:                "CreateInstance",
+		IsAIPStandardCreate: true,
+		IsLRO:               true,
+		InputType: &api.Message{
+			Name: "CreateInstanceRequest",
+			Fields: []*api.Field{
+				{Name: "parent", Typez: api.TypezString},
+				{Name: "instance_id", Typez: api.TypezString, Behavior: []api.FieldBehavior{api.FieldBehaviorRequired}},
+				{Name: "instance", Typez: api.TypezMessage, TypezID: createInstance.ID, MessageType: createInstance, Behavior: []api.FieldBehavior{api.FieldBehaviorRequired}},
+			},
+		},
+	}
+
 	for _, test := range []struct {
-		name     string
-		method   *api.Method
-		goClient *goClientInfo
-		hasPath  bool
-		want     *ClientCall
+		name      string
+		method    *api.Method
+		model     *api.API
+		goClient  *goClientInfo
+		hasPath   bool
+		want      *ClientCall
+		wantFlags []Flag
 	}{
 		{
 			name: "Get method",
@@ -101,6 +143,60 @@ func TestBuildClientCall(t *testing.T) {
 			},
 		},
 		{
+			name:     "Create method",
+			method:   createMethod,
+			model:    createModel,
+			goClient: goClient,
+			hasPath:  true,
+			want: &ClientCall{
+				IsCreate:    true,
+				IsLRO:       true,
+				Method:      "CreateInstance",
+				NameField:   "Parent",
+				Package:     "parallelstore",
+				RequestType: "parallelstorepb.CreateInstanceRequest",
+				IDField:     "InstanceId",
+				IDFlag:      "instance-id",
+				BodyField:   "Instance",
+				BodyType:    "parallelstorepb.Instance",
+				BodyAssignments: []BodyAssignment{
+					{Name: "Description", Flag: "description", Kind: "String"},
+					{Name: "CapacityGib", Flag: "capacity-gib", Kind: "Int64"},
+				},
+				BodySkippedFields: []string{
+					`enum field "state"`,
+					`map field "labels"`,
+				},
+			},
+			wantFlags: []Flag{
+				{Name: "instance-id", Kind: "String", Required: true, Usage: "The instance id."},
+				{Name: "description", Kind: "String", Usage: "The description."},
+				{Name: "capacity-gib", Kind: "Int64", Required: true, Usage: "The capacity gib."},
+			},
+		},
+		{
+			name: "ImportData LRO method",
+			method: &api.Method{
+				Name:      "ImportData",
+				InputType: &api.Message{Name: "ImportDataRequest"},
+				IsLRO:     true,
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want:     nil,
+		},
+		{
+			name: "ExportData LRO method",
+			method: &api.Method{
+				Name:      "ExportData",
+				InputType: &api.Message{Name: "ExportDataRequest"},
+				IsLRO:     true,
+			},
+			goClient: goClient,
+			hasPath:  true,
+			want:     nil,
+		},
+		{
 			name: "nil goClient",
 			method: &api.Method{
 				Name:      "GetInstance",
@@ -130,10 +226,10 @@ func TestBuildClientCall(t *testing.T) {
 			want:     nil,
 		},
 		{
-			name: "not get list or delete",
+			name: "unknown method",
 			method: &api.Method{
-				Name:      "ImportData",
-				InputType: &api.Message{Name: "ImportDataRequest"},
+				Name:      "DoSomethingCustom",
+				InputType: &api.Message{Name: "DoSomethingCustomRequest"},
 			},
 			goClient: goClient,
 			hasPath:  true,
@@ -141,9 +237,12 @@ func TestBuildClientCall(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := buildClientCall(test.method, test.goClient, test.hasPath)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
+			gotCall, gotFlags := buildClientCall(test.method, test.model, test.goClient, test.hasPath)
+			if diff := cmp.Diff(test.want, gotCall); diff != "" {
+				t.Errorf("call mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantFlags, gotFlags); diff != "" {
+				t.Errorf("flags mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/gcloud/command.go
+++ b/internal/sidekick/gcloud/command.go
@@ -33,6 +33,35 @@ type Command struct {
 // ClientCall describes a Go client method invocation that should replace the
 // default print-only action for a generated command.
 type ClientCall struct {
+	// BodyAssignments lists the body's scalar fields that become CLI
+	// flags. Each assignment is rendered as `Name: cmd.<Kind>("flag")`.
+	BodyAssignments []BodyAssignment
+
+	// BodyField is the Go field name on the request that takes the new
+	// resource's body (e.g., "Instance"). Empty when not Create.
+	BodyField string
+
+	// BodySkippedFields lists fields skipped during body walking with
+	// the reason. Rendered as `// TODO: <reason>` comments inside the
+	// body literal so the generated code documents what's missing.
+	BodySkippedFields []string
+
+	// BodyType is the qualified Go type of the body field, e.g.
+	// "parallelstorepb.Instance". Empty when BodyField is empty.
+	BodyType string
+
+	// IDField is the Go field name on the request that takes the new
+	// resource's id (e.g., "InstanceId" for AIP-133 Create). Empty when
+	// the request has no id field.
+	IDField string
+
+	// IDFlag is the kebab-cased CLI flag name corresponding to IDField
+	// (e.g., "instance-id"). Empty when IDField is empty.
+	IDFlag string
+
+	// IsCreate reports whether the method is a standard Create method.
+	IsCreate bool
+
 	// IsDelete reports whether the method is a standard Delete method.
 	IsDelete bool
 
@@ -62,6 +91,20 @@ type ClientCall struct {
 	// "parallelstorepb.GetInstanceRequest". The template composites a
 	// literal of this type and passes its address to the method.
 	RequestType string
+}
+
+// BodyAssignment is a scalar field on the resource body that becomes a
+// CLI flag.
+type BodyAssignment struct {
+	// Name is the Go field name on the resource (e.g., "Description").
+	Name string
+
+	// Flag is the kebab-cased CLI flag name (e.g., "description").
+	Flag string
+
+	// Kind is the urfave/cli accessor type (e.g., "String", "Int64",
+	// "Bool"), matching Flag.Kind.
+	Kind string
 }
 
 // HasPath reports whether the command composes a resource path.

--- a/internal/sidekick/gcloud/model.go
+++ b/internal/sidekick/gcloud/model.go
@@ -117,14 +117,19 @@ func constructSurfaceModel(model *api.API, clientImportPath string) SurfaceModel
 			commandName, _ := provider.GetCommandName(method)
 			commandName = strcase.ToKebab(commandName)
 			cmd := buildCommand(method, model, commandName, subName)
-			if call := buildClientCall(method, goClient, cmd.HasPath()); call != nil {
+			call, extraFlags := buildClientCall(method, model, goClient, cmd.HasPath())
+			if call != nil {
 				cmd.ClientCall = call
+				cmd.Flags = append(cmd.Flags, extraFlags...)
 				hasClientCall = true
 				if call.Paged {
 					hasListCall = true
 					cmd.Flags = append(cmd.Flags, flag("limit", "Int", false))
 				}
 			}
+			sort.Slice(cmd.Flags, func(i, j int) bool {
+				return cmd.Flags[i].Name < cmd.Flags[j].Name
+			})
 
 			sg, ok := subgroups[subName]
 			if !ok {

--- a/internal/sidekick/gcloud/model_test.go
+++ b/internal/sidekick/gcloud/model_test.go
@@ -185,8 +185,8 @@ func TestConstructSurfaceModel(t *testing.T) {
 							Args:       []string{"project", "location"},
 							PathLabel:  "parent",
 							Flags: []Flag{
-								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
 								{Name: "limit", Kind: "Int", Required: false, Usage: "The limit."},
+								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
 							},
 							ClientCall: &ClientCall{
 								Method:      "ListInstances",
@@ -263,8 +263,8 @@ func TestConstructSurfaceModel(t *testing.T) {
 							Args:       []string{"project", "location", "instance"},
 							PathLabel:  "name",
 							Flags: []Flag{
-								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
 								{Name: "instance", Kind: "String", Required: true, Usage: "The instance."},
+								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
 							},
 							ClientCall: &ClientCall{
 								Method:      "DeleteInstance",
@@ -279,6 +279,54 @@ func TestConstructSurfaceModel(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "create method",
+			model: createModel(),
+			want: SurfaceModel{
+				PackageName: "parallelstore",
+				Imports: []Import{
+					{Alias: "parallelstore", Path: "cloud.google.com/go/parallelstore/apiv1"},
+					{Path: "cloud.google.com/go/parallelstore/apiv1/parallelstorepb"},
+				},
+				Group: Group{
+					Name:  "parallelstore",
+					Usage: "manage Parallelstore resources",
+					Subgroups: []Subgroup{{
+						Name:  "instances",
+						Usage: "manage instances resources",
+						Commands: []Command{{
+							Name:       "create",
+							Usage:      "create instances",
+							PathFormat: "projects/%s/locations/%s",
+							Args:       []string{"project", "location"},
+							PathLabel:  "parent",
+							Flags: []Flag{
+								{Name: "capacity-gib", Kind: "Int64", Required: true, Usage: "The capacity gib."},
+								{Name: "description", Kind: "String", Usage: "The description."},
+								{Name: "instance-id", Kind: "String", Required: true, Usage: "The instance id."},
+								{Name: "location", Kind: "String", Required: true, Usage: "The location."},
+							},
+							ClientCall: &ClientCall{
+								IsCreate:    true,
+								IsLRO:       true,
+								Method:      "CreateInstance",
+								NameField:   "Parent",
+								Package:     "parallelstore",
+								RequestType: "parallelstorepb.CreateInstanceRequest",
+								IDField:     "InstanceId",
+								IDFlag:      "instance-id",
+								BodyField:   "Instance",
+								BodyType:    "parallelstorepb.Instance",
+								BodyAssignments: []BodyAssignment{
+									{Name: "Description", Flag: "description", Kind: "String"},
+									{Name: "CapacityGib", Flag: "capacity-gib", Kind: "Int64"},
+								},
+							},
+						}},
+					}},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := constructSurfaceModel(test.model, "")
@@ -286,5 +334,70 @@ func TestConstructSurfaceModel(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// createModel returns a minimal API model that exercises the AIP-133
+// Create code path: an Instance resource with a couple of scalar body
+// fields plus an identifier field that should be skipped, and a
+// CreateInstance method that takes the Instance as its body.
+func createModel() *api.API {
+	instance := &api.Message{
+		Name: "Instance",
+		ID:   ".google.cloud.parallelstore.v1.Instance",
+		Fields: []*api.Field{
+			{Name: "name", Typez: api.TypezString, Behavior: []api.FieldBehavior{api.FieldBehaviorIdentifier}},
+			{Name: "description", Typez: api.TypezString},
+			{Name: "capacity_gib", Typez: api.TypezInt64, Behavior: []api.FieldBehavior{api.FieldBehaviorRequired}},
+		},
+	}
+	instance.Resource = &api.Resource{
+		Type:     "parallelstore.googleapis.com/Instance",
+		Singular: "instance",
+		Self:     instance,
+		Patterns: []api.ResourcePattern{
+			(&api.PathTemplate{}).
+				WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+				WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+				WithLiteral("instances").WithVariable(api.NewPathVariable("instance")).
+				Segments,
+		},
+	}
+	return &api.API{
+		Name:        "parallelstore",
+		Title:       "Parallelstore",
+		PackageName: "google.cloud.parallelstore.v1",
+		Messages:    []*api.Message{instance},
+		Services: []*api.Service{{
+			Name: "InstanceService",
+			Methods: []*api.Method{{
+				Name:                "CreateInstance",
+				IsAIPStandardCreate: true,
+				IsLRO:               true,
+				InputType: &api.Message{
+					Name: "CreateInstanceRequest",
+					Fields: []*api.Field{
+						{
+							Name:              "parent",
+							Typez:             api.TypezString,
+							ResourceReference: &api.ResourceReference{ChildType: "parallelstore.googleapis.com/Instance"},
+						},
+						{Name: "instance_id", Typez: api.TypezString, Behavior: []api.FieldBehavior{api.FieldBehaviorRequired}},
+						{Name: "instance", Typez: api.TypezMessage, TypezID: instance.ID, MessageType: instance, Behavior: []api.FieldBehavior{api.FieldBehaviorRequired}},
+					},
+				},
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{{
+						Verb: "POST",
+						PathTemplate: (&api.PathTemplate{}).
+							WithLiteral("v1").
+							WithLiteral("projects").WithVariable(api.NewPathVariable("project")).
+							WithLiteral("locations").WithVariable(api.NewPathVariable("location")).
+							WithLiteral("instances"),
+					}},
+				},
+			}},
+		}},
+		ResourceDefinitions: []*api.Resource{instance.Resource},
 	}
 }

--- a/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
+++ b/internal/sidekick/gcloud/templates/package/surface_commands.go.tmpl
@@ -95,6 +95,42 @@ func Command() *cli.Command {
 			}
 		}
 		return nil
+		{{- else if .ClientCall.IsCreate}}
+		req := &{{.ClientCall.RequestType}}{
+			{{.ClientCall.NameField}}: {{.PathLabel}},
+			{{- if .ClientCall.IDField}}
+			{{.ClientCall.IDField}}: cmd.String("{{.ClientCall.IDFlag}}"),
+			{{- end}}
+			{{.ClientCall.BodyField}}: &{{.ClientCall.BodyType}}{
+				{{- range .ClientCall.BodyAssignments}}
+				{{.Name}}: cmd.{{.Kind}}("{{.Flag}}"),
+				{{- end}}
+				{{- range .ClientCall.BodySkippedFields}}
+				// TODO: {{.}}
+				{{- end}}
+			},
+		}
+		{{- if .ClientCall.IsLRO}}
+		op, err := client.{{.ClientCall.Method}}(ctx, req)
+		if err != nil {
+			return err
+		}
+		resp, err := op.Wait(ctx)
+		if err != nil {
+			return err
+		}
+		{{- else}}
+		resp, err := client.{{.ClientCall.Method}}(ctx, req)
+		if err != nil {
+			return err
+		}
+		{{- end}}
+		out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(resp)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+		return nil
 		{{- else if .ClientCall.IsDelete}}
 		{{- if .ClientCall.IsLRO}}
 		op, err := client.{{.ClientCall.Method}}(ctx, &{{.ClientCall.RequestType}}{ {{.ClientCall.NameField}}: {{.PathLabel}} })

--- a/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
+++ b/internal/sidekick/gcloud/testdata/internal/generated/parallelstore/commands.go.golden
@@ -25,8 +25,8 @@ func Command() *cli.Command {
 						Name:  "list",
 						Usage: "list instances",
 						Flags: []cli.Flag{
-							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 							&cli.IntFlag{Name: "limit", Usage: "The limit.", Required: false},
+							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -66,8 +66,8 @@ func Command() *cli.Command {
 						Name:  "describe",
 						Usage: "describe instances",
 						Flags: []cli.Flag{
-							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 							&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -95,14 +95,50 @@ func Command() *cli.Command {
 						Name:  "create",
 						Usage: "create instances",
 						Flags: []cli.Flag{
+							&cli.Int64Flag{Name: "capacity-gib", Usage: "The capacity gib.", Required: true},
+							&cli.StringFlag{Name: "description", Usage: "The description.", Required: false},
+							&cli.StringFlag{Name: "instance-id", Usage: "The instance id.", Required: true},
 							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
+							&cli.StringFlag{Name: "network", Usage: "The network.", Required: false},
+							&cli.StringFlag{Name: "reserved-ip-range", Usage: "The reserved ip range.", Required: false},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
 								return fmt.Errorf("--project is required")
 							}
 							parent := fmt.Sprintf("projects/%s/locations/%s", cmd.String("project"), cmd.String("location"))
-							fmt.Printf("Executing create on %s\n", parent)
+							client, err := parallelstore.NewClient(ctx)
+							if err != nil {
+								return err
+							}
+							defer client.Close()
+							req := &parallelstorepb.CreateInstanceRequest{
+								Parent:     parent,
+								InstanceId: cmd.String("instance-id"),
+								Instance: &parallelstorepb.Instance{
+									Description:     cmd.String("description"),
+									CapacityGib:     cmd.Int64("capacity-gib"),
+									Network:         cmd.String("network"),
+									ReservedIpRange: cmd.String("reserved-ip-range"),
+									// TODO: map field "labels"
+									// TODO: enum field "file_stripe_level"
+									// TODO: enum field "directory_stripe_level"
+									// TODO: enum field "deployment_type"
+								},
+							}
+							op, err := client.CreateInstance(ctx, req)
+							if err != nil {
+								return err
+							}
+							resp, err := op.Wait(ctx)
+							if err != nil {
+								return err
+							}
+							out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(resp)
+							if err != nil {
+								return err
+							}
+							fmt.Println(string(out))
 							return nil
 						},
 					},
@@ -110,8 +146,8 @@ func Command() *cli.Command {
 						Name:  "update",
 						Usage: "update instances",
 						Flags: []cli.Flag{
-							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 							&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -126,8 +162,8 @@ func Command() *cli.Command {
 						Name:  "delete",
 						Usage: "delete instances",
 						Flags: []cli.Flag{
-							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 							&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -154,8 +190,8 @@ func Command() *cli.Command {
 						Name:  "import-data",
 						Usage: "import-data instances",
 						Flags: []cli.Flag{
-							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 							&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -170,8 +206,8 @@ func Command() *cli.Command {
 						Name:  "export-data",
 						Usage: "export-data instances",
 						Flags: []cli.Flag{
-							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 							&cli.StringFlag{Name: "instance", Usage: "The instance.", Required: true},
+							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {
@@ -214,8 +250,8 @@ func Command() *cli.Command {
 						Name:  "list",
 						Usage: "list operations",
 						Flags: []cli.Flag{
-							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 							&cli.IntFlag{Name: "limit", Usage: "The limit.", Required: false},
+							&cli.StringFlag{Name: "location", Usage: "The location.", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.String("project") == "" {


### PR DESCRIPTION
Add support for AIP-133 Create methods. The generated action composes the parent path, builds the resource body from CLI flags, calls the client method, waits for completion when the call is an LRO, and prints the returned resource via protojson.

Enums, maps, repeated fields, nested messages, and fields are skipped with TODOs in the generated code for now.

For https://github.com/googleapis/librarian/issues/5769