### PR TITLE
feat(sidekick/rust): Show resource name format in field setter examples.

### DIFF
--- a/internal/sidekick/rust/annotate_field.go
+++ b/internal/sidekick/rust/annotate_field.go
@@ -80,7 +80,7 @@ type fieldAnnotations struct {
 
 // FormattedResource contain the format string and the format arguments of a resource name.
 type FormattedResource struct {
-	// The Rust format string, e.g., "projects/{}/secrets/{}"
+	// The Rust format string, e.g., "projects/{project_id}/secrets/{secret_id}"
 	FormatString string
 	// The variables used in the format string.
 	FormatArgs []string

--- a/internal/sidekick/rust/templates/common/setter_preamble/singular_option.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/singular_option.mustache
@@ -20,7 +20,15 @@ limitations under the License.
 /// ```ignore,no_run
 {{#IsString}}
 /// # use {{Parent.Codec.NameInExamples}};
+{{#Codec.FormattedResource}}
+{{#FormatArgs}}
+/// # let {{.}} = "{{.}}";
+{{/FormatArgs}}
+/// let x = {{Parent.Codec.Name}}::new().set_or_clear_{{Codec.SetterName}}(Some(format!("{{FormatString}}")));
+{{/Codec.FormattedResource}}
+{{^Codec.FormattedResource}}
 /// let x = {{Parent.Codec.Name}}::new().set_or_clear_{{Codec.SetterName}}(Some("example"));
+{{/Codec.FormattedResource}}
 /// let x = {{Parent.Codec.Name}}::new().set_or_clear_{{Codec.SetterName}}(None::<String>);
 {{/IsString}}
 {{#IsBytes}}

--- a/internal/sidekick/rust/templates/common/setter_preamble/singular_value_samples.mustache
+++ b/internal/sidekick/rust/templates/common/setter_preamble/singular_value_samples.mustache
@@ -15,7 +15,15 @@ limitations under the License.
 }}
 {{#IsString}}
 /// # use {{Parent.Codec.NameInExamples}};
+{{#Codec.FormattedResource}}
+{{#FormatArgs}}
+/// # let {{.}} = "{{.}}";
+{{/FormatArgs}}
+/// let x = {{Parent.Codec.Name}}::new().set_{{Codec.SetterName}}(format!("{{FormatString}}"));
+{{/Codec.FormattedResource}}
+{{^Codec.FormattedResource}}
 /// let x = {{Parent.Codec.Name}}::new().set_{{Codec.SetterName}}("example");
+{{/Codec.FormattedResource}}
 {{/IsString}}
 {{#IsBytes}}
 /// # use {{Parent.Codec.NameInExamples}};


### PR DESCRIPTION
For string fields that we are resource names and we know their format, show one of the patterns in setter examples.