### PR TITLE
feature(internal/sidekick/surfer): specify output table in the gcloud config

### DIFF
--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -45,7 +45,7 @@ func newCommand(method *api.Method, overrides *provider.Config, model *api.API, 
 		Method:               requestMethod(method),
 		Arguments:            args,
 		ResponseIDField:      responseIDField(method),
-		OutputFormat:         outputFormat(),
+		OutputFormat:         outputFormat(overrides, method),
 		ReadModifyUpdate:     provider.IsUpdate(method),
 		StarUpdateMask:       useUpdateMask,
 		DisableAutoFieldMask: useUpdateMask,
@@ -107,11 +107,12 @@ func responseIDField(method *api.Method) string {
 	return ""
 }
 
-// outputFormat generates the string output format for List commands.
-// TODO(https://github.com/googleapis/librarian/issues/5231): Make this default configurable by gcloud.yaml.
-// Use tableFormat if specified.
-func outputFormat() string {
-	return ""
+// TODO(https://github.com/googleapis/librarian/issues/5231): add default table output if not specified in the config.
+func outputFormat(overrides *provider.Config, method *api.Method) string {
+	if !provider.IsList(method) {
+		return ""
+	}
+	return provider.OutputFormat(overrides, method.ID)
 }
 
 // async creates the `Async` part of the command definition for long-running operations.

--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -109,9 +109,6 @@ func responseIDField(method *api.Method) string {
 
 // TODO(https://github.com/googleapis/librarian/issues/5231): add default table output if not specified in the config.
 func outputFormat(overrides *provider.Config, method *api.Method) string {
-	if !provider.IsList(method) {
-		return ""
-	}
 	return provider.OutputFormat(overrides, method.ID)
 }
 

--- a/internal/sidekick/surfer/command_builder_test.go
+++ b/internal/sidekick/surfer/command_builder_test.go
@@ -78,6 +78,35 @@ func TestOutputFormat(t *testing.T) {
 			},
 			want: "json",
 		},
+		{
+			name: "non-list method with override format in gcloud config",
+			method: func() *api.Method {
+				m := api.NewTestMethod("DescribeInstance").WithVerb("GET").WithOutput(
+					api.NewTestMessage("Instance").WithFields(
+						api.NewTestField("name").WithType(api.TypezString),
+					),
+				)
+				m.ID = "google.cloud.test.v1.Service.DescribeInstance"
+				m.Service = api.NewTestService("TestService").WithPackage("google.cloud.test.v1")
+				m.Service.DefaultHost = "test.googleapis.com"
+				return m
+			}(),
+			overrides: &provider.Config{
+				APIs: []provider.API{
+					{
+						Name:       "TestService",
+						APIVersion: "v1",
+						OutputFormatting: []*provider.OutputFormatting{
+							{
+								Selector: "google.cloud.test.v1.Service.DescribeInstance",
+								Format:   "json",
+							},
+						},
+					},
+				},
+			},
+			want: "json",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/sidekick/surfer/command_builder_test.go
+++ b/internal/sidekick/surfer/command_builder_test.go
@@ -26,12 +26,13 @@ import (
 
 func TestOutputFormat(t *testing.T) {
 	for _, test := range []struct {
-		name   string
-		method *api.Method
-		want   string
+		name      string
+		method    *api.Method
+		overrides *provider.Config
+		want      string
 	}{
 		{
-			name: "standard list method",
+			name: "standard list method fallback to auto-table format",
 			method: api.NewTestMethod("ListThings").WithVerb("GET").WithOutput(
 				api.NewTestMessage("ListResponse").WithFields(
 					api.NewTestField("things").WithType(api.TypezMessage).WithRepeated().WithMessageType(
@@ -44,6 +45,39 @@ func TestOutputFormat(t *testing.T) {
 			),
 			want: "",
 		},
+		{
+			name: "override format in gcloud config",
+			method: func() *api.Method {
+				m := api.NewTestMethod("ListThings").WithVerb("GET").WithOutput(
+					api.NewTestMessage("ListResponse").WithFields(
+						api.NewTestField("things").WithType(api.TypezMessage).WithRepeated().WithMessageType(
+							api.NewTestMessage("Thing").WithFields(
+								api.NewTestField("name").WithType(api.TypezString),
+							),
+						),
+					),
+				)
+				m.ID = "google.cloud.test.v1.Service.ListThings"
+				m.Service = api.NewTestService("TestService").WithPackage("google.cloud.test.v1")
+				m.Service.DefaultHost = "test.googleapis.com"
+				return m
+			}(),
+			overrides: &provider.Config{
+				APIs: []provider.API{
+					{
+						Name:       "TestService",
+						APIVersion: "v1",
+						OutputFormatting: []*provider.OutputFormatting{
+							{
+								Selector: "google.cloud.test.v1.Service.ListThings",
+								Format:   "json",
+							},
+						},
+					},
+				},
+			},
+			want: "json",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -51,7 +85,7 @@ func TestOutputFormat(t *testing.T) {
 			test.method.OutputType.Pagination = &api.PaginationInfo{
 				PageableItem: test.method.OutputType.Fields[0],
 			}
-			got := outputFormat()
+			got := outputFormat(test.overrides, test.method)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("outputFormat() mismatch (-want +got):\n%s", diff)
 			}
@@ -80,7 +114,7 @@ func TestOutputFormat_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			if got := outputFormat(); got != "" {
+			if got := outputFormat(&provider.Config{}, test.method); got != "" {
 				t.Errorf("outputFormat() = %v, want empty string", got)
 			}
 		})

--- a/internal/sidekick/surfer/provider/config.go
+++ b/internal/sidekick/surfer/provider/config.go
@@ -16,6 +16,8 @@
 package provider
 
 import (
+	"strings"
+
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -276,6 +278,22 @@ func FindFieldHelpTextRule(c *Config, fieldID string) *HelpTextRule {
 		}
 	}
 	return nil
+}
+
+// OutputFormat returns the output format configuration for the given method from overrides.
+func OutputFormat(c *Config, methodID string) string {
+	if c == nil || c.APIs == nil {
+		return ""
+	}
+	methodID = strings.TrimPrefix(methodID, ".")
+	for _, api := range c.APIs {
+		for _, fmtRule := range api.OutputFormatting {
+			if fmtRule.Selector == methodID {
+				return fmtRule.Format
+			}
+		}
+	}
+	return ""
 }
 
 // ShouldGenerateOperations returns true if operations commands should be generated.

--- a/internal/sidekick/surfer/provider/config_test.go
+++ b/internal/sidekick/surfer/provider/config_test.go
@@ -252,3 +252,84 @@ func TestSupportsStarUpdateMasks(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputFormat(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		overrides *Config
+		methodID  string
+		want      string
+	}{
+		{
+			name:      "Nil Config",
+			overrides: nil,
+			methodID:  "google.cloud.test.v1.Service.ListInstances",
+			want:      "",
+		},
+		{
+			name:      "No APIs in Config",
+			overrides: &Config{},
+			methodID:  "google.cloud.test.v1.Service.ListInstances",
+			want:      "",
+		},
+		{
+			name: "Matching selector found (exact selector)",
+			overrides: &Config{
+				APIs: []API{
+					{
+						OutputFormatting: []*OutputFormatting{
+							{
+								Selector: "google.cloud.test.v1.Service.ListInstances",
+								Format:   "table(name, createTime)",
+							},
+						},
+					},
+				},
+			},
+			methodID: "google.cloud.test.v1.Service.ListInstances",
+			want:     "table(name, createTime)",
+		},
+		{
+			name: "Matching selector with leading dot in methodID",
+			overrides: &Config{
+				APIs: []API{
+					{
+						OutputFormatting: []*OutputFormatting{
+							{
+								Selector: "google.cloud.test.v1.Service.ListInstances",
+								Format:   "table(name, createTime)",
+							},
+						},
+					},
+				},
+			},
+			methodID: ".google.cloud.test.v1.Service.ListInstances",
+			want:     "table(name, createTime)",
+		},
+		{
+			name: "No matching selector",
+			overrides: &Config{
+				APIs: []API{
+					{
+						OutputFormatting: []*OutputFormatting{
+							{
+								Selector: "google.cloud.test.v1.Service.OtherMethod",
+								Format:   "table(name)",
+							},
+						},
+					},
+				},
+			},
+			methodID: "google.cloud.test.v1.Service.ListInstances",
+			want:     "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := OutputFormat(test.overrides, test.methodID)
+			if got != test.want {
+				t.Errorf("OutputFormat() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_create_ga.yaml
+++ b/internal/surfer/testdata/apis/developerconnect/expected/current/surface/developerconnect/connections/_partials/_create_ga.yaml
@@ -186,3 +186,5 @@
     collection:
       - developerconnect.projects.locations.operations
     extract_resource_result: true
+  output:
+    format: csv[no-heading,separator="\\n"](installationState.stage,installationState.message,installationState.actionUri)

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_list_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/policy_bindings/_partials/_list_ga.yaml
@@ -60,3 +60,17 @@
       - iam.projects.locations.policyBindings
   response:
     id_field: name
+  output:
+    format: |-
+      table(name,
+            uid,
+            etag,
+            displayName,
+            annotations,
+            target.principalSet:label=principalSet,
+            policyKind,
+            policy,
+            policy_uid,
+            condition,
+            createTime,
+            updateTime)

--- a/internal/surfer/testdata/apis/iam/expected/current/surface/iam/principal_access_boundary_policies/_partials/_list_ga.yaml
+++ b/internal/surfer/testdata/apis/iam/expected/current/surface/iam/principal_access_boundary_policies/_partials/_list_ga.yaml
@@ -54,3 +54,14 @@
       - iam.organizations.locations.principalAccessBoundaryPolicies
   response:
     id_field: name
+  output:
+    format: |-
+      table(name,
+            uid,
+            etag,
+            displayName,
+            annotations,
+            createTime,
+            updateTime,
+            state,
+            details.rules:label=rules)

--- a/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_list_ga.yaml
+++ b/internal/surfer/testdata/apis/parallelstore/expected/current/surface/parallelstore/instances/_partials/_list_ga.yaml
@@ -56,3 +56,14 @@
       - parallelstore.projects.locations.instances
   response:
     id_field: name
+  output:
+    format: |-
+      table(name,
+            capacityGib:label=Capacity,
+            description,
+            createTime,
+            updateTime,
+            state,
+            network,
+            reserved_ip_range,
+            accessPoints.join(","))

--- a/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_list_ga.yaml
+++ b/internal/surfer/testdata/apis/seclm/expected/current/surface/seclm/workbenches/_partials/_list_ga.yaml
@@ -53,3 +53,9 @@
       - seclm.projects.locations.workbenches
   response:
     id_field: name
+  output:
+    format: |-
+      table(name,
+            createTime,
+            updateTime,
+            labels.join(","))

--- a/internal/surfer/testdata/method_output_format/expected/current/surface/method_output_format/resources/_partials/_list_ga.yaml
+++ b/internal/surfer/testdata/method_output_format/expected/current/surface/method_output_format/resources/_partials/_list_ga.yaml
@@ -49,3 +49,8 @@
       - methodoutputformat.projects.locations.resources
   response:
     id_field: name
+  output:
+    format: |-
+      table(name,
+            createTime,
+            updateTime)


### PR DESCRIPTION
User can specify table format using gcloud config

For #5231