### PR TITLE
fix(sidekick): restore method absolute xref links

### DIFF
--- a/internal/sidekick/api/scopes.go
+++ b/internal/sidekick/api/scopes.go
@@ -85,10 +85,6 @@ func (x *Field) Scopes() []string {
 
 // Scopes returns the scopes for a method.
 func (x *Method) Scopes() []string {
-	if x.SourceService != nil {
-		// For mixing methods, the local names probably refer to symbols in the source service.
-		return x.SourceService.Scopes()
-	}
 	if x.Service != nil {
 		return x.Service.Scopes()
 	}

--- a/internal/sidekick/api/scopes_test.go
+++ b/internal/sidekick/api/scopes_test.go
@@ -201,22 +201,12 @@ func TestScopesMethod(t *testing.T) {
 			want: []string{"test.Service", "test"},
 		},
 		{
-			name: "both set",
-			method: &Method{
-				Name:          "Method",
-				ID:            ".test.Service.Method",
-				Service:       service,
-				SourceService: &Service{Name: "Other", Package: "other", ID: ".other.Other"},
-			},
-			want: []string{"other.Other", "other"},
-		},
-		{
-			name: "nil both",
+			name: "none set",
 			method: &Method{
 				Name: "Method",
-				ID:   ".test.Service.Method",
+				ID:   ".test2.Service2.Method",
 			},
-			want: []string{"test.Service", "test"},
+			want: []string{"test2.Service2", "test2"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Absolute xref links from methods, even mixin methods, require the last scope to the the current package scope. My previous changes may have improved things for relative links, but definitely broke absolute links, so I am reverting them.

Fixes #5906 