### PR TITLE
refactor(sidekick): use string for PathTemplate.Verb

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -727,7 +727,7 @@ const (
 // PathTemplate is a template for a path.
 type PathTemplate struct {
 	Segments []PathSegment
-	Verb     *string
+	Verb     string
 }
 
 // FlatPath returns a simplified representation of the path template as a string.
@@ -792,7 +792,7 @@ func (p *PathTemplate) WithVariableNamed(fields ...string) *PathTemplate {
 
 // WithVerb adds a verb to the path template.
 func (p *PathTemplate) WithVerb(v string) *PathTemplate {
-	p.Verb = &v
+	p.Verb = v
 	return p
 }
 

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -226,7 +226,7 @@ func TestPathTemplateBuilder(t *testing.T) {
 				},
 			},
 		},
-		Verb: &verb,
+		Verb: verb,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("bad builder result (-want, +got):\n%s", diff)

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -185,9 +185,9 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 			builder.WriteString("}")
 		}
 	}
-	if t.Verb != nil {
+	if t.Verb != "" {
 		builder.WriteString(":")
-		builder.WriteString(*t.Verb)
+		builder.WriteString(t.Verb)
 	}
 
 	return builder.String()

--- a/internal/sidekick/parser/discovery/uritemplate.go
+++ b/internal/sidekick/parser/discovery/uritemplate.go
@@ -70,7 +70,7 @@ func ParseUriTemplate(uriTemplate string) (*api.PathTemplate, error) {
 			return nil, err
 		}
 		pos += width
-		template.Verb = &literal.Literal
+		template.Verb = literal.Literal
 	}
 	if pos != len(uriTemplate) {
 		return nil, fmt.Errorf("trailing data (%q) cannot be parsed as a URI template", uriTemplate[pos:])

--- a/internal/sidekick/parser/httprule/http_rule_parser.go
+++ b/internal/sidekick/parser/httprule/http_rule_parser.go
@@ -144,9 +144,13 @@ func parsePathTemplate(pathTemplate string) (*api.PathTemplate, error) {
 	if pos != len(pathTemplate) {
 		return nil, fmt.Errorf("invalid path template, expected it to end at position %d: %s", pos, pathTemplate)
 	}
+	var v string
+	if verb != nil {
+		v = *verb
+	}
 	return &api.PathTemplate{
 		Segments: segments,
-		Verb:     verb,
+		Verb:     v,
 	}, nil
 
 }

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -764,8 +764,8 @@ func httpPathFmt(t *api.PathTemplate) string {
 			fmt = fmt + "/{}"
 		}
 	}
-	if t.Verb != nil {
-		fmt = fmt + ":" + *t.Verb
+	if t.Verb != "" {
+		fmt = fmt + ":" + t.Verb
 	}
 	return fmt
 }

--- a/internal/sidekick/surfer/command_builder.go
+++ b/internal/sidekick/surfer/command_builder.go
@@ -167,8 +167,8 @@ func helpText(overrides *provider.Config, method *api.Method, model *api.API) He
 func requestMethod(method *api.Method) string {
 	// For custom methods (AIP-136), the `method` field in the request configuration
 	// MUST match the custom verb defined in the HTTP binding (e.g., ":exportData" -> "exportData").
-	if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 && method.PathInfo.Bindings[0].PathTemplate.Verb != nil {
-		return *method.PathInfo.Bindings[0].PathTemplate.Verb
+	if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 && method.PathInfo.Bindings[0].PathTemplate.Verb != "" {
+		return method.PathInfo.Bindings[0].PathTemplate.Verb
 	} else if !provider.IsStandardMethod(method) {
 		commandName, _ := provider.GetCommandName(method)
 		// GetCommandName returns snake_case (e.g. "export_data"), but request.method expects camelCase (e.g. "exportData").

--- a/internal/sidekick/surfer/provider/method.go
+++ b/internal/sidekick/surfer/provider/method.go
@@ -44,8 +44,8 @@ func GetCommandName(method *api.Method) (string, error) {
 		// The custom verb is the part after the colon (e.g., .../instances/*:exportData).
 		if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 {
 			binding := method.PathInfo.Bindings[0]
-			if binding.PathTemplate != nil && binding.PathTemplate.Verb != nil {
-				return strcase.ToSnake(*binding.PathTemplate.Verb), nil
+			if binding.PathTemplate != nil && binding.PathTemplate.Verb != "" {
+				return strcase.ToSnake(binding.PathTemplate.Verb), nil
 			}
 		}
 		// Fallback: use the method name converted to snake_case.
@@ -279,8 +279,8 @@ func GetMethodHelpText(overrides *Config, method *api.Method, model *api.API) He
 		verb := commandName
 		if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 {
 			binding := method.PathInfo.Bindings[0]
-			if binding.PathTemplate != nil && binding.PathTemplate.Verb != nil {
-				verb = *binding.PathTemplate.Verb
+			if binding.PathTemplate != nil && binding.PathTemplate.Verb != "" {
+				verb = binding.PathTemplate.Verb
 			}
 		}
 		sentenceCaseVerb := ToSentenceCase(verb)

--- a/internal/sidekick/surfer/provider/method_test.go
+++ b/internal/sidekick/surfer/provider/method_test.go
@@ -129,7 +129,6 @@ func TestIsDelete(t *testing.T) {
 }
 
 func TestGetCommandName(t *testing.T) {
-	v := "exportData"
 	for _, test := range []struct {
 		name   string
 		method *api.Method
@@ -138,7 +137,7 @@ func TestGetCommandName(t *testing.T) {
 		{"Standard Create", &api.Method{Name: "CreateInstance"}, "create"},
 		{"Standard List", &api.Method{Name: "ListInstances"}, "list"},
 		{"Standard Get", &api.Method{Name: "GetInstance"}, "describe"},
-		{"Custom Verb in Path", api.NewTestMethod("ExportData").WithPathTemplate(&api.PathTemplate{Verb: &v}), "export_data"},
+		{"Custom Verb in Path", api.NewTestMethod("ExportData").WithPathTemplate(&api.PathTemplate{Verb: "exportData"}), "export_data"},
 		{"Fallback to Name", &api.Method{Name: "ExportData"}, "export_data"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -554,7 +553,6 @@ func TestGetMethodHelpText(t *testing.T) {
 		{
 			name: "Custom Verb Fallback",
 			method: func() *api.Method {
-				v := "exportData"
 				m := api.NewTestMethod("ExportData")
 				m.ID = ".ExportData"
 				m.InputType = &api.Message{
@@ -569,7 +567,7 @@ func TestGetMethodHelpText(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							PathTemplate: &api.PathTemplate{
-								Verb: &v,
+								Verb: "exportData",
 							},
 						},
 					},

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -33,9 +33,8 @@ func pathExpression(t *api.PathTemplate) string {
 		}
 	}
 	path := "/" + strings.Join(pathComponents, "/")
-	if t.Verb != nil {
-		// t.Verb cannot be an empty string, the parsers reject empty verbs.
-		path += ":" + *t.Verb
+	if t.Verb != "" {
+		path += ":" + t.Verb
 	}
 	return path
 }


### PR DESCRIPTION
This change converts the Verb field in the PathTemplatre struct from a pointer to a string.