### PR TITLE
fix(internal/librarian/java): pass gapic option generate-version-java to gapic generator

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -278,16 +278,13 @@ func resolveGAPICOptions(cfg *config.Config, library *config.Library, api *confi
 	// transport specifies whether to generate gRPC, REST, or both types of clients.
 	transport := apiCfg.Transport(config.LanguageJava)
 	gapicOpts = append(gapicOpts, gapicOpt("transport", string(transport)))
-
 	// rest-numeric-enums ensures that enums in REST requests are encoded as numbers
 	// rather than strings.
 	if apiCfg.HasRESTNumericEnums(config.LanguageJava) {
 		gapicOpts = append(gapicOpts, "rest-numeric-enums")
 	}
-
 	// generate-version-java ensures that the Version.java file is generated.
 	gapicOpts = append(gapicOpts, "generate-version-java")
-
 	return gapicOpts, nil
 }
 

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -284,6 +284,10 @@ func resolveGAPICOptions(cfg *config.Config, library *config.Library, api *confi
 	if apiCfg.HasRESTNumericEnums(config.LanguageJava) {
 		gapicOpts = append(gapicOpts, "rest-numeric-enums")
 	}
+
+	// generate-version-java ensures that the Version.java file is generated.
+	gapicOpts = append(gapicOpts, "generate-version-java")
+
 	return gapicOpts, nil
 }
 

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -60,6 +60,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"transport=grpc+rest",
 				"rest-numeric-enums",
+				"generate-version-java",
 			},
 		},
 		{
@@ -78,6 +79,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"transport=rest",
 				"rest-numeric-enums",
+				"generate-version-java",
 			},
 		},
 		{
@@ -98,6 +100,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 				"gapic-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_gapic.yaml"),
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"transport=grpc+rest",
+				"generate-version-java",
 			},
 		},
 		{
@@ -114,6 +117,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"transport=grpc+rest",
 				"rest-numeric-enums",
+				"generate-version-java",
 			},
 		},
 	} {


### PR DESCRIPTION
Added the `generate-version-java` flag to `resolveGAPICOptions` in `generate.go` to enable generation of `Version.java` by default. This is a new flag introduced in https://github.com/googleapis/google-cloud-java/pull/12955, intended to pass uniformly for all open source generation. 

Fix https://github.com/googleapis/librarian/issues/5820