### PR TITLE
fix(internal/librarian/java): ensure missing preserved files are generated

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -464,8 +464,8 @@ func removeKeptFilesFromStaging(library *config.Library, outDir string) error {
 					if err := os.RemoveAll(path); err != nil {
 						return fmt.Errorf("failed to remove kept dir %s from staging: %w", path, err)
 					}
-					return filepath.SkipDir
 				}
+				return filepath.SkipDir
 			}
 			return nil
 		}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -459,16 +459,22 @@ func removeKeptFilesFromStaging(library *config.Library, outDir string) error {
 		keepPath := relSlash[i+1:]
 		if d.IsDir() {
 			if keepSet[keepPath] {
-				if err := os.RemoveAll(path); err != nil {
-					return fmt.Errorf("failed to remove kept dir %s from staging: %w", path, err)
+				destPath := filepath.Join(outDir, keepPath)
+				if _, err := os.Stat(destPath); err == nil {
+					if err := os.RemoveAll(path); err != nil {
+						return fmt.Errorf("failed to remove kept dir %s from staging: %w", path, err)
+					}
+					return filepath.SkipDir
 				}
-				return filepath.SkipDir
 			}
 			return nil
 		}
 		if shouldPreserve(keepPath, keepSet) {
-			if err := os.Remove(path); err != nil {
-				return fmt.Errorf("failed to remove kept file %s from staging: %w", path, err)
+			destPath := filepath.Join(outDir, keepPath)
+			if _, err := os.Stat(destPath); err == nil {
+				if err := os.Remove(path); err != nil {
+					return fmt.Errorf("failed to remove kept file %s from staging: %w", path, err)
+				}
 			}
 		}
 		return nil

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -904,8 +904,25 @@ func TestRemoveKeptFilesFromStaging(t *testing.T) {
 	regularFile := filepath.Join(stagingDir, "v1", "google-cloud-lib", "src", "main", "java", "com", "google", "cloud", "lib", "v1", "stub", "Regular.java")
 	// 4. File inside an explicitly kept directory
 	keptDirFile := filepath.Join(stagingDir, "v1", "google-cloud-lib", "src", "main", "java", "com", "google", "keptdir", "SubDir", "File.java")
+	// 5. Kept file that does NOT exist in destination (should remain in staging)
+	nonExistentKeptFile := filepath.Join(stagingDir, "v1", "google-cloud-lib", "src", "main", "java", "com", "google", "kept", "NonExistent.java")
 
-	for _, file := range []string{keptFile, versionFile, regularFile, keptDirFile} {
+	for _, file := range []string{keptFile, versionFile, regularFile, keptDirFile, nonExistentKeptFile} {
+		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(file, []byte("public class Dummy {}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create corresponding destination files for keptFile, versionFile, and keptDirFile
+	// so that they are recognized as existing and removed from staging.
+	destKeptFile := filepath.Join(outDir, "google-cloud-lib", "src", "main", "java", "com", "google", "kept", "File.java")
+	destVersionFile := filepath.Join(outDir, "google-cloud-lib", "src", "main", "java", "com", "google", "cloud", "lib", "v1", "stub", "Version.java")
+	destKeptDirFile := filepath.Join(outDir, "google-cloud-lib", "src", "main", "java", "com", "google", "keptdir", "SubDir", "File.java")
+
+	for _, file := range []string{destKeptFile, destVersionFile, destKeptDirFile} {
 		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
 			t.Fatal(err)
 		}
@@ -921,6 +938,7 @@ func TestRemoveKeptFilesFromStaging(t *testing.T) {
 		},
 		Keep: []string{
 			"google-cloud-lib/src/main/java/com/google/kept/File.java",
+			"google-cloud-lib/src/main/java/com/google/kept/NonExistent.java",
 			"google-cloud-lib/src/main/java/com/google/keptdir/", // Test with trailing slash
 		},
 	}
@@ -931,7 +949,7 @@ func TestRemoveKeptFilesFromStaging(t *testing.T) {
 	if _, err := os.Stat(keptFile); !errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("expected kept file %s to be removed from staging, but it exists", keptFile)
 	}
-	if _, err := os.Stat(keptFile); !errors.Is(err, fs.ErrNotExist) {
+	if _, err := os.Stat(versionFile); !errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("expected version file %s to be removed from staging due to regex match, but it exists", versionFile)
 	}
 	if _, err := os.Stat(regularFile); err != nil {
@@ -939,5 +957,8 @@ func TestRemoveKeptFilesFromStaging(t *testing.T) {
 	}
 	if _, err := os.Stat(keptDirFile); !errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("expected file inside kept dir %s to be removed from staging, but it exists", keptDirFile)
+	}
+	if _, err := os.Stat(nonExistentKeptFile); err != nil {
+		t.Errorf("expected non-existent kept file %s to remain in staging, but got error: %v", nonExistentKeptFile, err)
 	}
 }


### PR DESCRIPTION
Allow files in keep list that is generated to be in final output if it does not exist in filesystem to start.

Updated  logic in postprocess that removes kept files from staging to check whether a preserved file or directory actually exists in the target repository before removing it from the temporary staging area. This ensures that explicitly kept files (such as `Version.java`) are successfully generated and copied over initially if they are not already present, while still protecting existing customized files from being overwritten.

Fix #5925