### PR TITLE
fix(internal/librarian/java): prevent isPOMMissing from returning error when directory does not exist

### DIFF
--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -16,9 +16,7 @@ package java
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,8 +42,6 @@ const (
 	managedModulesStartMarker      = "<!-- {x-generated-modules-start} -->"
 	managedModulesEndMarker        = "<!-- {x-generated-modules-end} -->"
 )
-
-var errTargetDir = errors.New("target directory does not exist")
 
 // grpcProtoPOMData holds the data for rendering POM templates.
 type gRPCProtoPOMData struct {
@@ -115,6 +111,7 @@ func loadTransports(library *config.Library, googleapisDir string) (map[string]s
 	return transports, nil
 }
 
+//nolint:unparam // error return kept to avoid cascading changes
 func discoverModules(library *config.Library, libraryDir string, transports map[string]serviceconfig.Transport) ([]expectedModule, error) {
 	var modules []expectedModule
 	libCoord := DeriveLibraryCoordinates(library)
@@ -125,10 +122,7 @@ func discoverModules(library *config.Library, libraryDir string, transports map[
 		transport := transports[api.Path]
 		// Proto module
 		protoDir := filepath.Join(libraryDir, apiCoord.Proto.ArtifactID)
-		isProtoMissing, err := isPOMMissing(protoDir)
-		if err != nil {
-			return nil, err
-		}
+		isProtoMissing := isPOMMissing(protoDir)
 		modules = append(modules, expectedModule{
 			ArtifactID: apiCoord.Proto.ArtifactID,
 			Dir:        protoDir,
@@ -140,10 +134,7 @@ func discoverModules(library *config.Library, libraryDir string, transports map[
 		// gRPC module
 		if transport != serviceconfig.Rest {
 			gRPCDir := filepath.Join(libraryDir, apiCoord.GRPC.ArtifactID)
-			isGRPCMissing, err := isPOMMissing(gRPCDir)
-			if err != nil {
-				return nil, err
-			}
+			isGRPCMissing := isPOMMissing(gRPCDir)
 			modules = append(modules, expectedModule{
 				ArtifactID: apiCoord.GRPC.ArtifactID,
 				Dir:        gRPCDir,
@@ -156,10 +147,7 @@ func discoverModules(library *config.Library, libraryDir string, transports map[
 	}
 	// Client module
 	clientDir := filepath.Join(libraryDir, libCoord.GAPIC.ArtifactID)
-	isClientMissing, err := isPOMMissing(clientDir)
-	if err != nil {
-		return nil, err
-	}
+	isClientMissing := isPOMMissing(clientDir)
 	modules = append(modules, expectedModule{
 		ArtifactID: libCoord.GAPIC.ArtifactID,
 		Dir:        clientDir,
@@ -169,10 +157,7 @@ func discoverModules(library *config.Library, libraryDir string, transports map[
 	})
 	// BOM module
 	bomDir := filepath.Join(libraryDir, libCoord.BOM.ArtifactID)
-	isBOMMissing, err := isPOMMissing(bomDir)
-	if err != nil {
-		return nil, err
-	}
+	isBOMMissing := isPOMMissing(bomDir)
 	modules = append(modules, expectedModule{
 		ArtifactID: libCoord.BOM.ArtifactID,
 		Dir:        bomDir,
@@ -182,10 +167,7 @@ func discoverModules(library *config.Library, libraryDir string, transports map[
 	})
 	// Parent module
 	parentDir := libraryDir
-	isParentMissing, err := isPOMMissing(parentDir)
-	if err != nil {
-		return nil, err
-	}
+	isParentMissing := isPOMMissing(parentDir)
 	modules = append(modules, expectedModule{
 		ArtifactID: libCoord.Parent.ArtifactID,
 		Dir:        parentDir,
@@ -456,18 +438,18 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 	return modules, nil
 }
 
-func isPOMMissing(dir string) (bool, error) {
+func isPOMMissing(dir string) bool {
 	pomPath := filepath.Join(dir, "pom.xml")
 	if _, err := os.Stat(pomPath); err == nil {
-		return false, nil
+		return false
 	}
-	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
-		return false, fmt.Errorf("%w: %s does not exist: %w", errTargetDir, dir, err)
-	}
-	return true, nil
+	return true
 }
 
 func writePOM(pomPath, templateName string, data any) (err error) {
+	if err := os.MkdirAll(filepath.Dir(pomPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", pomPath, err)
+	}
 	f, err := os.Create(pomPath)
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %w", pomPath, err)

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -15,9 +15,7 @@
 package java
 
 import (
-	"errors"
 	"flag"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -417,39 +415,6 @@ func TestCollectModules(t *testing.T) {
 	}
 }
 
-func TestCollectModules_Error(t *testing.T) {
-
-	for _, test := range []struct {
-		name       string
-		library    *config.Library
-		transports map[string]serviceconfig.Transport
-	}{
-		{
-			name: "invalid distribution name",
-			library: &config.Library{
-				Java: &config.JavaModule{
-					DistributionNameOverride: "invalid-name",
-				},
-			},
-		},
-		{
-			name: "failed to find api config",
-			library: &config.Library{
-				APIs: []*config.API{
-					{Path: "google/ads/unrecognized/v1"},
-				},
-			},
-			transports: map[string]serviceconfig.Transport{},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if _, err := collectModules(test.library, t.TempDir(), "1.2.3", &repoMetadata{}, test.transports); err == nil {
-				t.Error("collectModules() error = nil, want non-nil")
-			}
-		})
-	}
-}
-
 func TestIsPOMMissing(t *testing.T) {
 	for _, test := range []struct {
 		name  string
@@ -476,10 +441,7 @@ func TestIsPOMMissing(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := test.setup(t)
-			got, err := isPOMMissing(dir)
-			if err != nil {
-				t.Fatal(err)
-			}
+			got := isPOMMissing(dir)
 			if got != test.want {
 				t.Errorf("isPOMMissing(%q) = %v, want %v", dir, got, test.want)
 			}
@@ -487,11 +449,11 @@ func TestIsPOMMissing(t *testing.T) {
 	}
 }
 
-func TestIsPOMMissing_DirMissingError(t *testing.T) {
+func TestIsPOMMissing_DirMissing(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nonexistent")
-	_, err := isPOMMissing(dir)
-	if !errors.Is(err, fs.ErrNotExist) {
-		t.Errorf("isPOMMissing(%q) error = %v, want %v", dir, err, fs.ErrNotExist)
+	got := isPOMMissing(dir)
+	if !got {
+		t.Errorf("isPOMMissing(%q) = %v, want true", dir, got)
 	}
 }
 
@@ -580,6 +542,17 @@ func TestIdentifyMissingModules(t *testing.T) {
 			want: []string{
 				"proto-google-cloud-secretmanager-v1",
 				"grpc-google-cloud-secretmanager-v1",
+			},
+		},
+		{
+			name:  "all modules missing, directories missing",
+			setup: nil,
+			want: []string{
+				"proto-google-cloud-secretmanager-v1",
+				"grpc-google-cloud-secretmanager-v1",
+				"google-cloud-secretmanager",
+				"google-cloud-secretmanager-bom",
+				"google-cloud-secretmanager-parent",
 			},
 		},
 	} {

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -617,17 +617,6 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			},
 			wantErr: errRunOwlBot,
 		},
-		{
-			name: "syncPOMs failure (missing module directories)",
-			cfg:  defaultCfg,
-			setup: func(t *testing.T, outDir string) {
-				writeOwlBot(t, outDir, "sys.exit(0)")
-				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
-					t.Fatal(err)
-				}
-			},
-			wantErr: errTargetDir,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
isPOMMissing is used in java.IdentifyMissingModules, which is called prior 
to java.Generate. Because of this sequence, the directory might not exist 
yet when the check runs. 

Update isPOMMissing to return a boolean instead of an error, treating 
a missing directory as "POM is missing" rather than a failure.

For #5904