### PR TITLE
feat(tool/cmd/migrate): hardcode showcase library version

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -258,6 +258,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 		var roots []string
 		if name == showcaseLibraryName {
 			roots = []string{showcaseLibraryName, "googleapis"}
+			version = "0.0.1-SNAPSHOT"
 		}
 		for _, g := range l.GAPICs {
 			if g.ProtoPath == "" {

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -421,8 +421,9 @@ func TestBuildConfig(t *testing.T) {
 				},
 				Libraries: []*config.Library{
 					{
-						Name:  "showcase",
-						Roots: []string{"showcase", "googleapis"},
+						Name:    "showcase",
+						Version: "0.0.1-SNAPSHOT",
+						Roots:   []string{"showcase", "googleapis"},
 						APIs: []*config.API{
 							{Path: "schema/google/showcase/v1beta1"},
 						},


### PR DESCRIPTION
The library version for showcase is hardcoded to 0.0.1-SNAPSHOT in Java migration config to ensure valid snapshot versioning. Tests are updated to reflect this expectation. This needs to be hardcoded because in migrate script, we source versions from versions.txt, but this recent change https://github.com/googleapis/google-cloud-java/pull/13030 removed showcase tracking from it.

For #5731