### PR TITLE
ci(rust): replace install-taplo with librarian install

### DIFF
--- a/.github/workflows/sidekick.yaml
+++ b/.github/workflows/sidekick.yaml
@@ -32,7 +32,10 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustup show active-toolchain -v
-      - uses: ./.github/actions/install-taplo
+      - name: Setup librarian.yaml for test tool dependency installation
+        run: cp internal/librarian/rust/testdata/librarian.yaml .
+      - name: Install tools
+        run: librarian install rust
       - name: Verify git and tar are available
         run: |
           git --version
@@ -47,12 +50,14 @@ jobs:
       - uses: ./.github/actions/setup-librarian
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: ./.github/actions/install-taplo
       - name: Checkout google-cloud-rust
         uses: actions/checkout@v6
         with:
           repository: googleapis/google-cloud-rust
           path: google-cloud-rust
+      - name: Install tools
+        working-directory: google-cloud-rust
+        run: librarian install rust
       - name: Run librarian generate
         working-directory: google-cloud-rust
         run: librarian generate --all

--- a/internal/librarian/rust/testdata/librarian.yaml
+++ b/internal/librarian/rust/testdata/librarian.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+language: rust
+tools:
+  cargo:
+    - name: taplo-cli
+      version: 0.10.0


### PR DESCRIPTION
Replaces custom install-taplo action with librarian install rust. This is to measure installation time.