### PR TITLE
fix(internal/librarian/java): prevent isPOMMissing from returning error when directory does not exist

### DIFF
--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -45,8 +45,6 @@ const (
 	managedModulesEndMarker        = "<!-- {x-generated-modules-end} -->"
 )
 
-var errTargetDir = errors.New("target directory does not exist")
-
 // grpcProtoPOMData holds the data for rendering POM templates.
 type gRPCProtoPOMData struct {
 	Proto          Coordinate
@@ -456,18 +454,25 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 	return modules, nil
 }
 
+// isPOMMissing checks if a pom.xml exists in the given directory.
+// It returns true if the file is confirmed to be missing (fs.ErrNotExist).
+// It returns an error if the check fails for unexpected reasons (e.g., permission issues).
 func isPOMMissing(dir string) (bool, error) {
 	pomPath := filepath.Join(dir, "pom.xml")
-	if _, err := os.Stat(pomPath); err == nil {
+	_, err := os.Stat(pomPath)
+	if err == nil {
 		return false, nil
 	}
-	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
-		return false, fmt.Errorf("%w: %s does not exist: %w", errTargetDir, dir, err)
+	if errors.Is(err, fs.ErrNotExist) {
+		return true, nil
 	}
-	return true, nil
+	return false, fmt.Errorf("failed to check %s: %w", pomPath, err)
 }
 
 func writePOM(pomPath, templateName string, data any) (err error) {
+	if err := os.MkdirAll(filepath.Dir(pomPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", pomPath, err)
+	}
 	f, err := os.Create(pomPath)
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %w", pomPath, err)

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -456,7 +456,7 @@ func TestIsPOMMissing_DirMissing(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nonexistent")
 	got, err := isPOMMissing(dir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 	if !got {
 		t.Errorf("isPOMMissing(%q) = %v, want true", dir, got)

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -15,9 +15,7 @@
 package java
 
 import (
-	"errors"
 	"flag"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -417,39 +415,6 @@ func TestCollectModules(t *testing.T) {
 	}
 }
 
-func TestCollectModules_Error(t *testing.T) {
-
-	for _, test := range []struct {
-		name       string
-		library    *config.Library
-		transports map[string]serviceconfig.Transport
-	}{
-		{
-			name: "invalid distribution name",
-			library: &config.Library{
-				Java: &config.JavaModule{
-					DistributionNameOverride: "invalid-name",
-				},
-			},
-		},
-		{
-			name: "failed to find api config",
-			library: &config.Library{
-				APIs: []*config.API{
-					{Path: "google/ads/unrecognized/v1"},
-				},
-			},
-			transports: map[string]serviceconfig.Transport{},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if _, err := collectModules(test.library, t.TempDir(), "1.2.3", &repoMetadata{}, test.transports); err == nil {
-				t.Error("collectModules() error = nil, want non-nil")
-			}
-		})
-	}
-}
-
 func TestIsPOMMissing(t *testing.T) {
 	for _, test := range []struct {
 		name  string
@@ -487,11 +452,14 @@ func TestIsPOMMissing(t *testing.T) {
 	}
 }
 
-func TestIsPOMMissing_DirMissingError(t *testing.T) {
+func TestIsPOMMissing_DirMissing(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nonexistent")
-	_, err := isPOMMissing(dir)
-	if !errors.Is(err, fs.ErrNotExist) {
-		t.Errorf("isPOMMissing(%q) error = %v, want %v", dir, err, fs.ErrNotExist)
+	got, err := isPOMMissing(dir)
+	if err != nil {
+		t.Fatal()
+	}
+	if !got {
+		t.Errorf("isPOMMissing(%q) = %v, want true", dir, got)
 	}
 }
 
@@ -580,6 +548,17 @@ func TestIdentifyMissingModules(t *testing.T) {
 			want: []string{
 				"proto-google-cloud-secretmanager-v1",
 				"grpc-google-cloud-secretmanager-v1",
+			},
+		},
+		{
+			name:  "all modules missing, directories missing",
+			setup: nil,
+			want: []string{
+				"proto-google-cloud-secretmanager-v1",
+				"grpc-google-cloud-secretmanager-v1",
+				"google-cloud-secretmanager",
+				"google-cloud-secretmanager-bom",
+				"google-cloud-secretmanager-parent",
 			},
 		},
 	} {

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -617,17 +617,6 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			},
 			wantErr: errRunOwlBot,
 		},
-		{
-			name: "syncPOMs failure (missing module directories)",
-			cfg:  defaultCfg,
-			setup: func(t *testing.T, outDir string) {
-				writeOwlBot(t, outDir, "sys.exit(0)")
-				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
-					t.Fatal(err)
-				}
-			},
-			wantErr: errTargetDir,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
isPOMMissing is used in java.IdentifyMissingModules, which is called prior to java.Generate. Because of this sequence, the directory might not exist yet when the check runs.

Update isPOMMissing to treat a missing directory as "POM is missing" rather than a failure. Also, it now returns an error if the check fails for unexpected reasons, this is previously missed.
Separately, removed a misleading test (TestCollectModules_Error), collectModules don't validate these anymore, this test was passing because test setup used empty temp dir, tripping over missing directories.

For https://github.com/googleapis/librarian/issues/5904