### PR TITLE
feat(sidekick/swift): init w/ `ClientOptions`

### DIFF
--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -58,13 +58,8 @@ extension Clients {
     let inner: GoogleCloudGax.HTTPClient
 
     /// Creates a new `{{Codec.ClientName}}` instance.
-    public init(
-      endpoint: String? = nil,
-      credentials: GoogleCloudAuth.Credentials? = nil,
-      session: URLSession? = nil,
-    ) throws {
-      let endpoint = endpoint ?? "https://{{DefaultHost}}"
-      self.inner = try GoogleCloudGax.HTTPClient(endpoint: endpoint, credentials: credentials, session: session)
+    public init(_ options: GoogleCloudGax.ClientOptions = GoogleCloudGax.ClientOptions()) throws {
+      self.inner = try GoogleCloudGax.HTTPClient(from: options, withDefaultEndpoint: "https://{{DefaultHost}}")
     }
     {{#Codec.RestMethods}}
 

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -58,7 +58,7 @@ extension Clients {
     let inner: GoogleCloudGax.HTTPClient
 
     /// Creates a new `{{Codec.ClientName}}` instance.
-    public init(_ options: GoogleCloudGax.ClientOptions = GoogleCloudGax.ClientOptions()) throws {
+    public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {
       self.inner = try GoogleCloudGax.HTTPClient(from: options, withDefaultEndpoint: "https://{{DefaultHost}}")
     }
     {{#Codec.RestMethods}}


### PR DESCRIPTION
Change the code generator to initialize clients using the `GoogleCloudGax.ClientOptions` type. The expectation is that this type will grow over time, but the initializer for the client will remain stable.

Towards #5929 