### PR TITLE
feat(sidekick/rust): add LRO options to generated stub interfaces

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -411,6 +411,7 @@ This document describes the schema for the librarian.yaml.
 | `generate_setter_samples` | string | Indicates whether to generate setter samples. |
 | `generate_rpc_samples` | string | Indicates whether to generate RPC samples. |
 | `detailed_tracing_attributes` | bool (optional) | Indicates whether to include detailed tracing attributes. |
+| `lro_stub_options` | bool (optional) | Indicates whether to include LRO poller options in generated stub traits. |
 | `resource_name_heuristic` | bool (optional) | Indicates whether to apply heuristics to identify and generate resource names. |
 
 ## RustDiscovery Configuration
@@ -434,6 +435,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `disabled_rustdoc_warnings` | yaml.StringSlice | Specifies rustdoc lints to disable. An empty slice explicitly enables all warnings. |
 | `detailed_tracing_attributes` | bool (optional) | Indicates whether to include detailed tracing attributes. This overrides the crate-level setting. |
+| `lro_stub_options` | bool (optional) | Indicates whether to include LRO poller options in generated stub traits. This overrides the crate-level setting. |
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |
 | `extend_grpc_transport` | bool | Indicates whether the transport stub can be extended (in order to support streams). |
 | `generate_setter_samples` | string | Indicates whether to generate setter samples. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -114,6 +114,9 @@ type RustDefault struct {
 	// DetailedTracingAttributes indicates whether to include detailed tracing attributes.
 	DetailedTracingAttributes *bool `yaml:"detailed_tracing_attributes,omitempty"`
 
+	// LroStubOptions indicates whether to include LRO poller options in generated stub traits.
+	LroStubOptions *bool `yaml:"lro_stub_options,omitempty"`
+
 	// ResourceNameHeuristic indicates whether to apply heuristics to identify and generate resource names.
 	ResourceNameHeuristic *bool `yaml:"resource_name_heuristic,omitempty"`
 }
@@ -128,6 +131,10 @@ type RustModule struct {
 	// DetailedTracingAttributes indicates whether to include detailed tracing attributes.
 	// This overrides the crate-level setting.
 	DetailedTracingAttributes *bool `yaml:"detailed_tracing_attributes,omitempty"`
+
+	// LroStubOptions indicates whether to include LRO poller options in generated stub traits.
+	// This overrides the crate-level setting.
+	LroStubOptions *bool `yaml:"lro_stub_options,omitempty"`
 
 	// DocumentationOverrides contains overrides for element documentation.
 	DocumentationOverrides []RustDocumentationOverride `yaml:"documentation_overrides,omitempty"`

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -68,6 +68,9 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Rust.DetailedTracingAttributes == nil {
 		lib.Rust.DetailedTracingAttributes = d.Rust.DetailedTracingAttributes
 	}
+	if lib.Rust.LroStubOptions == nil {
+		lib.Rust.LroStubOptions = d.Rust.LroStubOptions
+	}
 	if lib.Rust.ResourceNameHeuristic == nil {
 		lib.Rust.ResourceNameHeuristic = d.Rust.ResourceNameHeuristic
 	}
@@ -677,6 +680,9 @@ func mergeRust(dst, src *config.RustCrate) *config.RustCrate {
 	}
 	if src.DetailedTracingAttributes != nil {
 		res.DetailedTracingAttributes = src.DetailedTracingAttributes
+	}
+	if src.LroStubOptions != nil {
+		res.LroStubOptions = src.LroStubOptions
 	}
 	if src.ResourceNameHeuristic != nil {
 		res.ResourceNameHeuristic = src.ResourceNameHeuristic

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -142,6 +142,9 @@ func buildCodec(library *config.Library, releaseLevel string) map[string]string 
 	if rust.DetailedTracingAttributes != nil && *rust.DetailedTracingAttributes {
 		codec["detailed-tracing-attributes"] = "true"
 	}
+	if rust.LroStubOptions != nil && *rust.LroStubOptions {
+		codec["lro-stub-options"] = "true"
+	}
 	if rust.HasVeneer {
 		codec["has-veneer"] = "true"
 	}
@@ -311,6 +314,13 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	}
 	if detailedTracingAttributes {
 		codec["detailed-tracing-attributes"] = "true"
+	}
+	lroStubOptions := library.Rust != nil && library.Rust.LroStubOptions != nil && *library.Rust.LroStubOptions
+	if module.LroStubOptions != nil {
+		lroStubOptions = *module.LroStubOptions
+	}
+	if lroStubOptions {
+		codec["lro-stub-options"] = "true"
 	}
 	if module.ModulePath != "" {
 		codec["module-path"] = module.ModulePath

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -72,6 +72,8 @@ type modelAnnotations struct {
 	// If true, the generated code includes detailed tracing attributes on HTTP
 	// requests.
 	DetailedTracingAttributes bool
+	// If true, the generated code includes LRO poller options in generated stub traits.
+	LroStubOptions bool
 	// If true, the generated builders's visibility should be restricted to the crate.
 	InternalBuilders bool
 	// The service to use for the package-level quickstart sample.
@@ -253,6 +255,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		GenerateSetterSamples:     codec.generateSetterSamples,
 		GenerateRpcSamples:        codec.generateRpcSamples,
 		DetailedTracingAttributes: codec.detailedTracingAttributes,
+		LroStubOptions:            codec.lroStubOptions,
 		InternalBuilders:          codec.internalBuilders,
 		QuickstartService:         quickstartService,
 	}

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -416,6 +416,42 @@ func TestAnnotateModelWithDetailedTracing(t *testing.T) {
 	}
 }
 
+func TestAnnotateModelWithLroStubOptions(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		options map[string]string
+		want    bool
+	}{
+		{
+			name:    "LroStubOptionsTrue",
+			options: map[string]string{"lro-stub-options": "true"},
+			want:    true,
+		},
+		{
+			name:    "LroStubOptionsFalse",
+			options: map[string]string{"lro-stub-options": "false"},
+			want:    false,
+		},
+		{
+			name:    "LroStubOptionsMissing",
+			options: map[string]string{},
+			want:    false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+			codec := newTestCodec(t, libconfig.SpecProtobuf, "", test.options)
+			got, err := annotateModel(model, codec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.LroStubOptions != test.want {
+				t.Errorf("annotateModel() LroStubOptions = %v, want %v", got.LroStubOptions, test.want)
+			}
+		})
+	}
+}
+
 func TestRoutingRequired(t *testing.T) {
 	message := &api.Message{
 		Name:    "Message",

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -146,6 +146,12 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `detailed-tracing-attributes` value %q to boolean: %w", definition, err)
 			}
 			codec.detailedTracingAttributes = value
+		case key == "lro-stub-options":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `lro-stub-options` value %q to boolean: %w", definition, err)
+			}
+			codec.lroStubOptions = value
 		case key == "has-veneer":
 			value, err := strconv.ParseBool(definition)
 			if err != nil {
@@ -310,6 +316,8 @@ type codec struct {
 	// TODO(https://github.com/googleapis/google-cloud-rust/issues/3239) -
 	//   remove this flag once we switch the default.
 	detailedTracingAttributes bool
+	// If true, the generated code includes LRO poller options in generated stub traits.
+	lroStubOptions bool
 	// If true, there is a handwritten client surface.
 	hasVeneer bool
 	// Additional modules, maybe with hand-crafted code.

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -264,6 +264,15 @@ func TestParseOptions(t *testing.T) {
 		{
 			Format: libconfig.SpecProtobuf,
 			Options: map[string]string{
+				"lro-stub-options": "true",
+			},
+			Update: func(c *codec) {
+				c.lroStubOptions = true
+			},
+		},
+		{
+			Format: libconfig.SpecProtobuf,
+			Options: map[string]string{
 				"has-veneer": "true",
 			},
 			Update: func(c *codec) {
@@ -377,6 +386,7 @@ func TestParseOptionsErrors(t *testing.T) {
 		{Options: map[string]string{"include-streaming-methods": ""}},
 		{Options: map[string]string{"per-service-features": ""}},
 		{Options: map[string]string{"detailed-tracing-attributes": ""}},
+		{Options: map[string]string{"lro-stub-options": ""}},
 		{Options: map[string]string{"has-veneer": ""}},
 		{Options: map[string]string{"routing-required": ""}},
 		{Options: map[string]string{"generate-setter-samples": ""}},

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -85,6 +85,8 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         std::sync::Arc::new(google_cloud_gax::exponential_backoff::ExponentialBackoff::default())
     }
 
+    {{#Model.Codec.LroStubOptions}}
+    #[cfg(google_cloud_unstable_tracing)]
     /// Returns the poller options.
     ///
     /// When mocking, this method is typically irrelevant. Do not try to verify
@@ -95,6 +97,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     ) -> google_cloud_lro::PollerOptions {
         google_cloud_lro::PollerOptions::default()
     }
+    {{/Model.Codec.LroStubOptions}}
     {{/Codec.HasLROs}}
 }
 

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -84,6 +84,17 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy> {
         std::sync::Arc::new(google_cloud_gax::exponential_backoff::ExponentialBackoff::default())
     }
+
+    /// Returns the poller options.
+    ///
+    /// When mocking, this method is typically irrelevant. Do not try to verify
+    /// it is called by your mocks.
+    fn get_poller_options(
+        &self,
+        _options: &crate::RequestOptions,
+    ) -> google_cloud_lro::internal::PollerOptions {
+        google_cloud_lro::internal::PollerOptions::default()
+    }
     {{/Codec.HasLROs}}
 }
 

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -92,8 +92,8 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     fn get_poller_options(
         &self,
         _options: &crate::RequestOptions,
-    ) -> google_cloud_lro::internal::PollerOptions {
-        google_cloud_lro::internal::PollerOptions::default()
+    ) -> google_cloud_lro::PollerOptions {
+        google_cloud_lro::PollerOptions::default()
     }
     {{/Codec.HasLROs}}
 }

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -43,6 +43,12 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         &self,
         options: &crate::RequestOptions,
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy>;
+
+    #[allow(dead_code)]
+    fn get_poller_options(
+        &self,
+        options: &crate::RequestOptions,
+    ) -> google_cloud_lro::internal::PollerOptions;
     {{/Codec.HasLROs}}
 }
 
@@ -76,6 +82,14 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
         options: &crate::RequestOptions,
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy> {
         T::get_polling_backoff_policy(self, options)
+    }
+
+    #[allow(dead_code)]
+    fn get_poller_options(
+        &self,
+        options: &crate::RequestOptions,
+    ) -> google_cloud_lro::internal::PollerOptions {
+        T::get_poller_options(self, options)
     }
     {{/Codec.HasLROs}}
 }

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -48,7 +48,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,
-    ) -> google_cloud_lro::internal::PollerOptions;
+    ) -> google_cloud_lro::PollerOptions;
     {{/Codec.HasLROs}}
 }
 
@@ -88,7 +88,7 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,
-    ) -> google_cloud_lro::internal::PollerOptions {
+    ) -> google_cloud_lro::PollerOptions {
         T::get_poller_options(self, options)
     }
     {{/Codec.HasLROs}}

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -44,11 +44,14 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         options: &crate::RequestOptions,
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy>;
 
+    {{#Model.Codec.LroStubOptions}}
+    #[cfg(google_cloud_unstable_tracing)]
     #[allow(dead_code)]
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,
     ) -> google_cloud_lro::PollerOptions;
+    {{/Model.Codec.LroStubOptions}}
     {{/Codec.HasLROs}}
 }
 
@@ -84,6 +87,8 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
         T::get_polling_backoff_policy(self, options)
     }
 
+    {{#Model.Codec.LroStubOptions}}
+    #[cfg(google_cloud_unstable_tracing)]
     #[allow(dead_code)]
     fn get_poller_options(
         &self,
@@ -91,6 +96,7 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
     ) -> google_cloud_lro::PollerOptions {
         T::get_poller_options(self, options)
     }
+    {{/Model.Codec.LroStubOptions}}
     {{/Codec.HasLROs}}
 }
 {{/Codec.Services}}

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -102,6 +102,16 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy> {
         self.inner.get_polling_backoff_policy(options)
     }
+
+    fn get_poller_options(
+        &self,
+        options: &crate::RequestOptions,
+    ) -> google_cloud_lro::internal::PollerOptions {
+        let mut opts = self.inner.get_poller_options(options);
+        let details = google_cloud_lro::internal::TracingDetails::default();
+        opts.tracing = Some(details);
+        opts
+    }
     {{/Codec.HasLROs}}
 }
 

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -103,6 +103,8 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         self.inner.get_polling_backoff_policy(options)
     }
 
+    {{#Model.Codec.LroStubOptions}}
+    #[cfg(google_cloud_unstable_tracing)]
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,
@@ -112,6 +114,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         opts.tracing = Some(details);
         opts
     }
+    {{/Model.Codec.LroStubOptions}}
     {{/Codec.HasLROs}}
 }
 

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -106,9 +106,9 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,
-    ) -> google_cloud_lro::internal::PollerOptions {
+    ) -> google_cloud_lro::PollerOptions {
         let mut opts = self.inner.get_poller_options(options);
-        let details = google_cloud_lro::internal::TracingDetails::default();
+        let details = google_cloud_lro::TracingDetails::default();
         opts.tracing = Some(details);
         opts
     }


### PR DESCRIPTION
Introduce options plumbing in the generated stubs and dynamic decorators to lay the foundation for LRO tracing.

Staged @ https://github.com/googleapis/google-cloud-rust/pull/5629