### PR TITLE
chore(librarian/rust): Publish params struct

### DIFF
--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -99,7 +99,14 @@ func legacyRustPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command
 	dryRunKeepGoing := cmd.Bool("dry-run-keep-going")
 	verbose := cmd.Bool("verbose")
 	command.Verbose = verbose
-	return rust.Publish(ctx, cfg, dryRun, dryRunKeepGoing, skipSemverChecks, verbose, IgnoredChanges)
+	return rust.Publish(ctx, rust.PublishParams{
+		Config:           cfg,
+		DryRun:           dryRun,
+		DryRunKeepGoing:  dryRunKeepGoing,
+		SkipSemverChecks: skipSemverChecks,
+		Verbose:          verbose,
+		IgnoredChanges:   IgnoredChanges,
+	})
 }
 
 // publish implements the publish command. It is provided with the configuration

--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -62,11 +62,27 @@ const semverCheckCPUDivisor = 8
 // errSemverCheck is returned when a semver check fails.
 var errSemverCheck = errors.New("semver check failed")
 
+// PublishParams holds parameters for running the Publish function.
+type PublishParams struct {
+	// Config is the repository configuration.
+	Config *config.Config
+	// DryRun indicates whether to run publish without actually pushing crates.
+	DryRun bool
+	// DryRunKeepGoing indicates whether to run in dry-run mode without stopping on errors.
+	DryRunKeepGoing bool
+	// SkipSemverChecks indicates whether to skip semantic versioning checks.
+	SkipSemverChecks bool
+	// Verbose indicates whether to stream the output of executed commands.
+	Verbose bool
+	// IgnoredChanges is a list of file paths/patterns to ignore when detecting changed crates.
+	IgnoredChanges []string
+}
+
 // Publish finds all the crates that should be published. It can optionally
 // run in dry-run mode, dry-run mode with continue on errors, and/or skip semver checks.
-func Publish(ctx context.Context, cfg *config.Config, dryRun, dryRunKeepGoing, skipSemverChecks, verbose bool, ignoredChanges []string) error {
-	release := cfg.Release
-	if err := preFlight(ctx, release.Preinstalled, cargoTools(cfg)); err != nil {
+func Publish(ctx context.Context, params PublishParams) error {
+	release := params.Config.Release
+	if err := preFlight(ctx, release.Preinstalled, cargoTools(params.Config)); err != nil {
 		return err
 	}
 	gitExe := command.GetExecutablePath(release.Preinstalled, command.Git)
@@ -77,11 +93,11 @@ func Publish(ctx context.Context, cfg *config.Config, dryRun, dryRunKeepGoing, s
 	if err := git.MatchesBranchPoint(ctx, gitExe, config.RemoteUpstream, config.BranchMain); err != nil {
 		return err
 	}
-	files, err := git.FilesChangedSince(ctx, gitExe, lastTag, ignoredChanges)
+	files, err := git.FilesChangedSince(ctx, gitExe, lastTag, params.IgnoredChanges)
 	if err != nil {
 		return err
 	}
-	return publishCrates(ctx, release, dryRun, dryRunKeepGoing, skipSemverChecks, verbose, lastTag, files)
+	return publishCrates(ctx, params, lastTag, files)
 }
 
 // cargoTools returns cargo tools from Config.Tools if available,
@@ -103,7 +119,8 @@ func cargoTools(cfg *config.Config) []config.Tool {
 }
 
 // publishCrates publishes the crates that have changed.
-func publishCrates(ctx context.Context, cfg *config.Release, dryRun, dryRunKeepGoing, skipSemverChecks, verbose bool, lastTag string, files []string) error {
+func publishCrates(ctx context.Context, params PublishParams, lastTag string, files []string) error {
+	release := params.Config.Release
 	manifests := map[string]string{}
 	for _, manifest := range findCargoManifests(files) {
 		names, err := publishedCrate(manifest)
@@ -114,7 +131,7 @@ func publishCrates(ctx context.Context, cfg *config.Release, dryRun, dryRunKeepG
 			manifests[name] = manifest
 		}
 	}
-	cargoPath := command.GetExecutablePath(cfg.Preinstalled, command.Cargo)
+	cargoPath := command.GetExecutablePath(release.Preinstalled, command.Cargo)
 	output, err := command.Output(ctx, cargoPath, "workspaces", "plan", "--skip-published")
 	if err != nil {
 		return err
@@ -129,26 +146,26 @@ func publishCrates(ctx context.Context, cfg *config.Release, dryRun, dryRunKeepG
 		}
 	}
 
-	if !skipSemverChecks {
-		gitPath := command.GetExecutablePath(cfg.Preinstalled, command.Git)
+	if !params.SkipSemverChecks {
+		gitPath := command.GetExecutablePath(release.Preinstalled, command.Git)
 		if err := runSemverChecks(ctx, semverData{
-			dryRunKeepGoing: dryRunKeepGoing,
+			dryRunKeepGoing: params.DryRunKeepGoing,
 			manifests:       manifests,
 			lastTag:         lastTag,
 			cargoPath:       cargoPath,
 			gitPath:         gitPath,
-			verbose:         verbose,
+			verbose:         params.Verbose,
 		}); err != nil {
 			return err
 		}
 	}
 	args := []string{"workspaces", "publish", "--skip-published", "--publish-interval=60", "--no-git-commit", "--from-git", "skip"}
-	if dryRunKeepGoing {
+	if params.DryRunKeepGoing {
 		args = append(args, "--dry-run", "--keep-going")
-	} else if dryRun {
+	} else if params.DryRun {
 		args = append(args, "--dry-run")
 	}
-	if verbose {
+	if params.Verbose {
 		return command.RunStreaming(ctx, cargoPath, args...)
 	}
 	return command.Run(ctx, cargoPath, args...)

--- a/internal/librarian/rust/publish_test.go
+++ b/internal/librarian/rust/publish_test.go
@@ -52,7 +52,10 @@ func TestPublishCratesSuccess(t *testing.T) {
 	}
 	lastTag := "release-2001-02-03"
 
-	if err := publishCrates(t.Context(), cfg, true, false, false, false, lastTag, files); err != nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config: &config.Config{Release: cfg},
+		DryRun: true,
+	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -81,7 +84,10 @@ func TestPublishCratesWithNewCrate(t *testing.T) {
 		path.Join("src", "pubsub", "src", "lib.rs"),
 	}
 	lastTag := "release-with-new-crate"
-	if err := publishCrates(t.Context(), cfg, true, false, false, false, lastTag, files); err != nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config: &config.Config{Release: cfg},
+		DryRun: true,
+	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -116,7 +122,10 @@ func TestPublishCratesWithBadManifest(t *testing.T) {
 		path.Join("src", "storage", "src", "lib.rs"),
 	}
 	lastTag := "release-2001-02-03"
-	if err := publishCrates(t.Context(), cfg, true, false, false, false, lastTag, files); err == nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config: &config.Config{Release: cfg},
+		DryRun: true,
+	}, lastTag, files); err == nil {
 		t.Errorf("expected an error with a bad manifest file")
 	}
 }
@@ -136,7 +145,10 @@ func TestPublishCratesGetPlanError(t *testing.T) {
 		path.Join("src", "storage", "src", "lib.rs"),
 	}
 	lastTag := "release-2001-02-03"
-	if err := publishCrates(t.Context(), cfg, true, false, false, false, lastTag, files); err == nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config: &config.Config{Release: cfg},
+		DryRun: true,
+	}, lastTag, files); err == nil {
 		t.Fatalf("expected an error during plan generation")
 	}
 }
@@ -163,7 +175,10 @@ func TestPublishCratesPlanMismatchError(t *testing.T) {
 		path.Join("src", "storage", "src", "lib.rs"),
 	}
 	lastTag := "release-2001-02-03"
-	if err := publishCrates(t.Context(), cfg, true, false, false, false, lastTag, files); err == nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config: &config.Config{Release: cfg},
+		DryRun: true,
+	}, lastTag, files); err == nil {
 		t.Fatalf("expected an error during plan comparison")
 	}
 }
@@ -206,11 +221,18 @@ fi
 	lastTag := "release-2001-02-03"
 
 	// This should fail because semver-checks fails.
-	if err := publishCrates(t.Context(), cfg, true, false, false, false, lastTag, files); err == nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config: &config.Config{Release: cfg},
+		DryRun: true,
+	}, lastTag, files); err == nil {
 		t.Fatal("expected an error from semver-checks")
 	}
 	// Skipping the checks should succeed.
-	if err := publishCrates(t.Context(), cfg, true, false, true, false, lastTag, files); err != nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config:           &config.Config{Release: cfg},
+		DryRun:           true,
+		SkipSemverChecks: true,
+	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -235,7 +257,10 @@ func TestPublishSuccess(t *testing.T) {
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 
-	if err := Publish(t.Context(), cfg, true, false, false, false, nil); err != nil {
+	if err := Publish(t.Context(), PublishParams{
+		Config: cfg,
+		DryRun: true,
+	}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -262,7 +287,10 @@ func TestPublishWithLocalChangesError(t *testing.T) {
 	testhelper.AddCrate(t, path.Join("src", "pubsub"), "google-cloud-pubsub")
 	testhelper.RunGit(t, "add", path.Join("src", "pubsub"))
 	testhelper.RunGit(t, "commit", "-m", "feat: created pubsub", ".")
-	if err := Publish(t.Context(), cfg, true, false, false, false, nil); err == nil {
+	if err := Publish(t.Context(), PublishParams{
+		Config: cfg,
+		DryRun: true,
+	}); err == nil {
 		t.Errorf("expected an error publishing with unpushed local commits")
 	}
 }
@@ -275,7 +303,10 @@ func TestPublishPreflightError(t *testing.T) {
 			},
 		},
 	}
-	if err := Publish(t.Context(), cfg, true, false, false, false, nil); err == nil {
+	if err := Publish(t.Context(), PublishParams{
+		Config: cfg,
+		DryRun: true,
+	}); err == nil {
 		t.Errorf("expected a preflight error with a bad git command")
 	}
 }
@@ -316,7 +347,11 @@ fi
 	}
 	lastTag := "release-2001-02-03"
 
-	if err := publishCrates(t.Context(), cfg, true, true, false, false, lastTag, files); err != nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config:          &config.Config{Release: cfg},
+		DryRun:          true,
+		DryRunKeepGoing: true,
+	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
 
@@ -371,11 +406,18 @@ fi
 	lastTag := "release-2001-02-03"
 
 	// This should fail because semver-checks fails.
-	if err := publishCrates(t.Context(), cfg, true, false, false, false, lastTag, files); err == nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config: &config.Config{Release: cfg},
+		DryRun: true,
+	}, lastTag, files); err == nil {
 		t.Fatal("expected an error from semver-checks")
 	}
 	// With --keep-going, this should succeed.
-	if err := publishCrates(t.Context(), cfg, true, true, false, false, lastTag, files); err != nil {
+	if err := publishCrates(t.Context(), PublishParams{
+		Config:          &config.Config{Release: cfg},
+		DryRun:          true,
+		DryRunKeepGoing: true,
+	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -441,7 +483,11 @@ fi
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := publishCrates(t.Context(), cfg, true, false, true, false, lastTag, test.files)
+			err := publishCrates(t.Context(), PublishParams{
+				Config:           &config.Config{Release: cfg},
+				DryRun:           true,
+				SkipSemverChecks: true,
+			}, lastTag, test.files)
 			var got string
 			if err != nil {
 				got = err.Error()


### PR DESCRIPTION
Consolidates the `Publish` signature into a dedicated `type PublishParams struct`.

Fixes #5408