### PR TITLE
fix(nodejs): isolate owl-bot-staging cleanups to package subdirectories

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -365,7 +365,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		}
 	}
 
-	if err := os.RemoveAll(filepath.Join(repoRoot, "owl-bot-staging", library.Name)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err := os.RemoveAll(stagingDir); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to remove package staging: %w", err)
 	}
 	return nil

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -365,8 +365,8 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		}
 	}
 
-	if err := os.RemoveAll(filepath.Join(repoRoot, "owl-bot-staging")); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to remove owl-bot-staging: %w", err)
+	if err := os.RemoveAll(filepath.Join(repoRoot, "owl-bot-staging", library.Name)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to remove package staging: %w", err)
 	}
 	return nil
 }

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -445,8 +445,13 @@ func TestRunPostProcessor(t *testing.T) {
 	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(repoRoot, "owl-bot-staging")); !errors.Is(err, fs.ErrNotExist) {
-		t.Error("expected owl-bot-staging to be removed after post-processing")
+	// Verify that the package staging directory is successfully cleaned up
+	if _, err := os.Stat(filepath.Join(repoRoot, "owl-bot-staging", library.Name)); !errors.Is(err, fs.ErrNotExist) {
+		t.Error("expected package staging directory to be removed after post-processing")
+	}
+	// Verify that the top-level owl-bot-staging parent folder itself remains intact to support parallel executions
+	if _, err := os.Stat(filepath.Join(repoRoot, "owl-bot-staging")); err != nil {
+		t.Error("expected top-level owl-bot-staging directory to remain intact")
 	}
 }
 
@@ -549,8 +554,13 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(repoRoot, "owl-bot-staging")); !errors.Is(err, fs.ErrNotExist) {
-		t.Error("expected owl-bot-staging to be removed after post-processing")
+	// Verify package staging directory is cleaned up
+	if _, err := os.Stat(filepath.Join(repoRoot, "owl-bot-staging", library.Name)); !errors.Is(err, fs.ErrNotExist) {
+		t.Error("expected package staging directory to be removed after post-processing")
+	}
+	// Verify parent folder remains intact
+	if _, err := os.Stat(filepath.Join(repoRoot, "owl-bot-staging")); err != nil {
+		t.Error("expected top-level owl-bot-staging directory to remain intact")
 	}
 
 	if _, err := os.Stat(filepath.Join(repoRoot, "librarian-ran.txt")); err != nil {


### PR DESCRIPTION
When running `librarian generate --all` or concurrent generations in
 parallel async threads, the Go engine's Node.js post-processor executed a
 sweeping `os.RemoveAll` cleanup on the shared top-level `owl-bot-
 staging/` folder. This pulled the directory out from underneath other
 active parallel compilation processes, leading to random `No such file or
 directory` crashes.

 This patch isolates the post-processor cleanup to package-specific
 subdirectories (`owl-bot-staging/<package_name>`), eliminating the
 parallel staging deletion race condition.


Closes #5957