### PR TITLE
feat(serviceconfig): authorize Node.js generation for geocode and dat…

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1069,6 +1069,7 @@
 - path: google/cloud/databasecenter/v1beta
   languages:
     - java
+    - nodejs
     - python
   release_level:
     java: preview
@@ -2973,6 +2974,7 @@
   languages:
     - go
     - java
+    - nodejs
     - python
   release_level:
     java: stable


### PR DESCRIPTION
This pull request updates the central allowed-languages configuration
  to authorize Node.js generation natively for the following released
  packages:
    1. `google-maps-geocode`
    2. `google-cloud-databasecenter`

 Both packages have released versions inside the monorepo, but code
 generation was previously blocked because `nodejs` was omitted from the
 allowed languages list inside `internal/serviceconfig/sdk.yaml`.

Closes #5951