### PR TITLE
feat(internal/librarian/python): update gapic-generator to v1.32.0

### DIFF
--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -19,7 +19,7 @@ language: python
 tools:
   pip:
     - name: gapic-generator
-      version: "1.30.13"
+      version: "1.32.0"
     - name: nox
       version: "2025.11.12"
     - name: ruff


### PR DESCRIPTION
The version of gapic-generator in the embedded librarian.yaml (used by librarian install) is updated to v1.32.0. This will update the generated code and documentation in terms of supported Python versions, and will unblock dialogflow generation.