### PR TITLE
fix(tool/cmd/migrate): set artifact id overrride and no sample for bigtable

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -31,6 +31,7 @@ var (
 		"grafeas":           true,
 		"iam":               true,
 		"iam-policy":        true,
+		"bigtable":          true,
 	}
 
 	keepOverride = map[string][]string{
@@ -169,6 +170,11 @@ var (
 		{apiPath: "google/devtools/clouderrorreporting/v1beta1"}: {
 			protoArtifactID: "proto-google-cloud-error-reporting-v1beta1",
 			grpcArtifactID:  "grpc-google-cloud-error-reporting-v1beta1",
+		},
+		{apiPath: "google/bigtable/admin/v2"}: {
+			protoArtifactID: "proto-google-cloud-bigtable-admin-v2",
+			grpcArtifactID:  "grpc-google-cloud-bigtable-admin-v2",
+			gapicArtifactID: "google-cloud-bigtable",
 		},
 		{apiPath: "google/storage/v2"}: {
 			protoArtifactID: "proto-google-cloud-storage-v2",


### PR DESCRIPTION
Set artifact id overrides for "google/bigtable/admin/v2" and no sample for bigtable. 
These are inferred from copy rules in [java-bigtable/.OwlBot-hermetic.yaml](https://github.com/googleapis/google-cloud-java/blob/main/java-bigtable/.OwlBot-hermetic.yaml).

For #5740
