### PR TITLE
fix(internal/serviceconfig): allow java for google/bigtable/v2 and set transport to grpc

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -276,7 +276,10 @@
 - path: google/bigtable/v2
   languages:
     - go
+    - java
     - python
+  transports:
+    java: grpc
 - path: google/chat/v1
   languages:
     - go


### PR DESCRIPTION
Add java to allowed languages for API path google/bigtable/v2, and set transport to grpc to match existing code in google-cloud-java code.

For https://github.com/googleapis/librarian/issues/5740