### PR TITLE
refactor: remove Config.Release

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -11,24 +11,8 @@ This document describes the schema for the librarian.yaml.
 | `repo` | string | Is the repository name, such as "googleapis/google-cloud-python". It is used for:<br>- Providing to the Java GAPIC generator for observability features.<br>- Generating the .repo-metadata.json. |
 | `sources` | [Sources](#sources-configuration) (optional) | References external source repositories. |
 | `tools` | [Tools](#tools-configuration) (optional) | Defines required tools. |
-| `release` | [Release](#release-configuration) (optional) | Holds the configuration parameter for publishing and release subcommands. |
 | `default` | [Default](#default-configuration) (optional) | Contains default settings for all libraries. They apply to all libraries unless overridden. |
 | `libraries` | list of [Library](#library-configuration) (optional) | Contains configuration overrides for libraries that need special handling, and differ from default settings. |
-
-## Release Configuration
-
-| Field | Type | Description |
-| :--- | :--- | :--- |
-| `ignored_changes` | list of string | Defines globs that are ignored in change analysis. |
-| `preinstalled` | map[string]string | Tools defines the list of tools that must be preinstalled.<br><br>This is indexed by the well-known name of the tool vs. its path, e.g. [preinstalled] cargo = /usr/bin/cargo |
-| `tools` | map[string][]Tool | Defines the list of tools to install, indexed by installer. |
-
-## Tool Configuration
-
-| Field | Type | Description |
-| :--- | :--- | :--- |
-| `name` | string | Is the name of the tool e.g. nox. |
-| `version` | string | Is the version of the tool e.g. 1.2.4. |
 
 ## Sources Configuration
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/librarian/internal/config"
 )
 
 const (
@@ -116,42 +115,38 @@ func TestOutput_Error(t *testing.T) {
 
 func TestGetExecutablePath(t *testing.T) {
 	tests := []struct {
-		name           string
-		releaseConfig  *config.Release
-		executableName string
-		want           string
+		name             string
+		commandOverrides map[string]string
+		executableName   string
+		want             string
 	}{
 		{
 			name: "Preinstalled tool found",
-			releaseConfig: &config.Release{
-				Preinstalled: map[string]string{
-					"cargo": "/usr/bin/cargo",
-					"git":   "/usr/bin/git",
-				},
+			commandOverrides: map[string]string{
+				"cargo": "/usr/bin/cargo",
+				"git":   "/usr/bin/git",
 			},
 			executableName: "cargo",
 			want:           "/usr/bin/cargo",
 		},
 		{
 			name: "Preinstalled tool not found",
-			releaseConfig: &config.Release{
-				Preinstalled: map[string]string{
-					"git": "/usr/bin/git",
-				},
+			commandOverrides: map[string]string{
+				"git": "/usr/bin/git",
 			},
 			executableName: "cargo",
 			want:           "cargo",
 		},
 		{
-			name:           "No preinstalled section",
-			releaseConfig:  &config.Release{},
-			executableName: "cargo",
-			want:           "cargo",
+			name:             "No preinstalled section",
+			commandOverrides: nil,
+			executableName:   "cargo",
+			want:             "cargo",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := GetExecutablePath(test.releaseConfig.Preinstalled, test.executableName)
+			got := GetExecutablePath(test.commandOverrides, test.executableName)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -114,7 +114,7 @@ func TestOutput_Error(t *testing.T) {
 }
 
 func TestGetExecutablePath(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		name             string
 		commandOverrides map[string]string
 		executableName   string
@@ -143,8 +143,7 @@ func TestGetExecutablePath(t *testing.T) {
 			executableName:   "cargo",
 			want:             "cargo",
 		},
-	}
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := GetExecutablePath(test.commandOverrides, test.executableName)
 			if diff := cmp.Diff(test.want, got); diff != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,42 +49,12 @@ type Config struct {
 	// Tools defines required tools.
 	Tools *Tools `yaml:"tools,omitempty"`
 
-	// Release holds the configuration parameter for publishing and release subcommands.
-	Release *Release `yaml:"release,omitempty"`
-
 	// Default contains default settings for all libraries. They apply to all libraries unless overridden.
 	Default *Default `yaml:"default,omitempty"`
 
 	// Libraries contains configuration overrides for libraries that need
 	// special handling, and differ from default settings.
 	Libraries []*Library `yaml:"libraries,omitempty"`
-}
-
-// Release holds the configuration parameter for publish command.
-//
-// TODO(https://github.com/googleapis/librarian/issues/4910): delete Release.
-type Release struct {
-	// IgnoredChanges defines globs that are ignored in change analysis.
-	IgnoredChanges []string `yaml:"ignored_changes,omitempty"`
-
-	// Preinstalled tools defines the list of tools that must be preinstalled.
-	//
-	// This is indexed by the well-known name of the tool vs. its path, e.g.
-	// [preinstalled]
-	// cargo = /usr/bin/cargo
-	Preinstalled map[string]string `yaml:"preinstalled,omitempty"`
-
-	// Tools defines the list of tools to install, indexed by installer.
-	Tools map[string][]Tool `yaml:"tools,omitempty"`
-}
-
-// Tool defines the configuration required to install helper tools.
-type Tool struct {
-	// Name is the name of the tool e.g. nox.
-	Name string `yaml:"name"`
-
-	// Version is the version of the tool e.g. 1.2.4.
-	Version string `yaml:"version,omitempty"`
 }
 
 // Sources references external source repositories.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -69,8 +69,7 @@ func TestIsNewFileSuccess(t *testing.T) {
 	if err := os.WriteFile(existingName, []byte(newLibRsContents), 0644); err != nil {
 		t.Fatal(err)
 	}
-	cfg := &config.Release{}
-	gitExe := command.GetExecutablePath(cfg.Preinstalled, command.Git)
+	gitExe := command.Git
 
 	newName := path.Join("src", "storage", "src", "new.rs")
 	if err := os.MkdirAll(path.Dir(newName), 0755); err != nil {
@@ -93,8 +92,7 @@ func TestIsNewFileDiffError(t *testing.T) {
 	const wantTag = "new-file-success"
 	t.Chdir(t.TempDir())
 	testhelper.SetupForVersionBump(t, wantTag)
-	cfg := &config.Release{}
-	gitExe := command.GetExecutablePath(cfg.Preinstalled, command.Git)
+	gitExe := command.Git
 	existingName := path.Join("src", "storage", "src", "lib.rs")
 	if IsNewFile(t.Context(), gitExe, "invalid-tag", existingName) {
 		t.Errorf("diff errors should return false for isNewFile(): %s", existingName)
@@ -188,11 +186,6 @@ func TestFilterSomeGlobs(t *testing.T) {
 }
 
 func TestAssertGitStatusClean(t *testing.T) {
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git": "git",
-		},
-	}
 	for _, test := range []struct {
 		name    string
 		setup   func(t *testing.T)
@@ -222,7 +215,7 @@ func TestAssertGitStatusClean(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
 			test.setup(t)
-			err := AssertGitStatusClean(t.Context(), command.GetExecutablePath(cfg.Preinstalled, command.Git))
+			err := AssertGitStatusClean(t.Context(), command.Git)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("AssertGitStatusClean() error = %v, wantErr %v", err, test.wantErr)
 			}

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -109,15 +109,14 @@ Examples:
 // runBump performs the actual work of the bump command, after all the command
 // lines arguments have been validated and the configuration loaded.
 func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride string) error {
-	gitExe := command.Git
-	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
+	if err := git.AssertGitStatusClean(ctx, command.Git); err != nil {
 		return err
 	}
 	if cfg.Language == config.LanguageRust {
-		return legacyRustBump(ctx, cfg, all, libraryName, versionOverride, gitExe)
+		return legacyRustBump(ctx, cfg, all, libraryName, versionOverride)
 	}
 
-	librariesToBump, err := findLibrariesToBump(ctx, cfg, gitExe, all, libraryName)
+	librariesToBump, err := findLibrariesToBump(ctx, cfg, all, libraryName)
 	if err != nil {
 		return err
 	}
@@ -142,7 +141,7 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 
 // findLibrariesToBump determines which versions should be bumped based on
 // command line options.
-func findLibrariesToBump(ctx context.Context, cfg *config.Config, gitExe string, all bool, libraryName string) ([]*config.Library, error) {
+func findLibrariesToBump(ctx context.Context, cfg *config.Config, all bool, libraryName string) ([]*config.Library, error) {
 	if !all {
 		library, err := FindLibrary(cfg, libraryName)
 		if err != nil {
@@ -157,11 +156,11 @@ func findLibrariesToBump(ctx context.Context, cfg *config.Config, gitExe string,
 			continue
 		}
 		lastReleaseTagName := formatTagName(cfg.Default.TagFormat, lib)
-		lastReleaseTagCommit, err := git.GetCommitHash(ctx, gitExe, lastReleaseTagName)
+		lastReleaseTagCommit, err := git.GetCommitHash(ctx, command.Git, lastReleaseTagName)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving commit for tag %s (from library %s version %s): %w", lastReleaseTagName, lib.Name, lib.Version, err)
 		}
-		filesChanged, err := git.FilesChangedSince(ctx, gitExe, lastReleaseTagCommit, IgnoredChanges)
+		filesChanged, err := git.FilesChangedSince(ctx, command.Git, lastReleaseTagCommit, IgnoredChanges)
 		if err != nil {
 			return nil, err
 		}
@@ -347,14 +346,14 @@ func findLatestReleaseCommitHash(ctx context.Context) (string, error) {
 // releasing. This is separated from the main logic to allow non-Rust languages
 // to work on the newer "tag-per-library" logic without interrupting Rust
 // releases. The "fake" language is still valid here, for testing purposes.
-func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride, gitExe string) error {
-	lastTag, err := git.GetLastTag(ctx, gitExe, config.RemoteUpstream, config.BranchMain)
+func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride string) error {
+	lastTag, err := git.GetLastTag(ctx, command.Git, config.RemoteUpstream, config.BranchMain)
 	if err != nil {
 		return err
 	}
 
 	if all {
-		if err := legacyRustBumpAll(ctx, cfg, lastTag, gitExe); err != nil {
+		if err := legacyRustBumpAll(ctx, cfg, lastTag); err != nil {
 			return err
 		}
 	} else {
@@ -362,7 +361,7 @@ func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryNa
 		if err != nil {
 			return err
 		}
-		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, gitExe, versionOverride); err != nil {
+		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, versionOverride); err != nil {
 			return err
 		}
 	}
@@ -377,8 +376,8 @@ func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryNa
 // of assuming a single tag for the latest release, and checking everything
 // since that tag. (Compare this with findLibrariesToBump, which expects each
 // library to have its own tag for its last release.)
-func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe string) error {
-	filesChanged, err := git.FilesChangedSince(ctx, gitExe, lastTag, IgnoredChanges)
+func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag string) error {
+	filesChanged, err := git.FilesChangedSince(ctx, command.Git, lastTag, IgnoredChanges)
 	if err != nil {
 		return err
 	}
@@ -390,7 +389,7 @@ func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe 
 		if !hasChangesIn(output, "", filesChanged) {
 			continue
 		}
-		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, gitExe, ""); err != nil {
+		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, ""); err != nil {
 			return err
 		}
 	}
@@ -401,7 +400,7 @@ func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag, gitExe 
 // assuming a single tag for the latest release, and passing that tag into the
 // rust.Bump code. (Compare this with bumpLibrary, which only uses git to derive
 // the next version.)
-func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, lastTag, gitExe, versionOverride string) error {
+func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, lastTag, versionOverride string) error {
 	opts := languageVersioningOptions[cfg.Language]
 	version, err := deriveNextVersion(lib, opts, versionOverride)
 	if err != nil {
@@ -410,7 +409,7 @@ func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.
 	output := libraryOutput(cfg.Language, lib, cfg.Default)
 	switch cfg.Language {
 	case config.LanguageRust:
-		return rust.Bump(ctx, lib, output, version, gitExe, lastTag)
+		return rust.Bump(ctx, lib, output, version, command.Git, lastTag)
 	case config.LanguageFake:
 		lib.Version = version
 		return fakeBumpLibrary(output, version)

--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -109,11 +109,7 @@ Examples:
 // runBump performs the actual work of the bump command, after all the command
 // lines arguments have been validated and the configuration loaded.
 func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride string) error {
-	var preinstalled map[string]string
-	if cfg.Release != nil {
-		preinstalled = cfg.Release.Preinstalled
-	}
-	gitExe := command.GetExecutablePath(preinstalled, command.Git)
+	gitExe := command.Git
 	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
 		return err
 	}
@@ -237,11 +233,7 @@ func bumpLibrary(cfg *config.Config, lib *config.Library, versionOverride string
 func postBump(ctx context.Context, cfg *config.Config) error {
 	switch cfg.Language {
 	case config.LanguageRust:
-		cargoExe := command.Cargo
-		if cfg.Release != nil {
-			cargoExe = command.GetExecutablePath(cfg.Release.Preinstalled, command.Cargo)
-		}
-		if err := command.Run(ctx, cargoExe, "update", "--workspace"); err != nil {
+		if err := command.Run(ctx, command.Cargo, "update", "--workspace"); err != nil {
 			return err
 		}
 	}
@@ -313,8 +305,8 @@ func findReleasedLibraries(cfgBefore, cfgAfter *config.Config) ([]string, error)
 // this *without* using tags, as it's used in circumstances where the full
 // release process has not yet been completed (e.g. to find which commit
 // *should* be tagged).
-func findLatestReleaseCommitHash(ctx context.Context, gitExe string) (string, error) {
-	commits, err := git.FindCommitsForPath(ctx, gitExe, config.LibrarianYAML)
+func findLatestReleaseCommitHash(ctx context.Context) (string, error) {
+	commits, err := git.FindCommitsForPath(ctx, command.Git, config.LibrarianYAML)
 	if err != nil {
 		return "", err
 	}
@@ -324,7 +316,7 @@ func findLatestReleaseCommitHash(ctx context.Context, gitExe string) (string, er
 	var candidateConfig *config.Config
 	candidateCommit := ""
 	for _, commit := range commits {
-		commitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, commit, config.LibrarianYAML)
+		commitCfgContent, err := git.ShowFileAtRevision(ctx, command.Git, commit, config.LibrarianYAML)
 		if err != nil {
 			return "", err
 		}

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -513,7 +513,7 @@ func TestFindLibrariesToBump(t *testing.T) {
 				test.setup(t, cfg)
 			}
 
-			gotLibraries, err := findLibrariesToBump(t.Context(), cfg, "git", test.all, test.libraryName)
+			gotLibraries, err := findLibrariesToBump(t.Context(), cfg, test.all, test.libraryName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -564,7 +564,7 @@ func TestFindLibrariesToBump_Error(t *testing.T) {
 				test.setup(t, cfg)
 			}
 
-			_, gotErr := findLibrariesToBump(t.Context(), cfg, "git", test.all, test.libraryName)
+			_, gotErr := findLibrariesToBump(t.Context(), cfg, test.all, test.libraryName)
 			if gotErr == nil {
 				t.Fatal("expected error; got nil")
 			}
@@ -1030,7 +1030,7 @@ func TestLegacyRustBumpLibrary(t *testing.T) {
 
 			targetLibCfg := test.cfg.Libraries[0]
 			// Unused string param: lastTag.
-			err := legacyRustBumpLibrary(t.Context(), test.cfg, targetLibCfg, testUnusedStringParam, "git", test.versionOverride)
+			err := legacyRustBumpLibrary(t.Context(), test.cfg, targetLibCfg, testUnusedStringParam, test.versionOverride)
 			if err != nil {
 				t.Fatalf("legacyRustBumpLibrary() error = %v", err)
 			}
@@ -1094,7 +1094,7 @@ func TestLegacyRustBump(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			if err := legacyRustBump(t.Context(), cfg, test.all, test.libraryName, test.versionOverride, "git"); err != nil {
+			if err := legacyRustBump(t.Context(), cfg, test.all, test.libraryName, test.versionOverride); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1156,7 +1156,7 @@ func TestLegacyRustBumpAll(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			err := legacyRustBumpAll(t.Context(), targetCfg, sinceTag, "git")
+			err := legacyRustBumpAll(t.Context(), targetCfg, sinceTag)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -576,7 +576,8 @@ func TestFindLibrariesToBump_Error(t *testing.T) {
 }
 
 func TestPostBump(t *testing.T) {
-	fakeCargo := filepath.Join(t.TempDir(), "fake-cargo")
+	tmpDir := t.TempDir()
+	fakeCargo := filepath.Join(tmpDir, "cargo")
 	for _, test := range []struct {
 		name    string
 		setup   func()
@@ -590,14 +591,10 @@ func TestPostBump(t *testing.T) {
 				if err := os.WriteFile(fakeCargo, []byte(script), 0755); err != nil {
 					t.Fatal(err)
 				}
+				t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			},
 			cfg: &config.Config{
 				Language: config.LanguageRust,
-				Release: &config.Release{
-					Preinstalled: map[string]string{
-						"cargo": fakeCargo,
-					},
-				},
 			},
 		},
 		{
@@ -607,14 +604,10 @@ func TestPostBump(t *testing.T) {
 				if err := os.WriteFile(fakeCargo, []byte(script), 0755); err != nil {
 					t.Fatal(err)
 				}
+				t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			},
 			cfg: &config.Config{
 				Language: config.LanguageRust,
-				Release: &config.Release{
-					Preinstalled: map[string]string{
-						"cargo": fakeCargo,
-					},
-				},
 			},
 			wantErr: true,
 		},
@@ -919,7 +912,7 @@ func TestFindLatestReleaseCommitHash(t *testing.T) {
 			if test.wantCommitCount != len(commits) {
 				t.Fatalf("expected setup to create %d commits; got %d", test.wantCommitCount, len(commits))
 			}
-			got, err := findLatestReleaseCommitHash(t.Context(), "git")
+			got, err := findLatestReleaseCommitHash(t.Context())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -990,7 +983,7 @@ func TestFindLatestReleaseCommitHash_Error(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 			test.setup(cfg)
-			got, err := findLatestReleaseCommitHash(t.Context(), "git")
+			got, err := findLatestReleaseCommitHash(t.Context())
 			if err == nil {
 				t.Errorf("expected error; succeeded with hash %s", got)
 			}

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -85,7 +85,7 @@ Examples:
 			if cfg.Language == config.LanguageRust {
 				return legacyRustPublish(ctx, cfg, cmd)
 			}
-			return publish(ctx, cfg, cmd.String("release-commit"), cmd.Bool("execute"))
+			return publish(ctx, cmd.String("release-commit"), cmd.Bool("execute"))
 		},
 	}
 }
@@ -110,24 +110,20 @@ func legacyRustPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command
 	})
 }
 
-// publish implements the publish command. It is provided with the configuration
-// at HEAD, just to find the git executable to use, after which it finds the
-// release commit to publish. The configuration at the release commit is used
-// for all further operations (and the repo will be checked out at that commit).
+// publish implements the publish command. It finds the release commit to
+// publish. The configuration at the release commit is used for all further
+// operations (and the repo will be checked out at that commit).
 // The releaseCommit flag allows a user to identify a specific release commit to
 // publish, in case of overlapping releases being performed. The execute flag
 // says whether to actually publish (true) or just perform a dry run (false).
-func publish(ctx context.Context, cfg *config.Config, releaseCommit string, execute bool) error {
+func publish(ctx context.Context, releaseCommit string, execute bool) error {
 	gitExe := command.Git
-	if cfg.Release != nil {
-		gitExe = command.GetExecutablePath(cfg.Release.Preinstalled, command.Git)
-	}
 	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
 		return err
 	}
 	var err error
 	if releaseCommit == "" {
-		releaseCommit, err = findLatestReleaseCommitHash(ctx, gitExe)
+		releaseCommit, err = findLatestReleaseCommitHash(ctx)
 		if err != nil {
 			return err
 		}
@@ -136,7 +132,7 @@ func publish(ctx context.Context, cfg *config.Config, releaseCommit string, exec
 		return err
 	}
 	// Reload the config after checking out the release commit.
-	cfg, err = yaml.Read[config.Config](config.LibrarianYAML)
+	cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -117,8 +117,7 @@ func legacyRustPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command
 // publish, in case of overlapping releases being performed. The execute flag
 // says whether to actually publish (true) or just perform a dry run (false).
 func publish(ctx context.Context, releaseCommit string, execute bool) error {
-	gitExe := command.Git
-	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
+	if err := git.AssertGitStatusClean(ctx, command.Git); err != nil {
 		return err
 	}
 	var err error
@@ -128,7 +127,7 @@ func publish(ctx context.Context, releaseCommit string, execute bool) error {
 			return err
 		}
 	}
-	if err := git.Checkout(ctx, gitExe, releaseCommit); err != nil {
+	if err := git.Checkout(ctx, command.Git, releaseCommit); err != nil {
 		return err
 	}
 	// Reload the config after checking out the release commit.
@@ -141,7 +140,7 @@ func publish(ctx context.Context, releaseCommit string, execute bool) error {
 	// findLatestReleaseCommitHash, but keeps the interface simple - and means
 	// that if we want to be able to specify the release commit directly, we
 	// can skip findLatestReleaseCommitHash entirely.)
-	cfgContentBeforeCommit, err := git.ShowFileAtRevision(ctx, gitExe, "HEAD~", config.LibrarianYAML)
+	cfgContentBeforeCommit, err := git.ShowFileAtRevision(ctx, command.Git, "HEAD~", config.LibrarianYAML)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/publish_test.go
+++ b/internal/librarian/publish_test.go
@@ -84,7 +84,7 @@ func TestPublish(t *testing.T) {
 			cfg.Libraries[1].Version = "1.2.0"
 			testhelper.Setup(t, testhelper.SetupOptions{Config: cfg})
 			test.setup(cfg)
-			if err := publish(t.Context(), cfg, test.releaseCommit, test.execute); err != nil {
+			if err := publish(t.Context(), test.releaseCommit, test.execute); err != nil {
 				t.Fatal(err)
 			}
 			got, err := os.ReadFile(fakePublishedFile)
@@ -105,20 +105,6 @@ func TestPublish_Error(t *testing.T) {
 		releaseCommit string
 		wantErr       error
 	}{
-		{
-			name: "custom tool specified for git and doesn't exist",
-			setup: func(cfg *config.Config) {
-				// Add a release commit to distinguish this case from "no releases"
-				cfg.Libraries[0].Version = "1.1.0"
-				cfg.Release = &config.Release{
-					Preinstalled: map[string]string{
-						"git": "/usr/bin/does-not-exist",
-					},
-				}
-				writeConfigAndCommit(t, cfg)
-			},
-			// Can't easily check this error.
-		},
 		{
 			name: "repo is dirty",
 			setup: func(cfg *config.Config) {
@@ -167,7 +153,7 @@ func TestPublish_Error(t *testing.T) {
 			cfg.Libraries[1].Version = "1.2.0"
 			testhelper.Setup(t, testhelper.SetupOptions{Config: cfg})
 			test.setup(cfg)
-			err := publish(t.Context(), cfg, test.releaseCommit, false)
+			err := publish(t.Context(), test.releaseCommit, false)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -34,8 +34,6 @@ type semverData struct {
 	dryRunKeepGoing bool
 	manifests       map[string]string
 	lastTag         string
-	cargoPath       string
-	gitPath         string
 	verbose         bool
 }
 
@@ -76,8 +74,6 @@ type PublishParams struct {
 	Verbose bool
 	// IgnoredChanges is a list of file paths/patterns to ignore when detecting changed crates.
 	IgnoredChanges []string
-	// commandOverrides maps command names to override paths, primarily used for testing.
-	commandOverrides map[string]string
 }
 
 // Publish finds all the crates that should be published. It can optionally
@@ -87,18 +83,17 @@ func Publish(ctx context.Context, params PublishParams) error {
 	if params.Config != nil && params.Config.Tools != nil {
 		tools = params.Config.Tools.Cargo
 	}
-	if err := preFlight(ctx, params.commandOverrides, tools); err != nil {
+	if err := preFlight(ctx, tools); err != nil {
 		return err
 	}
-	gitExe := command.GetExecutablePath(params.commandOverrides, command.Git)
-	lastTag, err := git.GetLastTag(ctx, gitExe, config.RemoteUpstream, config.BranchMain)
+	lastTag, err := git.GetLastTag(ctx, command.Git, config.RemoteUpstream, config.BranchMain)
 	if err != nil {
 		return err
 	}
-	if err := git.MatchesBranchPoint(ctx, gitExe, config.RemoteUpstream, config.BranchMain); err != nil {
+	if err := git.MatchesBranchPoint(ctx, command.Git, config.RemoteUpstream, config.BranchMain); err != nil {
 		return err
 	}
-	files, err := git.FilesChangedSince(ctx, gitExe, lastTag, params.IgnoredChanges)
+	files, err := git.FilesChangedSince(ctx, command.Git, lastTag, params.IgnoredChanges)
 	if err != nil {
 		return err
 	}
@@ -117,29 +112,23 @@ func publishCrates(ctx context.Context, params PublishParams, lastTag string, fi
 			manifests[name] = manifest
 		}
 	}
-	cargoPath := command.GetExecutablePath(params.commandOverrides, command.Cargo)
-	output, err := command.Output(ctx, cargoPath, "workspaces", "plan", "--skip-published")
+	output, err := command.Output(ctx, command.Cargo, "workspaces", "plan", "--skip-published")
 	if err != nil {
 		return err
 	}
 	plannedCrates := strings.Split(string(output), "\n")
 	plannedCrates = slices.DeleteFunc(plannedCrates, func(a string) bool { return a == "" })
-	if !isMockCargo(cargoPath) {
-		for _, crate := range plannedCrates {
-			if _, ok := manifests[crate]; !ok {
-				return fmt.Errorf("unplanned crate %q found in workspace plan", crate)
-			}
+	for _, crate := range plannedCrates {
+		if _, ok := manifests[crate]; !ok {
+			return fmt.Errorf("unplanned crate %q found in workspace plan", crate)
 		}
 	}
 
 	if !params.SkipSemverChecks {
-		gitPath := command.GetExecutablePath(params.commandOverrides, command.Git)
 		if err := runSemverChecks(ctx, semverData{
 			dryRunKeepGoing: params.DryRunKeepGoing,
 			manifests:       manifests,
 			lastTag:         lastTag,
-			cargoPath:       cargoPath,
-			gitPath:         gitPath,
 			verbose:         params.Verbose,
 		}); err != nil {
 			return err
@@ -152,9 +141,9 @@ func publishCrates(ctx context.Context, params PublishParams, lastTag string, fi
 		args = append(args, "--dry-run")
 	}
 	if params.Verbose {
-		return command.RunStreaming(ctx, cargoPath, args...)
+		return command.RunStreaming(ctx, command.Cargo, args...)
 	}
-	return command.Run(ctx, cargoPath, args...)
+	return command.Run(ctx, command.Cargo, args...)
 }
 
 // runSemverChecks iterates through manifests and runs semver checks for each.
@@ -174,23 +163,19 @@ func runSemverChecks(ctx context.Context, semverData semverData) error {
 
 // semverCheck runs semver checks for a specific crate.
 func semverCheck(ctx context.Context, semverData semverData, name string, manifest string) error {
-	if git.IsNewFile(ctx, semverData.gitPath, semverData.lastTag, manifest) {
+	if git.IsNewFile(ctx, command.Git, semverData.lastTag, manifest) {
 		// If the manifest is new, we can skip semver checks, since there is no previous version to compare against.
 		return nil
 	}
 	var err error
 	if semverData.verbose {
-		err = command.RunStreaming(ctx, semverData.cargoPath, "semver-checks", "--all-features", "-p", name)
+		err = command.RunStreaming(ctx, command.Cargo, "semver-checks", "--all-features", "-p", name)
 	} else {
-		err = command.Run(ctx, semverData.cargoPath, "semver-checks", "--all-features", "-p", name)
+		err = command.Run(ctx, command.Cargo, "semver-checks", "--all-features", "-p", name)
 	}
 	if err != nil && semverData.dryRunKeepGoing {
 		slog.Warn("semver check failed, but continuing due to --keep-going", "crate", name, "error", err)
 		return nil
 	}
 	return err
-}
-
-func isMockCargo(path string) bool {
-	return path == "/bin/echo"
 }

--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -76,16 +76,21 @@ type PublishParams struct {
 	Verbose bool
 	// IgnoredChanges is a list of file paths/patterns to ignore when detecting changed crates.
 	IgnoredChanges []string
+	// commandOverrides maps command names to override paths, primarily used for testing.
+	commandOverrides map[string]string
 }
 
 // Publish finds all the crates that should be published. It can optionally
 // run in dry-run mode, dry-run mode with continue on errors, and/or skip semver checks.
 func Publish(ctx context.Context, params PublishParams) error {
-	release := params.Config.Release
-	if err := preFlight(ctx, release.Preinstalled, cargoTools(params.Config)); err != nil {
+	var tools []*config.CargoTool
+	if params.Config != nil && params.Config.Tools != nil {
+		tools = params.Config.Tools.Cargo
+	}
+	if err := preFlight(ctx, params.commandOverrides, tools); err != nil {
 		return err
 	}
-	gitExe := command.GetExecutablePath(release.Preinstalled, command.Git)
+	gitExe := command.GetExecutablePath(params.commandOverrides, command.Git)
 	lastTag, err := git.GetLastTag(ctx, gitExe, config.RemoteUpstream, config.BranchMain)
 	if err != nil {
 		return err
@@ -100,27 +105,8 @@ func Publish(ctx context.Context, params PublishParams) error {
 	return publishCrates(ctx, params, lastTag, files)
 }
 
-// cargoTools returns cargo tools from Config.Tools if available,
-// falling back to Release.Tools for backwards compatibility.
-//
-// TODO(https://github.com/googleapis/librarian/issues/4910): delete when Release is removed.
-func cargoTools(cfg *config.Config) []config.Tool {
-	if cfg.Tools != nil && len(cfg.Tools.Cargo) > 0 {
-		tools := make([]config.Tool, len(cfg.Tools.Cargo))
-		for i, t := range cfg.Tools.Cargo {
-			tools[i] = config.Tool{Name: t.Name, Version: t.Version}
-		}
-		return tools
-	}
-	if cfg.Release != nil {
-		return cfg.Release.Tools["cargo"]
-	}
-	return nil
-}
-
 // publishCrates publishes the crates that have changed.
 func publishCrates(ctx context.Context, params PublishParams, lastTag string, files []string) error {
-	release := params.Config.Release
 	manifests := map[string]string{}
 	for _, manifest := range findCargoManifests(files) {
 		names, err := publishedCrate(manifest)
@@ -131,7 +117,7 @@ func publishCrates(ctx context.Context, params PublishParams, lastTag string, fi
 			manifests[name] = manifest
 		}
 	}
-	cargoPath := command.GetExecutablePath(release.Preinstalled, command.Cargo)
+	cargoPath := command.GetExecutablePath(params.commandOverrides, command.Cargo)
 	output, err := command.Output(ctx, cargoPath, "workspaces", "plan", "--skip-published")
 	if err != nil {
 		return err
@@ -147,7 +133,7 @@ func publishCrates(ctx context.Context, params PublishParams, lastTag string, fi
 	}
 
 	if !params.SkipSemverChecks {
-		gitPath := command.GetExecutablePath(release.Preinstalled, command.Git)
+		gitPath := command.GetExecutablePath(params.commandOverrides, command.Git)
 		if err := runSemverChecks(ctx, semverData{
 			dryRunKeepGoing: params.DryRunKeepGoing,
 			manifests:       manifests,

--- a/internal/librarian/rust/publish_test.go
+++ b/internal/librarian/rust/publish_test.go
@@ -32,17 +32,17 @@ import (
 func TestPublishCratesSuccess(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	testhelper.RequireCommand(t, "/bin/echo")
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": "/bin/echo",
-		},
-		Tools: map[string][]config.Tool{
-			"cargo": {
+	cfg := &config.Config{
+		Tools: &config.Tools{
+			Cargo: []*config.CargoTool{
 				{Name: "cargo-semver-checks", Version: "1.2.3"},
 				{Name: "cargo-workspaces", Version: "3.4.5"},
 			},
 		},
+	}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": "/bin/echo",
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
@@ -53,8 +53,9 @@ func TestPublishCratesSuccess(t *testing.T) {
 	lastTag := "release-2001-02-03"
 
 	if err := publishCrates(t.Context(), PublishParams{
-		Config: &config.Config{Release: cfg},
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
@@ -63,17 +64,17 @@ func TestPublishCratesSuccess(t *testing.T) {
 func TestPublishCratesWithNewCrate(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	testhelper.RequireCommand(t, "/bin/echo")
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": "/bin/echo",
-		},
-		Tools: map[string][]config.Tool{
-			"cargo": {
+	cfg := &config.Config{
+		Tools: &config.Tools{
+			Cargo: []*config.CargoTool{
 				{Name: "cargo-semver-checks", Version: "1.2.3"},
 				{Name: "cargo-workspaces", Version: "3.4.5"},
 			},
 		},
+	}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": "/bin/echo",
 	}
 	_ = testhelper.SetupRepoWithChange(t, "release-with-new-crate")
 	testhelper.AddCrate(t, path.Join("src", "pubsub"), "google-cloud-pubsub")
@@ -85,8 +86,9 @@ func TestPublishCratesWithNewCrate(t *testing.T) {
 	}
 	lastTag := "release-with-new-crate"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config: &config.Config{Release: cfg},
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
@@ -95,17 +97,17 @@ func TestPublishCratesWithNewCrate(t *testing.T) {
 func TestPublishCratesWithBadManifest(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	testhelper.RequireCommand(t, "/bin/echo")
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": "/bin/echo",
-		},
-		Tools: map[string][]config.Tool{
-			"cargo": {
+	cfg := &config.Config{
+		Tools: &config.Tools{
+			Cargo: []*config.CargoTool{
 				{Name: "cargo-semver-checks", Version: "1.2.3"},
 				{Name: "cargo-workspaces", Version: "3.4.5"},
 			},
 		},
+	}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": "/bin/echo",
 	}
 	_ = testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	name := path.Join("src", "storage", "src", "lib.rs")
@@ -123,8 +125,9 @@ func TestPublishCratesWithBadManifest(t *testing.T) {
 	}
 	lastTag := "release-2001-02-03"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config: &config.Config{Release: cfg},
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}, lastTag, files); err == nil {
 		t.Errorf("expected an error with a bad manifest file")
 	}
@@ -132,11 +135,10 @@ func TestPublishCratesWithBadManifest(t *testing.T) {
 
 func TestPublishCratesGetPlanError(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": "git",
-		},
+	cfg := &config.Config{}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": "git",
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
@@ -146,8 +148,9 @@ func TestPublishCratesGetPlanError(t *testing.T) {
 	}
 	lastTag := "release-2001-02-03"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config: &config.Config{Release: cfg},
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}, lastTag, files); err == nil {
 		t.Fatalf("expected an error during plan generation")
 	}
@@ -156,17 +159,17 @@ func TestPublishCratesGetPlanError(t *testing.T) {
 func TestPublishCratesPlanMismatchError(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	testhelper.RequireCommand(t, "echo")
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": "echo",
-		},
-		Tools: map[string][]config.Tool{
-			"cargo": {
+	cfg := &config.Config{
+		Tools: &config.Tools{
+			Cargo: []*config.CargoTool{
 				{Name: "cargo-semver-checks", Version: "1.2.3"},
 				{Name: "cargo-workspaces", Version: "3.4.5"},
 			},
 		},
+	}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": "echo",
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
@@ -176,8 +179,9 @@ func TestPublishCratesPlanMismatchError(t *testing.T) {
 	}
 	lastTag := "release-2001-02-03"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config: &config.Config{Release: cfg},
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}, lastTag, files); err == nil {
 		t.Fatalf("expected an error during plan comparison")
 	}
@@ -206,11 +210,10 @@ fi
 		t.Fatal(err)
 	}
 
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": cargoScript,
-		},
+	cfg := &config.Config{}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": cargoScript,
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
@@ -222,14 +225,16 @@ fi
 
 	// This should fail because semver-checks fails.
 	if err := publishCrates(t.Context(), PublishParams{
-		Config: &config.Config{Release: cfg},
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}, lastTag, files); err == nil {
 		t.Fatal("expected an error from semver-checks")
 	}
 	// Skipping the checks should succeed.
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           &config.Config{Release: cfg},
+		Config:           cfg,
+		commandOverrides: overrides,
 		DryRun:           true,
 		SkipSemverChecks: true,
 	}, lastTag, files); err != nil {
@@ -241,25 +246,24 @@ func TestPublishSuccess(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	testhelper.RequireCommand(t, "/bin/echo")
 	cfg := &config.Config{
-		Release: &config.Release{
-			Preinstalled: map[string]string{
-				"git":   "git",
-				"cargo": "/bin/echo",
-			},
-			Tools: map[string][]config.Tool{
-				"cargo": {
-					{Name: "cargo-semver-checks", Version: "1.2.3"},
-					{Name: "cargo-workspaces", Version: "3.4.5"},
-				},
+		Tools: &config.Tools{
+			Cargo: []*config.CargoTool{
+				{Name: "cargo-semver-checks", Version: "1.2.3"},
+				{Name: "cargo-workspaces", Version: "3.4.5"},
 			},
 		},
+	}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": "/bin/echo",
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 
 	if err := Publish(t.Context(), PublishParams{
-		Config: cfg,
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -269,18 +273,16 @@ func TestPublishWithLocalChangesError(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	testhelper.RequireCommand(t, "/bin/echo")
 	cfg := &config.Config{
-		Release: &config.Release{
-			Preinstalled: map[string]string{
-				"git":   "git",
-				"cargo": "/bin/echo",
-			},
-			Tools: map[string][]config.Tool{
-				"cargo": {
-					{Name: "cargo-semver-checks", Version: "1.2.3"},
-					{Name: "cargo-workspaces", Version: "3.4.5"},
-				},
+		Tools: &config.Tools{
+			Cargo: []*config.CargoTool{
+				{Name: "cargo-semver-checks", Version: "1.2.3"},
+				{Name: "cargo-workspaces", Version: "3.4.5"},
 			},
 		},
+	}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": "/bin/echo",
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-with-local-changes-error")
 	testhelper.CloneRepository(t, remoteDir)
@@ -288,24 +290,23 @@ func TestPublishWithLocalChangesError(t *testing.T) {
 	testhelper.RunGit(t, "add", path.Join("src", "pubsub"))
 	testhelper.RunGit(t, "commit", "-m", "feat: created pubsub", ".")
 	if err := Publish(t.Context(), PublishParams{
-		Config: cfg,
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}); err == nil {
 		t.Errorf("expected an error publishing with unpushed local commits")
 	}
 }
 
 func TestPublishPreflightError(t *testing.T) {
-	cfg := &config.Config{
-		Release: &config.Release{
-			Preinstalled: map[string]string{
-				"git": "git-not-found",
-			},
-		},
+	cfg := &config.Config{}
+	overrides := map[string]string{
+		"git": "git-not-found",
 	}
 	if err := Publish(t.Context(), PublishParams{
-		Config: cfg,
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}); err == nil {
 		t.Errorf("expected a preflight error with a bad git command")
 	}
@@ -333,11 +334,10 @@ fi
 		t.Fatal(err)
 	}
 
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": cargoScript,
-		},
+	cfg := &config.Config{}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": cargoScript,
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
@@ -348,9 +348,10 @@ fi
 	lastTag := "release-2001-02-03"
 
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:          &config.Config{Release: cfg},
-		DryRun:          true,
-		DryRunKeepGoing: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
+		DryRunKeepGoing:  true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
@@ -391,11 +392,10 @@ fi
 		t.Fatal(err)
 	}
 
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": cargoScript,
-		},
+	cfg := &config.Config{}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": cargoScript,
 	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
@@ -407,16 +407,18 @@ fi
 
 	// This should fail because semver-checks fails.
 	if err := publishCrates(t.Context(), PublishParams{
-		Config: &config.Config{Release: cfg},
-		DryRun: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
 	}, lastTag, files); err == nil {
 		t.Fatal("expected an error from semver-checks")
 	}
 	// With --keep-going, this should succeed.
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:          &config.Config{Release: cfg},
-		DryRun:          true,
-		DryRunKeepGoing: true,
+		Config:           cfg,
+		commandOverrides: overrides,
+		DryRun:           true,
+		DryRunKeepGoing:  true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
@@ -444,11 +446,10 @@ fi
 		t.Fatal(err)
 	}
 
-	cfg := &config.Release{
-		Preinstalled: map[string]string{
-			"git":   "git",
-			"cargo": cargoScript,
-		},
+	cfg := &config.Config{}
+	overrides := map[string]string{
+		"git":   "git",
+		"cargo": cargoScript,
 	}
 	// Setup a dummy repo
 	remoteDir := testhelper.SetupRepoWithChange(t, "test-validation")
@@ -484,7 +485,8 @@ fi
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := publishCrates(t.Context(), PublishParams{
-				Config:           &config.Config{Release: cfg},
+				Config:           cfg,
+				commandOverrides: overrides,
 				DryRun:           true,
 				SkipSemverChecks: true,
 			}, lastTag, test.files)

--- a/internal/librarian/rust/publish_test.go
+++ b/internal/librarian/rust/publish_test.go
@@ -24,14 +24,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
 func TestPublishCratesSuccess(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
 	cfg := &config.Config{
 		Tools: &config.Tools{
 			Cargo: []*config.CargoTool{
@@ -40,10 +38,13 @@ func TestPublishCratesSuccess(t *testing.T) {
 			},
 		},
 	}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": "/bin/echo",
-	}
+	setupFakeCargoScript(t, `#!/bin/bash
+if [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
+	echo "google-cloud-storage"
+else
+	exit 0
+fi
+`)
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 	files := []string{
@@ -53,9 +54,8 @@ func TestPublishCratesSuccess(t *testing.T) {
 	lastTag := "release-2001-02-03"
 
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,6 @@ func TestPublishCratesSuccess(t *testing.T) {
 
 func TestPublishCratesWithNewCrate(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
 	cfg := &config.Config{
 		Tools: &config.Tools{
 			Cargo: []*config.CargoTool{
@@ -72,10 +71,13 @@ func TestPublishCratesWithNewCrate(t *testing.T) {
 			},
 		},
 	}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": "/bin/echo",
-	}
+	setupFakeCargoScript(t, `#!/bin/bash
+if [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
+	echo "google-cloud-pubsub"
+else
+	exit 0
+fi
+`)
 	_ = testhelper.SetupRepoWithChange(t, "release-with-new-crate")
 	testhelper.AddCrate(t, path.Join("src", "pubsub"), "google-cloud-pubsub")
 	testhelper.RunGit(t, "add", path.Join("src", "pubsub"))
@@ -86,9 +88,8 @@ func TestPublishCratesWithNewCrate(t *testing.T) {
 	}
 	lastTag := "release-with-new-crate"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +97,6 @@ func TestPublishCratesWithNewCrate(t *testing.T) {
 
 func TestPublishCratesWithBadManifest(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
 	cfg := &config.Config{
 		Tools: &config.Tools{
 			Cargo: []*config.CargoTool{
@@ -105,10 +105,9 @@ func TestPublishCratesWithBadManifest(t *testing.T) {
 			},
 		},
 	}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": "/bin/echo",
-	}
+	setupFakeCargoScript(t, `#!/bin/bash
+exit 0
+`)
 	_ = testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	name := path.Join("src", "storage", "src", "lib.rs")
 	if err := os.WriteFile(name, []byte(testhelper.NewLibRsContents), 0644); err != nil {
@@ -125,9 +124,8 @@ func TestPublishCratesWithBadManifest(t *testing.T) {
 	}
 	lastTag := "release-2001-02-03"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}, lastTag, files); err == nil {
 		t.Errorf("expected an error with a bad manifest file")
 	}
@@ -136,10 +134,9 @@ func TestPublishCratesWithBadManifest(t *testing.T) {
 func TestPublishCratesGetPlanError(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	cfg := &config.Config{}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": "git",
-	}
+	setupFakeCargoScript(t, `#!/bin/bash
+exit 1
+`)
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 	files := []string{
@@ -148,9 +145,8 @@ func TestPublishCratesGetPlanError(t *testing.T) {
 	}
 	lastTag := "release-2001-02-03"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}, lastTag, files); err == nil {
 		t.Fatalf("expected an error during plan generation")
 	}
@@ -158,7 +154,6 @@ func TestPublishCratesGetPlanError(t *testing.T) {
 
 func TestPublishCratesPlanMismatchError(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "echo")
 	cfg := &config.Config{
 		Tools: &config.Tools{
 			Cargo: []*config.CargoTool{
@@ -167,10 +162,13 @@ func TestPublishCratesPlanMismatchError(t *testing.T) {
 			},
 		},
 	}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": "echo",
-	}
+	setupFakeCargoScript(t, `#!/bin/bash
+if [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
+	echo "unplanned-crate"
+else
+	exit 0
+fi
+`)
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 	files := []string{
@@ -179,42 +177,27 @@ func TestPublishCratesPlanMismatchError(t *testing.T) {
 	}
 	lastTag := "release-2001-02-03"
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}, lastTag, files); err == nil {
 		t.Fatalf("expected an error during plan comparison")
 	}
 }
 
 func TestPublishCratesSkipSemverChecks(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows, bash script set up does not work")
-	}
-
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
-	tmpDir := t.TempDir()
-	// Create a fake cargo that fails on `semver-checks`
-	cargoScript := path.Join(tmpDir, "cargo")
 	script := `#!/bin/bash
 if [ "$1" == "semver-checks" ]; then
 	exit 1
 elif [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
 	echo "google-cloud-storage"
 else
-	/bin/echo $@
+	exit 0
 fi
 `
-	if err := os.WriteFile(cargoScript, []byte(script), 0755); err != nil {
-		t.Fatal(err)
-	}
+	setupFakeCargoScript(t, script)
 
 	cfg := &config.Config{}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": cargoScript,
-	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 	files := []string{
@@ -225,16 +208,14 @@ fi
 
 	// This should fail because semver-checks fails.
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}, lastTag, files); err == nil {
 		t.Fatal("expected an error from semver-checks")
 	}
 	// Skipping the checks should succeed.
 	if err := publishCrates(t.Context(), PublishParams{
 		Config:           cfg,
-		commandOverrides: overrides,
 		DryRun:           true,
 		SkipSemverChecks: true,
 	}, lastTag, files); err != nil {
@@ -244,7 +225,6 @@ fi
 
 func TestPublishSuccess(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
 	cfg := &config.Config{
 		Tools: &config.Tools{
 			Cargo: []*config.CargoTool{
@@ -253,17 +233,19 @@ func TestPublishSuccess(t *testing.T) {
 			},
 		},
 	}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": "/bin/echo",
-	}
+	setupFakeCargoScript(t, `#!/bin/bash
+if [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
+	echo "google-cloud-storage"
+else
+	exit 0
+fi
+`)
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 
 	if err := Publish(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +253,6 @@ func TestPublishSuccess(t *testing.T) {
 
 func TestPublishWithLocalChangesError(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
 	cfg := &config.Config{
 		Tools: &config.Tools{
 			Cargo: []*config.CargoTool{
@@ -280,19 +261,17 @@ func TestPublishWithLocalChangesError(t *testing.T) {
 			},
 		},
 	}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": "/bin/echo",
-	}
+	setupFakeCargoScript(t, `#!/bin/bash
+exit 0
+`)
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-with-local-changes-error")
 	testhelper.CloneRepository(t, remoteDir)
 	testhelper.AddCrate(t, path.Join("src", "pubsub"), "google-cloud-pubsub")
 	testhelper.RunGit(t, "add", path.Join("src", "pubsub"))
 	testhelper.RunGit(t, "commit", "-m", "feat: created pubsub", ".")
 	if err := Publish(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}); err == nil {
 		t.Errorf("expected an error publishing with unpushed local commits")
 	}
@@ -300,45 +279,32 @@ func TestPublishWithLocalChangesError(t *testing.T) {
 
 func TestPublishPreflightError(t *testing.T) {
 	cfg := &config.Config{}
-	overrides := map[string]string{
-		"git": "git-not-found",
-	}
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir) // empty path so git is not found
 	if err := Publish(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}); err == nil {
 		t.Errorf("expected a preflight error with a bad git command")
 	}
 }
 
 func TestPublishCratesDryRunKeepGoing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows, bash script set up does not work")
-	}
-
 	testhelper.RequireCommand(t, "git")
 	tmpDir := t.TempDir()
 	// Create a fake cargo that captures its arguments.
-	cargoScript := path.Join(tmpDir, "cargo")
 	script := `#!/bin/bash
 if [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
 	echo "google-cloud-storage"
 elif [ "$1" == "workspaces" ] && [ "$2" == "publish" ]; then
-	echo $@ >> "` + path.Join(tmpDir, "cargo_args.txt") + `"
+	echo $@ >> "` + filepath.Join(tmpDir, "cargo_args.txt") + `"
 else
-	/bin/echo $@
+	exit 0
 fi
 `
-	if err := os.WriteFile(cargoScript, []byte(script), 0755); err != nil {
-		t.Fatal(err)
-	}
+	setupFakeCargoScript(t, script)
 
 	cfg := &config.Config{}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": cargoScript,
-	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 	files := []string{
@@ -348,16 +314,15 @@ fi
 	lastTag := "release-2001-02-03"
 
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
-		DryRunKeepGoing:  true,
+		Config:          cfg,
+		DryRun:          true,
+		DryRunKeepGoing: true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify that arguments were passed to cargo workspaces publish.
-	output, err := os.ReadFile(path.Join(tmpDir, "cargo_args.txt"))
+	output, err := os.ReadFile(filepath.Join(tmpDir, "cargo_args.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,33 +335,19 @@ fi
 }
 
 func TestPublishCratesSemverChecksKeepGoing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows, bash script set up does not work")
-	}
-
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
-	tmpDir := t.TempDir()
-	// Create a fake cargo that fails on `semver-checks`
-	cargoScript := path.Join(tmpDir, "cargo")
 	script := `#!/bin/bash
 if [ "$1" == "semver-checks" ]; then
 	exit 1
 elif [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
 	echo "google-cloud-storage"
 else
-	/bin/echo $@
+	exit 0
 fi
 `
-	if err := os.WriteFile(cargoScript, []byte(script), 0755); err != nil {
-		t.Fatal(err)
-	}
+	setupFakeCargoScript(t, script)
 
 	cfg := &config.Config{}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": cargoScript,
-	}
 	remoteDir := testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	testhelper.CloneRepository(t, remoteDir)
 	files := []string{
@@ -407,50 +358,34 @@ fi
 
 	// This should fail because semver-checks fails.
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
+		Config: cfg,
+		DryRun: true,
 	}, lastTag, files); err == nil {
 		t.Fatal("expected an error from semver-checks")
 	}
 	// With --keep-going, this should succeed.
 	if err := publishCrates(t.Context(), PublishParams{
-		Config:           cfg,
-		commandOverrides: overrides,
-		DryRun:           true,
-		DryRunKeepGoing:  true,
+		Config:          cfg,
+		DryRun:          true,
+		DryRunKeepGoing: true,
 	}, lastTag, files); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPublishCratesValidation(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows, bash script set up does not work")
-	}
-
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
-	tmpDir := t.TempDir()
-
 	// Create a fake cargo that ALWAYS plans "google-cloud-storage"
-	cargoScript := path.Join(tmpDir, "cargo")
 	script := `#!/bin/bash
 if [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
 	echo "google-cloud-storage"
 else
-	/bin/echo $@
+	exit 0
 fi
 `
-	if err := os.WriteFile(cargoScript, []byte(script), 0755); err != nil {
-		t.Fatal(err)
-	}
+	setupFakeCargoScript(t, script)
 
 	cfg := &config.Config{}
-	overrides := map[string]string{
-		"git":   "git",
-		"cargo": cargoScript,
-	}
 	// Setup a dummy repo
 	remoteDir := testhelper.SetupRepoWithChange(t, "test-validation")
 	testhelper.CloneRepository(t, remoteDir)
@@ -486,7 +421,6 @@ fi
 		t.Run(test.name, func(t *testing.T) {
 			err := publishCrates(t.Context(), PublishParams{
 				Config:           cfg,
-				commandOverrides: overrides,
 				DryRun:           true,
 				SkipSemverChecks: true,
 			}, lastTag, test.files)
@@ -523,16 +457,15 @@ func TestRunSemverChecks(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			src := `package main
-import ("os"; "strings")
-func main() {
-	if strings.Contains(strings.Join(os.Args, " "), "fail-me") { os.Exit(1) }
-	os.Exit(0)
-}`
-			fakeCargoExe := buildFakeCargo(t, src)
+			script := `#!/bin/bash
+if [[ "$*" == *"fail-me"* ]]; then
+	exit 1
+fi
+exit 0
+`
+			setupFakeCargoScript(t, script)
 			sData := semverData{
 				manifests:       test.manifests,
-				cargoPath:       fakeCargoExe,
 				dryRunKeepGoing: test.dryRunKeepGoing,
 			}
 
@@ -549,11 +482,12 @@ func TestRunSemverChecks_Errors(t *testing.T) {
 	}
 	wantErr := errSemverCheck
 
-	src := `package main; import "os"; func main() { os.Exit(1) }`
-	fakeCargoExe := buildFakeCargo(t, src)
+	script := `#!/bin/bash
+exit 1
+`
+	setupFakeCargoScript(t, script)
 	sData := semverData{
 		manifests: manifests,
-		cargoPath: fakeCargoExe,
 	}
 	err := runSemverChecks(t.Context(), sData)
 	if err == nil {
@@ -564,26 +498,17 @@ func TestRunSemverChecks_Errors(t *testing.T) {
 	}
 }
 
-// buildFakeCargo compiles a small Go program to serve as a mock 'cargo' binary.
-// It returns the path to the resulting executable.
-func buildFakeCargo(t *testing.T, src string) string {
+// setupFakeCargoScript writes a shell script named 'cargo' to a temporary
+// directory and prepends it to PATH.
+func setupFakeCargoScript(t *testing.T, script string) {
 	t.Helper()
-	tmpDir := t.TempDir()
-	mainGo := filepath.Join(tmpDir, "main.go")
-
-	exeName := "fake_cargo"
 	if runtime.GOOS == "windows" {
-		exeName += ".exe"
+		t.Skip("skipping on windows, bash script set up does not work")
 	}
-	fakeCargoExe := filepath.Join(tmpDir, exeName)
-
-	if err := os.WriteFile(mainGo, []byte(src), 0644); err != nil {
-		t.Errorf("failed to write fake cargo source: %v", err)
+	tmpDir := t.TempDir()
+	cargoScript := filepath.Join(tmpDir, "cargo")
+	if err := os.WriteFile(cargoScript, []byte(script), 0755); err != nil {
+		t.Fatal(err)
 	}
-
-	if err := command.Run(t.Context(), command.Go, "build", "-o", fakeCargoExe, mainGo); err != nil {
-		t.Errorf("failed to build fake cargo: %v", err)
-	}
-
-	return fakeCargoExe
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/librarian/rust/verify_cargo_tools.go
+++ b/internal/librarian/rust/verify_cargo_tools.go
@@ -24,7 +24,7 @@ import (
 )
 
 // preFlight performs all the necessary checks before a release.
-func preFlight(ctx context.Context, preinstalled map[string]string, cargoTools []config.Tool) error {
+func preFlight(ctx context.Context, preinstalled map[string]string, cargoTools []*config.CargoTool) error {
 	gitExe := command.GetExecutablePath(preinstalled, command.Git)
 	if err := git.CheckVersion(ctx, gitExe); err != nil {
 		return err
@@ -36,7 +36,7 @@ func preFlight(ctx context.Context, preinstalled map[string]string, cargoTools [
 }
 
 // cargoPreFlight verifies all the necessary cargo tools are installed.
-func cargoPreFlight(ctx context.Context, cargoExe string, tools []config.Tool) error {
+func cargoPreFlight(ctx context.Context, cargoExe string, tools []*config.CargoTool) error {
 	if err := command.Run(ctx, cargoExe, "--version"); err != nil {
 		return err
 	}

--- a/internal/librarian/rust/verify_cargo_tools.go
+++ b/internal/librarian/rust/verify_cargo_tools.go
@@ -24,20 +24,19 @@ import (
 )
 
 // preFlight performs all the necessary checks before a release.
-func preFlight(ctx context.Context, preinstalled map[string]string, cargoTools []*config.CargoTool) error {
-	gitExe := command.GetExecutablePath(preinstalled, command.Git)
-	if err := git.CheckVersion(ctx, gitExe); err != nil {
+func preFlight(ctx context.Context, cargoTools []*config.CargoTool) error {
+	if err := git.CheckVersion(ctx, command.Git); err != nil {
 		return err
 	}
-	if err := git.CheckRemoteURL(ctx, gitExe, config.RemoteUpstream); err != nil {
+	if err := git.CheckRemoteURL(ctx, command.Git, config.RemoteUpstream); err != nil {
 		return err
 	}
-	return cargoPreFlight(ctx, command.GetExecutablePath(preinstalled, command.Cargo), cargoTools)
+	return cargoPreFlight(ctx, cargoTools)
 }
 
 // cargoPreFlight verifies all the necessary cargo tools are installed.
-func cargoPreFlight(ctx context.Context, cargoExe string, tools []*config.CargoTool) error {
-	if err := command.Run(ctx, cargoExe, "--version"); err != nil {
+func cargoPreFlight(ctx context.Context, tools []*config.CargoTool) error {
+	if err := command.Run(ctx, command.Cargo, "--version"); err != nil {
 		return err
 	}
 	for _, tool := range tools {
@@ -45,7 +44,7 @@ func cargoPreFlight(ctx context.Context, cargoExe string, tools []*config.CargoT
 			continue
 		}
 		spec := fmt.Sprintf("%s@%s", tool.Name, tool.Version)
-		if err := command.Run(ctx, cargoExe, "install", "--locked", spec); err != nil {
+		if err := command.Run(ctx, command.Cargo, "install", "--locked", spec); err != nil {
 			return err
 		}
 	}

--- a/internal/librarian/rust/verify_cargo_tools_test.go
+++ b/internal/librarian/rust/verify_cargo_tools_test.go
@@ -15,6 +15,8 @@
 package rust
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -22,65 +24,85 @@ import (
 )
 
 func TestCargoPreFlightSuccess(t *testing.T) {
-	testhelper.RequireCommand(t, "cargo")
+	tmpDir := t.TempDir()
+	cargoScript := filepath.Join(tmpDir, "cargo")
+	os.WriteFile(cargoScript, []byte("#!/bin/sh\nexit 0"), 0755)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	tools := []*config.CargoTool{
 		{Name: "cargo-semver-checks"},
 	}
-	if err := cargoPreFlight(t.Context(), "cargo", tools); err != nil {
+	if err := cargoPreFlight(t.Context(), tools); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestCargoPreFlightBadCargo(t *testing.T) {
+	tmpDir := t.TempDir()
+	cargoScript := filepath.Join(tmpDir, "cargo")
+	os.WriteFile(cargoScript, []byte("#!/bin/sh\nexit 1"), 0755)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	tools := []*config.CargoTool{
 		{Name: "cargo-semver-checks"},
 	}
-	if err := cargoPreFlight(t.Context(), "not-a-valid-cargo", tools); err == nil {
+	if err := cargoPreFlight(t.Context(), tools); err == nil {
 		t.Error("expected an error, got none")
 	}
 }
 
 func TestCargoPreFlightBadTool(t *testing.T) {
-	testhelper.RequireCommand(t, "cargo")
+	tmpDir := t.TempDir()
+	cargoScript := filepath.Join(tmpDir, "cargo")
+	script := `#!/bin/sh
+if [ "$1" = "install" ]; then exit 1; fi
+exit 0
+`
+	os.WriteFile(cargoScript, []byte(script), 0755)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	tools := []*config.CargoTool{
 		{Name: "not-a-valid-tool", Version: "0.0.1"},
 	}
-	if err := cargoPreFlight(t.Context(), "cargo", tools); err == nil {
+	if err := cargoPreFlight(t.Context(), tools); err == nil {
 		t.Error("expected an error, got none")
 	}
 }
 
 func TestPreFlightMissingGit(t *testing.T) {
-	if err := preFlight(t.Context(), map[string]string{"git": "git-is-not-installed"}, nil); err == nil {
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+	if err := preFlight(t.Context(), nil); err == nil {
 		t.Fatal("expected an error, got nil")
 	}
 }
 
 func TestPreFlightMissingCargo(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	if err := preFlight(t.Context(), map[string]string{"cargo": "cargo-is-not-installed"}, nil); err == nil {
+	tmpDir := t.TempDir()
+	gitScript := filepath.Join(tmpDir, "git")
+	os.WriteFile(gitScript, []byte("#!/bin/sh\nexit 0"), 0755)
+	t.Setenv("PATH", tmpDir)
+	if err := preFlight(t.Context(), nil); err == nil {
 		t.Fatal("expected an error, got nil")
 	}
 }
 
 func TestPreFlightMissingUpstream(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
-	preinstalled := map[string]string{
-		"cargo": "/bin/echo",
-	}
 	testhelper.ContinueInNewGitRepository(t, t.TempDir())
-	if err := preFlight(t.Context(), preinstalled, nil); err == nil {
+	if err := preFlight(t.Context(), nil); err == nil {
 		t.Fatal("expected an error, got nil")
 	}
 }
 
 func TestPreFlightWithTools(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	testhelper.RequireCommand(t, "/bin/echo")
-	preinstalled := map[string]string{
-		"cargo": "/bin/echo",
-	}
+	tmpDir := t.TempDir()
+	cargoScript := filepath.Join(tmpDir, "cargo")
+	os.WriteFile(cargoScript, []byte("#!/bin/sh\nexit 0"), 0755)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	tools := []*config.CargoTool{
 		{
 			Name:    "cargo-semver-checks",
@@ -88,17 +110,22 @@ func TestPreFlightWithTools(t *testing.T) {
 		},
 	}
 	testhelper.SetupForVersionBump(t, "test-preflight-with-tools")
-	if err := preFlight(t.Context(), preinstalled, tools); err != nil {
+	if err := preFlight(t.Context(), tools); err != nil {
 		t.Errorf("expected a successful run, got=%v", err)
 	}
 }
 
 func TestPreFlightToolFailure(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	preinstalled := map[string]string{
-		// Using `git install blah blah` will fail.
-		"cargo": "git",
-	}
+	tmpDir := t.TempDir()
+	cargoScript := filepath.Join(tmpDir, "cargo")
+	script := `#!/bin/sh
+if [ "$1" = "install" ]; then exit 1; fi
+exit 0
+`
+	os.WriteFile(cargoScript, []byte(script), 0755)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	tools := []*config.CargoTool{
 		{
 			Name:    "invalid-tool-name---",
@@ -106,7 +133,7 @@ func TestPreFlightToolFailure(t *testing.T) {
 		},
 	}
 	testhelper.SetupForVersionBump(t, "test-preflight-with-tools")
-	if err := preFlight(t.Context(), preinstalled, tools); err == nil {
+	if err := preFlight(t.Context(), tools); err == nil {
 		t.Errorf("expected an error installing cargo-semver-checks")
 	}
 }

--- a/internal/librarian/rust/verify_cargo_tools_test.go
+++ b/internal/librarian/rust/verify_cargo_tools_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestCargoPreFlightSuccess(t *testing.T) {
 	testhelper.RequireCommand(t, "cargo")
-	tools := []config.Tool{
+	tools := []*config.CargoTool{
 		{Name: "cargo-semver-checks"},
 	}
 	if err := cargoPreFlight(t.Context(), "cargo", tools); err != nil {
@@ -32,7 +32,7 @@ func TestCargoPreFlightSuccess(t *testing.T) {
 }
 
 func TestCargoPreFlightBadCargo(t *testing.T) {
-	tools := []config.Tool{
+	tools := []*config.CargoTool{
 		{Name: "cargo-semver-checks"},
 	}
 	if err := cargoPreFlight(t.Context(), "not-a-valid-cargo", tools); err == nil {
@@ -42,7 +42,7 @@ func TestCargoPreFlightBadCargo(t *testing.T) {
 
 func TestCargoPreFlightBadTool(t *testing.T) {
 	testhelper.RequireCommand(t, "cargo")
-	tools := []config.Tool{
+	tools := []*config.CargoTool{
 		{Name: "not-a-valid-tool", Version: "0.0.1"},
 	}
 	if err := cargoPreFlight(t.Context(), "cargo", tools); err == nil {
@@ -81,7 +81,7 @@ func TestPreFlightWithTools(t *testing.T) {
 	preinstalled := map[string]string{
 		"cargo": "/bin/echo",
 	}
-	tools := []config.Tool{
+	tools := []*config.CargoTool{
 		{
 			Name:    "cargo-semver-checks",
 			Version: "0.42.0",
@@ -99,7 +99,7 @@ func TestPreFlightToolFailure(t *testing.T) {
 		// Using `git install blah blah` will fail.
 		"cargo": "git",
 	}
-	tools := []config.Tool{
+	tools := []*config.CargoTool{
 		{
 			Name:    "invalid-tool-name---",
 			Version: "a.b.c",

--- a/internal/librarian/rust/verify_cargo_tools_test.go
+++ b/internal/librarian/rust/verify_cargo_tools_test.go
@@ -24,10 +24,7 @@ import (
 )
 
 func TestCargoPreFlightSuccess(t *testing.T) {
-	tmpDir := t.TempDir()
-	cargoScript := filepath.Join(tmpDir, "cargo")
-	os.WriteFile(cargoScript, []byte("#!/bin/sh\nexit 0"), 0755)
-	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setupFakeCargoScript(t, "#!/bin/bash\nexit 0")
 
 	tools := []*config.CargoTool{
 		{Name: "cargo-semver-checks"},
@@ -38,10 +35,7 @@ func TestCargoPreFlightSuccess(t *testing.T) {
 }
 
 func TestCargoPreFlightBadCargo(t *testing.T) {
-	tmpDir := t.TempDir()
-	cargoScript := filepath.Join(tmpDir, "cargo")
-	os.WriteFile(cargoScript, []byte("#!/bin/sh\nexit 1"), 0755)
-	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setupFakeCargoScript(t, "#!/bin/bash\nexit 1")
 
 	tools := []*config.CargoTool{
 		{Name: "cargo-semver-checks"},
@@ -52,14 +46,11 @@ func TestCargoPreFlightBadCargo(t *testing.T) {
 }
 
 func TestCargoPreFlightBadTool(t *testing.T) {
-	tmpDir := t.TempDir()
-	cargoScript := filepath.Join(tmpDir, "cargo")
-	script := `#!/bin/sh
+	script := `#!/bin/bash
 if [ "$1" = "install" ]; then exit 1; fi
 exit 0
 `
-	os.WriteFile(cargoScript, []byte(script), 0755)
-	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setupFakeCargoScript(t, script)
 
 	tools := []*config.CargoTool{
 		{Name: "not-a-valid-tool", Version: "0.0.1"},
@@ -98,10 +89,7 @@ func TestPreFlightMissingUpstream(t *testing.T) {
 
 func TestPreFlightWithTools(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	tmpDir := t.TempDir()
-	cargoScript := filepath.Join(tmpDir, "cargo")
-	os.WriteFile(cargoScript, []byte("#!/bin/sh\nexit 0"), 0755)
-	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setupFakeCargoScript(t, "#!/bin/bash\nexit 0")
 
 	tools := []*config.CargoTool{
 		{
@@ -117,14 +105,11 @@ func TestPreFlightWithTools(t *testing.T) {
 
 func TestPreFlightToolFailure(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
-	tmpDir := t.TempDir()
-	cargoScript := filepath.Join(tmpDir, "cargo")
-	script := `#!/bin/sh
+	script := `#!/bin/bash
 if [ "$1" = "install" ]; then exit 1; fi
 exit 0
 `
-	os.WriteFile(cargoScript, []byte(script), 0755)
-	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setupFakeCargoScript(t, script)
 
 	tools := []*config.CargoTool{
 		{

--- a/internal/librarian/tag.go
+++ b/internal/librarian/tag.go
@@ -70,29 +70,21 @@ Examples:
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
-			if err != nil {
-				return err
-			}
-			return tag(ctx, cfg, cmd.String("release-commit"), cmd.Bool("create-release-tag"))
+			return tag(ctx, cmd.String("release-commit"), cmd.Bool("create-release-tag"))
 		},
 	}
 }
 
-// tag implements the tag command. It is provided with the configuration
-// at HEAD, just to find the git executable to use, after which it finds the
-// release commit to publish (unless already specified). The configuration at
-// the release commit is used for all further operations.
-func tag(ctx context.Context, cfg *config.Config, releaseCommit string, createReleaseTag bool) error {
+// tag implements the tag command. It finds the release commit to publish
+// (unless already specified). The configuration at the release commit is used
+// for all further operations.
+func tag(ctx context.Context, releaseCommit string, createReleaseTag bool) error {
 	gitExe := command.Git
-	if cfg.Release != nil {
-		gitExe = command.GetExecutablePath(cfg.Release.Preinstalled, command.Git)
-	}
 	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
 		return err
 	}
 	if releaseCommit == "" {
-		latestReleaseCommit, err := findLatestReleaseCommitHash(ctx, gitExe)
+		latestReleaseCommit, err := findLatestReleaseCommitHash(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/tag.go
+++ b/internal/librarian/tag.go
@@ -79,8 +79,7 @@ Examples:
 // (unless already specified). The configuration at the release commit is used
 // for all further operations.
 func tag(ctx context.Context, releaseCommit string, createReleaseTag bool) error {
-	gitExe := command.Git
-	if err := git.AssertGitStatusClean(ctx, gitExe); err != nil {
+	if err := git.AssertGitStatusClean(ctx, command.Git); err != nil {
 		return err
 	}
 	if releaseCommit == "" {
@@ -90,7 +89,7 @@ func tag(ctx context.Context, releaseCommit string, createReleaseTag bool) error
 		}
 		releaseCommit = latestReleaseCommit
 	}
-	releaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, releaseCommit, config.LibrarianYAML)
+	releaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, command.Git, releaseCommit, config.LibrarianYAML)
 	if err != nil {
 		return err
 	}
@@ -103,7 +102,7 @@ func tag(ctx context.Context, releaseCommit string, createReleaseTag bool) error
 	// findLatestReleaseCommitHash, but keeps the interface simple - and means
 	// that if we specify the release commit directly, we can skip
 	// findLatestReleaseCommitHash entirely.)
-	beforeReleaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, gitExe, releaseCommit+"~", config.LibrarianYAML)
+	beforeReleaseCommitCfgContent, err := git.ShowFileAtRevision(ctx, command.Git, releaseCommit+"~", config.LibrarianYAML)
 	if err != nil {
 		return err
 	}
@@ -122,7 +121,7 @@ func tag(ctx context.Context, releaseCommit string, createReleaseTag bool) error
 	// If we need to create a release tag, do that first - in case we can't
 	// determine the tag name.
 	if createReleaseTag {
-		commitSubject, err := git.GetCommitSubject(ctx, gitExe, releaseCommit)
+		commitSubject, err := git.GetCommitSubject(ctx, command.Git, releaseCommit)
 		if err != nil {
 			return fmt.Errorf("can't get commit subject for %s: %w, %w", releaseCommit, errCannotDeriveReleaseTag, err)
 		}
@@ -131,7 +130,7 @@ func tag(ctx context.Context, releaseCommit string, createReleaseTag bool) error
 			return fmt.Errorf("commit subject has unexpected format '%s': %w", commitSubject, errCannotDeriveReleaseTag)
 		}
 		tagName := "release-" + matches[1]
-		err = git.Tag(ctx, gitExe, tagName, releaseCommit)
+		err = git.Tag(ctx, command.Git, tagName, releaseCommit)
 		if err != nil {
 			return fmt.Errorf("error creating tag %s: %w", tagName, err)
 		}
@@ -144,7 +143,7 @@ func tag(ctx context.Context, releaseCommit string, createReleaseTag bool) error
 			return err
 		}
 		tagName := formatTagName(tagFormat, lib)
-		err = git.Tag(ctx, gitExe, tagName, releaseCommit)
+		err = git.Tag(ctx, command.Git, tagName, releaseCommit)
 		if err != nil {
 			return fmt.Errorf("error creating tag %s: %w", tagName, err)
 		}

--- a/internal/librarian/tag_test.go
+++ b/internal/librarian/tag_test.go
@@ -100,7 +100,7 @@ func TestTag(t *testing.T) {
 			testhelper.Setup(t, testhelper.SetupOptions{Config: cfg})
 			test.setup(t, cfg)
 
-			if err := tag(t.Context(), cfg, test.releaseCommit, test.createReleaseTag); err != nil {
+			if err := tag(t.Context(), test.releaseCommit, test.createReleaseTag); err != nil {
 				t.Fatal(err)
 			}
 
@@ -133,20 +133,6 @@ func TestTag_Error(t *testing.T) {
 		createReleaseTag bool
 		wantErr          error
 	}{
-		{
-			name: "custom tool specified for git and doesn't exist",
-			setup: func(t *testing.T, cfg *config.Config) {
-				// Add a release commit to distinguish this case from "no releases"
-				cfg.Libraries[0].Version = "1.1.0"
-				cfg.Release = &config.Release{
-					Preinstalled: map[string]string{
-						"git": "/usr/bin/does-not-exist",
-					},
-				}
-				writeConfigAndCommit(t, cfg)
-			},
-			// Can't easily check this error
-		},
 		{
 			name: "repo is dirty",
 			setup: func(t *testing.T, cfg *config.Config) {
@@ -198,7 +184,7 @@ func TestTag_Error(t *testing.T) {
 			cfg.Libraries[1].Version = "1.2.0"
 			testhelper.Setup(t, testhelper.SetupOptions{Config: cfg})
 			test.setup(t, cfg)
-			err := tag(t.Context(), cfg, test.releaseCommit, test.createReleaseTag)
+			err := tag(t.Context(), test.releaseCommit, test.createReleaseTag)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -237,11 +237,6 @@ func tidyRustConfig(lib *config.Library) *config.Library {
 	return lib
 }
 
-// isReleaseEmpty returns true if the release configuration is empty.
-func isReleaseEmpty(release *config.Release) bool {
-	return len(release.IgnoredChanges) == 0 && len(release.Preinstalled) == 0 && len(release.Tools) == 0
-}
-
 // isToolsEmpty returns true if the tools configuration is empty.
 func isToolsEmpty(tools *config.Tools) bool {
 	return len(tools.Cargo) == 0 && len(tools.NPM) == 0 && len(tools.Pip) == 0 && len(tools.Go) == 0
@@ -265,9 +260,6 @@ func isDefaultEmpty(defaults *config.Default) bool {
 
 // tidyConfig removes unused sections from the configuration.
 func tidyConfig(cfg *config.Config) *config.Config {
-	if cfg.Release != nil && isReleaseEmpty(cfg.Release) {
-		cfg.Release = nil
-	}
 	if cfg.Tools != nil && isToolsEmpty(cfg.Tools) {
 		cfg.Tools = nil
 	}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -830,7 +830,6 @@ func TestTidy_UnusedSections(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		cfg         *config.Config
-		wantRelease bool
 		wantTools   bool
 		wantDefault bool
 	}{
@@ -841,11 +840,9 @@ func TestTidy_UnusedSections(t *testing.T) {
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Commit: "commit"},
 				},
-				Release: &config.Release{},
 				Tools:   &config.Tools{},
 				Default: &config.Default{},
 			},
-			wantRelease: false,
 			wantTools:   false,
 			wantDefault: false,
 		},
@@ -856,11 +853,9 @@ func TestTidy_UnusedSections(t *testing.T) {
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Commit: "commit"},
 				},
-				Release: &config.Release{IgnoredChanges: []string{"foo"}},
 				Tools:   &config.Tools{Cargo: []*config.CargoTool{{Name: "taplo", Version: "1.0"}}},
 				Default: &config.Default{Output: "output"},
 			},
-			wantRelease: true,
 			wantTools:   true,
 			wantDefault: true,
 		},
@@ -873,9 +868,6 @@ func TestTidy_UnusedSections(t *testing.T) {
 			got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
 			if err != nil {
 				t.Fatal(err)
-			}
-			if (got.Release != nil) != test.wantRelease {
-				t.Errorf("Release present = %v, want %v", got.Release != nil, test.wantRelease)
 			}
 			if (got.Tools != nil) != test.wantTools {
 				t.Errorf("Tools present = %v, want %v", got.Tools != nil, test.wantTools)


### PR DESCRIPTION
Removes the `type Release`, which was a top-level `Config` property for `librarian.yaml`, and all references to it.

Also removes the `type Tool`, which was only referenced from `Release` and is effectively replaced by language-specific `Tools` properties e.g. `CargoTool`, `GoTool`, etc.

Refactors tag, bump, and publish code accordingly. Most notable refactoring here is that we will no longer be able to define a "preinstalled" tool/binary (e.g. `git` or `cargo`). As per https://github.com/googleapis/librarian/issues/4910#issuecomment-4407139116 we are no longer using that config anyways and our playbooks have the appropriate one-time setup requirements documented. We otherwise don't have a strong use case (yet) for continuing to support the use case of pointing at a preinstall tool that isn't in the `PATH`. This may change in the future, but it wouldn't be part of the `Release` section anyways.

Furthermore, it refactors a lot of the rust publish testing code to use `t.SetEnv`-based PATH overrides with a per-test bash script for mocking installed tools rather than plumbing "command overrides" through the codebase to override using a preinstalled tool. This allows us to "just use" the binary we want to use in the code, but requires that we mock it in all of our tests (which we were already doing to some extent).

Fixes #4910