### PR TITLE
chore(internal/serviceconfig): remove release_level override for google/maps/geocode/v4

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -2990,8 +2990,6 @@
     - java
     - nodejs
     - python
-  release_level:
-    java: stable
 - path: google/maps/mapmanagement/v2beta
   languages:
     - go


### PR DESCRIPTION
Remove release_level override for google/maps/geocode/v4, preview is explicit set in [generation_config.yaml](https://github.com/googleapis/google-cloud-java/blob/fe81dfeaf86c010681da2b76d47085816015e4cd/generation_config.yaml#L1661) for this API path. This is reflected in [.repo-metadata.json](https://github.com/googleapis/google-cloud-java/blob/fe81dfeaf86c010681da2b76d47085816015e4cd/java-maps-geocode/.repo-metadata.json#L7).

Fix #5589