### PR TITLE
chore(golang): clean up Generate signature

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -232,14 +232,10 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		}
 		return g.Wait()
 	case config.LanguageGo:
-		var toolchain string
-		if cfg.Default != nil && cfg.Default.Go != nil {
-			toolchain = cfg.Default.Go.Toolchain
-		}
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {
 			g.Go(func() error {
-				if err := golang.Generate(gctx, library, src, toolchain); err != nil {
+				if err := golang.Generate(gctx, cfg, library, src); err != nil {
 					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
 				}
 				return nil

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -42,7 +42,11 @@ var (
 )
 
 // Generate generates a Go client library.
-func Generate(ctx context.Context, library *config.Library, srcs *sources.Sources, toolchain string) (err error) {
+func Generate(ctx context.Context, cfg *config.Config, library *config.Library, srcs *sources.Sources) (err error) {
+	var toolchain string
+	if cfg != nil && cfg.Default != nil && cfg.Default.Go != nil {
+		toolchain = cfg.Default.Go.Toolchain
+	}
 	outDir, err := filepath.Abs(library.Output)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path of output directory: %w", err)

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -98,7 +98,7 @@ func TestGenerate(t *testing.T) {
 		library.Output = filepath.Join(repoRoot, library.Output, library.Name)
 	}
 	for _, library := range libraries {
-		if err := Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir}, ""); err != nil {
+		if err := Generate(t.Context(), nil, library, &sources.Sources{Googleapis: googleapisDir}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -155,7 +155,7 @@ func TestGenerate_Error(t *testing.T) {
 			outdir := t.TempDir()
 			test.library.Output = outdir
 
-			gotErr := Generate(t.Context(), test.library, &sources.Sources{Googleapis: googleapisDir}, "")
+			gotErr := Generate(t.Context(), nil, test.library, &sources.Sources{Googleapis: googleapisDir})
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("Generate error = %v, wantErr %v", gotErr, test.wantErr)
 			}
@@ -189,7 +189,7 @@ func TestGenerate_MkdirAllError(t *testing.T) {
 		},
 	}
 
-	gotErr := Generate(t.Context(), library, &sources.Sources{Googleapis: googleapisDir}, "")
+	gotErr := Generate(t.Context(), nil, library, &sources.Sources{Googleapis: googleapisDir})
 	if !errors.Is(gotErr, syscall.ENOTDIR) {
 		t.Errorf("Generate error = %v, want %v", gotErr, syscall.ENOTDIR)
 	}
@@ -413,7 +413,7 @@ func TestGenerateLibrary(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if err := Generate(t.Context(), test.library, &sources.Sources{Googleapis: googleapisDir}, ""); err != nil {
+			if err := Generate(t.Context(), nil, test.library, &sources.Sources{Googleapis: googleapisDir}); err != nil {
 				t.Fatal(err)
 			}
 			for _, path := range test.want {


### PR DESCRIPTION
Pulls Go toolchain loading into `golang.Generate`, remove `toolchain string` from signature, add `cfg *config.Config` to signature (not uncommon in other languages). Doesn't make sweeping changes to `Generate` signature, but we may want to consider consolidating some things (like do we need `srcs *config.Sources` if we have `cfg *config.Config`?) across languages.

Fixes #5847