### PR TITLE
chore(internal/librarian): stop deriving API paths for node

### DIFF
--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -234,8 +234,8 @@ func libraryOutput(language string, lib *config.Library, defaults *config.Defaul
 func applyDefaults(language string, lib *config.Library, defaults *config.Default) (*config.Library, error) {
 	if !isVeneer(language, lib) {
 		if len(lib.APIs) == 0 && canDeriveAPIPath(language) {
-			// Do not derive API path for Go because the library name
-			// doesn't contain relevant info.
+			// Do not derive API path for some languages because the library
+			// name doesn't contain all the required info.
 			lib.APIs = append(lib.APIs, &config.API{})
 		}
 		for _, api := range lib.APIs {
@@ -261,7 +261,7 @@ func applyDefaults(language string, lib *config.Library, defaults *config.Defaul
 // derive the API path.
 func canDeriveAPIPath(language string) bool {
 	switch language {
-	case config.LanguageGo, config.LanguagePython:
+	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs:
 		return false
 	default:
 		return true

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -626,6 +626,10 @@ func TestCanDeriveAPIPath(t *testing.T) {
 			language: config.LanguagePython,
 		},
 		{
+			name:     "nodejs",
+			language: config.LanguageNodejs,
+		},
+		{
 			name:     "rust",
 			language: config.LanguageRust,
 			want:     true,


### PR DESCRIPTION
NodeJS libraries do not derive API paths from the library name. The library name doesn't include a variant (v1beta, v1 etc) so it's unsuitable for deriving an API path.

Handwritten libraries can be represented by simply omitting API paths, as is already the case for Go and Python.

Fixes #5970