### PR TITLE
chore(internal/librarian/serviceconfig): allowlist nodejs for beta APIs

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -702,6 +702,7 @@
     - dart
     - go
     - java
+    - nodejs
     - python
 - path: google/cloud/bigquery/dataexchange/v1beta1
   documentation_uri: https://cloud.google.com/bigquery/docs/analytics-hub-introduction
@@ -1960,6 +1961,7 @@
     - dart
     - go
     - java
+    - nodejs
     - python
 - path: google/cloud/oslogin/common
   languages:


### PR DESCRIPTION
google/cloud/osconfig/v1beta and
google/cloud/bigquery/connection/v1beta1 are currently generated for NodeJS, so need to be allow-listed in librarian.