### PR TITLE
fix(internal/librarian/nodejs): fix library name derivation

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -139,6 +139,8 @@ func deriveLibraryName(language string, api string) string {
 		return golang.DefaultLibraryName(api)
 	case config.LanguageJava:
 		return java.DefaultLibraryName(api)
+	case config.LanguageNodejs:
+		return nodejs.DefaultLibraryName(api)
 	case config.LanguagePython:
 		return python.DefaultLibraryName(api)
 	case config.LanguageRust:

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -575,6 +575,10 @@ func TestDeriveLibraryName(t *testing.T) {
 		{config.LanguageJava, "google/pubsub/v1", "pubsub"},
 		{config.LanguageJava, "other/api/v1", "other-api"},
 		{config.LanguageJava, "google/cloud/datacatalog/lineage/v1", "datacatalog-lineage"},
+		{config.LanguageNodejs, "google/cloud/secretmanager/v1", "google-cloud-secretmanager"},
+		{config.LanguageNodejs, "google/cloud/secretmanager/v1beta2", "google-cloud-secretmanager"},
+		{config.LanguageNodejs, "google/cloud/storage/v2alpha", "google-cloud-storage"},
+		{config.LanguageNodejs, "google/maps/addressvalidation/v1", "google-maps-addressvalidation"},
 	} {
 		t.Run(test.language+"/"+test.apiPath, func(t *testing.T) {
 			got := deriveLibraryName(test.language, test.apiPath)

--- a/internal/librarian/nodejs/add.go
+++ b/internal/librarian/nodejs/add.go
@@ -15,11 +15,25 @@
 package nodejs
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 )
+
+// DefaultLibraryName derives a library name from an API path by stripping
+// the version suffix and replacing "/" with "-".
+// For example: "google/cloud/secretmanager/v1" ->
+// "google-cloud-secretmanager".
+func DefaultLibraryName(api string) string {
+	slashPath := api
+	if serviceconfig.ExtractVersion(api) != "" {
+		// Strip version suffix (v1, v1beta2, v2alpha, etc.).
+		slashPath = filepath.Dir(api)
+	}
+	return strings.ReplaceAll(slashPath, "/", "-")
+}
 
 // FindExistingLibraryForNewAPI attempts to find an existing library that should
 // contain the given new API path. The rule is currently for matching against

--- a/internal/librarian/nodejs/add_test.go
+++ b/internal/librarian/nodejs/add_test.go
@@ -21,6 +21,27 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+func TestDefaultLibraryName(t *testing.T) {
+	for _, test := range []struct {
+		api  string
+		want string
+	}{
+		{"google/cloud/secretmanager/v1", "google-cloud-secretmanager"},
+		{"google/cloud/secretmanager/v1beta2", "google-cloud-secretmanager"},
+		{"google/cloud/storage/v2alpha", "google-cloud-storage"},
+		{"google/maps/addressvalidation/v1", "google-maps-addressvalidation"},
+		{"google/api/v1", "google-api"},
+		{"google/cloud/vision", "google-cloud-vision"},
+	} {
+		t.Run(test.api, func(t *testing.T) {
+			got := DefaultLibraryName(test.api)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestFindExistingLibraryForNewAPI(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {


### PR DESCRIPTION
The correct library name is now derived from the API name, excluding
any trailing version. Library names in Node don't include the API
variant/version - so google/cloud/functions/v1 is in
google-cloud-functions, for example. This logic is currently identical
to the Python logic, but is maintained separately so that they can
diverge easily if necessary.