### PR TITLE
refactor(internal/librarian/java): consolidate AdditionalProtos config for fine-grained generation control

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -274,7 +274,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `monolithic` | bool | Indicates whether to merge all modules (proto, grpc, gapic) into a single directory. This is currently only used for the grafeas library to maintain its legacy code structure. |
-| `additional_protos` | list of [AdditionalProto](#additionalproto-configuration) (optional) | Is a list of additional proto files to include in generation. Note: google/cloud/common_resources.proto is included by default unless OmitCommonResources is set to true. |
+| `additional_protos` | list of [AdditionalProto](#additionalproto-configuration) (optional) | Is a list of additional proto files to include in generation. By default, these files are used purely as compilation dependencies for the GAPIC generator. Note: google/cloud/common_resources.proto is included by default unless OmitCommonResources is set to true. |
 | `omit_common_resources` | bool | Indicates whether to omit the default inclusion of google/cloud/common_resources.proto. |
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `skip_proto_class_generation` | list of string | Is a list of proto files to exclude from generating proto module, but included in generating gRPC or GAPIC modules and packaged proto files. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1beta1/schema/geometry.proto"). TODO(https://github.com/googleapis/librarian/issues/5661): remove after migration. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -130,6 +130,14 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `toolchain` | string | Is the desired Go toolchain version (e.g., "go1.25.0"). |
 
+## AdditionalProto Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `path` | string | Is the path to the proto file, relative to the googleapis root. |
+| `generate_proto_classes` | bool | Indicates whether to include this proto in standard Protocol Buffer Java classes generation. |
+| `copy_to_output` | bool | Indicates whether to copy this proto to the output directory. |
+
 ## DartPackage Configuration
 
 | Field | Type | Description |
@@ -266,8 +274,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `monolithic` | bool | Indicates whether to merge all modules (proto, grpc, gapic) into a single directory. This is currently only used for the grafeas library to maintain its legacy code structure. |
-| `additional_protos` | list of string | Is a list of additional proto files to include in GAPIC generation as dependencies. They are NOT included in the standard Proto Java classes generation step and are NOT copied to the destination directory. Use this for common protos that are needed for building the client but should not be packaged with the library. Note: google/cloud/common_resources.proto is included by default unless OmitCommonResources is set to true. |
-| `additional_protos_to_generate_and_copy` | list of string | Is a list of additional proto files to include in BOTH standard Protocol Buffer Java classes generation and GAPIC generation. They ARE copied to the destination directory (src/main/proto). Use this for protos that belong to this library but are located in a different directory (e.g., common protos specific to this API). |
+| `additional_protos` | list of [AdditionalProto](#additionalproto-configuration) (optional) | Is a list of additional proto files to include in generation. Note: google/cloud/common_resources.proto is included by default unless OmitCommonResources is set to true. |
 | `omit_common_resources` | bool | Indicates whether to omit the default inclusion of google/cloud/common_resources.proto. |
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `skip_proto_class_generation` | list of string | Is a list of proto files to exclude from generating proto module, but included in generating gRPC or GAPIC modules and packaged proto files. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1beta1/schema/geometry.proto"). TODO(https://github.com/googleapis/librarian/issues/5661): remove after migration. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -558,6 +558,20 @@ type JavaModule struct {
 	SkipAPIID bool `yaml:"skip_api_id,omitempty"`
 }
 
+// AdditionalProto represents an additional proto file to include in generation.
+// If neither GenerateProtoClasses nor CopyToOutput is true, the file is used purely
+// as a compilation dependency for the GAPIC generator.
+type AdditionalProto struct {
+	// Path is the path to the proto file, relative to the googleapis root.
+	Path string `yaml:"path"`
+
+	// GenerateProtoClasses indicates whether to include this proto in standard Protocol Buffer Java classes generation.
+	GenerateProtoClasses bool `yaml:"generate_proto_classes,omitempty"`
+
+	// CopyToOutput indicates whether to copy this proto to the output directory.
+	CopyToOutput bool `yaml:"copy_to_output,omitempty"`
+}
+
 // JavaAPI represents configuration for a single API within a Java module.
 type JavaAPI struct {
 	// Monolithic indicates whether to merge all modules (proto, grpc, gapic)
@@ -565,21 +579,10 @@ type JavaAPI struct {
 	// to maintain its legacy code structure.
 	Monolithic bool `yaml:"monolithic,omitempty"`
 
-	// AdditionalProtos is a list of additional proto files to include in GAPIC generation
-	// as dependencies. They are NOT included in the standard Proto Java classes
-	// generation step and are NOT copied to the destination directory. Use this for
-	// common protos that are needed for building the client but should not be
-	// packaged with the library.
+	// AdditionalProtos is a list of additional proto files to include in generation.
 	// Note: google/cloud/common_resources.proto is included by default unless
 	// OmitCommonResources is set to true.
-	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
-
-	// AdditionalProtosToGenerateAndCopy is a list of additional proto files to include
-	// in BOTH standard Protocol Buffer Java classes generation and GAPIC generation.
-	// They ARE copied to the destination directory (src/main/proto).
-	// Use this for protos that belong to this library but are located in a different
-	// directory (e.g., common protos specific to this API).
-	AdditionalProtosToGenerateAndCopy []string `yaml:"additional_protos_to_generate_and_copy,omitempty"`
+	AdditionalProtos []*AdditionalProto `yaml:"additional_protos,omitempty"`
 
 	// OmitCommonResources indicates whether to omit the default inclusion of
 	// google/cloud/common_resources.proto.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -559,8 +559,6 @@ type JavaModule struct {
 }
 
 // AdditionalProto represents an additional proto file to include in generation.
-// If neither GenerateProtoClasses nor CopyToOutput is true, the file is used purely
-// as a compilation dependency for the GAPIC generator.
 type AdditionalProto struct {
 	// Path is the path to the proto file, relative to the googleapis root.
 	Path string `yaml:"path"`
@@ -580,6 +578,7 @@ type JavaAPI struct {
 	Monolithic bool `yaml:"monolithic,omitempty"`
 
 	// AdditionalProtos is a list of additional proto files to include in generation.
+	// By default, these files are used purely as compilation dependencies for the GAPIC generator.
 	// Note: google/cloud/common_resources.proto is included by default unless
 	// OmitCommonResources is set to true.
 	AdditionalProtos []*AdditionalProto `yaml:"additional_protos,omitempty"`

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -92,7 +92,6 @@ func isEmptyJavaAPI(j *config.JavaAPI) bool {
 	}
 	return !j.Monolithic &&
 		len(j.AdditionalProtos) == 0 &&
-		len(j.AdditionalProtosToGenerateAndCopy) == 0 &&
 		!j.OmitCommonResources &&
 		len(j.ExcludedProtos) == 0 &&
 		len(j.SkipProtoClassGeneration) == 0 &&
@@ -132,7 +131,7 @@ func Validate(library *config.Library) error {
 			continue
 		}
 		for _, p := range api.Java.AdditionalProtos {
-			if p == commonResourcesProto {
+			if p != nil && p.Path == commonResourcesProto {
 				return fmt.Errorf("%s: %w", api.Path, ErrOmitCommonResourcesConflict)
 			}
 		}

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -16,6 +16,7 @@ package java
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -79,6 +80,9 @@ func Tidy(library *config.Library) *config.Library {
 		if api.Java.GenerateResourceNames != nil && *api.Java.GenerateResourceNames {
 			api.Java.GenerateResourceNames = nil
 		}
+		api.Java.AdditionalProtos = slices.DeleteFunc(api.Java.AdditionalProtos, func(p *config.AdditionalProto) bool {
+			return p == nil || p.Path == ""
+		})
 		if isEmptyJavaAPI(api.Java) {
 			api.Java = nil
 		}

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -130,8 +130,8 @@ func Validate(library *config.Library) error {
 		if api.Java == nil || !api.Java.OmitCommonResources {
 			continue
 		}
-		for _, p := range api.Java.AdditionalProtos {
-			if p != nil && p.Path == commonResourcesProto {
+		for _, proto := range api.Java.AdditionalProtos {
+			if proto != nil && proto.Path == commonResourcesProto {
 				return fmt.Errorf("%s: %w", api.Path, ErrOmitCommonResourcesConflict)
 			}
 		}

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -300,7 +300,9 @@ func TestValidate_Error(t *testing.T) {
 						Path: "google/cloud/conflict/v1",
 						Java: &config.JavaAPI{
 							OmitCommonResources: true,
-							AdditionalProtos:    []string{"google/cloud/common_resources.proto"},
+							AdditionalProtos: []*config.AdditionalProto{
+								{Path: "google/cloud/common_resources.proto"},
+							},
 						},
 					},
 				},

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -199,6 +199,56 @@ func TestTidy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tidy empty additional protos",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						Java: &config.JavaAPI{
+							AdditionalProtos: []*config.AdditionalProto{
+								{Path: ""},
+								{Path: "google/cloud/common_resources.proto"},
+							},
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						Java: &config.JavaAPI{
+							AdditionalProtos: []*config.AdditionalProto{
+								{Path: "google/cloud/common_resources.proto"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "tidy nil additional protos",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						Java: &config.JavaAPI{
+							AdditionalProtos: []*config.AdditionalProto{
+								nil,
+							},
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := Tidy(test.lib)

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -201,20 +201,20 @@ func processAdditionalProtos(javaAPI *config.JavaAPI, googleapisDir string) (all
 	if !javaAPI.OmitCommonResources {
 		allAbs = append(allAbs, filepath.Join(googleapisDir, filepath.FromSlash(commonResourcesProto)))
 	}
-	for _, p := range javaAPI.AdditionalProtos {
-		if p == nil {
+	for _, proto := range javaAPI.AdditionalProtos {
+		if proto == nil {
 			continue
 		}
-		if p.Path == commonResourcesProto {
+		if proto.Path == commonResourcesProto {
 			continue
 		}
-		absPath := filepath.Join(googleapisDir, filepath.FromSlash(p.Path))
+		absPath := filepath.Join(googleapisDir, filepath.FromSlash(proto.Path))
 		allAbs = append(allAbs, absPath)
-		if p.GenerateProtoClasses {
+		if proto.GenerateProtoClasses {
 			toGenerateAbs = append(toGenerateAbs, absPath)
 		}
-		if p.CopyToOutput {
-			toCopyRel = append(toCopyRel, p.Path)
+		if proto.CopyToOutput {
+			toCopyRel = append(toCopyRel, proto.Path)
 		}
 	}
 	return

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -125,8 +125,8 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 	javaAPI := params.api.Java
 	primaryDir := params.srcCfg.Root(params.srcCfg.ActiveRoots[0])
 	googleapisDir := params.srcCfg.Root("googleapis")
-	additionalProtos := deriveAdditionalProtoPaths(javaAPI, googleapisDir)
-	additionalProtosToGenerateAndCopyAbs := deriveAbsoluteProtoPaths(javaAPI.AdditionalProtosToGenerateAndCopy, googleapisDir)
+	allAdditionalProtosAbs, additionalProtosToGenerateAbs,
+		additionalProtosToCopyRel := processAdditionalProtos(javaAPI, googleapisDir)
 
 	postParams := postProcessParams{
 		cfg:            params.cfg,
@@ -155,7 +155,7 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 	if len(apiProtos) == 0 {
 		return fmt.Errorf("%s: %w", params.api.Path, errNoProtos)
 	}
-	postParams.protosToCopy, err = deriveProtosToCopy(apiProtos, primaryDir, javaAPI.AdditionalProtosToGenerateAndCopy, googleapisDir)
+	postParams.protosToCopy, err = deriveProtosToCopy(apiProtos, primaryDir, additionalProtosToCopyRel, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 	// 1. Generate standard Protocol Buffer Java classes.
 	if shouldGenerateProtoGRPC(javaAPI) {
 		protoProtos := filterProtos(apiProtos, javaAPI.SkipProtoClassGeneration, primaryDir)
-		protoProtos = append(protoProtos, additionalProtosToGenerateAndCopyAbs...)
+		protoProtos = append(protoProtos, additionalProtosToGenerateAbs...)
 		args := protoProtocArgs(protoProtos, params.srcCfg, protoDir)
 		if err := runProtoc(ctx, args); err != nil {
 			return fmt.Errorf("failed to generate proto: %w", err)
@@ -182,7 +182,7 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 		if err != nil {
 			return fmt.Errorf("failed to resolve gapic options: %w", err)
 		}
-		args := gapicProtocArgs(apiProtos, append(additionalProtos, additionalProtosToGenerateAndCopyAbs...), params.srcCfg, gapicDir, gapicOpts)
+		args := gapicProtocArgs(apiProtos, allAdditionalProtosAbs, params.srcCfg, gapicDir, gapicOpts)
 		if err := runProtoc(ctx, args); err != nil {
 			return fmt.Errorf("failed to generate gapic: %w", err)
 		}
@@ -194,29 +194,30 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 	return nil
 }
 
-// deriveAdditionalProtoPaths returns the absolute paths to additional proto files
-// configured via AdditionalProtos to include in GAPIC generation. It includes
-// google/cloud/common_resources.proto unless opted out via OmitCommonResources.
-func deriveAdditionalProtoPaths(javaAPI *config.JavaAPI, googleapisDir string) []string {
-	var additionalProtos []string
+// processAdditionalProtos returns absolute paths for all additional protos (GAPIC deps),
+// absolute paths for additional protos to generate proto classes for,
+// and relative paths for additional protos to copy to the output.
+func processAdditionalProtos(javaAPI *config.JavaAPI, googleapisDir string) (allAbs []string, toGenerateAbs []string, toCopyRel []string) {
 	if !javaAPI.OmitCommonResources {
-		additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, filepath.FromSlash(commonResourcesProto)))
+		allAbs = append(allAbs, filepath.Join(googleapisDir, filepath.FromSlash(commonResourcesProto)))
 	}
 	for _, p := range javaAPI.AdditionalProtos {
-		if p == commonResourcesProto {
+		if p == nil {
 			continue
 		}
-		additionalProtos = append(additionalProtos, filepath.Join(googleapisDir, filepath.FromSlash(p)))
+		if p.Path == commonResourcesProto {
+			continue
+		}
+		absPath := filepath.Join(googleapisDir, filepath.FromSlash(p.Path))
+		allAbs = append(allAbs, absPath)
+		if p.GenerateProtoClasses {
+			toGenerateAbs = append(toGenerateAbs, absPath)
+		}
+		if p.CopyToOutput {
+			toCopyRel = append(toCopyRel, p.Path)
+		}
 	}
-	return additionalProtos
-}
-
-func deriveAbsoluteProtoPaths(paths []string, baseDir string) []string {
-	var absPaths []string
-	for _, p := range paths {
-		absPaths = append(absPaths, filepath.Join(baseDir, filepath.FromSlash(p)))
-	}
-	return absPaths
+	return
 }
 
 // deriveProtosToCopy resolves absolute and relative paths for API and additional protos.

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -935,11 +935,11 @@ func TestFilterProtos(t *testing.T) {
 
 func TestProcessAdditionalProtos(t *testing.T) {
 	for _, test := range []struct {
-		name          string
-		javaAPI       *config.JavaAPI
-		wantAll       []string
-		wantGenerate  []string
-		wantCopy      []string
+		name         string
+		javaAPI      *config.JavaAPI
+		wantAll      []string
+		wantGenerate []string
+		wantCopy     []string
 	}{
 		{
 			name:    "included by default",

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -265,7 +265,9 @@ func TestGenerateAPI(t *testing.T) {
 			{
 				Path: "google/cloud/secretmanager/v1",
 				Java: &config.JavaAPI{
-					AdditionalProtos: []string{"google/cloud/common_resources.proto"},
+					AdditionalProtos: []*config.AdditionalProto{
+						{Path: "google/cloud/common_resources.proto"},
+					},
 				},
 			},
 		},
@@ -468,7 +470,13 @@ func TestGenerateAPI_WithAdditionalProtosToGenerateAndCopy(t *testing.T) {
 			{
 				Path: "google/cloud/secretmanager/v1",
 				Java: &config.JavaAPI{
-					AdditionalProtosToGenerateAndCopy: []string{additionalProto},
+					AdditionalProtos: []*config.AdditionalProto{
+						{
+							Path:                 additionalProto,
+							GenerateProtoClasses: true,
+							CopyToOutput:         true,
+						},
+					},
 				},
 			},
 		},
@@ -925,16 +933,18 @@ func TestFilterProtos(t *testing.T) {
 	}
 }
 
-func TestDeriveAdditionalProtoPaths(t *testing.T) {
+func TestProcessAdditionalProtos(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		javaAPI *config.JavaAPI
-		want    []string
+		name          string
+		javaAPI       *config.JavaAPI
+		wantAll       []string
+		wantGenerate  []string
+		wantCopy      []string
 	}{
 		{
 			name:    "included by default",
 			javaAPI: &config.JavaAPI{},
-			want: []string{
+			wantAll: []string{
 				filepath.Join(googleapisDir, commonResourcesProto),
 			},
 		},
@@ -943,42 +953,69 @@ func TestDeriveAdditionalProtoPaths(t *testing.T) {
 			javaAPI: &config.JavaAPI{
 				OmitCommonResources: true,
 			},
-			want: nil,
 		},
 		{
 			name: "explicitly included in AdditionalProtos (still only one)",
 			javaAPI: &config.JavaAPI{
-				AdditionalProtos: []string{commonResourcesProto},
+				AdditionalProtos: []*config.AdditionalProto{
+					{Path: commonResourcesProto},
+				},
 			},
-			want: []string{
+			wantAll: []string{
 				filepath.Join(googleapisDir, commonResourcesProto),
 			},
 		},
 		{
 			name: "other additional protos",
 			javaAPI: &config.JavaAPI{
-				AdditionalProtos: []string{"other.proto"},
+				AdditionalProtos: []*config.AdditionalProto{
+					{Path: "other.proto"},
+				},
 			},
-			want: []string{
+			wantAll: []string{
 				filepath.Join(googleapisDir, commonResourcesProto),
 				filepath.Join(googleapisDir, "other.proto"),
 			},
 		},
 		{
-			name: "omitted via flag with other additional protos",
+			name: "generate and copy flags",
 			javaAPI: &config.JavaAPI{
-				OmitCommonResources: true,
-				AdditionalProtos:    []string{"other.proto"},
+				AdditionalProtos: []*config.AdditionalProto{
+					{
+						Path:                 "generate_copy.proto",
+						GenerateProtoClasses: true,
+						CopyToOutput:         true,
+					},
+					{
+						Path:                 "generate_only.proto",
+						GenerateProtoClasses: true,
+					},
+				},
 			},
-			want: []string{
-				filepath.Join(googleapisDir, "other.proto"),
+			wantAll: []string{
+				filepath.Join(googleapisDir, commonResourcesProto),
+				filepath.Join(googleapisDir, "generate_copy.proto"),
+				filepath.Join(googleapisDir, "generate_only.proto"),
+			},
+			wantGenerate: []string{
+				filepath.Join(googleapisDir, "generate_copy.proto"),
+				filepath.Join(googleapisDir, "generate_only.proto"),
+			},
+			wantCopy: []string{
+				"generate_copy.proto",
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := deriveAdditionalProtoPaths(test.javaAPI, googleapisDir)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
+			gotAll, gotGenerate, gotCopy := processAdditionalProtos(test.javaAPI, googleapisDir)
+			if diff := cmp.Diff(test.wantAll, gotAll); diff != "" {
+				t.Errorf("mismatch all (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantGenerate, gotGenerate); diff != "" {
+				t.Errorf("mismatch generate (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantCopy, gotCopy); diff != "" {
+				t.Errorf("mismatch copy (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -504,20 +504,7 @@ func applyJavaLibraryOverrides(lib *config.Library) {
 func applyJavaProtoOverrides(apiPath string, api *config.JavaAPI) {
 	for prefix, protos := range javaAdditionalProtosOverrides {
 		if strings.HasPrefix(apiPath, prefix) {
-			for _, p := range protos {
-				api.AdditionalProtos = append(api.AdditionalProtos, &config.AdditionalProto{Path: p})
-			}
-		}
-	}
-	for prefix, protos := range javaAdditionalProtosToGenerateOverrides {
-		if strings.HasPrefix(apiPath, prefix) {
-			for _, p := range protos {
-				api.AdditionalProtos = append(api.AdditionalProtos, &config.AdditionalProto{
-					Path:                 p,
-					GenerateProtoClasses: true,
-					CopyToOutput:         true,
-				})
-			}
+			api.AdditionalProtos = append(api.AdditionalProtos, protos...)
 		}
 	}
 	switch {

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -282,8 +282,12 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 				log.Printf("Warning: skipping API %s for library %s because no Java build info was found", g.ProtoPath, name)
 				continue
 			}
+			var additionalProtos []*config.AdditionalProto
+			for _, p := range info.AdditionalProtos {
+				additionalProtos = append(additionalProtos, &config.AdditionalProto{Path: p})
+			}
 			javaAPI := &config.JavaAPI{
-				AdditionalProtos:    info.AdditionalProtos,
+				AdditionalProtos:    additionalProtos,
 				OmitCommonResources: info.OmitCommonResources,
 			}
 			if info.ProtoGRPCOnly {
@@ -500,12 +504,20 @@ func applyJavaLibraryOverrides(lib *config.Library) {
 func applyJavaProtoOverrides(apiPath string, api *config.JavaAPI) {
 	for prefix, protos := range javaAdditionalProtosOverrides {
 		if strings.HasPrefix(apiPath, prefix) {
-			api.AdditionalProtos = append(api.AdditionalProtos, protos...)
+			for _, p := range protos {
+				api.AdditionalProtos = append(api.AdditionalProtos, &config.AdditionalProto{Path: p})
+			}
 		}
 	}
 	for prefix, protos := range javaAdditionalProtosToGenerateOverrides {
 		if strings.HasPrefix(apiPath, prefix) {
-			api.AdditionalProtosToGenerateAndCopy = append(api.AdditionalProtosToGenerateAndCopy, protos...)
+			for _, p := range protos {
+				api.AdditionalProtos = append(api.AdditionalProtos, &config.AdditionalProto{
+					Path:                 p,
+					GenerateProtoClasses: true,
+					CopyToOutput:         true,
+				})
+			}
 		}
 	}
 	switch {

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -14,6 +14,10 @@
 
 package main
 
+import (
+	"github.com/googleapis/librarian/internal/config"
+)
+
 type overrideKey struct {
 	libraryName string
 	apiPath     string
@@ -222,19 +226,23 @@ var (
 		"grafeas/v1": true,
 	}
 
-	javaAdditionalProtosOverrides = map[string][]string{
+	javaAdditionalProtosOverrides = map[string][]*config.AdditionalProto{
 		"schema/google/showcase/v1beta1": {
-			"google/cloud/location/locations.proto",
-			"google/iam/v1/iam_policy.proto",
+			{Path: "google/cloud/location/locations.proto"},
+			{Path: "google/iam/v1/iam_policy.proto"},
 		},
 		"google/cloud/filestore": {
-			"google/cloud/common/operation_metadata.proto",
+			{
+				Path:                 "google/cloud/common/operation_metadata.proto",
+				GenerateProtoClasses: true,
+			},
 		},
-	}
-
-	javaAdditionalProtosToGenerateOverrides = map[string][]string{
 		"google/cloud/oslogin": {
-			"google/cloud/oslogin/common/common.proto",
+			{
+				Path:                 "google/cloud/oslogin/common/common.proto",
+				GenerateProtoClasses: true,
+				CopyToOutput:         true,
+			},
 		},
 	}
 

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -62,7 +62,10 @@ func TestApplyJavaProtoOverrides(t *testing.T) {
 			path: "google/cloud/filestore/v1",
 			want: &config.JavaAPI{
 				AdditionalProtos: []*config.AdditionalProto{
-					{Path: "google/cloud/common/operation_metadata.proto"},
+					{
+						Path:                 "google/cloud/common/operation_metadata.proto",
+						GenerateProtoClasses: true,
+					},
 				},
 			},
 		},

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -61,14 +61,22 @@ func TestApplyJavaProtoOverrides(t *testing.T) {
 			name: "filestore",
 			path: "google/cloud/filestore/v1",
 			want: &config.JavaAPI{
-				AdditionalProtos: []string{"google/cloud/common/operation_metadata.proto"},
+				AdditionalProtos: []*config.AdditionalProto{
+					{Path: "google/cloud/common/operation_metadata.proto"},
+				},
 			},
 		},
 		{
 			name: "oslogin",
 			path: "google/cloud/oslogin/v1",
 			want: &config.JavaAPI{
-				AdditionalProtosToGenerateAndCopy: []string{"google/cloud/oslogin/common/common.proto"},
+				AdditionalProtos: []*config.AdditionalProto{
+					{
+						Path:                 "google/cloud/oslogin/common/common.proto",
+						GenerateProtoClasses: true,
+						CopyToOutput:         true,
+					},
+				},
 			},
 		},
 		{
@@ -80,9 +88,9 @@ func TestApplyJavaProtoOverrides(t *testing.T) {
 			name: "showcase",
 			path: "schema/google/showcase/v1beta1",
 			want: &config.JavaAPI{
-				AdditionalProtos: []string{
-					"google/cloud/location/locations.proto",
-					"google/iam/v1/iam_policy.proto",
+				AdditionalProtos: []*config.AdditionalProto{
+					{Path: "google/cloud/location/locations.proto"},
+					{Path: "google/iam/v1/iam_policy.proto"},
 				},
 			},
 		},
@@ -425,7 +433,10 @@ func TestBuildConfig(t *testing.T) {
 							{
 								Path: "schema/google/showcase/v1beta1",
 								Java: &config.JavaAPI{
-									AdditionalProtos:        []string{"google/cloud/location/locations.proto", "google/iam/v1/iam_policy.proto"},
+									AdditionalProtos: []*config.AdditionalProto{
+										{Path: "google/cloud/location/locations.proto"},
+										{Path: "google/iam/v1/iam_policy.proto"},
+									},
 									GRPCArtifactIDOverride:  "grpc-gapic-showcase-v1beta1",
 									ProtoArtifactIDOverride: "proto-gapic-showcase-v1beta1",
 									OmitCommonResources:     true,


### PR DESCRIPTION
Replaces `additional_protos` (string list) and `additional_protos_to_generate_and_copy` in the Java API configuration with a single structured `additional_protos` field. Each entry now accepts boolean flags (`generate_proto_classes` and `copy_to_output`) to decouple standard Protocol Buffer class generation from source file copying.

This structured approach natively supports a new variation needed for filestore case: generating proto classes without copying the source `.proto` files to the output repository.

Also updated migrate tool hardcoded value for "google/cloud/filestore".


Fixes #6001