### PR TITLE
fix(tool/cmd/migrate): support outputDir prefixed deep-preserve-regex paths

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -427,8 +427,9 @@ func parseOwlBotKeep(repoPath, outputDir string) ([]string, error) {
 			return err
 		}
 		rel = filepath.ToSlash(rel)
+		matchPath := outputDir + "/" + rel
 		for _, re := range compiledRegexes {
-			if re.MatchString(rel) {
+			if re.MatchString(matchPath) || re.MatchString(rel) {
 				keeps = append(keeps, rel)
 				break
 			}

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -1018,6 +1018,7 @@ func TestParseOwlBotKeep(t *testing.T) {
 				"google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java",
 				"google-cloud-vision/src/test/resources/placeholder.txt",
 				"proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ImageName.java",
+				"proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/PrefixedName.java",
 			},
 		},
 		{

--- a/tool/cmd/migrate/testdata/google-cloud-java/java-vision/.OwlBot-hermetic.yaml
+++ b/tool/cmd/migrate/testdata/google-cloud-java/java-vision/.OwlBot-hermetic.yaml
@@ -15,5 +15,6 @@ deep-preserve-regex:
   - "/.*google-.*/src/main/java/.*/stub/Version.java"
   - "/.*google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
   - "/.*proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ImageName.java"
+  - "/java-vision/proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/PrefixedName.java"
   - "/.*google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java"
   - "/.*google-cloud-vision/src/test/resources/placeholder.txt"

--- a/tool/cmd/migrate/testdata/google-cloud-java/java-vision/proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/PrefixedName.java
+++ b/tool/cmd/migrate/testdata/google-cloud-java/java-vision/proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/PrefixedName.java
@@ -1,0 +1,1 @@
+/* placeholder */

--- a/tool/cmd/migrate/testdata/google-cloud-java/java-vision/proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/PrefixedName.java
+++ b/tool/cmd/migrate/testdata/google-cloud-java/java-vision/proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/PrefixedName.java
@@ -1,1 +1,17 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* placeholder */


### PR DESCRIPTION
Updates parseOwlBotKeep to match both the direct relative file path and the relative path prefixed with outputDir. 

For https://github.com/googleapis/librarian/issues/6012