### PR TITLE
fix(legacylibrarian): sync preview versions

### DIFF
--- a/internal/legacylibrarian/legacylibrarian/release_stage.go
+++ b/internal/legacylibrarian/legacylibrarian/release_stage.go
@@ -404,6 +404,9 @@ func syncVersion(state *legacyconfig.LibrarianState, cfg *config.Config) (*confi
 	return cfg, nil
 }
 
+// syncLibraryVersion checks that the verison in librarian.yaml is not greater than the same in
+// .librarian/state.yaml, which would imply version drift. Once that check is complete, it sets the library's
+// version in librarian.yaml to match that of .librarian/state.yaml, which is the current source of truth.
 func syncLibraryVersion(name string, state *legacyconfig.LibrarianState, currentVersion string) (string, error) {
 	legacyLibrary := state.LibraryByID(name)
 	if legacyLibrary == nil || legacyLibrary.Version == "" {

--- a/internal/legacylibrarian/legacylibrarian/release_stage.go
+++ b/internal/legacylibrarian/legacylibrarian/release_stage.go
@@ -388,17 +388,30 @@ func (r *stageRunner) updateLibrarianYAML(ctx context.Context) error {
 
 func syncVersion(state *legacyconfig.LibrarianState, cfg *config.Config) (*config.Config, error) {
 	for _, lib := range cfg.Libraries {
-		legacyLibrary := state.LibraryByID(lib.Name)
-		if legacyLibrary == nil || legacyLibrary.Version == "" {
-			continue
+		var err error
+		lib.Version, err = syncLibraryVersion(lib.Name, state, lib.Version)
+		if err != nil {
+			return nil, err
 		}
-		maxVersion := semver.MaxVersion(lib.Version, legacyLibrary.Version)
-		if maxVersion == lib.Version && legacyLibrary.Version != lib.Version {
-			// lib.Version is greater than legacyLibrary.Version, something is
-			// wrong, fail in this case.
-			return nil, fmt.Errorf("library %s, version in state, %s, is smaller than version in librarian.yaml, %s: %w", lib.Name, legacyLibrary.Version, lib.Version, errVersionRegression)
+
+		if lib.Preview != nil {
+			lib.Preview.Version, err = syncLibraryVersion(lib.Name+"-preview", state, lib.Preview.Version)
+			if err != nil {
+				return nil, err
+			}
 		}
-		lib.Version = legacyLibrary.Version
 	}
 	return cfg, nil
+}
+
+func syncLibraryVersion(name string, state *legacyconfig.LibrarianState, currentVersion string) (string, error) {
+	legacyLibrary := state.LibraryByID(name)
+	if legacyLibrary == nil || legacyLibrary.Version == "" {
+		return currentVersion, nil
+	}
+	maxVersion := semver.MaxVersion(currentVersion, legacyLibrary.Version)
+	if maxVersion == currentVersion && legacyLibrary.Version != currentVersion {
+		return "", fmt.Errorf("library %s, version in state, %s, is smaller than version in librarian.yaml, %s: %w", name, legacyLibrary.Version, currentVersion, errVersionRegression)
+	}
+	return legacyLibrary.Version, nil
 }

--- a/internal/legacylibrarian/legacylibrarian/release_stage.go
+++ b/internal/legacylibrarian/legacylibrarian/release_stage.go
@@ -404,7 +404,7 @@ func syncVersion(state *legacyconfig.LibrarianState, cfg *config.Config) (*confi
 	return cfg, nil
 }
 
-// syncLibraryVersion checks that the verison in librarian.yaml is not greater than the same in
+// syncLibraryVersion checks that the version in librarian.yaml is not greater than the same in
 // .librarian/state.yaml, which would imply version drift. Once that check is complete, it sets the library's
 // version in librarian.yaml to match that of .librarian/state.yaml, which is the current source of truth.
 func syncLibraryVersion(name string, state *legacyconfig.LibrarianState, currentVersion string) (string, error) {

--- a/internal/legacylibrarian/legacylibrarian/release_stage_test.go
+++ b/internal/legacylibrarian/legacylibrarian/release_stage_test.go
@@ -2198,6 +2198,55 @@ func TestSyncVersion(t *testing.T) {
 				{Name: "lib1", Version: "1.0.0"},
 			},
 		},
+		{
+			name: "sync preview version when present",
+			legacyLibraries: []*legacyconfig.LibraryState{
+				{ID: "lib1", Version: "1.1.0"},
+				{ID: "lib1-preview", Version: "1.1.0-preview.2"},
+			},
+			libraries: []*config.Library{
+				{
+					Name:    "lib1",
+					Version: "1.0.0",
+					Preview: &config.Library{
+						Version: "1.1.0-preview.1",
+					},
+				},
+			},
+			want: []*config.Library{
+				{
+					Name:    "lib1",
+					Version: "1.1.0",
+					Preview: &config.Library{
+						Version: "1.1.0-preview.2",
+					},
+				},
+			},
+		},
+		{
+			name: "sync preview version when main library is missing in state",
+			legacyLibraries: []*legacyconfig.LibraryState{
+				{ID: "lib1-preview", Version: "1.1.0-preview.2"},
+			},
+			libraries: []*config.Library{
+				{
+					Name:    "lib1",
+					Version: "1.0.0",
+					Preview: &config.Library{
+						Version: "1.1.0-preview.1",
+					},
+				},
+			},
+			want: []*config.Library{
+				{
+					Name:    "lib1",
+					Version: "1.0.0",
+					Preview: &config.Library{
+						Version: "1.1.0-preview.2",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			state := &legacyconfig.LibrarianState{Libraries: test.legacyLibraries}
@@ -2214,20 +2263,46 @@ func TestSyncVersion(t *testing.T) {
 }
 
 func TestSyncVersion_Error(t *testing.T) {
-	state := &legacyconfig.LibrarianState{
-		Libraries: []*legacyconfig.LibraryState{
-			{ID: "lib1", Version: "1.0.0"},
-		},
-	}
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{Name: "lib1", Version: "1.1.0"},
-		},
-	}
-	_, err := syncVersion(state, cfg)
-	if !errors.Is(err, errVersionRegression) {
-		t.Errorf("got error %v, want %v", err, errVersionRegression)
-	}
+	t.Run("main library regression", func(t *testing.T) {
+		state := &legacyconfig.LibrarianState{
+			Libraries: []*legacyconfig.LibraryState{
+				{ID: "lib1", Version: "1.0.0"},
+			},
+		}
+		cfg := &config.Config{
+			Libraries: []*config.Library{
+				{Name: "lib1", Version: "1.1.0"},
+			},
+		}
+		_, err := syncVersion(state, cfg)
+		if !errors.Is(err, errVersionRegression) {
+			t.Errorf("got error %v, want %v", err, errVersionRegression)
+		}
+	})
+
+	t.Run("preview library regression", func(t *testing.T) {
+		state := &legacyconfig.LibrarianState{
+			Libraries: []*legacyconfig.LibraryState{
+				{ID: "lib1", Version: "1.1.0"},
+				{ID: "lib1-preview", Version: "1.1.0-preview.1"},
+			},
+		}
+		cfg := &config.Config{
+			Libraries: []*config.Library{
+				{
+					Name:    "lib1",
+					Version: "1.0.0",
+					Preview: &config.Library{
+						Version: "1.1.0-preview.2",
+					},
+				},
+			},
+		}
+		_, err := syncVersion(state, cfg)
+		if !errors.Is(err, errVersionRegression) {
+			t.Errorf("got error %v, want %v", err, errVersionRegression)
+		}
+	})
 }
 
 func TestUpdateLibrarianYAML(t *testing.T) {


### PR DESCRIPTION
If a Library has a Preview client, make sure its version is synced as well.

Preview clients will have state.yaml entries upon add as of #5963.

Towards #5894