### PR TITLE
ci: re-enable google-cloud-go integration job

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,7 +28,7 @@ jobs:
         run: go run ./tool/cmd/coverage ./internal/librarian/golang
   integration:
     runs-on: ubuntu-24.04
-    if: false # Temporarily disabled for Go configuration migration (Issue #5471)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian


### PR DESCRIPTION
The librarian.yaml file in google-cloud-go has been updated in https://github.com/googleapis/google-cloud-go/pull/14587 (merged). Let's bring back the integration test.