### PR TITLE
feat(internal/librarian/nodejs): remove synthtool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,3 @@ go.work.sum
 
 # VSCode file
 .vscode/*
-AGENT_WORKFLOW.md
-bin/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ go.work.sum
 
 # VSCode file
 .vscode/*
+AGENT_WORKFLOW.md
+bin/

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -234,7 +234,7 @@ ARG NODEJS_PROTOC_VERSION
 ARG NODEJS_PROTOC_CHECKSUM
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 nodejs npm \
+    nodejs npm \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node-specific protoc version

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -234,7 +234,7 @@ ARG NODEJS_PROTOC_VERSION
 ARG NODEJS_PROTOC_CHECKSUM
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv nodejs npm \
+    python3 nodejs npm \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node-specific protoc version
@@ -243,20 +243,8 @@ RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
     echo "${NODEJS_PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip
 
-# Make sure Python uses /python-packages for all installations.
-# This makes it easier to predict where things are installed, e.g. for
-# SYNTHTOOL_TEMPLATES later.
-ENV PYTHONPATH=/python-packages
-ENV PATH=${PATH}:${PYTHONPATH}/bin
-# Specify where pip should install, and disable its cache.
-ENV PIP_TARGET=${PYTHONPATH}
-ENV PIP_NO_CACHE_DIR=1
-
 # Install all the tools that Librarian needs for Node generation.
 RUN /app/librarian install nodejs -v
-
-# Ensure we use the local synthtool templates.
-ENV SYNTHTOOL_TEMPLATES=${PYTHONPATH}/synthtool/gcp/templates
 
 # Allow normal users to read /root (as the generator is installed
 # in /root/.cache, for example)

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -242,21 +242,6 @@ func buildGeneratorArgs(api *config.API, library *config.Library, googleapisDir,
 // runPostProcessor combines versioned API outputs from owl-bot-staging/ into
 // the output directory using gapic-node-processing, then compiles protos.
 func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.Library, googleapisDir, repoRoot, outDir string) error {
-	owlbotPath := filepath.Join(outDir, "owlbot.py")
-	if _, err := os.Stat(owlbotPath); err == nil {
-		// Old way: use synthtool
-		if err := command.RunInDir(ctx, outDir, "python3", "owlbot.py"); err != nil {
-			return fmt.Errorf("owlbot.py failed: %w", err)
-		}
-		return nil
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to check for owlbot.py: %w", err)
-	}
-
-	// Template generation and exclusions are handled at the generator level.
-	// Synthtool is only used for post-processing handled by standalone scripts
-	// like librarian.js and owlbot.py. (Note: librarian.js is unrelated to the
-	// Librarian CLI tool).
 
 	// combine-library wipes the destination directory before writing generated
 	// files (src/, protos/). Save the keep files it would delete, then restore

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -361,33 +361,6 @@ func TestBuildGeneratorArgs(t *testing.T) {
 	}
 }
 
-func TestRunPostProcessor_Owlbot(t *testing.T) {
-	testhelper.RequireCommand(t, "python3")
-
-	repoRoot := t.TempDir()
-	library := &config.Library{Name: "google-cloud-test"}
-	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	owlbotScript := filepath.Join(outDir, "owlbot.py")
-	if err := os.WriteFile(owlbotScript, []byte("import pathlib\npathlib.Path('owlbot-ran.txt').write_text('yes')\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &config.Config{
-		Language: config.LanguageNodejs,
-		Repo:     "googleapis/google-cloud-node",
-	}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(filepath.Join(outDir, "owlbot-ran.txt")); err != nil {
-		t.Errorf("expected owlbot.py to run and create owlbot-ran.txt: %v", err)
-	}
-}
-
 func TestGenerateAPI(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow test: Node.js GAPIC code generation")

--- a/internal/librarian/nodejs/librarian.yaml
+++ b/internal/librarian/nodejs/librarian.yaml
@@ -33,7 +33,3 @@ tools:
       version: "0.1.8"
     - name: gapic-tools
       version: "1.0.5"
-  pip:
-    - name: synthtool
-      version: "5aa438a342707842d11fbbb302c6277fbf9e4655"
-      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@5aa438a342707842d11fbbb302c6277fbf9e4655"


### PR DESCRIPTION
`google-cloud-node` removed `synthtool` entirely, which simplifies the container environment, reduces build dependencies, and eliminates unnecessary execution overhead. This change removes all `synthtool` code from `generate`.
