### PR TITLE
chore(internal/librarian/nodejs): remove pip installation code

### DIFF
--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -56,15 +56,6 @@ func Install(ctx context.Context) error {
 			return err
 		}
 	}
-	for _, tool := range cfg.Tools.Pip {
-		pkg := tool.Package
-		if pkg == "" {
-			pkg = fmt.Sprintf("%s==%s", tool.Name, tool.Version)
-		}
-		if err := command.RunStreaming(ctx, "pip", "install", pkg); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -68,9 +68,6 @@ chmod +x node_modules/.bin/tsc
 	if err := os.WriteFile(filepath.Join(bin, "npm"), []byte(npmStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(bin, "pip"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	if err := Install(t.Context()); err != nil {


### PR DESCRIPTION
We no longer use Python at all during Node generation, so we don't need to handle Tools.Pip in the Install function.