### PR TITLE
chore(tool/cmd/migrate): ignore metadata when migrating NodeJS

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -221,9 +221,6 @@ func buildGeneratorArgs(api *config.API, library *config.Library, googleapisDir,
 			args = append(args, "--bundle-config", library.Nodejs.BundleConfig)
 		}
 		for _, param := range library.Nodejs.ExtraProtocParameters {
-			if param == "metadata" {
-				continue
-			}
 			args = append(args, "--"+param)
 		}
 		if library.Nodejs.HandwrittenLayer {

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -298,29 +298,6 @@ func TestBuildGeneratorArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "metadata in extra params is skipped",
-			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
-			library: &config.Library{
-				Name: "google-cloud-secretmanager",
-				Nodejs: &config.NodejsPackage{
-					ExtraProtocParameters: []string{"metadata", "some-other-param"},
-				},
-			},
-			want: []string{
-				"gapic-generator-typescript",
-				"--protoc=" + protocPath,
-				"--common-proto-path=.",
-				"-I", ".",
-				"--output-dir", "staging",
-				"--grpc-service-config", "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json",
-				"--service-yaml", "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
-				"--package-name", "@google-cloud/secretmanager",
-				"--metadata",
-				"--rest-numeric-enums",
-				"--some-other-param",
-			},
-		},
-		{
 			name: "DIREGAPIC support",
 			api:  &config.API{Path: "google/cloud/secretmanager/v1"},
 			library: &config.Library{

--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -356,10 +357,17 @@ func parseBazelNodejsInfo(googleapisDir, apiDir string) (*nodejsGapicInfo, error
 		return nil, fmt.Errorf("file %s/BUILD.bazel contains multiple nodejs_gapic_library rules", apiDir)
 	}
 	rule := rules[0]
+	extraProtocParameters := rule.AttrStrings("extra_protoc_parameters")
+	extraProtocParameters = slices.DeleteFunc(extraProtocParameters, func(p string) bool {
+		return p == "metadata"
+	})
+	if len(extraProtocParameters) == 0 {
+		extraProtocParameters = nil
+	}
 	info := &nodejsGapicInfo{
 		packageName:           rule.AttrString("package_name"),
 		bundleConfig:          rule.AttrString("bundle_config"),
-		extraProtocParameters: rule.AttrStrings("extra_protoc_parameters"),
+		extraProtocParameters: extraProtocParameters,
 		mainService:           rule.AttrString("main_service"),
 		mixins:                rule.AttrString("mixins"),
 	}

--- a/tool/cmd/migrate/nodejs_test.go
+++ b/tool/cmd/migrate/nodejs_test.go
@@ -37,8 +37,7 @@ func TestBuildNodejsLibraries(t *testing.T) {
 				{Path: "google/cloud/secretmanager/v1"},
 			},
 			Nodejs: &config.NodejsPackage{
-				ExtraProtocParameters: []string{"metadata"},
-				PackageName:           "@google-cloud/secret-manager",
+				PackageName: "@google-cloud/secret-manager",
 			},
 		},
 		{
@@ -52,7 +51,6 @@ func TestBuildNodejsLibraries(t *testing.T) {
 					"@google-cloud/common": "^6.0.0",
 					"pumpify":              "^2.0.1",
 				},
-				ExtraProtocParameters: []string{"metadata"},
 			},
 		},
 		{
@@ -64,7 +62,6 @@ func TestBuildNodejsLibraries(t *testing.T) {
 			Nodejs: &config.NodejsPackage{
 				BundleConfig: "google/cloud/translate/v3/translate_gapic.yaml",
 				ExtraProtocParameters: []string{
-					"metadata",
 					"auto-populate-field-oauth-scope",
 				},
 				HandwrittenLayer: true,
@@ -78,9 +75,7 @@ func TestBuildNodejsLibraries(t *testing.T) {
 			APIs: []*config.API{
 				{Path: "google/cloud/workstations/v1"},
 			},
-			Nodejs: &config.NodejsPackage{
-				ExtraProtocParameters: []string{"metadata"},
-			},
+			Nodejs: &config.NodejsPackage{},
 		},
 	}
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b *config.Library) bool { return a.Name < b.Name })); diff != "" {
@@ -134,8 +129,7 @@ func TestParseBazelNodejsInfo(t *testing.T) {
 			name: "secretmanager",
 			api:  "google/cloud/secretmanager/v1",
 			want: &nodejsGapicInfo{
-				packageName:           "@google-cloud/secret-manager",
-				extraProtocParameters: []string{"metadata"},
+				packageName: "@google-cloud/secret-manager",
 			},
 		},
 		{
@@ -145,7 +139,6 @@ func TestParseBazelNodejsInfo(t *testing.T) {
 				packageName:  "@google-cloud/translate",
 				bundleConfig: "google/cloud/translate/v3/translate_gapic.yaml",
 				extraProtocParameters: []string{
-					"metadata",
 					"auto-populate-field-oauth-scope",
 				},
 				handwrittenLayer: true,


### PR DESCRIPTION
Rather than ignore a "metadata" protoc parameter when generating (and always specify it unconditionally), ignore it when migrating.

Fixes #6023