### PR TITLE
feat(internal/librarian): allow java to update existing library with librarian add

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -260,7 +260,7 @@ func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api 
 			return "", nil, err
 		}
 		existingLib.APIs = append(existingLib.APIs, api)
-	case config.LanguageGo, config.LanguageNodejs:
+	case config.LanguageGo, config.LanguageJava, config.LanguageNodejs:
 		existingLib.APIs = append(existingLib.APIs, api)
 	default:
 		return "", nil, fmt.Errorf("%w: %s", errLibraryAlreadyExists, existingLib.Name)

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -372,6 +372,36 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "update existing library (java)",
+			apiPath: "google/cloud/secretmanager/v1beta2",
+			cfg: &config.Config{
+				Language: config.LanguageJava,
+				Libraries: []*config.Library{
+					{
+						Name:    "secretmanager",
+						Version: "1.2.3",
+						APIs: []*config.API{
+							{Path: "google/cloud/secretmanager/v1"},
+						},
+					},
+				},
+			},
+			wantName: "secretmanager",
+			wantCfg: &config.Config{
+				Language: config.LanguageJava,
+				Libraries: []*config.Library{
+					{
+						Name:    "secretmanager",
+						Version: "1.2.3",
+						APIs: []*config.API{
+							{Path: "google/cloud/secretmanager/v1"},
+							{Path: "google/cloud/secretmanager/v1beta2"},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
@@ -417,23 +447,6 @@ func TestAddLibrary_ExistingLibrary_Error(t *testing.T) {
 				},
 			},
 			wantErr: errAPIAlreadyExists,
-		},
-		{
-			name:    "java doesn't support updating existing library",
-			apiPath: "google/cloud/secretmanager/v1beta2",
-			cfg: &config.Config{
-				Language: config.LanguageJava,
-				Libraries: []*config.Library{
-					{
-						Name:    "secretmanager",
-						Version: "1.2.3",
-						APIs: []*config.API{
-							{Path: "google/cloud/secretmanager/v1"},
-						},
-					},
-				},
-			},
-			wantErr: errLibraryAlreadyExists,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
When running librarian add with API path that belongs to existing library in Java, allow it to append API to the existing library.

Fixes https://github.com/googleapis/librarian/issues/6027