### PR TITLE
chore(tool/cmd/migrate): add firestore native-image configurations to java keep overrides

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -77,6 +77,10 @@ var (
 			"gapic-showcase/src/test",
 			"gapic-showcase/src/main/java/com/google/showcase/v1beta1/Version.java",
 		},
+		"firestore": {
+			"google-cloud-firestore/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-firestore/reflect-config.json",
+			"google-cloud-firestore/src/test/resources/META-INF/native-image/reflect-config.json",
+		},
 	}
 
 	javaArtifactIDOverrides = map[overrideKey]javaArtifactOverrides{


### PR DESCRIPTION
Add the paths for main and test reflect-config.json files in google-cloud-firestore to the hardcoded keepOverrides list for Java libraries. This ensures these GraalVM native-image configuration files are preserved when running the migrate tool.

For #6012