### PR TITLE
feat(librarian/internal/java): tidy can remove default group id and emtpy java module in librarian.yaml

### DIFF
--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -64,6 +64,14 @@ func Tidy(library *config.Library) *config.Library {
 	if library.Output == deriveOutput(library.Name) {
 		library.Output = ""
 	}
+	if library.Java != nil {
+		if library.Java.GroupID == "com.google.cloud" {
+			library.Java.GroupID = ""
+		}
+		if isEmptyJavaModule(library.Java) {
+			library.Java = nil
+		}
+	}
 	for _, api := range library.APIs {
 		if api.Java == nil {
 			continue
@@ -107,6 +115,37 @@ func isEmptyJavaAPI(j *config.JavaAPI) bool {
 		j.GenerateResourceNames == nil &&
 		len(j.CopyFiles) == 0 &&
 		j.Samples == nil
+}
+
+func isEmptyJavaModule(j *config.JavaModule) bool {
+	if j == nil {
+		return true
+	}
+	return j.APIIDOverride == "" &&
+		j.APIReference == "" &&
+		j.APIDescriptionOverride == "" &&
+		j.APIShortnameOverride == "" &&
+		j.ClientDocumentationOverride == "" &&
+		!j.NonCloudAPI &&
+		j.CodeownerTeam == "" &&
+		j.DistributionNameOverride == "" &&
+		j.ExcludedDependencies == "" &&
+		len(j.ExcludedPOMs) == 0 &&
+		j.ExtraVersionedModules == "" &&
+		j.GroupID == "" &&
+		j.IssueTrackerOverride == "" &&
+		j.LibrariesBOMVersion == "" &&
+		j.LibraryTypeOverride == "" &&
+		j.MinJavaVersion == 0 &&
+		j.NamePrettyOverride == "" &&
+		j.ProductDocumentationOverride == "" &&
+		j.RecommendedPackage == "" &&
+		!j.BillingNotRequired &&
+		j.RestDocumentation == "" &&
+		j.RpcDocumentation == "" &&
+		j.TransportOverride == "" &&
+		!j.SkipPOMUpdates &&
+		!j.SkipAPIID
 }
 
 var (

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -249,6 +249,28 @@ func TestTidy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tidy default group id",
+			lib: &config.Library{
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
+			},
+			want: &config.Library{},
+		},
+		{
+			name: "do not tidy custom group id",
+			lib: &config.Library{
+				Java: &config.JavaModule{
+					GroupID: "com.google.analytics",
+				},
+			},
+			want: &config.Library{
+				Java: &config.JavaModule{
+					GroupID: "com.google.analytics",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := Tidy(test.lib)


### PR DESCRIPTION
Default group id ("com.google.cloud") is removed by Tidy, and remove JavaModule if empty after removing group_id.

For #6035

