### PR TITLE
refactor(librarian/internal/java): fill default Java.GroupID

### DIFF
--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -81,6 +81,9 @@ func TestClean(t *testing.T) {
 				Java: &config.JavaAPI{},
 			},
 		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
+		},
 	}
 	if err := Clean(lib); err != nil {
 		t.Fatal(err)
@@ -248,6 +251,9 @@ func TestCleanPatterns(t *testing.T) {
 						Java: &config.JavaAPI{},
 					},
 				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 			want: map[string]bool{
 				filepath.Join("google-cloud-secretmanager", "src"):          true,
@@ -274,6 +280,9 @@ func TestCleanPatterns(t *testing.T) {
 						},
 					},
 				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 			want: map[string]bool{
 				"google-cloud-accesscontextmanager/src":            true,
@@ -290,6 +299,7 @@ func TestCleanPatterns(t *testing.T) {
 			library: &config.Library{
 				Name: "secretmanager",
 				Java: &config.JavaModule{
+					GroupID:                  "com.google.cloud",
 					DistributionNameOverride: "com.google.cloud:secretmanager-special",
 				},
 				APIs: []*config.API{
@@ -321,6 +331,9 @@ func TestCleanPatterns(t *testing.T) {
 						Java: &config.JavaAPI{},
 					},
 				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 			want: map[string]bool{
 				filepath.Join("google-cloud-secretmanager", "src"):               true,
@@ -343,6 +356,9 @@ func TestCleanPatterns(t *testing.T) {
 							GAPICArtifactIDOverride: "custom-gapic-artifact",
 						},
 					},
+				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
 				},
 			},
 			want: map[string]bool{

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -71,7 +71,7 @@ func Tidy(library *config.Library) *config.Library {
 		library.Output = ""
 	}
 	if library.Java != nil {
-		if library.Java.GroupID == "com.google.cloud" {
+		if library.Java.GroupID == defaultGroupID {
 			library.Java.GroupID = ""
 		}
 		if isEmptyJavaModule(library.Java) {

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -22,7 +22,10 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-const javaPrefix = "java-"
+const (
+	javaPrefix     = "java-"
+	defaultGroupID = "com.google.cloud"
+)
 
 // deriveOutput computes the default output directory name for a given library name.
 func deriveOutput(name string) string {
@@ -36,6 +39,9 @@ func Fill(library *config.Library) (*config.Library, error) {
 	}
 	if library.Java == nil {
 		library.Java = &config.JavaModule{}
+	}
+	if library.Java.GroupID == "" {
+		library.Java.GroupID = defaultGroupID
 	}
 	for _, api := range library.APIs {
 		if api.Java == nil {

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -115,7 +115,7 @@ func TestFill(t *testing.T) {
 			},
 		},
 		{
-			name: "do not overwrite group id",
+			name: "do not overwrite non-default group id",
 			lib: &config.Library{
 				Name: "secretmanager",
 				Java: &config.JavaModule{

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -36,7 +36,9 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "java-secretmanager",
-				Java:   &config.JavaModule{},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 		},
 		{
@@ -48,7 +50,9 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:   "secretmanager",
 				Output: "custom-output",
-				Java:   &config.JavaModule{},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 		},
 		{
@@ -73,7 +77,9 @@ func TestFill(t *testing.T) {
 						},
 					},
 				},
-				Java: &config.JavaModule{},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 		},
 		{
@@ -103,7 +109,25 @@ func TestFill(t *testing.T) {
 						},
 					},
 				},
-				Java: &config.JavaModule{},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
+			},
+		},
+		{
+			name: "do not overwrite group id",
+			lib: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{
+					GroupID: "com.google.custom",
+				},
+			},
+			want: &config.Library{
+				Name:   "secretmanager",
+				Output: "java-secretmanager",
+				Java: &config.JavaModule{
+					GroupID: "com.google.custom",
+				},
 			},
 		},
 	} {

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -47,7 +47,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 		{
 			name:    "basic case",
 			cfg:     &config.Config{Repo: "googleapis/google-cloud-java"},
-			library: &config.Library{Name: "secretmanager"},
+			library: &config.Library{Name: "secretmanager", Java: &config.JavaModule{GroupID: "com.google.cloud"}},
 			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			apiCfgs: &serviceconfig.API{Transports: map[string]serviceconfig.Transport{
 				config.LanguageJava: serviceconfig.GRPCRest,
@@ -66,7 +66,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 		{
 			name:    "rest transport",
 			cfg:     &config.Config{Repo: "googleapis/google-cloud-java"},
-			library: &config.Library{Name: "secretmanager"},
+			library: &config.Library{Name: "secretmanager", Java: &config.JavaModule{GroupID: "com.google.cloud"}},
 			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			apiCfgs: &serviceconfig.API{Transports: map[string]serviceconfig.Transport{
 				config.LanguageJava: serviceconfig.Rest,
@@ -85,7 +85,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 		{
 			name:    "no rest numeric enum case",
 			cfg:     &config.Config{Repo: "googleapis/google-cloud-java"},
-			library: &config.Library{Name: "secretmanager"},
+			library: &config.Library{Name: "secretmanager", Java: &config.JavaModule{GroupID: "com.google.cloud"}},
 			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			apiCfgs: &serviceconfig.API{
 				Transports: map[string]serviceconfig.Transport{
@@ -106,7 +106,7 @@ func TestResolveGAPICOptions(t *testing.T) {
 		{
 			name:    "default transport with no apiCfgs",
 			cfg:     &config.Config{Repo: "googleapis/google-cloud-java"},
-			library: &config.Library{Name: "secretmanager"},
+			library: &config.Library{Name: "secretmanager", Java: &config.JavaModule{GroupID: "com.google.cloud"}},
 			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			apiCfgs: &serviceconfig.API{},
 			want: []string{
@@ -170,7 +170,7 @@ func TestResolveGAPICOptions_MultipleConfigsError(t *testing.T) {
 			apiCfgs := &serviceconfig.API{Transports: map[string]serviceconfig.Transport{
 				config.LanguageJava: serviceconfig.GRPC,
 			}}
-			_, err := resolveGAPICOptions(&config.Config{Repo: "test-repo"}, &config.Library{Name: "test"}, &config.API{Path: test.apiPath}, tmpDir, apiCfgs)
+			_, err := resolveGAPICOptions(&config.Config{Repo: "test-repo"}, &config.Library{Name: "test", Java: &config.JavaModule{GroupID: "com.google.cloud"}}, &config.API{Path: test.apiPath}, tmpDir, apiCfgs)
 			if err == nil {
 				t.Fatal("resolveGAPICOptions() error = nil, want non-nil")
 			}

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -159,10 +159,6 @@ func DeriveDistributionName(library *config.Library) string {
 	if library.Java != nil && library.Java.DistributionNameOverride != "" {
 		return library.Java.DistributionNameOverride
 	}
-	groupID := defaultGroupID
-	if library.Java != nil && library.Java.GroupID != "" {
-		groupID = library.Java.GroupID
-	}
 	artifactID := ensureCloudPrefix(library.Name)
-	return fmt.Sprintf("%s:%s", groupID, artifactID)
+	return fmt.Sprintf("%s:%s", library.Java.GroupID, artifactID)
 }

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -159,7 +159,7 @@ func DeriveDistributionName(library *config.Library) string {
 	if library.Java != nil && library.Java.DistributionNameOverride != "" {
 		return library.Java.DistributionNameOverride
 	}
-	groupID := "com.google.cloud"
+	groupID := defaultGroupID
 	if library.Java != nil && library.Java.GroupID != "" {
 		groupID = library.Java.GroupID
 	}

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -29,7 +29,7 @@ func TestDeriveDistributionName(t *testing.T) {
 	}{
 		{
 			name:    "default case",
-			library: &config.Library{Name: "secretmanager"},
+			library: &config.Library{Name: "secretmanager", Java: &config.JavaModule{GroupID: "com.google.cloud"}},
 			want:    "com.google.cloud:google-cloud-secretmanager",
 		},
 		{
@@ -44,13 +44,13 @@ func TestDeriveDistributionName(t *testing.T) {
 			name: "distributionName override",
 			library: &config.Library{
 				Name: "secretmanager",
-				Java: &config.JavaModule{DistributionNameOverride: "com.google.cloud:google-cloud-secretmanager-v1"},
+				Java: &config.JavaModule{GroupID: "com.google.cloud", DistributionNameOverride: "com.google.cloud:google-cloud-secretmanager-v1"},
 			},
 			want: "com.google.cloud:google-cloud-secretmanager-v1",
 		},
 		{
 			name:    "library name already has prefix",
-			library: &config.Library{Name: "google-cloud-secretmanager"},
+			library: &config.Library{Name: "google-cloud-secretmanager", Java: &config.JavaModule{GroupID: "com.google.cloud"}},
 			want:    "com.google.cloud:google-cloud-secretmanager",
 		},
 	} {
@@ -110,6 +110,7 @@ func TestDeriveLibraryCoordinates(t *testing.T) {
 			library: &config.Library{
 				Name:    "secretmanager",
 				Version: "1.2.3",
+				Java:    &config.JavaModule{GroupID: "com.google.cloud"},
 			},
 			want: LibraryCoordinate{
 				GAPIC: Coordinate{
@@ -135,6 +136,7 @@ func TestDeriveLibraryCoordinates(t *testing.T) {
 				Name:    "secretmanager",
 				Version: "1.2.3",
 				Java: &config.JavaModule{
+					GroupID:                  "com.google.cloud",
 					DistributionNameOverride: "com.google.cloud:google-secretmanager",
 				},
 			},

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -44,6 +44,9 @@ func TestSyncPOMs_Golden(t *testing.T) {
 				Java: &config.JavaAPI{},
 			},
 		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
+		},
 	}
 	apiPath := library.APIs[0].Path
 	transports := map[string]serviceconfig.Transport{
@@ -189,6 +192,9 @@ func TestSyncPOMs_Update(t *testing.T) {
 				Java: &config.JavaAPI{},
 			},
 		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
+		},
 	}
 	transports := map[string]serviceconfig.Transport{
 		"google/cloud/secretmanager/v1": serviceconfig.GRPC,
@@ -251,6 +257,9 @@ func TestSyncPOMs_NoUpdate(t *testing.T) {
 				Java: &config.JavaAPI{},
 			},
 		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
+		},
 	}
 	transports := map[string]serviceconfig.Transport{
 		"google/cloud/secretmanager/v1": serviceconfig.GRPC,
@@ -298,6 +307,9 @@ func TestCollectModules(t *testing.T) {
 						Java: &config.JavaAPI{},
 					},
 				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 			monorepoVersion: "1.2.3",
 			metadata: &repoMetadata{
@@ -340,6 +352,9 @@ func TestCollectModules(t *testing.T) {
 						Java: &config.JavaAPI{},
 					},
 				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 			monorepoVersion: "1.2.3",
 			metadata: &repoMetadata{
@@ -378,6 +393,9 @@ func TestCollectModules(t *testing.T) {
 						Path: "google/cloud/secretmanager/v1",
 						Java: &config.JavaAPI{},
 					},
+				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
 				},
 			},
 			monorepoVersion: "1.2.3",
@@ -425,6 +443,7 @@ func TestCollectModules(t *testing.T) {
 					},
 				},
 				Java: &config.JavaModule{
+					GroupID:      "com.google.cloud",
 					ExcludedPOMs: []string{"grpc-google-cloud-secretmanager-v1"},
 				},
 			},
@@ -468,6 +487,9 @@ func TestCollectModules(t *testing.T) {
 						},
 					},
 				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 			monorepoVersion: "1.2.3",
 			metadata: &repoMetadata{
@@ -507,6 +529,9 @@ func TestCollectModules(t *testing.T) {
 							GenerateResourceNames: func() *bool { b := false; return &b }(),
 						},
 					},
+				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
 				},
 			},
 			monorepoVersion: "1.2.3",
@@ -607,15 +632,18 @@ func TestIsPOMMissing_DirMissing(t *testing.T) {
 
 func TestIdentifyMissingModules(t *testing.T) {
 	library := &config.Library{
-		Name:    "secretmanager",
-		Version: "1.2.3",
-		APIs: []*config.API{
-			{
-				Path: "google/cloud/secretmanager/v1",
-				Java: &config.JavaAPI{},
-			},
-		},
-	}
+				Name:    "secretmanager",
+				Version: "1.2.3",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						Java: &config.JavaAPI{},
+					},
+				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
+			}
 	for _, test := range []struct {
 		name  string
 		setup func(t *testing.T, libraryDir string)
@@ -733,6 +761,7 @@ func TestIdentifyMissingModules_SkipPOMUpdates(t *testing.T) {
 			{Path: "google/cloud/secretmanager/v1"},
 		},
 		Java: &config.JavaModule{
+			GroupID:        "com.google.cloud",
 			SkipPOMUpdates: true,
 		},
 	}
@@ -758,6 +787,7 @@ func TestIdentifyMissingModules_ExcludedPOMs(t *testing.T) {
 			},
 		},
 		Java: &config.JavaModule{
+			GroupID:      "com.google.cloud",
 			ExcludedPOMs: []string{"grpc-google-cloud-secretmanager-v1"},
 		},
 	}
@@ -802,6 +832,9 @@ func TestIdentifyMissingModules_GenerateProtoGRPCFalse(t *testing.T) {
 				},
 			},
 		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
+		},
 	}
 	tmpDir := t.TempDir()
 	dirs := []string{
@@ -842,6 +875,9 @@ func TestIdentifyMissingModules_GenerateGAPICFalse(t *testing.T) {
 					GenerateResourceNames: func() *bool { b := false; return &b }(),
 				},
 			},
+		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
 		},
 	}
 	tmpDir := t.TempDir()

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -632,18 +632,18 @@ func TestIsPOMMissing_DirMissing(t *testing.T) {
 
 func TestIdentifyMissingModules(t *testing.T) {
 	library := &config.Library{
-				Name:    "secretmanager",
-				Version: "1.2.3",
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-						Java: &config.JavaAPI{},
-					},
-				},
-				Java: &config.JavaModule{
-					GroupID: "com.google.cloud",
-				},
-			}
+		Name:    "secretmanager",
+		Version: "1.2.3",
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				Java: &config.JavaAPI{},
+			},
+		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
+		},
+	}
 	for _, test := range []struct {
 		name  string
 		setup func(t *testing.T, libraryDir string)

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -112,6 +112,9 @@ func TestPostProcessAPI(t *testing.T) {
 		library: &config.Library{
 			Name: libraryName,
 			APIs: []*config.API{api},
+			Java: &config.JavaModule{
+				GroupID: "com.google.cloud",
+			},
 		},
 		apiBase: apiBase,
 		protosToCopy: []protoFileToCopy{
@@ -197,7 +200,12 @@ func TestRestructureModules(t *testing.T) {
 	additionalProtoPath := filepath.Join(googleapisDir, "google", "cloud", "oslogin", "common", "common.proto")
 	p := postProcessParams{
 		outDir:  tmpDir,
-		library: &config.Library{Name: libraryID},
+		library: &config.Library{
+			Name: libraryID,
+			Java: &config.JavaModule{
+				GroupID: "com.google.cloud",
+			},
+		},
 		apiBase: apiBase,
 		protosToCopy: []protoFileToCopy{
 			{
@@ -246,7 +254,12 @@ func TestRestructureModules_CommonProtos(t *testing.T) {
 	setupLocationProtoFile(t, tmpDir, apiBase)
 	p := postProcessParams{
 		outDir:  tmpDir,
-		library: &config.Library{Name: commonProtosLibrary},
+		library: &config.Library{
+			Name: commonProtosLibrary,
+			Java: &config.JavaModule{
+				GroupID: "com.google.cloud",
+			},
+		},
 		apiBase: apiBase,
 
 		includeSamples: false,
@@ -271,7 +284,12 @@ func TestRestructureModules_ShouldRemoveClasses(t *testing.T) {
 	setupLocationProtoFile(t, tmpDir, apiBase)
 	p := postProcessParams{
 		outDir:  tmpDir,
-		library: &config.Library{Name: "secretmanager"},
+		library: &config.Library{
+			Name: "secretmanager",
+			Java: &config.JavaModule{
+				GroupID: "com.google.cloud",
+			},
+		},
 		apiBase: apiBase,
 
 		includeSamples: false,
@@ -323,7 +341,12 @@ func TestRestructureModules_SamplesDisabled(t *testing.T) {
 
 	p := postProcessParams{
 		outDir:  tmpDir,
-		library: &config.Library{Name: libraryID},
+		library: &config.Library{
+			Name: libraryID,
+			Java: &config.JavaModule{
+				GroupID: "com.google.cloud",
+			},
+		},
 		apiBase: apiBase,
 
 		includeSamples: false,
@@ -372,7 +395,12 @@ func TestRestructureModules_Monolithic(t *testing.T) {
 	}
 	p := postProcessParams{
 		outDir:  tmpDir,
-		library: &config.Library{Name: libraryID, Java: &config.JavaModule{}},
+		library: &config.Library{
+			Name: libraryID,
+			Java: &config.JavaModule{
+				GroupID: "com.google.cloud",
+			},
+		},
 		apiBase: apiBase,
 
 		includeSamples: false,
@@ -483,6 +511,9 @@ func TestPostProcessLibrary(t *testing.T) {
 				Java: &config.JavaAPI{},
 			},
 		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
+		},
 	}
 	defaultCfg := &config.Config{
 		Libraries: []*config.Library{
@@ -578,6 +609,9 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 				Path: "google/cloud/secretmanager/v1",
 				Java: &config.JavaAPI{},
 			},
+		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
 		},
 	}
 	defaultCfg := &config.Config{

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -199,7 +199,7 @@ func TestRestructureModules(t *testing.T) {
 
 	additionalProtoPath := filepath.Join(googleapisDir, "google", "cloud", "oslogin", "common", "common.proto")
 	p := postProcessParams{
-		outDir:  tmpDir,
+		outDir: tmpDir,
 		library: &config.Library{
 			Name: libraryID,
 			Java: &config.JavaModule{
@@ -253,7 +253,7 @@ func TestRestructureModules_CommonProtos(t *testing.T) {
 	apiBase := "v1"
 	setupLocationProtoFile(t, tmpDir, apiBase)
 	p := postProcessParams{
-		outDir:  tmpDir,
+		outDir: tmpDir,
 		library: &config.Library{
 			Name: commonProtosLibrary,
 			Java: &config.JavaModule{
@@ -283,7 +283,7 @@ func TestRestructureModules_ShouldRemoveClasses(t *testing.T) {
 	apiBase := "v1"
 	setupLocationProtoFile(t, tmpDir, apiBase)
 	p := postProcessParams{
-		outDir:  tmpDir,
+		outDir: tmpDir,
 		library: &config.Library{
 			Name: "secretmanager",
 			Java: &config.JavaModule{
@@ -340,7 +340,7 @@ func TestRestructureModules_SamplesDisabled(t *testing.T) {
 	}
 
 	p := postProcessParams{
-		outDir:  tmpDir,
+		outDir: tmpDir,
 		library: &config.Library{
 			Name: libraryID,
 			Java: &config.JavaModule{
@@ -394,7 +394,7 @@ func TestRestructureModules_Monolithic(t *testing.T) {
 		t.Fatal(err)
 	}
 	p := postProcessParams{
-		outDir:  tmpDir,
+		outDir: tmpDir,
 		library: &config.Library{
 			Name: libraryID,
 			Java: &config.JavaModule{

--- a/internal/librarian/java/repometadata_test.go
+++ b/internal/librarian/java/repometadata_test.go
@@ -126,6 +126,7 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 		{
 			name: "only overrides api shortname",
 			java: &config.JavaModule{
+				GroupID:              "com.google.cloud",
 				APIShortnameOverride: "custom-shortname",
 			},
 			want: &repoMetadata{
@@ -149,6 +150,7 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 		{
 			name: "transport override",
 			java: &config.JavaModule{
+				GroupID:           "com.google.cloud",
 				TransportOverride: "rest",
 			},
 			want: &repoMetadata{

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -481,6 +481,9 @@ func applyJavaArtifactOverrides(apiPath string, api *config.JavaAPI, libraryName
 
 // applyJavaLibraryOverrides sets library-level overrides.
 func applyJavaLibraryOverrides(lib *config.Library) {
+	if lib.Java.GroupID == "" {
+		lib.Java.GroupID = "com.google.cloud"
+	}
 	if transport, ok := javaTransportOverrides[lib.Name]; ok {
 		lib.Java.TransportOverride = transport
 	}

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -179,6 +179,7 @@ func TestApplyJavaLibraryOverrides(t *testing.T) {
 			want: &config.Library{
 				Name: "alloydb-connectors",
 				Java: &config.JavaModule{
+					GroupID:           "com.google.cloud",
 					TransportOverride: "grpc",
 				},
 			},
@@ -192,6 +193,7 @@ func TestApplyJavaLibraryOverrides(t *testing.T) {
 			want: &config.Library{
 				Name: "common-protos",
 				Java: &config.JavaModule{
+					GroupID:              "com.google.cloud",
 					APIShortnameOverride: "common-protos",
 					SkipPOMUpdates:       true,
 					SkipAPIID:            true,
@@ -208,6 +210,7 @@ func TestApplyJavaLibraryOverrides(t *testing.T) {
 			want: &config.Library{
 				Name: "grafeas",
 				Java: &config.JavaModule{
+					GroupID:        "com.google.cloud",
 					SkipPOMUpdates: true,
 				},
 			},
@@ -241,6 +244,7 @@ func TestApplyJavaLibraryOverrides(t *testing.T) {
 					},
 				},
 				Java: &config.JavaModule{
+					GroupID:        "com.google.cloud",
 					SkipPOMUpdates: true,
 				},
 			},
@@ -253,7 +257,9 @@ func TestApplyJavaLibraryOverrides(t *testing.T) {
 			},
 			want: &config.Library{
 				Name: "language",
-				Java: &config.JavaModule{},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
 			},
 		},
 	} {
@@ -399,7 +405,9 @@ func TestBuildConfig(t *testing.T) {
 						APIs: []*config.API{
 							{Path: "google/cloud/secretmanager/v1"},
 						},
-						Java: &config.JavaModule{},
+						Java: &config.JavaModule{
+							GroupID: "com.google.cloud",
+						},
 					},
 				},
 			},
@@ -451,6 +459,7 @@ func TestBuildConfig(t *testing.T) {
 							"gapic-showcase/src/main/java/com/google/showcase/v1beta1/Version.java",
 						},
 						Java: &config.JavaModule{
+							GroupID:   "com.google.cloud",
 							SkipAPIID: true,
 						},
 					},
@@ -485,7 +494,9 @@ func TestBuildConfig(t *testing.T) {
 						APIs: []*config.API{
 							{Path: "google/cloud/language/v1"},
 						},
-						Java: &config.JavaModule{},
+						Java: &config.JavaModule{
+							GroupID: "com.google.cloud",
+						},
 					},
 				},
 			},
@@ -524,14 +535,18 @@ func TestBuildConfig(t *testing.T) {
 						APIs: []*config.API{
 							{Path: "google/cloud/vision/v1"},
 						},
-						Java: &config.JavaModule{},
+						Java: &config.JavaModule{
+							GroupID: "com.google.cloud",
+						},
 					},
 					{
 						Name: "language",
 						APIs: []*config.API{
 							{Path: "google/cloud/language/v1"},
 						},
-						Java: &config.JavaModule{},
+						Java: &config.JavaModule{
+							GroupID: "com.google.cloud",
+						},
 					},
 				},
 			},
@@ -657,6 +672,7 @@ func TestBuildConfig(t *testing.T) {
 							{Path: "google/cloud/accessapproval/v1"},
 						},
 						Java: &config.JavaModule{
+							GroupID:                  "com.google.cloud",
 							DistributionNameOverride: "com.google.cloud:" + "google-cloud-accessapproval",
 						},
 					},
@@ -693,6 +709,7 @@ func TestBuildConfig(t *testing.T) {
 							{Path: "google/maps/places/v1"},
 						},
 						Java: &config.JavaModule{
+							GroupID:              "com.google.cloud",
 							APIShortnameOverride: "maps-places",
 						},
 					},
@@ -735,7 +752,9 @@ func TestBuildConfig(t *testing.T) {
 								},
 							},
 						},
-						Java: &config.JavaModule{},
+						Java: &config.JavaModule{
+							GroupID: "com.google.cloud",
+						},
 					},
 				},
 			},
@@ -777,7 +796,9 @@ func TestBuildConfig(t *testing.T) {
 								},
 							},
 						},
-						Java: &config.JavaModule{},
+						Java: &config.JavaModule{
+							GroupID: "com.google.cloud",
+						},
 					},
 				},
 			},
@@ -842,7 +863,9 @@ func TestBuildConfig(t *testing.T) {
 							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslationTest.java",
 							"google-cloud-translate/src/test/java/com/google/cloud/translate/it/ITTranslateTest.java",
 						},
-						Java: &config.JavaModule{},
+						Java: &config.JavaModule{
+							GroupID: "com.google.cloud",
+						},
 					},
 				},
 			},
@@ -999,6 +1022,7 @@ func TestBuildConfig_ArtifactIDOverrides(t *testing.T) {
 							},
 						},
 						Java: &config.JavaModule{
+							GroupID:           "com.google.cloud",
 							TransportOverride: test.wantTransport,
 						},
 					},
@@ -1319,6 +1343,9 @@ func TestGetModuleArtifactIDs(t *testing.T) {
 			{Path: "google/cloud/vision/v1"},
 			{Path: "google/cloud/vision/v1p1beta1"},
 			{Path: "google/cloud/vision/type"},
+		},
+		Java: &config.JavaModule{
+			GroupID: "com.google.cloud",
 		},
 	}
 	ids := getModuleArtifactIDs(lib)


### PR DESCRIPTION
Fill default Java.GroupID early with java.Fill and remove unnecessary deriving logic in DeriveDistributionName.
Unit test setups to include Java.GroupID because it does not call java.Fill.

For https://github.com/googleapis/librarian/issues/6035