### PR TITLE
feat(tool/cmd/migrate): add keep list appends support for Java modules

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -370,6 +370,11 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 			}
 			lib.Keep = keep
 		}
+		if appends, ok := keepAppends[lib.Name]; ok {
+			lib.Keep = append(lib.Keep, appends...)
+			slices.Sort(lib.Keep)
+			lib.Keep = slices.Compact(lib.Keep)
+		}
 		libs = append(libs, lib)
 	}
 	if len(libs) == 0 {

--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -79,6 +79,13 @@ var (
 		},
 	}
 
+	keepAppends = map[string][]string{
+		"firestore": {
+			"google-cloud-firestore/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-firestore/reflect-config.json",
+			"google-cloud-firestore/src/test/resources/META-INF/native-image/reflect-config.json",
+		},
+	}
+
 	javaArtifactIDOverrides = map[overrideKey]javaArtifactOverrides{
 		{apiPath: "google/datastore/admin/v1"}: {
 			protoArtifactID: "proto-google-cloud-datastore-admin-v1",

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -847,6 +847,51 @@ func TestBuildConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "keep appends",
+			gen: &GenerationConfig{
+				Libraries: []LibraryConfig{
+					{
+						APIShortName: "firestore",
+						GAPICs: []GAPICConfig{
+							{ProtoPath: "google/cloud/translate/v3"},
+						},
+					},
+				},
+			},
+			src: &config.Source{Dir: "testdata/googleapis"},
+			want: &config.Config{
+				Language: "java",
+				Repo:     "googleapis/google-cloud-java",
+				Default: &config.Default{
+					Java: &config.JavaModule{},
+				},
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Dir: "testdata/googleapis"},
+				},
+				Libraries: []*config.Library{
+					{
+						Name: "firestore",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/translate/v3",
+								Java: &config.JavaAPI{
+									OmitCommonResources: true,
+									Samples:             new(false),
+								},
+							},
+						},
+						Keep: []string{
+							"google-cloud-firestore/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-firestore/reflect-config.json",
+							"google-cloud-firestore/src/test/resources/META-INF/native-image/reflect-config.json",
+						},
+						Java: &config.JavaModule{
+							SkipPOMUpdates: true,
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := buildConfig(test.gen, ".", test.src, nil, test.versions)


### PR DESCRIPTION
A keepAppends map is added to java_module.go which permits appending specific files to a library's keep list, instead of completely overriding it. For the firestore library, the hardcoded native-image configuration files are added to this map and appended to the final keep list during migration.

I checked, these files are static (created [here](https://github.com/googleapis/java-firestore/pull/1419) and [here](https://github.com/googleapis/java-firestore/pull/1728/) so they are OK to just hardcode (they are not being "updated" anywhere)

For https://github.com/googleapis/librarian/issues/6012