### PR TITLE
chore(tool/cmd/migrate): rm keep override for translate

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -40,33 +40,6 @@ var (
 	}
 
 	keepOverride = map[string][]string{
-		"translate": {
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/Detection.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/Language.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/Option.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/Translate.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateException.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateFactory.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateImpl.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateOptions.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/Translation.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/package-info.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/TranslateRpcFactory.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/HttpTranslateRpc.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/TranslateRpc.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/RemoteTranslateHelper.java",
-			"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/package-info.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/DetectionTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/LanguageTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/OptionTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/SerializationTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateExceptionTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateImplTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateOptionsTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslationTest.java",
-			"google-cloud-translate/src/test/java/com/google/cloud/translate/it/ITTranslateTest.java",
-		},
 		"aiplatform": {
 			"google-cloud-aiplatform/src/test/java/com/google/cloud/location/MockLocations.java",
 			"google-cloud-aiplatform/src/test/java/com/google/cloud/location/MockLocationsImpl.java",

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -787,9 +787,9 @@ func TestBuildConfig(t *testing.T) {
 			gen: &GenerationConfig{
 				Libraries: []LibraryConfig{
 					{
-						APIShortName: "translate",
+						APIShortName: "aiplatform",
 						GAPICs: []GAPICConfig{
-							{ProtoPath: "google/cloud/translate/v3"},
+							{ProtoPath: "google/cloud/aiplatform/v1"},
 						},
 					},
 				},
@@ -806,41 +806,17 @@ func TestBuildConfig(t *testing.T) {
 				},
 				Libraries: []*config.Library{
 					{
-						Name: "translate",
+						Name: "aiplatform",
 						APIs: []*config.API{
 							{
-								Path: "google/cloud/translate/v3",
-								Java: &config.JavaAPI{
-									OmitCommonResources: true, // common_resources_proto not in testdata BUILD.bazel
-								},
+								Path: "google/cloud/aiplatform/v1",
 							},
 						},
 						Keep: []string{
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/Detection.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/Language.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/Option.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/Translate.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateException.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateFactory.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateImpl.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/TranslateOptions.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/Translation.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/package-info.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/TranslateRpcFactory.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/HttpTranslateRpc.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/spi/v2/TranslateRpc.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/RemoteTranslateHelper.java",
-							"google-cloud-translate/src/main/java/com/google/cloud/translate/testing/package-info.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/DetectionTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/LanguageTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/OptionTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/SerializationTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateExceptionTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateImplTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateOptionsTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslateTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/TranslationTest.java",
-							"google-cloud-translate/src/test/java/com/google/cloud/translate/it/ITTranslateTest.java",
+							"google-cloud-aiplatform/src/test/java/com/google/cloud/location/MockLocations.java",
+							"google-cloud-aiplatform/src/test/java/com/google/cloud/location/MockLocationsImpl.java",
+							"google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicy.java",
+							"google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicyImpl.java",
 						},
 						Java: &config.JavaModule{},
 					},


### PR DESCRIPTION
Remove keep overrides for translate. These are not manual files inside gapic client module, they are preserved by default, don't need to be explicit listed after https://github.com/googleapis/librarian/pull/5861.
Verified in local test, this removal does not affect generation results.

Fixes https://github.com/googleapis/librarian/issues/6055