### PR TITLE
chore(tool/cmd/migrate): remove unused constants

### DIFF
--- a/tool/cmd/migrate/main.go
+++ b/tool/cmd/migrate/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	googleapisRepo      = "github.com/googleapis/googleapis"
+	googleapisRepo = "github.com/googleapis/googleapis"
 )
 
 var (

--- a/tool/cmd/migrate/main.go
+++ b/tool/cmd/migrate/main.go
@@ -29,10 +29,6 @@ import (
 )
 
 const (
-	librarianDir        = ".librarian"
-	librarianStateFile  = "state.yaml"
-	librarianConfigFile = "config.yaml"
-	defaultTagFormat    = "{name}/v{version}"
 	googleapisRepo      = "github.com/googleapis/googleapis"
 )
 


### PR DESCRIPTION
The unused constants librarianDir, librarianStateFile, librarianConfigFile, and defaultTagFormat are removed from the migration tool main entrypoint.

These constants were defined but not referenced anywhere in the package, making them redundant.