### PR TITLE
test(internal/testhelper): disable automatic git garbage collection in test repos

### DIFF
--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -95,6 +95,7 @@ func ContinueInNewGitRepository(t *testing.T, tmpDir string) {
 func configNewGitRepository(t *testing.T) {
 	RunGit(t, "config", "user.email", "test@test-only.com")
 	RunGit(t, "config", "user.name", "Test Account")
+	RunGit(t, "config", "gc.auto", "0")
 	RunGit(t, "remote", "add", TestRemote, testRemoteURL)
 }
 


### PR DESCRIPTION
Seems like there is a race condition between git and Go. On environments with slow filesystems or CPU resource limits (such as GitHub Actions runners), the background git gc process may still be active within the .git folder when a Go subtest finishes. When the test framework attempts to clean up the temporary directory (t.TempDir()), it fails because the active git gc process is writing to it, resulting in the error. This fix solves it by disabling automatic git garbage collection is disabled in test repositories created by testhelper. 

Fixes https://github.com/googleapis/librarian/issues/6058