### PR TITLE
feat(internal/librarian): java add to resolve mixin protos

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -110,6 +110,16 @@ func runAdd(ctx context.Context, cfg *config.Config, api string) error {
 
 func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (*config.Config, error) {
 	switch cfg.Language {
+	case config.LanguageJava:
+		lib, err := FindLibrary(cfg, name)
+		if err != nil {
+			return nil, err
+		}
+		sources, err := LoadSources(ctx, cfg.Sources)
+		if err != nil {
+			return nil, err
+		}
+		return java.ResolveDependencies(ctx, cfg, lib, sources)
 	case config.LanguageRust:
 		lib, err := FindLibrary(cfg, name)
 		if err != nil {

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -119,7 +119,7 @@ func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (
 		if err != nil {
 			return nil, err
 		}
-		return java.ResolveDependencies(ctx, cfg, lib, sources)
+		return java.ResolveMixinDependencies(cfg, lib, sources)
 	case config.LanguageRust:
 		lib, err := FindLibrary(cfg, name)
 		if err != nil {

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -36,6 +36,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
 	"github.com/googleapis/librarian/internal/semver"
+	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/yaml"
 	"github.com/urfave/cli/v3"
 )
@@ -111,21 +112,13 @@ func runAdd(ctx context.Context, cfg *config.Config, api string) error {
 func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (*config.Config, error) {
 	switch cfg.Language {
 	case config.LanguageJava:
-		lib, err := FindLibrary(cfg, name)
-		if err != nil {
-			return nil, err
-		}
-		sources, err := LoadSources(ctx, cfg.Sources)
+		lib, sources, err := setupResolve(ctx, cfg, name)
 		if err != nil {
 			return nil, err
 		}
 		return java.ResolveMixinDependencies(cfg, lib, sources)
 	case config.LanguageRust:
-		lib, err := FindLibrary(cfg, name)
-		if err != nil {
-			return nil, err
-		}
-		sources, err := LoadSources(ctx, cfg.Sources)
+		lib, sources, err := setupResolve(ctx, cfg, name)
 		if err != nil {
 			return nil, err
 		}
@@ -133,6 +126,18 @@ func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (
 	default:
 		return cfg, nil
 	}
+}
+
+func setupResolve(ctx context.Context, cfg *config.Config, name string) (*config.Library, *sources.Sources, error) {
+	lib, err := FindLibrary(cfg, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	sources, err := LoadSources(ctx, cfg.Sources)
+	if err != nil {
+		return nil, nil, err
+	}
+	return lib, sources, nil
 }
 
 // deriveLibraryName derives a library name from an API path.

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1058,9 +1058,7 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 					Java: &config.JavaAPI{
 						AdditionalProtos: []*config.AdditionalProto{
 							{
-								Path:                 "google/cloud/location/locations.proto",
-								GenerateProtoClasses: false,
-								CopyToOutput:         false,
+								Path: "google/cloud/location/locations.proto",
 							},
 						},
 					},

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1021,3 +1021,56 @@ func TestSyncToStateYAML_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestAddLibraryCommand_Java(t *testing.T) {
+	copyrightYear := strconv.Itoa(time.Now().Year())
+	_ = copyrightYear // might not be used if it is reset to empty
+	googleapisDir, err := filepath.Abs("../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	cfg := sample.Config()
+	cfg.Language = config.LanguageJava
+	cfg.Default.Output = "output"
+	cfg.Libraries = []*config.Library{}
+	cfg.Sources.Googleapis.Dir = googleapisDir
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+		t.Fatal(err)
+	}
+	// developerconnect has Locations mixin in its service.yaml
+	err = runAdd(t.Context(), cfg, "google/cloud/developerconnect/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLibraries := []*config.Library{
+		{
+			Name:          "developerconnect",
+			CopyrightYear: "",
+			Version:       "0.1.0-SNAPSHOT",
+			APIs: []*config.API{
+				{
+					Path: "google/cloud/developerconnect/v1",
+					Java: &config.JavaAPI{
+						AdditionalProtos: []*config.AdditionalProto{
+							{
+								Path:                 "google/cloud/location/locations.proto",
+								GenerateProtoClasses: false,
+								CopyToOutput:         false,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1023,8 +1023,6 @@ func TestSyncToStateYAML_Error(t *testing.T) {
 }
 
 func TestAddLibraryCommand_Java(t *testing.T) {
-	copyrightYear := strconv.Itoa(time.Now().Year())
-	_ = copyrightYear // might not be used if it is reset to empty
 	googleapisDir, err := filepath.Abs("../testdata/googleapis")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/librarian/java/resolve.go
+++ b/internal/librarian/java/resolve.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package java
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+// ResolveDependencies automatically resolves Protobuf dependencies for a Java library.
+func ResolveDependencies(ctx context.Context, cfg *config.Config, lib *config.Library, srcs *sources.Sources) (*config.Config, error) {
+	if len(lib.APIs) == 0 {
+		return cfg, nil
+	}
+	for _, apiCfg := range lib.APIs {
+		if err := resolveAPIDependencies(lib, apiCfg, srcs); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}
+
+func resolveAPIDependencies(lib *config.Library, apiCfg *config.API, srcs *sources.Sources) error {
+	if apiCfg.Java == nil {
+		apiCfg.Java = &config.JavaAPI{}
+	}
+
+	primaryRoot := srcs.Googleapis
+	if apiCfg.Path == "schema/google/showcase/v1beta1" {
+		primaryRoot = srcs.Showcase
+	}
+
+	svcConfig, err := serviceconfig.Find(primaryRoot, apiCfg.Path, config.LanguageJava)
+	if err != nil {
+		return fmt.Errorf("failed to find service config for %s: %w", apiCfg.Path, err)
+	}
+
+	if svcConfig.ServiceConfig == "" {
+		return nil
+	}
+
+	serviceConfig, err := serviceconfig.Read(filepath.Join(primaryRoot, svcConfig.ServiceConfig))
+	if err != nil {
+		return fmt.Errorf("failed to read service config for %s: %w", apiCfg.Path, err)
+	}
+
+	for _, api := range serviceConfig.GetApis() {
+		var mixinProto string
+		switch api.GetName() {
+		case "google.cloud.location.Locations":
+			mixinProto = "google/cloud/location/locations.proto"
+		case "google.iam.v1.IAMPolicy":
+			mixinProto = "google/iam/v1/iam_policy.proto"
+		default:
+			continue
+		}
+
+		if !hasAdditionalProto(apiCfg.Java.AdditionalProtos, mixinProto) {
+			apiCfg.Java.AdditionalProtos = append(apiCfg.Java.AdditionalProtos, &config.AdditionalProto{
+				Path:                 mixinProto,
+				GenerateProtoClasses: false,
+				CopyToOutput:         false,
+			})
+		}
+	}
+
+	sortAdditionalProtos(apiCfg.Java.AdditionalProtos)
+	return nil
+}
+
+func hasAdditionalProto(protos []*config.AdditionalProto, path string) bool {
+	for _, p := range protos {
+		if p.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func sortAdditionalProtos(protos []*config.AdditionalProto) {
+	sort.Slice(protos, func(i, j int) bool {
+		return protos[i].Path < protos[j].Path
+	})
+}

--- a/internal/librarian/java/resolve.go
+++ b/internal/librarian/java/resolve.go
@@ -15,7 +15,6 @@
 package java
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -25,43 +24,40 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
-// ResolveDependencies automatically resolves Protobuf dependencies for a Java library.
-func ResolveDependencies(ctx context.Context, cfg *config.Config, lib *config.Library, srcs *sources.Sources) (*config.Config, error) {
+// ResolveMixinDependencies automatically resolves mixin dependencies for a Java library.
+func ResolveMixinDependencies(cfg *config.Config, lib *config.Library, srcs *sources.Sources) (*config.Config, error) {
 	if len(lib.APIs) == 0 {
 		return cfg, nil
 	}
 	for _, apiCfg := range lib.APIs {
-		if err := resolveAPIDependencies(lib, apiCfg, srcs); err != nil {
+		if err := resolveAPIMixinDependencies(lib, apiCfg, srcs); err != nil {
 			return nil, err
 		}
 	}
 	return cfg, nil
 }
 
-func resolveAPIDependencies(lib *config.Library, apiCfg *config.API, srcs *sources.Sources) error {
+// resolveAPIMixinDependencies automatically resolves mixin dependencies for a single API.
+// It parses the API's service config to identify and add required mixin dependencies
+// (e.g., locations, IAM policy) to the API's Java configuration.
+func resolveAPIMixinDependencies(lib *config.Library, apiCfg *config.API, srcs *sources.Sources) error {
 	if apiCfg.Java == nil {
 		apiCfg.Java = &config.JavaAPI{}
 	}
 
-	primaryRoot := srcs.Googleapis
-	if apiCfg.Path == "schema/google/showcase/v1beta1" {
-		primaryRoot = srcs.Showcase
-	}
-
+	srcCfg := sources.NewSourceConfig(srcs, lib.Roots)
+	primaryRoot := srcCfg.Root(srcCfg.ActiveRoots[0])
 	svcConfig, err := serviceconfig.Find(primaryRoot, apiCfg.Path, config.LanguageJava)
 	if err != nil {
 		return fmt.Errorf("failed to find service config for %s: %w", apiCfg.Path, err)
 	}
-
 	if svcConfig.ServiceConfig == "" {
 		return nil
 	}
-
 	serviceConfig, err := serviceconfig.Read(filepath.Join(primaryRoot, svcConfig.ServiceConfig))
 	if err != nil {
 		return fmt.Errorf("failed to read service config for %s: %w", apiCfg.Path, err)
 	}
-
 	for _, api := range serviceConfig.GetApis() {
 		var mixinProto string
 		switch api.GetName() {
@@ -72,7 +68,6 @@ func resolveAPIDependencies(lib *config.Library, apiCfg *config.API, srcs *sourc
 		default:
 			continue
 		}
-
 		if !hasAdditionalProto(apiCfg.Java.AdditionalProtos, mixinProto) {
 			apiCfg.Java.AdditionalProtos = append(apiCfg.Java.AdditionalProtos, &config.AdditionalProto{
 				Path:                 mixinProto,
@@ -81,7 +76,6 @@ func resolveAPIDependencies(lib *config.Library, apiCfg *config.API, srcs *sourc
 			})
 		}
 	}
-
 	sortAdditionalProtos(apiCfg.Java.AdditionalProtos)
 	return nil
 }

--- a/internal/librarian/java/resolve_test.go
+++ b/internal/librarian/java/resolve_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package java
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+func TestResolveDependencies(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcs := &sources.Sources{
+		Googleapis: googleapisDir,
+	}
+	for _, tt := range []struct {
+		name    string
+		lib     *config.Library
+		want    []*config.AdditionalProto
+		wantErr bool
+	}{
+		{
+			name: "no APIs",
+			lib: &config.Library{
+				APIs: []*config.API{},
+			},
+			want: nil,
+		},
+		{
+			name: "locations mixin (developerconnect)",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/developerconnect/v1"},
+				},
+			},
+			want: []*config.AdditionalProto{
+				{
+					Path:                 "google/cloud/location/locations.proto",
+					GenerateProtoClasses: false,
+					CopyToOutput:         false,
+				},
+			},
+		},
+		{
+			name: "locations mixin (secretmanager)",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: []*config.AdditionalProto{
+				{
+					Path:                 "google/cloud/location/locations.proto",
+					GenerateProtoClasses: false,
+					CopyToOutput:         false,
+				},
+			},
+		},
+		{
+			name: "no mixins (dataproc)",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/dataproc/v1"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "preserve existing and sort",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/developerconnect/v1",
+						Java: &config.JavaAPI{
+							AdditionalProtos: []*config.AdditionalProto{
+								{
+									Path: "google/example/v1/example.proto",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*config.AdditionalProto{
+				{
+					Path:                 "google/cloud/location/locations.proto",
+					GenerateProtoClasses: false,
+					CopyToOutput:         false,
+				},
+				{
+					Path: "google/example/v1/example.proto",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveDependencies(context.Background(), &config.Config{}, tt.lib, srcs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveDependencies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			var got []*config.AdditionalProto
+			if len(tt.lib.APIs) > 0 && tt.lib.APIs[0].Java != nil {
+				got = tt.lib.APIs[0].Java.AdditionalProtos
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ResolveDependencies() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/java/resolve_test.go
+++ b/internal/librarian/java/resolve_test.go
@@ -15,7 +15,6 @@
 package java
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -113,7 +112,7 @@ func TestResolveDependencies(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ResolveDependencies(context.Background(), &config.Config{}, tt.lib, srcs)
+			_, err := ResolveMixinDependencies(&config.Config{}, tt.lib, srcs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ResolveDependencies() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/librarian/java/resolve_test.go
+++ b/internal/librarian/java/resolve_test.go
@@ -31,18 +31,16 @@ func TestResolveDependencies(t *testing.T) {
 	srcs := &sources.Sources{
 		Googleapis: googleapisDir,
 	}
-	for _, tt := range []struct {
-		name    string
-		lib     *config.Library
-		want    []*config.AdditionalProto
-		wantErr bool
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want []*config.AdditionalProto
 	}{
 		{
 			name: "no APIs",
 			lib: &config.Library{
 				APIs: []*config.API{},
 			},
-			want: nil,
 		},
 		{
 			name: "locations mixin (developerconnect)",
@@ -53,9 +51,7 @@ func TestResolveDependencies(t *testing.T) {
 			},
 			want: []*config.AdditionalProto{
 				{
-					Path:                 "google/cloud/location/locations.proto",
-					GenerateProtoClasses: false,
-					CopyToOutput:         false,
+					Path: "google/cloud/location/locations.proto",
 				},
 			},
 		},
@@ -68,9 +64,7 @@ func TestResolveDependencies(t *testing.T) {
 			},
 			want: []*config.AdditionalProto{
 				{
-					Path:                 "google/cloud/location/locations.proto",
-					GenerateProtoClasses: false,
-					CopyToOutput:         false,
+					Path: "google/cloud/location/locations.proto",
 				},
 			},
 		},
@@ -81,7 +75,6 @@ func TestResolveDependencies(t *testing.T) {
 					{Path: "google/cloud/dataproc/v1"},
 				},
 			},
-			want: nil,
 		},
 		{
 			name: "preserve existing and sort",
@@ -101,9 +94,7 @@ func TestResolveDependencies(t *testing.T) {
 			},
 			want: []*config.AdditionalProto{
 				{
-					Path:                 "google/cloud/location/locations.proto",
-					GenerateProtoClasses: false,
-					CopyToOutput:         false,
+					Path: "google/cloud/location/locations.proto",
 				},
 				{
 					Path: "google/example/v1/example.proto",
@@ -111,23 +102,17 @@ func TestResolveDependencies(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := ResolveMixinDependencies(&config.Config{}, tt.lib, srcs)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ResolveDependencies() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ResolveMixinDependencies(&config.Config{}, test.lib, srcs)
 			if err != nil {
-				return
+				t.Fatal()
 			}
-
 			var got []*config.AdditionalProto
-			if len(tt.lib.APIs) > 0 && tt.lib.APIs[0].Java != nil {
-				got = tt.lib.APIs[0].Java.AdditionalProtos
+			if len(test.lib.APIs) > 0 && test.lib.APIs[0].Java != nil {
+				got = test.lib.APIs[0].Java.AdditionalProtos
 			}
-
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("ResolveDependencies() mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
When running librarian add, it now resolves mixins to be added to `additional_protos` from parsing service config apis. This eliminates the need to manually enter these values when adding new libraries or new API path.

Fixes https://github.com/googleapis/librarian/issues/6034