### PR TITLE
fix(golang): move release level coercion to Go

### DIFF
--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -226,7 +226,17 @@ func buildGAPICOpts(apiPath string, goAPI *config.GoAPI, version, googleapisDir 
 	if trans := transport(sc); trans != "" {
 		opts = append(opts, fmt.Sprintf("transport=%s", trans))
 	}
-	opts = append(opts, "release-level="+sc.ReleaseLevel(config.LanguageGo, version))
+	releaseLevel := sc.ReleaseLevel(config.LanguageGo, version)
+	switch releaseLevel {
+	case "preview":
+		releaseLevel = "beta"
+		if strings.Contains(serviceconfig.ExtractVersion(apiPath), "alpha") {
+			releaseLevel = "alpha"
+		}
+	case "stable":
+		releaseLevel = "ga"
+	}
+	opts = append(opts, "release-level="+releaseLevel)
 	return opts, nil
 }
 

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -646,7 +646,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"api-service-config=" + filepath.Join(googleapisDir, "google/cloud/bigquery/v2/bigquery_v2.yaml"),
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/bigquery/v2/bigquery_grpc_service_config.json"),
 				"transport=grpc+rest",
-				"release-level=alpha",
+				"release-level=beta",
 			},
 		},
 		{
@@ -718,7 +718,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"api-service-config=" + filepath.Join(googleapisDir, "google/cloud/bigquery/v2/bigquery_v2.yaml"),
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/bigquery/v2/bigquery_grpc_service_config.json"),
 				"transport=grpc+rest",
-				"release-level=alpha",
+				"release-level=beta",
 			},
 		},
 		{

--- a/internal/librarian/golang/repometadata.go
+++ b/internal/librarian/golang/repometadata.go
@@ -33,7 +33,7 @@ func generateRepoMetadata(api *serviceconfig.API, library *config.Library, goAPI
 		DistributionName:    distributionName(goAPI.ImportPath),
 		Language:            config.LanguageGo,
 		LibraryType:         repometadata.GAPICAutoLibraryType,
-		ReleaseLevel:        api.RepoMetadataReleaseLevel(config.LanguageGo, library.Version),
+		ReleaseLevel:        api.ReleaseLevel(config.LanguageGo, library.Version),
 	}
 	return metadata.Write(filepath.Join(repoRootPath(library.Output, library.Name), clientPathFromRepoRoot(library, goAPI)))
 }

--- a/internal/librarian/golang/repometadata_test.go
+++ b/internal/librarian/golang/repometadata_test.go
@@ -29,51 +29,96 @@ import (
 
 func TestGenerateRepoMetadata(t *testing.T) {
 	t.Parallel()
-	tmpDir := t.TempDir()
-	library := &config.Library{
-		Name:    "secretmanager",
-		Output:  filepath.Join(tmpDir, "secretmanager"),
-		Version: "1.2.3",
-		APIs: []*config.API{
-			{
-				Path: "google/cloud/secretmanager/v1",
-				Go: &config.GoAPI{
-					ClientPackage: "secretmanager",
-					ImportPath:    "secretmanager/apiv1",
-				},
+	for _, test := range []struct {
+		name       string
+		path       string
+		importPath string
+		want       *repometadata.RepoMetadata
+	}{
+		{
+			name:       "stable release level",
+			path:       "google/cloud/secretmanager/v1",
+			importPath: "secretmanager/apiv1",
+			want: &repometadata.RepoMetadata{
+				APIShortname:        "secretmanager",
+				ClientDocumentation: "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1",
+				ClientLibraryType:   "generated",
+				Description:         "Secret Manager API",
+				DistributionName:    "cloud.google.com/go/secretmanager/apiv1",
+				Language:            config.LanguageGo,
+				LibraryType:         repometadata.GAPICAutoLibraryType,
+				ReleaseLevel:        "stable",
 			},
 		},
-	}
-	api := &serviceconfig.API{
-		ShortName: "secretmanager",
-		Title:     "Secret Manager API",
-		Path:      "google/cloud/secretmanager/v1",
-	}
-	metadataDir := filepath.Join(tmpDir, "secretmanager", "apiv1")
-	want := &repometadata.RepoMetadata{
-		APIShortname:        "secretmanager",
-		ClientDocumentation: "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1",
-		ClientLibraryType:   "generated",
-		Description:         "Secret Manager API",
-		DistributionName:    "cloud.google.com/go/secretmanager/apiv1",
-		Language:            config.LanguageGo,
-		LibraryType:         repometadata.GAPICAutoLibraryType,
-		ReleaseLevel:        "stable",
-	}
-	if err := os.MkdirAll(metadataDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := generateRepoMetadata(api, library, library.APIs[0].Go); err != nil {
-		t.Fatal(err)
-	}
+		{
+			name:       "preview release level",
+			path:       "google/cloud/secretmanager/v1alpha",
+			importPath: "secretmanager/apiv1alpha",
+			want: &repometadata.RepoMetadata{
+				APIShortname:        "secretmanager",
+				ClientDocumentation: "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1alpha",
+				ClientLibraryType:   "generated",
+				Description:         "Secret Manager API",
+				DistributionName:    "cloud.google.com/go/secretmanager/apiv1alpha",
+				Language:            config.LanguageGo,
+				LibraryType:         repometadata.GAPICAutoLibraryType,
+				ReleaseLevel:        "preview",
+			},
+		},
+		{
+			name:       "preview release level (beta path)",
+			path:       "google/cloud/secretmanager/v1beta",
+			importPath: "secretmanager/apiv1beta",
+			want: &repometadata.RepoMetadata{
+				APIShortname:        "secretmanager",
+				ClientDocumentation: "https://cloud.google.com/go/docs/reference/cloud.google.com/go/secretmanager/latest/apiv1beta",
+				ClientLibraryType:   "generated",
+				Description:         "Secret Manager API",
+				DistributionName:    "cloud.google.com/go/secretmanager/apiv1beta",
+				Language:            config.LanguageGo,
+				LibraryType:         repometadata.GAPICAutoLibraryType,
+				ReleaseLevel:        "preview",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			library := &config.Library{
+				Name:    "secretmanager",
+				Output:  filepath.Join(tmpDir, "secretmanager"),
+				Version: "1.2.3",
+				APIs: []*config.API{
+					{
+						Path: test.path,
+						Go: &config.GoAPI{
+							ClientPackage: "secretmanager",
+							ImportPath:    test.importPath,
+						},
+					},
+				},
+			}
+			api := &serviceconfig.API{
+				ShortName: "secretmanager",
+				Title:     "Secret Manager API",
+				Path:      test.path,
+			}
+			metadataDir := filepath.Join(tmpDir, "secretmanager", filepath.Base(test.importPath))
+			if err := os.MkdirAll(metadataDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := generateRepoMetadata(api, library, library.APIs[0].Go); err != nil {
+				t.Fatal(err)
+			}
 
-	got, err := repometadata.Read(metadataDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+			got, err := repometadata.Read(metadataDir)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -162,37 +162,7 @@ func (api *API) ReleaseLevel(language, version string) string {
 	if isAlpha || isBeta || strings.HasPrefix(version, "0.") {
 		level = "preview"
 	}
-
-	// TODO(https://github.com/googleapis/librarian/issues/4834): standardize
-	// release level vocabulary across languages.
-	if language == config.LanguageGo {
-		if isAlpha {
-			return "alpha"
-		}
-		if isBeta || level == "preview" {
-			return "beta"
-		}
-		if level == "stable" {
-			return "ga"
-		}
-	}
 	return level
-}
-
-// RepoMetadataReleaseLevel returns the release level for repo metadata.
-//
-// TODO(https://github.com/googleapis/librarian/issues/4834): delete this
-// function once the issue is resolved.
-// For Go, it maps the raw release level to "stable" or "preview".
-// For other languages, it returns the raw release level.
-func (api *API) RepoMetadataReleaseLevel(language, version string) string {
-	if language == config.LanguageGo {
-		if api.ReleaseLevel(language, version) == "ga" {
-			return "stable"
-		}
-		return "preview"
-	}
-	return api.ReleaseLevel(language, version)
 }
 
 // RepoMetadataTransport returns the transport for repo metadata.

--- a/internal/serviceconfig/api_test.go
+++ b/internal/serviceconfig/api_test.go
@@ -77,10 +77,10 @@ func TestReleaseLevel(t *testing.T) {
 			want:     "stable",
 		},
 		{
-			name:     "go defaults to ga",
+			name:     "go defaults to stable",
 			sc:       &API{},
 			language: config.LanguageGo,
-			want:     "ga",
+			want:     "stable",
 		},
 		{
 			name: "language-specific level",
@@ -137,121 +137,70 @@ func TestReleaseLevel(t *testing.T) {
 			want:     "preview",
 		},
 		{
-			name:     "go alpha due to alpha path",
+			name:     "go preview due to alpha path",
 			sc:       &API{Path: "google/cloud/secretmanager/v1alpha"},
 			language: config.LanguageGo,
-			want:     "alpha",
+			want:     "preview",
 		},
 		{
-			name:     "go beta due to beta path",
+			name:     "go preview due to beta path",
 			sc:       &API{Path: "google/cloud/secretmanager/v1beta"},
 			language: config.LanguageGo,
-			want:     "beta",
+			want:     "preview",
 		},
 		{
-			name:     "go ga for stable path",
+			name:     "go stable for stable path",
 			sc:       &API{Path: "google/cloud/secretmanager/v1"},
 			language: config.LanguageGo,
 			version:  "1.0.0",
-			want:     "ga",
+			want:     "stable",
 		},
 		{
-			name:     "go beta for stable path with 0.x version",
+			name:     "go preview for stable path with 0.x version",
 			sc:       &API{Path: "google/cloud/secretmanager/v1"},
 			language: config.LanguageGo,
 			version:  "0.1.0",
-			want:     "beta",
+			want:     "preview",
+		},
+		{
+			name: "go preview explicitly set",
+			sc: &API{
+				Path:          "google/cloud/secretmanager/v1",
+				ReleaseLevels: map[string]string{config.LanguageGo: "preview"},
+			},
+			language: config.LanguageGo,
+			want:     "preview",
+		},
+		{
+			name: "go stable explicitly set",
+			sc: &API{
+				Path:          "google/cloud/secretmanager/v1",
+				ReleaseLevels: map[string]string{config.LanguageGo: "stable"},
+			},
+			language: config.LanguageGo,
+			want:     "stable",
+		},
+		{
+			name: "all preview set maps to preview for go",
+			sc: &API{
+				Path:          "google/cloud/secretmanager/v1",
+				ReleaseLevels: map[string]string{config.LanguageAll: "preview"},
+			},
+			language: config.LanguageGo,
+			want:     "preview",
+		},
+		{
+			name: "all stable set maps to stable for go",
+			sc: &API{
+				Path:          "google/cloud/secretmanager/v1",
+				ReleaseLevels: map[string]string{config.LanguageAll: "stable"},
+			},
+			language: config.LanguageGo,
+			want:     "stable",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.sc.ReleaseLevel(test.language, test.version)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestRepoMetadataReleaseLevel(t *testing.T) {
-	for _, test := range []struct {
-		name     string
-		sc       *API
-		language string
-		version  string
-		want     string
-	}{
-		{
-			name: "go, stable",
-			sc: &API{
-				Path: "google/cloud/secretmanager/v1",
-			},
-			language: config.LanguageGo,
-			version:  "1.0.0",
-			want:     "stable",
-		},
-		{
-			name:     "go, stable empty path",
-			sc:       &API{},
-			language: config.LanguageGo,
-			version:  "1.0.0",
-			want:     "stable",
-		},
-		{
-			name: "go, preview alpha api path",
-			sc: &API{
-				Path: "google/cloud/secretmanager/v1alpha",
-			},
-			language: config.LanguageGo,
-			want:     "preview",
-		},
-		{
-			name: "go, preview alpha release level",
-			sc: &API{
-				ReleaseLevels: map[string]string{config.LanguageGo: "alpha"},
-			},
-			language: config.LanguageGo,
-			want:     "preview",
-		},
-		{
-			name: "go, preview beta api path",
-			sc: &API{
-				Path: "google/cloud/secretmanager/v1beta",
-			},
-			language: config.LanguageGo,
-			want:     "preview",
-		},
-		{
-			name: "go, preview beta release level",
-			sc: &API{
-				ReleaseLevels: map[string]string{config.LanguageGo: "beta"},
-			},
-			language: config.LanguageGo,
-			want:     "preview",
-		},
-		{
-			name:     "go, preview due to version 0.x",
-			sc:       &API{Path: "google/cloud/secretmanager/v1"},
-			language: config.LanguageGo,
-			version:  "0.1.0",
-			want:     "preview",
-		},
-		{
-			name:     "non-go returns raw release level",
-			sc:       &API{},
-			language: config.LanguageRust,
-			want:     "stable",
-		},
-		{
-			name: "non-go returns language-specific level",
-			sc: &API{
-				ReleaseLevels: map[string]string{config.LanguageRust: "beta"},
-			},
-			language: config.LanguageRust,
-			want:     "beta",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := test.sc.RepoMetadataReleaseLevel(test.language, test.version)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -42,7 +42,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
 - path: google/ai/generativelanguage/v1beta
   languages:
     - dart
@@ -421,7 +421,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
 - path: google/cloud/alloydb/v1beta
   languages:
     - go
@@ -691,7 +691,7 @@
     - java
     - python
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/cloud/bigquery/connection/v1
   documentation_uri: https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
@@ -740,7 +740,7 @@
   languages:
     - all
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/cloud/bigquery/datapolicies/v2beta1
   languages:
@@ -814,7 +814,7 @@
     - java
     - python
   release_level:
-    go: beta
+    go: preview
   transports:
     all: grpc
 - path: google/cloud/bigquery/storage/v1beta
@@ -855,7 +855,7 @@
   skip_rest_numeric_enums:
     - go
   release_level:
-    go: alpha
+    go: preview
   transports:
     python: rest
 - path: google/cloud/billing/budgets/v1
@@ -1030,7 +1030,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/cloud/config/v1
   languages:
@@ -1233,7 +1233,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
 - path: google/cloud/discoveryengine/v1beta
   languages:
     - go
@@ -2223,7 +2223,7 @@
   languages:
     - all
   release_level:
-    go: beta
+    go: preview
     java: stable
 - path: google/cloud/security/publicca/v1alpha1
   languages:
@@ -2276,7 +2276,7 @@
   languages:
     - all
   release_level:
-    go: beta
+    go: preview
 - path: google/cloud/securitycentermanagement/v1
   languages:
     - all
@@ -2787,7 +2787,7 @@
     - all
   new_issue_uri: https://issuetracker.google.com/savedsearches/559776
   release_level:
-    go: beta
+    go: preview
   title: Cloud Trace API
 - path: google/devtools/containeranalysis/v1
   documentation_uri: https://cloud.google.com/container-registry/docs/container-analysis
@@ -2895,7 +2895,7 @@
   languages:
     - all
   release_level:
-    go: beta
+    go: preview
 - path: google/iam/v3beta
   languages:
     - go
@@ -2944,7 +2944,7 @@
     - go
     - php
   release_level:
-    go: ga
+    go: stable
 - path: google/maps/addressvalidation/v1
   documentation_uri: https://mapsplatform.google.com/maps-products/address-validation/
   languages:
@@ -2964,7 +2964,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/maps/fleetengine/delivery/v1
   languages:
@@ -3017,7 +3017,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/maps/routeoptimization/v1
   languages:
@@ -3026,7 +3026,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/maps/routing/v2
   documentation_uri: https://mapsplatform.google.com/maps-products/#routes-section
@@ -3075,7 +3075,7 @@
     - all
   new_issue_uri: https://issuetracker.google.com/savedsearches/559785
   release_level:
-    go: beta
+    go: preview
   transports:
     csharp: grpc
     go: grpc
@@ -3108,7 +3108,7 @@
     - nodejs
     - python
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/shopping/merchant/accounts/v1
   languages:
@@ -3224,7 +3224,7 @@
     - java
     - python
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/shopping/merchant/promotions/v1
   languages:
@@ -3292,7 +3292,7 @@
     - go
     - java
   release_level:
-    go: beta
+    go: preview
     java: preview
 - path: google/spanner/admin/database/v1
   languages:
@@ -3305,7 +3305,7 @@
     - go
     - java
   release_level:
-    go: beta
+    go: preview
   transports:
     go: grpc
 - path: google/spanner/v1
@@ -3347,9 +3347,9 @@
 - path: schema/google/showcase/v1beta1
   languages:
     - all
-  service_config: schema/google/showcase/v1beta1/showcase_v1beta1.yaml
   skip_rest_numeric_enums:
     - java
+  service_config: schema/google/showcase/v1beta1/showcase_v1beta1.yaml
 - path: src/google/protobuf
   languages:
     - all


### PR DESCRIPTION
Move `release_level` normalization for `Go` to `golang/generate.go` following guidance in #4834 for mapping to `alpha`/`beta`, simplify `api.go#ReleaseLevels` logic, remove extraneous function for Go repo-metadata generation.

Normalize `go` `release_level` values in `sdk.yaml` to aligned values. Produces [this diff](https://github.com/googleapis/google-cloud-go/commit/6cb9707ec85b40064fec6a433154b86b4c4acf83#diff-62baa1edb8b92966baaf722e25962ef4561e106742c0ba1834807e0a9797860c).

Refactor some tests into table test, add more cases, remove some others that are no longer necessary and align values on expected values.

Fixes #4834