### PR TITLE
feat(tool/cmd/migrate): exclude pubsub from samples generation

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -37,6 +37,7 @@ var (
 		"iam-policy":        true,
 		"bigtable":          true,
 		"firestore":         true,
+		"pubsub":            true,
 	}
 
 	keepOverride = map[string][]string{

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -873,8 +873,14 @@ func TestShouldExcludeSamples(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "exclude if lib is in excludedSamplesLibraries",
+			name: "exclude if lib is in excludedSamplesLibraries (datastore)",
 			lib:  "datastore",
+			info: &javaGAPICInfo{Samples: true},
+			want: true,
+		},
+		{
+			name: "exclude if lib is in excludedSamplesLibraries (pubsub)",
+			lib:  "pubsub",
 			info: &javaGAPICInfo{Samples: true},
 			want: true,
 		},


### PR DESCRIPTION
Add pubsub to the excludedSamplesLibraries map in java_module.go so that running librarian migrate and generate does not recreate the generated samples directory for java-pubsub.

Fixes https://github.com/googleapis/librarian/issues/5739
