### PR TITLE
fix(internal/serviceconfig/sdk.yaml): remove redundant release_level for iamconnectorcredentials v1alpha

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1593,8 +1593,6 @@
 - path: google/cloud/iamconnectorcredentials/v1alpha
   languages:
     - python
-  release_level:
-    all: preview
 - path: google/cloud/iap/v1
   documentation_uri: https://cloud.google.com/iap
   languages:


### PR DESCRIPTION
The `google/cloud/iamconnectorcredentials/v1alpha` API is enabled only for Python. Its `release_level.all: preview` field is redundant because the generator automatically defaults to preview for alpha versions. This redundancy does not meet [the principle of sdk.yaml](https://github.com/googleapis/librarian/blob/main/doc/sdk-yaml-principles.md#management) where we manage exceptions in the YAML file:

> When we identify an API that requires an exception that cannot be inferred via standard discovery, an entry should be added or updated in this file.

Let's remove this `release_level.all: preview` from the section.

Implementation-wise, this field is handled by the [ReleaseLevel function in internal/serviceconfig/api.go](https://github.com/googleapis/librarian/blob/main/internal/serviceconfig/api.go#L148-L180), which extracts the version from the API path and defaults to `preview` if it contains `alpha` or `beta`:

```go
	// Not explicitly set, derive release level from API and client stability.
	apiVersion := ExtractVersion(api.Path)
	isAlpha := strings.Contains(apiVersion, "alpha")
	isBeta := strings.Contains(apiVersion, "beta")

	level := "stable"
	if isAlpha || isBeta || strings.HasPrefix(version, "0.") {
		level = "preview"
	}
```

Removing this field has no effect on the generated code.

For https://github.com/googleapis/librarian/issues/5098, where we want to remove conditions of release_level as much as possible. `iamconnectorcredentials/v1alpha` is the only usage of `release_level.all`. 