### PR TITLE
fix(internal/librarian/java): exclude google-cloud-bigtable-deps-bom from gapic-libraries-bom

### DIFF
--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -41,6 +41,7 @@ const (
 	versionsFileName = "versions.txt"
 )
 
+// excludedBOMs is a set of artifact IDs to exclude from the generated GAPIC BOM.
 var excludedBOMs = map[string]bool{
 	"google-cloud-bigtable-deps-bom": true,
 }

--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -41,6 +41,10 @@ const (
 	versionsFileName = "versions.txt"
 )
 
+var excludedBOMs = map[string]bool{
+	"google-cloud-bigtable-deps-bom": true,
+}
+
 var (
 	errModuleDiscovery      = errors.New("failed to search for java modules")
 	errRootPOMGeneration    = errors.New("failed to generate root pom.xml")
@@ -248,6 +252,9 @@ func searchModuleForBOM(repoPath, moduleName string) ([]*bomConfig, error) {
 		conf, err := extractBOMConfig(repoPath, moduleName, submodule.Name())
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract BOM config from %s: %w", pomPath, err)
+		}
+		if excludedBOMs[conf.ArtifactID] {
+			continue
 		}
 		if groupInclusions[conf.GroupID] {
 			configs = append(configs, conf)

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -132,6 +132,11 @@ func verifyBOM(t *testing.T, path string, wantVersion string, wantDeps []bomDepe
 	}) {
 		t.Errorf("%s should NOT contain google-maps-places-bom", path)
 	}
+	if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
+		return d.ArtifactID == "google-cloud-bigtable-deps-bom"
+	}) {
+		t.Errorf("%s should NOT contain google-cloud-bigtable-deps-bom", path)
+	}
 }
 
 func TestSearchForJavaModules(t *testing.T) {

--- a/internal/librarian/java/testdata/postgenerate/java-bigtable/google-cloud-bigtable-deps-bom/pom.xml
+++ b/internal/librarian/java/testdata/postgenerate/java-bigtable/google-cloud-bigtable-deps-bom/pom.xml
@@ -1,0 +1,5 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+  <version>1.2.3</version>
+</project>


### PR DESCRIPTION
Hardcoded to exclude google-cloud-bigtable-deps-bom from gapic-libraries-bom/pom.xml generation. This is to sync with recent change in google-cloud-java https://github.com/googleapis/google-cloud-java/commit/ce156f236f3222dab89f1298318e77b0c72cce14.

Fixes #6065