### PR TITLE
feat(internal/librarian/java): support non-cloud GroupID inference

### DIFF
--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -34,6 +34,7 @@ var knownPrefixes = []string{
 var nonCloudGroupIDs = map[string]string{
 	"google/shopping/": "com.google.shopping",
 	"google/maps/":     "com.google.maps",
+	"google/ads/":      "com.google.api-ads",
 }
 
 const defaultVersion = "0.1.0-SNAPSHOT"

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -31,12 +31,6 @@ var knownPrefixes = []string{
 	"google/",
 }
 
-var nonCloudGroupIDs = map[string]string{
-	"google/shopping/": "com.google.shopping",
-	"google/maps/":     "com.google.maps",
-	"google/ads/":      "com.google.api-ads",
-}
-
 const defaultVersion = "0.1.0-SNAPSHOT"
 
 // Add initializes a new Java library with default values.
@@ -46,28 +40,33 @@ func Add(lib *config.Library) *config.Library {
 	// so we reset it here to avoid redundancy in librarian.yaml.
 	lib.CopyrightYear = ""
 
-	if len(lib.APIs) > 0 {
-		apiPath := lib.APIs[0].Path
-		matched := false
-		for prefix, groupID := range nonCloudGroupIDs {
-			if strings.HasPrefix(apiPath, prefix) {
-				if lib.Java == nil {
-					lib.Java = &config.JavaModule{}
-				}
-				lib.Java.GroupID = groupID
-				lib.Java.DistributionNameOverride = groupID + ":google-" + lib.Name
-				matched = true
-				break
-			}
-		}
-		if !matched && !strings.HasPrefix(apiPath, "google/cloud/") {
-			log.Printf(
-				"WARNING: unrecognized non-cloud API path %q. Defaulting to com.google.cloud GroupID. "+
-					"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml if this is incorrect.",
-				apiPath,
-			)
-		}
+	// We use the first API to infer the GroupID and distribution name override.
+	// It is unrealistic for a single library to mix cloud and non-cloud APIs.
+	apiPath := lib.APIs[0].Path
+	switch {
+	case strings.HasPrefix(apiPath, "google/shopping/"):
+		return setJavaConfig(lib, "com.google.shopping")
+	case strings.HasPrefix(apiPath, "google/maps/"):
+		return setJavaConfig(lib, "com.google.maps")
+	case strings.HasPrefix(apiPath, "google/ads/"):
+		return setJavaConfig(lib, "com.google.api-ads")
 	}
+	if !strings.HasPrefix(apiPath, "google/cloud/") {
+		log.Printf(
+			"WARNING: unrecognized non-cloud API path %q. Defaulting to com.google.cloud GroupID. "+
+				"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml if this is incorrect.",
+			apiPath,
+		)
+	}
+	return lib
+}
+
+func setJavaConfig(lib *config.Library, groupID string) *config.Library {
+	if lib.Java == nil {
+		lib.Java = &config.JavaModule{}
+	}
+	lib.Java.GroupID = groupID
+	lib.Java.DistributionNameOverride = groupID + ":google-" + lib.Name
 	return lib
 }
 

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -31,7 +31,10 @@ var knownPrefixes = []string{
 	"google/",
 }
 
-const defaultVersion = "0.1.0-SNAPSHOT"
+const (
+	defaultVersion = "0.1.0-SNAPSHOT"
+	fakeGroupID    = "please-configure-java-group-id"
+)
 
 // Add initializes a new Java library with default values.
 func Add(lib *config.Library) *config.Library {
@@ -53,10 +56,11 @@ func Add(lib *config.Library) *config.Library {
 	}
 	if !strings.HasPrefix(apiPath, "google/cloud/") {
 		log.Printf(
-			"WARNING: unrecognized non-cloud API path %q. Defaulting to com.google.cloud GroupID. "+
-				"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml if this is incorrect.",
-			apiPath,
+			"WARNING: unrecognized non-cloud API path %q. Setting fake GroupID %q. "+
+				"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml.",
+			apiPath, fakeGroupID,
 		)
+		setJavaConfig(lib, fakeGroupID)
 	}
 	return lib
 }

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"log"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -30,6 +31,11 @@ var knownPrefixes = []string{
 	"google/",
 }
 
+var nonCloudGroupIDs = map[string]string{
+	"google/shopping/": "com.google.shopping",
+	"google/maps/":     "com.google.maps",
+}
+
 const defaultVersion = "0.1.0-SNAPSHOT"
 
 // Add initializes a new Java library with default values.
@@ -38,6 +44,29 @@ func Add(lib *config.Library) *config.Library {
 	// Java generation defaults to the system year for license headers,
 	// so we reset it here to avoid redundancy in librarian.yaml.
 	lib.CopyrightYear = ""
+
+	if len(lib.APIs) > 0 {
+		apiPath := lib.APIs[0].Path
+		matched := false
+		for prefix, groupID := range nonCloudGroupIDs {
+			if strings.HasPrefix(apiPath, prefix) {
+				if lib.Java == nil {
+					lib.Java = &config.JavaModule{}
+				}
+				lib.Java.GroupID = groupID
+				lib.Java.DistributionNameOverride = groupID + ":google-" + lib.Name
+				matched = true
+				break
+			}
+		}
+		if !matched && !strings.HasPrefix(apiPath, "google/cloud/") {
+			log.Printf(
+				"WARNING: unrecognized non-cloud API path %q. Defaulting to com.google.cloud GroupID. "+
+					"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml if this is incorrect.",
+				apiPath,
+			)
+		}
+	}
 	return lib
 }
 

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -22,17 +22,94 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	lib := &config.Library{
-		Name: "test-library",
-	}
-	want := &config.Library{
-		Name:          "test-library",
-		Version:       defaultVersion,
-		CopyrightYear: "",
-	}
-	got := Add(lib)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want *config.Library
+	}{
+		{
+			name: "standard cloud API",
+			lib: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Version:       defaultVersion,
+				CopyrightYear: "",
+			},
+		},
+		{
+			name: "shopping API",
+			lib: &config.Library{
+				Name: "shopping-css",
+				APIs: []*config.API{
+					{Path: "google/shopping/css/v1"},
+				},
+			},
+			want: &config.Library{
+				Name: "shopping-css",
+				APIs: []*config.API{
+					{Path: "google/shopping/css/v1"},
+				},
+				Version:       defaultVersion,
+				CopyrightYear: "",
+				Java: &config.JavaModule{
+					GroupID:                  "com.google.shopping",
+					DistributionNameOverride: "com.google.shopping:google-shopping-css",
+				},
+			},
+		},
+		{
+			name: "maps API",
+			lib: &config.Library{
+				Name: "maps-routing",
+				APIs: []*config.API{
+					{Path: "google/maps/routing/v1"},
+				},
+			},
+			want: &config.Library{
+				Name: "maps-routing",
+				APIs: []*config.API{
+					{Path: "google/maps/routing/v1"},
+				},
+				Version:       defaultVersion,
+				CopyrightYear: "",
+				Java: &config.JavaModule{
+					GroupID:                  "com.google.maps",
+					DistributionNameOverride: "com.google.maps:google-maps-routing",
+				},
+			},
+		},
+		{
+			name: "unrecognized non-cloud API",
+			lib: &config.Library{
+				Name: "foo-bar",
+				APIs: []*config.API{
+					{Path: "google/foo/bar/v1"},
+				},
+			},
+			want: &config.Library{
+				Name: "foo-bar",
+				APIs: []*config.API{
+					{Path: "google/foo/bar/v1"},
+				},
+				Version:       defaultVersion,
+				CopyrightYear: "",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Add(test.lib)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -101,6 +101,10 @@ func TestAdd(t *testing.T) {
 				},
 				Version:       defaultVersion,
 				CopyrightYear: "",
+				Java: &config.JavaModule{
+					GroupID:                  "please-configure-java-group-id",
+					DistributionNameOverride: "please-configure-java-group-id:google-foo-bar",
+				},
 			},
 		},
 		{

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -103,6 +103,27 @@ func TestAdd(t *testing.T) {
 				CopyrightYear: "",
 			},
 		},
+		{
+			name: "ads API",
+			lib: &config.Library{
+				Name: "ads-admanager",
+				APIs: []*config.API{
+					{Path: "google/ads/admanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name: "ads-admanager",
+				APIs: []*config.API{
+					{Path: "google/ads/admanager/v1"},
+				},
+				Version:       defaultVersion,
+				CopyrightYear: "",
+				Java: &config.JavaModule{
+					GroupID:                  "com.google.api-ads",
+					DistributionNameOverride: "com.google.api-ads:google-ads-admanager",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := Add(test.lib)

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -48,10 +48,14 @@ var (
 	errNoProtos          = errors.New("no protos found")
 	errMonorepoVersion   = fmt.Errorf("failed to find monorepo version for %q in config", rootLibrary)
 	errBOMVersionMissing = errors.New("libraries bom version not found in config")
+	errUnrecognizedAPI   = errors.New("unrecognized non-cloud API: configure java.group_id and java.distribution_name_override in librarian.yaml")
 )
 
 // Generate generates a Java client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, srcs *sources.Sources) error {
+	if library.Java.GroupID == fakeGroupID {
+		return errUnrecognizedAPI
+	}
 	outdir, err := filepath.Abs(library.Output)
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -582,6 +582,20 @@ func TestGenerateLibrary_Error(t *testing.T) {
 			},
 			wantErr: errMonorepoVersion,
 		},
+		{
+			name: "fake group ID error",
+			library: &config.Library{
+				Name:   "secretmanager",
+				Output: t.TempDir(),
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Java: &config.JavaModule{
+					GroupID: fakeGroupID,
+				},
+			},
+			wantErr: errUnrecognizedAPI,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := Fill(test.library); err != nil {


### PR DESCRIPTION
Java library onboarding now automatically infers the Maven GroupID and distribution name override for recognized non-cloud APIs (Shopping, Maps, and Ads) based on their API path prefixes. This reduces manual configuration steps and ensures consistency.
Referenced existing rules recorded in [guide](https://github.com/googleapis/google-cloud-java/blob/main/generation/new_client_hermetic_build/README.md#special-case-example-google-maps).

If a new library is added with an unrecognized non-cloud API path, prints a warning and sets a fake group id. When running generate on this fake group id, returns error.

Fixes https://github.com/googleapis/librarian/issues/6047