### PR TITLE
chore(internal/librarian/java): simplify and remove ensureCloudPrefix

### DIFF
--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -144,21 +144,12 @@ func protoGroupID(mainArtifactGroupID string) string {
 	return prefix + protoGRPCSuffix
 }
 
-// ensureCloudPrefix returns name with the "google-cloud-" prefix,
-// adding it if not already present.
-func ensureCloudPrefix(name string) string {
-	if !strings.HasPrefix(name, cloudPrefix) {
-		return cloudPrefix + name
-	}
-	return name
-}
-
 // DeriveDistributionName returns the Maven distribution name (GroupID:ArtifactID)
 // for the library, applying overrides and defaults as necessary.
 func DeriveDistributionName(library *config.Library) string {
 	if library.Java != nil && library.Java.DistributionNameOverride != "" {
 		return library.Java.DistributionNameOverride
 	}
-	artifactID := ensureCloudPrefix(library.Name)
+	artifactID := cloudPrefix + library.Name
 	return fmt.Sprintf("%s:%s", library.Java.GroupID, artifactID)
 }

--- a/internal/librarian/java/maven_coordinate.go
+++ b/internal/librarian/java/maven_coordinate.go
@@ -147,7 +147,7 @@ func protoGroupID(mainArtifactGroupID string) string {
 // DeriveDistributionName returns the Maven distribution name (GroupID:ArtifactID)
 // for the library, applying overrides and defaults as necessary.
 func DeriveDistributionName(library *config.Library) string {
-	if library.Java != nil && library.Java.DistributionNameOverride != "" {
+	if library.Java.DistributionNameOverride != "" {
 		return library.Java.DistributionNameOverride
 	}
 	artifactID := cloudPrefix + library.Name

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -48,11 +48,7 @@ func TestDeriveDistributionName(t *testing.T) {
 			},
 			want: "com.google.cloud:google-cloud-secretmanager-v1",
 		},
-		{
-			name:    "library name already has prefix",
-			library: &config.Library{Name: "google-cloud-secretmanager", Java: &config.JavaModule{GroupID: "com.google.cloud"}},
-			want:    "com.google.cloud:google-cloud-secretmanager",
-		},
+
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := DeriveDistributionName(test.library)
@@ -283,20 +279,3 @@ func TestDeriveAPICoordinates(t *testing.T) {
 	}
 }
 
-func TestEnsureCloudPrefix(t *testing.T) {
-	for _, test := range []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"no prefix", "secretmanager", "google-cloud-secretmanager"},
-		{"with prefix", "google-cloud-secretmanager", "google-cloud-secretmanager"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := ensureCloudPrefix(test.input)
-			if got != test.want {
-				t.Errorf("ensureCloudPrefix(%q) = %q, want %q", test.input, got, test.want)
-			}
-		})
-	}
-}

--- a/internal/librarian/java/maven_coordinate_test.go
+++ b/internal/librarian/java/maven_coordinate_test.go
@@ -48,7 +48,6 @@ func TestDeriveDistributionName(t *testing.T) {
 			},
 			want: "com.google.cloud:google-cloud-secretmanager-v1",
 		},
-
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := DeriveDistributionName(test.library)
@@ -278,4 +277,3 @@ func TestDeriveAPICoordinates(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Simplify logic and always add cloud prefix. In migrated google-cloud-java/librarian.yaml, there is no library name prefixed with "google-cloud-" (other than google-cloud-java which skip_generate). And when adding new libraries, library name is inferred from API path stripping "google/cloud/" prefix (see [code](https://github.com/googleapis/librarian/blob/610657252b7ee76b8dc6079117a738b29da261bd/internal/librarian/java/add.go#L47)), so removing the extra check here is safe.

Fixes #6081