### PR TITLE
fix(internal/librarian/java): respect partial generation flags in clean

### DIFF
--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -80,13 +80,13 @@ func cleanPatterns(library *config.Library) map[string]bool {
 		javaAPI := api.Java
 		version := filepath.Base(api.Path)
 		apiCoordinates := DeriveAPICoordinates(libraryCoordinates, version, javaAPI)
-		if apiCoordinates.Proto.ArtifactID != "" {
+		if apiCoordinates.Proto.ArtifactID != "" && shouldGenerateProto(javaAPI) {
 			patterns[filepath.Join(apiCoordinates.Proto.ArtifactID, "src")] = false
 		}
-		if apiCoordinates.GRPC.ArtifactID != "" {
+		if apiCoordinates.GRPC.ArtifactID != "" && shouldGenerateGRPC(javaAPI) {
 			patterns[filepath.Join(apiCoordinates.GRPC.ArtifactID, "src")] = false
 		}
-		if apiCoordinates.GAPIC.ArtifactID != "" {
+		if apiCoordinates.GAPIC.ArtifactID != "" && shouldGenerateGAPIC(javaAPI) {
 			patterns[filepath.Join(apiCoordinates.GAPIC.ArtifactID, "src")] = true
 		}
 	}

--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -74,9 +74,9 @@ func Clean(library *config.Library) error {
 // The key is the path pattern relative to the library output directory.
 // The boolean value indicates whether marker-based cleaning should be used:
 //   - true: Enable marker-based cleaning. Only .java files containing auto-generation
-//           markers are deleted. Used for GAPIC source directories to protect manual edits.
+//     markers are deleted. Used for GAPIC source directories to protect manual edits.
 //   - false: Disable marker-based cleaning. Files are deleted unconditionally
-//            (subject to general preservation rules). Used for Proto, GRPC, and samples.
+//     (subject to general preservation rules). Used for Proto, GRPC, and samples.
 func cleanPatterns(library *config.Library) map[string]bool {
 	libraryCoordinates := DeriveLibraryCoordinates(library)
 	patterns := map[string]bool{

--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -70,6 +70,13 @@ func Clean(library *config.Library) error {
 	return nil
 }
 
+// cleanPatterns returns a map of directory patterns to be cleaned.
+// The key is the path pattern relative to the library output directory.
+// The boolean value indicates whether marker-based cleaning should be used:
+//   - true: Enable marker-based cleaning. Only .java files containing auto-generation
+//           markers are deleted. Used for GAPIC source directories to protect manual edits.
+//   - false: Disable marker-based cleaning. Files are deleted unconditionally
+//            (subject to general preservation rules). Used for Proto, GRPC, and samples.
 func cleanPatterns(library *config.Library) map[string]bool {
 	libraryCoordinates := DeriveLibraryCoordinates(library)
 	patterns := map[string]bool{

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -369,6 +369,52 @@ func TestCleanPatterns(t *testing.T) {
 				".repo-metadata.json":                                  false,
 			},
 		},
+		{
+			name: "gapic_disabled_for_all_apis",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						Java: &config.JavaAPI{
+							GenerateGAPIC: new(false),
+						},
+					},
+				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
+			},
+			want: map[string]bool{
+				filepath.Join("proto-google-cloud-secretmanager-v1", "src"): false,
+				filepath.Join("grpc-google-cloud-secretmanager-v1", "src"):  false,
+				filepath.Join("samples", "snippets", "generated"):           false,
+				".repo-metadata.json": false,
+			},
+		},
+		{
+			name: "proto_and_grpc_disabled",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						Java: &config.JavaAPI{
+							GenerateProto: new(false),
+							GenerateGRPC:  new(false),
+						},
+					},
+				},
+				Java: &config.JavaModule{
+					GroupID: "com.google.cloud",
+				},
+			},
+			want: map[string]bool{
+				filepath.Join("google-cloud-secretmanager", "src"): true,
+				filepath.Join("samples", "snippets", "generated"):  false,
+				".repo-metadata.json":                              false,
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := cleanPatterns(test.library)


### PR DESCRIPTION
The clean logic in the Java librarian now respects partial generation flags (GenerateProto, GenerateGRPC, and GenerateGAPIC) configured for APIs. 
Previously, the clean step unconditionally targeted all modules for cleaning. Although in reality, we don't have cases that non-generated module exists, so no generation diff caused by this. But in theory this could lead to unexpected deletion of directories, or redundant cleaning attempts for disabled modules in configurations.

Fixes #5430