### PR TITLE
feat(sidekick/rust): generate LRO poller builders with options propagation

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -209,6 +209,10 @@ pub mod {{Codec.ModuleName}} {
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
             {{#Model.Codec.LroStubOptions}}
+            {{!
+              `poller_options` must be extracted here before `self` is moved into
+              the `start` closure.
+            }}
             #[cfg(google_cloud_unstable_tracing)]
             let mut poller_options = self.0.stub.get_poller_options(&self.0.options);
             #[cfg(google_cloud_unstable_tracing)]
@@ -248,14 +252,14 @@ pub mod {{Codec.ModuleName}} {
             {{#Model.Codec.LroStubOptions}}
             #[cfg(google_cloud_unstable_tracing)]
             {
-                let poller = google_cloud_lro::internal::new_discovery_poller(
+                use google_cloud_lro::internal::PollerExt;
+                google_cloud_lro::internal::new_discovery_poller(
                     polling_error_policy,
                     polling_backoff_policy,
                     start,
                     query,
-                );
-                use google_cloud_lro::internal::PollerExt;
-                poller.with_options(poller_options)
+                )
+                .with_options(poller_options)
             }
 
             #[cfg(not(google_cloud_unstable_tracing))]
@@ -299,6 +303,10 @@ pub mod {{Codec.ModuleName}} {
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
             {{#Model.Codec.LroStubOptions}}
+            {{!
+              `poller_options` must be extracted here before `self` is moved into
+              the `start` closure.
+            }}
             #[cfg(google_cloud_unstable_tracing)]
             let mut poller_options = self.0.stub.get_poller_options(&self.0.options);
             #[cfg(google_cloud_unstable_tracing)]
@@ -332,18 +340,21 @@ pub mod {{Codec.ModuleName}} {
             #[cfg(google_cloud_unstable_tracing)]
             {
                 use google_cloud_lro::internal::PollerExt;
-                {{#Codec.NoneAreEmpty}}
-                google_cloud_lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
-                {{/Codec.NoneAreEmpty}}
-                {{#Codec.OnlyResponseIsEmpty}}
-                google_cloud_lro::internal::new_unit_response_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
-                {{/Codec.OnlyResponseIsEmpty}}
-                {{#Codec.OnlyMetadataIsEmpty}}
-                google_cloud_lro::internal::new_unit_metadata_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
-                {{/Codec.OnlyMetadataIsEmpty}}
-                {{#Codec.BothAreEmpty}}
-                google_cloud_lro::internal::new_unit_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
-                {{/Codec.BothAreEmpty}}
+                {
+                    {{#Codec.NoneAreEmpty}}
+                    google_cloud_lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+                    {{/Codec.NoneAreEmpty}}
+                    {{#Codec.OnlyResponseIsEmpty}}
+                    google_cloud_lro::internal::new_unit_response_poller(polling_error_policy, polling_backoff_policy, start, query)
+                    {{/Codec.OnlyResponseIsEmpty}}
+                    {{#Codec.OnlyMetadataIsEmpty}}
+                    google_cloud_lro::internal::new_unit_metadata_poller(polling_error_policy, polling_backoff_policy, start, query)
+                    {{/Codec.OnlyMetadataIsEmpty}}
+                    {{#Codec.BothAreEmpty}}
+                    google_cloud_lro::internal::new_unit_poller(polling_error_policy, polling_backoff_policy, start, query)
+                    {{/Codec.BothAreEmpty}}
+                }
+                .with_options(poller_options)
             }
 
             #[cfg(not(google_cloud_unstable_tracing))]

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -208,6 +208,14 @@ pub mod {{Codec.ModuleName}} {
         {
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
+            {{#Model.Codec.LroStubOptions}}
+            #[cfg(google_cloud_unstable_tracing)]
+            let mut poller_options = self.0.stub.get_poller_options(&self.0.options);
+            #[cfg(google_cloud_unstable_tracing)]
+            if let Some(ref mut details) = poller_options.tracing {
+                details.method_name = "{{Model.Codec.PackageNamespace}}::client::{{Codec.ServiceNameToPascal}}::{{Codec.MethodName}}::until_done";
+            }
+            {{/Model.Codec.LroStubOptions}}
 
             let stub = self.0.stub.clone();
             let mut options = self.0.options.clone();
@@ -237,12 +245,35 @@ pub mod {{Codec.ModuleName}} {
                 self.send().await
             };
 
+            {{#Model.Codec.LroStubOptions}}
+            #[cfg(google_cloud_unstable_tracing)]
+            {
+                let poller = google_cloud_lro::internal::new_discovery_poller(
+                    polling_error_policy,
+                    polling_backoff_policy,
+                    start,
+                    query,
+                );
+                use google_cloud_lro::internal::PollerExt;
+                poller.with_options(poller_options)
+            }
+
+            #[cfg(not(google_cloud_unstable_tracing))]
             google_cloud_lro::internal::new_discovery_poller(
                 polling_error_policy,
                 polling_backoff_policy,
                 start,
                 query,
             )
+            {{/Model.Codec.LroStubOptions}}
+            {{^Model.Codec.LroStubOptions}}
+            google_cloud_lro::internal::new_discovery_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
+            {{/Model.Codec.LroStubOptions}}
         }
         {{/DiscoveryLro}}
         {{#OperationInfo}}
@@ -267,6 +298,14 @@ pub mod {{Codec.ModuleName}} {
             type Operation = google_cloud_lro::internal::Operation<{{Codec.ResponseType}}, {{Codec.MetadataType}}>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
+            {{#Model.Codec.LroStubOptions}}
+            #[cfg(google_cloud_unstable_tracing)]
+            let mut poller_options = self.0.stub.get_poller_options(&self.0.options);
+            #[cfg(google_cloud_unstable_tracing)]
+            if let Some(ref mut details) = poller_options.tracing {
+                details.method_name = "{{Model.Codec.PackageNamespace}}::client::{{Method.Codec.ServiceNameToPascal}}::{{Method.Codec.Name}}::until_done";
+            }
+            {{/Model.Codec.LroStubOptions}}
 
             let stub = self.0.stub.clone();
             let mut options = self.0.options.clone();
@@ -289,6 +328,41 @@ pub mod {{Codec.ModuleName}} {
                 Ok(Operation::new(op))
             };
 
+            {{#Model.Codec.LroStubOptions}}
+            #[cfg(google_cloud_unstable_tracing)]
+            {
+                use google_cloud_lro::internal::PollerExt;
+                {{#Codec.NoneAreEmpty}}
+                google_cloud_lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
+                {{/Codec.NoneAreEmpty}}
+                {{#Codec.OnlyResponseIsEmpty}}
+                google_cloud_lro::internal::new_unit_response_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
+                {{/Codec.OnlyResponseIsEmpty}}
+                {{#Codec.OnlyMetadataIsEmpty}}
+                google_cloud_lro::internal::new_unit_metadata_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
+                {{/Codec.OnlyMetadataIsEmpty}}
+                {{#Codec.BothAreEmpty}}
+                google_cloud_lro::internal::new_unit_poller(polling_error_policy, polling_backoff_policy, start, query).with_options(poller_options)
+                {{/Codec.BothAreEmpty}}
+            }
+
+            #[cfg(not(google_cloud_unstable_tracing))]
+            {
+                {{#Codec.NoneAreEmpty}}
+                google_cloud_lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+                {{/Codec.NoneAreEmpty}}
+                {{#Codec.OnlyResponseIsEmpty}}
+                google_cloud_lro::internal::new_unit_response_poller(polling_error_policy, polling_backoff_policy, start, query)
+                {{/Codec.OnlyResponseIsEmpty}}
+                {{#Codec.OnlyMetadataIsEmpty}}
+                google_cloud_lro::internal::new_unit_metadata_poller(polling_error_policy, polling_backoff_policy, start, query)
+                {{/Codec.OnlyMetadataIsEmpty}}
+                {{#Codec.BothAreEmpty}}
+                google_cloud_lro::internal::new_unit_poller(polling_error_policy, polling_backoff_policy, start, query)
+                {{/Codec.BothAreEmpty}}
+            }
+            {{/Model.Codec.LroStubOptions}}
+            {{^Model.Codec.LroStubOptions}}
             {{#Codec.NoneAreEmpty}}
             google_cloud_lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
             {{/Codec.NoneAreEmpty}}
@@ -301,6 +375,7 @@ pub mod {{Codec.ModuleName}} {
             {{#Codec.BothAreEmpty}}
             google_cloud_lro::internal::new_unit_poller(polling_error_policy, polling_backoff_policy, start, query)
             {{/Codec.BothAreEmpty}}
+            {{/Model.Codec.LroStubOptions}}
         }
         {{/OperationInfo}}
         {{#HasAutoPopulatedFields}}

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -87,6 +87,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
 
     {{#Model.Codec.LroStubOptions}}
     #[cfg(google_cloud_unstable_tracing)]
+    #[doc(hidden)]
     /// Returns the poller options.
     ///
     /// When mocking, this method is typically irrelevant. Do not try to verify

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -105,6 +105,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
 
     {{#Model.Codec.LroStubOptions}}
     #[cfg(google_cloud_unstable_tracing)]
+    #[doc(hidden)]
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,


### PR DESCRIPTION
Construct and propagate client-level `TracingDetails` configuration options to generated LRO poller constructors. 

We need `method_name` for `"otel.name", so the generated client builders must extract it and pass them through the LRO poller factory constructors.

Staged @ [bc06ba5](https://github.com/googleapis/google-cloud-rust/pull/5629/commits/bc06ba5b9627f2ee4cf364db96cbac294facb025)