### PR TITLE
refactor(internal/librarian/java): move formatting logic to separate files

### DIFF
--- a/internal/librarian/java/format.go
+++ b/internal/librarian/java/format.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package java
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// Format formats a Java client library using google-java-format.
+func Format(ctx context.Context, library *config.Library) error {
+	files, err := collectJavaFiles(library.Output)
+	if err != nil {
+		return fmt.Errorf("failed to find java files for formatting: %w", err)
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	if _, err := exec.LookPath("google-java-format"); err != nil {
+		return fmt.Errorf("google-java-format not found in PATH: %w", err)
+	}
+
+	args := append([]string{"--replace"}, files...)
+	if err := command.Run(ctx, "google-java-format", args...); err != nil {
+		return fmt.Errorf("failed to format files: %w", err)
+	}
+	return nil
+}
+
+func collectJavaFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".java" {
+			return nil
+		}
+		// exclude samples/snippets/generated
+		if strings.Contains(path, filepath.Join("samples", "snippets", "generated")) {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	return files, err
+}

--- a/internal/librarian/java/format_test.go
+++ b/internal/librarian/java/format_test.go
@@ -102,6 +102,7 @@ func TestCollectJavaFiles(t *testing.T) {
 		"subdir/NotJava.txt",
 		"samples/snippets/generated/Ignored.java",
 		"another/dir/More.java",
+		"samples/snippets/src/Ignored.java",
 	}
 	for _, f := range filesToCreate {
 		path := filepath.Join(tmpDir, f)

--- a/internal/librarian/java/format_test.go
+++ b/internal/librarian/java/format_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package java
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+func TestFormat(t *testing.T) {
+	testhelper.RequireCommand(t, "google-java-format")
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T, root string)
+	}{
+		{
+			name: "successful format",
+			setup: func(t *testing.T, root string) {
+				if err := os.WriteFile(filepath.Join(root, "SomeClass.java"), []byte("public class SomeClass {}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "no files found",
+			setup: func(t *testing.T, root string) {},
+		},
+		{
+			name: "nested files in subdirectories",
+			setup: func(t *testing.T, root string) {
+				dir := filepath.Join(root, "sub", "dir")
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "Nested.java"), []byte("public class Nested {}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "files in excluded samples path are ignored",
+			setup: func(t *testing.T, root string) {
+				dir := filepath.Join(root, "samples", "snippets", "generated")
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				// This file should NOT be passed to the formatter.
+				if err := os.WriteFile(filepath.Join(dir, "Ignored.java"), []byte("public class Ignored {}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			test.setup(t, tmpDir)
+			if err := Format(t.Context(), &config.Library{Output: tmpDir}); err != nil {
+				t.Errorf("Format() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestFormat_LookPathError(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "SomeClass.java"), []byte("public class SomeClass {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", "")
+	err := Format(t.Context(), &config.Library{Output: tmpDir})
+	if err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectJavaFiles(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	// Create a mix of files
+	filesToCreate := []string{
+		"Root.java",
+		"subdir/Nested.java",
+		"subdir/NotJava.txt",
+		"samples/snippets/generated/Ignored.java",
+		"another/dir/More.java",
+	}
+	for _, f := range filesToCreate {
+		path := filepath.Join(tmpDir, f)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := []string{
+		filepath.Join(tmpDir, "Root.java"),
+		filepath.Join(tmpDir, "subdir", "Nested.java"),
+		filepath.Join(tmpDir, "another", "dir", "More.java"),
+	}
+	got, err := collectJavaFiles(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -332,46 +331,6 @@ func resolveGAPICOptions(cfg *config.Config, library *config.Library, api *confi
 
 func gapicOpt(key, value string) string {
 	return fmt.Sprintf("%s=%s", key, value)
-}
-
-// Format formats a Java client library using google-java-format.
-func Format(ctx context.Context, library *config.Library) error {
-	files, err := collectJavaFiles(library.Output)
-	if err != nil {
-		return fmt.Errorf("failed to find java files for formatting: %w", err)
-	}
-	if len(files) == 0 {
-		return nil
-	}
-
-	if _, err := exec.LookPath("google-java-format"); err != nil {
-		return fmt.Errorf("google-java-format not found in PATH: %w", err)
-	}
-
-	args := append([]string{"--replace"}, files...)
-	if err := command.Run(ctx, "google-java-format", args...); err != nil {
-		return fmt.Errorf("failed to format files: %w", err)
-	}
-	return nil
-}
-
-func collectJavaFiles(root string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || filepath.Ext(path) != ".java" {
-			return nil
-		}
-		// exclude samples/snippets/generated
-		if strings.Contains(path, filepath.Join("samples", "snippets", "generated")) {
-			return nil
-		}
-		files = append(files, path)
-		return nil
-	})
-	return files, err
 }
 
 // TODO(https://github.com/googleapis/librarian/issues/5152):

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"syscall"
 
-	"sort"
-
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -747,109 +745,6 @@ func TestGenerate_ProtoExclusion(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(protoPkgDir, "ServiceProto.java")); err != nil {
 		t.Errorf("ServiceProto.java SHOULD be generated: %v", err)
-	}
-}
-
-func TestFormat_Success(t *testing.T) {
-	testhelper.RequireCommand(t, "google-java-format")
-	for _, test := range []struct {
-		name  string
-		setup func(t *testing.T, root string)
-	}{
-		{
-			name: "successful format",
-			setup: func(t *testing.T, root string) {
-				if err := os.WriteFile(filepath.Join(root, "SomeClass.java"), []byte("public class SomeClass {}"), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
-		{
-			name:  "no files found",
-			setup: func(t *testing.T, root string) {},
-		},
-		{
-			name: "nested files in subdirectories",
-			setup: func(t *testing.T, root string) {
-				dir := filepath.Join(root, "sub", "dir")
-				if err := os.MkdirAll(dir, 0755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.WriteFile(filepath.Join(dir, "Nested.java"), []byte("public class Nested {}"), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
-		{
-			name: "files in excluded samples path are ignored",
-			setup: func(t *testing.T, root string) {
-				dir := filepath.Join(root, "samples", "snippets", "generated")
-				if err := os.MkdirAll(dir, 0755); err != nil {
-					t.Fatal(err)
-				}
-				// This file should NOT be passed to the formatter.
-				if err := os.WriteFile(filepath.Join(dir, "Ignored.java"), []byte("public class Ignored {}"), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			tmpDir := t.TempDir()
-			test.setup(t, tmpDir)
-			if err := Format(t.Context(), &config.Library{Output: tmpDir}); err != nil {
-				t.Errorf("Format() error = %v, want nil", err)
-			}
-		})
-	}
-}
-
-func TestFormat_LookPathError(t *testing.T) {
-	tmpDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmpDir, "SomeClass.java"), []byte("public class SomeClass {}"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", "")
-	err := Format(t.Context(), &config.Library{Output: tmpDir})
-	if err == nil {
-		t.Fatal(err)
-	}
-}
-
-func TestCollectJavaFiles(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
-	// Create a mix of files
-	filesToCreate := []string{
-		"Root.java",
-		"subdir/Nested.java",
-		"subdir/NotJava.txt",
-		"samples/snippets/generated/Ignored.java",
-		"another/dir/More.java",
-	}
-	for _, f := range filesToCreate {
-		path := filepath.Join(tmpDir, f)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	want := []string{
-		filepath.Join(tmpDir, "Root.java"),
-		filepath.Join(tmpDir, "subdir", "Nested.java"),
-		filepath.Join(tmpDir, "another", "dir", "More.java"),
-	}
-	got, err := collectJavaFiles(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sort.Strings(got)
-	sort.Strings(want)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
The `Format` function, `collectJavaFiles` helper, and their associated unit tests are extracted from generate.go and generate_test.go into format.go and format_test.go.

This refactoring isolates the java-format execution and source file collection logic from the main library generation logic, improving package organization.