### PR TITLE
fix(internal/librarian/java): fix prerelease snapshot version derivation

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -379,7 +379,9 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 }
 
 // deriveLastReleasedVersion derives the last released version from a snapshot version
-// (e.g., x.y.z-SNAPSHOT) by decrementing the patch or minor version.
+// (e.g., x.y.z-SNAPSHOT or x.y.z-beta-SNAPSHOT) by decrementing the patch or minor version.
+// If the version has a prerelease tag (like "beta") before "SNAPSHOT", that tag is preserved
+// in the derived version (e.g., x.y.z-beta-SNAPSHOT becomes x.y.(z-1)-beta).
 //
 // It returns an error if both minor and patch versions are zero, as it's
 // ambiguous what the last released version was in that case.
@@ -388,7 +390,7 @@ func deriveLastReleasedVersion(v string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if sv.Prerelease != "SNAPSHOT" {
+	if !strings.HasSuffix(sv.Prerelease, "SNAPSHOT") {
 		return sv.String(), nil
 	}
 	if sv.Patch > 0 {
@@ -399,7 +401,8 @@ func deriveLastReleasedVersion(v string) (string, error) {
 	} else {
 		return "", errInvalidVersion
 	}
-	sv.Prerelease = ""
+	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "SNAPSHOT")
+	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "-")
 	return sv.String(), nil
 }
 

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -702,6 +702,8 @@ func TestDeriveLastReleasedVersion(t *testing.T) {
 		{input: "0.87.0-SNAPSHOT", want: "0.86.0"},
 		{input: "0.0.1-SNAPSHOT", want: "0.0.0"},
 		{input: "1.10.1-SNAPSHOT", want: "1.10.0"},
+		{input: "0.214.0-beta-SNAPSHOT", want: "0.213.0-beta"},
+		{input: "0.214.0-beta", want: "0.214.0-beta"},
 		{input: "1.2.3", want: "1.2.3"},
 	} {
 		t.Run(test.input, func(t *testing.T) {


### PR DESCRIPTION
The deriveLastReleasedVersion function is updated to support versions that have a prerelease tag before SNAPSHOT (e.g., errorreporting, 0.214.0-beta-SNAPSHOT) so that README version are generated correctly. Previously, the function only checked for exact equality with SNAPSHOT to identify snapshot versions, causing it to skip versions with other prerelease tags and return them unmodified.

Fixes https://github.com/googleapis/librarian/issues/6097