### PR TITLE
chore(internal/serviceconfig): add java grpc transport to spanner executor

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -3295,6 +3295,7 @@
     go: preview
   transports:
     go: grpc
+    java: grpc
 - path: google/spanner/v1
   languages:
     - all


### PR DESCRIPTION
The transport config for the Java SDK is updated to use gRPC for the Spanner executor v1 API path.

This enables generating the Java client library for the Spanner executor service using gRPC transport.

Fixes #6011