### PR TITLE
feat(sidekick/swift): use `@nonexhaustive`

### DIFF
--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -179,6 +179,7 @@ func TestGenerateOneOf(t *testing.T) {
 
 
   /// A group of fields where only one is set.
+  @nonexhaustive
   public enum OneOf_Choice: Codable, Equatable, Sendable {
     /// A string field that is part of the oneof.
     case stringField(String)

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -16,6 +16,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
+@nonexhaustive
 public enum {{Codec.Name}}: Int, Codable, Equatable, Sendable {
     {{#UniqueNumberValues}}
     {{#DocLines}}

--- a/internal/sidekick/swift/templates/common/oneof.mustache
+++ b/internal/sidekick/swift/templates/common/oneof.mustache
@@ -16,6 +16,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
+@nonexhaustive
 public enum {{Codec.Name}}: Codable, Equatable, Sendable {
   {{#Fields}}
   {{#Codec.DocLines}}


### PR DESCRIPTION
The `@nonexhaustive` attribute allows growing a Swift enum without breaking applications that consume them.

Towards #6043 