### PR TITLE
fix(tool/cmd/migrate): map spanner executor GAPIC to google-cloud-spanner-executor

### DIFF
--- a/tool/cmd/migrate/java_module.go
+++ b/tool/cmd/migrate/java_module.go
@@ -169,6 +169,7 @@ var (
 		{apiPath: "google/spanner/executor/v1"}: {
 			protoArtifactID: "proto-google-cloud-spanner-executor-v1",
 			grpcArtifactID:  "grpc-google-cloud-spanner-executor-v1",
+			gapicArtifactID: "google-cloud-spanner-executor",
 		},
 		{apiPath: "google/devtools/clouderrorreporting/v1beta1"}: {
 			protoArtifactID: "proto-google-cloud-error-reporting-v1beta1",


### PR DESCRIPTION
Adds the missing gapicArtifactID override to google/spanner/executor/v1 in javaArtifactIDOverrides. This ensures that the Spanner Executor's GAPIC client files are correctly outputted into the google-cloud-spanner-executor module instead of defaulting to the main google-cloud-spanner module.
Fixes https://github.com/googleapis/librarian/issues/6079