### PR TITLE
feat(sidekick/rust): propagate LRO telemetry attributes via task-local context

### DIFF
--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -397,6 +397,8 @@ type Method struct {
 	ClientSideStreaming bool
 	// ServerSideStreaming is true if the method supports server-side streaming.
 	ServerSideStreaming bool
+	// IsLroPoller is true if the method is an LRO poller.
+	IsLroPoller bool
 	// OperationInfo contains information for methods returning long-running operations.
 	OperationInfo *OperationInfo
 	// DiscoveryLro has a value if this is a discovery-style long-running operation.

--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -357,6 +357,12 @@ func enrichMethodSamples(m *Method) {
 
 	m.IsLRO = m.OperationInfo != nil
 
+	if m.SourceServiceID == ".google.longrunning.Operations" &&
+		m.Name == "GetOperation" &&
+		m.Service != nil && m.Service.Package != "google.longrunning" {
+		m.IsLroPoller = true
+	}
+
 	if m.OperationInfo != nil && m.Model != nil {
 		m.LongRunningResponseType = m.Model.Message(m.OperationInfo.ResponseTypeID)
 	}

--- a/internal/sidekick/parser/discovery/lro.go
+++ b/internal/sidekick/parser/discovery/lro.go
@@ -64,6 +64,7 @@ func lroAnnotations(model *api.API, discoveryConfig *api.Discovery) error {
 			Service:         svc,
 			SourceService:   svcMixin.Service,
 			SourceServiceID: svcMixin.SourceServiceID,
+			IsLroPoller:     true,
 		}
 		svc.Methods = append(svc.Methods, method)
 		model.AddMethod(method)

--- a/internal/sidekick/parser/discovery/lro_test.go
+++ b/internal/sidekick/parser/discovery/lro_test.go
@@ -79,6 +79,7 @@ func TestLroAnnotations(t *testing.T) {
 		Name:         "getOperation",
 		InputTypeID:  "..zoneOperations.getRequest",
 		OutputTypeID: "..Operation",
+		IsLroPoller:  true,
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -44,7 +44,7 @@ type methodAnnotation struct {
 	HasResourceNameGeneration bool
 	ResourceNameTemplateGrpc  string
 	GrpcResourceNameArgs      []string
-	IsLongRunningPoll         bool
+	IsLroPoller               bool
 }
 
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
@@ -312,7 +312,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		RoutingRequired:           c.routingRequired,
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
-		IsLongRunningPoll:         isLongRunningPoll(m),
+		IsLroPoller:               isLongRunningPoll(m),
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {
@@ -630,7 +630,5 @@ func isIdempotent(p *api.PathInfo) string {
 }
 
 func isLongRunningPoll(m *api.Method) bool {
-	return m.SourceServiceID == ".google.longrunning.Operations" &&
-		m.Name == "GetOperation" &&
-		m.Service.Package != "google.longrunning"
+	return m.IsLroPoller
 }

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -44,7 +44,7 @@ type methodAnnotation struct {
 	HasResourceNameGeneration bool
 	ResourceNameTemplateGrpc  string
 	GrpcResourceNameArgs      []string
-	IsGetOperation            bool
+	IsLongRunningPoll         bool
 }
 
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
@@ -312,7 +312,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		RoutingRequired:           c.routingRequired,
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
-		IsGetOperation:            m.SourceServiceID == "google.longrunning.Operations" && m.Name == "GetOperation",
+		IsLongRunningPoll:         isLongRunningPoll(m),
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {
@@ -627,4 +627,10 @@ func isIdempotent(p *api.PathInfo) string {
 		}
 	}
 	return "true"
+}
+
+func isLongRunningPoll(m *api.Method) bool {
+	return m.SourceServiceID == ".google.longrunning.Operations" &&
+		m.Name == "GetOperation" &&
+		m.Service.Package != "google.longrunning"
 }

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -312,7 +312,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		RoutingRequired:           c.routingRequired,
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
-		IsLroPoller:               isLongRunningPoll(m),
+		IsLroPoller:               m.IsLroPoller,
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {
@@ -627,8 +627,4 @@ func isIdempotent(p *api.PathInfo) string {
 		}
 	}
 	return "true"
-}
-
-func isLongRunningPoll(m *api.Method) bool {
-	return m.IsLroPoller
 }

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -44,6 +44,7 @@ type methodAnnotation struct {
 	HasResourceNameGeneration bool
 	ResourceNameTemplateGrpc  string
 	GrpcResourceNameArgs      []string
+	IsGetOperation            bool
 }
 
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
@@ -311,6 +312,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		RoutingRequired:           c.routingRequired,
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
+		IsGetOperation:            m.SourceServiceID == "google.longrunning.Operations" && m.Name == "GetOperation",
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -46,7 +46,6 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
 
     {{#Model.Codec.LroStubOptions}}
     #[cfg(google_cloud_unstable_tracing)]
-    #[allow(dead_code)]
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,
@@ -89,7 +88,6 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
 
     {{#Model.Codec.LroStubOptions}}
     #[cfg(google_cloud_unstable_tracing)]
-    #[allow(dead_code)]
     fn get_poller_options(
         &self,
         options: &crate::RequestOptions,

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -63,12 +63,6 @@ impl<T> super::stub::{{Codec.Name}} for {{Codec.Name}}<T>
 where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     {{#Codec.Methods}}
 
-    {{#Codec.DetailedTracingAttributes}}
-    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
-    {{/Codec.DetailedTracingAttributes}}
-    {{^Codec.DetailedTracingAttributes}}
-    #[tracing::instrument(ret)]
-    {{/Codec.DetailedTracingAttributes}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -79,7 +73,18 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
             metric: self.duration.clone(),
             info: *info::INSTRUMENTATION_CLIENT_INFO,
             method: "client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}",
-            self.inner.{{Codec.Name}}(req, options));
+            self.inner.{{Codec.Name}}(req.clone(), options.clone()));
+        {{#Codec.HasLROs}}
+        {{#Codec.IsGetOperation}}
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+                _span.record("gcp.longrunning.poll_attempt_count", attempt);
+                _span.record("gcp.longrunning.done", false);
+            }
+        }
+        {{/Codec.IsGetOperation}}
+        {{/Codec.HasLROs}}
         pending.await
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -63,6 +63,12 @@ impl<T> super::stub::{{Codec.Name}} for {{Codec.Name}}<T>
 where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     {{#Codec.Methods}}
 
+    {{#Codec.DetailedTracingAttributes}}
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
+    {{/Codec.DetailedTracingAttributes}}
+    {{^Codec.DetailedTracingAttributes}}
+    #[tracing::instrument(ret)]
+    {{/Codec.DetailedTracingAttributes}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -74,8 +80,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
             info: *info::INSTRUMENTATION_CLIENT_INFO,
             method: "client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}",
             self.inner.{{Codec.Name}}(req, options));
-        {{#Codec.HasLROs}}
-        {{#Codec.IsLongRunningPoll}}
+        {{#Codec.IsLroPoller}}
         #[cfg(google_cloud_unstable_tracing)]
         {
             if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
@@ -83,9 +88,8 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                 _span.record("gcp.longrunning.done", false);
             }
         }
-        {{/Codec.IsLongRunningPoll}}
-        {{/Codec.HasLROs}}
-        {{#Codec.IsLongRunningPoll}}
+        {{/Codec.IsLroPoller}}
+        {{#Codec.IsLroPoller}}
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
@@ -116,10 +120,10 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
             }
         }
         result
-        {{/Codec.IsLongRunningPoll}}
-        {{^Codec.IsLongRunningPoll}}
+        {{/Codec.IsLroPoller}}
+        {{^Codec.IsLroPoller}}
         pending.await
-        {{/Codec.IsLongRunningPoll}}
+        {{/Codec.IsLroPoller}}
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         self.inner.{{Codec.Name}}(req, options).await

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -100,13 +100,11 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                                 _ => 0,
                             };
                             _span.record("gcp.longrunning.status_code", code);
-                            if let Some(err) = &op.result {
-                                if let {{Codec.LongrunningModelModule}}::operation::Result::Error(status) = err {
-                                    _span.record("otel.status_code", "ERROR");
-                                    _span.record("otel.status_description", &status.message);
-                                    _span.record("rpc.response.status_code", status.code);
-                                    _span.record("error.type", google_cloud_gax::error::rpc::Code::from(status.code).to_string());
-                                }
+                            if let Some({{Codec.LongrunningModelModule}}::operation::Result::Error(status)) = &op.result {
+                                _span.record("otel.status_code", "ERROR");
+                                _span.record("otel.status_description", &status.message);
+                                _span.record("rpc.response.status_code", status.code);
+                                _span.record("error.type", google_cloud_gax::error::rpc::Code::from(status.code).to_string());
                             }
                         }
                     }

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -85,7 +85,43 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         }
         {{/Codec.IsGetOperation}}
         {{/Codec.HasLROs}}
+        {{#Codec.IsGetOperation}}
+        let result = pending.await;
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            if google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c).is_ok() {
+                match &result {
+                    Ok(response) => {
+                        let op = response.body();
+                        _span.record("gcp.longrunning.done", op.done);
+                        if op.done {
+                            let code = match &op.result {
+                                Some({{Codec.LongrunningModelModule}}::operation::Result::Error(status)) => status.code,
+                                _ => 0,
+                            };
+                            _span.record("gcp.longrunning.status_code", code);
+                            if let Some(err) = &op.result {
+                                if let {{Codec.LongrunningModelModule}}::operation::Result::Error(status) = err {
+                                    _span.record("otel.status_code", "ERROR");
+                                    _span.record("otel.status_description", &status.message);
+                                    _span.record("rpc.response.status_code", status.code);
+                                    _span.record("error.type", google_cloud_gax::error::rpc::Code::from(status.code).to_string());
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        _span.record("otel.status_code", "ERROR");
+                        _span.record("otel.status_description", e.to_string());
+                    }
+                }
+            }
+        }
+        result
+        {{/Codec.IsGetOperation}}
+        {{^Codec.IsGetOperation}}
         pending.await
+        {{/Codec.IsGetOperation}}
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         self.inner.{{Codec.Name}}(req, options).await

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -73,9 +73,9 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
             metric: self.duration.clone(),
             info: *info::INSTRUMENTATION_CLIENT_INFO,
             method: "client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}",
-            self.inner.{{Codec.Name}}(req.clone(), options.clone()));
+            self.inner.{{Codec.Name}}(req, options));
         {{#Codec.HasLROs}}
-        {{#Codec.IsGetOperation}}
+        {{#Codec.IsLongRunningPoll}}
         #[cfg(google_cloud_unstable_tracing)]
         {
             if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
@@ -83,9 +83,9 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                 _span.record("gcp.longrunning.done", false);
             }
         }
-        {{/Codec.IsGetOperation}}
+        {{/Codec.IsLongRunningPoll}}
         {{/Codec.HasLROs}}
-        {{#Codec.IsGetOperation}}
+        {{#Codec.IsLongRunningPoll}}
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
@@ -96,11 +96,11 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                         _span.record("gcp.longrunning.done", op.done);
                         if op.done {
                             let code = match &op.result {
-                                Some({{Codec.LongrunningModelModule}}::operation::Result::Error(status)) => status.code,
+                                Some(google_cloud_longrunning::model::operation::Result::Error(status)) => status.code,
                                 _ => 0,
                             };
                             _span.record("gcp.longrunning.status_code", code);
-                            if let Some({{Codec.LongrunningModelModule}}::operation::Result::Error(status)) = &op.result {
+                            if let Some(google_cloud_longrunning::model::operation::Result::Error(status)) = &op.result {
                                 _span.record("otel.status_code", "ERROR");
                                 _span.record("otel.status_description", &status.message);
                                 _span.record("rpc.response.status_code", status.code);
@@ -116,10 +116,10 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
             }
         }
         result
-        {{/Codec.IsGetOperation}}
-        {{^Codec.IsGetOperation}}
+        {{/Codec.IsLongRunningPoll}}
+        {{^Codec.IsLongRunningPoll}}
         pending.await
-        {{/Codec.IsGetOperation}}
+        {{/Codec.IsLongRunningPoll}}
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         self.inner.{{Codec.Name}}(req, options).await


### PR DESCRIPTION
Extract LRO attempt counts and done/logical error status details ambiently from `tokio::task-local!` context, recording them directly onto active T3/polling spans without polluting handwritten traits or generated client interfaces.

Also add logic for polling span detection for both aip151 and discovery api.