### PR TITLE
feat(swift): support recursive message types with transparent referen…

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -108,7 +108,7 @@ func (c *codec) annotateField(field *api.Field) error {
 	}
 	// Swift value types (structs) cannot contain recursive references directly because their
 	// size must be known at compile time. To break the cycle, we wrap the reference in a box type
-	// when the followin conditions are met:
+	// when the following conditions are met:
 	// 1. field.Recursive: The field is part of a recursive reference cycle.
 	// 2. field.Singular(): Repeated fields ([T]) and Maps ([K: V]) store their elements dynamically
 	//    on the heap, so they do not cause compile-time infinite struct size issues.

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -15,6 +15,8 @@
 package swift
 
 import (
+	"fmt"
+
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -45,6 +47,14 @@ type fieldAnnotations struct {
 	//
 	// This is empty for fields that are not part of a oneof group.
 	OneOfPropertyName string
+
+	// Recursive is true if the field is a recursive reference to another message.
+	Recursive bool
+
+	// UnwrappedType is the FieldType of the field without the optional Recursive Wrapper.
+	//
+	// Only set if Recursive is true.
+	UnwrappedType string
 }
 
 func (c *codec) annotateField(field *api.Field) error {
@@ -95,6 +105,20 @@ func (c *codec) annotateField(field *api.Field) error {
 		BaseFieldType: baseFieldType,
 		PackageName:   packageName,
 		DocLines:      docLines,
+	}
+	// Swift value types (structs) cannot contain recursive references directly because their
+	// size must be known at compile time. To break the cycle, we wrap the reference in a box type
+	// when the followin conditions are met:
+	// 1. field.Recursive: The field is part of a recursive reference cycle.
+	// 2. field.Singular(): Repeated fields ([T]) and Maps ([K: V]) store their elements dynamically
+	//    on the heap, so they do not cause compile-time infinite struct size issues.
+	// 3. !field.IsOneOf: Oneof fields are nested inside a Swift enum which handles recursive boxing
+	//    automatically using the native indirect case mechanism.
+	if field.Recursive && field.Singular() && !field.IsOneOf {
+		annotations.Recursive = true
+		annotations.UnwrappedType = fieldType
+		annotations.BaseFieldType = fmt.Sprintf("%s.Recursive<%s>", wellKnownSwiftPackage, baseFieldType)
+		annotations.FieldType = fmt.Sprintf("%s.Recursive<%s>?", wellKnownSwiftPackage, baseFieldType)
 	}
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -51,10 +51,11 @@ type fieldAnnotations struct {
 	// Recursive is true if the field is a recursive reference to another message.
 	Recursive bool
 
-	// UnwrappedType is the FieldType of the field without the optional Recursive Wrapper.
+	// InitializerType is the Swift type name of this field as it appears in the initializer signature.
 	//
-	// Only set if Recursive is true.
-	UnwrappedType string
+	// For recursive fields, this is the unwrapped type with an optional suffix (e.g., `Node?`), rather
+	// than the boxed type (`GoogleCloudWkt.Recursive<Node>?`). For standard fields, it matches `FieldType`.
+	InitializerType string
 }
 
 func (c *codec) annotateField(field *api.Field) error {
@@ -100,11 +101,12 @@ func (c *codec) annotateField(field *api.Field) error {
 		}
 	}
 	annotations := &fieldAnnotations{
-		Name:          camelCase(field.Name),
-		FieldType:     fieldType,
-		BaseFieldType: baseFieldType,
-		PackageName:   packageName,
-		DocLines:      docLines,
+		Name:            camelCase(field.Name),
+		FieldType:       fieldType,
+		BaseFieldType:   baseFieldType,
+		PackageName:     packageName,
+		DocLines:        docLines,
+		InitializerType: fieldType,
 	}
 	// Swift value types (structs) cannot contain recursive references directly because their
 	// size must be known at compile time. To break the cycle, we wrap the reference in a box type
@@ -116,7 +118,7 @@ func (c *codec) annotateField(field *api.Field) error {
 	//    automatically using the native indirect case mechanism.
 	if field.Recursive && field.Singular() && !field.IsOneOf {
 		annotations.Recursive = true
-		annotations.UnwrappedType = fieldType
+		annotations.InitializerType = baseFieldType + "?"
 		annotations.BaseFieldType = fmt.Sprintf("%s.Recursive<%s>", wellKnownSwiftPackage, baseFieldType)
 		annotations.FieldType = fmt.Sprintf("%s.Recursive<%s>?", wellKnownSwiftPackage, baseFieldType)
 	}

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -74,10 +74,11 @@ func TestAnnotateField(t *testing.T) {
 				t.Fatal(err)
 			}
 			want := &fieldAnnotations{
-				Name:          "secretPayload",
-				DocLines:      []string{"The secret version payload."},
-				FieldType:     test.wantType,
-				BaseFieldType: test.wantBaseType,
+				Name:            "secretPayload",
+				DocLines:        []string{"The secret version payload."},
+				FieldType:       test.wantType,
+				BaseFieldType:   test.wantBaseType,
+				InitializerType: test.wantType,
 			}
 
 			if diff := cmp.Diff(want, field.Codec); diff != "" {
@@ -117,10 +118,11 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 				t.Fatal(err)
 			}
 			want := &fieldAnnotations{
-				Name:          "testField",
-				FieldType:     test.wantType,
-				BaseFieldType: test.wantType,
-				DocLines:      []string{"Test documentation."},
+				Name:            "testField",
+				FieldType:       test.wantType,
+				BaseFieldType:   test.wantType,
+				DocLines:        []string{"Test documentation."},
+				InitializerType: test.wantType,
 			}
 			if diff := cmp.Diff(want, field.Codec); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -163,11 +165,12 @@ func TestAnnotateField_PackageName(t *testing.T) {
 	}
 	got := field.Codec.(*fieldAnnotations)
 	want := &fieldAnnotations{
-		Name:          "externalMessage",
-		FieldType:     "GoogleCloudExternalV1.SomeMessage",
-		BaseFieldType: "GoogleCloudExternalV1.SomeMessage",
-		PackageName:   "google.cloud.external.v1",
-		DocLines:      []string{"The external message."},
+		Name:            "externalMessage",
+		FieldType:       "GoogleCloudExternalV1.SomeMessage",
+		BaseFieldType:   "GoogleCloudExternalV1.SomeMessage",
+		PackageName:     "google.cloud.external.v1",
+		DocLines:        []string{"The external message."},
+		InitializerType: "GoogleCloudExternalV1.SomeMessage",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -183,7 +186,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 		wantType      string
 		wantBaseType  string
 		wantRecursive bool
-		wantUnwrapped string
+		wantInitType  string
 		oneofProperty string
 	}{
 		{
@@ -194,7 +197,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			wantType:      "GoogleCloudWkt.Recursive<Node>?",
 			wantBaseType:  "GoogleCloudWkt.Recursive<Node>",
 			wantRecursive: true,
-			wantUnwrapped: "Node?",
+			wantInitType:  "Node?",
 		},
 		{
 			name:          "repeated recursive",
@@ -204,7 +207,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			wantType:      "[Node]",
 			wantBaseType:  "Node",
 			wantRecursive: false,
-			wantUnwrapped: "",
+			wantInitType:  "[Node]",
 		},
 		{
 			name:          "oneof recursive",
@@ -214,7 +217,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			wantType:      "Node",
 			wantBaseType:  "Node",
 			wantRecursive: false,
-			wantUnwrapped: "",
+			wantInitType:  "Node",
 			oneofProperty: "alternatives",
 		},
 	} {
@@ -261,7 +264,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 				BaseFieldType:     test.wantBaseType,
 				PackageName:       "test",
 				Recursive:         test.wantRecursive,
-				UnwrappedType:     test.wantUnwrapped,
+				InitializerType:   test.wantInitType,
 				OneOfPropertyName: test.oneofProperty,
 			}
 

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -173,3 +173,101 @@ func TestAnnotateField_PackageName(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestAnnotateField_Recursive(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		optional      bool
+		repeated      bool
+		isOneOf       bool
+		wantType      string
+		wantBaseType  string
+		wantRecursive bool
+		wantUnwrapped string
+		oneofProperty string
+	}{
+		{
+			name:          "singular optional recursive",
+			optional:      true,
+			repeated:      false,
+			isOneOf:       false,
+			wantType:      "GoogleCloudWkt.Recursive<Node>?",
+			wantBaseType:  "GoogleCloudWkt.Recursive<Node>",
+			wantRecursive: true,
+			wantUnwrapped: "Node?",
+		},
+		{
+			name:          "repeated recursive",
+			optional:      false,
+			repeated:      true,
+			isOneOf:       false,
+			wantType:      "[Node]",
+			wantBaseType:  "Node",
+			wantRecursive: false,
+			wantUnwrapped: "",
+		},
+		{
+			name:          "oneof recursive",
+			optional:      false,
+			repeated:      false,
+			isOneOf:       true,
+			wantType:      "Node",
+			wantBaseType:  "Node",
+			wantRecursive: false,
+			wantUnwrapped: "",
+			oneofProperty: "alternatives",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			field := &api.Field{
+				Name:          "child_node",
+				ID:            ".test.Node.child_node",
+				Typez:         api.TypezMessage,
+				TypezID:       ".test.Node",
+				Documentation: "Recursive link.",
+				Optional:      test.optional,
+				Repeated:      test.repeated,
+				IsOneOf:       test.isOneOf,
+				Recursive:     true,
+			}
+			msg := &api.Message{
+				Name:    "Node",
+				ID:      ".test.Node",
+				Package: "test",
+				Fields:  []*api.Field{field},
+			}
+			field.Parent = msg
+			field.MessageType = msg
+
+			if test.isOneOf {
+				oneof := &api.OneOf{
+					Name:   test.oneofProperty,
+					Fields: []*api.Field{field},
+				}
+				field.Group = oneof
+				msg.OneOfs = []*api.OneOf{oneof}
+			}
+
+			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+			codec := newTestCodec(t, model, map[string]string{})
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+
+			want := &fieldAnnotations{
+				Name:              "childNode",
+				DocLines:          []string{"Recursive link."},
+				FieldType:         test.wantType,
+				BaseFieldType:     test.wantBaseType,
+				PackageName:       "test",
+				Recursive:         test.wantRecursive,
+				UnwrappedType:     test.wantUnwrapped,
+				OneOfPropertyName: test.oneofProperty,
+			}
+
+			if diff := cmp.Diff(want, field.Codec); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -247,3 +247,262 @@ func TestGenerateMessage_WithExternalImports(t *testing.T) {
 		t.Errorf("unexpected 'import GoogleCloudUnusedV1' in %s", filename)
 	}
 }
+
+func TestGenerateMessage_WithRecursiveTypes(t *testing.T) {
+	outDir := t.TempDir()
+
+	nodeA := &api.Message{
+		Name:    "NodeA",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.NodeA",
+	}
+	nodeB := &api.Message{
+		Name:    "NodeB",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.NodeB",
+	}
+
+	fieldA := &api.Field{
+		Name:     "node_b",
+		Typez:    api.TypezMessage,
+		TypezID:  ".google.cloud.test.v1.NodeB",
+		Optional: true,
+		Parent:   nodeA,
+	}
+	nodeA.Fields = []*api.Field{fieldA}
+
+	fieldB := &api.Field{
+		Name:     "node_a",
+		Typez:    api.TypezMessage,
+		TypezID:  ".google.cloud.test.v1.NodeA",
+		Optional: true,
+		Parent:   nodeB,
+	}
+	nodeB.Fields = []*api.Field{fieldB}
+
+	// Set the MessageType fields correctly
+	fieldA.MessageType = nodeB
+	fieldB.MessageType = nodeA
+
+	model := api.NewTestAPI([]*api.Message{nodeA, nodeB}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+
+	// Run LabelRecursiveFields to mark recursive fields
+	api.LabelRecursiveFields(model)
+
+	cfg := &parser.ModelConfig{
+		Codec: map[string]string{
+			"copyright-year": "2038",
+		},
+	}
+
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	filenameA := filepath.Join(expectedDir, "NodeA.swift")
+	contentA, err := os.ReadFile(filenameA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStrA := string(contentA)
+
+	// Verify struct property uses Recursive
+	wantProp := "public var nodeB: GoogleCloudWkt.Recursive<NodeB>?"
+	if !strings.Contains(contentStrA, wantProp) {
+		t.Errorf("property definition mismatch: want %q; got:\n%s", wantProp, contentStrA)
+	}
+
+	// Verify initializer parameter uses the unwrapped type
+	wantParam := "nodeB: NodeB? = nil"
+	if !strings.Contains(contentStrA, wantParam) {
+		t.Errorf("initializer parameter mismatch: want %q; got:\n%s", wantParam, contentStrA)
+	}
+
+	// Verify initializer maps the value
+	wantMap := "self.nodeB = nodeB.map { GoogleCloudWkt.Recursive(value: $0) }"
+	if !strings.Contains(contentStrA, wantMap) {
+		t.Errorf("initializer body mapping mismatch: want %q; got:\n%s", wantMap, contentStrA)
+	}
+}
+
+func TestGenerateMessage_SelfRecursive(t *testing.T) {
+	outDir := t.TempDir()
+
+	node := &api.Message{
+		Name:    "Node",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.Node",
+	}
+
+	field := &api.Field{
+		Name:     "child",
+		Typez:    api.TypezMessage,
+		TypezID:  ".google.cloud.test.v1.Node",
+		Optional: true,
+		Parent:   node,
+	}
+	node.Fields = []*api.Field{field}
+	field.MessageType = node
+
+	model := api.NewTestAPI([]*api.Message{node}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+
+	// Run LabelRecursiveFields to mark recursive fields
+	api.LabelRecursiveFields(model)
+
+	cfg := &parser.ModelConfig{
+		Codec: map[string]string{
+			"copyright-year": "2038",
+		},
+	}
+
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	filename := filepath.Join(expectedDir, "Node.swift")
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+
+	// Verify struct property uses Recursive
+	wantProp := "public var child: GoogleCloudWkt.Recursive<Node>?"
+	if !strings.Contains(contentStr, wantProp) {
+		t.Errorf("property definition mismatch: want %q; got:\n%s", wantProp, contentStr)
+	}
+
+	// Verify initializer parameter uses the unwrapped type
+	wantParam := "child: Node? = nil"
+	if !strings.Contains(contentStr, wantParam) {
+		t.Errorf("initializer parameter mismatch: want %q; got:\n%s", wantParam, contentStr)
+	}
+
+	// Verify initializer maps the value
+	wantMap := "self.child = child.map { GoogleCloudWkt.Recursive(value: $0) }"
+	if !strings.Contains(contentStr, wantMap) {
+		t.Errorf("initializer body mapping mismatch: want %q; got:\n%s", wantMap, contentStr)
+	}
+}
+
+func TestGenerateMessage_RecursiveChain(t *testing.T) {
+	outDir := t.TempDir()
+
+	nodeA := &api.Message{
+		Name:    "NodeA",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.NodeA",
+	}
+	nodeB := &api.Message{
+		Name:    "NodeB",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.NodeB",
+	}
+	nodeC := &api.Message{
+		Name:    "NodeC",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.NodeC",
+	}
+
+	fieldA := &api.Field{
+		Name:     "node_b",
+		Typez:    api.TypezMessage,
+		TypezID:  ".google.cloud.test.v1.NodeB",
+		Optional: true,
+		Parent:   nodeA,
+	}
+	nodeA.Fields = []*api.Field{fieldA}
+
+	fieldB := &api.Field{
+		Name:     "node_c",
+		Typez:    api.TypezMessage,
+		TypezID:  ".google.cloud.test.v1.NodeC",
+		Optional: true,
+		Parent:   nodeB,
+	}
+	nodeB.Fields = []*api.Field{fieldB}
+
+	fieldC := &api.Field{
+		Name:     "node_a",
+		Typez:    api.TypezMessage,
+		TypezID:  ".google.cloud.test.v1.NodeA",
+		Optional: true,
+		Parent:   nodeC,
+	}
+	nodeC.Fields = []*api.Field{fieldC}
+
+	fieldA.MessageType = nodeB
+	fieldB.MessageType = nodeC
+	fieldC.MessageType = nodeA
+
+	model := api.NewTestAPI([]*api.Message{nodeA, nodeB, nodeC}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.cloud.test.v1"
+
+	// Run LabelRecursiveFields to mark recursive fields
+	api.LabelRecursiveFields(model)
+
+	cfg := &parser.ModelConfig{
+		Codec: map[string]string{
+			"copyright-year": "2038",
+		},
+	}
+
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+
+	// Verify NodeA contains wrapped NodeB
+	filenameA := filepath.Join(expectedDir, "NodeA.swift")
+	contentA, err := os.ReadFile(filenameA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStrA := string(contentA)
+	// Verify NodeA contains wrapped NodeB
+	wantPropA := "public var nodeB: GoogleCloudWkt.Recursive<NodeB>?"
+	if !strings.Contains(contentStrA, wantPropA) {
+		t.Errorf("nodeB property definition mismatch: want %q; got:\n%s", wantPropA, contentStrA)
+	}
+	wantParamA := "nodeB: NodeB? = nil"
+	if !strings.Contains(contentStrA, wantParamA) {
+		t.Errorf("nodeB initializer parameter mismatch: want %q; got:\n%s", wantParamA, contentStrA)
+	}
+
+	// Verify NodeB contains wrapped NodeC
+	filenameB := filepath.Join(expectedDir, "NodeB.swift")
+	contentB, err := os.ReadFile(filenameB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStrB := string(contentB)
+	wantPropB := "public var nodeC: GoogleCloudWkt.Recursive<NodeC>?"
+	if !strings.Contains(contentStrB, wantPropB) {
+		t.Errorf("nodeC property definition mismatch: want %q; got:\n%s", wantPropB, contentStrB)
+	}
+	wantParamB := "nodeC: NodeC? = nil"
+	if !strings.Contains(contentStrB, wantParamB) {
+		t.Errorf("nodeC initializer parameter mismatch: want %q; got:\n%s", wantParamB, contentStrB)
+	}
+
+	// Verify NodeC contains wrapped NodeA
+	filenameC := filepath.Join(expectedDir, "NodeC.swift")
+	contentC, err := os.ReadFile(filenameC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStrC := string(contentC)
+	wantPropC := "public var nodeA: GoogleCloudWkt.Recursive<NodeA>?"
+	if !strings.Contains(contentStrC, wantPropC) {
+		t.Errorf("nodeA property definition mismatch: want %q; got:\n%s", wantPropC, contentStrC)
+	}
+	wantParamC := "nodeA: NodeA? = nil"
+	if !strings.Contains(contentStrC, wantParamC) {
+		t.Errorf("nodeA initializer parameter mismatch: want %q; got:\n%s", wantParamC, contentStrC)
+	}
+}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -27,7 +27,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
-  public var {{Codec.Name}}: {{Codec.FieldType}}
+  public var {{Codec.Name}}: {{{Codec.FieldType}}}
   {{/IsOneOf}}
   {{/Fields}}
   {{#OneOfs}}
@@ -46,17 +46,22 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     {{! Recall that fields can be Singular (and then Optional or not) or Repeated or Map }}
     {{#Singular}}
     {{^Optional}}
-    {{Codec.Name}}: {{Codec.FieldType}} = {{Codec.FieldType}}(),
+    {{Codec.Name}}: {{{Codec.FieldType}}} = {{{Codec.FieldType}}}(),
     {{/Optional}}
     {{#Optional}}
-    {{Codec.Name}}: {{Codec.FieldType}} = nil,
+    {{#Codec.Recursive}}
+    {{Codec.Name}}: {{{Codec.UnwrappedType}}} = nil,
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
+    {{Codec.Name}}: {{{Codec.FieldType}}} = nil,
+    {{/Codec.Recursive}}
     {{/Optional}}
     {{/Singular}}
     {{#Repeated}}
-    {{Codec.Name}}: {{Codec.FieldType}} = [],
+    {{Codec.Name}}: {{{Codec.FieldType}}} = [],
     {{/Repeated}}
     {{#Map}}
-    {{Codec.Name}}: {{Codec.FieldType}} = [:],
+    {{Codec.Name}}: {{{Codec.FieldType}}} = [:],
     {{/Map}}
     {{/IsOneOf}}
     {{/Fields}}
@@ -66,7 +71,12 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
   ) {
     {{#Fields}}
     {{^IsOneOf}}
+    {{#Codec.Recursive}}
+    self.{{Codec.Name}} = {{Codec.Name}}.map { GoogleCloudWkt.Recursive(value: $0) }
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
     self.{{Codec.Name}} = {{Codec.Name}}
+    {{/Codec.Recursive}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}
@@ -86,10 +96,10 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     {{#Fields}}
     {{^IsOneOf}}
     {{#Optional}}
-    self.{{Codec.Name}} = try container.decodeIfPresent({{Codec.BaseFieldType}}.self, forKey: .{{Codec.Name}})
+    self.{{Codec.Name}} = try container.decodeIfPresent({{{Codec.BaseFieldType}}}.self, forKey: .{{Codec.Name}})
     {{/Optional}}
     {{^Optional}}
-    self.{{Codec.Name}} = try container.decode({{Codec.FieldType}}.self, forKey: .{{Codec.Name}})
+    self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
     {{/Optional}}
     {{/IsOneOf}}
     {{/Fields}}
@@ -103,7 +113,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
       {{Codec.PropertyName}} = value
     }
     {{#Fields}}
-    if let {{Codec.Name}} = try container.decodeIfPresent({{Codec.FieldType}}.self, forKey: .{{Codec.Name}}) {
+    if let {{Codec.Name}} = try container.decodeIfPresent({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}}) {
       try {{Codec.OneOfPropertyName}}CheckAndSet(.{{Codec.Name}}({{Codec.Name}}))
     }
     {{/Fields}}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -72,7 +72,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     {{#Fields}}
     {{^IsOneOf}}
     {{#Codec.Recursive}}
-    self.{{Codec.Name}} = {{Codec.Name}}.map { GoogleCloudWkt.Recursive(value: $0) }
+    self.{{Codec.Name}} = {{Codec.Name}}.map { {{Parent.Codec.Model.WktPackage}}.Recursive(value: $0) }
     {{/Codec.Recursive}}
     {{^Codec.Recursive}}
     self.{{Codec.Name}} = {{Codec.Name}}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -45,17 +45,17 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     {{^IsOneOf}}
     {{! Recall that fields can be Singular (and then Optional or not) or Repeated or Map }}
     {{#Singular}}
+    {{#Codec.Recursive}}
+    {{Codec.Name}}: {{{Codec.InitializerType}}} = nil,
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
     {{^Optional}}
     {{Codec.Name}}: {{{Codec.FieldType}}} = {{{Codec.FieldType}}}(),
     {{/Optional}}
     {{#Optional}}
-    {{#Codec.Recursive}}
-    {{Codec.Name}}: {{{Codec.UnwrappedType}}} = nil,
-    {{/Codec.Recursive}}
-    {{^Codec.Recursive}}
-    {{Codec.Name}}: {{{Codec.FieldType}}} = nil,
-    {{/Codec.Recursive}}
+    {{Codec.Name}}: {{{Codec.InitializerType}}} = nil,
     {{/Optional}}
+    {{/Codec.Recursive}}
     {{/Singular}}
     {{#Repeated}}
     {{Codec.Name}}: {{{Codec.FieldType}}} = [],
@@ -99,7 +99,12 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     self.{{Codec.Name}} = try container.decodeIfPresent({{{Codec.BaseFieldType}}}.self, forKey: .{{Codec.Name}})
     {{/Optional}}
     {{^Optional}}
+    {{#Codec.Recursive}}
+    self.{{Codec.Name}} = try container.decodeIfPresent({{{Codec.BaseFieldType}}}.self, forKey: .{{Codec.Name}})
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
     self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
+    {{/Codec.Recursive}}
     {{/Optional}}
     {{/IsOneOf}}
     {{/Fields}}


### PR DESCRIPTION
…ce boxing

Introduced support for recursive singular fields and cyclic message dependency graphs (such as self-recursive messages and multi-step loops: A -> B -> C -> A) in the generated Swift client library, preventing compiler infinite struct sizing errors.

Tagged matching fields with `Recursive` and `UnwrappedType` annotations to drive templated Swift generation.