### PR TITLE
chore(python): update synthtool commit identifier to drop python 3.9 from README

### DIFF
--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -30,5 +30,5 @@ tools:
       version: "23.7.0"
       package: "black[jupyter]==23.7.0"
     - name: synthtool
-      version: "e8051785da36c3f23860bf45dfa5adc8325d973f"
-      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e8051785da36c3f23860bf45dfa5adc8325d973f"
+      version: "e643ce8e20f8fe237a31a1754524ba987de72875"
+      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875"

--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -30,5 +30,5 @@ tools:
       version: "23.7.0"
       package: "black[jupyter]==23.7.0"
     - name: synthtool
-      version: "96f416c959fbe8048200b6c16000de32b352902e"
-      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@96f416c959fbe8048200b6c16000de32b352902e"
+      version: "e8051785da36c3f23860bf45dfa5adc8325d973f"
+      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e8051785da36c3f23860bf45dfa5adc8325d973f"


### PR DESCRIPTION
This updates the synthtool reference to a commit that includes the most recent change to the README text.

The change in the README text drops Python 3.9 as a supported runtime.