### PR TITLE
feat(internal/librarian/java): implement Maven external tools installation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -69,7 +69,7 @@ This document describes the schema for the librarian.yaml.
 | `group_id` | string | Is the Maven artifact group ID. |
 | `artifact_id` | string | Is the Maven artifact ID. |
 | `classifier` | string | Is the classifier of the Maven artifact. |
-| `packaging` | string | Is the Maven packaging (e.g. jar, exe). If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar". |
+| `packaging` | string | Is the Maven packaging. Acceptable values are lowercase "jar" and "exe". If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar". |
 
 ## PipTool Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -39,6 +39,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `cargo` | list of [CargoTool](#cargotool-configuration) (optional) | Defines tools to install via cargo. |
 | `npm` | list of [NPMTool](#npmtool-configuration) (optional) | Defines tools to install via npm. |
+| `maven` | list of [MavenTool](#maventool-configuration) (optional) | Defines tools to install via maven. |
 | `pip` | list of [PipTool](#piptool-configuration) (optional) | Defines tools to install via pip. |
 | `go` | list of [GoTool](#gotool-configuration) (optional) | Defines tools to install via go. |
 
@@ -58,6 +59,17 @@ This document describes the schema for the librarian.yaml.
 | `package` | string | Is the URL or path of the package to install. |
 | `checksum` | string | Is the SHA256 checksum of the package. |
 | `build` | list of string | Defines the commands to run to build the tool after installation. |
+
+## MavenTool Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | string | Is the maven tool name. |
+| `version` | string | Is the version to install. |
+| `group_id` | string | Is the maven groupId. |
+| `artifact_id` | string | Is the maven artifactId. |
+| `classifier` | string | Is the maven classifier. |
+| `packaging` | string | Is the maven packaging (e.g. jar, exe). |
 
 ## PipTool Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -38,8 +38,8 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `cargo` | list of [CargoTool](#cargotool-configuration) (optional) | Defines tools to install via cargo. |
-| `npm` | list of [NPMTool](#npmtool-configuration) (optional) | Defines tools to install via npm. |
 | `maven` | list of [MavenTool](#maventool-configuration) (optional) | Defines tools to install via maven. |
+| `npm` | list of [NPMTool](#npmtool-configuration) (optional) | Defines tools to install via npm. |
 | `pip` | list of [PipTool](#piptool-configuration) (optional) | Defines tools to install via pip. |
 | `go` | list of [GoTool](#gotool-configuration) (optional) | Defines tools to install via go. |
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -38,7 +38,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `cargo` | list of [CargoTool](#cargotool-configuration) (optional) | Defines tools to install via cargo. |
-| `maven` | list of [MavenTool](#maventool-configuration) (optional) | Defines tools to install via maven. |
+| `maven` | list of [MavenTool](#maventool-configuration) (optional) | Defines tools to install via Maven. |
 | `npm` | list of [NPMTool](#npmtool-configuration) (optional) | Defines tools to install via npm. |
 | `pip` | list of [PipTool](#piptool-configuration) (optional) | Defines tools to install via pip. |
 | `go` | list of [GoTool](#gotool-configuration) (optional) | Defines tools to install via go. |
@@ -64,12 +64,12 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `name` | string | Is the maven tool name. |
+| `name` | string | Is the Maven tool name. It is used as the filename for the generated executable wrapper script. |
 | `version` | string | Is the version to install. |
-| `group_id` | string | Is the maven groupId. |
-| `artifact_id` | string | Is the maven artifactId. |
-| `classifier` | string | Is the maven classifier. |
-| `packaging` | string | Is the maven packaging (e.g. jar, exe). |
+| `group_id` | string | Is the Maven artifact group ID. |
+| `artifact_id` | string | Is the Maven artifact ID. |
+| `classifier` | string | Is the classifier of the Maven artifact. |
+| `packaging` | string | Is the Maven packaging (e.g. jar, exe). If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar". |
 
 ## PipTool Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,7 +97,7 @@ type Tools struct {
 	// Cargo defines tools to install via cargo.
 	Cargo []*CargoTool `yaml:"cargo,omitempty"`
 
-	// Maven defines tools to install via maven.
+	// Maven defines tools to install via Maven.
 	Maven []*MavenTool `yaml:"maven,omitempty"`
 
 	// NPM defines tools to install via npm.
@@ -137,9 +137,9 @@ type NPMTool struct {
 	Build []string `yaml:"build,omitempty"`
 }
 
-// MavenTool defines a tool to install via maven.
+// MavenTool defines a tool to install via Maven.
 type MavenTool struct {
-	// Name is the maven tool name.
+	// Name is the Maven tool name. It is used as the filename for the generated executable wrapper script.
 	Name string `yaml:"name"`
 
 	// Version is the version to install.
@@ -154,7 +154,7 @@ type MavenTool struct {
 	// Classifier is the maven classifier.
 	Classifier string `yaml:"classifier,omitempty"`
 
-	// Packaging is the maven packaging (e.g. jar, exe).
+	// Packaging is the Maven packaging (e.g. jar, exe). If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar".
 	Packaging string `yaml:"packaging,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,7 +154,9 @@ type MavenTool struct {
 	// Classifier is the classifier of the Maven artifact.
 	Classifier string `yaml:"classifier,omitempty"`
 
-	// Packaging is the Maven packaging. Acceptable values are lowercase "jar" and "exe". If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar".
+	// Packaging is the Maven packaging. Acceptable values are lowercase "jar" and "exe".
+	// If the packaging is "exe", the wrapper script executes it directly.
+	// Otherwise, it executes the tool using "java -jar".
 	Packaging string `yaml:"packaging,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,13 +145,13 @@ type MavenTool struct {
 	// Version is the version to install.
 	Version string `yaml:"version,omitempty"`
 
-	// GroupID is the maven groupId.
+	// GroupID is the Maven artifact group ID.
 	GroupID string `yaml:"group_id,omitempty"`
 
-	// ArtifactID is the maven artifactId.
+	// ArtifactID is the Maven artifact ID.
 	ArtifactID string `yaml:"artifact_id,omitempty"`
 
-	// Classifier is the maven classifier.
+	// Classifier is the classifier of the Maven artifact.
 	Classifier string `yaml:"classifier,omitempty"`
 
 	// Packaging is the Maven packaging (e.g. jar, exe). If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,7 +154,7 @@ type MavenTool struct {
 	// Classifier is the classifier of the Maven artifact.
 	Classifier string `yaml:"classifier,omitempty"`
 
-	// Packaging is the Maven packaging (e.g. jar, exe). If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar".
+	// Packaging is the Maven packaging. Acceptable values are lowercase "jar" and "exe". If the packaging is "exe", the wrapper script executes it directly. Otherwise, it executes the tool using "java -jar".
 	Packaging string `yaml:"packaging,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,9 @@ type Tools struct {
 	// Cargo defines tools to install via cargo.
 	Cargo []*CargoTool `yaml:"cargo,omitempty"`
 
+	// Maven defines tools to install via maven.
+	Maven []*MavenTool `yaml:"maven,omitempty"`
+
 	// NPM defines tools to install via npm.
 	NPM []*NPMTool `yaml:"npm,omitempty"`
 
@@ -132,6 +135,27 @@ type NPMTool struct {
 
 	// Build defines the commands to run to build the tool after installation.
 	Build []string `yaml:"build,omitempty"`
+}
+
+// MavenTool defines a tool to install via maven.
+type MavenTool struct {
+	// Name is the maven tool name.
+	Name string `yaml:"name"`
+
+	// Version is the version to install.
+	Version string `yaml:"version,omitempty"`
+
+	// GroupID is the maven groupId.
+	GroupID string `yaml:"group_id,omitempty"`
+
+	// ArtifactID is the maven artifactId.
+	ArtifactID string `yaml:"artifact_id,omitempty"`
+
+	// Classifier is the maven classifier.
+	Classifier string `yaml:"classifier,omitempty"`
+
+	// Packaging is the maven packaging (e.g. jar, exe).
+	Packaging string `yaml:"packaging,omitempty"`
 }
 
 // PipTool defines a tool to install via pip.

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -111,9 +111,9 @@ func installExternalMavenTool(ctx context.Context, mvnTool *config.MavenTool, bi
 	return createBinWrapper(mvnTool.Name, destPath, binDir, isExe)
 }
 
-// getM2ArtifactSpec constructs the Maven coordinate string and returns it along with the lowercased file extension.
+// getM2ArtifactSpec constructs the Maven coordinate string and returns it along with the file extension.
 func getM2ArtifactSpec(mvnTool *config.MavenTool) (string, string) {
-	ext := strings.ToLower(mvnTool.Packaging)
+	ext := mvnTool.Packaging
 	if ext == "" {
 		ext = "jar"
 	}

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -48,6 +48,8 @@ func Install(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// binDir ($HOME/java_tools/bin) stores the generated executable wrapper scripts.
+	// libDir ($HOME/java_tools/lib) is a sibling directory that hermetically isolates the downloaded compiled .jar/.exe files.
 	libDir := filepath.Join(filepath.Dir(binDir), "lib")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)
@@ -105,22 +107,15 @@ func installExternalMavenTool(ctx context.Context, mvnTool *config.MavenTool, bi
 		return fmt.Errorf("failed to download artifact %s: %w", artifact, err)
 	}
 	// 3. Resolve path in .m2/repository
-	home, err := os.UserHomeDir()
+	artifactPath, err := resolveM2ArtifactPath(mvnTool, ext)
 	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
+		return err
 	}
-	m2Repo := filepath.Join(home, ".m2", "repository")
-	groupIDPath := strings.ReplaceAll(mvnTool.GroupID, ".", "/")
-	fileName := fmt.Sprintf("%s-%s", mvnTool.ArtifactID, mvnTool.Version)
-	if mvnTool.Classifier != "" {
-		fileName = fmt.Sprintf("%s-%s", fileName, mvnTool.Classifier)
-	}
-	fileName = fmt.Sprintf("%s.%s", fileName, ext)
-	artifactPath := filepath.Join(m2Repo, groupIDPath, mvnTool.ArtifactID, mvnTool.Version, fileName)
 	if _, err := os.Stat(artifactPath); err != nil {
 		return fmt.Errorf("downloaded artifact not found at %s: %w", artifactPath, err)
 	}
 	// 4. Copy artifact file to hermetic libDir
+	fileName := filepath.Base(artifactPath)
 	destPath := filepath.Join(libDir, fileName)
 	if err := filesystem.CopyFile(artifactPath, destPath); err != nil {
 		return fmt.Errorf("failed to copy artifact to lib folder: %w", err)
@@ -139,4 +134,20 @@ func installExternalMavenTool(ctx context.Context, mvnTool *config.MavenTool, bi
 		wrapperContent = fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", destPath)
 	}
 	return os.WriteFile(wrapperPath, []byte(wrapperContent), 0755)
+}
+
+// resolveM2ArtifactPath returns the absolute path to the downloaded artifact in the local .m2 repository.
+func resolveM2ArtifactPath(mvnTool *config.MavenTool, ext string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	m2Repo := filepath.Join(home, ".m2", "repository")
+	groupIDPath := strings.ReplaceAll(mvnTool.GroupID, ".", "/")
+	fileName := fmt.Sprintf("%s-%s", mvnTool.ArtifactID, mvnTool.Version)
+	if mvnTool.Classifier != "" {
+		fileName = fmt.Sprintf("%s-%s", fileName, mvnTool.Classifier)
+	}
+	fileName = fmt.Sprintf("%s.%s", fileName, ext)
+	return filepath.Join(m2Repo, groupIDPath, mvnTool.ArtifactID, mvnTool.Version, fileName), nil
 }

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -127,14 +127,14 @@ func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, 
 	wrapperPath := filepath.Join(binDir, t.Name)
 	var wrapperContent string
 	if ext == "exe" {
-		wrapperContent = fmt.Sprintf("#!/bin/bash\nexec %q \"$@\"\n", destPath)
+		wrapperContent = fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", destPath)
 	} else {
-		wrapperContent = fmt.Sprintf("#!/bin/bash\nexec java -jar %q \"$@\"\n", destPath)
+		wrapperContent = fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", destPath)
 	}
 	return os.WriteFile(wrapperPath, []byte(wrapperContent), 0755)
 }
 
-func copyFile(src, dst string, perm os.FileMode) error {
+func copyFile(src, dst string, perm os.FileMode) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -144,9 +144,13 @@ func copyFile(src, dst string, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if cErr := out.Close(); err == nil {
+			err = cErr
+		}
+	}()
 	if _, err = io.Copy(out, in); err != nil {
 		return err
 	}
-	return nil
+	return out.Sync()
 }

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -86,15 +86,15 @@ func getInstallDir() (string, error) {
 // installExternalMavenTool downloads a Maven-based external tool, copies its compiled artifact
 // (.jar or .exe) hermetically to the sibling lib folder, and creates an executable wrapper script
 // in the bin folder pointing directly to that library file.
-func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, libDir string) error {
+func installExternalMavenTool(ctx context.Context, mvnTool *config.MavenTool, binDir, libDir string) error {
 	// 1. Construct artifact string for maven
-	ext := strings.ToLower(t.Packaging)
+	ext := strings.ToLower(mvnTool.Packaging)
 	if ext == "" {
 		ext = "jar"
 	}
-	artifact := fmt.Sprintf("%s:%s:%s:%s", t.GroupID, t.ArtifactID, t.Version, ext)
-	if t.Classifier != "" {
-		artifact = fmt.Sprintf("%s:%s", artifact, t.Classifier)
+	artifact := fmt.Sprintf("%s:%s:%s:%s", mvnTool.GroupID, mvnTool.ArtifactID, mvnTool.Version, ext)
+	if mvnTool.Classifier != "" {
+		artifact = fmt.Sprintf("%s:%s", artifact, mvnTool.Classifier)
 	}
 	// 2. Download via mvn inside binDir (local .m2 populate)
 	args := []string{
@@ -110,13 +110,13 @@ func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, 
 		return fmt.Errorf("failed to get user home directory: %w", err)
 	}
 	m2Repo := filepath.Join(home, ".m2", "repository")
-	groupIDPath := strings.ReplaceAll(t.GroupID, ".", "/")
-	fileName := fmt.Sprintf("%s-%s", t.ArtifactID, t.Version)
-	if t.Classifier != "" {
-		fileName = fmt.Sprintf("%s-%s", fileName, t.Classifier)
+	groupIDPath := strings.ReplaceAll(mvnTool.GroupID, ".", "/")
+	fileName := fmt.Sprintf("%s-%s", mvnTool.ArtifactID, mvnTool.Version)
+	if mvnTool.Classifier != "" {
+		fileName = fmt.Sprintf("%s-%s", fileName, mvnTool.Classifier)
 	}
 	fileName = fmt.Sprintf("%s.%s", fileName, ext)
-	artifactPath := filepath.Join(m2Repo, groupIDPath, t.ArtifactID, t.Version, fileName)
+	artifactPath := filepath.Join(m2Repo, groupIDPath, mvnTool.ArtifactID, mvnTool.Version, fileName)
 	if _, err := os.Stat(artifactPath); err != nil {
 		return fmt.Errorf("downloaded artifact not found at %s: %w", artifactPath, err)
 	}
@@ -131,7 +131,7 @@ func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, 
 		}
 	}
 	// 5. Create wrapper script in binDir pointing to libDir
-	wrapperPath := filepath.Join(binDir, t.Name)
+	wrapperPath := filepath.Join(binDir, mvnTool.Name)
 	var wrapperContent string
 	if ext == "exe" {
 		wrapperContent = fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", destPath)

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/pip"
 	"github.com/googleapis/librarian/internal/yaml"
 )
@@ -124,8 +124,13 @@ func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, 
 	}
 	// 4. Copy artifact file to hermetic libDir
 	destPath := filepath.Join(libDir, fileName)
-	if err := copyFile(artifactPath, destPath, 0755); err != nil {
+	if err := filesystem.CopyFile(artifactPath, destPath); err != nil {
 		return fmt.Errorf("failed to copy artifact to lib folder: %w", err)
+	}
+	if ext == "exe" {
+		if err := os.Chmod(destPath, 0755); err != nil {
+			return fmt.Errorf("failed to make copied exe executable: %w", err)
+		}
 	}
 	// 5. Create wrapper script in binDir pointing to libDir
 	wrapperPath := filepath.Join(binDir, t.Name)
@@ -136,29 +141,4 @@ func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, 
 		wrapperContent = fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", destPath)
 	}
 	return os.WriteFile(wrapperPath, []byte(wrapperContent), 0755)
-}
-
-func copyFile(src, dst string, perm os.FileMode) (err error) {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cErr := in.Close(); err == nil {
-			err = cErr
-		}
-	}()
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cErr := out.Close(); err == nil {
-			err = cErr
-		}
-	}()
-	if _, err = io.Copy(out, in); err != nil {
-		return err
-	}
-	return out.Sync()
 }

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -55,13 +55,11 @@ func Install(ctx context.Context) error {
 	if err := os.MkdirAll(libDir, 0755); err != nil {
 		return fmt.Errorf("failed to create lib directory %q: %w", libDir, err)
 	}
-	// Install Maven tools
 	for _, mvnTool := range cfg.Tools.Maven {
 		if err := installExternalMavenTool(ctx, mvnTool, binDir, libDir); err != nil {
 			return fmt.Errorf("failed to install external maven tool %s: %w", mvnTool.Name, err)
 		}
 	}
-	// Install Pip tools
 	if len(cfg.Tools.Pip) > 0 {
 		if err := pip.Install(ctx, cfg.Tools.Pip); err != nil {
 			return fmt.Errorf("failed to install pip tools: %w", err)

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -34,6 +34,9 @@ import (
 var librarianYAML []byte
 
 // Install installs Java tool dependencies.
+// It creates two sibling directories:
+// - bin/ ($HOME/java_tools/bin) stores the generated executable wrapper scripts.
+// - lib/ ($HOME/java_tools/lib) hermetically isolates the downloaded compiled .jar/.exe files.
 func Install(ctx context.Context) error {
 	for _, cmd := range []string{"java", "mvn", "pip"} {
 		if _, err := exec.LookPath(cmd); err != nil {
@@ -48,8 +51,6 @@ func Install(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// binDir ($HOME/java_tools/bin) stores the generated executable wrapper scripts.
-	// libDir ($HOME/java_tools/lib) is a sibling directory that hermetically isolates the downloaded compiled .jar/.exe files.
 	libDir := filepath.Join(filepath.Dir(binDir), "lib")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -61,6 +61,7 @@ func Install(ctx context.Context) error {
 			return fmt.Errorf("failed to install external maven tool %s: %w", mvnTool.Name, err)
 		}
 	}
+	// TODO(https://github.com/googleapis/librarian/issues/5850): Refactor this once Librarian-wide variable is ready.
 	// Install Pip tools
 	if len(cfg.Tools.Pip) > 0 {
 		if err := pip.Install(ctx, cfg.Tools.Pip); err != nil {
@@ -84,6 +85,9 @@ func getInstallDir() (string, error) {
 	return filepath.Abs(dir)
 }
 
+// installExternalMavenTool downloads a Maven-based external tool, copies its compiled artifact
+// (.jar or .exe) hermetically to the sibling lib folder, and creates an executable wrapper script
+// in the bin folder pointing directly to that library file.
 func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, libDir string) error {
 	// 1. Construct artifact string for maven
 	ext := strings.ToLower(t.Packaging)
@@ -139,7 +143,11 @@ func copyFile(src, dst string, perm os.FileMode) (err error) {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() {
+		if cErr := in.Close(); err == nil {
+			err = cErr
+		}
+	}()
 	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
 	if err != nil {
 		return err

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -36,7 +36,7 @@ var librarianYAML []byte
 // Install installs Java tool dependencies.
 // It creates two sibling directories:
 // - bin/ ($HOME/java_tools/bin) stores the generated executable wrapper scripts.
-// - lib/ ($HOME/java_tools/lib) hermetically isolates the downloaded compiled .jar/.exe files.
+// - lib/ ($HOME/java_tools/lib) isolates the downloaded compiled .jar/.exe files.
 func Install(ctx context.Context) error {
 	for _, cmd := range []string{"java", "mvn", "pip"} {
 		if _, err := exec.LookPath(cmd); err != nil {
@@ -51,6 +51,8 @@ func Install(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// binDir ($HOME/java_tools/bin) stores the generated executable wrapper scripts.
+	// libDir ($HOME/java_tools/lib) is a sibling directory that isolates the downloaded compiled .jar/.exe files.
 	libDir := filepath.Join(filepath.Dir(binDir), "lib")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)
@@ -87,10 +89,30 @@ func getInstallDir() (string, error) {
 }
 
 // installExternalMavenTool downloads a Maven-based external tool, copies its compiled artifact
-// (.jar or .exe) hermetically to the sibling lib folder, and creates an executable wrapper script
+// (.jar or .exe) to the sibling lib folder, and creates an executable wrapper script
 // in the bin folder pointing directly to that library file.
 func installExternalMavenTool(ctx context.Context, mvnTool *config.MavenTool, binDir, libDir string) error {
-	// 1. Construct artifact string for maven
+	artifact, ext := getM2ArtifactSpec(mvnTool)
+	if err := downloadM2Artifact(ctx, artifact, binDir); err != nil {
+		return err
+	}
+	artifactPath, err := resolveM2ArtifactPath(mvnTool, ext)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(artifactPath); err != nil {
+		return fmt.Errorf("downloaded artifact not found at %s: %w", artifactPath, err)
+	}
+	isExe := ext == "exe"
+	destPath, err := copyArtifactToLib(artifactPath, libDir, isExe)
+	if err != nil {
+		return err
+	}
+	return createBinWrapper(mvnTool.Name, destPath, binDir, isExe)
+}
+
+// getM2ArtifactSpec constructs the Maven coordinate string and returns it along with the lowercased file extension.
+func getM2ArtifactSpec(mvnTool *config.MavenTool) (string, string) {
 	ext := strings.ToLower(mvnTool.Packaging)
 	if ext == "" {
 		ext = "jar"
@@ -99,42 +121,19 @@ func installExternalMavenTool(ctx context.Context, mvnTool *config.MavenTool, bi
 	if mvnTool.Classifier != "" {
 		artifact = fmt.Sprintf("%s:%s", artifact, mvnTool.Classifier)
 	}
-	// 2. Download via mvn inside binDir (local .m2 populate)
+	return artifact, ext
+}
+
+// downloadM2Artifact executes mvn dependency:get to download the target artifact.
+func downloadM2Artifact(ctx context.Context, artifact, workDir string) error {
 	args := []string{
 		"dependency:get",
 		"-Dartifact=" + artifact,
 	}
-	if err := command.RunStreamingInDir(ctx, binDir, "mvn", args...); err != nil {
+	if err := command.RunStreamingInDir(ctx, workDir, "mvn", args...); err != nil {
 		return fmt.Errorf("failed to download artifact %s: %w", artifact, err)
 	}
-	// 3. Resolve path in .m2/repository
-	artifactPath, err := resolveM2ArtifactPath(mvnTool, ext)
-	if err != nil {
-		return err
-	}
-	if _, err := os.Stat(artifactPath); err != nil {
-		return fmt.Errorf("downloaded artifact not found at %s: %w", artifactPath, err)
-	}
-	// 4. Copy artifact file to hermetic libDir
-	fileName := filepath.Base(artifactPath)
-	destPath := filepath.Join(libDir, fileName)
-	if err := filesystem.CopyFile(artifactPath, destPath); err != nil {
-		return fmt.Errorf("failed to copy artifact to lib folder: %w", err)
-	}
-	if ext == "exe" {
-		if err := os.Chmod(destPath, 0755); err != nil {
-			return fmt.Errorf("failed to make copied exe executable: %w", err)
-		}
-	}
-	// 5. Create wrapper script in binDir pointing to libDir
-	wrapperPath := filepath.Join(binDir, mvnTool.Name)
-	var wrapperContent string
-	if ext == "exe" {
-		wrapperContent = fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", destPath)
-	} else {
-		wrapperContent = fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", destPath)
-	}
-	return os.WriteFile(wrapperPath, []byte(wrapperContent), 0755)
+	return nil
 }
 
 // resolveM2ArtifactPath returns the absolute path to the downloaded artifact in the local .m2 repository.
@@ -151,4 +150,31 @@ func resolveM2ArtifactPath(mvnTool *config.MavenTool, ext string) (string, error
 	}
 	fileName = fmt.Sprintf("%s.%s", fileName, ext)
 	return filepath.Join(m2Repo, groupIDPath, mvnTool.ArtifactID, mvnTool.Version, fileName), nil
+}
+
+// copyArtifactToLib copies the artifact file into the isolated sibling lib directory, applying execution permission bits if needed.
+func copyArtifactToLib(srcPath, libDir string, makeExecutable bool) (string, error) {
+	fileName := filepath.Base(srcPath)
+	destPath := filepath.Join(libDir, fileName)
+	if err := filesystem.CopyFile(srcPath, destPath); err != nil {
+		return "", fmt.Errorf("failed to copy artifact to lib folder: %w", err)
+	}
+	if makeExecutable {
+		if err := os.Chmod(destPath, 0755); err != nil {
+			return "", fmt.Errorf("failed to make copied exe executable: %w", err)
+		}
+	}
+	return destPath, nil
+}
+
+// createBinWrapper creates a shell wrapper script in the bin directory that forwards executions to the library file.
+func createBinWrapper(wrapperName, destPath, binDir string, isExecutable bool) error {
+	wrapperPath := filepath.Join(binDir, wrapperName)
+	var content string
+	if isExecutable {
+		content = fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", destPath)
+	} else {
+		content = fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", destPath)
+	}
+	return os.WriteFile(wrapperPath, []byte(content), 0755)
 }

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -18,8 +18,13 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/pip"
 	"github.com/googleapis/librarian/internal/yaml"
@@ -30,7 +35,7 @@ var librarianYAML []byte
 
 // Install installs Java tool dependencies.
 func Install(ctx context.Context) error {
-	for _, cmd := range []string{"pip"} {
+	for _, cmd := range []string{"java", "mvn", "pip"} {
 		if _, err := exec.LookPath(cmd); err != nil {
 			return fmt.Errorf("%s is not installed or not in PATH, which is required for Java tool installation: %w", cmd, err)
 		}
@@ -39,10 +44,109 @@ func Install(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("parsing embedded librarian.yaml: %w", err)
 	}
+	binDir, err := getInstallDir()
+	if err != nil {
+		return err
+	}
+	libDir := filepath.Join(filepath.Dir(binDir), "lib")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)
+	}
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		return fmt.Errorf("failed to create lib directory %q: %w", libDir, err)
+	}
+	// Install Maven tools
+	for _, mvnTool := range cfg.Tools.Maven {
+		if err := installExternalMavenTool(ctx, mvnTool, binDir, libDir); err != nil {
+			return fmt.Errorf("failed to install external maven tool %s: %w", mvnTool.Name, err)
+		}
+	}
+	// Install Pip tools
 	if len(cfg.Tools.Pip) > 0 {
 		if err := pip.Install(ctx, cfg.Tools.Pip); err != nil {
 			return fmt.Errorf("failed to install pip tools: %w", err)
 		}
+	}
+	return nil
+}
+
+// getInstallDir returns the absolute path of the installation directory for Java tools.
+// It resolves LIBRARIAN_INSTALL_DIR if set, otherwise defaults to "$HOME/java_tools/bin".
+func getInstallDir() (string, error) {
+	dir := os.Getenv("LIBRARIAN_INSTALL_DIR")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		dir = filepath.Join(home, "java_tools", "bin")
+	}
+	return filepath.Abs(dir)
+}
+
+func installExternalMavenTool(ctx context.Context, t *config.MavenTool, binDir, libDir string) error {
+	// 1. Construct artifact string for maven
+	ext := strings.ToLower(t.Packaging)
+	if ext == "" {
+		ext = "jar"
+	}
+	artifact := fmt.Sprintf("%s:%s:%s:%s", t.GroupID, t.ArtifactID, t.Version, ext)
+	if t.Classifier != "" {
+		artifact = fmt.Sprintf("%s:%s", artifact, t.Classifier)
+	}
+	// 2. Download via mvn inside binDir (local .m2 populate)
+	args := []string{
+		"dependency:get",
+		"-Dartifact=" + artifact,
+	}
+	if err := command.RunStreamingInDir(ctx, binDir, "mvn", args...); err != nil {
+		return fmt.Errorf("failed to download artifact %s: %w", artifact, err)
+	}
+	// 3. Resolve path in .m2/repository
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	m2Repo := filepath.Join(home, ".m2", "repository")
+	groupIDPath := strings.ReplaceAll(t.GroupID, ".", "/")
+	fileName := fmt.Sprintf("%s-%s", t.ArtifactID, t.Version)
+	if t.Classifier != "" {
+		fileName = fmt.Sprintf("%s-%s", fileName, t.Classifier)
+	}
+	fileName = fmt.Sprintf("%s.%s", fileName, ext)
+	artifactPath := filepath.Join(m2Repo, groupIDPath, t.ArtifactID, t.Version, fileName)
+	if _, err := os.Stat(artifactPath); err != nil {
+		return fmt.Errorf("downloaded artifact not found at %s: %w", artifactPath, err)
+	}
+	// 4. Copy artifact file to hermetic libDir
+	destPath := filepath.Join(libDir, fileName)
+	if err := copyFile(artifactPath, destPath, 0755); err != nil {
+		return fmt.Errorf("failed to copy artifact to lib folder: %w", err)
+	}
+	// 5. Create wrapper script in binDir pointing to libDir
+	wrapperPath := filepath.Join(binDir, t.Name)
+	var wrapperContent string
+	if ext == "exe" {
+		wrapperContent = fmt.Sprintf("#!/bin/bash\nexec %q \"$@\"\n", destPath)
+	} else {
+		wrapperContent = fmt.Sprintf("#!/bin/bash\nexec java -jar %q \"$@\"\n", destPath)
+	}
+	return os.WriteFile(wrapperPath, []byte(wrapperContent), 0755)
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err = io.Copy(out, in); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -61,7 +61,6 @@ func Install(ctx context.Context) error {
 			return fmt.Errorf("failed to install external maven tool %s: %w", mvnTool.Name, err)
 		}
 	}
-	// TODO(https://github.com/googleapis/librarian/issues/5850): Refactor this once Librarian-wide variable is ready.
 	// Install Pip tools
 	if len(cfg.Tools.Pip) > 0 {
 		if err := pip.Install(ctx, cfg.Tools.Pip); err != nil {
@@ -73,6 +72,7 @@ func Install(ctx context.Context) error {
 
 // getInstallDir returns the absolute path of the installation directory for Java tools.
 // It resolves LIBRARIAN_INSTALL_DIR if set, otherwise defaults to "$HOME/java_tools/bin".
+// TODO(https://github.com/googleapis/librarian/issues/5850): Refactor this once Librarian-wide variable is ready.
 func getInstallDir() (string, error) {
 	dir := os.Getenv("LIBRARIAN_INSTALL_DIR")
 	if dir == "" {

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -152,7 +152,8 @@ func resolveM2ArtifactPath(mvnTool *config.MavenTool, ext string) (string, error
 	return filepath.Join(m2Repo, groupIDPath, mvnTool.ArtifactID, mvnTool.Version, fileName), nil
 }
 
-// copyArtifactToLib copies the artifact file into the isolated sibling lib directory, applying execution permission bits if needed.
+// copyArtifactToLib copies the artifact file into the isolated sibling lib directory,
+// applying execution permission bits if needed.
 func copyArtifactToLib(srcPath, libDir string, makeExecutable bool) (string, error) {
 	fileName := filepath.Base(srcPath)
 	destPath := filepath.Join(libDir, fileName)

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -45,23 +45,32 @@ func TestInstall(t *testing.T) {
 	if err := os.WriteFile(grpcExePath, []byte("grpc exe content"), 0755); err != nil {
 		t.Fatal(err)
 	}
+	stubs := []struct {
+		name        string
+		logFilename string
+		wantArgs    string
+	}{
+		{
+			name:        "pip",
+			logFilename: "pip_invocations.log",
+			wantArgs:    "pip install PyYAML==6.0.2 jinja2==3.1.6",
+		},
+		{
+			name:        "mvn",
+			logFilename: "mvn_invocations.log",
+			wantArgs:    "mvn dependency:get -Dartifact=com.google.googlejavaformat:google-java-format:1.25.2:jar:all-deps\nmvn dependency:get -Dartifact=io.grpc:protoc-gen-grpc-java:1.76.3:exe:linux-x86_64",
+		},
+	}
 	stubDir := filepath.Join(tmpDir, "bin")
 	if err := os.MkdirAll(stubDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	pipLogPath := filepath.Join(tmpDir, "pip_invocations.log")
-	pipContent := fmt.Sprintf(`#!/bin/sh
-echo "pip $@" >> %q
-`, pipLogPath)
-	if err := os.WriteFile(filepath.Join(stubDir, "pip"), []byte(pipContent), 0755); err != nil {
-		t.Fatal(err)
-	}
-	mvnLogPath := filepath.Join(tmpDir, "mvn_invocations.log")
-	mvnContent := fmt.Sprintf(`#!/bin/sh
-echo "mvn $@" >> %q
-`, mvnLogPath)
-	if err := os.WriteFile(filepath.Join(stubDir, "mvn"), []byte(mvnContent), 0755); err != nil {
-		t.Fatal(err)
+	for _, s := range stubs {
+		logPath := filepath.Join(tmpDir, s.logFilename)
+		content := fmt.Sprintf("#!/bin/sh\necho %q \"$@\" >> %q\n", s.name, logPath)
+		if err := os.WriteFile(filepath.Join(stubDir, s.name), []byte(content), 0755); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
 		t.Fatal(err)
@@ -73,23 +82,16 @@ echo "mvn $@" >> %q
 	if err != nil {
 		t.Fatal(err)
 	}
-	pipData, err := os.ReadFile(pipLogPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	gotPip := strings.TrimSpace(string(pipData))
-	wantPip := "pip install PyYAML==6.0.2 jinja2==3.1.6"
-	if diff := cmp.Diff(wantPip, gotPip); diff != "" {
-		t.Errorf("pip invocations mismatch (-want +got):\n%s", diff)
-	}
-	mvnData, err := os.ReadFile(mvnLogPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	gotMvn := strings.TrimSpace(string(mvnData))
-	wantMvn := "mvn dependency:get -Dartifact=com.google.googlejavaformat:google-java-format:1.25.2:jar:all-deps\nmvn dependency:get -Dartifact=io.grpc:protoc-gen-grpc-java:1.76.3:exe:linux-x86_64"
-	if diff := cmp.Diff(wantMvn, gotMvn); diff != "" {
-		t.Errorf("mvn invocations mismatch (-want +got):\n%s", diff)
+	for _, s := range stubs {
+		logPath := filepath.Join(tmpDir, s.logFilename)
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := strings.TrimSpace(string(data))
+		if diff := cmp.Diff(s.wantArgs, got); diff != "" {
+			t.Errorf("%s invocations mismatch (-want +got):\n%s", s.name, diff)
+		}
 	}
 	libDir := filepath.Join(tmpDir, "java_tools", "lib")
 	for _, test := range []struct {

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -26,14 +26,11 @@ import (
 
 func TestInstall(t *testing.T) {
 	tmpDir := t.TempDir()
-
 	// 1. Setup temp HOME to isolate .m2/repository
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
-
 	// 2. Pre-create dummy downloaded artifacts in mock .m2 repository
 	m2Repo := filepath.Join(tempHome, ".m2", "repository")
-
 	// (a) Pre-create google-java-format JAR
 	gjfDir := filepath.Join(m2Repo, "com", "google", "googlejavaformat", "google-java-format", "1.25.2")
 	if err := os.MkdirAll(gjfDir, 0755); err != nil {
@@ -43,7 +40,6 @@ func TestInstall(t *testing.T) {
 	if err := os.WriteFile(gjfJarPath, []byte("gjf jar content"), 0644); err != nil {
 		t.Fatal(err)
 	}
-
 	// (b) Pre-create protoc-gen-grpc-java exe
 	grpcDir := filepath.Join(m2Repo, "io", "grpc", "protoc-gen-grpc-java", "1.76.3")
 	if err := os.MkdirAll(grpcDir, 0755); err != nil {
@@ -53,13 +49,11 @@ func TestInstall(t *testing.T) {
 	if err := os.WriteFile(grpcExePath, []byte("grpc exe content"), 0755); err != nil {
 		t.Fatal(err)
 	}
-
 	// 3. Setup stub executables directory
 	stubDir := filepath.Join(tmpDir, "bin")
 	if err := os.MkdirAll(stubDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-
 	// (a) Stub pip
 	pipLogPath := filepath.Join(tmpDir, "pip_invocations.log")
 	pipContent := fmt.Sprintf(`#!/bin/bash
@@ -68,7 +62,6 @@ echo "pip $@" >> %q
 	if err := os.WriteFile(filepath.Join(stubDir, "pip"), []byte(pipContent), 0755); err != nil {
 		t.Fatal(err)
 	}
-
 	// (b) Stub mvn
 	mvnLogPath := filepath.Join(tmpDir, "mvn_invocations.log")
 	mvnContent := fmt.Sprintf(`#!/bin/bash
@@ -77,26 +70,20 @@ echo "mvn $@" >> %q
 	if err := os.WriteFile(filepath.Join(stubDir, "mvn"), []byte(mvnContent), 0755); err != nil {
 		t.Fatal(err)
 	}
-
 	// (c) Stub java
 	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
-
 	t.Setenv("PATH", stubDir)
-
 	// 4. Setup temp install dir
 	installDir := filepath.Join(tmpDir, "java_tools", "bin")
 	t.Setenv("LIBRARIAN_INSTALL_DIR", installDir)
-
 	// 5. Execute Installer
 	err := Install(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	// 6. Assertions
-
 	// (a) Verify pip calls
 	pipData, err := os.ReadFile(pipLogPath)
 	if err != nil {
@@ -107,7 +94,6 @@ echo "mvn $@" >> %q
 	if diff := cmp.Diff(wantPip, gotPip); diff != "" {
 		t.Errorf("pip invocations mismatch (-want +got):\n%s", diff)
 	}
-
 	// (b) Verify mvn calls
 	mvnData, err := os.ReadFile(mvnLogPath)
 	if err != nil {
@@ -118,10 +104,8 @@ echo "mvn $@" >> %q
 	if diff := cmp.Diff(wantMvn, gotMvn); diff != "" {
 		t.Errorf("mvn invocations mismatch (-want +got):\n%s", diff)
 	}
-
 	// (c) Verify files copied to libDir
 	libDir := filepath.Join(tmpDir, "java_tools", "lib")
-
 	gjfCopiedPath := filepath.Join(libDir, "google-java-format-1.25.2-all-deps.jar")
 	gjfData, err := os.ReadFile(gjfCopiedPath)
 	if err != nil {
@@ -130,7 +114,6 @@ echo "mvn $@" >> %q
 	if string(gjfData) != "gjf jar content" {
 		t.Errorf("copied GJF jar contents mismatch: got %q", string(gjfData))
 	}
-
 	grpcCopiedPath := filepath.Join(libDir, "protoc-gen-grpc-java-1.76.3-linux-x86_64.exe")
 	grpcData, err := os.ReadFile(grpcCopiedPath)
 	if err != nil {
@@ -139,7 +122,6 @@ echo "mvn $@" >> %q
 	if string(grpcData) != "grpc exe content" {
 		t.Errorf("copied grpc exe contents mismatch: got %q", string(grpcData))
 	}
-
 	// (d) Verify wrappers are written to binDir pointing to libDir
 	gjfWrapperPath := filepath.Join(installDir, "google-java-format")
 	gjfWrapper, err := os.ReadFile(gjfWrapperPath)
@@ -150,7 +132,6 @@ echo "mvn $@" >> %q
 	if diff := cmp.Diff(wantGjfWrapper, string(gjfWrapper)); diff != "" {
 		t.Errorf("GJF wrapper contents mismatch (-want +got):\n%s", diff)
 	}
-
 	grpcWrapperPath := filepath.Join(installDir, "protoc-gen-java_grpc")
 	grpcWrapper, err := os.ReadFile(grpcWrapperPath)
 	if err != nil {

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -50,20 +50,20 @@ func TestInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 	pipLogPath := filepath.Join(tmpDir, "pip_invocations.log")
-	pipContent := fmt.Sprintf(`#!/bin/bash
+	pipContent := fmt.Sprintf(`#!/bin/sh
 echo "pip $@" >> %q
 `, pipLogPath)
 	if err := os.WriteFile(filepath.Join(stubDir, "pip"), []byte(pipContent), 0755); err != nil {
 		t.Fatal(err)
 	}
 	mvnLogPath := filepath.Join(tmpDir, "mvn_invocations.log")
-	mvnContent := fmt.Sprintf(`#!/bin/bash
+	mvnContent := fmt.Sprintf(`#!/bin/sh
 echo "mvn $@" >> %q
 `, mvnLogPath)
 	if err := os.WriteFile(filepath.Join(stubDir, "mvn"), []byte(mvnContent), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -26,12 +26,9 @@ import (
 
 func TestInstall(t *testing.T) {
 	tmpDir := t.TempDir()
-	// 1. Setup temp HOME to isolate .m2/repository
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
-	// 2. Pre-create dummy downloaded artifacts in mock .m2 repository
 	m2Repo := filepath.Join(tempHome, ".m2", "repository")
-	// (a) Pre-create google-java-format JAR
 	gjfDir := filepath.Join(m2Repo, "com", "google", "googlejavaformat", "google-java-format", "1.25.2")
 	if err := os.MkdirAll(gjfDir, 0755); err != nil {
 		t.Fatal(err)
@@ -40,7 +37,6 @@ func TestInstall(t *testing.T) {
 	if err := os.WriteFile(gjfJarPath, []byte("gjf jar content"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	// (b) Pre-create protoc-gen-grpc-java exe
 	grpcDir := filepath.Join(m2Repo, "io", "grpc", "protoc-gen-grpc-java", "1.76.3")
 	if err := os.MkdirAll(grpcDir, 0755); err != nil {
 		t.Fatal(err)
@@ -49,12 +45,10 @@ func TestInstall(t *testing.T) {
 	if err := os.WriteFile(grpcExePath, []byte("grpc exe content"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	// 3. Setup stub executables directory
 	stubDir := filepath.Join(tmpDir, "bin")
 	if err := os.MkdirAll(stubDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	// (a) Stub pip
 	pipLogPath := filepath.Join(tmpDir, "pip_invocations.log")
 	pipContent := fmt.Sprintf(`#!/bin/bash
 echo "pip $@" >> %q
@@ -62,7 +56,6 @@ echo "pip $@" >> %q
 	if err := os.WriteFile(filepath.Join(stubDir, "pip"), []byte(pipContent), 0755); err != nil {
 		t.Fatal(err)
 	}
-	// (b) Stub mvn
 	mvnLogPath := filepath.Join(tmpDir, "mvn_invocations.log")
 	mvnContent := fmt.Sprintf(`#!/bin/bash
 echo "mvn $@" >> %q
@@ -70,21 +63,16 @@ echo "mvn $@" >> %q
 	if err := os.WriteFile(filepath.Join(stubDir, "mvn"), []byte(mvnContent), 0755); err != nil {
 		t.Fatal(err)
 	}
-	// (c) Stub java
 	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)
-	// 4. Setup temp install dir
 	installDir := filepath.Join(tmpDir, "java_tools", "bin")
 	t.Setenv("LIBRARIAN_INSTALL_DIR", installDir)
-	// 5. Execute Installer
 	err := Install(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	// 6. Assertions
-	// (a) Verify pip calls
 	pipData, err := os.ReadFile(pipLogPath)
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +82,6 @@ echo "mvn $@" >> %q
 	if diff := cmp.Diff(wantPip, gotPip); diff != "" {
 		t.Errorf("pip invocations mismatch (-want +got):\n%s", diff)
 	}
-	// (b) Verify mvn calls
 	mvnData, err := os.ReadFile(mvnLogPath)
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +91,6 @@ echo "mvn $@" >> %q
 	if diff := cmp.Diff(wantMvn, gotMvn); diff != "" {
 		t.Errorf("mvn invocations mismatch (-want +got):\n%s", diff)
 	}
-	// (c) Verify files copied to libDir
 	libDir := filepath.Join(tmpDir, "java_tools", "lib")
 	gjfCopiedPath := filepath.Join(libDir, "google-java-format-1.25.2-all-deps.jar")
 	gjfData, err := os.ReadFile(gjfCopiedPath)
@@ -122,7 +108,6 @@ echo "mvn $@" >> %q
 	if string(grpcData) != "grpc exe content" {
 		t.Errorf("copied grpc exe contents mismatch: got %q", string(grpcData))
 	}
-	// (d) Verify wrappers are written to binDir pointing to libDir
 	gjfWrapperPath := filepath.Join(installDir, "google-java-format")
 	gjfWrapper, err := os.ReadFile(gjfWrapperPath)
 	if err != nil {

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -92,38 +92,46 @@ echo "mvn $@" >> %q
 		t.Errorf("mvn invocations mismatch (-want +got):\n%s", diff)
 	}
 	libDir := filepath.Join(tmpDir, "java_tools", "lib")
-	gjfCopiedPath := filepath.Join(libDir, "google-java-format-1.25.2-all-deps.jar")
-	gjfData, err := os.ReadFile(gjfCopiedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(gjfData) != "gjf jar content" {
-		t.Errorf("copied GJF jar contents mismatch: got %q", string(gjfData))
-	}
-	grpcCopiedPath := filepath.Join(libDir, "protoc-gen-grpc-java-1.76.3-linux-x86_64.exe")
-	grpcData, err := os.ReadFile(grpcCopiedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(grpcData) != "grpc exe content" {
-		t.Errorf("copied grpc exe contents mismatch: got %q", string(grpcData))
-	}
-	gjfWrapperPath := filepath.Join(installDir, "google-java-format")
-	gjfWrapper, err := os.ReadFile(gjfWrapperPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wantGjfWrapper := fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", gjfCopiedPath)
-	if diff := cmp.Diff(wantGjfWrapper, string(gjfWrapper)); diff != "" {
-		t.Errorf("GJF wrapper contents mismatch (-want +got):\n%s", diff)
-	}
-	grpcWrapperPath := filepath.Join(installDir, "protoc-gen-java_grpc")
-	grpcWrapper, err := os.ReadFile(grpcWrapperPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wantGrpcWrapper := fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", grpcCopiedPath)
-	if diff := cmp.Diff(wantGrpcWrapper, string(grpcWrapper)); diff != "" {
-		t.Errorf("grpc wrapper contents mismatch (-want +got):\n%s", diff)
+	for _, test := range []struct {
+		name        string
+		filename    string
+		wantContent string
+		wrapperName string
+		wantFormat  string
+	}{
+		{
+			name:        "google-java-format",
+			filename:    "google-java-format-1.25.2-all-deps.jar",
+			wantContent: "gjf jar content",
+			wrapperName: "google-java-format",
+			wantFormat:  "#!/bin/sh\nexec java -jar %q \"$@\"\n",
+		},
+		{
+			name:        "protoc-gen-java_grpc",
+			filename:    "protoc-gen-grpc-java-1.76.3-linux-x86_64.exe",
+			wantContent: "grpc exe content",
+			wrapperName: "protoc-gen-java_grpc",
+			wantFormat:  "#!/bin/sh\nexec %q \"$@\"\n",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			copiedPath := filepath.Join(libDir, test.filename)
+			data, err := os.ReadFile(copiedPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != test.wantContent {
+				t.Errorf("copied file contents mismatch: got %q, want %q", string(data), test.wantContent)
+			}
+			wrapperPath := filepath.Join(installDir, test.wrapperName)
+			wrapper, err := os.ReadFile(wrapperPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantWrapper := fmt.Sprintf(test.wantFormat, copiedPath)
+			if diff := cmp.Diff(wantWrapper, string(wrapper)); diff != "" {
+				t.Errorf("wrapper contents mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -90,7 +90,7 @@ func TestInstall(t *testing.T) {
 		}
 		got := strings.TrimSpace(string(data))
 		if diff := cmp.Diff(s.wantArgs, got); diff != "" {
-			t.Errorf("%s invocations mismatch (-want +got):\n%s", s.name, diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 	libDir := filepath.Join(tmpDir, "java_tools", "lib")
@@ -122,8 +122,8 @@ func TestInstall(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if string(data) != test.wantContent {
-				t.Errorf("copied file contents mismatch: got %q, want %q", string(data), test.wantContent)
+			if diff := cmp.Diff(test.wantContent, string(data)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			wrapperPath := filepath.Join(installDir, test.wrapperName)
 			wrapper, err := os.ReadFile(wrapperPath)
@@ -132,7 +132,7 @@ func TestInstall(t *testing.T) {
 			}
 			wantWrapper := fmt.Sprintf(test.wantFormat, copiedPath)
 			if diff := cmp.Diff(wantWrapper, string(wrapper)); diff != "" {
-				t.Errorf("wrapper contents mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -128,7 +128,7 @@ echo "mvn $@" >> %q
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantGjfWrapper := fmt.Sprintf("#!/bin/bash\nexec java -jar %q \"$@\"\n", gjfCopiedPath)
+	wantGjfWrapper := fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", gjfCopiedPath)
 	if diff := cmp.Diff(wantGjfWrapper, string(gjfWrapper)); diff != "" {
 		t.Errorf("GJF wrapper contents mismatch (-want +got):\n%s", diff)
 	}
@@ -137,7 +137,7 @@ echo "mvn $@" >> %q
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantGrpcWrapper := fmt.Sprintf("#!/bin/bash\nexec %q \"$@\"\n", grpcCopiedPath)
+	wantGrpcWrapper := fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", grpcCopiedPath)
 	if diff := cmp.Diff(wantGrpcWrapper, string(grpcWrapper)); diff != "" {
 		t.Errorf("grpc wrapper contents mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -26,30 +26,138 @@ import (
 
 func TestInstall(t *testing.T) {
 	tmpDir := t.TempDir()
-	stubLogPath := filepath.Join(tmpDir, "pip_invocations.log")
-	stubContent := fmt.Sprintf(`#!/bin/bash
-echo "pip $@" >> %q
-`, stubLogPath)
+
+	// 1. Setup temp HOME to isolate .m2/repository
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	// 2. Pre-create dummy downloaded artifacts in mock .m2 repository
+	m2Repo := filepath.Join(tempHome, ".m2", "repository")
+
+	// (a) Pre-create google-java-format JAR
+	gjfDir := filepath.Join(m2Repo, "com", "google", "googlejavaformat", "google-java-format", "1.25.2")
+	if err := os.MkdirAll(gjfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gjfJarPath := filepath.Join(gjfDir, "google-java-format-1.25.2-all-deps.jar")
+	if err := os.WriteFile(gjfJarPath, []byte("gjf jar content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// (b) Pre-create protoc-gen-grpc-java exe
+	grpcDir := filepath.Join(m2Repo, "io", "grpc", "protoc-gen-grpc-java", "1.76.3")
+	if err := os.MkdirAll(grpcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	grpcExePath := filepath.Join(grpcDir, "protoc-gen-grpc-java-1.76.3-linux-x86_64.exe")
+	if err := os.WriteFile(grpcExePath, []byte("grpc exe content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Setup stub executables directory
 	stubDir := filepath.Join(tmpDir, "bin")
 	if err := os.MkdirAll(stubDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	stubPath := filepath.Join(stubDir, "pip")
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0755); err != nil {
+
+	// (a) Stub pip
+	pipLogPath := filepath.Join(tmpDir, "pip_invocations.log")
+	pipContent := fmt.Sprintf(`#!/bin/bash
+echo "pip $@" >> %q
+`, pipLogPath)
+	if err := os.WriteFile(filepath.Join(stubDir, "pip"), []byte(pipContent), 0755); err != nil {
 		t.Fatal(err)
 	}
+
+	// (b) Stub mvn
+	mvnLogPath := filepath.Join(tmpDir, "mvn_invocations.log")
+	mvnContent := fmt.Sprintf(`#!/bin/bash
+echo "mvn $@" >> %q
+`, mvnLogPath)
+	if err := os.WriteFile(filepath.Join(stubDir, "mvn"), []byte(mvnContent), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// (c) Stub java
+	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
 	t.Setenv("PATH", stubDir)
+
+	// 4. Setup temp install dir
+	installDir := filepath.Join(tmpDir, "java_tools", "bin")
+	t.Setenv("LIBRARIAN_INSTALL_DIR", installDir)
+
+	// 5. Execute Installer
 	err := Install(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := os.ReadFile(stubLogPath)
+
+	// 6. Assertions
+
+	// (a) Verify pip calls
+	pipData, err := os.ReadFile(pipLogPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got := strings.TrimSpace(string(data))
-	want := "pip install PyYAML==6.0.2 jinja2==3.1.6"
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	gotPip := strings.TrimSpace(string(pipData))
+	wantPip := "pip install PyYAML==6.0.2 jinja2==3.1.6"
+	if diff := cmp.Diff(wantPip, gotPip); diff != "" {
+		t.Errorf("pip invocations mismatch (-want +got):\n%s", diff)
+	}
+
+	// (b) Verify mvn calls
+	mvnData, err := os.ReadFile(mvnLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotMvn := strings.TrimSpace(string(mvnData))
+	wantMvn := "mvn dependency:get -Dartifact=com.google.googlejavaformat:google-java-format:1.25.2:jar:all-deps\nmvn dependency:get -Dartifact=io.grpc:protoc-gen-grpc-java:1.76.3:exe:linux-x86_64"
+	if diff := cmp.Diff(wantMvn, gotMvn); diff != "" {
+		t.Errorf("mvn invocations mismatch (-want +got):\n%s", diff)
+	}
+
+	// (c) Verify files copied to libDir
+	libDir := filepath.Join(tmpDir, "java_tools", "lib")
+
+	gjfCopiedPath := filepath.Join(libDir, "google-java-format-1.25.2-all-deps.jar")
+	gjfData, err := os.ReadFile(gjfCopiedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gjfData) != "gjf jar content" {
+		t.Errorf("copied GJF jar contents mismatch: got %q", string(gjfData))
+	}
+
+	grpcCopiedPath := filepath.Join(libDir, "protoc-gen-grpc-java-1.76.3-linux-x86_64.exe")
+	grpcData, err := os.ReadFile(grpcCopiedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(grpcData) != "grpc exe content" {
+		t.Errorf("copied grpc exe contents mismatch: got %q", string(grpcData))
+	}
+
+	// (d) Verify wrappers are written to binDir pointing to libDir
+	gjfWrapperPath := filepath.Join(installDir, "google-java-format")
+	gjfWrapper, err := os.ReadFile(gjfWrapperPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantGjfWrapper := fmt.Sprintf("#!/bin/bash\nexec java -jar %q \"$@\"\n", gjfCopiedPath)
+	if diff := cmp.Diff(wantGjfWrapper, string(gjfWrapper)); diff != "" {
+		t.Errorf("GJF wrapper contents mismatch (-want +got):\n%s", diff)
+	}
+
+	grpcWrapperPath := filepath.Join(installDir, "protoc-gen-java_grpc")
+	grpcWrapper, err := os.ReadFile(grpcWrapperPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantGrpcWrapper := fmt.Sprintf("#!/bin/bash\nexec %q \"$@\"\n", grpcCopiedPath)
+	if diff := cmp.Diff(wantGrpcWrapper, string(grpcWrapper)); diff != "" {
+		t.Errorf("grpc wrapper contents mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/librarian/java/librarian.yaml
+++ b/internal/librarian/java/librarian.yaml
@@ -23,7 +23,7 @@ tools:
       artifact_id: google-java-format
       version: "1.25.2"
       classifier: all-deps
-      packaging: JAR
+      packaging: jar
     - name: protoc-gen-java_grpc
       group_id: io.grpc
       artifact_id: protoc-gen-grpc-java

--- a/internal/librarian/java/librarian.yaml
+++ b/internal/librarian/java/librarian.yaml
@@ -17,6 +17,19 @@
 # librarian.
 language: java
 tools:
+  maven:
+    - name: google-java-format
+      group_id: com.google.googlejavaformat
+      artifact_id: google-java-format
+      version: "1.25.2"
+      classifier: all-deps
+      packaging: JAR
+    - name: protoc-gen-java_grpc
+      group_id: io.grpc
+      artifact_id: protoc-gen-grpc-java
+      version: 1.76.3
+      packaging: exe
+      classifier: linux-x86_64
   pip:
     - name: PyYAML
       version: "6.0.2"


### PR DESCRIPTION
This pull request implements the Java installer capability for installing Maven-based external tools (specifically com.google.googlejavaformat:google-java-format and io.grpc:protoc-gen-grpc-java).

Architectural Decoupling and Isolation:
To safeguard the compiled installer binaries from other Maven command clean/purge executions or local repository cache evictions, the downloaded jar and exe files are copied hermetically into a dedicated sibling library directory ($HOME/java_tools/lib). The executable wrapper scripts installed inside the bin folder ($HOME/java_tools/bin) execute these isolated library files directly.

Key Changes:
1. Adds MavenTool configuration structures and documentation inside config.go and doc/config-schema.md.
2. Implements the installExternalMavenTool and resolveM2ArtifactPath helper logic inside internal/librarian/java/install.go.
3. Adds unit tests inside internal/librarian/java/install_test.go to mock-populate local artifacts, verify copier actions, and validate shebang wrappers.

For https://github.com/googleapis/librarian/issues/5154
