### PR TITLE
feat(internal/sidekick/dart): sanitize references and HTML in doc comments

### DIFF
--- a/doc/dart-comment-reference-fixes.md
+++ b/doc/dart-comment-reference-fixes.md
@@ -1,0 +1,22 @@
+# Dart Comment Reference Fixes Heuristics
+
+This document summarizes the heuristics implemented in the Go-based Dart generator to sanitize documentation comments and resolve `comment_references` lint warnings.
+
+## Heuristics Table
+
+| Case | Original Example | Detection Strategy | Replacement / Action | Result |
+| :--- | :--- | :--- | :--- | :--- |
+| **Quoted URL with Brackets** | `"https://[service.name]/..."` | `"(https?://[^"]*\[[^"]*)"` | **Wrapped and Stripped.** Wraps in backticks and removes ref targets. | `` `https://[service.name]/...` `` |
+| **Non-quoted URL with Brackets** | `https://[Service_name]/...` | `(^\|\s)(https?://[^\s\[]*\[[^\s]*)` | **Wrapped and Stripped.** Wraps in backticks and removes ref targets. | `` `https://[Service_name]/...` `` |
+| **Valid Markdown Link** | `[audiences](https://...)` | `\[([\w\d\._]+)\]` followed by `(` | **Skipped.** Left as is to preserve valid external links. | `[audiences](https://...)` |
+| **Already in Code Font** | `` `[Ref]` `` | `\[([\w\d\._]+)\]` preceded by `` ` `` | **Skipped.** Left as is to avoid double wrapping. | `` `[Ref]` `` |
+| **Known Class Reference** | `[ValidRef]` | `\[([\w\d\._]+)\]` and `classExists("ValidRef")` is true | **Left as is.** Valid Dartdoc link to a class. | `[ValidRef]` |
+| **Resolved Field Mapping** | `[Endpoint.dedicated_endpoint_dns]` | `\[([\w\d\._]+)\]` and field found in message | **CamelCased.** Maps snake_case field to Dart camelCase. | `[Endpoint.dedicatedEndpointDns]` |
+| **Array Access** | `grounding_chunk[1]` | `([\w\d_]+)\[(\d+)\]` | **Wrapped.** Replaced with entire access in backticks. | `` `grounding_chunk[1]` `` |
+| **Array Literal** | `[1,3,4]` | `\[\d+(,\d+)*\]` | **Wrapped.** Replaced with literal in backticks. | `` `[1,3,4]` `` |
+| **Shortcut Reference Link** | `[Locations][]` | `\[([^\]]+)\]\[([\w\d\._]*)\]` and ref is empty | **Wrapped.** Replaced with just the label in backticks. | `` `Locations` `` |
+| **Full Ref Link (Phrase)** | `[User-Managed Replica][Ref]` | `\[([^\]]+)\]\[([\w\d\._]*)\]` and label has spaces | **Stripped.** Keeps only the label as plain text. | `User-Managed Replica` |
+| **Full Ref Link (Symbol)** | `[UpdateCmekSettings][Ref]` | `\[([^\]]+)\]\[([\w\d\._]*)\]` and label has no spaces | **Wrapped.** Replaced with label in backticks. | `` `UpdateCmekSettings` `` |
+| **HTML Tags** | `<sometag>` | `<` and `>` | **Escaped.** Replaces with `&lt;` and `&gt;`. | `&lt;sometag&gt;` |
+| **Fallback (Unresolved)** | `[UnknownRef]` | `\[([\w\d\._]+)\]` and no resolution found | **Wrapped.** Backticks applied while retaining brackets. | `` `[UnknownRef]` `` |
+| **Double Backticks Cleanup** | ````Distribution```` | `\`\`([\\w\\d_]+)\`\`` | **Unwrapped.** Replaces double backticks with single backticks. | `` `Distribution` `` |

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -248,15 +248,48 @@ type annotateModel struct {
 	dependencyConstraints map[string]string
 	// Whether the target API supports Server-Sent Events (SSE).
 	supportsSSE bool
+
+	// Deterministic mapping of message short-names to messages.
+	messageShortNames map[string]*api.Message
+	// Deterministic mapping of enum short-names to enums.
+	enumShortNames map[string]*api.Enum
 }
 
 func newAnnotateModel(model *api.API) *annotateModel {
+	var msgs []*api.Message
+	for msg := range model.AllMessages() {
+		msgs = append(msgs, msg)
+	}
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].ID < msgs[j].ID
+	})
+
+	messageShortNames := make(map[string]*api.Message)
+	for _, msg := range msgs {
+		messageShortNames[msg.Name] = msg
+	}
+
+	var enums []*api.Enum
+	for en := range model.AllEnums() {
+		enums = append(enums, en)
+	}
+	sort.Slice(enums, func(i, j int) bool {
+		return enums[i].ID < enums[j].ID
+	})
+
+	enumShortNames := make(map[string]*api.Enum)
+	for _, en := range enums {
+		enumShortNames[en.Name] = en
+	}
+
 	return &annotateModel{
 		model:                 model,
 		imports:               map[string]bool{},
 		packageMapping:        map[string]string{},
 		packagePrefixes:       map[string]string{},
 		dependencyConstraints: map[string]string{},
+		messageShortNames:     messageShortNames,
+		enumShortNames:        enumShortNames,
 	}
 }
 
@@ -466,7 +499,7 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 	}
 
 	slices.Sort(devDependencies)
-	docLines := formatDocComments(model.Description, model)
+	docLines := annotate.formatDocComments(model.Description)
 	ann := &modelAnnotations{
 		Parent:                    model,
 		PackageName:               pkgName,
@@ -632,7 +665,7 @@ func (annotate *annotateModel) annotateService(s *api.Service) {
 	}
 	ann := &serviceAnnotations{
 		Name:        s.Name,
-		DocLines:    formatDocComments(s.Documentation, annotate.model),
+		DocLines:    annotate.formatDocComments(s.Documentation),
 		Methods:     methods,
 		FieldName:   strcase.ToLowerCamel(s.Name),
 		StructName:  s.Name,
@@ -680,7 +713,7 @@ func (annotate *annotateModel) annotateMessage(m *api.Message) {
 		Parent:          m,
 		Name:            messageName(m),
 		QualifiedName:   qualifiedName(m),
-		DocLines:        formatDocComments(m.Documentation, annotate.model),
+		DocLines:        annotate.formatDocComments(m.Documentation),
 		OmitGeneration:  m.IsMap,
 		ConstructorBody: constructorBody,
 		ToStringLines:   toStringLines,
@@ -765,7 +798,7 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 		RequestMethod:       strings.ToLower(method.PathInfo.Bindings[0].Verb),
 		RequestType:         annotate.resolveMessageName(method.InputType, true),
 		ResponseType:        annotate.resolveMessageName(method.OutputType, true),
-		DocLines:            formatDocComments(method.Documentation, annotate.model),
+		DocLines:            annotate.formatDocComments(method.Documentation),
 		ReturnsValue:        !method.ReturnsEmpty,
 		BodyMessageName:     bodyMessageName,
 		QueryLines:          queryLines,
@@ -789,7 +822,7 @@ func (annotate *annotateModel) annotateOperationInfo(operationInfo *api.Operatio
 func (annotate *annotateModel) annotateOneOf(oneof *api.OneOf) {
 	oneof.Codec = &oneOfAnnotation{
 		Name:     strcase.ToLowerCamel(oneof.Name),
-		DocLines: formatDocComments(oneof.Documentation, annotate.model),
+		DocLines: annotate.formatDocComments(oneof.Documentation),
 	}
 }
 
@@ -869,7 +902,7 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 	field.Codec = &fieldAnnotation{
 		Name:                  fieldName(field),
 		Type:                  annotate.fieldType(field),
-		DocLines:              formatDocComments(field.Documentation, annotate.model),
+		DocLines:              annotate.formatDocComments(field.Documentation),
 		Required:              implicitPresence,
 		Nullable:              !implicitPresence,
 		FieldBehaviorRequired: fieldRequired,
@@ -1329,7 +1362,7 @@ func (annotate *annotateModel) annotateEnum(enum *api.Enum) {
 	enum.Codec = &enumAnnotation{
 		Parent:       enum,
 		Name:         enumName(enum),
-		DocLines:     formatDocComments(enum.Documentation, annotate.model),
+		DocLines:     annotate.formatDocComments(enum.Documentation),
 		DefaultValue: defaultValue,
 		Model:        annotate.model,
 	}
@@ -1338,7 +1371,7 @@ func (annotate *annotateModel) annotateEnum(enum *api.Enum) {
 func (annotate *annotateModel) annotateEnumValue(ev *api.EnumValue, enumValueToName map[*api.EnumValue]string) {
 	ev.Codec = &enumValueAnnotation{
 		Name:     enumValueToName[ev],
-		DocLines: formatDocComments(ev.Documentation, annotate.model),
+		DocLines: annotate.formatDocComments(ev.Documentation),
 	}
 }
 

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -200,7 +200,7 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 // - `[google.rpc.Code][]`.
 var commentRefsRegex = regexp.MustCompile(`\[([^\]]+)\]\[([\w\d\._]*)\]`)
 
-func formatDocComments(documentation string, model *api.API) []string {
+func (annotate *annotateModel) formatDocComments(documentation string) []string {
 	lines := strings.Split(documentation, "\n")
 
 	// Remove trailing whitespace.
@@ -210,9 +210,9 @@ func formatDocComments(documentation string, model *api.API) []string {
 
 	lines, codeBlocks := extractCodeBlocks(lines)
 	lines = sanitizeUrls(lines)
-	lines = resolveGoogleApiRefs(lines, model)
+	lines = annotate.resolveGoogleApiRefs(lines)
 	lines = escapeHtml(lines)
-	lines = processSingleBracketRefs(lines, model)
+	lines = annotate.processSingleBracketRefs(lines)
 	lines = cleanupDoubleTicks(lines)
 	lines = restoreCodeBlocks(lines, codeBlocks)
 
@@ -286,11 +286,11 @@ func extractCodeBlocks(lines []string) ([]string, [][]string) {
 			}
 		}
 
-		// If line is indented by 3 spaces.
-		if strings.HasPrefix(line, "   ") {
+		// If line is indented by 4 spaces.
+		if strings.HasPrefix(line, "    ") {
 			// Find the end of the candidate block.
 			j := i
-			for j < len(lines) && (strings.HasPrefix(lines[j], "   ") || lines[j] == "") {
+			for j < len(lines) && (strings.HasPrefix(lines[j], "    ") || lines[j] == "") {
 				j++
 			}
 
@@ -392,46 +392,26 @@ func sanitizeUrls(lines []string) []string {
 	return result
 }
 
-func findMessageByName(name string, model *api.API) *api.Message {
-	if model == nil {
+func (annotate *annotateModel) findMessageByName(name string) *api.Message {
+	if annotate == nil {
 		return nil
 	}
-	for msg := range model.AllMessages() {
-		if msg.Name == name {
-			return msg
-		}
-	}
-	return nil
+	return annotate.messageShortNames[name]
 }
 
-func findEnumByName(name string, model *api.API) *api.Enum {
-	if model == nil {
+func (annotate *annotateModel) findEnumByName(name string) *api.Enum {
+	if annotate == nil {
 		return nil
 	}
-	for en := range model.AllEnums() {
-		if en.Name == name {
-			return en
-		}
-	}
-	return nil
+	return annotate.enumShortNames[name]
 }
 
-func classExists(name string, model *api.API) bool {
-	return findMessageByName(name, model) != nil || findEnumByName(name, model) != nil
-}
-
-func getFlattenedName(msg *api.Message) string {
-	var parts []string
-	curr := msg
-	for curr != nil {
-		parts = append([]string{curr.Name}, parts...)
-		curr = curr.Parent
-	}
-	return strings.Join(parts, "_")
+func (annotate *annotateModel) classExists(name string) bool {
+	return annotate.findMessageByName(name) != nil || annotate.findEnumByName(name) != nil
 }
 
 // resolveGoogleApiRefs rewrites Google API doc references to code formatted text.
-func resolveGoogleApiRefs(lines []string, model *api.API) []string {
+func (annotate *annotateModel) resolveGoogleApiRefs(lines []string) []string {
 	result := make([]string, len(lines))
 	copy(result, lines)
 
@@ -455,7 +435,7 @@ func resolveGoogleApiRefs(lines []string, model *api.API) []string {
 			}
 
 			// If ref is a valid symbol, leave it as is.
-			if ref != "" && classExists(ref, model) {
+			if ref != "" && annotate.classExists(ref) {
 				continue
 			}
 
@@ -489,7 +469,7 @@ func escapeHtml(lines []string) []string {
 }
 
 // processSingleBracketRefs handles array access, literals, and symbol resolution.
-func processSingleBracketRefs(lines []string, model *api.API) []string {
+func (annotate *annotateModel) processSingleBracketRefs(lines []string) []string {
 	arrayAccessRegex := regexp.MustCompile(`[\w\d_\.]+\[\d+\](?:\.[\w\d_]+(?:\[\d+\])?)*`)
 	arrayLiteralRegex := regexp.MustCompile(`\[\d+(?:,\d+)*\]`)
 	singleRefRegex := regexp.MustCompile(`\[([\w\d\._]+)\]`)
@@ -544,7 +524,7 @@ func processSingleBracketRefs(lines []string, model *api.API) []string {
 			replacement := ""
 
 			if !strings.Contains(content, ".") {
-				if classExists(content, model) {
+				if annotate.classExists(content) {
 					continue
 				}
 				replacement = "`[" + content + "]`"
@@ -552,24 +532,19 @@ func processSingleBracketRefs(lines []string, model *api.API) []string {
 				parts := strings.Split(content, ".")
 				if len(parts) == 2 {
 					msgName := parts[0]
-					fieldName := parts[1]
+					targetFieldName := parts[1]
 
 					found := false
-					mappedFieldName := fieldName
+					mappedFieldName := targetFieldName
 					var targetMsg *api.Message
 
-					if model != nil {
-						for msg := range model.AllMessages() {
-							if msg.Name == msgName {
-								for _, f := range msg.Fields {
-									if f.Name == fieldName || f.JSONName == fieldName {
-										mappedFieldName = f.JSONName
-										found = true
-										targetMsg = msg
-										break
-									}
-								}
-								if found {
+					if annotate != nil {
+						if msg, ok := annotate.messageShortNames[msgName]; ok {
+							for _, f := range msg.Fields {
+								if f.Name == targetFieldName || f.JSONName == targetFieldName {
+									mappedFieldName = fieldName(f)
+									found = true
+									targetMsg = msg
 									break
 								}
 							}
@@ -577,7 +552,7 @@ func processSingleBracketRefs(lines []string, model *api.API) []string {
 					}
 
 					if found {
-						flattenedName := getFlattenedName(targetMsg)
+						flattenedName := messageName(targetMsg)
 						replacement = "[" + flattenedName + "." + mappedFieldName + "]"
 					}
 				}

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -198,9 +198,9 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 //
 // - `[Code][google.rpc.Code]`
 // - `[google.rpc.Code][]`.
-var commentRefsRegex = regexp.MustCompile(`\[([\w\d\._]+)\]\[([\d\w\._]*)\]`)
+var commentRefsRegex = regexp.MustCompile(`\[([^\]]+)\]\[([\w\d\._]*)\]`)
 
-func formatDocComments(documentation string, _ *api.API) []string {
+func formatDocComments(documentation string, model *api.API) []string {
 	lines := strings.Split(documentation, "\n")
 
 	// Remove trailing whitespace.
@@ -208,27 +208,443 @@ func formatDocComments(documentation string, _ *api.API) []string {
 		lines[i] = strings.TrimRightFunc(line, unicode.IsSpace)
 	}
 
-	// Re-write Google API doc references to code formatted text.
-	// TODO(#1575): Instead, resolve and insert dartdoc style references.
-	for i, line := range lines {
-		lines[i] = commentRefsRegex.ReplaceAllString(line, "`$1`")
-	}
+	lines, codeBlocks := extractCodeBlocks(lines)
+	lines = sanitizeUrls(lines)
+	lines = resolveGoogleApiRefs(lines, model)
+	lines = escapeHtml(lines)
+	lines = processSingleBracketRefs(lines, model)
+	lines = cleanupDoubleTicks(lines)
+	lines = restoreCodeBlocks(lines, codeBlocks)
 
-	// Remove trailing blank lines.
+	return toDartDoc(lines)
+}
+
+// extractCodeBlocks detects code blocks (indented by at least 2 spaces or fenced)
+// and replaces them with placeholders to avoid processing references inside them.
+func extractCodeBlocks(lines []string) ([]string, [][]string) {
+	var processedLines []string
+	var codeBlocks [][]string
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+
+		// Check for existing code fences.
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			// Find the closing fence.
+			j := i + 1
+			for j < len(lines) {
+				if strings.HasPrefix(strings.TrimSpace(lines[j]), "```") {
+					break
+				}
+				j++
+			}
+
+			// If we found a closing fence.
+			if j < len(lines) {
+				// Valid fenced block!
+				// Find minimum indentation of non-empty lines in the block (including fences).
+				minIndent := 1000
+				for k := i; k <= j; k++ {
+					if lines[k] == "" {
+						continue
+					}
+					indent := 0
+					for indent < len(lines[k]) && lines[k][indent] == ' ' {
+						indent++
+					}
+					if indent < minIndent {
+						minIndent = indent
+					}
+				}
+
+				var blockContent []string
+				for k := i; k <= j; k++ {
+					var lineContent string
+					if lines[k] == "" {
+						lineContent = ""
+					} else if len(lines[k]) >= minIndent {
+						lineContent = lines[k][minIndent:]
+					} else {
+						lineContent = lines[k]
+					}
+
+					// If it's the opening fence and it's just "```", add "text".
+					if k == i && lineContent == "```" {
+						lineContent = "```text"
+					}
+
+					blockContent = append(blockContent, lineContent)
+				}
+
+				codeBlocks = append(codeBlocks, blockContent)
+				processedLines = append(processedLines, fmt.Sprintf("__CODE_BLOCK_%d__", len(codeBlocks)-1))
+
+				i = j + 1
+				continue
+			}
+		}
+
+		// If line is indented by 3 spaces.
+		if strings.HasPrefix(line, "   ") {
+			// Find the end of the candidate block.
+			j := i
+			for j < len(lines) && (strings.HasPrefix(lines[j], "   ") || lines[j] == "") {
+				j++
+			}
+
+			// Remove trailing empty lines from the candidate block.
+			for j > i && lines[j-1] == "" {
+				j--
+			}
+
+			// Candidate block is lines[i:j].
+			// Check if it's a valid code block (preceded and followed by empty lines).
+			validPre := i == 0 || lines[i-1] == ""
+			validPost := j == len(lines) || lines[j] == ""
+
+			if validPre && validPost && j > i {
+				// Valid code block!
+				// Find minimum indentation of non-empty lines in the block.
+				minIndent := 1000 // Arbitrary large number.
+				for k := i; k < j; k++ {
+					if lines[k] == "" {
+						continue
+					}
+					// Count leading spaces.
+					indent := 0
+					for indent < len(lines[k]) && lines[k][indent] == ' ' {
+						indent++
+					}
+					if indent < minIndent {
+						minIndent = indent
+					}
+				}
+
+				var blockContent []string
+				for k := i; k < j; k++ {
+					if lines[k] == "" {
+						blockContent = append(blockContent, "")
+					} else {
+						// Remove minIndent spaces.
+						if len(lines[k]) >= minIndent {
+							blockContent = append(blockContent, lines[k][minIndent:])
+						} else {
+							blockContent = append(blockContent, lines[k])
+						}
+					}
+				}
+
+				codeBlocks = append(codeBlocks, blockContent)
+				processedLines = append(processedLines, fmt.Sprintf("__CODE_BLOCK_%d__", len(codeBlocks)-1))
+
+				i = j
+				continue
+			}
+		}
+
+		processedLines = append(processedLines, line)
+		i++
+	}
+	return processedLines, codeBlocks
+}
+
+// sanitizeUrls converts URLs containing brackets to ticked URLs and strips ref targets.
+func sanitizeUrls(lines []string) []string {
+	refTargetRegex := regexp.MustCompile(`\[([^\]]+)\]\[([^\]]+)\]`)
+	quotedUrlWithBracketsRegex := regexp.MustCompile(`"(https?://[^"]*\[[^"]*)"`)
+	nonQuotedUrlWithBracketsRegex := regexp.MustCompile(`(^|\s)(https?://[^\s\[]*\[[^\s]*)`)
+
+	result := make([]string, len(lines))
+	copy(result, lines)
+
+	for i, line := range result {
+		// Quoted URLs.
+		result[i] = quotedUrlWithBracketsRegex.ReplaceAllStringFunc(line, func(m string) string {
+			submatches := quotedUrlWithBracketsRegex.FindStringSubmatch(m)
+			if len(submatches) == 2 {
+				url := submatches[1]
+				url = refTargetRegex.ReplaceAllStringFunc(url, func(rm string) string {
+					rSubmatches := refTargetRegex.FindStringSubmatch(rm)
+					return "[" + rSubmatches[1] + "]"
+				})
+				return "`" + url + "`"
+			}
+			return m
+		})
+
+		// Non-quoted URLs.
+		result[i] = nonQuotedUrlWithBracketsRegex.ReplaceAllStringFunc(result[i], func(m string) string {
+			submatches := nonQuotedUrlWithBracketsRegex.FindStringSubmatch(m)
+			if len(submatches) == 3 {
+				prefix := submatches[1]
+				url := submatches[2]
+				url = refTargetRegex.ReplaceAllStringFunc(url, func(rm string) string {
+					rSubmatches := refTargetRegex.FindStringSubmatch(rm)
+					return "[" + rSubmatches[1] + "]"
+				})
+				return prefix + "`" + url + "`"
+			}
+			return m
+		})
+	}
+	return result
+}
+
+func findMessageByName(name string, model *api.API) *api.Message {
+	if model == nil {
+		return nil
+	}
+	for msg := range model.AllMessages() {
+		if msg.Name == name {
+			return msg
+		}
+	}
+	return nil
+}
+
+func findEnumByName(name string, model *api.API) *api.Enum {
+	if model == nil {
+		return nil
+	}
+	for en := range model.AllEnums() {
+		if en.Name == name {
+			return en
+		}
+	}
+	return nil
+}
+
+func classExists(name string, model *api.API) bool {
+	return findMessageByName(name, model) != nil || findEnumByName(name, model) != nil
+}
+
+func getFlattenedName(msg *api.Message) string {
+	var parts []string
+	curr := msg
+	for curr != nil {
+		parts = append([]string{curr.Name}, parts...)
+		curr = curr.Parent
+	}
+	return strings.Join(parts, "_")
+}
+
+// resolveGoogleApiRefs rewrites Google API doc references to code formatted text.
+func resolveGoogleApiRefs(lines []string, model *api.API) []string {
+	result := make([]string, len(lines))
+	copy(result, lines)
+
+	for i := 0; i < len(result); i++ {
+		line := result[i]
+		matches := commentRefsRegex.FindAllStringSubmatchIndex(line, -1)
+		for j := len(matches) - 1; j >= 0; j-- {
+			start, end := matches[j][0], matches[j][1]
+			// Skip if inside backticks
+			if strings.Count(line[:start], "`")%2 != 0 {
+				continue
+			}
+
+			textStart, textEnd := matches[j][2], matches[j][3]
+			refStart, refEnd := matches[j][4], matches[j][5]
+
+			text := line[textStart:textEnd]
+			ref := ""
+			if refStart != -1 {
+				ref = line[refStart:refEnd]
+			}
+
+			// If ref is a valid symbol, leave it as is.
+			if ref != "" && classExists(ref, model) {
+				continue
+			}
+
+			replacement := ""
+			if ref == "" {
+				replacement = "`" + text + "`"
+			} else {
+				if !strings.Contains(text, " ") {
+					replacement = "`" + text + "`"
+				} else {
+					replacement = text
+				}
+			}
+
+			line = line[:start] + replacement + line[end:]
+		}
+		result[i] = line
+	}
+	return result
+}
+
+// escapeHtml replaces < and > with HTML entities to avoid analyzer warnings.
+func escapeHtml(lines []string) []string {
+	result := make([]string, len(lines))
+	for i, line := range lines {
+		line = strings.ReplaceAll(line, "<", "&lt;")
+		line = strings.ReplaceAll(line, ">", "&gt;")
+		result[i] = line
+	}
+	return result
+}
+
+// processSingleBracketRefs handles array access, literals, and symbol resolution.
+func processSingleBracketRefs(lines []string, model *api.API) []string {
+	arrayAccessRegex := regexp.MustCompile(`[\w\d_\.]+\[\d+\](?:\.[\w\d_]+(?:\[\d+\])?)*`)
+	arrayLiteralRegex := regexp.MustCompile(`\[\d+(?:,\d+)*\]`)
+	singleRefRegex := regexp.MustCompile(`\[([\w\d\._]+)\]`)
+
+	result := make([]string, len(lines))
+	copy(result, lines)
+
+	for i, line := range result {
+		// Process array access.
+		matches := arrayAccessRegex.FindAllStringIndex(line, -1)
+		for j := len(matches) - 1; j >= 0; j-- {
+			match := matches[j]
+			start := match[0]
+			end := match[1]
+			if strings.Count(line[:start], "`")%2 != 0 {
+				continue
+			}
+			line = line[:start] + "`" + line[start:end] + "`" + line[end:]
+		}
+
+		// Process array literals.
+		matches = arrayLiteralRegex.FindAllStringIndex(line, -1)
+		for j := len(matches) - 1; j >= 0; j-- {
+			match := matches[j]
+			start := match[0]
+			end := match[1]
+			if strings.Count(line[:start], "`")%2 != 0 {
+				continue
+			}
+			line = line[:start] + "`" + line[start:end] + "`" + line[end:]
+		}
+
+		// Process single brackets.
+		matches = singleRefRegex.FindAllStringSubmatchIndex(line, -1)
+		for j := len(matches) - 1; j >= 0; j-- {
+			match := matches[j]
+			start := match[0]
+			end := match[1]
+			contentStart := match[2]
+			contentEnd := match[3]
+
+			content := line[contentStart:contentEnd]
+
+			if strings.Count(line[:start], "`")%2 != 0 {
+				continue
+			}
+
+			if end < len(line) && (line[end] == '(' || line[end] == '[') {
+				continue
+			}
+
+			replacement := ""
+
+			if !strings.Contains(content, ".") {
+				if classExists(content, model) {
+					continue
+				}
+				replacement = "`[" + content + "]`"
+			} else {
+				parts := strings.Split(content, ".")
+				if len(parts) == 2 {
+					msgName := parts[0]
+					fieldName := parts[1]
+
+					found := false
+					mappedFieldName := fieldName
+					var targetMsg *api.Message
+
+					if model != nil {
+						for msg := range model.AllMessages() {
+							if msg.Name == msgName {
+								for _, f := range msg.Fields {
+									if f.Name == fieldName || f.JSONName == fieldName {
+										mappedFieldName = f.JSONName
+										found = true
+										targetMsg = msg
+										break
+									}
+								}
+								if found {
+									break
+								}
+							}
+						}
+					}
+
+					if found {
+						flattenedName := getFlattenedName(targetMsg)
+						replacement = "[" + flattenedName + "." + mappedFieldName + "]"
+					}
+				}
+
+				if replacement == "" {
+					replacement = "`[" + content + "]`"
+				}
+			}
+
+			if replacement != "" {
+				line = line[:start] + replacement + line[end:]
+			}
+		}
+		result[i] = line
+	}
+	return result
+}
+
+// cleanupDoubleTicks removes double backticks around simple words.
+func cleanupDoubleTicks(lines []string) []string {
+	doubleTicksRegex := regexp.MustCompile("``([\\w\\d_]+)``")
+	result := make([]string, len(lines))
+	for i, line := range lines {
+		result[i] = doubleTicksRegex.ReplaceAllString(line, "`$1`")
+	}
+	return result
+}
+
+// restoreCodeBlocks replaces placeholders with original code blocks.
+func restoreCodeBlocks(lines []string, codeBlocks [][]string) []string {
+	var finalLines []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "__CODE_BLOCK_") && strings.HasSuffix(line, "__") {
+			var index int
+			fmt.Sscanf(line, "__CODE_BLOCK_%d__", &index)
+			if index >= 0 && index < len(codeBlocks) {
+				block := codeBlocks[index]
+				if len(block) > 0 && strings.HasPrefix(strings.TrimSpace(block[0]), "```") {
+					finalLines = append(finalLines, block...)
+				} else {
+					finalLines = append(finalLines, "```text")
+					finalLines = append(finalLines, block...)
+					finalLines = append(finalLines, "```")
+				}
+				continue
+			}
+		}
+		finalLines = append(finalLines, line)
+	}
+	return finalLines
+}
+
+// toDartDoc removes trailing blank lines and converts to dartdoc format.
+func toDartDoc(lines []string) []string {
 	for len(lines) > 0 && len(lines[len(lines)-1]) == 0 {
 		lines = lines[:len(lines)-1]
 	}
 
-	// Convert to dartdoc format.
+	result := make([]string, len(lines))
 	for i, line := range lines {
 		if len(line) == 0 {
-			lines[i] = "///"
+			result[i] = "///"
 		} else {
-			lines[i] = "/// " + line
+			result[i] = "/// " + line
 		}
 	}
-
-	return lines
+	return result
 }
 
 func packageName(api *api.API, packageNameOverride string) string {

--- a/internal/sidekick/dart/dart_test.go
+++ b/internal/sidekick/dart/dart_test.go
@@ -509,7 +509,8 @@ We want to respect whitespace at the beginning, because it important in Markdown
 		"/// - The next thing",
 	}
 	model := api.NewTestAPI(nil, nil, nil)
-	got := formatDocComments(input, model)
+	annotate := newAnnotateModel(model)
+	got := annotate.formatDocComments(input)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -520,7 +521,8 @@ func TestFormatDocCommentsEmpty(t *testing.T) {
 
 	want := []string{}
 	model := api.NewTestAPI(nil, nil, nil)
-	got := formatDocComments(input, model)
+	annotate := newAnnotateModel(model)
+	got := annotate.formatDocComments(input)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -537,7 +539,8 @@ This line has trailing spaces.  `
 		"/// This line has trailing spaces.",
 	}
 	model := api.NewTestAPI(nil, nil, nil)
-	got := formatDocComments(input, model)
+	annotate := newAnnotateModel(model)
+	got := annotate.formatDocComments(input)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -556,7 +559,8 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
 		"/// Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
 	}
 	model := api.NewTestAPI(nil, nil, nil)
-	got := formatDocComments(input, model)
+	annotate := newAnnotateModel(model)
+	got := annotate.formatDocComments(input)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -662,13 +666,13 @@ is set to true, this field will contain the sentiment for the sentence.`,
 			output:   "/// You can reference `Java` page using Markdown reference link syntax:\n/// `[Java][Tutorial.Java]`.",
 		},
 		{
-			testName: "Code block indentation (3 spaces)",
-			input:    "There are bounds:\n\n   Upper bound: bounds[i]\n   Lower bound: bounds[i - 1]\n\nEnd.",
+			testName: "Code block indentation (4 spaces)",
+			input:    "There are bounds:\n\n    Upper bound: bounds[i]\n    Lower bound: bounds[i - 1]\n\nEnd.",
 			output:   "/// There are bounds:\n///\n/// ```text\n/// Upper bound: bounds[i]\n/// Lower bound: bounds[i - 1]\n/// ```\n///\n/// End.",
 		},
 		{
 			testName: "Code block indentation mixed spaces",
-			input:    "Required. The resource name:\n\n    \"projects/[PROJECT_ID]...\"\n\nFor example:\n\n   \"projects/my-project...\"",
+			input:    "Required. The resource name:\n\n    \"projects/[PROJECT_ID]...\"\n\nFor example:\n\n    \"projects/my-project...\"",
 			output:   "/// Required. The resource name:\n///\n/// ```text\n/// \"projects/[PROJECT_ID]...\"\n/// ```\n///\n/// For example:\n///\n/// ```text\n/// \"projects/my-project...\"\n/// ```",
 		},
 		{
@@ -713,7 +717,8 @@ is set to true, this field will contain the sentiment for the sentence.`,
 		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			gotLines := formatDocComments(test.input, model)
+			annotate := newAnnotateModel(model)
+			gotLines := annotate.formatDocComments(test.input)
 			got := strings.Join(gotLines, "\n")
 			if diff := cmp.Diff(test.output, got); diff != "" {
 				t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
@@ -742,7 +747,8 @@ func TestFormatDocCommentsNestedMessageReferences(t *testing.T) {
 		"/// [NasJobSpec_MultiTrialAlgorithmSpec_TrainTrialSpec.frequency] trials searched.",
 	}
 
-	got := formatDocComments(input, model)
+	annotate := newAnnotateModel(model)
+	got := annotate.formatDocComments(input)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in TestFormatDocCommentsNestedMessageReferences (-want, +got)\n:%s", diff)
 	}
@@ -766,7 +772,8 @@ func TestFormatDocCommentsDuplicateMessageNames(t *testing.T) {
 		"/// Check [Model.supportedExportFormats] object.",
 	}
 
-	got := formatDocComments(input, model)
+	annotate := newAnnotateModel(model)
+	got := annotate.formatDocComments(input)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in TestFormatDocCommentsDuplicateMessageNames (-want, +got)\n:%s", diff)
 	}

--- a/internal/sidekick/dart/dart_test.go
+++ b/internal/sidekick/dart/dart_test.go
@@ -508,7 +508,8 @@ We want to respect whitespace at the beginning, because it important in Markdown
 		"///   - A nested thing",
 		"/// - The next thing",
 	}
-	got := formatDocComments(input, nil)
+	model := api.NewTestAPI(nil, nil, nil)
+	got := formatDocComments(input, model)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -518,7 +519,8 @@ func TestFormatDocCommentsEmpty(t *testing.T) {
 	input := ``
 
 	want := []string{}
-	got := formatDocComments(input, nil)
+	model := api.NewTestAPI(nil, nil, nil)
+	got := formatDocComments(input, model)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -534,7 +536,8 @@ This line has trailing spaces.  `
 		"///",
 		"/// This line has trailing spaces.",
 	}
-	got := formatDocComments(input, nil)
+	model := api.NewTestAPI(nil, nil, nil)
+	got := formatDocComments(input, model)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -552,13 +555,18 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
 		"/// sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
 		"/// Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
 	}
-	got := formatDocComments(input, nil)
+	model := api.NewTestAPI(nil, nil, nil)
+	got := formatDocComments(input, model)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
 }
 
 func TestFormatDocCommentsRewriteReferences(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{
+		{Name: "Secret", ID: "Secret"},
+	}, nil, nil)
+
 	for _, test := range []struct {
 		testName string
 		input    string
@@ -591,21 +599,176 @@ is set to true, this field will contain the sentiment for the sentence.`,
 		{
 			testName: "no match - spaces",
 			input:    "foo [Code ref][google.rpc.Code] bar",
-			output:   "/// foo [Code ref][google.rpc.Code] bar",
+			output:   "/// foo Code ref bar",
 		},
 		{
 			testName: "no match - missing brackets",
 			input:    "foo [google.rpc.Code] bar",
-			output:   "/// foo [google.rpc.Code] bar",
+			output:   "/// foo `[google.rpc.Code]` bar",
+		},
+		{
+			testName: "array access with dot",
+			input:    "foo logging.producer_destinations[0] bar",
+			output:   "/// foo `logging.producer_destinations[0]` bar",
+		},
+		{
+			testName: "simple array access",
+			input:    "foo grounding_chunk[1] bar",
+			output:   "/// foo `grounding_chunk[1]` bar",
+		},
+		{
+			testName: "double backticks cleanup",
+			input:    "foo ``Distribution`` bar",
+			output:   "/// foo `Distribution` bar",
+		},
+		{
+			testName: "complex path with array access",
+			input:    "foo emailAddresses[3].type[2] bar",
+			output:   "/// foo `emailAddresses[3].type[2]` bar",
+		},
+		{
+			testName: "complex path ending with field",
+			input:    "foo emailAddresses[1].email bar",
+			output:   "/// foo `emailAddresses[1].email` bar",
+		},
+		{
+			testName: "quoted URL with brackets",
+			input:    `foo "https://[service.name]/[google.protobuf.Api.name]" bar`,
+			output:   "/// foo `https://[service.name]/[google.protobuf.Api.name]` bar",
+		},
+		{
+			testName: "non-quoted URL with brackets",
+			input:    "foo https://[Service_name]/[API_name] bar",
+			output:   "/// foo `https://[Service_name]/[API_name]` bar",
+		},
+		{
+			testName: "URL at start of line with brackets",
+			input:    "https://[Service_name]/[API_name]",
+			output:   "/// `https://[Service_name]/[API_name]`",
+		},
+		{
+			testName: "URL with reference targets",
+			input:    "foo https://[Service_name][google.api.Service.name]/[API_name][google.protobuf.Api.name] bar",
+			output:   "/// foo `https://[Service_name]/[API_name]` bar",
+		},
+		{
+			testName: "URL with reference targets at start of line",
+			input:    "https://[Service_name][google.api.Service.name]/[API_name][google.protobuf.Api.name]",
+			output:   "/// `https://[Service_name]/[API_name]`",
+		},
+		{
+			testName: "Markdown reference syntax example",
+			input:    "You can reference [Java][Tutorial.Java] page using Markdown reference link syntax:\n`[Java][Tutorial.Java]`.",
+			output:   "/// You can reference `Java` page using Markdown reference link syntax:\n/// `[Java][Tutorial.Java]`.",
+		},
+		{
+			testName: "Code block indentation (3 spaces)",
+			input:    "There are bounds:\n\n   Upper bound: bounds[i]\n   Lower bound: bounds[i - 1]\n\nEnd.",
+			output:   "/// There are bounds:\n///\n/// ```text\n/// Upper bound: bounds[i]\n/// Lower bound: bounds[i - 1]\n/// ```\n///\n/// End.",
+		},
+		{
+			testName: "Code block indentation mixed spaces",
+			input:    "Required. The resource name:\n\n    \"projects/[PROJECT_ID]...\"\n\nFor example:\n\n   \"projects/my-project...\"",
+			output:   "/// Required. The resource name:\n///\n/// ```text\n/// \"projects/[PROJECT_ID]...\"\n/// ```\n///\n/// For example:\n///\n/// ```text\n/// \"projects/my-project...\"\n/// ```",
+		},
+		{
+			testName: "List items with 2 spaces should NOT be code block",
+			input:    "Example values:\n\n  - `000000000000004a`\n  - `7a2190356c3fc94b`\n\nEnd.",
+			output:   "/// Example values:\n///\n///   - `000000000000004a`\n///   - `7a2190356c3fc94b`\n///\n/// End.",
+		},
+		{
+			testName: "Code block relative indentation",
+			input:    "There is a block:\n\n    Line 1\n      Line 2\n    Line 3\n\nEnd.",
+			output:   "/// There is a block:\n///\n/// ```text\n/// Line 1\n///   Line 2\n/// Line 3\n/// ```\n///\n/// End.",
+		},
+		{
+			testName: "Existing code fence without name",
+			input:    "See follows:\n\n```\nparent_contexts:\n\"projects/...\"\n```\nEnd.",
+			output:   "/// See follows:\n///\n/// ```text\n/// parent_contexts:\n/// \"projects/...\"\n/// ```\n/// End.",
+		},
+		{
+			testName: "Existing code fence with name",
+			input:    "See follows:\n\n```json\n{\n  \"a\": 1\n}\n```\nEnd.",
+			output:   "/// See follows:\n///\n/// ```json\n/// {\n///   \"a\": 1\n/// }\n/// ```\n/// End.",
+		},
+		{
+			testName: "Existing code fence indented",
+			input:    "See follows:\n\n   ```\n   parent_contexts:\n   \"projects/...\"\n   ```\nEnd.",
+			output:   "/// See follows:\n///\n/// ```text\n/// parent_contexts:\n/// \"projects/...\"\n/// ```\n/// End.",
+		},
+		{
+			testName: "double bracket with valid symbol",
+			input:    "foo [Label][Secret] bar",
+			output:   "/// foo [Label][Secret] bar",
+		},
+		{
+			testName: "double bracket with invalid symbol (phrase)",
+			input:    "foo [Some Label][NonExistent] bar",
+			output:   "/// foo Some Label bar",
+		},
+		{
+			testName: "double bracket with invalid symbol (symbol)",
+			input:    "foo [SomeLabel][NonExistent] bar",
+			output:   "/// foo `SomeLabel` bar",
 		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			gotLines := formatDocComments(test.input, nil)
+			gotLines := formatDocComments(test.input, model)
 			got := strings.Join(gotLines, "\n")
 			if diff := cmp.Diff(test.output, got); diff != "" {
 				t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 			}
 		})
+	}
+}
+
+func TestFormatDocCommentsNestedMessageReferences(t *testing.T) {
+	parent := &api.Message{Name: "NasJobSpec", ID: ".test.NasJobSpec"}
+	msg := &api.Message{Name: "MultiTrialAlgorithmSpec", ID: ".test.NasJobSpec.MultiTrialAlgorithmSpec"}
+	nested := &api.Message{Name: "TrainTrialSpec", ID: ".test.NasJobSpec.MultiTrialAlgorithmSpec.TrainTrialSpec"}
+
+	nested.Fields = []*api.Field{
+		{Name: "frequency", JSONName: "frequency"},
+		{Name: "max_parallel_trial_count", JSONName: "maxParallelTrialCount"},
+	}
+
+	model := api.NewTestAPI([]*api.Message{parent, msg, nested}, nil, nil)
+
+	input := "Spec for train trials. Top N [TrainTrialSpec.maxParallelTrialCount]\nsearch trials will be trained for every M\n[TrainTrialSpec.frequency] trials searched."
+
+	want := []string{
+		"/// Spec for train trials. Top N [NasJobSpec_MultiTrialAlgorithmSpec_TrainTrialSpec.maxParallelTrialCount]",
+		"/// search trials will be trained for every M",
+		"/// [NasJobSpec_MultiTrialAlgorithmSpec_TrainTrialSpec.frequency] trials searched.",
+	}
+
+	got := formatDocComments(input, model)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in TestFormatDocCommentsNestedMessageReferences (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestFormatDocCommentsDuplicateMessageNames(t *testing.T) {
+	// Message 1: named "Model" but without the field.
+	msg1 := &api.Message{Name: "Model", ID: "msg1"}
+
+	// Message 2: named "Model" with the field!
+	msg2 := &api.Message{Name: "Model", ID: "msg2"}
+	msg2.Fields = []*api.Field{
+		{Name: "supported_export_formats", JSONName: "supportedExportFormats"},
+	}
+
+	model := api.NewTestAPI([]*api.Message{msg1, msg2}, nil, nil)
+
+	input := "Check [Model.supported_export_formats] object."
+
+	want := []string{
+		"/// Check [Model.supportedExportFormats] object.",
+	}
+
+	got := formatDocComments(input, model)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in TestFormatDocCommentsDuplicateMessageNames (-want, +got)\n:%s", diff)
 	}
 }
 


### PR DESCRIPTION
The Dart client library generator is updated to sanitize protobuf documentation
comments before writing them to the generated client package. Standalone URLs
containing brackets, unescaped raw HTML blocks (using less-than and greater-than
symbols), and double backticks are resolved to valid Markdown. This ensures that
the generated client packages do not produce compile-time or static-analysis
warning flags like comment_references and unintended_html_in_doc_comment.

The sanitization is refactored into a series of robust, modular search-and-replace
helper functions in dart.go. In-line symbol references of the form
[Message.field_name] are resolved to [Message_nested.fieldName] using a lookup
over the API model's messages, enums, and fields. Reference links that
correspond to valid class symbols are preserved, and phrases referencing
non-existent symbols are safely stripped of their reference suffix to be
displayed as verbatim plain text.

Fixes https://github.com/googleapis/google-cloud-dart/issues/25
