### PR TITLE
fix(tool/cmd/migrate): parse group ID and artifact ID from distribution name

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -251,7 +251,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 			name = l.APIShortName
 		}
 		output := "java-" + name
-		artifactID := parseArtifactID(l.DistributionName, name)
+		groupID, artifactID := parseGroupAndArtifactID(l.DistributionName, name)
 		version := versions[artifactID]
 		var apis []*config.API
 		var roots []string
@@ -337,7 +337,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 				ExcludedDependencies:         l.ExcludedDependencies,
 				ExcludedPOMs:                 parseStringList(l.ExcludedPoms),
 				ExtraVersionedModules:        l.ExtraVersionedModules,
-				GroupID:                      l.GroupID,
+				GroupID:                      groupID,
 				IssueTrackerOverride:         l.IssueTracker,
 				LibraryTypeOverride:          l.LibraryType,
 				MinJavaVersion:               l.MinJavaVersion,
@@ -453,17 +453,15 @@ func parseOwlBotKeep(repoPath, outputDir string) ([]string, error) {
 	return keeps, nil
 }
 
-// parseArtifactID returns the Maven artifact ID from distributionName (groupId:artifactId)
-// or name. If distributionName is empty, it returns "google-cloud-" + name.
-func parseArtifactID(distributionName, name string) string {
-	artifactID := distributionName
-	if artifactID == "" {
-		artifactID = "google-cloud-" + name
+// parseGroupAndArtifactID returns the Maven group ID and artifact ID from
+// distributionName (groupId:artifactId) or fallback to default value if
+// distributionName is empty.
+func parseGroupAndArtifactID(distributionName, name string) (string, string) {
+	if distributionName != "" {
+		parts := strings.Split(distributionName, ":")
+		return parts[0], parts[1]
 	}
-	if i := strings.Index(artifactID, ":"); i != -1 {
-		artifactID = artifactID[i+1:]
-	}
-	return artifactID
+	return "com.google.cloud", "google-cloud-" + name
 }
 
 // applyJavaArtifactOverrides sets artifact ID overrides for specific cases where

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -458,6 +458,8 @@ func parseOwlBotKeep(repoPath, outputDir string) ([]string, error) {
 // distributionName is empty.
 func parseGroupAndArtifactID(distributionName, name string) (string, string) {
 	if distributionName != "" {
+		// We assume the distributionName is correct since it is parsed from
+		// generation_config.yaml.
 		parts := strings.Split(distributionName, ":")
 		return parts[0], parts[1]
 	}

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -1740,3 +1740,38 @@ func TestApplyJavaAPIOverrides(t *testing.T) {
 		})
 	}
 }
+
+func TestParseGroupAndArtifactID(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		distributionName string
+		libName          string
+		wantGroup        string
+		wantArtifact     string
+	}{
+		{
+			name:             "distributionName provided",
+			distributionName: "com.google.cloud:google-cloud-pubsub",
+			libName:          "pubsub",
+			wantGroup:        "com.google.cloud",
+			wantArtifact:     "google-cloud-pubsub",
+		},
+		{
+			name:             "empty distributionName fallback",
+			distributionName: "",
+			libName:          "secretmanager",
+			wantGroup:        "com.google.cloud",
+			wantArtifact:     "google-cloud-secretmanager",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotGroup, gotArtifact := parseGroupAndArtifactID(test.distributionName, test.libName)
+			if diff := cmp.Diff(test.wantGroup, gotGroup); diff != "" {
+				t.Errorf("mismatch group id (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantArtifact, gotArtifact); diff != "" {
+				t.Errorf("mismatch artifact id (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Java migration tool is updated to parse both the group ID and the artifact ID from the distribution name when building the Java library configuration.

Unit tests are added for the parsing logic, and a documentation comment is added for the artifact ID field in the configuration.

Fixed #6048 