### PR TITLE
feat(internal/pip): implement support for local pip project installations

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -78,6 +78,7 @@ This document describes the schema for the librarian.yaml.
 | `name` | string | Is the pip package name. |
 | `version` | string | Is the version to install. |
 | `package` | string | Is the pip install specifier (e.g., "pkg@git+https://..."). |
+| `local_path` | string | Is the path to a local Python package to install. |
 
 ## GoTool Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,6 +170,9 @@ type PipTool struct {
 
 	// Package is the pip install specifier (e.g., "pkg@git+https://...").
 	Package string `yaml:"package,omitempty"`
+
+	// LocalPath is the path to a local Python package to install.
+	LocalPath string `yaml:"local_path,omitempty"`
 }
 
 // GoTool defines a tool to install via go.

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -26,8 +26,13 @@ import (
 
 func TestInstall(t *testing.T) {
 	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
+	localPkgDir := filepath.Join(tmpDir, "sdk-platform-java", "hermetic_build", "library_generation")
+	if err := os.MkdirAll(localPkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 	m2Repo := filepath.Join(tempHome, ".m2", "repository")
 	gjfDir := filepath.Join(m2Repo, "com", "google", "googlejavaformat", "google-java-format", "1.25.2")
 	if err := os.MkdirAll(gjfDir, 0755); err != nil {
@@ -53,7 +58,7 @@ func TestInstall(t *testing.T) {
 		{
 			name:        "pip",
 			logFilename: "pip_invocations.log",
-			wantArgs:    "pip install PyYAML==6.0.2 jinja2==3.1.6",
+			wantArgs:    "pip install PyYAML==6.0.2 jinja2==3.1.6 " + localPkgDir,
 		},
 		{
 			name:        "mvn",

--- a/internal/librarian/java/librarian.yaml
+++ b/internal/librarian/java/librarian.yaml
@@ -35,3 +35,5 @@ tools:
       version: "6.0.2"
     - name: jinja2
       version: "3.1.6"
+    - name: synthtool
+      local_path: sdk-platform-java/hermetic_build/library_generation

--- a/internal/pip/pip.go
+++ b/internal/pip/pip.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
@@ -27,10 +29,24 @@ import (
 // ErrInstall indicates a failure to install pip packages.
 var ErrInstall = errors.New("failed to install python packages")
 
+// ErrLocalPathNotFound indicates that the specified local package path does not exist.
+var ErrLocalPathNotFound = errors.New("local pip package path not found")
+
 // Install installs a list of pip tools into the environment.
 func Install(ctx context.Context, tools []*config.PipTool) error {
 	var installTargets []string
 	for _, tool := range tools {
+		if tool.LocalPath != "" {
+			absPath, err := filepath.Abs(tool.LocalPath)
+			if err != nil {
+				return fmt.Errorf("failed to resolve absolute path for %s: %w", tool.LocalPath, err)
+			}
+			if _, err := os.Stat(absPath); err != nil {
+				return fmt.Errorf("%w: %s", ErrLocalPathNotFound, absPath)
+			}
+			installTargets = append(installTargets, absPath)
+			continue
+		}
 		if tool.Package != "" {
 			installTargets = append(installTargets, tool.Package)
 			continue

--- a/internal/pip/pip.go
+++ b/internal/pip/pip.go
@@ -26,11 +26,13 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-// ErrInstall indicates a failure to install pip packages.
-var ErrInstall = errors.New("failed to install python packages")
+var (
+	// ErrInstall indicates a failure to install pip packages.
+	ErrInstall = errors.New("failed to install python packages")
 
-// ErrLocalPathNotFound indicates that the specified local package path does not exist.
-var ErrLocalPathNotFound = errors.New("local pip package path not found")
+	// ErrLocalPathNotFound indicates that the specified local package path does not exist.
+	ErrLocalPathNotFound = errors.New("local pip package path not found")
+)
 
 // Install installs a list of pip tools into the environment.
 func Install(ctx context.Context, tools []*config.PipTool) error {

--- a/internal/pip/pip.go
+++ b/internal/pip/pip.go
@@ -42,7 +42,7 @@ func Install(ctx context.Context, tools []*config.PipTool) error {
 				return fmt.Errorf("failed to resolve absolute path for %s: %w", tool.LocalPath, err)
 			}
 			if _, err := os.Stat(absPath); err != nil {
-				return fmt.Errorf("%w: %s", ErrLocalPathNotFound, absPath)
+				return fmt.Errorf("%w: %w", ErrLocalPathNotFound, err)
 			}
 			installTargets = append(installTargets, absPath)
 			continue

--- a/internal/pip/pip_test.go
+++ b/internal/pip/pip_test.go
@@ -29,7 +29,7 @@ import (
 func TestInstall(t *testing.T) {
 	tmpDir := t.TempDir()
 	stubLogPath := filepath.Join(tmpDir, "pip_invocations.log")
-	stubContent := fmt.Sprintf(`#!/bin/bash
+	stubContent := fmt.Sprintf(`#!/bin/sh
 echo "pip $@" >> %q
 `, stubLogPath)
 	stubDir := filepath.Join(tmpDir, "bin")
@@ -41,6 +41,10 @@ echo "pip $@" >> %q
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)
+	localPkgPath := filepath.Join(tmpDir, "mylocalpkg")
+	if err := os.MkdirAll(localPkgPath, 0755); err != nil {
+		t.Fatal(err)
+	}
 	for _, test := range []struct {
 		name     string
 		tools    []*config.PipTool
@@ -67,6 +71,13 @@ echo "pip $@" >> %q
 				{Name: "requests"},
 			},
 			wantArgs: "install requests",
+		},
+		{
+			name: "install local package path",
+			tools: []*config.PipTool{
+				{Name: "synthtool", LocalPath: localPkgPath},
+			},
+			wantArgs: "install " + localPkgPath,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -95,7 +106,7 @@ func TestInstall_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 	stubPath := filepath.Join(stubDir, "pip")
-	if err := os.WriteFile(stubPath, []byte("#!/bin/bash\nexit 1\n"), 0755); err != nil {
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	for _, test := range []struct {
@@ -113,6 +124,13 @@ func TestInstall_Error(t *testing.T) {
 				t.Setenv("PATH", stubDir)
 			},
 			wantErr: ErrInstall,
+		},
+		{
+			name: "local path not found",
+			tools: []*config.PipTool{
+				{Name: "failpkg", LocalPath: filepath.Join(tmpDir, "nonexistentpkg")},
+			},
+			wantErr: ErrLocalPathNotFound,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This pull request implements support for installing local Python package paths via pip.

It is particularly useful for configuring the java installer package to fetch and build local pip projects such as synthtool directly from sdk-platform-java/hermetic_build/library_generation without spawning external remote download calls.

Key Changes:
1. Adds the LocalPath configuration schema field inside config.go and doc/config-schema.md.
2. Implements LocalPath folder validations and absolute path resolutions inside internal/pip/pip.go.
3. Integrates local_path configuration inside internal/librarian/java/librarian.yaml.
4. Updates pip_test.go and install_test.go to pre-create sandboxed paths and assert correct pip arguments.

For https://github.com/googleapis/librarian/issues/5154