### PR TITLE
chore(.github): exclude internal/sample from coverage check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         # TODO(https://github.com/googleapis/librarian/issues/4664): raise to 80.
         run: |
           go run ./tool/cmd/coverage -target=78 \
-            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian')
+            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian|internal/sample')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     needs: [legacylibrarian, test]


### PR DESCRIPTION
The internal/sample package is excluded from the test coverage check in the main CI workflow.

This package does not contain library or tool logic that needs to meet the codebase coverage target, so omitting it avoids unnecessary test coverage constraints on sample code.

For #6094