### PR TITLE
chore(.github): exclude internal/testhelper from coverage check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         # TODO(https://github.com/googleapis/librarian/issues/4664): raise to 80.
         run: |
           go run ./tool/cmd/coverage -target=78 \
-            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian|internal/sample')
+            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/legacylibrarian|internal/sample|internal/testhelper')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     needs: [legacylibrarian, test]


### PR DESCRIPTION
The internal/testhelper package is excluded from the test coverage check in the main CI workflow.

Since this package only contains testing utilities and helper functions for other tests, it does not need to meet the codebase coverage targets. Excluding it keeps the coverage check focused on the main codebase implementation.

For #6094