### PR TITLE
fix(sidekick/swift): use full return type for external package types

### DIFF
--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -81,7 +81,7 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 			return err
 		}
 		var err error
-		returnType, err = c.messageTypeName(method.OutputType)
+		returnType, err = c.fullyQualifiedMessageTypeName(method.OutputType)
 		if err != nil {
 			return err
 		}

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -32,6 +32,7 @@ type methodAnnotations struct {
 	BodyField      string
 	QueryParams    []*api.Field
 	Pagination     *paginationAnnotations
+	ReturnType     string
 }
 
 type paginationAnnotations struct {
@@ -74,8 +75,14 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 			return err
 		}
 	}
+	var returnType string
 	if method.OutputType != nil {
 		if err := c.annotateMessage(method.OutputType, modelAnn); err != nil {
+			return err
+		}
+		var err error
+		returnType, err = c.messageTypeName(method.OutputType)
+		if err != nil {
 			return err
 		}
 	}
@@ -116,6 +123,7 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 		BodyField:      bodyField,
 		QueryParams:    language.QueryParams(method, binding),
 		Pagination:     pagination,
+		ReturnType:     returnType,
 	}
 	if method.SampleInfo != nil {
 		c.annotateSampleInfo(method)

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -221,7 +222,7 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 				DocLines:       []string{"Test documentation."},
 				PathExpression: "/",
 				HTTPMethod:     "GET",
-				ReturnType:     "Google.Response",
+				ReturnType:     "Response",
 			}
 
 			if diff := cmp.Diff(want, method.Codec); diff != "" {
@@ -264,6 +265,12 @@ func TestAnnotateMethod_WithExternalMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 	codec := newTestCodec(t, model, nil)
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{
+			ApiPackage: "google.cloud.external.v1",
+			Name:       "GoogleCloudExternalV1",
+		},
+	})
 
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -221,7 +221,7 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 				DocLines:       []string{"Test documentation."},
 				PathExpression: "/",
 				HTTPMethod:     "GET",
-				ReturnType:     "Response",
+				ReturnType:     "Google.Response",
 			}
 
 			if diff := cmp.Diff(want, method.Codec); diff != "" {
@@ -349,7 +349,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		Pagination: &paginationAnnotations{
 			ItemType: "Item",
 		},
-		ReturnType: "ListResponse",
+		ReturnType: "GoogleTest.ListResponse",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -63,6 +63,7 @@ func TestAnnotateMethod(t *testing.T) {
 				DocLines:       []string{"Gets a thing.", "", "Test multiple comment lines.", ""},
 				HTTPMethod:     "GET",
 				HasBody:        false,
+				ReturnType:     "Response",
 			},
 		},
 		{
@@ -86,6 +87,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HasBody:        true,
 				IsBodyWildcard: false,
 				BodyField:      "key",
+				ReturnType:     "Response",
 			},
 		},
 		{
@@ -108,6 +110,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HTTPMethod:     "POST",
 				HasBody:        true,
 				IsBodyWildcard: true,
+				ReturnType:     "Response",
 			},
 		},
 		{
@@ -132,6 +135,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HTTPMethod:     "GET",
 				HasBody:        false,
 				QueryParams:    []*api.Field{keyField},
+				ReturnType:     "Response",
 			},
 		},
 	} {
@@ -217,6 +221,7 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 				DocLines:       []string{"Test documentation."},
 				PathExpression: "/",
 				HTTPMethod:     "GET",
+				ReturnType:     "Response",
 			}
 
 			if diff := cmp.Diff(want, method.Codec); diff != "" {
@@ -344,6 +349,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		Pagination: &paginationAnnotations{
 			ItemType: "Item",
 		},
+		ReturnType: "ListResponse",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -137,6 +137,26 @@ func (c *codec) messageTypeName(m *api.Message) (string, error) {
 	return fmt.Sprintf("%s.%s", parent, name), nil
 }
 
+func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
+	name := pascalCase(m.Name)
+	if m.Parent == nil {
+		if m.Package == c.Model.PackageName {
+			// this is the current package
+			return fmt.Sprintf("%s.%s", c.PackageName, name), nil
+		}
+		dep, ok := c.ApiPackages[m.Package]
+		if !ok {
+			return "", fmt.Errorf("package %q not found", m.Package)
+		}
+		return fmt.Sprintf("%s.%s", dep.Name, name), nil
+	}
+	parent, err := c.fullyQualifiedMessageTypeName(m.Parent)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s", parent, name), nil
+}
+
 func (c *codec) enumTypeName(e *api.Enum) (string, error) {
 	name := pascalCase(e.Name)
 	if e.Parent == nil {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -154,7 +154,7 @@ func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
 		}
 		dep, ok := c.ApiPackages[m.Package]
 		if !ok {
-			return "", fmt.Errorf("package %q not found", m.Package)
+return "", fmt.Errorf("package %q not found in ApiPackages", m.Package)
 		}
 		return fmt.Sprintf("%s.%s", dep.Name, name), nil
 	}

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -125,7 +125,11 @@ func scalarFieldTypeName(field *api.Field) (string, error) {
 func (c *codec) messageTypeName(m *api.Message) (string, error) {
 	name := pascalCase(m.Name)
 	if m.Parent == nil {
-		if prefix := c.externalTypePrefix(m.Package); prefix != "" {
+		prefix, err := c.externalTypePrefix(e.Package)
+		if err != nil {
+			return "", err
+		}
+		if prefix != "" {
 			return fmt.Sprintf("%s.%s", prefix, name), nil
 		}
 		return name, nil
@@ -159,8 +163,11 @@ func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
 
 func (c *codec) enumTypeName(e *api.Enum) (string, error) {
 	name := pascalCase(e.Name)
-	if e.Parent == nil {
-		if prefix := c.externalTypePrefix(e.Package); prefix != "" {
+	if e.Parent == nil {prefix, err := c.externalTypePrefix(e.Package)
+		if err != nil {
+			return "", err
+		}
+		if prefix != "" {
 			return fmt.Sprintf("%s.%s", prefix, name), nil
 		}
 		return name, nil
@@ -172,13 +179,13 @@ func (c *codec) enumTypeName(e *api.Enum) (string, error) {
 	return fmt.Sprintf("%s.%s", parent, name), nil
 }
 
-func (c *codec) externalTypePrefix(packageName string) string {
+func (c *codec) externalTypePrefix(packageName string) (string, error) {
 	if packageName == c.Model.PackageName {
-		return ""
+		return "", nil
 	}
 	dep, ok := c.ApiPackages[packageName]
 	if !ok {
-		return ""
+		return "", fmt.Errorf("package %q not found in ApiPackages", packageName)
 	}
-	return dep.Name
+	return dep.Name, nil
 }

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -125,11 +125,7 @@ func scalarFieldTypeName(field *api.Field) (string, error) {
 func (c *codec) messageTypeName(m *api.Message) (string, error) {
 	name := pascalCase(m.Name)
 	if m.Parent == nil {
-		prefix, err := c.externalTypePrefix(m.Package)
-		if err != nil {
-			return "", err
-		}
-		if prefix != "" {
+		if prefix := c.externalTypePrefix(m.Package); prefix != "" {
 			return fmt.Sprintf("%s.%s", prefix, name), nil
 		}
 		return name, nil
@@ -144,11 +140,7 @@ func (c *codec) messageTypeName(m *api.Message) (string, error) {
 func (c *codec) enumTypeName(e *api.Enum) (string, error) {
 	name := pascalCase(e.Name)
 	if e.Parent == nil {
-		prefix, err := c.externalTypePrefix(e.Package)
-		if err != nil {
-			return "", err
-		}
-		if prefix != "" {
+		if prefix := c.externalTypePrefix(e.Package); prefix != "" {
 			return fmt.Sprintf("%s.%s", prefix, name), nil
 		}
 		return name, nil
@@ -160,13 +152,13 @@ func (c *codec) enumTypeName(e *api.Enum) (string, error) {
 	return fmt.Sprintf("%s.%s", parent, name), nil
 }
 
-func (c *codec) externalTypePrefix(packageName string) (string, error) {
+func (c *codec) externalTypePrefix(packageName string) string {
 	if packageName == c.Model.PackageName {
-		return "", nil
+		return ""
 	}
 	dep, ok := c.ApiPackages[packageName]
 	if !ok {
-		return "", fmt.Errorf("package %q not found in ApiPackages", packageName)
+		return ""
 	}
-	return dep.Name, nil
+	return dep.Name
 }

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -154,7 +154,7 @@ func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
 		}
 		dep, ok := c.ApiPackages[m.Package]
 		if !ok {
-return "", fmt.Errorf("package %q not found in ApiPackages", m.Package)
+			return "", fmt.Errorf("package %q not found in ApiPackages", m.Package)
 		}
 		return fmt.Sprintf("%s.%s", dep.Name, name), nil
 	}

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -125,7 +125,7 @@ func scalarFieldTypeName(field *api.Field) (string, error) {
 func (c *codec) messageTypeName(m *api.Message) (string, error) {
 	name := pascalCase(m.Name)
 	if m.Parent == nil {
-		prefix, err := c.externalTypePrefix(e.Package)
+		prefix, err := c.externalTypePrefix(m.Package)
 		if err != nil {
 			return "", err
 		}
@@ -144,6 +144,10 @@ func (c *codec) messageTypeName(m *api.Message) (string, error) {
 func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
 	name := pascalCase(m.Name)
 	if m.Parent == nil {
+		if m.Package == "" {
+			// there is no package, so return the bare type name
+			return name, nil
+		}
 		if m.Package == c.Model.PackageName {
 			// this is the current package
 			return fmt.Sprintf("%s.%s", c.PackageName, name), nil
@@ -163,7 +167,8 @@ func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
 
 func (c *codec) enumTypeName(e *api.Enum) (string, error) {
 	name := pascalCase(e.Name)
-	if e.Parent == nil {prefix, err := c.externalTypePrefix(e.Package)
+	if e.Parent == nil {
+		prefix, err := c.externalTypePrefix(e.Package)
 		if err != nil {
 			return "", err
 		}

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -613,7 +613,7 @@ func verifyGeneratedService(t *testing.T, outDir string) {
     byItem: ListSecretsRequest, options: GoogleCloudGax.RequestOptions
 ) throws -> any AsyncSequence<Secret, Error>
  {
-      let listRpc = { (token: String) async throws -> ListSecretsResponse in
+      let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
         var request = byItem
         request.pageToken = token
         return try await self.listSecrets(request: request, options: options)

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -148,10 +148,6 @@ func TestGenerateService_Delegation(t *testing.T) {
 			Name:       "SomeTestPackage",
 			ApiPackage: "test",
 		},
-		{
-			Name:       "SomeTestPackage",
-			ApiPackage: "test",
-		},
 	})
 	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -143,7 +143,17 @@ func TestGenerateService_Delegation(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	swiftCfg := swiftConfig(t, []config.SwiftDependency{
+		{
+			Name:       "SomeTestPackage",
+			ApiPackage: "test",
+		},
+		{
+			Name:       "SomeTestPackage",
+			ApiPackage: "test",
+		},
+	})
+	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -206,7 +216,13 @@ func TestGenerateService_StubStructure(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	swiftCfg := swiftConfig(t, []config.SwiftDependency{
+		{
+			Name:       "SomeTestPackage",
+			ApiPackage: "test",
+		},
+	})
+	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -221,7 +237,7 @@ func TestGenerateService_StubStructure(t *testing.T) {
 	want := `  protocol ProtocolStub {
     func getThing(
     request: Request, options: GoogleCloudGax.RequestOptions
-) async throws -> Response
+) async throws -> SomeTestPackage.Response
 
   }`
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/internal/sidekick/swift/templates/common/logging.swift.mustache
+++ b/internal/sidekick/swift/templates/common/logging.swift.mustache
@@ -71,7 +71,7 @@ extension Clients {
         options: options,
         name: "{{Codec.Name}}",
         action: { (r: {{InputType.Codec.Name}}, o: GoogleCloudGax.RequestOptions) async throws ->
-            {{^ReturnsEmpty}}{{OutputType.Codec.Name}}{{/ReturnsEmpty}}
+            {{^ReturnsEmpty}}{{Codec.ReturnType}}{{/ReturnsEmpty}}
             {{#ReturnsEmpty}}Void{{/ReturnsEmpty}} in
               return try await self.inner.{{Codec.Name}}(request: r, options: o)
         })

--- a/internal/sidekick/swift/templates/common/method_signature/request.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/request.mustache
@@ -13,4 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{Codec.Name}}(request: {{InputType.Codec.Name}}) async throws{{^ReturnsEmpty}} -> {{OutputType.Codec.Name}}{{/ReturnsEmpty}}
+{{Codec.Name}}(request: {{InputType.Codec.Name}}) async throws{{^ReturnsEmpty}} -> {{Codec.ReturnType}}{{/ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/common/method_signature/request_options.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/request_options.mustache
@@ -15,4 +15,4 @@ limitations under the License.
 }}
 {{Codec.Name}}(
     request: {{InputType.Codec.Name}}, options: GoogleCloudGax.RequestOptions
-) async throws{{^ReturnsEmpty}} -> {{OutputType.Codec.Name}}{{/ReturnsEmpty}}
+) async throws{{^ReturnsEmpty}} -> {{Codec.ReturnType}}{{/ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -92,7 +92,7 @@ extension Clients {
     /// {{{.}}}
     {{/Codec.DocLines}}
     public func {{> /templates/common/method_signature/pagination_options}} {
-      let listRpc = { (token: String) async throws -> {{OutputType.Codec.Name}} in
+      let listRpc = { (token: String) async throws -> {{Codec.ReturnType}} in
         var request = byItem
         request.pageToken = token
         return try await self.{{Codec.Name}}(request: request, options: options)
@@ -122,7 +122,7 @@ extension {{Codec.Name}} {
   }
 
   public func {{> /templates/common/method_signature/pagination_options}} {
-    let listRpc = { (token: String) async throws -> {{OutputType.Codec.Name}} in
+    let listRpc = { (token: String) async throws -> {{Codec.ReturnType}} in
       throw GoogleCloudGax.RequestError.unimplemented
     }
     return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)

--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -91,7 +91,7 @@ extension Clients {
         ))
       }
       {{^ReturnsEmpty}}
-      return try GoogleCloudGax.ProtoJSONDecoder().decode({{OutputType.Codec.Name}}.self, from: data)
+      return try GoogleCloudGax.ProtoJSONDecoder().decode({{Codec.ReturnType}}.self, from: data)
       {{/ReturnsEmpty}}
     }
     {{/Codec.RestMethods}}


### PR DESCRIPTION
This prevents name conflicts between similarly named types. For example, `GoogleLongrunning` has an `Operation` type which conflicts with a built-in `Operation` type. Without using the fully qualified name, the compiler throws an error.

We will likely need to do something similar for the input types as well.