### PR TITLE
feat: add librarian action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,6 @@ runs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: "go.mod"
-        cache: false
     - uses: ./.github/actions/install-protoc
     - name: Install librarian
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -18,8 +18,8 @@ runs:
   steps:
     - uses: actions/setup-go@v6
       with:
-        go-version-file: "go.mod"
-    - uses: ./.github/actions/install-protoc
+        go-version-file: "${{ github.action_path }}/go.mod"
+    - uses: ${{ github.action_path }}/.github/actions/install-protoc
     - name: Install librarian
       run: |
         VERSION="latest"

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Setup Librarian
+description: Set up Go, install protoc, and Librarian.
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: "go.mod"
+        cache: false
+    - uses: ./.github/actions/install-protoc
+    - name: Install librarian
+      run: |
+        VERSION="latest"
+        if [ -f librarian.yaml ]; then
+          VERSION=$(sed -n 's/^version: *//p' librarian.yaml)
+        fi
+        go install tool
+        go install github.com/googleapis/librarian/cmd/librarian@$VERSION
+      shell: bash


### PR DESCRIPTION
Adds a root-level custom action for installing librarian based on the version specified in the triggering repo's `librarian.yaml` or `latest`. The version specified in the `uses` directive e.g. `@main` is the GitHub `ref` to use in pulling the **custom action definition**, **not** the version of `librarian` the action would ultimately use.

```
- name: Run librarian tidy
  uses: googleapis/librarian@main
  run: librarian tidy
```

Towards #5683