### PR TITLE
fix(tool/cmd/migrate): skip inserting markers if already present

### DIFF
--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -740,9 +740,15 @@ type wrapArgs struct {
 // wrapBlocks inserts start and end markers around a set of matching blocks.
 // If matching blocks are not contiguous, it moves them together to the
 // position of the first matching block.
+// It returns the original lines unchanged if the markers are already present.
 func wrapBlocks(args wrapArgs) []string {
 	if len(args.targets) == 0 {
 		return args.lines
+	}
+	for _, line := range args.lines {
+		if strings.Contains(line, args.startMarker) || strings.Contains(line, args.endMarker) {
+			return args.lines
+		}
 	}
 	kept, moved, insertAt := splitMatchingBlocks(args)
 	if insertAt == -1 {

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -440,7 +440,7 @@ func TestRunJavaMigration_insertMarker_repeatedly(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got := strings.Count(string(content), managedProtoStartMarker); got != 1 {
-		t.Fatal(err)
+		t.Fatalf("expected exactly 1 proto start marker after first run, got %d", got)
 	}
 
 	// Second run: should NOT duplicate markers

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -410,6 +410,53 @@ func TestRunJavaMigration_insertMarker(t *testing.T) {
 	}
 }
 
+func TestRunJavaMigration_insertMarker_repeatedly(t *testing.T) {
+	dir := setupMigrationTest(t, "testdata/run/success-java")
+	// Create dummy pom.xml to be updated
+	libDir := filepath.Join(dir, "java-language-v1")
+	clientDir := filepath.Join(libDir, "google-cloud-language-v1")
+	if err := os.MkdirAll(clientDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pomContent := `<project>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-language-v1-v1</artifactId>
+    </dependency>
+  </dependencies>
+</project>`
+	if err := os.WriteFile(filepath.Join(clientDir, "pom.xml"), []byte(pomContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// First run: should insert markers
+	err := runJavaMigration(t.Context(), dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pomPath := filepath.Join(dir, "java-language-v1", "google-cloud-language-v1", "pom.xml")
+	content, err := os.ReadFile(pomPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(content), managedProtoStartMarker); got != 1 {
+		t.Fatal(err)
+	}
+
+	// Second run: should NOT duplicate markers
+	err = runJavaMigration(t.Context(), dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content2, err := os.ReadFile(pomPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(content2), managedProtoStartMarker); got != 1 {
+		t.Errorf("expected exactly 1 proto start marker after second run, got %d. Content:\n%s", got, string(content2))
+	}
+}
+
 func TestBuildConfig(t *testing.T) {
 	for _, test := range []struct {
 		name     string


### PR DESCRIPTION
Update the Java migration tool to skip wrapping dependencies/modules with markers if those markers are already present in the target pom.xml. This prevents duplicating markers when the migration tool is run repeatedly on the same repository. This is needed during migration as we might need to rerun this command after new library additions done with hermetic build.

A new test is added to verify that repeated migration runs do not duplicate markers.

For #6134