### PR TITLE
fix(sidekick/swift): missing snippet imports

### DIFF
--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -44,7 +44,8 @@ func (ann *serviceAnnotations) ServiceImports() []string {
 	return result
 }
 
-// SnippetImports returns the list of dependencies for this service snippets.
+// SnippetImports returns the sorted list of dependencies for this service's
+// snippets.
 //
 // Service snippets are generated examples that show how to initialize the
 // service and call its key methods. They need imports beyond the package for

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -44,6 +44,25 @@ func (ann *serviceAnnotations) ServiceImports() []string {
 	return result
 }
 
+// SnippetImports returns the list of dependencies for this service snippets.
+//
+// Service snippets are generated examples that show how to initialize the
+// service and call its key methods. They need imports beyond the package for
+// mixins and other external packages. But they do not need the implementation
+// dependencies, such as `GoogleCloudAuth` or `GoogleCloudGax`.
+func (ann *serviceAnnotations) SnippetImports() []string {
+	var result []string
+	for _, dep := range ann.DependsOn {
+		// Only dependencies that map to some source-API package
+		// (e.g. google.protobuf) are needed by the snippets.
+		if dep.ApiPackage != "" {
+			result = append(result, dep.Name)
+		}
+	}
+	slices.Sort(result)
+	return result
+}
+
 func (c *codec) annotateService(service *api.Service, model *modelAnnotations) error {
 	docLines, err := c.formatDocumentation(service.Documentation, service.Scopes())
 	if err != nil {

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -24,9 +24,9 @@ limitations under the License.
 // snippet.show
 import Foundation
 import {{Codec.PackageName}}
-{{#Service.Codec.SnippetImports}}
+{{#Codec.SnippetImports}}
 import {{.}}
-{{/Service.Codec.SnippetImports}}
+{{/Codec.SnippetImports}}
 
 func sample() async throws {
     let client = try {{Codec.PackageName}}.Clients.{{Codec.ClientName}}()

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -22,9 +22,11 @@ limitations under the License.
 {{/Codec.Model.BoilerPlate}}
 
 // snippet.show
-import {{Codec.PackageName}}
 import Foundation
-import {{Codec.Model.WktPackage}}
+import {{Codec.PackageName}}
+{{#Service.Codec.SnippetImports}}
+import {{.}}
+{{/Service.Codec.SnippetImports}}
 
 func sample() async throws {
     let client = try {{Codec.PackageName}}.Clients.{{Codec.ClientName}}()

--- a/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
@@ -22,11 +22,11 @@ limitations under the License.
 {{/Service.Codec.Model.BoilerPlate}}
 
 // snippet.show
-{{#Service.Codec.Model.MessageImports}}
-import {{.}}
-{{/Service.Codec.Model.MessageImports}}
-import {{Service.Codec.PackageName}}
 import Foundation
+import {{Service.Codec.PackageName}}
+{{#Service.Codec.SnippetImports}}
+import {{.}}
+{{/Service.Codec.SnippetImports}}
 
 func sample(client: some {{Service.Codec.Name}}{{#SampleInfo}}{{#Codec.Parameters}}, {{.}}: String{{/Codec.Parameters}}{{/SampleInfo}}) async throws {
     {{^ReturnsEmpty}}


### PR DESCRIPTION
This adds many missing imports for snippets, while avoids adding unnecessary imports.

Towards #6158 
