### PR TITLE
fix(serviceconfig): loosen sdk.yaml path restrict

### DIFF
--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -817,15 +817,6 @@ func TestBuildGAPICOpts_Error(t *testing.T) {
 		googleapisDir string
 	}{
 		{
-			name:    "api not in allowlist",
-			apiPath: "nonexistent/api/v1",
-			goAPI: &config.GoAPI{
-				ClientPackage: "nonexistent",
-				ImportPath:    "nonexistent/apiv1",
-			},
-			googleapisDir: googleapisDir,
-		},
-		{
 			name:    "api not allowed for go",
 			apiPath: "google/cloud/asset/v1p1beta1",
 			goAPI: &config.GoAPI{

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -1373,10 +1373,10 @@ func TestCreateRepoMetadata_Error(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "invalid API path",
+			name: "python not allowlisted for path",
 			library: &config.Library{
-				Name:   "android-library",
-				APIs:   []*config.API{{Path: "android/notallowed/v1"}},
+				Name:   "google-spanner-executor",
+				APIs:   []*config.API{{Path: "google/spanner/executor/v1"}},
 				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 		},

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -106,8 +106,8 @@ func TestFromLibrary_Error(t *testing.T) {
 		{
 			name: "non-allowlisted API",
 			library: &config.Library{
-				Name: "google-cloud-secret-manager",
-				APIs: []*config.API{{Path: "android/notallowed/v1"}},
+				Name: "google-cloud-spanner-executor",
+				APIs: []*config.API{{Path: "google/spanner/executor/v1"}},
 			},
 			// Error returned by serviceconfig.Find isn't easily distinguished
 		},

--- a/internal/serviceconfig/api_test.go
+++ b/internal/serviceconfig/api_test.go
@@ -48,7 +48,7 @@ func TestHasAPIPath(t *testing.T) {
 		language string
 		want     bool
 	}{
-		{"matching path and language", "google/api", config.LanguageRust, true},
+		{"matching path and language", "google/cloud/accessapproval/v1", config.LanguageRust, true},
 		{"matching path but not language", "google/ads/admanager/v1", config.LanguageRust, false},
 		{"unknown path", "google/does/not/exist/v1", config.LanguageRust, false},
 		{"empty path", "", config.LanguageRust, false},

--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-- path: backstory
-  languages:
-    - all
 - path: google/ads/admanager/v1
   languages:
     - java
@@ -93,9 +90,6 @@
   new_issue_uri: https://issuetracker.google.com/issues?q=componentid:187400
   release_level:
     java: preview
-- path: google/api
-  languages:
-    - all
 - path: google/api/apikeys/v2
   documentation_uri: https://cloud.google.com/api-keys/docs
   languages:
@@ -2725,9 +2719,6 @@
     - java
     - python
   new_issue_uri: https://issuetracker.google.com/savedsearches/559768
-- path: google/devicesandservices/health/v4
-  languages:
-    - all
 - path: google/devtools/artifactregistry/v1
   documentation_uri: https://cloud.google.com/artifact-registry
   languages:
@@ -2760,9 +2751,6 @@
   new_issue_uri: https://issuetracker.google.com/savedsearches/559780
   release_level:
     java: preview
-- path: google/devtools/cloudprofiler/v2
-  languages:
-    - all
 - path: google/devtools/cloudtrace/v1
   documentation_uri: https://cloud.google.com/trace/docs
   languages:
@@ -3079,12 +3067,6 @@
   description: Core Protobuf types used by most services.
   languages:
     - all
-- path: google/pubsub/v1
-  languages:
-    - all
-- path: google/rpc
-  languages:
-    - all
 - path: google/rpc/context
   languages:
     - all
@@ -3281,12 +3263,6 @@
   release_level:
     go: preview
     java: preview
-- path: google/spanner/admin/database/v1
-  languages:
-    - all
-- path: google/spanner/admin/instance/v1
-  languages:
-    - all
 - path: google/spanner/executor/v1
   languages:
     - go
@@ -3296,12 +3272,6 @@
   transports:
     go: grpc
     java: grpc
-- path: google/spanner/v1
-  languages:
-    - all
-- path: google/storage/control/v2
-  languages:
-    - all
 - path: google/storage/v2
   languages:
     - all
@@ -3319,9 +3289,6 @@
   languages:
     - go
     - nodejs
-- path: google/type
-  languages:
-    - all
 - path: grafeas/v1
   documentation_uri: https://grafeas.io
   languages:
@@ -3338,6 +3305,3 @@
   skip_rest_numeric_enums:
     - java
   service_config: schema/google/showcase/v1beta1/showcase_v1beta1.yaml
-- path: src/google/protobuf
-  languages:
-    - all

--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -211,11 +211,8 @@ func populateFromServiceConfig(api *API, cfg *Service) *API {
 // API paths not starting with "google/cloud/" must be explicitly included in the
 // allowlist and satisfy its language restrictions.
 func validateAPI(path string, language string, api *API) (*API, error) {
-	if api == nil && strings.HasPrefix(path, "google/cloud/") {
+	if api == nil || len(api.Languages) == 0 {
 		return &API{Path: path}, nil
-	}
-	if api == nil {
-		return nil, fmt.Errorf("API %s is not in allowlist", path)
 	}
 	for _, l := range api.Languages {
 		if l == config.LanguageAll || l == language {

--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -211,8 +211,9 @@ func populateFromServiceConfig(api *API, cfg *Service) *API {
 // API paths not starting with "google/cloud/" must be explicitly included in the
 // allowlist and satisfy its language restrictions.
 func validateAPI(path string, language string, api *API) (*API, error) {
-	if api == nil || len(api.Languages) == 0 {
-		return &API{Path: path}, nil
+	if len(api.Languages) == 0 {
+		return api, nil
+	}
 	}
 	for _, l := range api.Languages {
 		if l == config.LanguageAll || l == language {

--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -211,9 +211,11 @@ func populateFromServiceConfig(api *API, cfg *Service) *API {
 // API paths not starting with "google/cloud/" must be explicitly included in the
 // allowlist and satisfy its language restrictions.
 func validateAPI(path string, language string, api *API) (*API, error) {
+	if api == nil {
+		return &API{Path: path}, nil
+	}
 	if len(api.Languages) == 0 {
 		return api, nil
-	}
 	}
 	for _, l := range api.Languages {
 		if l == config.LanguageAll || l == language {

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -413,6 +413,13 @@ func TestValidateAPI(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:     "api not in list, default",
+			path:     "google/ads/newapi/v1",
+			language: config.LanguageGo,
+			api:      &API{Path: "google/ads/newapi/v1"},
+			wantErr:  false,
+		},
+		{
 			name:     "api in allowlist, restricted language not allowed",
 			path:     "google/cloud/aiplatform/v1beta1",
 			language: config.LanguageGo,
@@ -421,20 +428,6 @@ func TestValidateAPI(t *testing.T) {
 				Languages: []string{config.LanguagePython},
 			},
 			wantErr: true,
-		},
-		{
-			name:     "api not in list, google/cloud/ prefix",
-			path:     "google/cloud/newapi/v1",
-			language: config.LanguageGo,
-			api:      nil,
-			wantErr:  false,
-		},
-		{
-			name:     "api not in list, no google/cloud/ prefix",
-			path:     "google/ads/newapi/v1",
-			language: config.LanguageGo,
-			api:      nil,
-			wantErr:  true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Remove API path restrictions in sdk.yaml. This allows any API path to be onboarded via `librarian add`, regardless of Cloud or not, and for any language without an explicit allowlisting. If specified, `languages` list is still respected as a restriction list for languages.

Removes all entries that were added with only `languages: all` to explicitly allowlist their path's onboarding, which is no longer necessary. Still respects `all` as a value in the event that its behavior in the codebase is necessary. We can clean it up separately if not.

Updates various error mode tests that call `serviceconfig.Find` and were using the original non-Cloud allowlist restriction as a test case for the error branch in the related code. Switched some to just use the language-restriction allowlist to produce an error instead.

Fixes #6144