### PR TITLE
feat(sidekick/swift): snippets use pagination

### DIFF
--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -28,7 +28,7 @@ import {{Codec.PackageName}}
 import {{.}}
 {{/Codec.SnippetImports}}
 
-func sample() async throws {
+func sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: String, {{/Codec.Parameters}}{{/Codec.QuickstartMethod.SampleInfo}}) async throws {
     let client = try {{Codec.PackageName}}.Clients.{{Codec.ClientName}}()
     {{#Codec.QuickstartMethod}}
     {{> /templates/snippet/generic}}
@@ -43,7 +43,7 @@ func sample() async throws {
 struct SnippetRunner {
     static func main() async throws {
         do {
-            try await sample()
+            try await sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: "[placeholder]", {{/Codec.Parameters}}{{/Codec.QuickstartMethod.SampleInfo}})
         } catch {
             print("Error: \(error)")
         }

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -31,10 +31,7 @@ import {{.}}
 func sample() async throws {
     let client = try {{Codec.PackageName}}.Clients.{{Codec.ClientName}}()
     {{#Codec.QuickstartMethod}}
-    let response = try await client.{{Codec.Name}}(
-        request: {{InputType.Codec.Name}}(/* set fields */)
-    )
-    print("Success: \(response)")
+    {{> /templates/snippet/generic}}
     {{/Codec.QuickstartMethod}}
     {{^Codec.QuickstartMethod}}
     // Use `client` to make requests to the {{Codec.Name}}.

--- a/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
@@ -29,16 +29,7 @@ import {{.}}
 {{/Service.Codec.SnippetImports}}
 
 func sample(client: some {{Service.Codec.Name}}{{#SampleInfo}}{{#Codec.Parameters}}, {{.}}: String{{/Codec.Parameters}}{{/SampleInfo}}) async throws {
-    {{^ReturnsEmpty}}
-    let response = try await client.{{Codec.Name}}(
-        {{> /templates/snippet/method_request_body}})
-    print("Success: \(response)")
-    {{/ReturnsEmpty}}
-    {{#ReturnsEmpty}}
-    try await client.{{Codec.Name}}(
-        {{> /templates/snippet/method_request_body}})
-    print("Success (no response expected)")
-    {{/ReturnsEmpty}}
+  {{> /templates/snippet/generic}}
 }
 // snippet.hide
 

--- a/internal/sidekick/swift/templates/snippet/generic.mustache
+++ b/internal/sidekick/swift/templates/snippet/generic.mustache
@@ -1,0 +1,36 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{#ReturnsEmpty}}
+{{! For now, only "simple" RPCs may return empty, so we can simplify the dispatch. }}
+try await client.{{Codec.Name}}(
+  request: {{> /templates/snippet/method_request_body}})
+print("Success (no response expected)")
+{{/ReturnsEmpty}}
+{{^ReturnsEmpty}}
+{{! The example code is different for simple vs. LRO vs. List RPCs }}
+{{#IsSimple}}
+let response = try await client.{{Codec.Name}}(
+  request: {{> /templates/snippet/method_request_body}})
+print("Success: \(response)")
+{{/IsSimple}}
+{{#IsList}}
+let items = try await client.{{Codec.Name}}(
+  byItem: {{> /templates/snippet/method_request_body}})
+for try await item in items {
+  print("  \(item)")
+}
+{{/IsList}}
+{{/ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/snippet/generic.mustache
+++ b/internal/sidekick/swift/templates/snippet/generic.mustache
@@ -27,7 +27,7 @@ let response = try await client.{{Codec.Name}}(
 print("Success: \(response)")
 {{/IsSimple}}
 {{#IsList}}
-let items = try await client.{{Codec.Name}}(
+let items = try client.{{Codec.Name}}(
   byItem: {{> /templates/snippet/method_request_body}})
 for try await item in items {
   print("  \(item)")

--- a/internal/sidekick/swift/templates/snippet/method_request_body.mustache
+++ b/internal/sidekick/swift/templates/snippet/method_request_body.mustache
@@ -22,7 +22,7 @@ limitations under the License.
   Conceptually there is a `list response = try await client.<<MethodName>>( ... )` around this
   partial.
 }}
-request: {{InputType.Codec.Name}}(
+{{InputType.Codec.Name}}(
   {{#SampleInfo}}
   {{#IsRequestResourceName}}
   {{Codec.Name}}: "{{Codec.FormatString}}",


### PR DESCRIPTION
Refactor the code to generate snippets so we can have different snippets for pagination and (in the future) LRO methods.

Towards #5915 
