### PR TITLE
feat(tool/cmd/migrate): update migrate keep list

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -93,7 +93,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `keep` | list of string | Lists files and directories to preserve during regeneration. |
+| `keep` | list of string | Lists files and directories to preserve during regeneration. These represent critical custom handwritten files (e.g., package.json, custom configs, and handwritten tests) and semi-handmade documentation files (README.md, CHANGELOG.md, .readme-partials.yaml) that are not natively generated from proto schemas but are strictly required by the post-processor's markdown generation and release tracking passes. |
 | `output` | string | Is the directory where code is written. For example, for Rust this is src/generated. |
 | `tag_format` | string | Is the template for git tags, such as "{name}/v{version}". |
 | `dart` | [DartPackage](#dartpackage-configuration) (optional) | Contains Dart-specific default configuration. |
@@ -115,7 +115,7 @@ This document describes the schema for the librarian.yaml.
 | `apis` | list of [API](#api-configuration) (optional) | API specifies which googleapis API to generate from (for generated libraries). |
 | `copyright_year` | string | Is the copyright year for the library. |
 | `title_override` | string | Overrides the title used in README generation. |
-| `keep` | list of string | Lists files and directories to preserve during regeneration. |
+| `keep` | list of string | Lists files and directories to preserve during regeneration. These represent critical custom handwritten files (e.g., package.json, custom configs, and handwritten tests) and semi-handmade documentation files (README.md, CHANGELOG.md, .readme-partials.yaml) that are not natively generated from proto schemas but are strictly required by the post-processor's markdown generation and release tracking passes. |
 | `output` | string | Is the directory where code is written. This overrides Default.Output. |
 | `roots` | list of string | Specifies the source roots to use for generation. Defaults to googleapis. |
 | `skip_generate` | bool | Disables code generation for this library. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,7 +193,11 @@ type GoTool struct {
 
 // Default contains default settings for all libraries.
 type Default struct {
-	// Keep lists files and directories to preserve during regeneration.
+	// Keep lists files and directories to preserve during regeneration. These represent
+	// critical custom handwritten files (e.g., package.json, custom configs, and handwritten tests)
+	// and semi-handmade documentation files (README.md, CHANGELOG.md, .readme-partials.yaml)
+	// that are not natively generated from proto schemas but are strictly required by the post-processor's
+	// markdown generation and release tracking passes.
 	Keep []string `yaml:"keep,omitempty"`
 	// Output is the directory where code is written. For example, for Rust
 	// this is src/generated.
@@ -270,7 +274,11 @@ type Library struct {
 	// TitleOverride overrides the title used in README generation.
 	TitleOverride string `yaml:"title_override,omitempty"`
 
-	// Keep lists files and directories to preserve during regeneration.
+	// Keep lists files and directories to preserve during regeneration. These represent
+	// critical custom handwritten files (e.g., package.json, custom configs, and handwritten tests)
+	// and semi-handmade documentation files (README.md, CHANGELOG.md, .readme-partials.yaml)
+	// that are not natively generated from proto schemas but are strictly required by the post-processor's
+	// markdown generation and release tracking passes.
 	Keep []string `yaml:"keep,omitempty"`
 
 	// Output is the directory where code is written. This overrides

--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -210,6 +210,7 @@ func buildNodejsLibrary(googleapisDir, packagesDir, libraryName string) (*config
 		}
 	}
 
+	// Tasks is the only service with ESM
 	if libraryName == "google-cloud-tasks" {
 		library.Nodejs.ESM = true
 	}

--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -210,6 +210,10 @@ func buildNodejsLibrary(googleapisDir, packagesDir, libraryName string) (*config
 		}
 	}
 
+	if libraryName == "google-cloud-tasks" {
+		library.Nodejs.ESM = true
+	}
+
 	if libraryName == "google-cloud-compute" {
 		v1smallKeep, err := nodejsV1SmallKeep(pkgDir)
 		if err != nil {

--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -91,7 +91,7 @@ func runNodejsMigration(ctx context.Context, repoPath string) error {
 		},
 		Default: &config.Default{
 			Output: "packages",
-			Keep:   []string{"package.json", "samples/package.json"},
+			Keep:   []string{"package.json", "samples/package.json", "README.md", "CHANGELOG.md", ".readme-partials.yaml"},
 		},
 		Libraries: libraries,
 	}

--- a/tool/cmd/migrate/nodejs_test.go
+++ b/tool/cmd/migrate/nodejs_test.go
@@ -265,42 +265,46 @@ nodejs_gapic_library(
 }
 
 func TestBuildNodejsLibrary_ESMOverride(t *testing.T) {
-	tmpDir := t.TempDir()
-	pkgJSON := `{"name": "@google-cloud/tasks", "version": "6.2.2"}`
-	pkgDir := filepath.Join(tmpDir, "packages", "google-cloud-tasks")
-	if err := os.MkdirAll(pkgDir, 0755); err != nil {
-		t.Fatal(err)
+	t.Parallel()
+	for _, test := range []struct {
+		name        string
+		libraryName string
+		pkgJSON     string
+		wantESM     bool
+	}{
+		{
+			name:        "tasks library receives ESM true",
+			libraryName: "google-cloud-tasks",
+			pkgJSON:     `{"name": "@google-cloud/tasks", "version": "6.2.2"}`,
+			wantESM:     true,
+		},
+		{
+			name:        "other standard library receives ESM false",
+			libraryName: "google-cloud-other",
+			pkgJSON:     `{"name": "@google-cloud/other", "version": "1.0.0"}`,
+			wantESM:     false,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			pkgDir := filepath.Join(tmpDir, "packages", test.libraryName)
+			if err := os.MkdirAll(pkgDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(test.pkgJSON), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := buildNodejsLibrary(t.TempDir(), filepath.Join(tmpDir, "packages"), test.libraryName)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(test.wantESM, got.Nodejs.ESM); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
-	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("tasks library receives ESM true", func(t *testing.T) {
-		got, err := buildNodejsLibrary(t.TempDir(), filepath.Join(tmpDir, "packages"), "google-cloud-tasks")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !got.Nodejs.ESM {
-			t.Errorf("expected ESM: true for google-cloud-tasks, got false")
-		}
-	})
-
-	t.Run("other standard library receives ESM false", func(t *testing.T) {
-		otherPkg := filepath.Join(tmpDir, "packages", "google-cloud-other")
-		if err := os.MkdirAll(otherPkg, 0755); err != nil {
-			t.Fatal(err)
-		}
-		otherJSON := `{"name": "@google-cloud/other", "version": "1.0.0"}`
-		if err := os.WriteFile(filepath.Join(otherPkg, "package.json"), []byte(otherJSON), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		got, err := buildNodejsLibrary(t.TempDir(), filepath.Join(tmpDir, "packages"), "google-cloud-other")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got.Nodejs.ESM {
-			t.Errorf("expected ESM: false for standard library, got true")
-		}
-	})
 }

--- a/tool/cmd/migrate/nodejs_test.go
+++ b/tool/cmd/migrate/nodejs_test.go
@@ -285,7 +285,6 @@ func TestBuildNodejsLibrary_ESMOverride(t *testing.T) {
 			wantESM:     false,
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
@@ -296,12 +295,10 @@ func TestBuildNodejsLibrary_ESMOverride(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(test.pkgJSON), 0644); err != nil {
 				t.Fatal(err)
 			}
-
 			got, err := buildNodejsLibrary(t.TempDir(), filepath.Join(tmpDir, "packages"), test.libraryName)
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			if diff := cmp.Diff(test.wantESM, got.Nodejs.ESM); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/tool/cmd/migrate/nodejs_test.go
+++ b/tool/cmd/migrate/nodejs_test.go
@@ -263,3 +263,44 @@ nodejs_gapic_library(
 		})
 	}
 }
+
+func TestBuildNodejsLibrary_ESMOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	pkgJSON := `{"name": "@google-cloud/tasks", "version": "6.2.2"}`
+	pkgDir := filepath.Join(tmpDir, "packages", "google-cloud-tasks")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("tasks library receives ESM true", func(t *testing.T) {
+		got, err := buildNodejsLibrary(t.TempDir(), filepath.Join(tmpDir, "packages"), "google-cloud-tasks")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.Nodejs.ESM {
+			t.Errorf("expected ESM: true for google-cloud-tasks, got false")
+		}
+	})
+
+	t.Run("other standard library receives ESM false", func(t *testing.T) {
+		otherPkg := filepath.Join(tmpDir, "packages", "google-cloud-other")
+		if err := os.MkdirAll(otherPkg, 0755); err != nil {
+			t.Fatal(err)
+		}
+		otherJSON := `{"name": "@google-cloud/other", "version": "1.0.0"}`
+		if err := os.WriteFile(filepath.Join(otherPkg, "package.json"), []byte(otherJSON), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := buildNodejsLibrary(t.TempDir(), filepath.Join(tmpDir, "packages"), "google-cloud-other")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Nodejs.ESM {
+			t.Errorf("expected ESM: false for standard library, got true")
+		}
+	})
+}


### PR DESCRIPTION
Add logic to explicitly append `esm: true` under `nodejs:` configuration blocks when scraping `google-cloud-tasks`, and explicitly appends `README.md`, `CHANGELOG.md`, and `.readme-partials.yaml` directly to the global defaults `keep:` array inside `librarian.yaml`.

Updates #4413