### PR TITLE
feat(internal/librarian/golang): support custom sample URIs in README

### DIFF
--- a/doc/api-allowlist-schema.md
+++ b/doc/api-allowlist-schema.md
@@ -14,7 +14,8 @@ This document describes the schema for the API Allowlist.
 | `new_issue_uri` | string | Overrides the new issue URI from the service config's publishing section. |
 | `skip_rest_numeric_enums` | list of string | Lists languages that should not pass the rest-numeric-enums flag to the generator. The special value "all" skips it for every language. If empty, all languages use numeric enums. |
 | `open_api` | string | Is the file path to an OpenAPI spec, currently in internal/testdata. This is not an official spec yet and exists only for Rust to validate OpenAPI support. |
-| `release_level` | map[string]string | Is the release level per language. Map key is the language name (e.g., "python", "rust"). Optional. If omitted, the generator default is used.<br><br>TODO(https://github.com/googleapis/librarian/issues/4834): Go uses "alpha", "beta", and "ga" instead of "preview" and "stable". We should standardize release level vocabulary across languages. |
+| `release_level` | map[string]string | Is the release level per language. Map key is the language name (e.g., "python", "rust"). Optional. If omitted, the generator default is used. |
+| `sample_uris` | map[string]string | Is the documentation URI for code samples per language. Map key is the language name (e.g., "go", "python"). Optional. If omitted, a default URI for the language is used. |
 | `short_name` | string | Overrides the API short name from the service config's publishing section. |
 | `service_config` | string | Is the service config file path override. If empty, the service config is discovered in the directory specified by Path. |
 | `service_name` | string | Is a DNS-like logical identifier for the service, such as `calendar.googleapis.com`. |

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -386,7 +386,7 @@ func isPreview(output string) bool {
 //
 // The default value is the empty string.
 func sampleURI(sc *serviceconfig.API) string {
-	if sc.SampleURIs == nil {
+	if sc == nil || sc.SampleURIs == nil {
 		return ""
 	}
 	if uri, ok := sc.SampleURIs[config.LanguageGo]; ok {

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -74,7 +74,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}
 
 	var fallbackTitle string
-	var sample string
+	var customSampleURI string
 	for i, api := range library.APIs {
 		goAPI := findGoAPI(library, api.Path)
 		if goAPI == nil {
@@ -97,15 +97,15 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		if i == 0 {
 			fallbackTitle = sc.Title
 		}
-		// Use the sample URI from the first API found.
-		if sample == "" {
-			sample = sampleURI(sc)
+		// Use the sample URI from the first API that has one defined.
+		if customSampleURI == "" {
+			customSampleURI = sampleURI(sc)
 		}
 		if err := generateRepoMetadata(sc, library, goAPI); err != nil {
 			return fmt.Errorf("failed to generate repo metadata: %w", err)
 		}
 	}
-	if err := generateREADME(library, fallbackTitle, sample, outDir); err != nil {
+	if err := generateREADME(library, fallbackTitle, customSampleURI, outDir); err != nil {
 		return fmt.Errorf("failed to generate README: %w", err)
 	}
 	if err := generateInternalVersionFile(outDir, library.CopyrightYear, library.Version); err != nil {

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -328,8 +328,6 @@ func generateREADME(library *config.Library, fallbackTitle, sampleURI, moduleRoo
 	readmePath := filepath.Join(moduleRoot, "README.md")
 	// Skip generating README if it's in the keep list.
 	// Handwritten/veneer libraries should have the top-level README in the keep list.
-	// TODO(https://github.com/googleapis/librarian/issues/4113): investigate the difference between
-	// GAPIC and handwritten libraries.
 	for _, k := range library.Keep {
 		path := filepath.Join(moduleRoot, k)
 		if path == readmePath {

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -74,6 +74,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}
 
 	var fallbackTitle string
+	var sample string
 	for i, api := range library.APIs {
 		goAPI := findGoAPI(library, api.Path)
 		if goAPI == nil {
@@ -96,12 +97,15 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		if i == 0 {
 			fallbackTitle = sc.Title
 		}
+		// Use the sample URI from the first API found.
+		if sample == "" {
+			sample = sampleURI(sc)
+		}
 		if err := generateRepoMetadata(sc, library, goAPI); err != nil {
 			return fmt.Errorf("failed to generate repo metadata: %w", err)
 		}
-
 	}
-	if err := generateREADME(library, fallbackTitle, outDir); err != nil {
+	if err := generateREADME(library, fallbackTitle, sample, outDir); err != nil {
 		return fmt.Errorf("failed to generate README: %w", err)
 	}
 	if err := generateInternalVersionFile(outDir, library.CopyrightYear, library.Version); err != nil {
@@ -320,7 +324,7 @@ func collectProtoFiles(googleapisDir, apiPath string, nestedProtos []string) ([]
 
 // generateREADME generates the top-level README for the library.
 // We only generate one README for the entire library.
-func generateREADME(library *config.Library, fallbackTitle string, moduleRoot string) error {
+func generateREADME(library *config.Library, fallbackTitle, sampleURI, moduleRoot string) error {
 	readmePath := filepath.Join(moduleRoot, "README.md")
 	// Skip generating README if it's in the keep list.
 	// Handwritten/veneer libraries should have the top-level README in the keep list.
@@ -341,6 +345,9 @@ func generateREADME(library *config.Library, fallbackTitle string, moduleRoot st
 		// Skip generating README if no title is available.
 		return nil
 	}
+	if sampleURI == "" {
+		sampleURI = "https://cloud.google.com/docs/samples?l=go"
+	}
 
 	f, err := os.Create(readmePath)
 	if err != nil {
@@ -349,6 +356,7 @@ func generateREADME(library *config.Library, fallbackTitle string, moduleRoot st
 	err = readmeTmplParsed.Execute(f, map[string]string{
 		"Name":       title,
 		"ModulePath": modulePath(library),
+		"SampleURI":  sampleURI,
 	})
 	cerr := f.Close()
 	if err != nil {
@@ -372,4 +380,17 @@ func transport(sc *serviceconfig.API) serviceconfig.Transport {
 // preview library.
 func isPreview(output string) bool {
 	return strings.Contains(output, "preview/internal")
+}
+
+// sampleURI gets the sample URI from serviceconfig.API for language Go.
+//
+// The default value is the empty string.
+func sampleURI(sc *serviceconfig.API) string {
+	if sc.SampleURIs == nil {
+		return ""
+	}
+	if uri, ok := sc.SampleURIs[config.LanguageGo]; ok {
+		return uri
+	}
+	return ""
 }

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -35,6 +35,8 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
+const defaultSampleURI = "https://cloud.google.com/docs/samples?l=go"
+
 var (
 	//go:embed template/_README.md.txt
 	readmeTmpl       string
@@ -104,6 +106,9 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		if err := generateRepoMetadata(sc, library, goAPI); err != nil {
 			return fmt.Errorf("failed to generate repo metadata: %w", err)
 		}
+	}
+	if customSampleURI == "" {
+		customSampleURI = defaultSampleURI
 	}
 	if err := generateREADME(library, fallbackTitle, customSampleURI, outDir); err != nil {
 		return fmt.Errorf("failed to generate README: %w", err)
@@ -342,9 +347,6 @@ func generateREADME(library *config.Library, fallbackTitle, sampleURI, moduleRoo
 	if title == "" {
 		// Skip generating README if no title is available.
 		return nil
-	}
-	if sampleURI == "" {
-		sampleURI = "https://cloud.google.com/docs/samples?l=go"
 	}
 
 	f, err := os.Create(readmePath)

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -446,11 +446,11 @@ func TestGenerateREADME(t *testing.T) {
 				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			},
 			fallbackTitle: "Secret Manager API",
-			sampleURI:     "https://cloud.google.com/docs/samples?l=go",
+			sampleURI:     defaultSampleURI,
 			wantContains: []string{
 				"Secret Manager API",
 				"cloud.google.com/go/secretmanager",
-				"https://cloud.google.com/docs/samples?l=go",
+				defaultSampleURI,
 			},
 		},
 		{
@@ -461,11 +461,11 @@ func TestGenerateREADME(t *testing.T) {
 				TitleOverride: "Custom Title",
 			},
 			fallbackTitle: "Secret Manager API",
-			sampleURI:     "https://cloud.google.com/docs/samples?l=go",
+			sampleURI:     defaultSampleURI,
 			wantContains: []string{
 				"Custom Title",
 				"cloud.google.com/go/secretmanager",
-				"https://cloud.google.com/docs/samples?l=go",
+				defaultSampleURI,
 			},
 		},
 		{

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -442,7 +442,7 @@ func TestGenerateREADME(t *testing.T) {
 		Output: dir,
 		APIs:   []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 	}
-	if err := generateREADME(library, "Secret Manager API", moduleRoot); err != nil {
+	if err := generateREADME(library, "Secret Manager API", "handwritten samples", moduleRoot); err != nil {
 		t.Fatal(err)
 	}
 	content, err := os.ReadFile(filepath.Join(moduleRoot, "README.md"))
@@ -455,6 +455,9 @@ func TestGenerateREADME(t *testing.T) {
 	}
 	if !strings.Contains(s, "cloud.google.com/go/secretmanager") {
 		t.Errorf("want module path in README, got:\n%s", s)
+	}
+	if !strings.Contains(s, "handwritten samples") {
+		t.Errorf("want sample uri in README, got:\n%s", s)
 	}
 }
 
@@ -471,7 +474,7 @@ func TestGenerateREADME_TitleOverride(t *testing.T) {
 		APIs:          []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 		TitleOverride: "Custom Title",
 	}
-	if err := generateREADME(library, "Secret Manager API", moduleRoot); err != nil {
+	if err := generateREADME(library, "Secret Manager API", "", moduleRoot); err != nil {
 		t.Fatal(err)
 	}
 	content, err := os.ReadFile(filepath.Join(moduleRoot, "README.md"))
@@ -518,7 +521,7 @@ func TestGenerateREADME_Skipped(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := generateREADME(test.library, test.fallbackTitle, moduleRoot); err != nil {
+			if err := generateREADME(test.library, test.fallbackTitle, "", moduleRoot); err != nil {
 				t.Fatal(err)
 			}
 			// README doesn't exist because the generation is skipped.

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -432,11 +432,11 @@ func TestGenerateLibrary(t *testing.T) {
 
 func TestGenerateREADME(t *testing.T) {
 	for _, test := range []struct {
-		name            string
-		library         *config.Library
-		fallbackTitle   string
-		sampleURI       string
-		wantContains    []string
+		name          string
+		library       *config.Library
+		fallbackTitle string
+		sampleURI     string
+		wantContains  []string
 	}{
 		{
 			name: "basic README generation",
@@ -458,18 +458,25 @@ func TestGenerateREADME(t *testing.T) {
 				APIs:          []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 				TitleOverride: "Custom Title",
 			},
-			fallbackTitle:   "Secret Manager API",
-			wantContains:    []string{"Custom Title"},
+			fallbackTitle: "Secret Manager API",
+			wantContains: []string{
+				"Custom Title",
+				"cloud.google.com/go/secretmanager",
+				"https://cloud.google.com/docs/samples?l=go",
+			},
 		},
 		{
 			name: "custom sample uri",
 			library: &config.Library{
-				Name:          "secretmanager",
-				APIs:          []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Name: "secretmanager",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			},
 			fallbackTitle: "Secret Manager API",
 			sampleURI:     "https://handwritten-samples",
-			wantContains:    []string{"https://handwritten-samples"},
+			wantContains: []string{
+				"Secret Manager API",
+				"cloud.google.com/go/secretmanager",
+				"https://handwritten-samples"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -1053,3 +1053,48 @@ func setupSnippets(t *testing.T, repoRoot string) {
 		t.Fatal(err)
 	}
 }
+
+func TestSampleURI(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		sc   *serviceconfig.API
+		want string
+	}{
+		{
+			name: "nil serviceconfig",
+			sc:   nil,
+			want: "",
+		},
+		{
+			name: "nil sample URIs",
+			sc:   &serviceconfig.API{SampleURIs: nil},
+			want: "",
+		},
+		{
+			name: "go sample URI not specified",
+			sc: &serviceconfig.API{
+				SampleURIs: map[string]string{
+					"python": "https://python-samples",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "go sample URI specified",
+			sc: &serviceconfig.API{
+				SampleURIs: map[string]string{
+					"go":     "https://go-samples",
+					"python": "https://python-samples",
+				},
+			},
+			want: "https://go-samples",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := sampleURI(test.sc)
+			if got != test.want {
+				t.Errorf("sampleURI(%+v) = %q, want %q", test.sc, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -445,6 +445,7 @@ func TestGenerateREADME(t *testing.T) {
 				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			},
 			fallbackTitle: "Secret Manager API",
+			sampleURI:     "https://cloud.google.com/docs/samples?l=go",
 			wantContains: []string{
 				"Secret Manager API",
 				"cloud.google.com/go/secretmanager",
@@ -459,6 +460,7 @@ func TestGenerateREADME(t *testing.T) {
 				TitleOverride: "Custom Title",
 			},
 			fallbackTitle: "Secret Manager API",
+			sampleURI:     "https://cloud.google.com/docs/samples?l=go",
 			wantContains: []string{
 				"Custom Title",
 				"cloud.google.com/go/secretmanager",

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -431,6 +431,7 @@ func TestGenerateLibrary(t *testing.T) {
 }
 
 func TestGenerateREADME(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name          string
 		library       *config.Library
@@ -482,6 +483,7 @@ func TestGenerateREADME(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			moduleRoot := filepath.Join(dir, "secretmanager")
 			if err := os.MkdirAll(moduleRoot, 0755); err != nil {

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -431,87 +431,45 @@ func TestGenerateLibrary(t *testing.T) {
 }
 
 func TestGenerateREADME(t *testing.T) {
-	dir := t.TempDir()
-	moduleRoot := filepath.Join(dir, "secretmanager")
-	if err := os.MkdirAll(moduleRoot, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	library := &config.Library{
-		Name:   "secretmanager",
-		Output: dir,
-		APIs:   []*config.API{{Path: "google/cloud/secretmanager/v1"}},
-	}
-	if err := generateREADME(library, "Secret Manager API", "handwritten samples", moduleRoot); err != nil {
-		t.Fatal(err)
-	}
-	content, err := os.ReadFile(filepath.Join(moduleRoot, "README.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	s := string(content)
-	if !strings.Contains(s, "Secret Manager API") {
-		t.Errorf("want title in README, got:\n%s", s)
-	}
-	if !strings.Contains(s, "cloud.google.com/go/secretmanager") {
-		t.Errorf("want module path in README, got:\n%s", s)
-	}
-	if !strings.Contains(s, "handwritten samples") {
-		t.Errorf("want sample uri in README, got:\n%s", s)
-	}
-}
-
-func TestGenerateREADME_TitleOverride(t *testing.T) {
-	dir := t.TempDir()
-	moduleRoot := filepath.Join(dir, "secretmanager")
-	if err := os.MkdirAll(moduleRoot, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	library := &config.Library{
-		Name:          "secretmanager",
-		Output:        dir,
-		APIs:          []*config.API{{Path: "google/cloud/secretmanager/v1"}},
-		TitleOverride: "Custom Title",
-	}
-	if err := generateREADME(library, "Secret Manager API", "", moduleRoot); err != nil {
-		t.Fatal(err)
-	}
-	content, err := os.ReadFile(filepath.Join(moduleRoot, "README.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	s := string(content)
-	if !strings.Contains(s, "Custom Title") {
-		t.Errorf("want overridden title in README, got:\n%s", s)
-	}
-	if strings.Contains(s, "Secret Manager API") {
-		t.Errorf("did not want original title in README, got:\n%s", s)
-	}
-}
-
-func TestGenerateREADME_Skipped(t *testing.T) {
 	for _, test := range []struct {
-		name          string
-		library       *config.Library
-		fallbackTitle string
+		name            string
+		library         *config.Library
+		fallbackTitle   string
+		sampleURI       string
+		wantContains    []string
 	}{
 		{
-			name: "skipped because in keep list",
+			name: "basic README generation",
 			library: &config.Library{
 				Name: "secretmanager",
 				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
-				Keep: []string{"README.md"},
 			},
 			fallbackTitle: "Secret Manager API",
+			wantContains: []string{
+				"Secret Manager API",
+				"cloud.google.com/go/secretmanager",
+				"https://cloud.google.com/docs/samples?l=go",
+			},
 		},
 		{
-			name: "skipped because no title",
+			name: "title override",
 			library: &config.Library{
-				Name: "secretmanager",
-				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Name:          "secretmanager",
+				APIs:          []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				TitleOverride: "Custom Title",
 			},
-			fallbackTitle: "",
+			fallbackTitle:   "Secret Manager API",
+			wantContains:    []string{"Custom Title"},
+		},
+		{
+			name: "custom sample uri",
+			library: &config.Library{
+				Name:          "secretmanager",
+				APIs:          []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+			fallbackTitle: "Secret Manager API",
+			sampleURI:     "https://handwritten-samples",
+			wantContains:    []string{"https://handwritten-samples"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -520,13 +478,21 @@ func TestGenerateREADME_Skipped(t *testing.T) {
 			if err := os.MkdirAll(moduleRoot, 0755); err != nil {
 				t.Fatal(err)
 			}
-
-			if err := generateREADME(test.library, test.fallbackTitle, "", moduleRoot); err != nil {
+			test.library.Output = dir
+			err := generateREADME(test.library, test.fallbackTitle, test.sampleURI, moduleRoot)
+			if err != nil {
 				t.Fatal(err)
 			}
-			// README doesn't exist because the generation is skipped.
-			if _, err := os.Stat(filepath.Join(moduleRoot, "README.md")); !errors.Is(err, fs.ErrNotExist) {
-				t.Errorf("want README.md to not exist, got: %v", err)
+			readmePath := filepath.Join(moduleRoot, "README.md")
+			content, err := os.ReadFile(readmePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := string(content)
+			for _, c := range test.wantContains {
+				if !strings.Contains(s, c) {
+					t.Errorf("want README to contain %q, got:\n%s", c, s)
+				}
 			}
 		})
 	}

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -505,6 +505,48 @@ func TestGenerateREADME(t *testing.T) {
 	}
 }
 
+func TestGenerateREADME_Skipped(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		library       *config.Library
+		fallbackTitle string
+	}{
+		{
+			name: "skipped because in keep list",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Keep: []string{"README.md"},
+			},
+			fallbackTitle: "Secret Manager API",
+		},
+		{
+			name: "skipped because no title",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+			fallbackTitle: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			moduleRoot := filepath.Join(dir, "secretmanager")
+			if err := os.MkdirAll(moduleRoot, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := generateREADME(test.library, test.fallbackTitle, "", moduleRoot); err != nil {
+				t.Fatal(err)
+			}
+			// README doesn't exist because the generation is skipped.
+			if _, err := os.Stat(filepath.Join(moduleRoot, "README.md")); !errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("want README.md to not exist, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestBuildGAPICImportPath(t *testing.T) {
 	for _, test := range []struct {
 		name  string

--- a/internal/librarian/golang/template/_README.md.txt
+++ b/internal/librarian/golang/template/_README.md.txt
@@ -32,7 +32,7 @@ or there is not yet a stable backend available.
 
 ## Google Cloud Samples
 
-To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=go).
+To browse ready to use code samples check [Google Cloud Samples]({{.SampleURI}}).
 
 ## Go Version Support
 

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -94,6 +94,8 @@ type API struct {
 	// standardize release level vocabulary across languages.
 	ReleaseLevels map[string]string `yaml:"release_level,omitempty"`
 
+	SampleURIs map[string]string `yaml:"sample_uris,omitempty"`
+
 	// ShortName overrides the API short name from the service config's
 	// publishing section.
 	ShortName string `yaml:"short_name,omitempty"`

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -88,12 +88,11 @@ type API struct {
 	// ReleaseLevels is the release level per language.
 	// Map key is the language name (e.g., "python", "rust").
 	// Optional. If omitted, the generator default is used.
-	//
-	// TODO(https://github.com/googleapis/librarian/issues/4834): Go uses
-	// "alpha", "beta", and "ga" instead of "preview" and "stable". We should
-	// standardize release level vocabulary across languages.
 	ReleaseLevels map[string]string `yaml:"release_level,omitempty"`
 
+	// SampleURIs is the documentation URI for code samples per language.
+	// Map key is the language name (e.g., "go", "python").
+	// Optional. If omitted, a default URI for the language is used.
 	SampleURIs map[string]string `yaml:"sample_uris,omitempty"`
 
 	// ShortName overrides the API short name from the service config's

--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -3004,6 +3004,8 @@
     - java
     - nodejs
     - python
+  sample_uris:
+    go: https://developers.google.com/maps/documentation/places/web-service/client-library-examples#go
   release_level:
     go: preview
     java: preview


### PR DESCRIPTION
A configuration option sample_uris is added to the API allowlist structure to permit specifying language-specific documentation URIs for code samples.

During README generation for Go client libraries, the generator now resolves the sample URI dynamically from the API configuration. If no custom sample URI is defined for Go, the default Google Cloud Samples link is used.

Fixes #6151