### PR TITLE
feat(sidekick/swift): enums with unknown values

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -21,29 +21,55 @@ import (
 )
 
 type enumAnnotations struct {
-	CopyrightYear   string
-	BoilerPlate     []string
-	Name            string
-	DocLines        []string
-	DefaultCaseName string
+	CopyrightYear     string
+	BoilerPlate       []string
+	Name              string
+	DocLines          []string
+	DefaultCaseName   string
+	UnknownIntName    string
+	UnknownStringName string
 }
 
 func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
+	// We need to find non-clashing names for the `unknownIntValue` and
+	// `unknownStringvalue` cases. In practice, no enum uses those names, but
+	// if one ever this, this will add enough trailing `_` to make the name
+	// unique.
+	type u struct{}
+	caseNames := make(map[string]u)
+	uniqueCaseName := func(seed string) string {
+		_, ok := caseNames[seed]
+		for ok {
+			seed = seed + "_"
+			_, ok = caseNames[seed]
+		}
+		return seed
+	}
+
 	existing := map[int32]*enumValueAnnotations{}
 	var defaultCaseName string
 	for _, ev := range enum.UniqueNumberValues {
 		if err := c.annotateUniqueEnumValue(ev); err != nil {
 			return err
 		}
-		existing[ev.Number] = ev.Codec.(*enumValueAnnotations)
+		ann := ev.Codec.(*enumValueAnnotations)
+		if ann == nil {
+			return fmt.Errorf("unknown annotation format for enum value: %s", ev.ID)
+		}
+		caseNames[ann.CaseName] = u{}
+		existing[ev.Number] = ann
 		if ev.Number == 0 {
-			defaultCaseName = ev.Codec.(*enumValueAnnotations).CaseName
+			defaultCaseName = ann.CaseName
 		}
 	}
 	// Fallback to first case if no 0 value found (should not happen in proto3)
 	if defaultCaseName == "" {
 		if len(enum.UniqueNumberValues) != 0 {
-			defaultCaseName = enum.UniqueNumberValues[0].Codec.(*enumValueAnnotations).CaseName
+			ann := enum.UniqueNumberValues[0].Codec.(*enumValueAnnotations)
+			if ann == nil {
+				panic("mismatched annotation, previously checked, must be a bug")
+			}
+			defaultCaseName = ann.CaseName
 		} else {
 			return fmt.Errorf("cannot determine a default value for enum: %s", enum.ID)
 		}
@@ -60,11 +86,13 @@ func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
 		return err
 	}
 	annotations := &enumAnnotations{
-		CopyrightYear:   model.CopyrightYear,
-		BoilerPlate:     model.BoilerPlate,
-		Name:            pascalCase(enum.Name),
-		DocLines:        docLines,
-		DefaultCaseName: defaultCaseName,
+		CopyrightYear:     model.CopyrightYear,
+		BoilerPlate:       model.BoilerPlate,
+		Name:              pascalCase(enum.Name),
+		DocLines:          docLines,
+		DefaultCaseName:   defaultCaseName,
+		UnknownIntName:    uniqueCaseName("unknownIntValue"),
+		UnknownStringName: uniqueCaseName("unknownStringValue"),
 	}
 
 	enum.Codec = annotations

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -28,9 +28,7 @@ func TestAnnotateEnum(t *testing.T) {
 		enumName      string
 		documentation string
 		values        []*api.EnumValue
-		wantName      string
-		wantDocs      []string
-		wantDefault   string
+		want          *enumAnnotations
 	}{
 		{
 			name:          "basic enum",
@@ -40,9 +38,13 @@ func TestAnnotateEnum(t *testing.T) {
 				{Name: "COLOR_UNSPECIFIED", Number: 0},
 				{Name: "COLOR_RED", Number: 1},
 			},
-			wantName:    "Color",
-			wantDocs:    []string{"A color enum.", "With two lines."},
-			wantDefault: "unspecified",
+			want: &enumAnnotations{
+				Name:              "Color",
+				DocLines:          []string{"A color enum.", "With two lines."},
+				DefaultCaseName:   "unspecified",
+				UnknownIntName:    "unknownIntValue",
+				UnknownStringName: "unknownStringValue",
+			},
 		},
 		{
 			name:          "escaped name",
@@ -51,9 +53,30 @@ func TestAnnotateEnum(t *testing.T) {
 			values: []*api.EnumValue{
 				{Name: "PROTOCOL_UNSPECIFIED", Number: 0},
 			},
-			wantName:    "Protocol_",
-			wantDocs:    []string{"An enum named Protocol."},
-			wantDefault: "unspecified",
+			want: &enumAnnotations{
+				Name:              "Protocol_",
+				DocLines:          []string{"An enum named Protocol."},
+				DefaultCaseName:   "unspecified",
+				UnknownIntName:    "unknownIntValue",
+				UnknownStringName: "unknownStringValue",
+			},
+		},
+		{
+			name:          "duplicate unknown",
+			enumName:      "Weird",
+			documentation: "An enum named Weird.",
+			values: []*api.EnumValue{
+				{Name: "WEIRD_UNSPECIFIED", Number: 0},
+				{Name: "UNKNOWN_INT_VALUE", Number: 1},
+				{Name: "UNKNOWN_STRING_VALUE", Number: 2},
+			},
+			want: &enumAnnotations{
+				Name:              "Weird",
+				DocLines:          []string{"An enum named Weird."},
+				DefaultCaseName:   "unspecified",
+				UnknownIntName:    "unknownIntValue_",
+				UnknownStringName: "unknownStringValue_",
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -73,13 +96,8 @@ func TestAnnotateEnum(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			want := &enumAnnotations{
-				Name:            test.wantName,
-				DocLines:        test.wantDocs,
-				DefaultCaseName: test.wantDefault,
-			}
 
-			if diff := cmp.Diff(want, enum.Codec, cmpopts.IgnoreFields(enumAnnotations{}, "BoilerPlate", "CopyrightYear")); diff != "" {
+			if diff := cmp.Diff(test.want, enum.Codec, cmpopts.IgnoreFields(enumAnnotations{}, "BoilerPlate", "CopyrightYear")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -179,7 +179,7 @@ func TestGenerateMessage_WithNestedEnum(t *testing.T) {
 	contentStr := string(content)
 
 	gotBlock := extractBlock(t, contentStr, "public enum NestedEnum", ", Sendable {")
-	wantBlock := "public enum NestedEnum: Int, Codable, Equatable, Sendable {"
+	wantBlock := "public enum NestedEnum: Codable, Equatable, Sendable {"
 	if diff := cmp.Diff(wantBlock, gotBlock); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -16,32 +16,106 @@ limitations under the License.
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
-public enum {{Codec.Name}}: Int, Codable, Equatable, Sendable {
+public enum {{Codec.Name}}: Codable, Equatable, Sendable {
+  {{#UniqueNumberValues}}
+  {{#DocLines}}
+  /// {{{.}}}
+  {{/DocLines}}
+  case {{Codec.CaseName}}
+  {{/UniqueNumberValues}}
+  /// Encodes an unknown integer value.
+  ///
+  /// The most common cause for an unknown values is for the service to send
+  /// a value unknown to the library. We recommend you update your library to
+  /// the latest version.
+  case {{Codec.UnknownIntName}}(Int)
+  /// Encodes an unknown string value.
+  ///
+  /// The most common cause for an unknown values is for the service to send
+  /// a value unknown to the library. We recommend you update your library to
+  /// the latest version.
+  case {{Codec.UnknownStringName}}(String)
+
+  public init() {
+    self = .{{Codec.DefaultCaseName}}
+  }
+
+  /// Returns the integer value associated with the enumeration.
+  ///
+  /// If the enumeration was initialized with an unknown string value, this returns `nil`.
+  public var intValue: Int? {
+    switch self {
     {{#UniqueNumberValues}}
-    {{#DocLines}}
-    /// {{{.}}}
-    {{/DocLines}}
-    case {{Codec.CaseName}} = {{Number}}
+    case .{{Codec.CaseName}}: return {{Number}}
     {{/UniqueNumberValues}}
-
-    public init() {
-        self = .{{Codec.DefaultCaseName}}
+    case .{{Codec.UnknownIntName}}(let v): return v
+    case .{{Codec.UnknownStringName}}: return nil
     }
+  }
 
-    public var stringValue: String {
-        switch self {
-        {{#UniqueNumberValues}}
-        case .{{Codec.CaseName}}: return "{{Name}}"
-        {{/UniqueNumberValues}}
-        }
+  /// Returns the string value (or name) associated with the enumeration.
+  ///
+  /// If the enumeration was initialized with an unknown integer value, this returns `nil`.
+  public var stringValue: String? {
+    switch self {
+    {{#UniqueNumberValues}}
+    case .{{Codec.CaseName}}: return "{{Name}}"
+    {{/UniqueNumberValues}}
+    case .{{Codec.UnknownIntName}}: return nil
+    case .{{Codec.UnknownStringName}}(let v): return v
     }
+  }
 
-    public init?(stringValue: String) {
-        switch stringValue {
-        {{#Values}}
-        case "{{Name}}": self = .{{Codec.CaseName}}
-        {{/Values}}
-        default: return nil
-        }
+  /// Initialize from a string value.
+  ///
+  /// If the value is unknown, this initializes to ``.{{Codec.UnknownStringName}}(_:)``.
+  public init(stringValue: String) {
+    switch stringValue {
+    {{#Values}}
+    case "{{Name}}": self = .{{Codec.CaseName}}
+    {{/Values}}
+    default: self = .{{Codec.UnknownStringName}}(stringValue)
     }
+  }
+
+  /// Initialize from an integer value.
+  ///
+  /// If the value is unknown, this initializes to ``.{{Codec.UnknownIntName}}(_:)``.
+  public init(intValue: Int) {
+    switch intValue {
+    {{#Values}}
+    case {{Number}}: self = .{{Codec.CaseName}}
+    {{/Values}}
+    default: self = .{{Codec.UnknownIntName}}(intValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let v = try? container.decode(Int.self) {
+      self.init(intValue: v)
+      return
+    }
+    if let s = try? container.decode(String.self) {
+      if let v = Int(s) {
+        self.init(intValue: v)
+      } else {
+        self.init(stringValue: s)
+      }
+      return
+    }
+    throw DecodingError.dataCorruptedError(
+      in: container, debugDescription: "Expected enum value, must be integer or string.")
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    {{#UniqueNumberValues}}
+    case .{{Codec.CaseName}}: return try container.encode({{Number}})
+    {{/UniqueNumberValues}}
+    case .{{Codec.UnknownIntName}}(let v): return try container.encode(v)
+    case .{{Codec.UnknownStringName}}(let v): return try container.encode(v)
+    }
+  }
 }


### PR DESCRIPTION
Handle unknown integer or string values in generated enumerations (i.e. from a protobuf `enum`). The service may gain new values before the library is updated, and we should be prepared to receive them.

Decoding strings or integers is a nice-to-have, we typically ask the service to send enums in numeric form, but they may be hidden as strings in an encoded `Any` or some nested JSON message.

Towards #5251 and #5749 

See `#204` in our internal repo for the generated code.

