### PR TITLE
chore(.github): make protoc version configurable

### DIFF
--- a/.github/actions/install-protoc/action.yaml
+++ b/.github/actions/install-protoc/action.yaml
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: Install protoc
+inputs:
+  version:
+    description: "The version of protoc to install"
+    required: false
+    default: "33.2"
+  checksum:
+    description: "The SHA512 checksum of the protoc zip file"
+    required: false
+    default: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf"
 runs:
   using: composite
   steps:
@@ -25,5 +34,5 @@ runs:
         protoc --version
       shell: bash
       env:
-        VERSION: "31.0"
-        CHECKSUM: 45776e351baa6c2a9ba3b05a20d5302c5226db0579a6279a540592244d9de9b5f80c9905e90b6a1cebda12c3f8a2bd15450b46d967ba2e80dfc26fb246a84654
+        VERSION: ${{ inputs.version }}
+        CHECKSUM: ${{ inputs.checksum }}

--- a/.github/actions/install-protoc/action.yaml
+++ b/.github/actions/install-protoc/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: "The version of protoc to install"
     required: false
   checksum:
-    description: "The SHA512 checksum of the protoc zip file"
+    description: "The SHA512 checksum of the protoc zip file. Required if version is specified."
     required: false
 runs:
   using: composite
@@ -26,7 +26,7 @@ runs:
       run: |
         set -e
         VERSION="${VERSION:-33.2}"
-        CHECKSUM="${CHECKSUM:-b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf}"
+        CHECKSUM="${CHECKSUM:-8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5}"
         curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip
         sha512sum -c <(echo "$CHECKSUM /tmp/protoc.zip")
         cd /usr/local

--- a/.github/actions/install-protoc/action.yaml
+++ b/.github/actions/install-protoc/action.yaml
@@ -16,17 +16,17 @@ inputs:
   version:
     description: "The version of protoc to install"
     required: false
-    default: "33.2"
   checksum:
     description: "The SHA512 checksum of the protoc zip file"
     required: false
-    default: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf"
 runs:
   using: composite
   steps:
     - name: Install protoc
       run: |
         set -e
+        VERSION="${VERSION:-33.2}"
+        CHECKSUM="${CHECKSUM:-b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf}"
         curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip
         sha512sum -c <(echo "$CHECKSUM /tmp/protoc.zip")
         cd /usr/local

--- a/action.yaml
+++ b/action.yaml
@@ -17,11 +17,9 @@ inputs:
   protoc-version:
     description: "The version of protoc to install"
     required: false
-    default: "33.2"
   protoc-checksum:
     description: "The SHA512 checksum of the protoc zip file"
     required: false
-    default: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf"
 runs:
   using: composite
   steps:

--- a/action.yaml
+++ b/action.yaml
@@ -25,8 +25,8 @@ runs:
   steps:
     - uses: actions/setup-go@v6
       with:
-        go-version-file: "${{ github.action_path }}/go.mod"
-    - uses: ${{ github.action_path }}/.github/actions/install-protoc
+        go-version-file: "${GITHUB_ACTION_PATH}/go.mod"
+    - uses: ${GITHUB_ACTION_PATH}/.github/actions/install-protoc
       with:
         version: ${{ inputs.protoc-version }}
         checksum: ${{ inputs.protoc-checksum }}

--- a/action.yaml
+++ b/action.yaml
@@ -25,8 +25,8 @@ runs:
   steps:
     - uses: actions/setup-go@v6
       with:
-        go-version-file: "${GITHUB_ACTION_PATH}/go.mod"
-    - uses: ${GITHUB_ACTION_PATH}/.github/actions/install-protoc
+        go-version-file: "${{ github.action_path }}/go.mod"
+    - uses: ${{ github.action_path }}/.github/actions/install-protoc
       with:
         version: ${{ inputs.protoc-version }}
         checksum: ${{ inputs.protoc-checksum }}

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ inputs:
     description: "The version of protoc to install"
     required: false
   protoc-checksum:
-    description: "The SHA512 checksum of the protoc zip file"
+    description: "The SHA512 checksum of the protoc zip file. Required if version is specified."
     required: false
 runs:
   using: composite

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,15 @@
 # limitations under the License.
 name: Setup Librarian
 description: Set up Go, install protoc, and Librarian.
+inputs:
+  protoc-version:
+    description: "The version of protoc to install"
+    required: false
+    default: "33.2"
+  protoc-checksum:
+    description: "The SHA512 checksum of the protoc zip file"
+    required: false
+    default: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf"
 runs:
   using: composite
   steps:
@@ -20,6 +29,9 @@ runs:
       with:
         go-version-file: "${{ github.action_path }}/go.mod"
     - uses: ${{ github.action_path }}/.github/actions/install-protoc
+      with:
+        version: ${{ inputs.protoc-version }}
+        checksum: ${{ inputs.protoc-checksum }}
     - name: Install librarian
       run: |
         VERSION="latest"

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ runs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: "${{ github.action_path }}/go.mod"
-    - uses: ${{ github.action_path }}/.github/actions/install-protoc
+    - uses: googleapis/librarian/.github/actions/install-protoc@main
       with:
         version: ${{ inputs.protoc-version }}
         checksum: ${{ inputs.protoc-checksum }}


### PR DESCRIPTION
Updates version of `protoc` installed via `install-protoc` to `33.2`, matching our language repos.

Adds input parameters to `install-protoc` to accept a different version of protoc and corresponding checksum, and similar ones to the root action for using librarian. Defaults to a statically assigned version and checksum in `install-protoc`.

Also fixes how the root action references the `install-protoc` action.

Fixes #5683