### PR TITLE
fix(internal/librarian/java): clean up staging when failure running owlbot.py

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -355,7 +355,15 @@ func restructureModules(p postProcessParams, destRoot string) error {
 //     directory in google-cloud-java/sdk-platform-java.
 //  4. python3 is available on the system PATH and has the synthtool package
 //     installed (from google-cloud-java/sdk-platform-java).
-func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion string) error {
+func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion string) (retErr error) {
+	// Clean up the staging directory on failure to avoid leaving dirty leftovers.
+	// If owlbot.py completes successfully, it is expected to clean it up.
+	defer func() {
+		if retErr != nil {
+			_ = os.RemoveAll(stagingDir(outDir))
+		}
+	}()
+
 	releasedVersion, err := deriveLastReleasedVersion(library.Version)
 	if err != nil {
 		return fmt.Errorf("%w %q: %w", errInvalidVersion, library.Version, err)

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -809,9 +809,22 @@ func TestRunOwlBot_Error(t *testing.T) {
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	sDir := stagingDir(outDir)
+	if err := os.MkdirAll(sDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create a dummy file to ensure the staging directory is non-empty,
+	// verifying that the cleanup logic correctly removes everything.
+	dummyFile := filepath.Join(sDir, "dummy.txt")
+	if err := os.WriteFile(dummyFile, []byte("dummy"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	library := &config.Library{}
 	if err := runOwlBot(t.Context(), library, outDir, ""); err == nil {
 		t.Error("expected error due to missing templates directory, got nil")
+	}
+	if _, err := os.Stat(sDir); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected staging directory %s to be removed on error, but it still exists (err: %v)", sDir, err)
 	}
 }
 


### PR DESCRIPTION
Clean up the staging directory on failure to avoid leaving dirty leftovers.

Fixes https://github.com/googleapis/librarian/issues/6180