### PR TITLE
feat(internal/librarian/python): update gapic-generator to v1.34.1

### DIFF
--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -19,7 +19,7 @@ language: python
 tools:
   pip:
     - name: gapic-generator
-      version: "1.34.0"
+      version: "1.34.1"
     - name: nox
       version: "2025.11.12"
     - name: ruff


### PR DESCRIPTION
The version of gapic-generator in the embedded librarian.yaml (used by librarian install) is updated to v1.34.1. This will unblock bigtable generation (b/503326310) which needs the fix from googleapis/google-cloud-python#17260 which is included in v1.34.0. v1.34.0 could not be used due to a regression. The regression was fixed in https://github.com/googleapis/google-cloud-python/pull/17273 (hence why we need gapic-generator v1.34.1 now).

See follow up issue to improve our testing strategy in https://github.com/googleapis/librarian/issues/6182