### PR TITLE
feat(sidekick/swift): qualify primitive types

### DIFF
--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -34,22 +34,22 @@ func TestAnnotateField(t *testing.T) {
 			name:         "regular",
 			optional:     false,
 			repeated:     false,
-			wantType:     "String",
-			wantBaseType: "String",
+			wantType:     "Swift.String",
+			wantBaseType: "Swift.String",
 		},
 		{
 			name:         "optional",
 			optional:     true,
 			repeated:     false,
-			wantType:     "String?",
-			wantBaseType: "String",
+			wantType:     "Swift.String?",
+			wantBaseType: "Swift.String",
 		},
 		{
 			name:         "repeated",
 			optional:     false,
 			repeated:     true,
-			wantType:     "[String]",
-			wantBaseType: "String",
+			wantType:     "[Swift.String]",
+			wantBaseType: "Swift.String",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -94,9 +94,9 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 		typez    api.Typez
 		wantType string
 	}{
-		{"string", api.TypezString, "String"},
-		{"int32", api.TypezInt32, "Int32"},
-		{"bytes", api.TypezBytes, "Data"},
+		{"string", api.TypezString, "Swift.String"},
+		{"int32", api.TypezInt32, "Swift.Int32"},
+		{"bytes", api.TypezBytes, "Foundation.Data"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			field := &api.Field{

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -88,35 +88,35 @@ func (c *codec) mapFieldTypeName(m *api.Message) (string, error) {
 func scalarFieldTypeName(field *api.Field) (string, error) {
 	switch field.Typez {
 	case api.TypezDouble:
-		return "Double", nil
+		return "Swift.Double", nil
 	case api.TypezFloat:
-		return "Float", nil
+		return "Swift.Float", nil
 	case api.TypezInt64:
-		return "Int64", nil
+		return "Swift.Int64", nil
 	case api.TypezUint64:
-		return "UInt64", nil
+		return "Swift.UInt64", nil
 	case api.TypezInt32:
-		return "Int32", nil
+		return "Swift.Int32", nil
 	case api.TypezFixed64:
-		return "UInt64", nil
+		return "Swift.UInt64", nil
 	case api.TypezFixed32:
-		return "UInt32", nil
+		return "Swift.UInt32", nil
 	case api.TypezBool:
-		return "Bool", nil
+		return "Swift.Bool", nil
 	case api.TypezString:
-		return "String", nil
+		return "Swift.String", nil
 	case api.TypezBytes:
-		return "Data", nil
+		return "Foundation.Data", nil
 	case api.TypezUint32:
-		return "UInt32", nil
+		return "Swift.UInt32", nil
 	case api.TypezSfixed32:
-		return "Int32", nil
+		return "Swift.Int32", nil
 	case api.TypezSfixed64:
-		return "Int64", nil
+		return "Swift.Int64", nil
 	case api.TypezSint32:
-		return "Int32", nil
+		return "Swift.Int32", nil
 	case api.TypezSint64:
-		return "Int64", nil
+		return "Swift.Int64", nil
 	default:
 		return "", fmt.Errorf("unexpected Typez (%s) for scalar field %q", field.Typez.String(), field.ID)
 	}

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -29,21 +29,21 @@ func TestScalarFieldTypeName(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"double", api.TypezDouble, "Double", false},
-		{"float", api.TypezFloat, "Float", false},
-		{"int64", api.TypezInt64, "Int64", false},
-		{"uint64", api.TypezUint64, "UInt64", false},
-		{"int32", api.TypezInt32, "Int32", false},
-		{"fixed64", api.TypezFixed64, "UInt64", false},
-		{"fixed32", api.TypezFixed32, "UInt32", false},
-		{"bool", api.TypezBool, "Bool", false},
-		{"string", api.TypezString, "String", false},
-		{"bytes", api.TypezBytes, "Data", false},
-		{"uint32", api.TypezUint32, "UInt32", false},
-		{"sfixed32", api.TypezSfixed32, "Int32", false},
-		{"sfixed64", api.TypezSfixed64, "Int64", false},
-		{"sint32", api.TypezSint32, "Int32", false},
-		{"sint64", api.TypezSint64, "Int64", false},
+		{"double", api.TypezDouble, "Swift.Double", false},
+		{"float", api.TypezFloat, "Swift.Float", false},
+		{"int64", api.TypezInt64, "Swift.Int64", false},
+		{"uint64", api.TypezUint64, "Swift.UInt64", false},
+		{"int32", api.TypezInt32, "Swift.Int32", false},
+		{"fixed64", api.TypezFixed64, "Swift.UInt64", false},
+		{"fixed32", api.TypezFixed32, "Swift.UInt32", false},
+		{"bool", api.TypezBool, "Swift.Bool", false},
+		{"string", api.TypezString, "Swift.String", false},
+		{"bytes", api.TypezBytes, "Foundation.Data", false},
+		{"uint32", api.TypezUint32, "Swift.UInt32", false},
+		{"sfixed32", api.TypezSfixed32, "Swift.Int32", false},
+		{"sfixed64", api.TypezSfixed64, "Swift.Int64", false},
+		{"sint32", api.TypezSint32, "Swift.Int32", false},
+		{"sint64", api.TypezSint64, "Swift.Int64", false},
 		{"default undefined", api.TypezUndefined, "", true},
 		{"default message", api.TypezMessage, "", true},
 		{"default enum", api.TypezEnum, "", true},
@@ -218,7 +218,7 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				ID:       ".test.field5",
 				Optional: true,
 			},
-			want: "String?",
+			want: "Swift.String?",
 		},
 		{
 			name: "optional bytes",
@@ -227,7 +227,7 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				ID:       ".test.field7",
 				Optional: true,
 			},
-			want: "Data?",
+			want: "Foundation.Data?",
 		},
 		{
 			name: "optional int32",
@@ -236,7 +236,7 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				ID:       ".test.field9",
 				Optional: true,
 			},
-			want: "Int32?",
+			want: "Swift.Int32?",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -284,7 +284,7 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				ID:       ".test.field6",
 				Repeated: true,
 			},
-			want: "[String]",
+			want: "[Swift.String]",
 		},
 		{
 			name: "repeated bytes",
@@ -293,7 +293,7 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				ID:       ".test.field8",
 				Repeated: true,
 			},
-			want: "[Data]",
+			want: "[Foundation.Data]",
 		},
 		{
 			name: "repeated int32",
@@ -302,7 +302,7 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				ID:       ".test.field10",
 				Repeated: true,
 			},
-			want: "[Int32]",
+			want: "[Swift.Int32]",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestFieldTypeName_Map(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "[String: Int32]"
+	want := "[Swift.String: Swift.Int32]"
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -110,7 +110,7 @@ func TestPathVariables(t *testing.T) {
 			want: []*pathVariable{
 				{
 					Name:       "pathVariable0",
-					Expression: ".name as String?",
+					Expression: ".name as Swift.String?",
 					Test:       "!pathVariable0.isEmpty",
 					FieldPath:  "name",
 				},
@@ -126,13 +126,13 @@ func TestPathVariables(t *testing.T) {
 			want: []*pathVariable{
 				{
 					Name:       "pathVariable0",
-					Expression: ".name as String?",
+					Expression: ".name as Swift.String?",
 					Test:       "!pathVariable0.isEmpty",
 					FieldPath:  "name",
 				},
 				{
 					Name:       "pathVariable1",
-					Expression: ".second as String?",
+					Expression: ".second as Swift.String?",
 					Test:       "!pathVariable1.isEmpty",
 					FieldPath:  "second",
 				},
@@ -237,7 +237,7 @@ func TestNewPathVariable(t *testing.T) {
 			count: 0,
 			want: &pathVariable{
 				Name:       "pathVariable0",
-				Expression: ".parent as String?",
+				Expression: ".parent as Swift.String?",
 				Test:       "!pathVariable0.isEmpty",
 				FieldPath:  "parent",
 			},

--- a/internal/sidekick/swift/generate_field_swift_test.go
+++ b/internal/sidekick/swift/generate_field_swift_test.go
@@ -79,8 +79,8 @@ func TestGenerateField_InitFromDecoder(t *testing.T) {
 	gotBlock := extractBlock(t, contentStr, "  public init(from decoder: Decoder) throws {", "\n  }")
 	wantBlock := `  public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.normalField = try container.decode(String.self, forKey: .normalField)
-    self.optionalField = try container.decodeIfPresent(String.self, forKey: .optionalField)
+    self.normalField = try container.decode(Swift.String.self, forKey: .normalField)
+    self.optionalField = try container.decodeIfPresent(Swift.String.self, forKey: .optionalField)
   }`
 
 	if diff := cmp.Diff(wantBlock, gotBlock); diff != "" {

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -293,13 +293,13 @@ func TestGenerateOneOfWithKeyword(t *testing.T) {
       }
       ` + "`in`" + ` = value
     }
-    if let header = try container.decodeIfPresent(String.self, forKey: .header) {
+    if let header = try container.decodeIfPresent(Swift.String.self, forKey: .header) {
       try inCheckAndSet(.header(header))
     }
-    if let query = try container.decodeIfPresent(String.self, forKey: .query) {
+    if let query = try container.decodeIfPresent(Swift.String.self, forKey: .query) {
       try inCheckAndSet(.query(query))
     }
-    if let cookie = try container.decodeIfPresent(String.self, forKey: .cookie) {
+    if let cookie = try container.decodeIfPresent(Swift.String.self, forKey: .cookie) {
       try inCheckAndSet(.cookie(cookie))
     }
     self.` + "`in` = `in`" + `

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -115,18 +115,18 @@ func TestGenerateOneOf(t *testing.T) {
   Sendable {
 
   /// A regular field.
-  public var regularInt32: Int32
+  public var regularInt32: Swift.Int32
 
   /// Another regular field.
-  public var regularString: String
+  public var regularString: Swift.String
 
   /// A group of fields where only one is set.
   public var choice: OneOf_Choice?
 
   /// Initialize a new instance of ` + "`Outer`" + `.
   public init(
-    regularInt32: Int32 = Int32(),
-    regularString: String = String(),
+    regularInt32: Swift.Int32 = Swift.Int32(),
+    regularString: Swift.String = Swift.String(),
     choice: OneOf_Choice? = nil,
   ) {
     self.regularInt32 = regularInt32
@@ -143,8 +143,8 @@ func TestGenerateOneOf(t *testing.T) {
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.regularInt32 = try container.decode(Int32.self, forKey: .regularInt32)
-    self.regularString = try container.decode(String.self, forKey: .regularString)
+    self.regularInt32 = try container.decode(Swift.Int32.self, forKey: .regularInt32)
+    self.regularString = try container.decode(Swift.String.self, forKey: .regularString)
 
     var choice: OneOf_Choice? = nil
     let choiceCheckAndSet = { (value: OneOf_Choice) throws in
@@ -153,7 +153,7 @@ func TestGenerateOneOf(t *testing.T) {
       }
       choice = value
     }
-    if let stringField = try container.decodeIfPresent(String.self, forKey: .stringField) {
+    if let stringField = try container.decodeIfPresent(Swift.String.self, forKey: .stringField) {
       try choiceCheckAndSet(.stringField(stringField))
     }
     if let messageField = try container.decodeIfPresent(Inner.self, forKey: .messageField) {
@@ -181,7 +181,7 @@ func TestGenerateOneOf(t *testing.T) {
   /// A group of fields where only one is set.
   public enum OneOf_Choice: Codable, Equatable, Sendable {
     /// A string field that is part of the oneof.
-    case stringField(String)
+    case stringField(Swift.String)
     /// A message field that is part of the oneof.
     indirect case messageField(Inner)
   }

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -407,7 +407,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 			path: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("secret", "name"),
-			wantBlock: `let path = try { () throws -> String in
+			wantBlock: `let path = try { () throws -> Swift.String in
         guard let pathVariable0 = request.secret.map({ $0.name }), !pathVariable0.isEmpty else {
           throw GoogleCloudGax.RequestError.binding("'request.secret.name' is not set or is empty")
         }
@@ -419,8 +419,8 @@ func TestGenerateService_PathParameters(t *testing.T) {
 			path: (&api.PathTemplate{}).
 				WithLiteral("v1").
 				WithVariableNamed("name"),
-			wantBlock: `let path = try { () throws -> String in
-        guard let pathVariable0 = request.name as String?, !pathVariable0.isEmpty else {
+			wantBlock: `let path = try { () throws -> Swift.String in
+        guard let pathVariable0 = request.name as Swift.String?, !pathVariable0.isEmpty else {
           throw GoogleCloudGax.RequestError.binding("'request.name' is not set or is empty")
         }
         return "/v1/\(pathVariable0)"
@@ -434,8 +434,8 @@ func TestGenerateService_PathParameters(t *testing.T) {
 				WithVariableNamed("project").
 				WithLiteral("locations").
 				WithVariableNamed("location"),
-			wantBlock: `let path = try { () throws -> String in
-        guard let pathVariable0 = request.project as String?, !pathVariable0.isEmpty else {
+			wantBlock: `let path = try { () throws -> Swift.String in
+        guard let pathVariable0 = request.project as Swift.String?, !pathVariable0.isEmpty else {
           throw GoogleCloudGax.RequestError.binding("'request.project' is not set or is empty")
         }
         guard let pathVariable1 = request.location, !pathVariable1.isEmpty else {
@@ -524,7 +524,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 			}
 			contentStr := string(content)
 
-			gotBlock := extractBlock(t, contentStr, "let path = try { () throws -> String in", "    }()")
+			gotBlock := extractBlock(t, contentStr, "let path = try { () throws -> Swift.String in", "    }()")
 			if diff := cmp.Diff(test.wantBlock, gotBlock); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -46,7 +46,7 @@ extension Clients {
     {{#Codec.RestMethods}}
 
     public func {{> /templates/common/method_signature/request_options}} {
-      let path = try { () throws -> String in
+      let path = try { () throws -> Swift.String in
         {{#Codec.PathVariables}}
         guard let {{Name}} = request{{Expression}}{{#Test}}, {{{.}}}{{/Test}} else {
           throw GoogleCloudGax.RequestError.binding("'request.{{FieldPath}}' is not set or is empty")


### PR DESCRIPTION
We need to qualify the primitive types (e.g. `String` or `Data`) to avoid clashes with any local messages or enums with the same name.

This PR changes the generator to use `Swift.*` and `Foundation.Data` on all these primitive types.

Towards https://github.com/googleapis/librarian/issues/5100
