### PR TITLE
fix(sidekick/swift): oneofs with keyword name

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -43,10 +43,10 @@ type fieldAnnotations struct {
 	// DocLines is the field documentation broken by lines with any filtering / corrections for Swift.
 	DocLines []string
 
-	// OneOfPropertyName is the name of the oneof property containing this field.
+	// OneOfChecker is the name of a function to set the oneof containing this field.
 	//
 	// This is empty for fields that are not part of a oneof group.
-	OneOfPropertyName string
+	OneOfChecker string
 
 	// Recursive is true if the field is a recursive reference to another message.
 	Recursive bool
@@ -124,7 +124,7 @@ func (c *codec) annotateField(field *api.Field) error {
 	}
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {
-			annotations.OneOfPropertyName = oneofAnn.PropertyName
+			annotations.OneOfChecker = oneofAnn.Checker
 		}
 	}
 	field.Codec = annotations

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -258,14 +258,16 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			}
 
 			want := &fieldAnnotations{
-				Name:              "childNode",
-				DocLines:          []string{"Recursive link."},
-				FieldType:         test.wantType,
-				BaseFieldType:     test.wantBaseType,
-				PackageName:       "test",
-				Recursive:         test.wantRecursive,
-				InitializerType:   test.wantInitType,
-				OneOfPropertyName: test.oneofProperty,
+				Name:            "childNode",
+				DocLines:        []string{"Recursive link."},
+				FieldType:       test.wantType,
+				BaseFieldType:   test.wantBaseType,
+				PackageName:     "test",
+				Recursive:       test.wantRecursive,
+				InitializerType: test.wantInitType,
+			}
+			if test.isOneOf {
+				want.OneOfChecker = test.oneofProperty + "CheckAndSet"
 			}
 
 			if diff := cmp.Diff(want, field.Codec); diff != "" {

--- a/internal/sidekick/swift/annotate_oneof.go
+++ b/internal/sidekick/swift/annotate_oneof.go
@@ -21,6 +21,7 @@ import (
 type oneOfAnnotations struct {
 	Name         string
 	PropertyName string
+	Checker      string
 	DocLines     []string
 }
 
@@ -32,6 +33,7 @@ func (c *codec) annotateOneOf(oneof *api.OneOf) error {
 	annotations := &oneOfAnnotations{
 		Name:         "OneOf_" + pascalCase(oneof.Name),
 		PropertyName: camelCase(oneof.Name),
+		Checker:      camelCase(oneof.Name + "CheckAndSet"),
 		DocLines:     docLines,
 	}
 	oneof.Codec = annotations

--- a/internal/sidekick/swift/annotate_oneof_test.go
+++ b/internal/sidekick/swift/annotate_oneof_test.go
@@ -43,6 +43,7 @@ func TestAnnotateOneOf(t *testing.T) {
 		Name:         "OneOf_TestAlternatives",
 		PropertyName: "testAlternatives",
 		DocLines:     []string{"A test oneof."},
+		Checker:      "testAlternativesCheckAndSet",
 	}
 
 	if diff := cmp.Diff(want, oneof.Codec); diff != "" {

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -200,3 +200,130 @@ func TestGenerateOneOf(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestGenerateOneOfWithKeyword(t *testing.T) {
+	outDir := t.TempDir()
+
+	oneof := &api.OneOf{Name: "in"}
+	jwtLocation := &api.Message{
+		Name:    "JwtLocation",
+		Package: "google.api",
+		ID:      ".google.api",
+		Fields: []*api.Field{
+			{
+				Name:          "header",
+				JSONName:      "header",
+				ID:            ".google.api.JwtLocation.header",
+				Documentation: "Specifies HTTP header name to extract JWT token.",
+				Typez:         api.TypezString,
+				IsOneOf:       true,
+				Group:         oneof,
+			},
+			{
+				Name:          "query",
+				JSONName:      "query",
+				ID:            ".google.api.JwtLocation.query",
+				Documentation: "Specifies URL query parameter name to extract JWT token.",
+				Typez:         api.TypezString,
+				IsOneOf:       true,
+				Group:         oneof,
+			},
+			{
+				Name:          "cookie",
+				JSONName:      "cookie",
+				ID:            ".google.api.JwtLocation.cookie",
+				Documentation: "Specifies cookie name to extract JWT token.",
+				Typez:         api.TypezString,
+				IsOneOf:       true,
+				Group:         oneof,
+			},
+		},
+		OneOfs: []*api.OneOf{oneof},
+	}
+	oneof.Fields = jwtLocation.Fields
+
+	model := api.NewTestAPI([]*api.Message{jwtLocation}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "google.api"
+	cfg := &parser.ModelConfig{}
+	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleApi")
+	filename := filepath.Join(expectedDir, "JwtLocation.swift")
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+	got := extractBlock(t, contentStr, "public struct JwtLocation", "public enum OneOf_In")
+
+	// I (coryan@) don't particularly like testing a big string like this. It is a bit of a change
+	// detector test. On the other hand, checking that the oneof fields are defined properly, and
+	// that the constructor has the right arguments is more tedious and also becomes a change detector
+	// test.
+	//
+	// To verify the code compile, use something like: https://godbolt.org/z/EE9G7KTr8
+	want := `public struct JwtLocation: Codable, Equatable, GoogleCloudWkt._AnyPackable,
+  Sendable {
+
+  public var ` + "`in`" + `: OneOf_In?
+
+  /// Initialize a new instance of ` + "`JwtLocation`" + `.
+  public init(
+    ` + "`in`" + `: OneOf_In? = nil,
+  ) {
+    self.` + "`in`" + ` = ` + "`in`" + `
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case header = "header"
+    case query = "query"
+    case cookie = "cookie"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    var ` + "`in`" + `: OneOf_In? = nil
+    let inCheckAndSet = { (value: OneOf_In) throws in
+      if ` + "`in`" + ` != nil {
+        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof '` + "`in`" + `'"))
+      }
+      ` + "`in`" + ` = value
+    }
+    if let header = try container.decodeIfPresent(String.self, forKey: .header) {
+      try inCheckAndSet(.header(header))
+    }
+    if let query = try container.decodeIfPresent(String.self, forKey: .query) {
+      try inCheckAndSet(.query(query))
+    }
+    if let cookie = try container.decodeIfPresent(String.self, forKey: .cookie) {
+      try inCheckAndSet(.cookie(cookie))
+    }
+    self.` + "`in` = `in`" + `
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    if let choice = self.` + "`in`" + ` {
+      switch choice {
+      case .header(let value):
+        try container.encode(value, forKey: .header)
+      case .query(let value):
+        try container.encode(value, forKey: .query)
+      case .cookie(let value):
+        try container.encode(value, forKey: .cookie)
+      }
+    }
+  }
+
+
+  public enum OneOf_In`
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -111,7 +111,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     {{#OneOfs}}
 
     var {{Codec.PropertyName}}: {{Codec.Name}}? = nil
-    let {{Codec.PropertyName}}CheckAndSet = { (value: {{Codec.Name}}) throws in
+    let {{Codec.Checker}} = { (value: {{Codec.Name}}) throws in
       if {{Codec.PropertyName}} != nil {
         throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof '{{Codec.PropertyName}}'"))
       }
@@ -119,7 +119,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     }
     {{#Fields}}
     if let {{Codec.Name}} = try container.decodeIfPresent({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}}) {
-      try {{Codec.OneOfPropertyName}}CheckAndSet(.{{Codec.Name}}({{Codec.Name}}))
+      try {{Codec.OneOfChecker}}(.{{Codec.Name}}({{Codec.Name}}))
     }
     {{/Fields}}
     self.{{Codec.PropertyName}} = {{Codec.PropertyName}}


### PR DESCRIPTION
Some oneofs have a name that conflicts with a keyword, e.g. `in`. We cannot concatenate the escaped name.

Towards #6187 