### PR TITLE
feat(sidekick/swift): no self import for wkt

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -76,7 +76,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if err != nil {
 		return err
 	}
-	if wktDep.ApiPackage != c.Model.PackageName {
+	if wktDep != nil && wktDep.ApiPackage != c.Model.PackageName {
 		// Messages generated in the library for WKT library (we have a few)
 		// should not import the library.
 		annotations.DependsOn[wktDep.Name] = wktDep

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -76,7 +76,11 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if err != nil {
 		return err
 	}
-	annotations.DependsOn[wktDep.Name] = wktDep
+	if wktDep.ApiPackage != c.Model.PackageName {
+		// Messages generated in the library for WKT library (we have a few)
+		// should not import the library.
+		annotations.DependsOn[wktDep.Name] = wktDep
+	}
 
 	message.Codec = annotations
 	for _, oneof := range message.OneOfs {


### PR DESCRIPTION
I am planning to generate types for the `WKT` library. Normally all generated messages include an `import GoogleCloudWkt`, but those produce compilation warnings (and therefore errors) from within the WKT library itself.

Towards #6187 