### PR TITLE
fix(nodejs): install nvm and pnpm in the Docker nodejs target

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -30,21 +30,16 @@ jobs:
         run: |
           corepack enable pnpm
           corepack prepare pnpm@7.32.2 --activate
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
       - name: "Install Node.js dependencies (resolve cache paths)"
         id: tool-paths
         run: |
           echo "npm=$(npm config get prefix)" >> "$GITHUB_OUTPUT"
-          echo "pip=$(python3 -c 'import site; print(site.getsitepackages()[0])')" >> "$GITHUB_OUTPUT"
       - name: "Install Node.js dependencies (restore cache)"
         uses: actions/cache@v5
         id: tools-cache
         with:
           path: |
             ${{ steps.tool-paths.outputs.npm }}
-            ${{ steps.tool-paths.outputs.pip }}
           key: nodejs-tools-v2-${{ hashFiles('internal/librarian/nodejs/librarian.yaml') }}
       - name: "Install Node.js dependencies (run librarian install)"
         if: steps.tools-cache.outputs.cache-hit != 'true'

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -62,6 +62,10 @@ ARG GO_GOIMPORTS_VERSION=latest
 # NodeJS dependency versions
 ARG NODEJS_PROTOC_VERSION=33.2
 ARG NODEJS_PROTOC_CHECKSUM=8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5
+ARG NODEJS_NVM_VERSION=0.40.4
+ARG NODEJS_NVM_CHECKSUM=a8e082d8d1a9b61a09e5d3e1902d2930e5b1b84a86f9777c7d2eb50ea204c0141f6a97c54a860bc3282e7b000f1c669c755f5e0db7bd6d492072744c302c0a21
+ARG NODEJS_NODE_VERSION=18
+ARG NODEJS_PNPM_VERSION=7.32.2
 
 # ============== Build Stage ==============
 # Use the MOSS-compliant base image.
@@ -232,10 +236,41 @@ RUN chmod a+rx /root/go/bin/* && \
 FROM base AS nodejs
 ARG NODEJS_PROTOC_VERSION
 ARG NODEJS_PROTOC_CHECKSUM
+ARG NODEJS_NVM_VERSION
+ARG NODEJS_NVM_CHECKSUM
+ARG NODEJS_NODE_VERSION
+ARG NODEJS_PNPM_VERSION
 
+# Node requires libatomic but doesn't install it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nodejs npm \
+    libatomic1 \
     && rm -rf /var/lib/apt/lists/*
+
+# See https://github.com/nvm-sh/nvm
+# Create a script file sourced by both interactive and non-interactive bash shells;
+# this is required for nvm installation.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENV BASH_ENV="/root/.bash_env"
+RUN touch "${BASH_ENV}"
+RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
+
+# Download and install nvm
+ENV NVM_DIR=/root/.nvm
+RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/nvm-install.sh \
+        https://raw.githubusercontent.com/nvm-sh/nvm/v${NODEJS_NVM_VERSION}/install.sh && \
+    echo "${NODEJS_NVM_CHECKSUM} /tmp/nvm-install.sh" | sha512sum -c - && \
+    chmod +x /tmp/nvm-install.sh && \
+    PROFILE="${BASH_ENV}" /tmp/nvm-install.sh && \
+    rm /tmp/nvm-install.sh
+RUN echo node > .nvmrc
+
+# Use nvm to install and use the specified version of node by default.
+RUN nvm install ${NODEJS_NODE_VERSION} && nvm alias default ${NODEJS_NODE_VERSION}
+
+# Install pnpm
+RUN npm install --global corepack@latest && \
+    corepack enable && \
+    corepack prepare pnpm@${NODEJS_PNPM_VERSION} --activate
 
 # Install Node-specific protoc version
 RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
@@ -249,3 +284,15 @@ RUN /app/librarian install nodejs -v
 # Allow normal users to read /root (as the generator is installed
 # in /root/.cache, for example)
 RUN chmod a+x /root
+
+# Put the installed version of Node on the path, by using
+# the version reported by "nvm current" to find the appropriate directory,
+# and creating a symlink. The Dockerfile "ENV" instruction cannot use the output
+# of a shell command.
+#
+# We need to get node and other installed binaries on the path separately from
+# what nvm provides in nvm.sh because we'll be running librarian directly (not
+# in bash); we don't need all of nvm to be available, because we're not calling
+# nvm from Librarian. We're only using it to set up the right version of Node.
+RUN ln -s /root/.nvm/versions/node/$(nvm current) /root/.nvm/versions/node/current 
+ENV PATH=$PATH:/root/.nvm/versions/node/current/bin

--- a/internal/librarian/nodejs/librarian.yaml
+++ b/internal/librarian/nodejs/librarian.yaml
@@ -28,7 +28,10 @@ tools:
         # and protos/ in build/ (resolved via __dirname at runtime).
         - "./node_modules/.bin/tsc"
         - "cp -r templates protos build/"
-        - "pnpm add -g ."
+        # Pass the full directory name into "pnpm add" so that the generator
+        # is registered with the name "gapic-generator-typescript" rather than
+        # an arbitrary name such as "5".
+        - "pnpm add -g \"$PWD\""
     - name: gapic-node-processing
       version: "0.1.8"
     - name: gapic-tools


### PR DESCRIPTION
The librarian install command requires pnpm to be present, and it is now installed when building a Docker image. We use nvm to give more control over which version of Node is installed.

When installing gapic-generator-typescript in librarian install, the full working directory is provided to pnpm add, so that we end up with a tool called gapic-generator-typescript installed. (Using "pnpm add ." ends up creating a directory called 5 for some reason.)