### PR TITLE
fix(sidekick/swift): return type for retry

### DIFF
--- a/internal/sidekick/swift/templates/common/retry.swift.mustache
+++ b/internal/sidekick/swift/templates/common/retry.swift.mustache
@@ -64,7 +64,7 @@ extension Clients {
         options: options,
         idempotent: {{Codec.Idempotent}},
         action: { (r: {{InputType.Codec.Name}}, o: GoogleCloudGax.RequestOptions) async throws ->
-            {{^ReturnsEmpty}}{{OutputType.Codec.Name}}{{/ReturnsEmpty}}
+            {{^ReturnsEmpty}}{{Codec.ReturnType}}{{/ReturnsEmpty}}
             {{#ReturnsEmpty}}Void{{/ReturnsEmpty}} in
               return try await self.inner.{{Codec.Name}}(request: r, options: o)
         })


### PR DESCRIPTION
The generated code needed fully qualified names for the retry loop closure. It only becomes a problem when things like `Operation` are defined both in the imports and the generated library.

Towards #6197 