### PR TITLE
feat(sidekick/swift): use `rpc()` helper

### DIFF
--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -83,12 +83,12 @@ extension Clients {
       {{/Codec.IsBodyWildcard}}
       {{/Codec.HasBody}}
       {{^ReturnsEmpty}}
-      let (data, _) = try (await self.inner.rpc(for: req)).get()
+      let (data, _) = try await self.inner.rpc(for: req).get()
       return try {{InputType.Codec.Model.WktPackage}}._ProtoJSONDecoder().decode(
         {{Codec.ReturnType}}.self, from: data)
       {{/ReturnsEmpty}}
       {{#ReturnsEmpty}}
-      let _ = try (await self.inner.rpc(for: req)).get()
+      _ = try await self.inner.rpc(for: req).get()
       {{/ReturnsEmpty}}
     }
     {{/Codec.RestMethods}}

--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -82,17 +82,13 @@ extension Clients {
       }
       {{/Codec.IsBodyWildcard}}
       {{/Codec.HasBody}}
-      let (data, response) = try await self.inner.data(for: req)
-      if !(200..<300).contains(response.statusCode) {
-        throw GoogleCloudGax.RequestError.http(GoogleCloudGax.HTTPDetails(
-          http_status_code: response.statusCode,
-          headers: [:],
-          payload: data,
-        ))
-      }
       {{^ReturnsEmpty}}
+      let (data, _) = try (await self.inner.rpc(for: req)).get()
       return try {{InputType.Codec.Model.WktPackage}}._ProtoJSONDecoder().decode(
         {{Codec.ReturnType}}.self, from: data)
+      {{/ReturnsEmpty}}
+      {{#ReturnsEmpty}}
+      let _ = try (await self.inner.rpc(for: req)).get()
       {{/ReturnsEmpty}}
     }
     {{/Codec.RestMethods}}


### PR DESCRIPTION
Use the `GoogleCloudGax.HTTPClient.rpc()` as it captures service errors with full details. Arguably the generated code is a little shorter too, which is not a bad thing.

Towards #5267 