### PR TITLE
fix(sidekick/swift): avoid warnings in snippets

### DIFF
--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -34,7 +34,7 @@ func sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: St
     {{> /templates/snippet/generic}}
     {{/Codec.QuickstartMethod}}
     {{^Codec.QuickstartMethod}}
-    // Use `client` to make requests to the {{Codec.Name}}.
+    print("use `client` to make requests: \(client)")
     {{/Codec.QuickstartMethod}}
 }
 // snippet.hide

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -29,23 +29,23 @@ import {{.}}
 {{/Codec.SnippetImports}}
 
 func sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: String, {{/Codec.Parameters}}{{/Codec.QuickstartMethod.SampleInfo}}) async throws {
-    let client = try {{Codec.PackageName}}.Clients.{{Codec.ClientName}}()
-    {{#Codec.QuickstartMethod}}
-    {{> /templates/snippet/generic}}
-    {{/Codec.QuickstartMethod}}
-    {{^Codec.QuickstartMethod}}
-    print("use `client` to make requests: \(client)")
-    {{/Codec.QuickstartMethod}}
+  let client = try {{Codec.PackageName}}.Clients.{{Codec.ClientName}}()
+  {{#Codec.QuickstartMethod}}
+  {{> /templates/snippet/generic}}
+  {{/Codec.QuickstartMethod}}
+  {{^Codec.QuickstartMethod}}
+  print("use `client` to make requests: \(client)")
+  {{/Codec.QuickstartMethod}}
 }
 // snippet.hide
 
 @main
 struct SnippetRunner {
-    static func main() async throws {
-        do {
-            try await sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: "[placeholder]", {{/Codec.Parameters}}{{/Codec.QuickstartMethod.SampleInfo}})
-        } catch {
-            print("Error: \(error)")
-        }
+  static func main() async throws {
+    do {
+      try await sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: "[placeholder]", {{/Codec.Parameters}}{{/Codec.QuickstartMethod.SampleInfo}})
+    } catch {
+      print("Error: \(error)")
     }
+  }
 }


### PR DESCRIPTION
Some of the services lack a quick start method, that is, a preferred method to invoke in the quickstart snippet.

In this case, the snippet just shows how to initiliaze the client, but without using the client we get compilation warnings.

I changed the snippet to print the client and the instructions, that avoids the warning.

Fixes #6225 