### PR TITLE
fix(sidekick/swift): clashes in generated code

### DIFF
--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -147,11 +147,11 @@ func TestGenerateOneOf(t *testing.T) {
     self.regularString = try container.decode(Swift.String.self, forKey: .regularString)
 
     var choice: OneOf_Choice? = nil
-    let choiceCheckAndSet = { (value: OneOf_Choice) throws in
+    let choiceCheckAndSet = {
       if choice != nil {
         throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof 'choice'"))
       }
-      choice = value
+      choice = $0
     }
     if let stringField = try container.decodeIfPresent(Swift.String.self, forKey: .stringField) {
       try choiceCheckAndSet(.stringField(stringField))
@@ -287,11 +287,11 @@ func TestGenerateOneOfWithKeyword(t *testing.T) {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
     var ` + "`in`" + `: OneOf_In? = nil
-    let inCheckAndSet = { (value: OneOf_In) throws in
+    let inCheckAndSet = {
       if ` + "`in`" + ` != nil {
         throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof '` + "`in`" + `'"))
       }
-      ` + "`in`" + ` = value
+      ` + "`in`" + ` = $0
     }
     if let header = try container.decodeIfPresent(Swift.String.self, forKey: .header) {
       try inCheckAndSet(.header(header))

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -111,11 +111,11 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     {{#OneOfs}}
 
     var {{Codec.PropertyName}}: {{Codec.Name}}? = nil
-    let {{Codec.Checker}} = { (value: {{Codec.Name}}) throws in
+    let {{Codec.Checker}} = { (_arg: {{Codec.Name}}) throws in
       if {{Codec.PropertyName}} != nil {
         throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof '{{Codec.PropertyName}}'"))
       }
-      {{Codec.PropertyName}} = value
+      {{Codec.PropertyName}} = _arg
     }
     {{#Fields}}
     if let {{Codec.Name}} = try container.decodeIfPresent({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}}) {

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -111,11 +111,11 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     {{#OneOfs}}
 
     var {{Codec.PropertyName}}: {{Codec.Name}}? = nil
-    let {{Codec.Checker}} = { (_arg: {{Codec.Name}}) throws in
+    let {{Codec.Checker}} = {
       if {{Codec.PropertyName}} != nil {
         throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Multiple values set for oneof '{{Codec.PropertyName}}'"))
       }
-      {{Codec.PropertyName}} = _arg
+      {{Codec.PropertyName}} = $0
     }
     {{#Fields}}
     if let {{Codec.Name}} = try container.decodeIfPresent({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}}) {


### PR DESCRIPTION
The generated code for `oneof` used `value` as helper closure parameter name. That can clash with a field name, if the field is also named `value`.

Use closure with unnamed arguments.  The type deduction is (contrary to what I first believed) good enough to deduce the argument type and then use the enum cases as arguments.

Fixes #6227 