### PR TITLE
fix(sidekick/swift): qualify `Swift.Error`

### DIFF
--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -632,7 +632,7 @@ func verifyGeneratedService(t *testing.T, outDir string) {
     byItem: ListSecretsRequest, options: `, "\n    }")
 	wantMethodOverload := `  public func listSecrets(
     byItem: ListSecretsRequest, options: GoogleCloudGax.RequestOptions
-) throws -> any AsyncSequence<Secret, Error>
+) throws -> any AsyncSequence<Secret, Swift.Error>
  {
       let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
         var request = byItem

--- a/internal/sidekick/swift/templates/common/method_signature/pagination.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/pagination.mustache
@@ -13,4 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{Codec.Name}}(byItem: {{InputType.Codec.Name}}) throws -> any AsyncSequence<{{ItemType}}, Error>
+{{Codec.Name}}(
+  byItem: {{InputType.Codec.Name}}
+) throws -> any AsyncSequence<{{ItemType}}, Swift.Error>

--- a/internal/sidekick/swift/templates/common/method_signature/pagination_options.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/pagination_options.mustache
@@ -15,4 +15,4 @@ limitations under the License.
 }}
 {{Codec.Name}}(
     byItem: {{InputType.Codec.Name}}, options: GoogleCloudGax.RequestOptions
-) throws -> any AsyncSequence<{{ItemType}}, Error>
+) throws -> any AsyncSequence<{{ItemType}}, Swift.Error>


### PR DESCRIPTION
Fully qualify `Swift.Error` to avoid clashes when the package also defines an `Error` struct or enum.

Fixes #6232 