### PR TITLE
feat(sidekick/swift): per-service traits

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -531,3 +531,5 @@ This document describes the schema for the librarian.yaml.
 | (embedded) | [SwiftDefault](#swiftdefault-configuration) |  |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]). |
 | `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, and output location. |
+| `per_service_traits` | bool | Enables per-service compile-time flags. |
+| `default_traits` | list of string | Is a list of compile-time traits enabled by default. |

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -26,13 +26,20 @@ type SwiftDefault struct {
 type SwiftPackage struct {
 	SwiftDefault `yaml:",inline"`
 
-	// IncludeList is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]).
+	// IncludeList is a subset of proto files under the target API path to
+	// include (e.g., ["date.proto", "expr.proto"]).
 	IncludeList []string `yaml:"include_list,omitempty"`
 
 	// Modules specifies generation targets for veneers and test packages.
 	//
 	// Each module defines a source proto path, and output location.
 	Modules []*SwiftModule `yaml:"modules,omitempty"`
+
+	// PerServiceTraits enables per-service compile-time flags.
+	PerServiceTraits bool `yaml:"per_service_traits,omitempty"`
+
+	// DefaultTraits is a list of compile-time traits enabled by default.
+	DefaultTraits []string `yaml:"default_traits,omitempty"`
 }
 
 // SwiftDependency represents a dependency in Swift Package Manager.

--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
@@ -28,6 +29,39 @@ type enumAnnotations struct {
 	DefaultCaseName   string
 	UnknownIntName    string
 	UnknownStringName string
+
+	// GatedBy is the list of package traits that enables this enum.
+	//
+	// Empty unless the package is configured with `per_service_traits` enabled.
+	GatedBy []string
+
+	// GatedOp is the operation (&& or ||) to combine all the `GatedBy` traits.
+	//
+	// For most enums, this is " || ", as enums are enabled when any service
+	// that needs them is enabled. Messages that do not map to any service use
+	// " && ".
+	GatedOp string
+}
+
+// IsGated returns true if this message is gated by some package traits.
+func (ann *enumAnnotations) IsGated() bool {
+	return len(ann.GatedBy) != 0
+}
+
+// GateExpression returns the expression for the `#if` directive.
+//
+// In the generated code this is used as:
+//
+// ```
+// #if {{GateExpression}}
+// ... all the normal code ...
+// #endif
+// ```
+//
+// Directing the compiler to enable the code only if GateExpression evaluates to
+// `true` at compile time.
+func (ann *enumAnnotations) GateExpression() string {
+	return strings.Join(ann.GatedBy, ann.GatedOp)
 }
 
 func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -118,3 +118,51 @@ func TestAnnotateEnum_Error(t *testing.T) {
 		t.Errorf("annotateModel() expected error for enum with no values, got nil")
 	}
 }
+
+func TestAnnotateEnum_Gating(t *testing.T) {
+	model := makeGatedTestModel()
+	codec := newTestCodec(t, model, nil)
+	codec.PerServiceTraits = true
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		enumName       string
+		wantExpression string
+	}{
+		{"Shared enum used by both services", "SharedEnum", "Service1 || Service2"},
+		{"Enum used by Service1 only", "Service1Enum", "Service1"},
+		{"Enum used by Service2 only", "Service2Enum", "Service2"},
+		{"Enum used by neither service", "UnusedEnum", "Service1 && Service2"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var enum *api.Enum
+			for e := range model.AllEnums() {
+				if e.Name == test.enumName {
+					enum = e
+					break
+				}
+			}
+			if enum == nil {
+				t.Fatalf("enum %s not found", test.enumName)
+			}
+			ann, ok := enum.Codec.(*enumAnnotations)
+			if !ok {
+				t.Fatalf("expected enum.Codec to be *enumAnnotations, got %T", enum.Codec)
+			}
+
+			if diff := cmp.Diff(test.wantExpression, ann.GateExpression()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+
+			if !ann.IsGated() {
+				t.Error("expected IsGated() to be true")
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -37,6 +37,17 @@ type messageAnnotations struct {
 	PageableItemField   string
 	PageableItemType    string
 	DependsOn           map[string]*Dependency
+
+	// GatedBy is the list of package traits that enables this message.
+	//
+	// Empty unless the package is configured with `per_service_traits` enabled.
+	GatedBy []string
+	// GatedOp is the operation (&& or ||) to combine all the `GatedBy` traits.
+	//
+	// For most messages, this is " || ", as messages are enabled when any
+	// service that needs them is enabled. Messages that do not map to any
+	// service use " && ".
+	GatedOp string
 }
 
 // MessageImports returns the list of dependencies for this message.
@@ -47,6 +58,27 @@ func (ann *messageAnnotations) MessageImports() []string {
 	}
 	slices.Sort(result)
 	return result
+}
+
+// IsGated returns true if this message is gated by some package traits.
+func (ann *messageAnnotations) IsGated() bool {
+	return len(ann.GatedBy) != 0
+}
+
+// GateExpression returns the expression for the `#if` directive.
+//
+// In the generated code this is used as:
+//
+// ```
+// #if {{GateExpression}}
+// ... all the normal code ...
+// #endif
+// ```
+//
+// Directing the compiler to enable the code only if GateExpression evaluates to
+// `true` at compile time.
+func (ann *messageAnnotations) GateExpression() string {
+	return strings.Join(ann.GatedBy, ann.GatedOp)
 }
 
 func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) error {

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -286,3 +286,51 @@ func TestAnnotateMessage_RecursiveNested(t *testing.T) {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 }
+
+func TestAnnotateMessage_Gating(t *testing.T) {
+	model := makeGatedTestModel()
+	codec := newTestCodec(t, model, nil)
+	codec.PerServiceTraits = true
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		msgName        string
+		wantExpression string
+	}{
+		{"Shared message used by both services", "SharedMessage", "Service1 || Service2"},
+		{"Message used by Service1 only", "Service1Message", "Service1"},
+		{"Message used by Service2 only", "Service2Message", "Service2"},
+		{"Message used by neither service", "UnusedMessage", "Service1 && Service2"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var msg *api.Message
+			for m := range model.AllMessages() {
+				if m.Name == test.msgName {
+					msg = m
+					break
+				}
+			}
+			if msg == nil {
+				t.Fatalf("message %s not found", test.msgName)
+			}
+			ann, ok := msg.Codec.(*messageAnnotations)
+			if !ok {
+				t.Fatalf("expected msg.Codec to be *messageAnnotations, got %T", msg.Codec)
+			}
+
+			if diff := cmp.Diff(test.wantExpression, ann.GateExpression()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+
+			if !ann.IsGated() {
+				t.Error("expected IsGated() to be true")
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	"cmp"
+	"log/slog"
 	"maps"
 	"slices"
 
@@ -23,12 +24,15 @@ import (
 )
 
 type modelAnnotations struct {
-	CopyrightYear string
-	BoilerPlate   []string
-	PackageName   string
-	MonorepoRoot  string
-	DependsOn     map[string]*Dependency
-	WktPackage    string
+	CopyrightYear    string
+	BoilerPlate      []string
+	PackageName      string
+	MonorepoRoot     string
+	DependsOn        map[string]*Dependency
+	WktPackage       string
+	PerServiceTraits bool
+	DefaultTraits    []string
+	AllTraits        []string
 }
 
 // HasDependencies returns true if the package has dependencies on other packages.
@@ -46,6 +50,10 @@ func (ann *modelAnnotations) Dependencies() []*Dependency {
 	return deps
 }
 
+func (ann *modelAnnotations) HasTraits() bool {
+	return len(ann.AllTraits) != 0
+}
+
 func (c *codec) annotateModel() error {
 	annotations := &modelAnnotations{
 		CopyrightYear: c.GenerationYear,
@@ -54,6 +62,7 @@ func (c *codec) annotateModel() error {
 		MonorepoRoot:  c.MonorepoRoot,
 		DependsOn:     map[string]*Dependency{},
 		WktPackage:    wellKnownSwiftPackage,
+		DefaultTraits: c.DefaultTraits,
 	}
 	if dep, ok := c.ApiPackages[wellKnownProtobufPackage]; ok {
 		annotations.WktPackage = dep.Name
@@ -69,10 +78,49 @@ func (c *codec) annotateModel() error {
 			return err
 		}
 	}
+	// The services are annotated last because the annotation assumes messages
+	// and enums are already annotated.
+	allTraits := make([]string, 0, len(c.Model.Services))
 	for _, service := range c.Model.Services {
 		if err := c.annotateService(service, annotations); err != nil {
 			return err
 		}
+		allTraits = append(allTraits, c.traitName(service))
+	}
+	if !c.PerServiceTraits {
+		// The maximum (15) was chosen more or less arbitrarily circa 2026-05. At
+		// the time, only a handful of packages exceeded this number of services.
+		if len(c.Model.Services) > 15 {
+			slog.Warn("package has more than 15 services, consider enabling per-service features", "package", c.PackageName, "count", len(c.Model.Services))
+		}
+		return nil
+	}
+	// Rarely, some messages and enums are not used by any service. These
+	// will lack any feature gates, but may depend on messages that do.
+	// Change them to work only if all features are enabled.
+	slices.Sort(allTraits)
+	annotations.AllTraits = allTraits
+	for msg := range c.Model.AllMessages() {
+		if msg.Codec == nil {
+			continue
+		}
+		annotation := msg.Codec.(*messageAnnotations)
+		if len(annotation.GatedBy) > 0 {
+			continue
+		}
+		annotation.GatedOp = " && "
+		annotation.GatedBy = allTraits
+	}
+	for enum := range c.Model.AllEnums() {
+		if enum.Codec == nil {
+			continue
+		}
+		annotation := enum.Codec.(*enumAnnotations)
+		if len(annotation.GatedBy) > 0 {
+			continue
+		}
+		annotation.GatedOp = " && "
+		annotation.GatedBy = allTraits
 	}
 	return nil
 }

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -271,3 +271,32 @@ func TestModelAnnotations_Pagination(t *testing.T) {
 		t.Errorf("expected GoogleCloudGax dependency to be present in DependsOn")
 	}
 }
+
+func TestModelAnnotations_Gating(t *testing.T) {
+	model := makeGatedTestModel()
+	codec := newTestCodec(t, model, nil)
+	codec.PerServiceTraits = true
+	codec.DefaultTraits = []string{"Service1"}
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	ann, ok := model.Codec.(*modelAnnotations)
+	if !ok {
+		t.Fatalf("expected model.Codec to be *modelAnnotations, got %T", model.Codec)
+	}
+
+	wantAllTraits := []string{"Service1", "Service2"}
+	if diff := cmp.Diff(wantAllTraits, ann.AllTraits); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	if !ann.HasTraits() {
+		t.Error("expected HasTraits() to be true")
+	}
+
+	if diff := cmp.Diff([]string{"Service1"}, ann.DefaultTraits); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -15,6 +15,7 @@
 package swift
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -32,6 +33,7 @@ type serviceAnnotations struct {
 	QuickstartMethod *api.Method
 	Model            *modelAnnotations
 	DependsOn        map[string]*Dependency
+	IsGated          bool
 }
 
 // ServiceImports returns the list of dependencies for this service.
@@ -94,6 +96,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 		QuickstartMethod: quickstartMethod,
 		Model:            model,
 		DependsOn:        map[string]*Dependency{},
+		IsGated:          c.PerServiceTraits,
 	}
 
 	// Iterate through the list of all dependencies declared in librarian.yaml
@@ -144,9 +147,51 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 	}
 
 	service.Codec = annotations
-	return nil
+	return c.addFeatureAnnotations(service)
 }
 
 func isGeneratedMethod(method *api.Method) bool {
 	return method.PathInfo != nil && len(method.PathInfo.Bindings) != 0
+}
+
+func (c *codec) addFeatureAnnotations(
+	service *api.Service) error {
+	if !c.PerServiceTraits {
+		return nil
+	}
+	traitName := c.traitName(service)
+	deps := api.FindServiceDependencies(c.Model, service.ID)
+	for _, id := range deps.Enums {
+		enum := c.Model.Enum(id)
+		// Some messages are not annotated (e.g. external messages).
+		if enum == nil || enum.Codec == nil {
+			continue
+		}
+		annotation, ok := enum.Codec.(*enumAnnotations)
+		if !ok {
+			return fmt.Errorf("bad annotation type for %s", id)
+		}
+		index, _ := slices.BinarySearch(annotation.GatedBy, traitName)
+		annotation.GatedBy = slices.Insert(annotation.GatedBy, index, traitName)
+		annotation.GatedOp = " || "
+	}
+	for _, id := range deps.Messages {
+		msg := c.Model.Message(id)
+		// Some messages are not annotated (e.g. external messages).
+		if msg == nil || msg.Codec == nil {
+			continue
+		}
+		annotation, ok := msg.Codec.(*messageAnnotations)
+		if !ok {
+			return fmt.Errorf("bad annotation type for %s", id)
+		}
+		index, _ := slices.BinarySearch(annotation.GatedBy, traitName)
+		annotation.GatedBy = slices.Insert(annotation.GatedBy, index, traitName)
+		annotation.GatedOp = " || "
+	}
+	return nil
+}
+
+func (c *codec) traitName(service *api.Service) string {
+	return pascalCase(service.Name)
 }

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -171,8 +171,7 @@ func (c *codec) addFeatureAnnotations(
 		if !ok {
 			return fmt.Errorf("bad annotation type for %s", id)
 		}
-		index, _ := slices.BinarySearch(annotation.GatedBy, traitName)
-		annotation.GatedBy = slices.Insert(annotation.GatedBy, index, traitName)
+		annotation.GatedBy = insertGatingTrait(annotation.GatedBy, traitName)
 		annotation.GatedOp = " || "
 	}
 	for _, id := range deps.Messages {
@@ -185,8 +184,7 @@ func (c *codec) addFeatureAnnotations(
 		if !ok {
 			return fmt.Errorf("bad annotation type for %s", id)
 		}
-		index, _ := slices.BinarySearch(annotation.GatedBy, traitName)
-		annotation.GatedBy = slices.Insert(annotation.GatedBy, index, traitName)
+		annotation.GatedBy = insertGatingTrait(annotation.GatedBy, traitName)
 		annotation.GatedOp = " || "
 	}
 	return nil
@@ -194,4 +192,11 @@ func (c *codec) addFeatureAnnotations(
 
 func (c *codec) traitName(service *api.Service) string {
 	return pascalCase(service.Name)
+}
+
+func insertGatingTrait(gatedBy []string, traitName string) []string {
+	if index, found := slices.BinarySearch(gatedBy, traitName); !found {
+		gatedBy = slices.Insert(gatedBy, index, traitName)
+	}
+	return gatedBy
 }

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -223,3 +223,25 @@ func TestAnnotateService_Quickstart(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotateService_Gating(t *testing.T) {
+	model := makeGatedTestModel()
+	codec := newTestCodec(t, model, nil)
+	codec.PerServiceTraits = true
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, service := range model.Services {
+		t.Run(service.Name, func(t *testing.T) {
+			ann, ok := service.Codec.(*serviceAnnotations)
+			if !ok {
+				t.Fatalf("expected service.Codec to be *serviceAnnotations, got %T", service.Codec)
+			}
+			if !ann.IsGated {
+				t.Error("expected IsGated to be true when PerServiceTraits is true")
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -43,21 +43,46 @@ const (
 // generated. That lends naturally into a single object that carries all the
 // information needed to generate the library.
 type codec struct {
+	// The API this codec is bound to.
+	Model *api.API
+
+	// When was the library originally generated.
+	//
+	// This preserves the copyright year and avoids churn when regenerating the
+	// library.
 	GenerationYear string
+
 	// The name of the swift package (e.g. "GoogleCloudSecretManagerV1")
-	PackageName  string
+	PackageName string
+
+	// The location of the monorepo, relative to the current directory.
+	//
+	// Recall that sidekick only generates clients within a monorepo, so this
+	// always makes sense.
 	MonorepoRoot string
+
 	// Most libraries are generated from `googleapis`. Rarely, we use protobuf,
 	// gapic-showcase, or a different root.
 	RootName string
+
 	// Modules have a different directory structure.
-	Module       bool
-	Model        *api.API
+	Module bool
+
+	// The set of dependencies configured for this codec.
 	Dependencies []*Dependency
+
 	// Map of proto package to dependency (e.g. "google.protobuf" -> <dependency>)
 	ApiPackages map[string]*Dependency
+
 	// Map of dependency name to dependency (e.g. GoogleCloudGax -> <dependency>)
 	DependenciesByName map[string]*Dependency
+
+	// If true, the generated code uses a trait (Swift #ifdef-analogs) for each
+	// service.
+	PerServiceTraits bool
+
+	// If true, these traits are enabled by default.
+	DefaultTraits []string
 }
 
 func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPackage, outdir string) (*codec, error) {
@@ -78,11 +103,11 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 		return nil, err
 	}
 	result := &codec{
+		Model:              model,
 		GenerationYear:     fmt.Sprintf("%04d", year),
 		PackageName:        PackageName(model),
 		MonorepoRoot:       rel,
 		RootName:           "googleapis",
-		Model:              model,
 		ApiPackages:        map[string]*Dependency{},
 		DependenciesByName: map[string]*Dependency{},
 	}
@@ -95,6 +120,8 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 			}
 			result.DependenciesByName[d.Name] = &dependency
 		}
+		result.PerServiceTraits = swiftCfg.PerServiceTraits
+		result.DefaultTraits = swiftCfg.DefaultTraits
 	}
 	for key, definition := range cfg.Codec {
 		switch key {

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -119,3 +119,57 @@ func (c *codec) withExtraDependencies(t *testing.T, deps []config.SwiftDependenc
 		c.Dependencies = append(c.Dependencies, dep)
 	}
 }
+
+func makeGatedTestModel() *api.API {
+	makeEnum := func(name string) *api.Enum {
+		e := &api.Enum{
+			Name: name, ID: ".google.cloud.test.v1." + name, Package: "google.cloud.test.v1",
+			Values: []*api.EnumValue{{Name: "UNSPECIFIED", Number: 0}},
+		}
+		e.UniqueNumberValues = e.Values
+		return e
+	}
+	sharedEnum := makeEnum("SharedEnum")
+	s1Enum := makeEnum("Service1Enum")
+	s2Enum := makeEnum("Service2Enum")
+	unusedEnum := makeEnum("UnusedEnum")
+
+	sharedMessage := &api.Message{
+		Name: "SharedMessage", ID: ".google.cloud.test.v1.SharedMessage", Package: "google.cloud.test.v1",
+		Fields: []*api.Field{{Name: "e", Typez: api.TypezEnum, TypezID: sharedEnum.ID}},
+	}
+	s1Message := &api.Message{
+		Name: "Service1Message", ID: ".google.cloud.test.v1.Service1Message", Package: "google.cloud.test.v1",
+		Fields: []*api.Field{{Name: "e", Typez: api.TypezEnum, TypezID: s1Enum.ID}},
+	}
+	s2Message := &api.Message{
+		Name: "Service2Message", ID: ".google.cloud.test.v1.Service2Message", Package: "google.cloud.test.v1",
+		Fields: []*api.Field{{Name: "e", Typez: api.TypezEnum, TypezID: s2Enum.ID}},
+	}
+	unusedMessage := &api.Message{
+		Name: "UnusedMessage", ID: ".google.cloud.test.v1.UnusedMessage", Package: "google.cloud.test.v1",
+		Fields: []*api.Field{{Name: "e", Typez: api.TypezEnum, TypezID: unusedEnum.ID}},
+	}
+
+	s1 := &api.Service{
+		Name: "Service1", ID: ".google.cloud.test.v1.Service1", Package: "google.cloud.test.v1",
+		Methods: []*api.Method{
+			{Name: "M1", ID: ".google.cloud.test.v1.Service1.M1", InputTypeID: sharedMessage.ID, OutputTypeID: s1Message.ID},
+		},
+	}
+	s2 := &api.Service{
+		Name: "Service2", ID: ".google.cloud.test.v1.Service2", Package: "google.cloud.test.v1",
+		Methods: []*api.Method{
+			{Name: "M2", ID: ".google.cloud.test.v1.Service2.M2", InputTypeID: sharedMessage.ID, OutputTypeID: s2Message.ID},
+		},
+	}
+
+	model := api.NewTestAPI(
+		[]*api.Message{sharedMessage, s1Message, s2Message, unusedMessage},
+		[]*api.Enum{sharedEnum, s1Enum, s2Enum, unusedEnum},
+		[]*api.Service{s1, s2},
+	)
+	model.PackageName = "google.cloud.test.v1"
+	api.CrossReference(model)
+	return model
+}

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -21,6 +21,9 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.Model.BoilerPlate}}
 
+{{#Codec.IsGated}}
+#if {{Codec.Name}}
+{{/Codec.IsGated}}
 // snippet.show
 import Foundation
 import {{Codec.PackageName}}
@@ -49,3 +52,6 @@ struct SnippetRunner {
         }
     }
 }
+{{#Codec.IsGated}}
+#endif
+{{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/enum_file.swift.mustache
+++ b/internal/sidekick/swift/templates/common/enum_file.swift.mustache
@@ -20,6 +20,12 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.BoilerPlate}}
 
+{{#Codec.IsGated}}
+#if {{Codec.GateExpression}}
+{{/Codec.IsGated}}
 import Foundation
 
 {{> /templates/common/enum}}
+{{#Codec.IsGated}}
+#endif
+{{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/logging.swift.mustache
+++ b/internal/sidekick/swift/templates/common/logging.swift.mustache
@@ -20,6 +20,9 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.Model.BoilerPlate}}
 
+{{#Codec.IsGated}}
+#if {{Codec.Name}}
+{{/Codec.IsGated}}
 import Foundation
 {{! On Linux we need this additional import for `URLSession`. }}
 #if canImport(FoundationNetworking)
@@ -79,3 +82,6 @@ extension Clients {
     {{/Codec.RestMethods}}
   }
 }
+{{#Codec.IsGated}}
+#endif
+{{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/message_file.swift.mustache
+++ b/internal/sidekick/swift/templates/common/message_file.swift.mustache
@@ -20,9 +20,15 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.Model.BoilerPlate}}
 
+{{#Codec.IsGated}}
+#if {{Codec.GateExpression}}
+{{/Codec.IsGated}}
 import Foundation
 {{#Codec.MessageImports}}
 import {{.}}
 {{/Codec.MessageImports}}
 
 {{> /templates/common/message}}
+{{#Codec.IsGated}}
+#endif
+{{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
@@ -21,6 +21,9 @@ limitations under the License.
 //{{{.}}}
 {{/Service.Codec.Model.BoilerPlate}}
 
+{{#Service.Codec.IsGated}}
+#if {{Service.Codec.Name}}
+{{/Service.Codec.IsGated}}
 // snippet.show
 import Foundation
 import {{Service.Codec.PackageName}}
@@ -44,3 +47,6 @@ struct SnippetRunner {
         }
     }
 }
+{{#Service.Codec.IsGated}}
+#endif
+{{/Service.Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/retry.swift.mustache
+++ b/internal/sidekick/swift/templates/common/retry.swift.mustache
@@ -20,6 +20,9 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.Model.BoilerPlate}}
 
+{{#Codec.IsGated}}
+#if {{Codec.Name}}
+{{/Codec.IsGated}}
 import Foundation
 {{! On Linux we need this additional import for `URLSession`. }}
 #if canImport(FoundationNetworking)
@@ -72,3 +75,6 @@ extension Clients {
     {{/Codec.RestMethods}}
   }
 }
+{{#Codec.IsGated}}
+#endif
+{{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -20,6 +20,9 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.Model.BoilerPlate}}
 
+{{#Codec.IsGated}}
+#if {{Codec.Name}}
+{{/Codec.IsGated}}
 import Foundation
 {{! On Linux we need this additional import for `URLSession`. }}
 #if canImport(FoundationNetworking)
@@ -131,3 +134,6 @@ extension {{Codec.Name}} {
   {{/Codec.Pagination}}
   {{/Codec.RestMethods}}
 }
+{{#Codec.IsGated}}
+#endif
+{{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -20,6 +20,9 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.Model.BoilerPlate}}
 
+{{#Codec.IsGated}}
+#if {{Codec.Name}}
+{{/Codec.IsGated}}
 import Foundation
 {{! On Linux we need this additional import for `URLSession`. }}
 #if canImport(FoundationNetworking)
@@ -94,3 +97,6 @@ extension Clients {
     {{/Codec.RestMethods}}
   }
 }
+{{#Codec.IsGated}}
+#endif
+{{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/package/Package.swift.mustache
+++ b/internal/sidekick/swift/templates/package/Package.swift.mustache
@@ -30,6 +30,18 @@ let package = Package(
   products: [
     .library(name: "{{Codec.PackageName}}", targets: ["{{Codec.PackageName}}"])
   ],
+  {{#Codec.HasTraits}}
+  traits: [
+    {{#Codec.AllTraits}}
+    .trait(name: "{{{.}}}"),
+    {{/Codec.AllTraits}}
+    .default(enabledTraits: [
+        {{#Codec.DefaultTraits}}
+        "{{{.}}}",
+        {{/Codec.DefaultTraits}}
+    ]),
+  ],
+  {{/Codec.HasTraits}}
   {{#Codec.HasDependencies}}
   dependencies: [
     {{#Codec.Dependencies}}


### PR DESCRIPTION
In some large APIs customers often use only a few services in the API, but pay for the full compilation size and time of all the services. With these changes the generator can emit `#if / #endif` conditional compilation directives. The directives are named traits in the package, named after the service.

Sidekick computes the transitive closure of all the types (enums and structs) used by the service. The struct or enum is enabled if any service that needs it is enabled.

Fixes #5274 