### PR TITLE
feat(node): add CompatibilityResources option for NodeJS APIs

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -348,6 +348,7 @@ This document describes the schema for the librarian.yaml.
 | `diregapic` | bool | Indicates whether generation uses DIREGAPIC (Discovery REST GAPICs). This is typically false. Used for the GCE (compute) client. |
 | `omit_common_resources` | bool | Indicates whether to omit the default inclusion of google/cloud/common_resources.proto. |
 | `path` | string | Is the source path. |
+| `compatibility_resources` | list of string | Is the list of resource names for which legacy single-pattern functions should be generated for compatibility reasons. |
 
 ## NodejsPackage Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -785,6 +785,10 @@ type NodejsAPI struct {
 
 	// Path is the source path.
 	Path string `yaml:"path,omitempty"`
+
+	// CompatibilityResources is the list of resource names for which legacy
+	// single-pattern functions should be generated for compatibility reasons.
+	CompatibilityResources []string `yaml:"compatibility_resources,omitempty"`
 }
 
 // GcloudCommand contains gcloud-specific library configuration.

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -145,6 +145,7 @@ func resolveNodejsAPI(library *config.Library, api *config.API) *config.NodejsAP
 		omitCommon = apiConfig.OmitCommonResources
 		res.DIREGAPIC = apiConfig.DIREGAPIC
 		res.OmitCommonResources = apiConfig.OmitCommonResources
+		res.CompatibilityResources = apiConfig.CompatibilityResources
 	}
 
 	var protos []string
@@ -230,6 +231,9 @@ func buildGeneratorArgs(api *config.API, library *config.Library, googleapisDir,
 
 	if nodejsAPI.DIREGAPIC {
 		args = append(args, "--diregapic")
+	}
+	if len(nodejsAPI.CompatibilityResources) > 0 {
+		args = append(args, "--compatibility-resources", strings.Join(nodejsAPI.CompatibilityResources, ";"))
 	}
 
 	if library.Nodejs != nil {


### PR DESCRIPTION
If compatibility resources are specified in librarian.yaml, they are passed to the GAPIC generator.

Related GAPIC generator option draft PR:
https://github.com/googleapis/google-cloud-node/pull/8405