### PR TITLE
chore(internal/serviceconfig): allow list google/developers/knowledge/v1 for java

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -2719,6 +2719,9 @@
     - java
     - python
   new_issue_uri: https://issuetracker.google.com/savedsearches/559768
+- path: google/developers/knowledge/v1
+  language:
+    - java
 - path: google/devtools/artifactregistry/v1
   documentation_uri: https://cloud.google.com/artifact-registry
   languages:

--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -2720,7 +2720,7 @@
     - python
   new_issue_uri: https://issuetracker.google.com/savedsearches/559768
 - path: google/developers/knowledge/v1
-  language:
+  languages:
     - java
 - path: google/devtools/artifactregistry/v1
   documentation_uri: https://cloud.google.com/artifact-registry


### PR DESCRIPTION
New API path added for Java in https://github.com/googleapis/google-cloud-java/pull/13313.
 
For #6173