### PR TITLE
chore(.github/workflows): cache  ~/.cache/librarian  alongside the global npm directory

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           path: |
             ${{ steps.tool-paths.outputs.npm }}
+            ~/.cache/librarian
           key: nodejs-tools-v2-${{ hashFiles('internal/librarian/nodejs/librarian.yaml') }}
       - name: "Install Node.js dependencies (run librarian install)"
         if: steps.tools-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Got recent ci errors where canno find  gapic-generator-typescript https://github.com/googleapis/librarian/actions/runs/26763424174/job/78883894883?pr=6240.

In this workflow, the generator ( gapic-generator-typescript ) is globally installed using  pnpm add -g "$PWD" , which creates a global symlink in the Node global folder pointing to a local cache directory ( ~/.cache/librarian/... ). The caching workflow caches only the global Node directory, but does not cache the source target directory.

Fixes #6243