### PR TITLE
feat(python): move allowed_namespaces to librarian.yaml

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -368,6 +368,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `allowed_namespaces` | list of string | Contains the list of allowed GAPIC namespaces. If empty, all namespaces are allowed. |
 | `common_gapic_paths` | list of string | Contains paths which are generated for any package containing a GAPIC API. These are relative to the package's output directory, and the string "{neutral-source}" is replaced with the path to the version-neutral source code (e.g. "google/cloud/run"). If a library defines its own common_gapic_paths, they will be appended to the defaults. |
 | `library_type` | string | Is the type to emit in .repo-metadata.json. |
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -391,6 +391,10 @@ type PythonPackage struct {
 
 // PythonDefault contains Python-specific default configuration.
 type PythonDefault struct {
+	// AllowedNamespaces contains the list of allowed GAPIC namespaces.
+	// If empty, all namespaces are allowed.
+	AllowedNamespaces []string `yaml:"allowed_namespaces,omitempty"`
+
 	// CommonGAPICPaths contains paths which are generated for any package
 	// containing a GAPIC API. These are relative to the package's output
 	// directory, and the string "{neutral-source}" is replaced with the path

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -251,7 +251,7 @@ func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config,
 		lib = java.Add(lib)
 	case config.LanguagePython:
 		var err error
-		lib, err = python.Add(lib)
+		lib, err = python.Add(cfg, lib)
 		if err != nil {
 			return "", nil, err
 		}

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -29,13 +29,6 @@ import (
 const defaultVersion = "0.0.0"
 
 var (
-	approvedGAPICNamespaces = []string{
-		"google.ads",
-		"google.apps",
-		"google.cloud",
-		"google.maps",
-		"google.shopping",
-	}
 	errNewLibraryMustHaveOneAPI          = errors.New("a newly added library (in Python) must have exactly one API so that the default version can be populated")
 	errNewLibraryBadNamespace            = errors.New("derived GAPIC namespace would not match any approved namespace; consult with the Python team to determine whether the namespace should be approved, or whether GAPIC options should be specified for this API in librarian.yaml. See go/clientlibs-python-registered-namespaces for more details")
 	errExistingLibraryNoDefaultVersion   = errors.New("new APIs cannot be automatically added to a library without a default version")
@@ -43,7 +36,7 @@ var (
 )
 
 // Add initializes a new Python library with default values.
-func Add(lib *config.Library) (*config.Library, error) {
+func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	lib.Version = defaultVersion
 	if len(lib.APIs) != 1 {
 		return nil, errNewLibraryMustHaveOneAPI
@@ -54,11 +47,21 @@ func Add(lib *config.Library) (*config.Library, error) {
 			DefaultVersion: packageDefaultVersion,
 		}
 	}
-	namespace := deriveGAPICNamespace(apiPath)
-	if !slices.Contains(approvedGAPICNamespaces, namespace) {
-		return nil, fmt.Errorf("%w: unapproved namespace %s derived from API path %s", errNewLibraryBadNamespace, namespace, apiPath)
+	if err := validateNamespace(cfg, apiPath); err != nil {
+		return nil, err
 	}
 	return lib, nil
+}
+
+func validateNamespace(cfg *config.Config, apiPath string) error {
+	if cfg == nil || cfg.Default == nil || cfg.Default.Python == nil || len(cfg.Default.Python.AllowedNamespaces) == 0 {
+		return nil
+	}
+	namespace := deriveGAPICNamespace(apiPath)
+	if !slices.Contains(cfg.Default.Python.AllowedNamespaces, namespace) {
+		return fmt.Errorf("%w: unapproved namespace %s derived from API path %s", errNewLibraryBadNamespace, namespace, apiPath)
+	}
+	return nil
 }
 
 // ValidateNewAPIs validates that new APIs can be added to an existing library.

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -66,7 +66,7 @@ func TestAdd(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			gotLib, err := Add(test.lib)
+			gotLib, err := Add(nil, test.lib)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -81,6 +81,7 @@ func TestAdd_Error(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
 		name    string
+		cfg     *config.Config
 		lib     *config.Library
 		wantErr error
 	}{
@@ -103,20 +104,77 @@ func TestAdd_Error(t *testing.T) {
 			wantErr: errNewLibraryMustHaveOneAPI,
 		},
 		{
-			name: "API in unapproved namespace",
+			name: "unallowed namespace",
+			cfg: &config.Config{
+				Default: &config.Default{
+					Python: &config.PythonDefault{
+						AllowedNamespaces: []string{"google.custom"},
+					},
+				},
+			},
 			lib: &config.Library{
-				Name: "google-unapproved-bad",
+				Name: "google-other-foo",
 				APIs: []*config.API{
-					{Path: "google/unapproved/bad/v1"},
+					{Path: "google/other/foo/v1"},
 				},
 			},
 			wantErr: errNewLibraryBadNamespace,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, gotErr := Add(test.lib)
+			_, gotErr := Add(test.cfg, test.lib)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateNamespace(t *testing.T) {
+	t.Parallel()
+	customCfg := &config.Config{
+		Default: &config.Default{
+			Python: &config.PythonDefault{
+				AllowedNamespaces: []string{"google.custom"},
+			},
+		},
+	}
+	for _, test := range []struct {
+		name    string
+		cfg     *config.Config
+		apiPath string
+		wantErr error
+	}{
+		{
+			name:    "no config - allow everything",
+			cfg:     nil,
+			apiPath: "google/cloud/foo/v1",
+		},
+		{
+			name: "empty allowed namespaces - allow everything",
+			cfg: &config.Config{
+				Default: &config.Default{
+					Python: &config.PythonDefault{},
+				},
+			},
+			apiPath: "google/cloud/foo/v1",
+		},
+		{
+			name:    "allowed namespace matches",
+			cfg:     customCfg,
+			apiPath: "google/custom/foo/v1",
+		},
+		{
+			name:    "unallowed namespace triggers error",
+			cfg:     customCfg,
+			apiPath: "google/other/foo/v1",
+			wantErr: errNewLibraryBadNamespace,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotErr := validateNamespace(test.cfg, test.apiPath)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("validateNamespace(%+v, %q) error = %v, wantErr %v", test.cfg, test.apiPath, gotErr, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Moves the hard coded python namespace allowlist to `librarian.yaml` under the `default.python` section. Defaults to "allow all" if unset.

Tested in `google-cloud-python` by adding the hard coded list to the `librarian.yaml`, then running several exercises:

- `tidy` to ensure it isn't removed as "unknown" schema
- `add` with an "unallowed" API path --> error as expected
- extend allowlist, then rerun same `add` --> adds as expected
- `add` with an allowlisted API path --> adds as expected

**Important**: We need to add the following stanza to the `google-cloud-python/librarian.yaml` (#6251):
```diff
python:
+    allowed_namespaces:
+      - google.ads
+      - google.apps
+      - google.cloud
+      - google.maps
+      - google.shopping
```

Fixes #6145