### PR TITLE
fix(librarian/internal/java): explicity list released_version as config

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -328,6 +328,7 @@ This document describes the schema for the librarian.yaml.
 | `group_id` | string | Is the Maven group ID, defaults to "com.google.cloud". |
 | `issue_tracker_override` | string | Allows the "issue_tracker" field in .repo-metadata.json to be overridden. |
 | `libraries_bom_version` | string | Is the version of the libraries-bom to use for Java. |
+| `released_version` | string | Is the last released version of the library. Needs to be explicitly listed for README generation. |
 | `library_type_override` | string | Allows the "library_type" field in .repo-metadata.json to be overridden. |
 | `min_java_version` | int | Is the minimum Java version required. |
 | `name_pretty_override` | string | Allows the "name_pretty" field in .repo-metadata.json to be overridden. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -518,6 +518,10 @@ type JavaModule struct {
 	// LibrariesBOMVersion is the version of the libraries-bom to use for Java.
 	LibrariesBOMVersion string `yaml:"libraries_bom_version,omitempty"`
 
+	// ReleasedVersion is the last released version of the library.
+	// Needs to be explicitly listed for README generation.
+	ReleasedVersion string `yaml:"released_version,omitempty"`
+
 	// LibraryTypeOverride allows the "library_type" field in .repo-metadata.json
 	// to be overridden.
 	LibraryTypeOverride string `yaml:"library_type_override,omitempty"`

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1064,6 +1064,9 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 					},
 				},
 			},
+			Java: &config.JavaModule{
+				ReleasedVersion: "0.0.0",
+			},
 		},
 	}
 	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -43,6 +43,11 @@ func Add(lib *config.Library) *config.Library {
 	// so we reset it here to avoid redundancy in librarian.yaml.
 	lib.CopyrightYear = ""
 
+	if lib.Java == nil {
+		lib.Java = &config.JavaModule{}
+	}
+	lib.Java.ReleasedVersion = "0.0.0"
+
 	// We use the first API to infer the group ID.
 	// It is unrealistic for a single library to mix cloud and non-cloud APIs.
 	apiPath := lib.APIs[0].Path
@@ -66,9 +71,6 @@ func Add(lib *config.Library) *config.Library {
 }
 
 func setJavaConfig(lib *config.Library, groupID string) *config.Library {
-	if lib.Java == nil {
-		lib.Java = &config.JavaModule{}
-	}
 	lib.Java.ArtifactID = "google-" + lib.Name
 	lib.Java.GroupID = groupID
 	return lib

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -54,11 +54,11 @@ func Add(lib *config.Library) *config.Library {
 	apiPath := lib.APIs[0].Path
 	switch {
 	case strings.HasPrefix(apiPath, "google/shopping/"):
-		return setJavaConfig(lib, "com.google.shopping")
+		return setNonCloudMavenDefaults(lib, "com.google.shopping")
 	case strings.HasPrefix(apiPath, "google/maps/"):
-		return setJavaConfig(lib, "com.google.maps")
+		return setNonCloudMavenDefaults(lib, "com.google.maps")
 	case strings.HasPrefix(apiPath, "google/ads/"):
-		return setJavaConfig(lib, "com.google.api-ads")
+		return setNonCloudMavenDefaults(lib, "com.google.api-ads")
 	}
 	if !strings.HasPrefix(apiPath, "google/cloud/") {
 		log.Printf(
@@ -66,12 +66,12 @@ func Add(lib *config.Library) *config.Library {
 				"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml.",
 			apiPath, fakeGroupID,
 		)
-		setJavaConfig(lib, fakeGroupID)
+		setNonCloudMavenDefaults(lib, fakeGroupID)
 	}
 	return lib
 }
 
-func setJavaConfig(lib *config.Library, groupID string) *config.Library {
+func setNonCloudMavenDefaults(lib *config.Library, groupID string) *config.Library {
 	lib.Java.ArtifactID = "google-" + lib.Name
 	lib.Java.GroupID = groupID
 	return lib

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -32,8 +32,9 @@ var knownPrefixes = []string{
 }
 
 const (
-	defaultVersion = "0.1.0-SNAPSHOT"
-	fakeGroupID    = "please-configure-java-group-id"
+	defaultVersion         = "0.1.0-SNAPSHOT"
+	defaultReleasedVersion = "0.0.0"
+	fakeGroupID            = "please-configure-java-group-id"
 )
 
 // Add initializes a new Java library with default values.
@@ -46,7 +47,7 @@ func Add(lib *config.Library) *config.Library {
 	if lib.Java == nil {
 		lib.Java = &config.JavaModule{}
 	}
-	lib.Java.ReleasedVersion = "0.0.0"
+	lib.Java.ReleasedVersion = defaultReleasedVersion
 
 	// We use the first API to infer the group ID.
 	// It is unrealistic for a single library to mix cloud and non-cloud APIs.

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -42,6 +42,9 @@ func TestAdd(t *testing.T) {
 				},
 				Version:       defaultVersion,
 				CopyrightYear: "",
+				Java: &config.JavaModule{
+					ReleasedVersion: "0.0.0",
+				},
 			},
 		},
 		{
@@ -60,8 +63,9 @@ func TestAdd(t *testing.T) {
 				Version:       defaultVersion,
 				CopyrightYear: "",
 				Java: &config.JavaModule{
-					ArtifactID: "google-shopping-css",
-					GroupID:    "com.google.shopping",
+					ArtifactID:      "google-shopping-css",
+					GroupID:         "com.google.shopping",
+					ReleasedVersion: "0.0.0",
 				},
 			},
 		},
@@ -81,8 +85,9 @@ func TestAdd(t *testing.T) {
 				Version:       defaultVersion,
 				CopyrightYear: "",
 				Java: &config.JavaModule{
-					ArtifactID: "google-maps-routing",
-					GroupID:    "com.google.maps",
+					ArtifactID:      "google-maps-routing",
+					GroupID:         "com.google.maps",
+					ReleasedVersion: "0.0.0",
 				},
 			},
 		},
@@ -102,8 +107,9 @@ func TestAdd(t *testing.T) {
 				Version:       defaultVersion,
 				CopyrightYear: "",
 				Java: &config.JavaModule{
-					ArtifactID: "google-foo-bar",
-					GroupID:    "please-configure-java-group-id",
+					ArtifactID:      "google-foo-bar",
+					GroupID:         "please-configure-java-group-id",
+					ReleasedVersion: "0.0.0",
 				},
 			},
 		},
@@ -123,8 +129,9 @@ func TestAdd(t *testing.T) {
 				Version:       defaultVersion,
 				CopyrightYear: "",
 				Java: &config.JavaModule{
-					ArtifactID: "google-ads-admanager",
-					GroupID:    "com.google.api-ads",
+					ArtifactID:      "google-ads-admanager",
+					GroupID:         "com.google.api-ads",
+					ReleasedVersion: "0.0.0",
 				},
 			},
 		},

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -43,7 +43,7 @@ func TestAdd(t *testing.T) {
 				Version:       defaultVersion,
 				CopyrightYear: "",
 				Java: &config.JavaModule{
-					ReleasedVersion: "0.0.0",
+					ReleasedVersion: defaultReleasedVersion,
 				},
 			},
 		},
@@ -65,7 +65,7 @@ func TestAdd(t *testing.T) {
 				Java: &config.JavaModule{
 					ArtifactID:      "google-shopping-css",
 					GroupID:         "com.google.shopping",
-					ReleasedVersion: "0.0.0",
+					ReleasedVersion: defaultReleasedVersion,
 				},
 			},
 		},
@@ -87,7 +87,7 @@ func TestAdd(t *testing.T) {
 				Java: &config.JavaModule{
 					ArtifactID:      "google-maps-routing",
 					GroupID:         "com.google.maps",
-					ReleasedVersion: "0.0.0",
+					ReleasedVersion: defaultReleasedVersion,
 				},
 			},
 		},
@@ -109,7 +109,7 @@ func TestAdd(t *testing.T) {
 				Java: &config.JavaModule{
 					ArtifactID:      "google-foo-bar",
 					GroupID:         "please-configure-java-group-id",
-					ReleasedVersion: "0.0.0",
+					ReleasedVersion: defaultReleasedVersion,
 				},
 			},
 		},
@@ -131,7 +131,7 @@ func TestAdd(t *testing.T) {
 				Java: &config.JavaModule{
 					ArtifactID:      "google-ads-admanager",
 					GroupID:         "com.google.api-ads",
-					ReleasedVersion: "0.0.0",
+					ReleasedVersion: defaultReleasedVersion,
 				},
 			},
 		},

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -15,11 +15,13 @@
 package java
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/semver"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -155,13 +157,25 @@ func tidyKeep(keep []string) []string {
 var (
 	// ErrOmitCommonResourcesConflict is returned when OmitCommonResources is true
 	// but common_resources.proto is also explicitly listed in AdditionalProtos.
-	ErrOmitCommonResourcesConflict = fmt.Errorf("conflict: OmitCommonResources is true but google/cloud/common_resources.proto is explicitly listed in AdditionalProtos")
+	ErrOmitCommonResourcesConflict = errors.New("conflict: OmitCommonResources is true but google/cloud/common_resources.proto is explicitly listed in AdditionalProtos")
+	// ErrReleasedVersionRequired is returned when released_version is missing.
+	ErrReleasedVersionRequired = errors.New("released_version is required under java section")
+	// ErrInvalidReleasedVersion is returned when released_version is not a valid semver.
+	ErrInvalidReleasedVersion = errors.New("invalid released_version")
 )
 
 // Validate checks that the Java-specific configuration for a library is
 // correctly formatted. It ensures that there are no conflicts in common
 // resources configuration.
 func Validate(library *config.Library) error {
+	if !library.SkipGenerate {
+		if library.Java == nil || library.Java.ReleasedVersion == "" {
+			return fmt.Errorf("library %q: %w", library.Name, ErrReleasedVersionRequired)
+		}
+		if _, err := semver.Parse(library.Java.ReleasedVersion); err != nil {
+			return fmt.Errorf("library %q: %w: %w", library.Name, ErrInvalidReleasedVersion, err)
+		}
+	}
 	for _, api := range library.APIs {
 		if api.Java == nil || !api.Java.OmitCommonResources {
 			continue

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -495,9 +495,6 @@ func TestValidate_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := Validate(test.lib)
-			if err == nil {
-				t.Fatal("Expect error")
-			}
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("Validate() error = %v, want %v", err, test.wantErr)
 			}

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -416,13 +416,19 @@ func TestValidate(t *testing.T) {
 		lib  *config.Library
 	}{
 		{
-			name: "empty java config",
-			lib:  &config.Library{},
+			name: "valid java config",
+			lib: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.2.3",
+				},
+			},
 		},
 		{
-			name: "empty distribution name override",
+			name: "skipped library does not require released_version",
 			lib: &config.Library{
-				Java: &config.JavaModule{},
+				Name:         "google-cloud-java",
+				SkipGenerate: true,
 			},
 		},
 	} {
@@ -441,8 +447,37 @@ func TestValidate_Error(t *testing.T) {
 		wantErr error
 	}{
 		{
+			name: "missing java section",
+			lib: &config.Library{
+				Name: "secretmanager",
+			},
+			wantErr: ErrReleasedVersionRequired,
+		},
+		{
+			name: "missing released version",
+			lib: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{},
+			},
+			wantErr: ErrReleasedVersionRequired,
+		},
+		{
+			name: "invalid released version",
+			lib: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{
+					ReleasedVersion: "invalid-semver",
+				},
+			},
+			wantErr: ErrInvalidReleasedVersion,
+		},
+		{
 			name: "omit common resources conflict",
 			lib: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.2.3",
+				},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/conflict/v1",
@@ -460,6 +495,9 @@ func TestValidate_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := Validate(test.lib)
+			if err == nil {
+				t.Fatal("Expect error")
+			}
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("Validate() error = %v, want %v", err, test.wantErr)
 			}

--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -102,10 +102,7 @@ func PostGenerate(ctx context.Context, repoPath string, cfg *config.Config, miss
 	}
 
 	// TODO(https://github.com/googleapis/librarian/issues/5529): remove appending to versions.txt.
-	versions, err := deriveVersionLines(missingArtifacts)
-	if err != nil {
-		return err
-	}
+	versions := deriveVersionLines(missingArtifacts)
 	if err := appendVersions(repoPath, versions); err != nil {
 		return err
 	}
@@ -127,16 +124,13 @@ func PostGenerate(ctx context.Context, repoPath string, cfg *config.Config, miss
 	return nil
 }
 
-func deriveVersionLines(missingArtifacts []MissingArtifact) ([]string, error) {
+func deriveVersionLines(missingArtifacts []MissingArtifact) []string {
 	var lines []string
 	for _, ma := range missingArtifacts {
-		releasedVersion, err := deriveLastReleasedVersion(ma.Library.Version)
-		if err != nil {
-			return nil, fmt.Errorf("failed to derive released version for %s (%s): %w", ma.ID, ma.Library.Version, err)
-		}
+		releasedVersion := ma.Library.Java.ReleasedVersion
 		lines = append(lines, fmt.Sprintf("%s:%s:%s", ma.ID, releasedVersion, ma.Library.Version))
 	}
-	return lines, nil
+	return lines
 }
 
 func appendVersions(repoPath string, versions []string) error {

--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -102,7 +102,7 @@ func PostGenerate(ctx context.Context, repoPath string, cfg *config.Config, miss
 	}
 
 	// TODO(https://github.com/googleapis/librarian/issues/5529): remove appending to versions.txt.
-	versions := deriveVersionLines(missingArtifacts)
+	versions := constructVersionLines(missingArtifacts)
 	if err := appendVersions(repoPath, versions); err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func PostGenerate(ctx context.Context, repoPath string, cfg *config.Config, miss
 	return nil
 }
 
-func deriveVersionLines(missingArtifacts []MissingArtifact) []string {
+func constructVersionLines(missingArtifacts []MissingArtifact) []string {
 	var lines []string
 	for _, ma := range missingArtifacts {
 		releasedVersion := ma.Library.Java.ReleasedVersion

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -358,23 +358,20 @@ func TestDeriveVersionLines(t *testing.T) {
 	library := &config.Library{
 		Name:    "secretmanager",
 		Version: "1.2.3",
-	}
-	invalidLibrary := &config.Library{
-		Name:    "invalid",
-		Version: "1.0.0-SNAPSHOT",
+		Java: &config.JavaModule{
+			ReleasedVersion: "1.2.3",
+		},
 	}
 
 	tests := []struct {
 		name             string
 		missingArtifacts []MissingArtifact
 		want             []string
-		wantErr          bool
 	}{
 		{
 			name:             "empty input",
 			missingArtifacts: nil,
 			want:             nil,
-			wantErr:          false,
 		},
 		{
 			name: "valid artifact IDs",
@@ -386,25 +383,12 @@ func TestDeriveVersionLines(t *testing.T) {
 				"proto-google-cloud-secretmanager-v1:1.2.3:1.2.3",
 				"google-cloud-secretmanager:1.2.3:1.2.3",
 			},
-			wantErr: false,
-		},
-		{
-			name: "invalid library version",
-			missingArtifacts: []MissingArtifact{
-				{ID: "proto-google-cloud-invalid-v1", Library: invalidLibrary},
-			},
-			want:    nil,
-			wantErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := deriveVersionLines(test.missingArtifacts)
-			if (err != nil) != test.wantErr {
-				t.Errorf("deriveVersionLines() error = %v, wantErr %v", err, test.wantErr)
-				return
-			}
+			got := deriveVersionLines(test.missingArtifacts)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("deriveVersionLines() mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -362,8 +362,7 @@ func TestDeriveVersionLines(t *testing.T) {
 			ReleasedVersion: "1.2.3",
 		},
 	}
-
-	tests := []struct {
+	for _, test := range []struct {
 		name             string
 		missingArtifacts []MissingArtifact
 		want             []string
@@ -384,13 +383,11 @@ func TestDeriveVersionLines(t *testing.T) {
 				"google-cloud-secretmanager:1.2.3:1.2.3",
 			},
 		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := deriveVersionLines(test.missingArtifacts)
+			got := constructVersionLines(test.missingArtifacts)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("deriveVersionLines() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -29,7 +29,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/license"
-	"github.com/googleapis/librarian/internal/semver"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
@@ -42,7 +41,6 @@ var (
 	errTemplatesMissing = errors.New("templates directory not found")
 	errRunOwlBot        = errors.New("failed to run owlbot.py")
 	errSyncPOMs         = errors.New("failed to generate or update pom.xml files")
-	errInvalidVersion   = errors.New("invalid java library version")
 )
 
 type protoFileToCopy struct {
@@ -364,10 +362,7 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 		}
 	}()
 
-	releasedVersion, err := deriveLastReleasedVersion(library.Version)
-	if err != nil {
-		return fmt.Errorf("%w %q: %w", errInvalidVersion, library.Version, err)
-	}
+	releasedVersion := library.Java.ReleasedVersion
 	// Versions used to populate README.md file.
 	env := map[string]string{
 		"SYNTHTOOL_LIBRARY_VERSION":       releasedVersion,
@@ -384,34 +379,6 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 	}
 	// Staging dirs cleans up as part of owlbot.py
 	return nil
-}
-
-// deriveLastReleasedVersion derives the last released version from a snapshot version
-// (e.g., x.y.z-SNAPSHOT or x.y.z-beta-SNAPSHOT) by decrementing the patch or minor version.
-// If the version has a prerelease tag (like "beta") before "SNAPSHOT", that tag is preserved
-// in the derived version (e.g., x.y.z-beta-SNAPSHOT becomes x.y.(z-1)-beta).
-//
-// It returns an error if both minor and patch versions are zero, as it's
-// ambiguous what the last released version was in that case.
-func deriveLastReleasedVersion(v string) (string, error) {
-	sv, err := semver.Parse(v)
-	if err != nil {
-		return "", err
-	}
-	if !strings.HasSuffix(sv.Prerelease, "SNAPSHOT") {
-		return sv.String(), nil
-	}
-	if sv.Patch > 0 {
-		sv.Patch--
-	} else if sv.Minor > 0 {
-		sv.Minor--
-		sv.Patch = 0
-	} else {
-		return "", errInvalidVersion
-	}
-	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "SNAPSHOT")
-	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "-")
-	return sv.String(), nil
 }
 
 func copyProtos(protos []protoFileToCopy, destDir string) error {

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/semver"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
@@ -514,7 +513,8 @@ func TestPostProcessLibrary(t *testing.T) {
 			},
 		},
 		Java: &config.JavaModule{
-			GroupID: "com.google.cloud",
+			GroupID:         "com.google.cloud",
+			ReleasedVersion: "1.2.3",
 		},
 	}
 	defaultCfg := &config.Config{
@@ -542,7 +542,8 @@ func TestPostProcessLibrary(t *testing.T) {
 				Version: "1.2.0-SNAPSHOT",
 				APIs:    []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 				Java: &config.JavaModule{
-					SkipPOMUpdates: true,
+					SkipPOMUpdates:  true,
+					ReleasedVersion: "1.1.0",
 				},
 			},
 			setup: func(t *testing.T, outDir string) {
@@ -613,7 +614,8 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			},
 		},
 		Java: &config.JavaModule{
-			GroupID: "com.google.cloud",
+			GroupID:         "com.google.cloud",
+			ReleasedVersion: "1.2.3",
 		},
 	}
 	defaultCfg := &config.Config{
@@ -694,57 +696,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 	}
 }
 
-func TestDeriveLastReleasedVersion(t *testing.T) {
-	for _, test := range []struct {
-		input string
-		want  string
-	}{
-		{input: "1.2.0-SNAPSHOT", want: "1.1.0"},
-		{input: "1.10.0-SNAPSHOT", want: "1.9.0"},
-		{input: "0.87.0-SNAPSHOT", want: "0.86.0"},
-		{input: "0.0.1-SNAPSHOT", want: "0.0.0"},
-		{input: "1.10.1-SNAPSHOT", want: "1.10.0"},
-		{input: "0.214.0-beta-SNAPSHOT", want: "0.213.0-beta"},
-		{input: "0.214.0-beta", want: "0.214.0-beta"},
-		{input: "1.2.3", want: "1.2.3"},
-	} {
-		t.Run(test.input, func(t *testing.T) {
-			got, err := deriveLastReleasedVersion(test.input)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestDeriveLastReleasedVersion_Error(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		input   string
-		wantErr error
-	}{
-		{
-			name:    "invalid version",
-			input:   "1.invalid.0-SNAPSHOT",
-			wantErr: semver.ErrInvalidVersion,
-		},
-		{
-			name:    "v1.0.0 snapshot",
-			input:   "1.0.0-SNAPSHOT",
-			wantErr: errInvalidVersion,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			_, err := deriveLastReleasedVersion(test.input)
-			if !errors.Is(err, test.wantErr) {
-				t.Errorf("error = %v, wantErr %v", err, test.wantErr)
-			}
-		})
-	}
-}
+// deriveLastReleasedVersion tests were removed as the function was deleted.
 
 func writeOwlBot(t *testing.T, outDir, script string) {
 	t.Helper()
@@ -792,7 +744,12 @@ with open("owlbot-ran.txt", "w") as f:
 		t.Fatal(err)
 	}
 
-	library := &config.Library{Version: "1.2.3"}
+	library := &config.Library{
+		Version: "1.2.3",
+		Java: &config.JavaModule{
+			ReleasedVersion: "1.2.3",
+		},
+	}
 	if err := runOwlBot(t.Context(), library, outDir, "4.5.6"); err != nil {
 		t.Fatal(err)
 	}
@@ -819,7 +776,9 @@ func TestRunOwlBot_Error(t *testing.T) {
 	if err := os.WriteFile(dummyFile, []byte("dummy"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	library := &config.Library{}
+	library := &config.Library{
+		Java: &config.JavaModule{},
+	}
 	if err := runOwlBot(t.Context(), library, outDir, ""); err == nil {
 		t.Error("expected error due to missing templates directory, got nil")
 	}

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -594,6 +594,9 @@ func mergeJava(dst, src *config.JavaModule) *config.JavaModule {
 	if src.LibrariesBOMVersion != "" {
 		res.LibrariesBOMVersion = src.LibrariesBOMVersion
 	}
+	if src.ReleasedVersion != "" {
+		res.ReleasedVersion = src.ReleasedVersion
+	}
 	if src.LibraryTypeOverride != "" {
 		res.LibraryTypeOverride = src.LibraryTypeOverride
 	}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -56,10 +56,12 @@ func TestValidateLibraries(t *testing.T) {
 				{
 					Name: "lib1",
 					APIs: []*config.API{{Path: "google/iam/v1"}},
+					Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
 				},
 				{
 					Name: "lib2",
 					APIs: []*config.API{{Path: "google/iam/v1"}},
+					Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
 				},
 			},
 			language: config.LanguageJava,
@@ -601,24 +603,26 @@ func TestTidy_DerivableOutput(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
+			lib := &config.Library{
+				Name:   test.libName,
+				Output: test.output,
+				Roots:  []string{"googleapis"},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+					},
+				},
+			}
+			if test.language == config.LanguageJava {
+				lib.Java = &config.JavaModule{ReleasedVersion: "1.0.0"}
+			}
 			cfg := &config.Config{
 				Language: test.language,
 				Default: &config.Default{
 					Output: "generated/",
 				},
-				Sources: googleapisSource,
-				Libraries: []*config.Library{
-					{
-						Name:   test.libName,
-						Output: test.output,
-						Roots:  []string{"googleapis"},
-						APIs: []*config.API{
-							{
-								Path: "google/cloud/secretmanager/v1",
-							},
-						},
-					},
-				},
+				Sources:   googleapisSource,
+				Libraries: []*config.Library{lib},
 			}
 			if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 				t.Fatal(err)

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -221,14 +221,19 @@ func readGenerationConfig(path string) (*GenerationConfig, error) {
 	return yaml.Read[GenerationConfig](filepath.Join(path, generationConfigFileName))
 }
 
-// readVersions parses versions.txt and returns a map of module names to snapshot versions.
+type versionInfo struct {
+	Released string
+	Current  string
+}
+
+// readVersions parses versions.txt and returns a map of module names to version info.
 // It expects the "module:released-version:current-version" format.
-func readVersions(path string) (map[string]string, error) {
+func readVersions(path string) (map[string]versionInfo, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
-	versions := make(map[string]string)
+	versions := make(map[string]versionInfo)
 	lines := strings.Split(string(content), "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -239,18 +244,21 @@ func readVersions(path string) (map[string]string, error) {
 		if len(parts) != 3 {
 			return nil, fmt.Errorf("read versions in %s: line %q has %d parts, want 3", path, line, len(parts))
 		}
-		versions[parts[0]] = parts[2] // snapshot-version
+		versions[parts[0]] = versionInfo{
+			Released: parts[1],
+			Current:  parts[2],
+		}
 	}
 	return versions, nil
 }
 
 // buildConfig converts a GenerationConfig to a Librarian Config.
-func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *config.Source, versions map[string]string) (*config.Config, error) {
+func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *config.Source, versions map[string]versionInfo) (*config.Config, error) {
 	var libs []*config.Library
-	if v, ok := versions["google-cloud-java"]; ok {
+	if vInfo, ok := versions["google-cloud-java"]; ok {
 		libs = append(libs, &config.Library{
 			Name:         "google-cloud-java",
-			Version:      v,
+			Version:      vInfo.Current,
 			SkipGenerate: true,
 		})
 	}
@@ -261,12 +269,15 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 		}
 		output := "java-" + name
 		groupID, artifactID := parseGroupAndArtifactID(l.DistributionName, name)
-		version := versions[artifactID]
+		vInfo := versions[artifactID]
+		version := vInfo.Current
+		releasedVersion := vInfo.Released
 		var apis []*config.API
 		var roots []string
 		if name == showcaseLibraryName {
 			roots = []string{showcaseLibraryName, "googleapis"}
 			version = "0.0.1-SNAPSHOT"
+			releasedVersion = "0.0.0"
 		}
 		for _, g := range l.GAPICs {
 			if g.ProtoPath == "" {
@@ -337,6 +348,7 @@ func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *confi
 			Roots:   roots,
 			APIs:    apis,
 			Java: &config.JavaModule{
+				ReleasedVersion:              releasedVersion,
 				APIIDOverride:                l.APIID,
 				APIReference:                 l.APIReference,
 				APIDescriptionOverride:       l.APIDescription,

--- a/tool/cmd/migrate/java.go
+++ b/tool/cmd/migrate/java.go
@@ -256,11 +256,17 @@ func readVersions(path string) (map[string]versionInfo, error) {
 func buildConfig(gen *GenerationConfig, repoPath string, src, showcaseSrc *config.Source, versions map[string]versionInfo) (*config.Config, error) {
 	var libs []*config.Library
 	if vInfo, ok := versions["google-cloud-java"]; ok {
-		libs = append(libs, &config.Library{
+		lib := &config.Library{
 			Name:         "google-cloud-java",
 			Version:      vInfo.Current,
 			SkipGenerate: true,
-		})
+		}
+		if vInfo.Released != "" {
+			lib.Java = &config.JavaModule{
+				ReleasedVersion: vInfo.Released,
+			}
+		}
+		libs = append(libs, lib)
 	}
 	for _, l := range gen.Libraries {
 		name := l.LibraryName

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -740,7 +740,7 @@ func TestBuildConfig(t *testing.T) {
 				},
 			},
 			versions: map[string]versionInfo{
-				"google-cloud-java":           {Current: "1.79.0"},
+				"google-cloud-java":           {Released: "1.78.0", Current: "1.79.0"},
 				"google-cloud-accessapproval": {Released: "2.85.0", Current: "2.86.0"},
 			},
 			src: &config.Source{},
@@ -758,6 +758,9 @@ func TestBuildConfig(t *testing.T) {
 						Name:         "google-cloud-java",
 						Version:      "1.79.0",
 						SkipGenerate: true,
+						Java: &config.JavaModule{
+							ReleasedVersion: "1.78.0",
+						},
 					},
 					{
 						Name:    "accessapproval",

--- a/tool/cmd/migrate/java_test.go
+++ b/tool/cmd/migrate/java_test.go
@@ -304,7 +304,7 @@ func setupMigrationTest(t *testing.T, sourceRepoPath string) string {
 	if err := os.CopyFS(dir, os.DirFS(sourceRepoPath)); err != nil {
 		t.Fatal(err)
 	}
-	writeVersionsFile(t, dir, "")
+	writeVersionsFile(t, dir, "google-cloud-language-v1:1.0.0:1.1.0-SNAPSHOT\ngoogle-cloud-java:1.0.0:1.1.0-SNAPSHOT")
 
 	// Create dummy showcase pom.xml to avoid failure in runJavaMigration
 	showcaseDir := filepath.Join(dir, "java-showcase", "gapic-showcase")
@@ -461,7 +461,7 @@ func TestBuildConfig(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		gen      *GenerationConfig
-		versions map[string]string
+		versions map[string]versionInfo
 		src      *config.Source
 		want     *config.Config
 	}{
@@ -549,9 +549,10 @@ func TestBuildConfig(t *testing.T) {
 							"gapic-showcase/src/main/java/com/google/showcase/v1beta1/Version.java",
 						},
 						Java: &config.JavaModule{
-							ArtifactID: "google-cloud-showcase",
-							GroupID:    "com.google.cloud",
-							SkipAPIID:  true,
+							ArtifactID:      "google-cloud-showcase",
+							GroupID:         "com.google.cloud",
+							SkipAPIID:       true,
+							ReleasedVersion: "0.0.0",
 						},
 					},
 				},
@@ -738,9 +739,9 @@ func TestBuildConfig(t *testing.T) {
 					},
 				},
 			},
-			versions: map[string]string{
-				"google-cloud-java":           "1.79.0",
-				"google-cloud-accessapproval": "2.86.0",
+			versions: map[string]versionInfo{
+				"google-cloud-java":           {Current: "1.79.0"},
+				"google-cloud-accessapproval": {Released: "2.85.0", Current: "2.86.0"},
 			},
 			src: &config.Source{},
 			want: &config.Config{
@@ -765,8 +766,9 @@ func TestBuildConfig(t *testing.T) {
 							{Path: "google/cloud/accessapproval/v1"},
 						},
 						Java: &config.JavaModule{
-							ArtifactID: "google-cloud-accessapproval",
-							GroupID:    "com.google.cloud",
+							ReleasedVersion: "2.85.0",
+							ArtifactID:      "google-cloud-accessapproval",
+							GroupID:         "com.google.cloud",
 						},
 					},
 				},
@@ -1223,9 +1225,9 @@ google-cloud-aiplatform:3.86.0:3.87.0-SNAPSHOT
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := map[string]string{
-		"google-cloud-accessapproval": "2.87.0-SNAPSHOT",
-		"google-cloud-aiplatform":     "3.87.0-SNAPSHOT",
+	want := map[string]versionInfo{
+		"google-cloud-accessapproval": {Released: "2.86.0", Current: "2.87.0-SNAPSHOT"},
+		"google-cloud-aiplatform":     {Released: "3.86.0", Current: "3.87.0-SNAPSHOT"},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Introduces an explicit Java config for `released_version` instead of deriving it from `library.version`. Because the derive logic does not work for partial release case that bumps patch versions.
This value is used for generating README.md and sync back to versions.txt for new modules.

In this change, `released_version` needs to be explicitly specified for each library that generated. Will work on a followup to Fill derived version and allow omitting this for most libraries.

For #6244

BEGIN_COMMIT_OVERRIDE
fix(librarian/internal/java): explicitly list released_version as config
END_COMMIT_OVERRIDE