### PR TITLE
fix(sidekick/rust): fix tracing template generation for discovery-based LROs

### DIFF
--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -45,6 +45,7 @@ type methodAnnotation struct {
 	ResourceNameTemplateGrpc  string
 	GrpcResourceNameArgs      []string
 	IsLroPoller               bool
+	IsDiscoveryLro            bool
 }
 
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
@@ -114,6 +115,7 @@ func (info *operationInfo) NoneAreEmpty() bool {
 type discoveryLroAnnotations struct {
 	MethodName            string
 	ReturnType            string
+	ServiceNameToPascal   string
 	PollingPathParameters []discoveryLroPathParameter
 }
 
@@ -313,6 +315,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
 		IsLroPoller:               m.IsLroPoller,
+		IsDiscoveryLro:            isDiscoveryLro(m),
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {
@@ -332,16 +335,19 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		if err != nil {
 			return nil, err
 		}
-		m.OperationInfo.Codec = &operationInfo{
+		opInfo := &operationInfo{
 			MetadataType:     metadataType,
 			ResponseType:     responseType,
 			PackageNamespace: c.rootModuleName(m.Model),
 		}
+		m.OperationInfo.Codec = opInfo
+		annotation.OperationInfo = opInfo
 	}
 	if m.DiscoveryLro != nil {
 		lroAnnotation := &discoveryLroAnnotations{
-			MethodName: annotation.Name,
-			ReturnType: returnType,
+			MethodName:          annotation.Name,
+			ReturnType:          returnType,
+			ServiceNameToPascal: annotation.ServiceNameToPascal,
 		}
 		for _, p := range m.DiscoveryLro.PollingPathParameters {
 			a := discoveryLroPathParameter{
@@ -354,6 +360,18 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 	}
 	m.Codec = annotation
 	return annotation, nil
+}
+
+func isDiscoveryLro(m *api.Method) bool {
+	if !m.IsLroPoller {
+		return false
+	}
+	if m.Service == nil {
+		return false
+	}
+	return slices.ContainsFunc(m.Service.Methods, func(meth *api.Method) bool {
+		return meth.DiscoveryLro != nil
+	})
 }
 
 func (c *codec) annotateRoutingAccessors(variant *api.RoutingInfoVariant, m *api.Method) ([]string, error) {

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -114,8 +114,9 @@ func TestAnnotateDiscoveryAnnotations(t *testing.T) {
 	}
 	got := gotMethod.DiscoveryLro.Codec.(*discoveryLroAnnotations)
 	want := &discoveryLroAnnotations{
-		MethodName: "delete",
-		ReturnType: "()",
+		MethodName:          "delete",
+		ReturnType:          "()",
+		ServiceNameToPascal: "ResourceService",
 		PollingPathParameters: []discoveryLroPathParameter{
 			{Name: "project", SetterName: "project"},
 			{Name: "zone", SetterName: "zone"},

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -97,6 +97,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
+                        {{^Codec.IsDiscoveryLro}}
                         _span.record("gcp.longrunning.done", op.done);
                         if op.done {
                             let code = match &op.result {
@@ -111,6 +112,11 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                                 _span.record("error.type", google_cloud_gax::error::rpc::Code::from(status.code).to_string());
                             }
                         }
+                        {{/Codec.IsDiscoveryLro}}
+                        {{#Codec.IsDiscoveryLro}}
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
+                        {{/Codec.IsDiscoveryLro}}
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -114,6 +114,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                         }
                         {{/Codec.IsDiscoveryLro}}
                         {{#Codec.IsDiscoveryLro}}
+                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
                         let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
                         _span.record("gcp.longrunning.done", done);
                         {{/Codec.IsDiscoveryLro}}


### PR DESCRIPTION
Fix compilation and tracing errors for discovery-based LROs (such as `compute`). 

The generator template now registers the `IsDiscoveryLro` boolean and exposes the Pascal-cased service name namespace. 

We resolve compilation errors by checking Discovery operation status with `DiscoveryOperation::done` instead of accessing nonexistent standard AIP-151 fields. We also populate blank namespace paths.

Staged @ [ca80780](https://github.com/googleapis/google-cloud-rust/pull/5629/commits/ca80780280a16b9d2cd1cb4f25097a7a6d1283d9)

Follow up 1 for https://github.com/googleapis/google-cloud-rust/pull/5695