### PR TITLE
feat(sidekick/rust): use consolidated `LroRecorder` in tracing decorator

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -83,8 +83,10 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         {{#Codec.IsLroPoller}}
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
-                _span.record("gcp.longrunning.poll_attempt_count", attempt);
+            if let Some(recorder) = google_cloud_lro::LroRecorder::current() {
+                if let Some(attempt) = recorder.attempt_count() {
+                    _span.record("gcp.longrunning.poll_attempt_count", attempt);
+                }
                 _span.record("gcp.longrunning.done", false);
             }
         }
@@ -93,7 +95,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c).is_ok() {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();


### PR DESCRIPTION
Update the template to generate code using our new consolidated `LroRecorder` API (https://github.com/googleapis/google-cloud-rust/pull/5803). 

Instead of querying the separated `POLL_ATTEMPT_COUNT` task-local directly, the telemetry stubs will now query the active recorder.

Staged @ https://github.com/googleapis/google-cloud-rust/pull/5804

Follow up 2 for https://github.com/googleapis/google-cloud-rust/pull/5695