### PR TITLE
feat(sidekick/swift): map-based pagination

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -153,7 +153,18 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 			return fmt.Errorf("internal error: pageable item field %q is not annotated", itemField.Name)
 		}
 		annotations.PageableItemField = itemFieldCodec.Name
-		annotations.PageableItemType = itemFieldCodec.BaseFieldType
+		switch {
+		case itemField.Repeated:
+			annotations.PageableItemType = itemFieldCodec.BaseFieldType
+		case itemField.Map:
+			keyType, valueType, err := c.mapFieldTypeComponents(itemField.MessageType)
+			if err != nil {
+				return err
+			}
+			annotations.PageableItemType = fmt.Sprintf("(%s, %s)", keyType, valueType)
+		default:
+			return fmt.Errorf("pageable item field should be a map or a repeated field: %s", message.ID)
+		}
 	}
 
 	for _, nested := range message.Messages {

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -107,7 +107,7 @@ func TestAnnotateMessage(t *testing.T) {
 				},
 				Pagination: &api.PaginationInfo{
 					NextPageToken: &api.Field{Name: "next_page_token", JSONName: "nextPageToken", Typez: api.TypezString},
-					PageableItem:  &api.Field{Name: "pageable_item", JSONName: "pageableItem", Typez: api.TypezString, Codec: &fieldAnnotations{Name: "secretKey", BaseFieldType: "SecretKey"}},
+					PageableItem:  &api.Field{Name: "pageable_item", JSONName: "pageableItem", Typez: api.TypezString, Repeated: true, Codec: &fieldAnnotations{Name: "secretKey", BaseFieldType: "SecretKey"}},
 				},
 			},
 			want: &messageAnnotations{

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -62,6 +62,14 @@ func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
 }
 
 func (c *codec) mapFieldTypeName(m *api.Message) (string, error) {
+	keyType, valueType, err := c.mapFieldTypeComponents(m)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("[%s: %s]", keyType, valueType), nil
+}
+
+func (c *codec) mapFieldTypeComponents(m *api.Message) (string, string, error) {
 	var keyField, valueField *api.Field
 	for _, f := range m.Fields {
 		switch f.Name {
@@ -72,17 +80,17 @@ func (c *codec) mapFieldTypeName(m *api.Message) (string, error) {
 		}
 	}
 	if keyField == nil || valueField == nil {
-		return "", fmt.Errorf("map message %q missing key or value field", m.ID)
+		return "", "", fmt.Errorf("map message %q missing key or value field", m.ID)
 	}
 	keyType, err := c.baseFieldTypeName(keyField)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	valueType, err := c.baseFieldTypeName(valueField)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return fmt.Sprintf("[%s: %s]", keyType, valueType), nil
+	return keyType, valueType, nil
 }
 
 func scalarFieldTypeName(field *api.Field) (string, error) {

--- a/internal/sidekick/swift/generate_pagination_swift_test.go
+++ b/internal/sidekick/swift/generate_pagination_swift_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerateService_MapPagination(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		optional          bool
+		wantNextPageToken string
+	}{
+		{
+			name:     "Required",
+			optional: false,
+			wantNextPageToken: `public func _nextPageToken() -> Swift.String {
+    return self.nextPageToken
+  }`,
+		},
+		{
+			name:     "Optional",
+			optional: true,
+			wantNextPageToken: `public func _nextPageToken() -> Swift.String {
+    return self.nextPageToken ?? ""
+  }`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outDir := t.TempDir()
+
+			pageSizeField := &api.Field{Name: "page_size", JSONName: "pageSize", Typez: api.TypezInt32}
+			pageTokenField := &api.Field{Name: "page_token", JSONName: "pageToken", Typez: api.TypezString}
+			inputType := &api.Message{
+				Name:    "ListSecretsRequest",
+				Package: "google.cloud.secretmanager.v1",
+				ID:      ".google.cloud.secretmanager.v1.ListSecretsRequest",
+				Fields:  []*api.Field{pageSizeField, pageTokenField},
+			}
+			pageSizeField.Parent = inputType
+			pageTokenField.Parent = inputType
+
+			secretType := &api.Message{
+				Name:    "Secret",
+				Package: "google.cloud.secretmanager.v1",
+				ID:      ".google.cloud.secretmanager.v1.Secret",
+			}
+
+			keyField := &api.Field{Name: "key", JSONName: "key", Typez: api.TypezString}
+			valueField := &api.Field{Name: "value", JSONName: "value", Typez: api.TypezMessage, TypezID: secretType.ID, MessageType: secretType}
+			mapEntryType := &api.Message{
+				Name:    "SecretsEntry",
+				Package: "google.cloud.secretmanager.v1",
+				ID:      ".google.cloud.secretmanager.v1.ListSecretsResponse.SecretsEntry",
+				IsMap:   true,
+				Fields:  []*api.Field{keyField, valueField},
+			}
+			keyField.Parent = mapEntryType
+			valueField.Parent = mapEntryType
+
+			itemField := &api.Field{Name: "secrets", JSONName: "secrets", Typez: api.TypezMessage, TypezID: mapEntryType.ID, MessageType: mapEntryType, Map: true}
+			nextPageTokenField := &api.Field{Name: "next_page_token", JSONName: "nextPageToken", Typez: api.TypezString, Optional: test.optional}
+			outputType := &api.Message{
+				Name:    "ListSecretsResponse",
+				Package: "google.cloud.secretmanager.v1",
+				ID:      ".google.cloud.secretmanager.v1.ListSecretsResponse",
+				Fields:  []*api.Field{itemField, nextPageTokenField},
+				Pagination: &api.PaginationInfo{
+					NextPageToken: nextPageTokenField,
+					PageableItem:  itemField,
+				},
+			}
+			itemField.Parent = outputType
+			nextPageTokenField.Parent = outputType
+
+			iam := &api.Service{
+				Name: "SecretManagerService",
+				Methods: []*api.Method{
+					{
+						Name:          "ListSecrets",
+						Documentation: "Lists secrets.",
+						InputTypeID:   inputType.ID,
+						InputType:     inputType,
+						OutputTypeID:  outputType.ID,
+						OutputType:    outputType,
+						PathInfo: &api.PathInfo{
+							Bindings: []*api.PathBinding{{
+								Verb:         "GET",
+								PathTemplate: (&api.PathTemplate{}).WithLiteral("v1").WithLiteral("secrets"),
+							}},
+						},
+						Pagination: pageTokenField,
+					},
+				},
+			}
+
+			model := api.NewTestAPI([]*api.Message{inputType, outputType, secretType, mapEntryType}, nil, []*api.Service{iam})
+			model.PackageName = "google.cloud.secretmanager.v1"
+
+			cfg := &parser.ModelConfig{
+				Codec: map[string]string{
+					"copyright-year": "2038",
+				},
+			}
+
+			swiftCfg := swiftConfig(t, []config.SwiftDependency{
+				{
+					Name:               "GoogleCloudGax",
+					RequiredByServices: true,
+				},
+				{
+					Name:               "GoogleCloudAuth",
+					RequiredByServices: true,
+				},
+			})
+
+			if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+				t.Fatal(err)
+			}
+
+			verifyGeneratedMapService(t, outDir)
+			verifyGeneratedMapResponse(t, outDir, test.wantNextPageToken)
+		})
+	}
+}
+
+func verifyGeneratedMapService(t *testing.T, outDir string) {
+	t.Helper()
+	filename := filepath.Join(outDir, "Sources", "GoogleCloudSecretmanagerV1", "SecretManagerService.swift")
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+
+	gotMethodOverload := extractBlock(t, contentStr, `  public func listSecrets(
+    byItem: `, "\n    }")
+	wantMethodOverload := `  public func listSecrets(
+    byItem: ListSecretsRequest, options: GoogleCloudGax.RequestOptions
+) throws -> any AsyncSequence<(Swift.String, Secret), Swift.Error>
+ {
+      let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
+        var request = byItem
+        request.pageToken = token
+        return try await self.listSecrets(request: request, options: options)
+      }
+      return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
+    }`
+	if diff := cmp.Diff(wantMethodOverload, gotMethodOverload); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func verifyGeneratedMapResponse(t *testing.T, outDir string, wantNextPageToken string) {
+	t.Helper()
+	respFilename := filepath.Join(outDir, "Sources", "GoogleCloudSecretmanagerV1", "ListSecretsResponse.swift")
+	respContent, err := os.ReadFile(respFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	respContentStr := string(respContent)
+
+	gotResponseMessage := extractBlock(t, respContentStr, "public struct ListSecretsResponse: ", "{")
+	for _, p := range []string{"Codable", "Equatable", "GoogleCloudWkt._AnyPackable", "GoogleCloudGax._PaginatedResponse", "Sendable"} {
+		if !strings.Contains(gotResponseMessage, p) {
+			t.Errorf("expected %q in ListSecretsResponse declaration, got: %s", p, gotResponseMessage)
+		}
+	}
+
+	gotGetItems := extractBlock(t, respContentStr, "public func _getPaginatedItems()", "  }")
+	wantGetItems := `public func _getPaginatedItems() -> [(Swift.String, Secret)] {
+    return self.secrets.map { ($0, $1) }
+  }`
+	if diff := cmp.Diff(wantGetItems, gotGetItems); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	gotNextPageToken := extractBlock(t, respContentStr, "public func _nextPageToken()", "  }")
+	if diff := cmp.Diff(wantNextPageToken, gotNextPageToken); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -170,7 +170,12 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
   {{#Codec.IsPaginatedResponse}}
 
   public func _getPaginatedItems() -> [{{Codec.PageableItemType}}] {
+    {{^Pagination.PageableItem.Map}}
     return self.{{Codec.PageableItemField}}
+    {{/Pagination.PageableItem.Map}}
+    {{#Pagination.PageableItem.Map}}
+    return self.{{Codec.PageableItemField}}.map { ($0, $1) }
+    {{/Pagination.PageableItem.Map}}
   }
 
   public func _nextPageToken() -> Swift.String {

--- a/internal/sidekick/swift/templates/common/method_signature/pagination.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/pagination.mustache
@@ -15,4 +15,4 @@ limitations under the License.
 }}
 {{Codec.Name}}(
   byItem: {{InputType.Codec.Name}}
-) throws -> any AsyncSequence<{{ItemType}}, Swift.Error>
+) throws -> any AsyncSequence<{{OutputType.Codec.PageableItemType}}, Swift.Error>

--- a/internal/sidekick/swift/templates/common/method_signature/pagination_options.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/pagination_options.mustache
@@ -15,4 +15,4 @@ limitations under the License.
 }}
 {{Codec.Name}}(
     byItem: {{InputType.Codec.Name}}, options: GoogleCloudGax.RequestOptions
-) throws -> any AsyncSequence<{{ItemType}}, Swift.Error>
+) throws -> any AsyncSequence<{{OutputType.Codec.PageableItemType}}, Swift.Error>


### PR DESCRIPTION
Some APIs return "aggregated" lists. A typical example may be listing VM instances grouped by zone.

In this case the `items` field is (in Swift notation) a `[K: T]` map. We can convert this to a vector of tuples (in Swift notation: `[(K, T)]`) and then use normal iteration.

Fixes #6235 