### PR TITLE
fix(internal/command): look up executables in custom path environments

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -145,7 +145,9 @@ func buildCmd(ctx context.Context, dir string, env map[string]string, command st
 
 // lookPath searches for cmdName in the directories of the provided pathEnv.
 func lookPath(cmdName string, pathEnv string) (string, error) {
-	if filepath.IsAbs(cmdName) || strings.HasPrefix(cmdName, "./") || strings.HasPrefix(cmdName, "../") {
+	if filepath.IsAbs(cmdName) ||
+		strings.Contains(cmdName, string(filepath.Separator)) ||
+		filepath.VolumeName(cmdName) != "" {
 		return cmdName, nil
 	}
 	for _, dir := range filepath.SplitList(pathEnv) {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 const (
@@ -113,7 +115,15 @@ func OutputWithEnv(ctx context.Context, env map[string]string, command string, a
 }
 
 func buildCmd(ctx context.Context, dir string, env map[string]string, command string, arg ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, command, arg...)
+	pathEnv := os.Getenv("PATH")
+	if env != nil && env["PATH"] != "" {
+		pathEnv = env["PATH"]
+	}
+	resolvedCommand, err := lookPath(command, pathEnv)
+	if err != nil {
+		resolvedCommand = command
+	}
+	cmd := exec.CommandContext(ctx, resolvedCommand, arg...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -127,6 +137,23 @@ func buildCmd(ctx context.Context, dir string, env map[string]string, command st
 		fmt.Fprintf(stdout, "%s\n", cmd.String())
 	}
 	return cmd
+}
+
+// lookPath searches for cmdName in the directories of the provided pathEnv.
+func lookPath(cmdName string, pathEnv string) (string, error) {
+	if filepath.IsAbs(cmdName) || strings.HasPrefix(cmdName, "./") || strings.HasPrefix(cmdName, "../") {
+		return cmdName, nil
+	}
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			dir = "."
+		}
+		commandPath := filepath.Join(dir, cmdName)
+		if fileInfo, err := os.Stat(commandPath); err == nil && !fileInfo.IsDir() {
+			return filepath.Abs(commandPath)
+		}
+	}
+	return "", &exec.Error{Name: cmdName, Err: exec.ErrNotFound}
 }
 
 func runCmd(ctx context.Context, dir string, env map[string]string, command string, arg ...string) (string, error) {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -33,6 +33,8 @@ const (
 	Git = "git"
 	// Go is the command name for the go executable.
 	Go = "go"
+	// envPath is the environment variable for the executable path.
+	envPath = "PATH"
 )
 
 var (
@@ -115,9 +117,9 @@ func OutputWithEnv(ctx context.Context, env map[string]string, command string, a
 }
 
 func buildCmd(ctx context.Context, dir string, env map[string]string, command string, arg ...string) *exec.Cmd {
-	pathEnv := os.Getenv("PATH")
-	if env != nil && env["PATH"] != "" {
-		pathEnv = env["PATH"]
+	pathEnv := os.Getenv(envPath)
+	if env != nil && env[envPath] != "" {
+		pathEnv = env[envPath]
 	}
 	resolvedCommand, err := lookPath(command, pathEnv)
 	if err != nil {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -118,8 +118,10 @@ func OutputWithEnv(ctx context.Context, env map[string]string, command string, a
 
 func buildCmd(ctx context.Context, dir string, env map[string]string, command string, arg ...string) *exec.Cmd {
 	pathEnv := os.Getenv(envPath)
-	if env != nil && env[envPath] != "" {
-		pathEnv = env[envPath]
+	if env != nil {
+		if val, ok := env[envPath]; ok {
+			pathEnv = val
+		}
 	}
 	resolvedCommand, err := lookPath(command, pathEnv)
 	if err != nil {
@@ -152,6 +154,9 @@ func lookPath(cmdName string, pathEnv string) (string, error) {
 		}
 		commandPath := filepath.Join(dir, cmdName)
 		if fileInfo, err := os.Stat(commandPath); err == nil && !fileInfo.IsDir() {
+			if filepath.Separator != '\\' && fileInfo.Mode().Perm()&0111 == 0 {
+				continue
+			}
 			return filepath.Abs(commandPath)
 		}
 	}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -253,3 +253,73 @@ func TestRunStreaming_Error(t *testing.T) {
 		t.Errorf("err.Error() should mention the invalid subcommand; got %q", err.Error())
 	}
 }
+
+func TestLookPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	exeName := "test-exe"
+	exePath := filepath.Join(tmpDir, exeName)
+	if err := os.WriteFile(exePath, []byte("dummy binary content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		cmdName string
+		pathEnv string
+		want    string
+	}{
+		{
+			name:    "absolute path bypasses search",
+			cmdName: exePath,
+			pathEnv: "/dummy/path",
+			want:    exePath,
+		},
+		{
+			name:    "relative path bypasses search",
+			cmdName: "./" + exeName,
+			pathEnv: "/dummy/path",
+			want:    "./" + exeName,
+		},
+		{
+			name:    "found in custom pathEnv",
+			cmdName: exeName,
+			pathEnv: "/another/path:" + tmpDir + ":/yet/another/path",
+			want:    exePath,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := lookPath(test.cmdName, test.pathEnv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("lookPath() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestLookPath_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		cmdName string
+		pathEnv string
+	}{
+		{
+			name:    "not found in custom pathEnv",
+			cmdName: "test-exe",
+			pathEnv: "/another/path:/yet/another/path",
+		},
+		{
+			name:    "empty pathEnv item defaults to current dir",
+			cmdName: "test-exe",
+			pathEnv: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := lookPath(test.cmdName, test.pathEnv)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -280,6 +280,12 @@ func TestLookPath(t *testing.T) {
 			want:    "./" + exeName,
 		},
 		{
+			name:    "parent path bypasses search",
+			cmdName: "../" + exeName,
+			pathEnv: "/dummy/path",
+			want:    "../" + exeName,
+		},
+		{
 			name:    "found in custom pathEnv",
 			cmdName: exeName,
 			pathEnv: "/another/path:" + tmpDir + ":/yet/another/path",

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -305,6 +305,12 @@ func TestLookPath(t *testing.T) {
 }
 
 func TestLookPath_Error(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirName := "test-dir"
+	if err := os.MkdirAll(filepath.Join(tmpDir, dirName), 0755); err != nil {
+		t.Fatal(err)
+	}
+
 	for _, test := range []struct {
 		name    string
 		cmdName string
@@ -315,6 +321,12 @@ func TestLookPath_Error(t *testing.T) {
 			name:    "not found in custom pathEnv",
 			cmdName: "test-exe",
 			pathEnv: "/another/path:/yet/another/path",
+			wantErr: exec.ErrNotFound,
+		},
+		{
+			name:    "matching path is a directory (non-executable)",
+			cmdName: dirName,
+			pathEnv: tmpDir,
 			wantErr: exec.ErrNotFound,
 		},
 	} {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -307,7 +307,7 @@ func TestLookPath(t *testing.T) {
 func TestLookPath_Error(t *testing.T) {
 	tmpDir := t.TempDir()
 	dirName := "test-dir"
-	if err := os.MkdirAll(filepath.Join(tmpDir, dirName), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, dirName), []byte("non-executable file"), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -291,8 +291,8 @@ func TestLookPath(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != test.want {
-				t.Errorf("lookPath() = %q, want %q", got, test.want)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -303,22 +303,19 @@ func TestLookPath_Error(t *testing.T) {
 		name    string
 		cmdName string
 		pathEnv string
+		wantErr error
 	}{
 		{
 			name:    "not found in custom pathEnv",
 			cmdName: "test-exe",
 			pathEnv: "/another/path:/yet/another/path",
-		},
-		{
-			name:    "empty pathEnv item defaults to current dir",
-			cmdName: "test-exe",
-			pathEnv: "",
+			wantErr: exec.ErrNotFound,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := lookPath(test.cmdName, test.pathEnv)
-			if err == nil {
-				t.Fatal("expected error, got nil")
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("lookPath() error = %v, want %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -247,7 +247,7 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		g, gctx = errgroup.WithContext(ctx)
 		for _, library := range libraries {
 			g.Go(func() error {
-				if err := golang.Format(gctx, library, cfg.Tools); err != nil {
+				if err := golang.Format(gctx, library); err != nil {
 					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
 				}
 				return nil

--- a/internal/librarian/golang/format.go
+++ b/internal/librarian/golang/format.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Format formats a generated Go library.
-func Format(ctx context.Context, library *config.Library, tools *config.Tools) error {
+func Format(ctx context.Context, library *config.Library) error {
 	// No need to format the root module because it does not
 	// have generated code.
 	if library.Name == rootModule {

--- a/internal/librarian/golang/format_test.go
+++ b/internal/librarian/golang/format_test.go
@@ -103,7 +103,7 @@ func main() {
 					t.Fatal(err)
 				}
 			}
-			if err := Format(t.Context(), test.library, nil); err != nil {
+			if err := Format(t.Context(), test.library); err != nil {
 				t.Fatal(err)
 			}
 			for _, aPath := range test.goFilePath {


### PR DESCRIPTION
When building commands via `buildCmd`, Go's `exec.CommandContext` resolves non-absolute executable names using the parent process's system `PATH` before custom environment maps (such as custom tool directories) are attached. This fails if the target executable is not globally installed on the parent `PATH`.

To resolve this, a lookPath helper is added that manually resolves the executable's absolute path using the provided custom `PATH` environment before `exec.CommandContext` is invoked. Since the binary is resolved to a fully qualified absolute path, Go successfully bypasses the parent system `PATH` lookup.

Tested in https://github.com/JoeWang1127/google-cloud-go/pull/27

Fixes #6271