### PR TITLE
fix(internal/librarian/java): allow omitting ReleasedVersion with fill and tidy

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -328,7 +328,7 @@ This document describes the schema for the librarian.yaml.
 | `group_id` | string | Is the Maven group ID, defaults to "com.google.cloud". |
 | `issue_tracker_override` | string | Allows the "issue_tracker" field in .repo-metadata.json to be overridden. |
 | `libraries_bom_version` | string | Is the version of the libraries-bom to use for Java. |
-| `released_version` | string | Is the last released version of the library. Needs to be explicitly listed for README generation. |
+| `released_version` | string | Is the last released version of the library. If omitted, it will be derived from the library version. Note: It assumes a minor bump from the previous '.0' version (e.g., '1.2.0-SNAPSHOT' -> '1.1.0') and does not support deriving previous patch releases (e.g., '1.1.1'). |
 | `library_type_override` | string | Allows the "library_type" field in .repo-metadata.json to be overridden. |
 | `min_java_version` | int | Is the minimum Java version required. |
 | `name_pretty_override` | string | Allows the "name_pretty" field in .repo-metadata.json to be overridden. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -523,7 +523,10 @@ type JavaModule struct {
 	LibrariesBOMVersion string `yaml:"libraries_bom_version,omitempty"`
 
 	// ReleasedVersion is the last released version of the library.
-	// Needs to be explicitly listed for README generation.
+	// If omitted, it will be derived from the library version.
+	// Note: It assumes a minor bump from the previous '.0' version
+	// (e.g., '1.2.0-SNAPSHOT' -> '1.1.0') and does not support
+	// deriving previous patch releases (e.g., '1.1.1').
 	ReleasedVersion string `yaml:"released_version,omitempty"`
 
 	// LibraryTypeOverride allows the "library_type" field in .repo-metadata.json

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1064,9 +1064,6 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 					},
 				},
 			},
-			Java: &config.JavaModule{
-				ReleasedVersion: "0.0.0",
-			},
 		},
 	}
 	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -172,10 +172,6 @@ var (
 	// ErrOmitCommonResourcesConflict is returned when OmitCommonResources is true
 	// but common_resources.proto is also explicitly listed in AdditionalProtos.
 	ErrOmitCommonResourcesConflict = errors.New("conflict: OmitCommonResources is true but google/cloud/common_resources.proto is explicitly listed in AdditionalProtos")
-	// ErrReleasedVersionRequired is returned when released_version is missing.
-	ErrReleasedVersionRequired = errors.New("released_version is required under java section")
-	// ErrInvalidReleasedVersion is returned when released_version is not a valid semver.
-	ErrInvalidReleasedVersion = errors.New("invalid released_version")
 	// ErrCannotDeriveReleasedVersion is returned when released_version cannot be derived.
 	ErrCannotDeriveReleasedVersion = errors.New("cannot derive released version")
 )
@@ -184,20 +180,14 @@ var (
 // correctly formatted. It ensures that there are no conflicts in common
 // resources configuration.
 func Validate(library *config.Library) error {
-	if !library.SkipGenerate {
-		releasedVersion := ""
-		if library.Java != nil {
-			releasedVersion = library.Java.ReleasedVersion
+	if library.Version != "" {
+		if _, err := semver.Parse(library.Version); err != nil {
+			return fmt.Errorf("library %q: invalid version %q: %w", library.Name, library.Version, err)
 		}
-		if releasedVersion == "" {
-			derived, err := deriveLastReleasedVersion(library.Version)
-			if err != nil {
-				return fmt.Errorf("library %q: %w: %w", library.Name, ErrReleasedVersionRequired, err)
-			}
-			releasedVersion = derived
-		}
-		if _, err := semver.Parse(releasedVersion); err != nil {
-			return fmt.Errorf("library %q: %w: %w", library.Name, ErrInvalidReleasedVersion, err)
+	}
+	if !library.SkipGenerate && library.Java != nil && library.Java.ReleasedVersion != "" {
+		if _, err := semver.Parse(library.Java.ReleasedVersion); err != nil {
+			return fmt.Errorf("library %q: invalid released_version %q: %w", library.Name, library.Java.ReleasedVersion, err)
 		}
 	}
 	for _, api := range library.APIs {

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/semver"
@@ -30,6 +31,8 @@ const (
 	defaultArtifactIDPrefix = "google-cloud-"
 	defaultGroupID          = "com.google.cloud"
 )
+
+var errInvalidVersion = errors.New("invalid java library version")
 
 func deriveArtifactID(name string) string {
 	return defaultArtifactIDPrefix + name
@@ -53,6 +56,13 @@ func Fill(library *config.Library) (*config.Library, error) {
 	}
 	if library.Java.GroupID == "" {
 		library.Java.GroupID = defaultGroupID
+	}
+	if library.Java.ReleasedVersion == "" && !library.SkipGenerate && library.Version != "" {
+		derived, err := deriveLastReleasedVersion(library.Version)
+		if err != nil {
+			return nil, fmt.Errorf("library %q: %w", library.Name, err)
+		}
+		library.Java.ReleasedVersion = derived
 	}
 	for _, api := range library.APIs {
 		if api.Java == nil {
@@ -91,6 +101,12 @@ func Tidy(library *config.Library) (*config.Library, error) {
 		}
 		if library.Java.GroupID == defaultGroupID {
 			library.Java.GroupID = ""
+		}
+		if library.Java.ReleasedVersion != "" {
+			derived, err := deriveLastReleasedVersion(library.Version)
+			if err == nil && library.Java.ReleasedVersion == derived {
+				library.Java.ReleasedVersion = ""
+			}
 		}
 		empty, err := yaml.Empty(library.Java)
 		if err != nil {
@@ -162,6 +178,8 @@ var (
 	ErrReleasedVersionRequired = errors.New("released_version is required under java section")
 	// ErrInvalidReleasedVersion is returned when released_version is not a valid semver.
 	ErrInvalidReleasedVersion = errors.New("invalid released_version")
+	// ErrCannotDeriveReleasedVersion is returned when released_version cannot be derived.
+	ErrCannotDeriveReleasedVersion = errors.New("cannot derive released version")
 )
 
 // Validate checks that the Java-specific configuration for a library is
@@ -169,10 +187,18 @@ var (
 // resources configuration.
 func Validate(library *config.Library) error {
 	if !library.SkipGenerate {
-		if library.Java == nil || library.Java.ReleasedVersion == "" {
-			return fmt.Errorf("library %q: %w", library.Name, ErrReleasedVersionRequired)
+		releasedVersion := ""
+		if library.Java != nil {
+			releasedVersion = library.Java.ReleasedVersion
 		}
-		if _, err := semver.Parse(library.Java.ReleasedVersion); err != nil {
+		if releasedVersion == "" {
+			derived, err := deriveLastReleasedVersion(library.Version)
+			if err != nil {
+				return fmt.Errorf("library %q: %w: %w", library.Name, ErrReleasedVersionRequired, err)
+			}
+			releasedVersion = derived
+		}
+		if _, err := semver.Parse(releasedVersion); err != nil {
 			return fmt.Errorf("library %q: %w: %w", library.Name, ErrInvalidReleasedVersion, err)
 		}
 	}
@@ -188,4 +214,32 @@ func Validate(library *config.Library) error {
 
 	}
 	return nil
+}
+
+// deriveLastReleasedVersion derives the last released version from a snapshot version
+// (e.g., x.y.z-SNAPSHOT or x.y.z-beta-SNAPSHOT) by decrementing the patch or minor version.
+// If the version has a prerelease tag (like "beta") before "SNAPSHOT", that tag is preserved
+// in the derived version (e.g., x.y.z-beta-SNAPSHOT becomes x.y.(z-1)-beta).
+//
+// It returns an error if both minor and patch versions are zero, as it's
+// ambiguous what the last released version was in that case.
+func deriveLastReleasedVersion(v string) (string, error) {
+	sv, err := semver.Parse(v)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasSuffix(sv.Prerelease, "SNAPSHOT") {
+		return sv.String(), nil
+	}
+	if sv.Patch > 0 {
+		sv.Patch--
+	} else if sv.Minor > 0 {
+		sv.Minor--
+		sv.Patch = 0
+	} else {
+		return "", errInvalidVersion
+	}
+	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "SNAPSHOT")
+	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "-")
+	return sv.String(), nil
 }

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -32,8 +32,6 @@ const (
 	defaultGroupID          = "com.google.cloud"
 )
 
-var errInvalidVersion = errors.New("invalid java library version")
-
 func deriveArtifactID(name string) string {
 	return defaultArtifactIDPrefix + name
 }
@@ -237,7 +235,7 @@ func deriveLastReleasedVersion(v string) (string, error) {
 		sv.Minor--
 		sv.Patch = 0
 	} else {
-		return "", errInvalidVersion
+		return "", ErrCannotDeriveReleasedVersion
 	}
 	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "SNAPSHOT")
 	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "-")

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/semver"
 )
 
 func TestFill(t *testing.T) {
@@ -164,6 +165,41 @@ func TestFill(t *testing.T) {
 				Output: "java-secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "custom-secretmanager",
+					GroupID:    "com.google.cloud",
+				},
+			},
+		},
+		{
+			name: "fill released version from version",
+			lib: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+			},
+			want: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+				Output:  "java-secretmanager",
+				Java: &config.JavaModule{
+					ArtifactID:      "google-cloud-secretmanager",
+					GroupID:         "com.google.cloud",
+					ReleasedVersion: "1.1.0",
+				},
+			},
+		},
+		{
+			name: "do not fill released version if skip generate",
+			lib: &config.Library{
+				Name:         "secretmanager",
+				Version:      "1.2.0-SNAPSHOT",
+				SkipGenerate: true,
+			},
+			want: &config.Library{
+				Name:         "secretmanager",
+				Version:      "1.2.0-SNAPSHOT",
+				SkipGenerate: true,
+				Output:       "java-secretmanager",
+				Java: &config.JavaModule{
+					ArtifactID: "google-cloud-secretmanager",
 					GroupID:    "com.google.cloud",
 				},
 			},
@@ -397,6 +433,37 @@ func TestTidy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tidy released version if same as derived",
+			lib: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.1.0",
+				},
+			},
+			want: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+			},
+		},
+		{
+			name: "do not tidy released version if different from derived",
+			lib: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.1.2",
+				},
+			},
+			want: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.1.2",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := Tidy(test.lib)
@@ -429,6 +496,13 @@ func TestValidate(t *testing.T) {
 			lib: &config.Library{
 				Name:         "google-cloud-java",
 				SkipGenerate: true,
+			},
+		},
+		{
+			name: "valid java config with derivable released version",
+			lib: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
 			},
 		},
 	} {
@@ -492,6 +566,15 @@ func TestValidate_Error(t *testing.T) {
 			},
 			wantErr: ErrOmitCommonResourcesConflict,
 		},
+		{
+			name: "missing released version and underivable version",
+			lib: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.0.0-SNAPSHOT",
+				Java:    &config.JavaModule{},
+			},
+			wantErr: ErrReleasedVersionRequired,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := Validate(test.lib)
@@ -545,6 +628,58 @@ func TestTidyKeep(t *testing.T) {
 			got := tidyKeep(test.keep)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeriveLastReleasedVersion(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "1.2.0-SNAPSHOT", want: "1.1.0"},
+		{input: "1.10.0-SNAPSHOT", want: "1.9.0"},
+		{input: "0.87.0-SNAPSHOT", want: "0.86.0"},
+		{input: "0.0.1-SNAPSHOT", want: "0.0.0"},
+		{input: "1.10.1-SNAPSHOT", want: "1.10.0"},
+		{input: "0.214.0-beta-SNAPSHOT", want: "0.213.0-beta"},
+		{input: "0.214.0-beta", want: "0.214.0-beta"},
+		{input: "1.2.3", want: "1.2.3"},
+	} {
+		t.Run(test.input, func(t *testing.T) {
+			got, err := deriveLastReleasedVersion(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeriveLastReleasedVersion_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{
+			name:    "invalid version",
+			input:   "1.invalid.0-SNAPSHOT",
+			wantErr: semver.ErrInvalidVersion,
+		},
+		{
+			name:    "v1.0.0 snapshot",
+			input:   "1.0.0-SNAPSHOT",
+			wantErr: errInvalidVersion,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := deriveLastReleasedVersion(test.input)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -521,19 +521,21 @@ func TestValidate_Error(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "missing java section",
+			name: "invalid version",
 			lib: &config.Library{
-				Name: "secretmanager",
+				Name:    "secretmanager",
+				Version: "invalid-semver",
 			},
-			wantErr: ErrReleasedVersionRequired,
+			wantErr: semver.ErrInvalidVersion,
 		},
 		{
-			name: "missing released version",
+			name: "invalid version with skip generate",
 			lib: &config.Library{
-				Name: "secretmanager",
-				Java: &config.JavaModule{},
+				Name:         "secretmanager",
+				Version:      "invalid-semver",
+				SkipGenerate: true,
 			},
-			wantErr: ErrReleasedVersionRequired,
+			wantErr: semver.ErrInvalidVersion,
 		},
 		{
 			name: "invalid released version",
@@ -543,7 +545,7 @@ func TestValidate_Error(t *testing.T) {
 					ReleasedVersion: "invalid-semver",
 				},
 			},
-			wantErr: ErrInvalidReleasedVersion,
+			wantErr: semver.ErrInvalidVersion,
 		},
 		{
 			name: "omit common resources conflict",
@@ -565,15 +567,6 @@ func TestValidate_Error(t *testing.T) {
 				},
 			},
 			wantErr: ErrOmitCommonResourcesConflict,
-		},
-		{
-			name: "missing released version and underivable version",
-			lib: &config.Library{
-				Name:    "secretmanager",
-				Version: "1.0.0-SNAPSHOT",
-				Java:    &config.JavaModule{},
-			},
-			wantErr: ErrReleasedVersionRequired,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -673,7 +673,7 @@ func TestDeriveLastReleasedVersion_Error(t *testing.T) {
 		{
 			name:    "v1.0.0 snapshot",
 			input:   "1.0.0-SNAPSHOT",
-			wantErr: errInvalidVersion,
+			wantErr: ErrCannotDeriveReleasedVersion,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -204,6 +204,26 @@ func TestFill(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "do not overwrite released version",
+			lib: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.1.5",
+				},
+			},
+			want: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0-SNAPSHOT",
+				Output:  "java-secretmanager",
+				Java: &config.JavaModule{
+					ArtifactID:      "google-cloud-secretmanager",
+					GroupID:         "com.google.cloud",
+					ReleasedVersion: "1.1.5",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := Fill(test.lib)


### PR DESCRIPTION
Bring back `deriveLastReleasedVersion`, so that `released_version` does not needs to be explicitly listed in librarian.yaml when can be derived. Fill `released_version` when omitted and Tidy to remove `released_version`  when same as derived value.
Followup to https://github.com/googleapis/librarian/pull/6252.

Fixes #6244