### PR TITLE
feat(sidekick/rust): add `gcp.resource.destination.id` and fix incorrect `gcp.longrunning.done` status in lro traces

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -85,9 +85,11 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         {
             if let Some(recorder) = google_cloud_lro::LroRecorder::current() {
                 if let Some(attempt) = recorder.attempt_count() {
-                    _span.record("gcp.longrunning.poll_attempt_count", attempt);
+                    _span.record("gcp.longrunning.poll_attempt_count", attempt as i64);
                 }
-                _span.record("gcp.longrunning.done", false);
+                if let Some(dest_id) = recorder.resource_destination_id() {
+                    _span.record("gcp.resource.destination.id", dest_id);
+                }
             }
         }
         {{/Codec.IsLroPoller}}

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -82,16 +82,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
             self.inner.{{Codec.Name}}(req, options));
         {{#Codec.IsLroPoller}}
         #[cfg(google_cloud_unstable_tracing)]
-        {
-            if let Some(recorder) = google_cloud_lro::LroRecorder::current() {
-                if let Some(attempt) = recorder.attempt_count() {
-                    _span.record("gcp.longrunning.poll_attempt_count", attempt as i64);
-                }
-                if let Some(dest_id) = recorder.resource_destination_id() {
-                    _span.record("gcp.resource.destination.id", dest_id);
-                }
-            }
-        }
+        google_cloud_lro::record_polling_attributes!(&_span);
         {{/Codec.IsLroPoller}}
         {{#Codec.IsLroPoller}}
         let result = pending.await;


### PR DESCRIPTION
Record `gcp.resource.destination.id` directly onto Wait spans by extracting it ambiently from the `LroRecorder` context.

Also fix a bug in the generated poller loop where `gcp.longrunning.done` was incorrectly hardcoded to `false`. The completion status is now accurately parsed and recorded directly from the operation body in the final polling iteration.