### PR TITLE
fix(internal/librarian): preserve derivable API paths with custom language config

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -117,17 +117,24 @@ func tidyLibrary(cfg *config.Config, lib *config.Library) (*config.Library, erro
 	if lib.SpecificationFormat == config.SpecProtobuf {
 		lib.SpecificationFormat = ""
 	}
+	// Tidy language config first so that empty language-specific API configs are cleared.
+	lib, err := tidyLanguageConfig(lib, cfg)
+	if err != nil {
+		return nil, err
+	}
 	// Only remove derivable API paths when there's exactly one API.
 	// When there are multiple APIs, preserve all of them.
 	if len(lib.APIs) == 1 && canDeriveAPIPath(cfg.Language) {
 		if lib.APIs[0].Path == deriveAPIPath(cfg.Language, lib.Name) {
-			lib.APIs[0].Path = ""
+			if lib.APIs[0].Go == nil && lib.APIs[0].Java == nil {
+				lib.APIs[0].Path = ""
+			}
 		}
 	}
 	lib.APIs = slices.DeleteFunc(lib.APIs, func(ch *config.API) bool {
 		return ch.Path == ""
 	})
-	return tidyLanguageConfig(lib, cfg)
+	return lib, nil
 }
 
 func isDerivableOutput(cfg *config.Config, lib *config.Library) bool {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -681,6 +681,77 @@ func TestTidy_DerivableAPIPath(t *testing.T) {
 	}
 }
 
+func TestTidy_DerivableAPIPathWithCustomConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		Language: config.LanguageJava,
+		Default: &config.Default{
+			Output: "generated/",
+		},
+		Sources: &config.Sources{
+			Googleapis: &config.Source{
+				Commit: "94ccedca05acb0bb60780789e93371c9e4100ddc",
+				SHA256: "fff40946e897d96bbdccd566cb993048a87029b7e08eacee3fe99eac792721ba",
+			},
+		},
+		Libraries: []*config.Library{
+			{
+				Name:  "backstory",
+				Roots: []string{"googleapis"},
+				APIs: []*config.API{
+					{
+						Path: "backstory",
+						Java: &config.JavaAPI{
+							GenerateGAPIC: new(bool), // false
+						},
+					},
+				},
+				Java: &config.JavaModule{
+					ReleasedVersion: "0.0.0",
+				},
+			},
+		},
+	}
+	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &config.Config{
+		Language: config.LanguageJava,
+		Default: &config.Default{
+			Output: "generated/",
+		},
+		Sources: &config.Sources{
+			Googleapis: &config.Source{
+				Commit: "94ccedca05acb0bb60780789e93371c9e4100ddc",
+				SHA256: "fff40946e897d96bbdccd566cb993048a87029b7e08eacee3fe99eac792721ba",
+			},
+		},
+		Libraries: []*config.Library{
+			{
+				Name: "backstory",
+				APIs: []*config.API{
+					{
+						Path: "backstory",
+						Java: &config.JavaAPI{
+							GenerateGAPIC: new(bool), // false
+						},
+					},
+				},
+				Java: &config.JavaModule{
+					ReleasedVersion: "0.0.0",
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestTidy_DerivableRoots(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := &config.Config{


### PR DESCRIPTION
Ensures that API entries with custom configurations are preserved, even if their path is derivable.
Moves "tidyLanguageConfig" execution before the API path derivation and only clears the derivable API path if all language-specific configurations (Go and Java) are nil.
"librarian tidy" removes derivable API paths for libraries with a single API to keep the configuration minimal. However, it was doing so unconditionally, discarding any custom language-specific API configurations (like "java: generate_gapic: false") nested within the API entry.

Fixes https://github.com/googleapis/librarian/issues/6282