### PR TITLE
fix(sidekick/swift): warnings in snippets

### DIFF
--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -53,5 +53,8 @@ struct SnippetRunner {
   }
 }
 {{#Codec.IsGated}}
+#else
+@main
+struct SnippetRunner { static func main() {} }
 #endif
 {{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -55,6 +55,8 @@ struct SnippetRunner {
 {{#Codec.IsGated}}
 #else
 @main
-struct SnippetRunner { static func main() {} }
+struct SnippetRunner {
+  static func main() {}
+}
 #endif
 {{/Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
@@ -50,6 +50,8 @@ struct SnippetRunner {
 {{#Service.Codec.IsGated}}
 #else
 @main
-struct SnippetRunner { static func main() {} }
+struct SnippetRunner {
+  static func main() {}
+}
 #endif
 {{/Service.Codec.IsGated}}

--- a/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
@@ -48,5 +48,8 @@ struct SnippetRunner {
     }
 }
 {{#Service.Codec.IsGated}}
+#else
+@main
+struct SnippetRunner { static func main() {} }
 #endif
 {{/Service.Codec.IsGated}}


### PR DESCRIPTION
Clients with per-service traits enabled compiled with warnings. The snippets are empty for any trait that is disabled, and the compiler wants a `main()` function.

Fixes #6266 