### PR TITLE
fix(internal/librarian): disable API path derive for Java

### DIFF
--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -303,7 +303,7 @@ func applyDefaults(language string, lib *config.Library, defaults *config.Defaul
 // derive the API path.
 func canDeriveAPIPath(language string) bool {
 	switch language {
-	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs:
+	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs, config.LanguageJava:
 		return false
 	default:
 		return true

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -746,6 +746,10 @@ func TestCanDeriveAPIPath(t *testing.T) {
 			language: config.LanguageGo,
 		},
 		{
+			name:     "java",
+			language: config.LanguagePython,
+		},
+		{
 			name:     "python",
 			language: config.LanguagePython,
 		},

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -747,7 +747,7 @@ func TestCanDeriveAPIPath(t *testing.T) {
 		},
 		{
 			name:     "java",
-			language: config.LanguagePython,
+			language: config.LanguageJava,
 		},
 		{
 			name:     "python",


### PR DESCRIPTION
Java API path usually cannot be derived from name. Allowing derive caused issue for the new `backstory` library.

Fixes https://github.com/googleapis/librarian/issues/6282