### PR TITLE
feat(sidekick/rust): track recording error info for discovery LROs

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -109,9 +109,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
                         }
                         {{/Codec.IsDiscoveryLro}}
                         {{#Codec.IsDiscoveryLro}}
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                         {{/Codec.IsDiscoveryLro}}
                     }
                     Err(e) => {


### PR DESCRIPTION
Add error telemetry for Discovery LROs so that their traces contain the same error information as standard LROs.

Staged @ https://github.com/googleapis/google-cloud-rust/pull/5861
Fixes #6286