### PR TITLE
feat(sidekick/swift): generate `with` helper

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -38,6 +38,9 @@ type messageAnnotations struct {
 	PageableItemType    string
 	DependsOn           map[string]*Dependency
 
+	// The name of a field to use in message examples.
+	SampleField string
+
 	// GatedBy is the list of package traits that enables this message.
 	//
 	// Empty unless the package is configured with `per_service_traits` enabled.
@@ -90,6 +93,10 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if err != nil {
 		return err
 	}
+	sampleField := "<placeholder>"
+	if len(message.Fields) != 0 {
+		sampleField = camelCase(message.Fields[0].Name)
+	}
 	annotations := &messageAnnotations{
 		Name:                pascalCase(message.Name),
 		DocLines:            docLines,
@@ -97,6 +104,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		TypeURL:             typeURLPrefix + strings.TrimPrefix(message.ID, "."),
 		CustomSerialization: len(message.OneOfs) > 0,
 		DependsOn:           map[string]*Dependency{},
+		SampleField:         sampleField,
 	}
 
 	// Ensure the entire package depends on the package this message belongs to.

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -45,6 +45,7 @@ func TestAnnotateMessage(t *testing.T) {
 				DocLines:            []string{"A secret message.", "With two lines."},
 				TypeURL:             "type.googleapis.com/test.Secret",
 				CustomSerialization: false,
+				SampleField:         "secretKey",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -61,6 +62,7 @@ func TestAnnotateMessage(t *testing.T) {
 				DocLines:            []string{"A message named Protocol."},
 				TypeURL:             "type.googleapis.com/test.Protocol",
 				CustomSerialization: false,
+				SampleField:         "<placeholder>",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -76,6 +78,7 @@ func TestAnnotateMessage(t *testing.T) {
 				Name:                "WithOneof",
 				TypeURL:             "type.googleapis.com/test.WithOneof",
 				CustomSerialization: true,
+				SampleField:         "<placeholder>",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -93,6 +96,7 @@ func TestAnnotateMessage(t *testing.T) {
 				Name:                "WithCustomJSON",
 				TypeURL:             "type.googleapis.com/test.WithCustomJSON",
 				CustomSerialization: true,
+				SampleField:         "secretKey",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -117,6 +121,7 @@ func TestAnnotateMessage(t *testing.T) {
 				IsPaginatedResponse: true,
 				PageableItemField:   "secretKey",
 				PageableItemType:    "SecretKey",
+				SampleField:         "secretKey",
 			},
 			wantImports: []string{"GoogleCloudGax", "GoogleCloudWkt"},
 		},
@@ -206,8 +211,9 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 	// Verify annotations on request message
 	gotRequest := inputType.Codec.(*messageAnnotations)
 	wantRequest := &messageAnnotations{
-		Name:    "ListSecretsRequest",
-		TypeURL: "type.googleapis.com/google.cloud.secretmanager.v1.ListSecretsRequest",
+		Name:        "ListSecretsRequest",
+		TypeURL:     "type.googleapis.com/google.cloud.secretmanager.v1.ListSecretsRequest",
+		SampleField: "pageSize",
 	}
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
@@ -225,6 +231,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		IsPaginatedResponse: true,
 		PageableItemField:   "secrets",
 		PageableItemType:    "Secret",
+		SampleField:         "secrets",
 	}
 	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
@@ -274,8 +281,9 @@ func TestAnnotateMessage_RecursiveNested(t *testing.T) {
 
 	gotOuter := outerMessage.Codec.(*messageAnnotations)
 	wantOuter := &messageAnnotations{
-		Name:    "OuterMessage",
-		TypeURL: "type.googleapis.com/google.cloud.secretmanager.v1.OuterMessage",
+		Name:        "OuterMessage",
+		TypeURL:     "type.googleapis.com/google.cloud.secretmanager.v1.OuterMessage",
+		SampleField: "<placeholder>",
 	}
 	if diff := cmp.Diff(wantOuter, gotOuter, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -365,8 +365,9 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 	// Verify request message annotations
 	gotRequest := inputType.Codec.(*messageAnnotations)
 	wantRequest := &messageAnnotations{
-		Name:    "ListRequest",
-		TypeURL: "type.googleapis.com/test.ListRequest",
+		Name:        "ListRequest",
+		TypeURL:     "type.googleapis.com/test.ListRequest",
+		SampleField: "pageSize",
 	}
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
@@ -384,6 +385,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		IsPaginatedResponse: true,
 		PageableItemField:   "items",
 		PageableItemType:    "Item",
+		SampleField:         "items",
 	}
 	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -314,16 +314,10 @@ func TestGenerateMessage_WithRecursiveTypes(t *testing.T) {
 		t.Errorf("property definition mismatch: want %q; got:\n%s", wantProp, contentStrA)
 	}
 
-	// Verify initializer parameter uses the unwrapped type
-	wantParam := "nodeB: NodeB? = nil"
-	if !strings.Contains(contentStrA, wantParam) {
-		t.Errorf("initializer parameter mismatch: want %q; got:\n%s", wantParam, contentStrA)
-	}
-
-	// Verify initializer maps the value
-	wantMap := "self.nodeB = nodeB.map { GoogleCloudWkt.Recursive(value: $0) }"
-	if !strings.Contains(contentStrA, wantMap) {
-		t.Errorf("initializer body mapping mismatch: want %q; got:\n%s", wantMap, contentStrA)
+	// Verify initializer is the default initializer
+	wantInit := "public init() {}"
+	if !strings.Contains(contentStrA, wantInit) {
+		t.Errorf("initializer mismatch: want %q; got:\n%s", wantInit, contentStrA)
 	}
 }
 
@@ -376,16 +370,10 @@ func TestGenerateMessage_SelfRecursive(t *testing.T) {
 		t.Errorf("property definition mismatch: want %q; got:\n%s", wantProp, contentStr)
 	}
 
-	// Verify initializer parameter uses the unwrapped type
-	wantParam := "child: Node? = nil"
-	if !strings.Contains(contentStr, wantParam) {
-		t.Errorf("initializer parameter mismatch: want %q; got:\n%s", wantParam, contentStr)
-	}
-
-	// Verify initializer maps the value
-	wantMap := "self.child = child.map { GoogleCloudWkt.Recursive(value: $0) }"
-	if !strings.Contains(contentStr, wantMap) {
-		t.Errorf("initializer body mapping mismatch: want %q; got:\n%s", wantMap, contentStr)
+	// Verify initializer is the default initializer
+	wantInit := "public init() {}"
+	if !strings.Contains(contentStr, wantInit) {
+		t.Errorf("initializer mismatch: want %q; got:\n%s", wantInit, contentStr)
 	}
 }
 
@@ -469,9 +457,9 @@ func TestGenerateMessage_RecursiveChain(t *testing.T) {
 	if !strings.Contains(contentStrA, wantPropA) {
 		t.Errorf("nodeB property definition mismatch: want %q; got:\n%s", wantPropA, contentStrA)
 	}
-	wantParamA := "nodeB: NodeB? = nil"
-	if !strings.Contains(contentStrA, wantParamA) {
-		t.Errorf("nodeB initializer parameter mismatch: want %q; got:\n%s", wantParamA, contentStrA)
+	wantInitA := "public init() {}"
+	if !strings.Contains(contentStrA, wantInitA) {
+		t.Errorf("nodeB initializer mismatch: want %q; got:\n%s", wantInitA, contentStrA)
 	}
 
 	// Verify NodeB contains wrapped NodeC
@@ -485,9 +473,9 @@ func TestGenerateMessage_RecursiveChain(t *testing.T) {
 	if !strings.Contains(contentStrB, wantPropB) {
 		t.Errorf("nodeC property definition mismatch: want %q; got:\n%s", wantPropB, contentStrB)
 	}
-	wantParamB := "nodeC: NodeC? = nil"
-	if !strings.Contains(contentStrB, wantParamB) {
-		t.Errorf("nodeC initializer parameter mismatch: want %q; got:\n%s", wantParamB, contentStrB)
+	wantInitB := "public init() {}"
+	if !strings.Contains(contentStrB, wantInitB) {
+		t.Errorf("nodeC initializer mismatch: want %q; got:\n%s", wantInitB, contentStrB)
 	}
 
 	// Verify NodeC contains wrapped NodeA
@@ -497,12 +485,12 @@ func TestGenerateMessage_RecursiveChain(t *testing.T) {
 		t.Fatal(err)
 	}
 	contentStrC := string(contentC)
-	wantPropC := "public var nodeA: GoogleCloudWkt.Recursive<NodeA>?"
+	wantPropC := "public var nodeA: GoogleCloudWkt.Recursive<NodeA>? = nil"
 	if !strings.Contains(contentStrC, wantPropC) {
 		t.Errorf("nodeA property definition mismatch: want %q; got:\n%s", wantPropC, contentStrC)
 	}
-	wantParamC := "nodeA: NodeA? = nil"
-	if !strings.Contains(contentStrC, wantParamC) {
-		t.Errorf("nodeA initializer parameter mismatch: want %q; got:\n%s", wantParamC, contentStrC)
+	wantInitC := "public init() {}"
+	if !strings.Contains(contentStrC, wantInitC) {
+		t.Errorf("nodeA initializer mismatch: want %q; got:\n%s", wantInitC, contentStrC)
 	}
 }

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -115,23 +115,28 @@ func TestGenerateOneOf(t *testing.T) {
   Sendable {
 
   /// A regular field.
-  public var regularInt32: Swift.Int32
+  public var regularInt32: Swift.Int32 = Swift.Int32()
 
   /// Another regular field.
-  public var regularString: Swift.String
+  public var regularString: Swift.String = Swift.String()
 
   /// A group of fields where only one is set.
-  public var choice: OneOf_Choice?
+  public var choice: OneOf_Choice? = nil
 
   /// Initialize a new instance of ` + "`Outer`" + `.
-  public init(
-    regularInt32: Swift.Int32 = Swift.Int32(),
-    regularString: Swift.String = Swift.String(),
-    choice: OneOf_Choice? = nil,
-  ) {
-    self.regularInt32 = regularInt32
-    self.regularString = regularString
-    self.choice = choice
+  public init() {}
+
+  /// Use ` + "`config`" + ` to return a new instance of this object, with some fields updated.
+  ///
+  /// Commonly used to initialize the value, for example:
+  ///
+  /// ` + "```" + `
+  /// let value = Outer().with { $0.stringField = ... }
+  /// ` + "```" + `
+  public func with(_ config: (inout Self) throws -> Swift.Void) rethrows -> Self {
+    var copy = self
+    try config(&copy)
+    return copy
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -268,13 +273,22 @@ func TestGenerateOneOfWithKeyword(t *testing.T) {
 	want := `public struct JwtLocation: Codable, Equatable, GoogleCloudWkt._AnyPackable,
   Sendable {
 
-  public var ` + "`in`" + `: OneOf_In?
+  public var ` + "`in`" + `: OneOf_In? = nil
 
   /// Initialize a new instance of ` + "`JwtLocation`" + `.
-  public init(
-    ` + "`in`" + `: OneOf_In? = nil,
-  ) {
-    self.` + "`in`" + ` = ` + "`in`" + `
+  public init() {}
+
+  /// Use ` + "`config`" + ` to return a new instance of this object, with some fields updated.
+  ///
+  /// Commonly used to initialize the value, for example:
+  ///
+  /// ` + "```" + `
+  /// let value = JwtLocation().with { $0.header = ... }
+  /// ` + "```" + `
+  public func with(_ config: (inout Self) throws -> Swift.Void) rethrows -> Self {
+    var copy = self
+    try config(&copy)
+    return copy
   }
 
   private enum CodingKeys: String, CodingKey {

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -764,7 +764,7 @@ func TestGenerateService_LRO(t *testing.T) {
 		"import GoogleRpc",
 		"public func createWorkflow(withPolling: CreateWorkflowRequest) async throws -> any GoogleCloudGax.PollableOperation<Workflow>",
 		"GoogleCloudGax._PollableOperationImpl(initialState: initialState, poll: poll)",
-		"self.getOperation(request: .init(name: rawOp.name), options: options)",
+		"self.getOperation(request: .init().with { $0.name = rawOp.name }, options: options)",
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(contentStr, want) {

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -27,7 +27,25 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
-  public var {{Codec.Name}}: {{{Codec.FieldType}}}
+  {{#Singular}}
+  {{#Codec.Recursive}}
+  public var {{Codec.Name}}: {{{Codec.FieldType}}} = nil
+  {{/Codec.Recursive}}
+  {{^Codec.Recursive}}
+  {{^Optional}}
+  public var {{Codec.Name}}: {{{Codec.FieldType}}} = {{{Codec.FieldType}}}()
+  {{/Optional}}
+  {{#Optional}}
+  public var {{Codec.Name}}: {{{Codec.FieldType}}} = nil
+  {{/Optional}}
+  {{/Codec.Recursive}}
+  {{/Singular}}
+  {{#Repeated}}
+  public var {{Codec.Name}}: {{{Codec.FieldType}}} = []
+  {{/Repeated}}
+  {{#Map}}
+  public var {{Codec.Name}}: {{{Codec.FieldType}}} = [:]
+  {{/Map}}
   {{/IsOneOf}}
   {{/Fields}}
   {{#OneOfs}}
@@ -35,53 +53,24 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
-  public var {{Codec.PropertyName}}: {{Codec.Name}}?
+  public var {{Codec.PropertyName}}: {{Codec.Name}}? = nil
   {{/OneOfs}}
 
-  {{! Provide a memberwise initializer, with defaults for each field. }}
   /// Initialize a new instance of `{{Codec.Name}}`.
-  public init(
-    {{#Fields}}
-    {{^IsOneOf}}
-    {{! Recall that fields can be Singular (and then Optional or not) or Repeated or Map }}
-    {{#Singular}}
-    {{#Codec.Recursive}}
-    {{Codec.Name}}: {{{Codec.InitializerType}}} = nil,
-    {{/Codec.Recursive}}
-    {{^Codec.Recursive}}
-    {{^Optional}}
-    {{Codec.Name}}: {{{Codec.FieldType}}} = {{{Codec.FieldType}}}(),
-    {{/Optional}}
-    {{#Optional}}
-    {{Codec.Name}}: {{{Codec.InitializerType}}} = nil,
-    {{/Optional}}
-    {{/Codec.Recursive}}
-    {{/Singular}}
-    {{#Repeated}}
-    {{Codec.Name}}: {{{Codec.FieldType}}} = [],
-    {{/Repeated}}
-    {{#Map}}
-    {{Codec.Name}}: {{{Codec.FieldType}}} = [:],
-    {{/Map}}
-    {{/IsOneOf}}
-    {{/Fields}}
-    {{#OneOfs}}
-    {{Codec.PropertyName}}: {{Codec.Name}}? = nil,
-    {{/OneOfs}}
-  ) {
-    {{#Fields}}
-    {{^IsOneOf}}
-    {{#Codec.Recursive}}
-    self.{{Codec.Name}} = {{Codec.Name}}.map { {{Parent.Codec.Model.WktPackage}}.Recursive(value: $0) }
-    {{/Codec.Recursive}}
-    {{^Codec.Recursive}}
-    self.{{Codec.Name}} = {{Codec.Name}}
-    {{/Codec.Recursive}}
-    {{/IsOneOf}}
-    {{/Fields}}
-    {{#OneOfs}}
-    self.{{Codec.PropertyName}} = {{Codec.PropertyName}}
-    {{/OneOfs}}
+  public init() {}
+
+  /// Use `config` to return a new instance of this object, with some fields updated.
+  ///
+  /// Commonly used to initialize the value, for example:
+  ///
+  /// ```
+  /// let value = {{Codec.Name}}().with { $0.{{{Codec.SampleField}}} = ... }
+  /// ```
+  {{! Using `with` for the name does not conflict with field name: https://godbolt.org/z/bxbsdfhfo }}
+  public func with(_ config: (inout Self) throws -> Swift.Void) rethrows -> Self {
+    var copy = self
+    try config(&copy)
+    return copy
   }
 
   {{#Codec.CustomSerialization}}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -157,7 +157,7 @@ extension Clients {
       let rawOp = try await self.{{Codec.Name}}(request: withPolling, options: options)
       let initialState = try extractStatus(rawOp)
       let poll = { () async throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
-        let op = try await self.getOperation(request: .init(name: rawOp.name), options: options)
+        let op = try await self.getOperation(request: .init().with { $0.name = rawOp.name }, options: options)
         return try extractStatus(op)
       }
       return GoogleCloudGax._PollableOperationImpl(initialState: initialState, poll: poll)

--- a/internal/sidekick/swift/templates/snippet/method_request_body.mustache
+++ b/internal/sidekick/swift/templates/snippet/method_request_body.mustache
@@ -22,20 +22,21 @@ limitations under the License.
   Conceptually there is a `list response = try await client.<<MethodName>>( ... )` around this
   partial.
 }}
-{{InputType.Codec.Name}}(
+{{InputType.Codec.Name}}().with {
   {{#SampleInfo}}
   {{#IsRequestResourceName}}
-  {{Codec.Name}}: "{{Codec.FormatString}}",
+  $0.{{Codec.Name}} = "{{Codec.FormatString}}"
   {{/IsRequestResourceName}}
   {{#IsMessageResourceName}}
-  {{MessageField.Codec.Name}}: {{MessageField.Codec.BaseFieldType}}(
-    {{Codec.Name}}: "{{Codec.FormatString}}",
-  ),
+  $0.{{MessageField.Codec.Name}} = {{MessageField.Codec.BaseFieldType}}().with {
+    $0.{{Codec.Name}} = "{{Codec.FormatString}}"
+  }
   {{/IsMessageResourceName}}
   {{#UpdateMaskField}}
-  {{Codec.Name}}: {{Service.Codec.Model.WktPackage}}.FieldMask(paths: ["field.path1", "field.path2"]),
+  $0.{{Codec.Name}} = {{Service.Codec.Model.WktPackage}}.FieldMask(paths: ["field.path1", "field.path2"])
   {{/UpdateMaskField}}
   {{/SampleInfo}}
   {{^SampleInfo}}
   /* set fields */
-  {{/SampleInfo}})
+  {{/SampleInfo}}
+}

--- a/internal/sidekick/swift/templates/snippet/method_request_body.mustache
+++ b/internal/sidekick/swift/templates/snippet/method_request_body.mustache
@@ -22,21 +22,22 @@ limitations under the License.
   Conceptually there is a `list response = try await client.<<MethodName>>( ... )` around this
   partial.
 }}
-{{InputType.Codec.Name}}().with {
+{{InputType.Codec.Name}}()
   {{#SampleInfo}}
   {{#IsRequestResourceName}}
-  $0.{{Codec.Name}} = "{{Codec.FormatString}}"
+  .with { $0.{{Codec.Name}} = "{{Codec.FormatString}}" }
   {{/IsRequestResourceName}}
   {{#IsMessageResourceName}}
-  $0.{{MessageField.Codec.Name}} = {{MessageField.Codec.BaseFieldType}}().with {
-    $0.{{Codec.Name}} = "{{Codec.FormatString}}"
+  .with {
+    $0.{{MessageField.Codec.Name}} = {{MessageField.Codec.BaseFieldType}}().with {
+      $0.{{Codec.Name}} = "{{Codec.FormatString}}"
+    }
   }
   {{/IsMessageResourceName}}
   {{#UpdateMaskField}}
-  $0.{{Codec.Name}} = {{Service.Codec.Model.WktPackage}}.FieldMask(paths: ["field.path1", "field.path2"])
+  .with { $0.{{Codec.Name}} = {{Service.Codec.Model.WktPackage}}.FieldMask(paths: ["field.path1", "field.path2"]) }
   {{/UpdateMaskField}}
   {{/SampleInfo}}
   {{^SampleInfo}}
-  /* set fields */
+  /* set fields using .with { $0... } */
   {{/SampleInfo}}
-}


### PR DESCRIPTION
Generate a `with()` helper for each message. This provides a much nicer experience to customers, as they do not need to worry about field ordering.

It also simplifies the code generation for us.

Fixes #6303 