### PR TITLE
fix(nodejs): manually create symlinks during librarian install

### DIFF
--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -41,7 +41,14 @@ func TestInstall(t *testing.T) {
 	genDir := filepath.Join(cache,
 		repo+"@"+tool.Version,
 		gapicGeneratorSubdir)
-	for _, sub := range []string{"templates", "protos"} {
+	// TODO(https://github.com/googleapis/librarian/issues/6313):
+	// this can be just "templates", "protos" once the workaround in
+	// librarian.yaml is removed.
+	for _, sub := range []string{
+		"templates/cjs/typescript_gapic",
+		"templates/esm/typescript_gapic",
+		"protos",
+	} {
 		if err := os.MkdirAll(filepath.Join(genDir, sub), 0o755); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/librarian/nodejs/librarian.yaml
+++ b/internal/librarian/nodejs/librarian.yaml
@@ -27,6 +27,12 @@ tools:
         # tsc only compiles TypeScript; the generator also needs templates/
         # and protos/ in build/ (resolved via __dirname at runtime).
         - "./node_modules/.bin/tsc"
+        # Recreate the symlinks that are in the tarball, as fetch doesn't handle them
+        # at the moment.
+        # TODO(https://github.com/googleapis/librarian/issues/6313):
+        # remove this workaround when the issue is fixed.
+        - "ln -sf package.json templates/cjs/typescript_gapic/package.json.njk"
+        - "ln -sf package.json templates/esm/typescript_gapic/package.json.njk"
         - "cp -r templates protos build/"
         # Pass the full directory name into "pnpm add" so that the generator
         # is registered with the name "gapic-generator-typescript" rather than


### PR DESCRIPTION
Adds symlinks that are in gapic-generator-typescript template directories to make the generator create package.json files. This is a temporary workaround for #6313 to unblock other Node work. It can be reverted once #6313 is fixed.

Fixes #6312