### PR TITLE
feat(internal/cache): add `BinDirectory` and `LIBRARIAN_BIN` override

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	// EnvLibrarianBin is the environment variable used to override the default bin directory.
 	EnvLibrarianBin = "LIBRARIAN_BIN"
 	// EnvLibrarianCache is the environment variable used to override the default cache directory.
 	EnvLibrarianCache = "LIBRARIAN_CACHE"

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -21,8 +21,11 @@ import (
 	"path/filepath"
 )
 
-// EnvLibrarianCache is the environment variable used to override the default cache directory.
-const EnvLibrarianCache = "LIBRARIAN_CACHE"
+const (
+	EnvLibrarianBin = "LIBRARIAN_BIN"
+	// EnvLibrarianCache is the environment variable used to override the default cache directory.
+	EnvLibrarianCache = "LIBRARIAN_CACHE"
+)
 
 // Directory returns the root cache directory for librarian operations. It
 // checks the $LIBRARIAN_CACHE environment variable, falling back to
@@ -37,4 +40,15 @@ func Directory() (string, error) {
 		return "", fmt.Errorf("failed to get user cache directory: %w", err)
 	}
 	return filepath.Join(home, "librarian"), nil
+}
+
+func BinDirectory() (string, error) {
+	if binDir := os.Getenv(EnvLibrarianBin); binDir != "" {
+		return binDir, nil
+	}
+	cacheDir, err := Directory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, "bin"), nil
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -42,6 +42,9 @@ func Directory() (string, error) {
 	return filepath.Join(home, "librarian"), nil
 }
 
+// BinDirectory returns the directory where librarian bin files are stored.
+// It checks the $LIBRARIAN_BIN environment variable, falling back to the "bin" subdirectory
+// under the cache directory if not set.
 func BinDirectory() (string, error) {
 	if binDir := os.Getenv(EnvLibrarianBin); binDir != "" {
 		return binDir, nil

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -57,3 +57,42 @@ func TestDirectory(t *testing.T) {
 		})
 	}
 }
+
+func TestBinDirectory(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		binEnv   string
+		cacheEnv string
+		wantDir  string
+	}{
+		{
+			name:    "uses LIBRARIAN_BIN when set",
+			binEnv:  "/custom/bin",
+			wantDir: "/custom/bin",
+		},
+		{
+			name:     "uses LIBRARIAN_CACHE/bin when LIBRARIAN_BIN not set",
+			cacheEnv: "/custom/cache",
+			wantDir:  "/custom/cache/bin",
+		},
+		{
+			name: "uses UserCacheDir/librarian/bin when neither set",
+			wantDir: func() string {
+				cache, _ := os.UserCacheDir()
+				return filepath.Join(cache, "librarian", "bin")
+			}(),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(EnvLibrarianBin, test.binEnv)
+			t.Setenv(EnvLibrarianCache, test.cacheEnv)
+			got, err := BinDirectory()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.wantDir, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A `BinDirectory` function is added to internal/cache to resolve the directory where librarian bin files are stored.

It checks the new `LIBRARIAN_BIN` environment variable for a custom directory path, falling back to the bin/ subdirectory under the main cache directory if not specified.

For #5850
Fixes #6199