### PR TITLE
tests(nodejs): fix nodejs installation test on MacOS

### DIFF
--- a/internal/librarian/nodejs/librarian.yaml
+++ b/internal/librarian/nodejs/librarian.yaml
@@ -33,11 +33,11 @@ tools:
         # remove this workaround when the issue is fixed.
         - "ln -sf package.json templates/cjs/typescript_gapic/package.json.njk"
         - "ln -sf package.json templates/esm/typescript_gapic/package.json.njk"
-        - "cp -r templates protos build/"
+        - "cp -a templates protos build/"
         # Pass the full directory name into "pnpm add" so that the generator
         # is registered with the name "gapic-generator-typescript" rather than
         # an arbitrary name such as "5".
-        - "pnpm add -g \"$PWD\""
+        - 'pnpm add -g "$PWD"'
     - name: gapic-node-processing
       version: "0.1.8"
     - name: gapic-tools


### PR DESCRIPTION
The "cp -r" step in librarian.yaml fails on Mac when the target of a symlink is absent. The targets will be present when "really" installing, but are absent in our fake version. "cp -a" succeeds on Mac, and is a better fit for what we're trying to do.
    
The format of a "pnpm add" line is fixed to avoid requiring escaping.
    
Fixes #6317