### PR TITLE
feat(librarian): add `Discovery` field to Swift config

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -160,7 +160,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `operation_id` | string | Is the ID of the LRO operation type (e.g., ".google.cloud.compute.v1.Operation"). |
-| `pollers` | list of RustPoller | Is a list of LRO polling configurations. |
+| `pollers` | list of [CommonPoller](#commonpoller-configuration) | Is a list of LRO polling configurations. |
 
 ## CommonPoller Configuration
 
@@ -518,7 +518,6 @@ This document describes the schema for the librarian.yaml.
 | `version` | string | Configures the minimum version for exaternal package definitions.<br><br>For example, if the `swift-protobuf` package used `1.36.1`, then the codec would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf", from: "1.36.1") ``` |
 | `required_by_services` | bool | Is true if this dependency is required by packages with services.<br><br>This will be set for the `gax` library and the `auth` library. Maybe more if we split the HTTP and gRPC clients into separate libraries. |
 | `api_package` | string | Is the name of the API package provided by this library.<br><br>In Swift a package contains at most one channel for one API. For packages that implement an API, this field contains the name of the package in the specification language of that API. At the moment this is only used by Protobuf-based APIs, as OpenAPI and discovery doc APIs are self-contained.<br><br>Note that some packages, for example `auth` and `gax`, do not implement APIs. This field is empty for such libraries.<br><br>Examples:<br>- The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.<br>- The `GoogleCloudLocation` package will set this to `google.cloud.location`. |
-| `discovery` | SwiftDiscovery (optional) | Contains discovery-specific configuration for LRO polling. |
 
 ## SwiftModule Configuration
 
@@ -536,3 +535,4 @@ This document describes the schema for the librarian.yaml.
 | `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, and output location. |
 | `per_service_traits` | bool | Enables per-service compile-time flags. |
 | `default_traits` | list of string | Is a list of compile-time traits enabled by default. |
+| `discovery` | SwiftDiscovery (optional) | Contains discovery-specific configuration for LRO polling. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -155,6 +155,20 @@ This document describes the schema for the librarian.yaml.
 | `generate_proto_classes` | bool | Indicates whether to include this proto in standard Protocol Buffer Java classes generation. |
 | `copy_to_output` | bool | Indicates whether to copy this proto to the output directory. |
 
+## CommonDiscovery Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `operation_id` | string | Is the ID of the LRO operation type (e.g., ".google.cloud.compute.v1.Operation"). |
+| `pollers` | list of RustPoller | Is a list of LRO polling configurations. |
+
+## CommonPoller Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `prefix` | string | Is an acceptable prefix for the URL path (e.g., "compute/v1/projects/{project}/zones/{zone}"). |
+| `method_id` | string | Is the corresponding method ID (e.g., ".google.cloud.compute.v1.zoneOperations.get"). |
+
 ## DartPackage Configuration
 
 | Field | Type | Description |
@@ -409,7 +423,7 @@ This document describes the schema for the librarian.yaml.
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |
 | `pagination_overrides` | list of [RustPaginationOverride](#rustpaginationoverride-configuration) | Contains overrides for pagination configuration. |
 | `name_overrides` | string | Contains codec-level overrides for type and service names. |
-| `discovery` | [RustDiscovery](#rustdiscovery-configuration) (optional) | Contains discovery-specific configuration for LRO polling. |
+| `discovery` | RustDiscovery (optional) | Contains discovery-specific configuration for LRO polling. |
 | `quickstart_service_override` | string | Overrides the default heuristically selected service for the package-level quickstart. |
 
 ## RustDefault Configuration
@@ -423,13 +437,6 @@ This document describes the schema for the librarian.yaml.
 | `detailed_tracing_attributes` | bool (optional) | Indicates whether to include detailed tracing attributes. |
 | `lro_stub_options` | bool (optional) | Indicates whether to include LRO poller options in generated stub traits. |
 | `resource_name_heuristic` | bool (optional) | Indicates whether to apply heuristics to identify and generate resource names. |
-
-## RustDiscovery Configuration
-
-| Field | Type | Description |
-| :--- | :--- | :--- |
-| `operation_id` | string | Is the ID of the LRO operation type (e.g., ".google.cloud.compute.v1.Operation"). |
-| `pollers` | list of [RustPoller](#rustpoller-configuration) | Is a list of LRO polling configurations. |
 
 ## RustDocumentationOverride Configuration
 
@@ -489,13 +496,6 @@ This document describes the schema for the librarian.yaml.
 | `id` | string | Is the fully qualified method ID (e.g., .google.cloud.sql.v1.Service.Method). |
 | `item_field` | string | Is the name of the field used for items. |
 
-## RustPoller Configuration
-
-| Field | Type | Description |
-| :--- | :--- | :--- |
-| `prefix` | string | Is an acceptable prefix for the URL path (e.g., "compute/v1/projects/{project}/zones/{zone}"). |
-| `method_id` | string | Is the corresponding method ID (e.g., ".google.cloud.compute.v1.zoneOperations.get"). |
-
 ## Surfer Configuration
 
 | Field | Type | Description |
@@ -518,6 +518,7 @@ This document describes the schema for the librarian.yaml.
 | `version` | string | Configures the minimum version for exaternal package definitions.<br><br>For example, if the `swift-protobuf` package used `1.36.1`, then the codec would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf", from: "1.36.1") ``` |
 | `required_by_services` | bool | Is true if this dependency is required by packages with services.<br><br>This will be set for the `gax` library and the `auth` library. Maybe more if we split the HTTP and gRPC clients into separate libraries. |
 | `api_package` | string | Is the name of the API package provided by this library.<br><br>In Swift a package contains at most one channel for one API. For packages that implement an API, this field contains the name of the package in the specification language of that API. At the moment this is only used by Protobuf-based APIs, as OpenAPI and discovery doc APIs are self-contained.<br><br>Note that some packages, for example `auth` and `gax`, do not implement APIs. This field is empty for such libraries.<br><br>Examples:<br>- The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.<br>- The `GoogleCloudLocation` package will set this to `google.cloud.location`. |
+| `discovery` | SwiftDiscovery (optional) | Contains discovery-specific configuration for LRO polling. |
 
 ## SwiftModule Configuration
 

--- a/internal/config/discovery.go
+++ b/internal/config/discovery.go
@@ -22,7 +22,7 @@ type CommonDiscovery struct {
 	OperationID string `yaml:"operation_id"`
 
 	// Pollers is a list of LRO polling configurations.
-	Pollers []RustPoller `yaml:"pollers,omitempty"`
+	Pollers []CommonPoller `yaml:"pollers,omitempty"`
 }
 
 // CommonPoller defines how to find a suitable poller RPC for discovery APIs.

--- a/internal/config/discovery.go
+++ b/internal/config/discovery.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// CommonDiscovery contains discovery-specific configuration for LRO polling.
+//
+// This is used (via some aliases) by both Swift and Rust, thus the `Common` prefix.
+type CommonDiscovery struct {
+	// OperationID is the ID of the LRO operation type (e.g., ".google.cloud.compute.v1.Operation").
+	OperationID string `yaml:"operation_id"`
+
+	// Pollers is a list of LRO polling configurations.
+	Pollers []RustPoller `yaml:"pollers,omitempty"`
+}
+
+// CommonPoller defines how to find a suitable poller RPC for discovery APIs.
+//
+// This is used (via some aliases) by both Swift and Rust, thus the `Common` prefix.
+type CommonPoller struct {
+	// Prefix is an acceptable prefix for the URL path (e.g., "compute/v1/projects/{project}/zones/{zone}").
+	Prefix string `yaml:"prefix"`
+
+	// MethodID is the corresponding method ID (e.g., ".google.cloud.compute.v1.zoneOperations.get").
+	MethodID string `yaml:"method_id"`
+}

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -334,22 +334,10 @@ type RustPaginationOverride struct {
 }
 
 // RustDiscovery contains discovery-specific configuration for LRO polling.
-type RustDiscovery struct {
-	// OperationID is the ID of the LRO operation type (e.g., ".google.cloud.compute.v1.Operation").
-	OperationID string `yaml:"operation_id"`
-
-	// Pollers is a list of LRO polling configurations.
-	Pollers []RustPoller `yaml:"pollers,omitempty"`
-}
+type RustDiscovery = CommonDiscovery
 
 // RustPoller defines how to find a suitable poller RPC for discovery APIs.
-type RustPoller struct {
-	// Prefix is an acceptable prefix for the URL path (e.g., "compute/v1/projects/{project}/zones/{zone}").
-	Prefix string `yaml:"prefix"`
-
-	// MethodID is the corresponding method ID (e.g., ".google.cloud.compute.v1.zoneOperations.get").
-	MethodID string `yaml:"method_id"`
-}
+type RustPoller = CommonPoller
 
 // PythonPackage contains Python-specific library configuration. It inherits
 // from PythonDefault, allowing library-specific overrides of global settings.

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -40,6 +40,9 @@ type SwiftPackage struct {
 
 	// DefaultTraits is a list of compile-time traits enabled by default.
 	DefaultTraits []string `yaml:"default_traits,omitempty"`
+
+	// Discovery contains discovery-specific configuration for LRO polling.
+	Discovery *SwiftDiscovery `yaml:"discovery,omitempty"`
 }
 
 // SwiftDependency represents a dependency in Swift Package Manager.
@@ -94,9 +97,6 @@ type SwiftDependency struct {
 	// - The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.
 	// - The `GoogleCloudLocation` package will set this to `google.cloud.location`.
 	ApiPackage string `yaml:"api_package,omitempty"`
-
-	// Discovery contains discovery-specific configuration for LRO polling.
-	Discovery *SwiftDiscovery `yaml:"discovery,omitempty"`
 }
 
 // SwiftModule defines a generation target within a larger crate. Typically a veneer, but sometimes also test targets.

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -94,6 +94,9 @@ type SwiftDependency struct {
 	// - The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.
 	// - The `GoogleCloudLocation` package will set this to `google.cloud.location`.
 	ApiPackage string `yaml:"api_package,omitempty"`
+
+	// Discovery contains discovery-specific configuration for LRO polling.
+	Discovery *SwiftDiscovery `yaml:"discovery,omitempty"`
 }
 
 // SwiftModule defines a generation target within a larger crate. Typically a veneer, but sometimes also test targets.
@@ -106,3 +109,9 @@ type SwiftModule struct {
 	// APIPath is the proto path to generate from (e.g., "google/storage/v2").
 	APIPath string `yaml:"api_path"`
 }
+
+// SwiftDiscovery contains discovery-specific configuration for LRO polling.
+type SwiftDiscovery = CommonDiscovery
+
+// SwiftPoller defines how to find a suitable poller RPC for discovery APIs.
+type SwiftPoller = CommonPoller


### PR DESCRIPTION
To generate LROs for discovery-based APIs, the Swift codec needs some configuration options. These are (and probably always will be) the same options as the Rust codec needs, so I decided to refactor them.

Fixes #6231 