### PR TITLE
fix(python): avoid adding to existing core lib

### DIFF
--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -27,6 +27,7 @@ import (
 // defaultVersion is the first version used for a new library.
 // This is set on the initial `librarian add` for a new API.
 const defaultVersion = "0.0.0"
+
 // libraryTypeCore is used in [config.PythonDefault.LibraryType] to signify that
 // the entry is a core library, not an individual API client library.
 const libraryTypeCore = "CORE"

--- a/internal/librarian/python/add.go
+++ b/internal/librarian/python/add.go
@@ -27,6 +27,9 @@ import (
 // defaultVersion is the first version used for a new library.
 // This is set on the initial `librarian add` for a new API.
 const defaultVersion = "0.0.0"
+// libraryTypeCore is used in [config.PythonDefault.LibraryType] to signify that
+// the entry is a core library, not an individual API client library.
+const libraryTypeCore = "CORE"
 
 var (
 	errNewLibraryMustHaveOneAPI          = errors.New("a newly added library (in Python) must have exactly one API so that the default version can be populated")
@@ -102,6 +105,12 @@ func FindExistingLibraryForNewAPI(libraries []*config.Library, apiPath string) *
 		}
 	}
 	for _, lib := range libraries {
+		// In order to avoid a CORE library like googleapis-common-proto from
+		// matching on all API paths starting with google/cloud, we do not
+		// automatically add to existing libraries with the CORE library type.
+		if lib.Python != nil && lib.Python.LibraryType == libraryTypeCore {
+			continue
+		}
 		set := make(map[string]struct{})
 		for _, api := range lib.APIs {
 			set[versionless(api.Path)] = struct{}{}

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -348,7 +348,7 @@ func TestFindExistingLibraryForNewAPI(t *testing.T) {
 					},
 					Python: &config.PythonPackage{
 						PythonDefault: config.PythonDefault{
-							LibraryType: "CORE",
+							LibraryType: libraryTypeCore,
 						},
 					},
 				},

--- a/internal/librarian/python/add_test.go
+++ b/internal/librarian/python/add_test.go
@@ -337,6 +337,57 @@ func TestFindExistingLibraryForNewAPI(t *testing.T) {
 			},
 			apiPath: "google/cloud/xyz/admin/v2",
 		},
+		{
+			name: "does not prefix match CORE library type",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-shared",
+					APIs: []*config.API{
+						{Path: "google/cloud/v1"},
+						{Path: "google/cloud/other/v1"},
+					},
+					Python: &config.PythonPackage{
+						PythonDefault: config.PythonDefault{
+							LibraryType: "CORE",
+						},
+					},
+				},
+			},
+			apiPath: "google/cloud/speech/v1",
+		},
+		{
+			name: "prefix match non-CORE library type",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-shared",
+					APIs: []*config.API{
+						{Path: "google/cloud/test/v1"},
+						{Path: "google/cloud/test/other/v1"},
+					},
+					Python: &config.PythonPackage{
+						PythonDefault: config.PythonDefault{
+							LibraryType: "GAPIC",
+						},
+					},
+				},
+			},
+			apiPath:  "google/cloud/test/speech/v1",
+			wantName: "google-cloud-shared",
+		},
+		{
+			name: "prefix match when python options are nil",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-shared",
+					APIs: []*config.API{
+						{Path: "google/cloud/test/v1"},
+						{Path: "google/cloud/test/other/v1"},
+					},
+				},
+			},
+			apiPath:  "google/cloud/test/speech/v1",
+			wantName: "google-cloud-shared",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := FindExistingLibraryForNewAPI(test.libraries, test.apiPath)

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -1264,7 +1264,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 					ClientDocumentationOverride: "overridden client_documentation",
 					IssueTrackerOverride:        "overridden issue_tracker",
 					PythonDefault: config.PythonDefault{
-						LibraryType: "CORE",
+						LibraryType: libraryTypeCore,
 					},
 				},
 			},
@@ -1280,7 +1280,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 				APIID:                "secretmanager.googleapis.com",
 				APIShortname:         "secretmanager",
 				APIDescription:       "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
-				LibraryType:          "CORE",
+				LibraryType:          libraryTypeCore,
 				ClientDocumentation:  "overridden client_documentation",
 				DefaultVersion:       "v1beta1",
 			},


### PR DESCRIPTION
The "add to existing" logic of Python's `librarian add` implementation inadvertently always matched an API path beginning with `google/cloud` to the `googleapis-common-protos` library entry in `google-cloud-python` because it has an API path `google/cloud`.

To avoid that, we will not automatically add new API paths to existing `CORE` libraries. These `CORE`  packages should typically have the new path added to their entry in a careful, manual manner anyways because they are typically common proto packages (or they are just a tool with no paths)

Verified locally based on the example in the bug below.

Fixes #6323