### PR TITLE
feat(internal/librarian/java): use com.google.cloud group id for CLOUD organization APIs

### DIFF
--- a/doc/api-allowlist-schema.md
+++ b/doc/api-allowlist-schema.md
@@ -18,6 +18,7 @@ This document describes the schema for the API Allowlist.
 | `sample_uris` | map[string]string | Is the documentation URI for code samples per language. Map key is the language name (e.g., "go", "python"). Optional. If omitted, a default URI for the language is used. |
 | `short_name` | string | Overrides the API short name from the service config's publishing section. |
 | `service_config` | string | Is the service config file path override. If empty, the service config is discovered in the directory specified by Path. |
+| `organization` | string | Is the organization from the service config's publishing section. This is populated from the service config during Find. |
 | `service_name` | string | Is a DNS-like logical identifier for the service, such as `calendar.googleapis.com`. |
 | `title` | string | Overrides the API title from the service config. |
 | `transports` | map[string]Transport | Defines the supported transports per language. Map key is the language name (e.g., "python", "rust"). Optional. If omitted, all languages use GRPCRest by default. |

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -91,11 +91,15 @@ A typical librarian workflow for adding a new client library is:
 }
 
 func runAdd(ctx context.Context, cfg *config.Config, api string) error {
-	name, cfg, err := addLibrary(cfg, api)
+	sources, err := LoadSources(ctx, cfg.Sources)
 	if err != nil {
 		return err
 	}
-	cfg, err = resolveDependencies(ctx, cfg, name)
+	name, cfg, err := addLibrary(cfg, api, sources.Googleapis)
+	if err != nil {
+		return err
+	}
+	cfg, err = resolveDependencies(ctx, cfg, name, sources)
 	if err != nil {
 		return err
 	}
@@ -109,16 +113,16 @@ func runAdd(ctx context.Context, cfg *config.Config, api string) error {
 	return RunTidyOnConfig(ctx, ".", cfg)
 }
 
-func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (*config.Config, error) {
+func resolveDependencies(ctx context.Context, cfg *config.Config, name string, sources *sources.Sources) (*config.Config, error) {
 	switch cfg.Language {
 	case config.LanguageJava:
-		lib, sources, err := setupResolve(ctx, cfg, name)
+		lib, err := FindLibrary(cfg, name)
 		if err != nil {
 			return nil, err
 		}
 		return java.ResolveMixinDependencies(cfg, lib, sources)
 	case config.LanguageRust:
-		lib, sources, err := setupResolve(ctx, cfg, name)
+		lib, err := FindLibrary(cfg, name)
 		if err != nil {
 			return nil, err
 		}
@@ -126,18 +130,6 @@ func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (
 	default:
 		return cfg, nil
 	}
-}
-
-func setupResolve(ctx context.Context, cfg *config.Config, name string) (*config.Library, *sources.Sources, error) {
-	lib, err := FindLibrary(cfg, name)
-	if err != nil {
-		return nil, nil, err
-	}
-	sources, err := LoadSources(ctx, cfg.Sources)
-	if err != nil {
-		return nil, nil, err
-	}
-	return lib, sources, nil
 }
 
 // deriveLibraryName derives a library name from an API path.
@@ -171,7 +163,7 @@ func deriveLibraryName(language string, api string) string {
 // It returns the name of the new or updated library, the updated config, and an
 // error if the API cannot be added (e.g. because it already exists, or the new
 // API is a preview and there is no corresponding stable library).
-func addLibrary(cfg *config.Config, apiPath string) (string, *config.Config, error) {
+func addLibrary(cfg *config.Config, apiPath string, googleapisDir string) (string, *config.Config, error) {
 	isPreview := strings.HasPrefix(apiPath, "preview/")
 	stablePath := apiPath
 	if isPreview {
@@ -188,7 +180,7 @@ func addLibrary(cfg *config.Config, apiPath string) (string, *config.Config, err
 	if existingLib != nil {
 		return updateExistingLibrary(cfg, existingLib, api)
 	}
-	return addNewLibrary(cfg, api)
+	return addNewLibrary(cfg, api, googleapisDir)
 }
 
 // findExistingLibraryForNewAPI determines if an existing library in cfg is
@@ -237,7 +229,7 @@ func addPreviewLibrary(cfg *config.Config, lib *config.Library, api *config.API)
 }
 
 // addNewLibrary adds a new library to the config.
-func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config, error) {
+func addNewLibrary(cfg *config.Config, api *config.API, googleapisDir string) (string, *config.Config, error) {
 	name := deriveLibraryName(cfg.Language, api.Path)
 	lib := &config.Library{
 		Name:          name,
@@ -248,7 +240,7 @@ func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config,
 	case config.LanguageGo:
 		lib = golang.Add(lib)
 	case config.LanguageJava:
-		lib = java.Add(lib)
+		lib = java.Add(lib, googleapisDir)
 	case config.LanguagePython:
 		var err error
 		lib, err = python.Add(cfg, lib)

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
+const googleapisDir = "../testdata/googleapis"
+
 func TestAddLibraryCommand(t *testing.T) {
 	copyrightYear := strconv.Itoa(time.Now().Year())
 	for _, test := range []struct {
@@ -234,7 +236,7 @@ func TestAddLibrary(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
-			gotName, cfg, err := addLibrary(cfg, test.apiPath)
+			gotName, cfg, err := addLibrary(cfg, test.apiPath, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -409,7 +411,7 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
 				t.Fatal(err)
 			}
-			gotName, gotCfg, err := addLibrary(test.cfg, test.apiPath)
+			gotName, gotCfg, err := addLibrary(test.cfg, test.apiPath, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -455,7 +457,7 @@ func TestAddLibrary_ExistingLibrary_Error(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
 				t.Fatal(err)
 			}
-			_, _, err := addLibrary(test.cfg, test.apiPath)
+			_, _, err := addLibrary(test.cfg, test.apiPath, googleapisDir)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}
@@ -491,7 +493,7 @@ func TestAddLibrary_Preview(t *testing.T) {
 				Language:  config.LanguageGo,
 				Libraries: test.initialLibraries,
 			}
-			gotName, gotCfg, err := addLibrary(cfg, test.apiPath)
+			gotName, gotCfg, err := addLibrary(cfg, test.apiPath, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -545,7 +547,7 @@ func TestAddLibrary_Preview_Error(t *testing.T) {
 				Language:  config.LanguageGo,
 				Libraries: test.initialLibraries,
 			}
-			_, _, err := addLibrary(cfg, test.apiPath)
+			_, _, err := addLibrary(cfg, test.apiPath, googleapisDir)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
 // knownPrefixes contains API path prefixes to be stripped when deriving a
@@ -38,17 +39,15 @@ const (
 )
 
 // Add initializes a new Java library with default values.
-func Add(lib *config.Library) *config.Library {
+func Add(lib *config.Library, googleapisDir string) *config.Library {
 	lib.Version = defaultVersion
 	// Java generation defaults to the system year for license headers,
 	// so we reset it here to avoid redundancy in librarian.yaml.
 	lib.CopyrightYear = ""
-
 	if lib.Java == nil {
 		lib.Java = &config.JavaModule{}
 	}
 	lib.Java.ReleasedVersion = defaultReleasedVersion
-
 	// We use the first API to infer the group ID.
 	// It is unrealistic for a single library to mix cloud and non-cloud APIs.
 	apiPath := lib.APIs[0].Path
@@ -60,14 +59,20 @@ func Add(lib *config.Library) *config.Library {
 	case strings.HasPrefix(apiPath, "google/ads/"):
 		return setNonCloudMavenDefaults(lib, "com.google.api-ads")
 	}
-	if !strings.HasPrefix(apiPath, "google/cloud/") {
-		log.Printf(
-			"WARNING: unrecognized non-cloud API path %q. Setting fake GroupID %q. "+
-				"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml.",
-			apiPath, fakeGroupID,
-		)
-		setNonCloudMavenDefaults(lib, fakeGroupID)
+	if strings.HasPrefix(apiPath, "google/cloud/") {
+		return lib
 	}
+	if googleapisDir != "" {
+		if apiCfg, err := serviceconfig.Find(googleapisDir, apiPath, config.LanguageJava); err == nil && apiCfg.Organization == "CLOUD" {
+			return lib
+		}
+	}
+	log.Printf(
+		"WARNING: unrecognized non-cloud API path %q. Setting fake GroupID %q. "+
+			"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml.",
+		apiPath, fakeGroupID,
+	)
+	setNonCloudMavenDefaults(lib, fakeGroupID)
 	return lib
 }
 

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -157,7 +157,7 @@ func TestAdd(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := Add(test.lib, googleapisDir)
+			got := Add(test.lib, "../../testdata/googleapis")
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -135,9 +135,29 @@ func TestAdd(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "cloud API outside google/cloud/",
+			lib: &config.Library{
+				Name: "iam",
+				APIs: []*config.API{
+					{Path: "google/iam/v3"},
+				},
+			},
+			want: &config.Library{
+				Name: "iam",
+				APIs: []*config.API{
+					{Path: "google/iam/v3"},
+				},
+				Version:       defaultVersion,
+				CopyrightYear: "",
+				Java: &config.JavaModule{
+					ReleasedVersion: defaultReleasedVersion,
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := Add(test.lib)
+			got := Add(test.lib, googleapisDir)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -103,6 +103,10 @@ type API struct {
 	// If empty, the service config is discovered in the directory specified by Path.
 	ServiceConfig string `yaml:"service_config,omitempty"`
 
+	// Organization is the organization from the service config's publishing section.
+	// This is populated from the service config during Find.
+	Organization string `yaml:"organization,omitempty"`
+
 	// ServiceName is a DNS-like logical identifier for the service, such as `calendar.googleapis.com`.
 	ServiceName string `yaml:"service_name,omitempty"`
 

--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/yaml"
+	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -194,6 +195,9 @@ func populateFromServiceConfig(api *API, cfg *Service) *API {
 		}
 		if api.ShortName == "" {
 			api.ShortName = publishing.GetApiShortName()
+		}
+		if api.Organization == "" && publishing.GetOrganization() != annotations.ClientLibraryOrganization_CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED {
+			api.Organization = publishing.GetOrganization().String()
 		}
 	}
 	if api.ShortName == "" {

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -103,6 +103,7 @@ func TestFind(t *testing.T) {
 				ShortName:        "secretmanager",
 				Languages:        []string{config.LanguageAll},
 				Title:            "Secret Manager API",
+				Organization:     "CLOUD",
 			},
 		},
 		{
@@ -151,6 +152,7 @@ func TestFind(t *testing.T) {
 				DocumentationURI: "https://cloud.google.com/secret-manager/docs/overview",
 				ServiceName:      "secretmanager.googleapis.com",
 				ShortName:        "secretmanager",
+				Organization:     "CLOUD",
 			},
 		},
 		{


### PR DESCRIPTION
When onboarding a new API in Java, we check the service config to see if the publishing organization is configured as CLOUD ([example](https://github.com/googleapis/googleapis/blob/0ff3c706a5e0964c6430529c406208f2ff57cf65/backstory/backstory.yaml#L24)). If so, we treat it as a Google Cloud API and use standard Cloud maven coordinates (group ID com.google.cloud) instead of prompting for custom coordinate configuration or warning about unrecognized non-cloud API path.

Fixes https://github.com/googleapis/librarian/issues/6267