### PR TITLE
chore(internal/librarian/golang): use cache package for tool installation

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,7 +28,7 @@ jobs:
         run: go run ./tool/cmd/coverage ./internal/librarian/golang
   integration:
     runs-on: ubuntu-24.04
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,7 +28,7 @@ jobs:
         run: go run ./tool/cmd/coverage ./internal/librarian/golang
   integration:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian

--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/command"
 )
@@ -42,11 +41,10 @@ func runInDirWithEnv(ctx context.Context, dir string, env map[string]string, cmd
 
 // mergeEnv merges the given environment with the installation directory.
 func mergeEnv(env map[string]string) (map[string]string, error) {
-	installDir, err := getInstallDir()
+	toolsBinDir, err := getInstallDir()
 	if err != nil {
 		return nil, err
 	}
-	toolsBinDir := filepath.Join(installDir, binDir)
 	res := map[string]string{envPath: fmt.Sprintf("%s:%s", toolsBinDir, os.Getenv(envPath))}
 	maps.Copy(res, env)
 	return res, nil

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/cache"
 )
 
 func TestMergeEnv(t *testing.T) {
@@ -34,7 +35,7 @@ func TestMergeEnv(t *testing.T) {
 			path: "/original/path",
 			want: func(base string) map[string]string {
 				return map[string]string{
-					envPath: filepath.Join(base, binDir) + ":/original/path",
+					envPath: base + ":/original/path",
 				}
 			},
 		},
@@ -46,7 +47,7 @@ func TestMergeEnv(t *testing.T) {
 			path: "/original/path",
 			want: func(base string) map[string]string {
 				return map[string]string{
-					envPath: filepath.Join(base, binDir) + ":/original/path",
+					envPath: base + ":/original/path",
 					"FOO":   "bar",
 				}
 			},
@@ -66,7 +67,7 @@ func TestMergeEnv(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			baseDir := t.TempDir()
-			t.Setenv(envLibrarianDir, baseDir)
+			t.Setenv(cache.EnvLibrarianBin, baseDir)
 			t.Setenv(envPath, test.path)
 			got, err := mergeEnv(test.env)
 			if err != nil {

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -35,7 +35,7 @@ func TestMergeEnv(t *testing.T) {
 			path: "/original/path",
 			want: func(base string) map[string]string {
 				return map[string]string{
-					envPath: base + ":/original/path",
+					envPath: filepath.Join(base, toolsDir) + ":/original/path",
 				}
 			},
 		},
@@ -47,7 +47,7 @@ func TestMergeEnv(t *testing.T) {
 			path: "/original/path",
 			want: func(base string) map[string]string {
 				return map[string]string{
-					envPath: base + ":/original/path",
+					envPath: filepath.Join(base, toolsDir) + ":/original/path",
 					"FOO":   "bar",
 				}
 			},

--- a/internal/librarian/golang/install.go
+++ b/internal/librarian/golang/install.go
@@ -18,20 +18,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 )
 
 const (
 	envGoBin = "GOBIN"
-	// TODO(https://github.com/googleapis/librarian/issues/5850): Use LIBRARIAN_BIN
-	// for tool binaries.
-	envLibrarianDir = "LIBRARIAN_INSTALL_DIR"
-	toolsDir        = "go_tools"
-	binDir          = "bin"
+	toolsDir = "go_tools"
 )
 
 var (
@@ -54,7 +50,7 @@ func installGoTools(ctx context.Context, goTools []*config.GoTool) error {
 	if err != nil {
 		return err
 	}
-	env := map[string]string{envGoBin: filepath.Join(installDir, binDir)}
+	env := map[string]string{envGoBin: installDir}
 	for _, tool := range goTools {
 		if tool.Version == "" {
 			return fmt.Errorf("%w: %s", errMissingToolVersion, tool.Name)
@@ -69,13 +65,9 @@ func installGoTools(ctx context.Context, goTools []*config.GoTool) error {
 
 // getInstallDir gets the directory where tools should be installed.
 func getInstallDir() (string, error) {
-	installDir := os.Getenv(envLibrarianDir)
-	if installDir != "" {
-		return filepath.Abs(installDir)
-	}
-	homeDir, err := os.UserHomeDir()
+	dir, err := cache.BinDirectory()
 	if err != nil {
-		return "", fmt.Errorf("failed to get user home directory: %w", err)
+		return "", err
 	}
-	return filepath.Abs(filepath.Join(homeDir, toolsDir))
+	return filepath.Abs(filepath.Join(dir, toolsDir))
 }

--- a/internal/librarian/golang/install_test.go
+++ b/internal/librarian/golang/install_test.go
@@ -84,7 +84,7 @@ func TestGetInstallDir(t *testing.T) {
 		{
 			name: "LIBRARIAN_BIN set",
 			env:  map[string]string{cache.EnvLibrarianBin: "/custom/install/dir"},
-			want: "/custom/install/dir",
+			want: "/custom/install/dir/go_tools",
 		},
 		{
 			name: "LIBRARIAN_BIN empty",

--- a/internal/librarian/golang/install_test.go
+++ b/internal/librarian/golang/install_test.go
@@ -67,7 +67,7 @@ func TestInstall_Success(t *testing.T) {
 		"protoc-gen-go",
 	} {
 		t.Run(tool, func(t *testing.T) {
-			path := filepath.Join(installDir, tool+suffix)
+			path := filepath.Join(installDir, toolsDir, tool+suffix)
 			if _, err := os.Stat(path); err != nil {
 				t.Error(err)
 			}

--- a/internal/librarian/golang/install_test.go
+++ b/internal/librarian/golang/install_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/config"
 )
 
@@ -43,7 +44,7 @@ func TestInstall_Error(t *testing.T) {
 
 func TestInstall_Success(t *testing.T) {
 	installDir := t.TempDir()
-	t.Setenv(envLibrarianDir, installDir)
+	t.Setenv(cache.EnvLibrarianBin, installDir)
 	tools := &config.Tools{
 		Go: []*config.GoTool{
 			{Name: "github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic", Version: "v0.58.0"},
@@ -66,7 +67,7 @@ func TestInstall_Success(t *testing.T) {
 		"protoc-gen-go",
 	} {
 		t.Run(tool, func(t *testing.T) {
-			path := filepath.Join(installDir, binDir, tool+suffix)
+			path := filepath.Join(installDir, tool+suffix)
 			if _, err := os.Stat(path); err != nil {
 				t.Error(err)
 			}
@@ -81,14 +82,14 @@ func TestGetInstallDir(t *testing.T) {
 		want string
 	}{
 		{
-			name: "LIBRARIAN_INSTALL_DIR set",
-			env:  map[string]string{envLibrarianDir: "/custom/install/dir"},
+			name: "LIBRARIAN_BIN set",
+			env:  map[string]string{cache.EnvLibrarianBin: "/custom/install/dir"},
 			want: "/custom/install/dir",
 		},
 		{
-			name: "LIBRARIAN_INSTALL_DIR empty",
-			env:  map[string]string{"HOME": "/my/home"},
-			want: "/my/home/go_tools",
+			name: "LIBRARIAN_BIN empty",
+			env:  map[string]string{cache.EnvLibrarianCache: "/my/home/cache"},
+			want: "/my/home/cache/bin/go_tools",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
The Go tool installation and execution logic is updated to use the shared `cache.BinDirectory` helper to resolve the installation path.

Go tools are now installed into a `go_tools` subdirectory within the standard binary directory resolved by the `cache` package.

For https://github.com/googleapis/librarian/issues/5850