### PR TITLE
docs(multi_approvers.yaml): explain use of pull_request_target

### DIFF
--- a/.github/workflows/multi_approvers.yaml
+++ b/.github/workflows/multi_approvers.yaml
@@ -18,6 +18,15 @@
 # ==============================================================================
 name: 'multi-approvers'
 on:
+  # We use `pull_request_target` instead of `pull_request` because this workflow
+  # requires the `secrets.MULTI_APPROVERS_TOKEN` to check membership in the
+  # 'googlers' GitHub team. Standard `pull_request` workflows triggered from
+  # forks do not have access to secrets. Since this is a public repository that
+  # receives PRs from forks, `pull_request_target` is required to access the
+  # token. This is safe because the workflow runs in the context of the base
+  # branch and does not check out or run untrusted code from the PR branch.
+  # For more details, see the action's documentation:
+  # https://github.com/abcxyz/actions/blob/main/.github/actions/multi-approvers/README.md
   pull_request_target:
     types:
       - 'opened'


### PR DESCRIPTION
In general, pull_request_target needs to be used with a caution. There many cases where it's exploited. We have to regularly scrutinize the usages in our repositories.

This PR adds comments to explain why pull_request_target is used instead of pull_request in the multi-approvers workflow. This is to ensure secrets are accessible for PRs from forks while maintaining security.

