### PR TITLE
refactor(internal/librarian/java): resolve tool paths using central cache

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -58,7 +58,7 @@ jobs:
         run: go run ./tool/cmd/coverage ./internal/librarian/java
   integration:
     runs-on: ubuntu-24.04
-    # if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -46,6 +46,7 @@ jobs:
         working-directory: google-cloud-java
         run: |
           librarian install
+          echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Verify tools
         run: |
           protoc --version

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -46,7 +46,6 @@ jobs:
         working-directory: google-cloud-java
         run: |
           librarian install
-          echo "$HOME/java_tools/bin" >> $GITHUB_PATH
       - name: Verify tools
         run: |
           protoc --version

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -58,7 +58,7 @@ jobs:
         run: go run ./tool/cmd/coverage ./internal/librarian/java
   integration:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
+    # if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -117,6 +117,7 @@ func OutputWithEnv(ctx context.Context, env map[string]string, command string, a
 }
 
 func buildCmd(ctx context.Context, dir string, env map[string]string, command string, arg ...string) *exec.Cmd {
+	// Merge system PATH env with the provided environment variables.
 	pathEnv := os.Getenv(envPath)
 	if env != nil {
 		if val, ok := env[envPath]; ok {
@@ -134,6 +135,10 @@ func buildCmd(ctx context.Context, dir string, env map[string]string, command st
 	if len(env) > 0 {
 		cmd.Env = os.Environ()
 		for k, v := range env {
+			// If the environment variable is PATH, merge it with the system PATH
+			if k == envPath {
+				v = pathEnv
+			}
 			cmd.Env = append(cmd.Env, k+"="+v)
 		}
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -120,7 +120,7 @@ func buildCmd(ctx context.Context, dir string, env map[string]string, command st
 	pathEnv := os.Getenv(envPath)
 	if env != nil {
 		if val, ok := env[envPath]; ok {
-			pathEnv = val
+			pathEnv = fmt.Sprintf("%s:%s", val, pathEnv)
 		}
 	}
 	resolvedCommand, err := lookPath(command, pathEnv)

--- a/internal/librarian/java/format.go
+++ b/internal/librarian/java/format.go
@@ -18,13 +18,14 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 )
+
+const envPath = "PATH"
 
 // Format formats a Java client library using google-java-format.
 func Format(ctx context.Context, library *config.Library) error {
@@ -35,13 +36,13 @@ func Format(ctx context.Context, library *config.Library) error {
 	if len(files) == 0 {
 		return nil
 	}
-
-	if _, err := exec.LookPath("google-java-format"); err != nil {
-		return fmt.Errorf("google-java-format not found in PATH: %w", err)
+	binDir, err := getBinDir()
+	if err != nil {
+		return err
 	}
-
+	env := map[string]string{envPath: binDir}
 	args := append([]string{"--replace"}, files...)
-	if err := command.Run(ctx, "google-java-format", args...); err != nil {
+	if err := command.RunWithEnv(ctx, env, "google-java-format", args...); err != nil {
 		return fmt.Errorf("failed to format files: %w", err)
 	}
 	return nil

--- a/internal/librarian/java/format.go
+++ b/internal/librarian/java/format.go
@@ -25,8 +25,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-const envPath = "PATH"
-
 // Format formats a Java client library using google-java-format.
 func Format(ctx context.Context, library *config.Library) error {
 	files, err := collectJavaFiles(library.Output)
@@ -36,12 +34,11 @@ func Format(ctx context.Context, library *config.Library) error {
 	if len(files) == 0 {
 		return nil
 	}
-	binDir, err := getBinDir()
+	args := append([]string{"--replace"}, files...)
+	env, err := getToolsEnv()
 	if err != nil {
 		return err
 	}
-	env := map[string]string{envPath: binDir}
-	args := append([]string{"--replace"}, files...)
 	if err := command.RunWithEnv(ctx, env, "google-java-format", args...); err != nil {
 		return fmt.Errorf("failed to format files: %w", err)
 	}

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -48,7 +48,12 @@ var (
 		"google/rpc":   true,
 	}
 	runProtoc = func(ctx context.Context, args []string) error {
-		return command.Run(ctx, "protoc", args...)
+		binDir, err := getBinDir()
+		if err != nil {
+			return err
+		}
+		env := map[string]string{envPath: binDir}
+		return command.RunWithEnv(ctx, env, "protoc", args...)
 	}
 )
 

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -48,11 +48,10 @@ var (
 		"google/rpc":   true,
 	}
 	runProtoc = func(ctx context.Context, args []string) error {
-		binDir, err := getBinDir()
+		env, err := getToolsEnv()
 		if err != nil {
 			return err
 		}
-		env := map[string]string{envPath: binDir}
 		return command.RunWithEnv(ctx, env, "protoc", args...)
 	}
 )

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -23,11 +23,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/pip"
 )
+
+const toolsDir = "java_tools"
 
 // errNoToolsSpecified indicates no Java tools were provided in the configuration.
 var errNoToolsSpecified = errors.New("no tools specified in configuration")
@@ -50,16 +53,15 @@ func Install(ctx context.Context, tools *config.Tools) error {
 			return fmt.Errorf("failed to install pip tools: %w", err)
 		}
 	}
-	binDir, err := getInstallDir()
+	installDir, err := getInstallDir()
 	if err != nil {
 		return err
 	}
-	// binDir ($HOME/java_tools/bin) stores the generated executable wrapper scripts.
-	// libDir ($HOME/java_tools/lib) is a sibling directory that isolates the downloaded compiled .jar/.exe files.
-	libDir := filepath.Join(filepath.Dir(binDir), "lib")
+	binDir := filepath.Join(installDir, "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)
 	}
+		libDir := filepath.Join(installDir, "lib")
 	if err := os.MkdirAll(libDir, 0755); err != nil {
 		return fmt.Errorf("failed to create lib directory %q: %w", libDir, err)
 	}
@@ -78,18 +80,12 @@ func Install(ctx context.Context, tools *config.Tools) error {
 }
 
 // getInstallDir returns the absolute path of the installation directory for Java tools.
-// It resolves LIBRARIAN_INSTALL_DIR if set, otherwise defaults to "$HOME/java_tools/bin".
-// TODO(https://github.com/googleapis/librarian/issues/5850): Refactor this once Librarian-wide variable is ready.
 func getInstallDir() (string, error) {
-	dir := os.Getenv("LIBRARIAN_INSTALL_DIR")
-	if dir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("failed to get user home directory: %w", err)
-		}
-		dir = filepath.Join(home, "java_tools", "bin")
+	dir, err := cache.BinDirectory()
+	if err != nil {
+		return "", err
 	}
-	return filepath.Abs(dir)
+	return filepath.Abs(filepath.Join(dir, toolsDir))
 }
 
 // installExternalMavenTool downloads a Maven-based external tool, copies its compiled artifact

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -53,15 +53,17 @@ func Install(ctx context.Context, tools *config.Tools) error {
 			return fmt.Errorf("failed to install pip tools: %w", err)
 		}
 	}
-	installDir, err := getInstallDir()
+	binDir, err := getBinDir()
 	if err != nil {
 		return err
 	}
-	binDir := filepath.Join(installDir, "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)
 	}
-	libDir := filepath.Join(installDir, "lib")
+	libDir, err := getLibDir()
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(libDir, 0755); err != nil {
 		return fmt.Errorf("failed to create lib directory %q: %w", libDir, err)
 	}
@@ -77,15 +79,6 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		}
 	}
 	return nil
-}
-
-// getInstallDir returns the absolute path of the installation directory for Java tools.
-func getInstallDir() (string, error) {
-	dir, err := cache.BinDirectory()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Abs(filepath.Join(dir, toolsDir))
 }
 
 // installExternalMavenTool downloads a Maven-based external tool, copies its compiled artifact
@@ -235,4 +228,29 @@ func buildLocalMavenProject(ctx context.Context, localPath string) error {
 		return fmt.Errorf("failed to build local Maven project %q: %w", localPath, err)
 	}
 	return nil
+}
+
+// getInstallDir returns the absolute path of the installation directory for Java tools.
+func getInstallDir() (string, error) {
+	dir, err := cache.BinDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Join(dir, toolsDir))
+}
+
+func getBinDir() (string, error) {
+	installDir, err := getInstallDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Join(installDir, "bin"))
+}
+
+func getLibDir() (string, error) {
+	installDir, err := getInstallDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Join(installDir, "lib"))
 }

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -239,6 +239,7 @@ func getInstallDir() (string, error) {
 	return filepath.Abs(filepath.Join(dir, toolsDir))
 }
 
+// getBinDir returns the absolute path of the directory where Java tool wrapper scripts are stored.
 func getBinDir() (string, error) {
 	installDir, err := getInstallDir()
 	if err != nil {
@@ -247,6 +248,8 @@ func getBinDir() (string, error) {
 	return filepath.Abs(filepath.Join(installDir, "bin"))
 }
 
+// getLibDir returns the absolute path of the directory where Java tool library files (such as .jar
+// or .exe files) are stored.
 func getLibDir() (string, error) {
 	installDir, err := getInstallDir()
 	if err != nil {

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -30,7 +30,10 @@ import (
 	"github.com/googleapis/librarian/internal/pip"
 )
 
-const toolsDir = "java_tools"
+const (
+	envPath  = "PATH"
+	toolsDir = "java_tools"
+)
 
 // errNoToolsSpecified indicates no Java tools were provided in the configuration.
 var errNoToolsSpecified = errors.New("no tools specified in configuration")
@@ -256,4 +259,13 @@ func getLibDir() (string, error) {
 		return "", err
 	}
 	return filepath.Abs(filepath.Join(installDir, "lib"))
+}
+
+// getToolsEnv returns an environment map with the Java tools bin directory prepended to the PATH.
+func getToolsEnv() (map[string]string, error) {
+	binDir, err := getBinDir()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{envPath: binDir}, nil
 }

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -61,7 +61,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)
 	}
-		libDir := filepath.Join(installDir, "lib")
+	libDir := filepath.Join(installDir, "lib")
 	if err := os.MkdirAll(libDir, 0755); err != nil {
 		return fmt.Errorf("failed to create lib directory %q: %w", libDir, err)
 	}

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -144,7 +144,7 @@ func TestInstall(t *testing.T) {
 		},
 	}
 	installDir := filepath.Join(tmpDir, "java_tools", "bin")
-	t.Setenv("LIBRARIAN_INSTALL_DIR", installDir)
+	t.Setenv("LIBRARIAN_BIN", tmpDir)
 	if err := Install(t.Context(), tools); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -276,3 +276,36 @@ func TestGetLibDir(t *testing.T) {
 		})
 	}
 }
+
+func TestGetToolsEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, test := range []struct {
+		name           string
+		librarianBin   string
+		librarianCache string
+		want           map[string]string
+	}{
+		{
+			name:         "LIBRARIAN_BIN is set",
+			librarianBin: tmpDir,
+			want:         map[string]string{"PATH": filepath.Join(tmpDir, "java_tools", "bin")},
+		},
+		{
+			name:           "LIBRARIAN_CACHE is set",
+			librarianCache: tmpDir,
+			want:           map[string]string{"PATH": filepath.Join(tmpDir, "bin", "java_tools", "bin")},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("LIBRARIAN_BIN", test.librarianBin)
+			t.Setenv("LIBRARIAN_CACHE", test.librarianCache)
+			got, err := getToolsEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -235,7 +235,40 @@ func TestGetBinDir(t *testing.T) {
 			t.Setenv("LIBRARIAN_CACHE", test.librarianCache)
 			got, err := getBinDir()
 			if err != nil {
-				t.Fatalf("getBinDir() failed: %v", err)
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetLibDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, test := range []struct {
+		name           string
+		librarianBin   string
+		librarianCache string
+		want           string
+	}{
+		{
+			name:         "LIBRARIAN_BIN is set",
+			librarianBin: tmpDir,
+			want:         filepath.Join(tmpDir, "java_tools", "lib"),
+		},
+		{
+			name:           "LIBRARIAN_CACHE is set",
+			librarianCache: tmpDir,
+			want:           filepath.Join(tmpDir, "bin", "java_tools", "lib"),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("LIBRARIAN_BIN", test.librarianBin)
+			t.Setenv("LIBRARIAN_CACHE", test.librarianCache)
+			got, err := getLibDir()
+			if err != nil {
+				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -213,7 +213,7 @@ func TestInstall(t *testing.T) {
 
 func TestGetBinDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	tests := []struct {
+	for _, test := range []struct {
 		name           string
 		librarianBin   string
 		librarianCache string
@@ -229,19 +229,16 @@ func TestGetBinDir(t *testing.T) {
 			librarianCache: tmpDir,
 			want:           filepath.Join(tmpDir, "bin", "java_tools", "bin"),
 		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("LIBRARIAN_BIN", test.librarianBin)
 			t.Setenv("LIBRARIAN_CACHE", test.librarianCache)
-
 			got, err := getBinDir()
 			if err != nil {
 				t.Fatalf("getBinDir() failed: %v", err)
 			}
-			if got != test.want {
-				t.Errorf("getBinDir() = %q, want %q", got, test.want)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -210,3 +210,39 @@ func TestInstall(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBinDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	tests := []struct {
+		name           string
+		librarianBin   string
+		librarianCache string
+		want           string
+	}{
+		{
+			name:         "LIBRARIAN_BIN is set",
+			librarianBin: tmpDir,
+			want:         filepath.Join(tmpDir, "java_tools", "bin"),
+		},
+		{
+			name:           "LIBRARIAN_CACHE is set",
+			librarianCache: tmpDir,
+			want:           filepath.Join(tmpDir, "bin", "java_tools", "bin"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("LIBRARIAN_BIN", test.librarianBin)
+			t.Setenv("LIBRARIAN_CACHE", test.librarianCache)
+
+			got, err := getBinDir()
+			if err != nil {
+				t.Fatalf("getBinDir() failed: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("getBinDir() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Java tools installer and command runners are refactored to use the central cache directory resolved via the cache package instead of a hardcoded location under the user home directory.

The command runner helper inside the command package is also updated to properly merge the `PATH` environment variable for child processes, ensuring that wrappers which depend on system utilities (like `java`) function correctly when executed.

For #5850