### PR TITLE
fix(nodejs): remove google/cloud/common_resources.proto after generation

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	commonProtos = "google/cloud/common_resources.proto"
+	cloudCommonResourcesProto = "google/cloud/common_resources.proto"
 )
 
 // IsMixedLibrary reports whether the library has handwritten code wrapping
@@ -149,7 +149,7 @@ func resolveNodejsAPI(library *config.Library, api *config.API) *config.NodejsAP
 
 	var protos []string
 	if !omitCommon {
-		protos = append(protos, commonProtos)
+		protos = append(protos, cloudCommonResourcesProto)
 	}
 
 	if library.Nodejs == nil {
@@ -394,6 +394,12 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		return fmt.Errorf("failed to remove redundant linter files: %w", err)
 	}
 
+	// Remove google/cloud/common_resources.proto from the protos directory.
+	// We don't need it in the repo (it isn't in googleapis-gen) and we don't
+	// want it to be in the diff.
+	if err := os.Remove(filepath.Join(outDir, "protos", cloudCommonResourcesProto)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to remove %s: %w", cloudCommonResourcesProto, err)
+	}
 	return nil
 }
 

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -508,6 +508,51 @@ func TestRunPostProcessor_RemovesOwlBotYaml(t *testing.T) {
 	}
 }
 
+func TestRunPostProcessor_RemovesCloudCommonResourcesProto(t *testing.T) {
+	testhelper.RequireCommand(t, "gapic-node-processing")
+	testhelper.RequireCommand(t, "compileProtos")
+
+	repoRoot := t.TempDir()
+	library := &config.Library{Name: "google-cloud-test"}
+	outDir := filepath.Join(repoRoot, "packages", library.Name)
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create staging structure with a .OwlBot.yaml file.
+	stagingBase := filepath.Join(repoRoot, "owl-bot-staging", library.Name, "v1")
+	srcDir := filepath.Join(stagingBase, "src", "v1")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {};\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	protoDir := filepath.Join(stagingBase, "protos", "google", "cloud", "test", "v1")
+	if err := os.MkdirAll(protoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingBase, "protos", cloudCommonResourcesProto), []byte("syntax = \"proto3\";\npackage google.cloud;\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fullResourcesProto := filepath.Join(protoDir, cloudCommonResourcesProto)
+	if err := os.MkdirAll(filepath.Dir(fullResourcesProto), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fullResourcesProto, []byte("syntax = \"proto3\";\npackage google.cloud;\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Language: config.LanguageNodejs}
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "protos", cloudCommonResourcesProto)); !errors.Is(err, fs.ErrNotExist) {
+		t.Error("expected common_resources.proto to be removed after post-processing")
+	}
+}
+
 func TestRunPostProcessor_CustomScripts(t *testing.T) {
 	testhelper.RequireCommand(t, "gapic-node-processing")
 	testhelper.RequireCommand(t, "compileProtos")
@@ -1041,7 +1086,7 @@ func TestResolveNodejsAPI(t *testing.T) {
 			api:     &config.API{Path: "google/cloud/secretmanager/v1"},
 			want: &config.NodejsAPI{
 				Path:             "google/cloud/secretmanager/v1",
-				AdditionalProtos: []string{commonProtos},
+				AdditionalProtos: []string{cloudCommonResourcesProto},
 			},
 		},
 		{
@@ -1059,7 +1104,7 @@ func TestResolveNodejsAPI(t *testing.T) {
 			api: &config.API{Path: "google/cloud/secretmanager/v1"},
 			want: &config.NodejsAPI{
 				Path:             "google/cloud/secretmanager/v1",
-				AdditionalProtos: []string{commonProtos, "other.proto"},
+				AdditionalProtos: []string{cloudCommonResourcesProto, "other.proto"},
 			},
 		},
 		{
@@ -1078,14 +1123,14 @@ func TestResolveNodejsAPI(t *testing.T) {
 			api: &config.API{Path: "google/cloud/secretmanager/v1"},
 			want: &config.NodejsAPI{
 				Path:             "google/cloud/secretmanager/v1",
-				AdditionalProtos: []string{commonProtos, "pkg.proto", "api.proto"},
+				AdditionalProtos: []string{cloudCommonResourcesProto, "pkg.proto", "api.proto"},
 			},
 		},
 		{
 			name: "deduplicates protos",
 			library: &config.Library{
 				Nodejs: &config.NodejsPackage{
-					AdditionalProtos: []string{commonProtos, "other.proto"},
+					AdditionalProtos: []string{cloudCommonResourcesProto, "other.proto"},
 					NodejsAPIs: []*config.NodejsAPI{
 						{
 							Path:             "google/cloud/secretmanager/v1",
@@ -1097,7 +1142,7 @@ func TestResolveNodejsAPI(t *testing.T) {
 			api: &config.API{Path: "google/cloud/secretmanager/v1"},
 			want: &config.NodejsAPI{
 				Path:             "google/cloud/secretmanager/v1",
-				AdditionalProtos: []string{commonProtos, "other.proto", "more.proto"},
+				AdditionalProtos: []string{cloudCommonResourcesProto, "other.proto", "more.proto"},
 			},
 		},
 		{
@@ -1115,7 +1160,7 @@ func TestResolveNodejsAPI(t *testing.T) {
 			api: &config.API{Path: "google/cloud/secretmanager/v1"},
 			want: &config.NodejsAPI{
 				Path:             "google/cloud/secretmanager/v1",
-				AdditionalProtos: []string{commonProtos},
+				AdditionalProtos: []string{cloudCommonResourcesProto},
 				DIREGAPIC:        true,
 			},
 		},
@@ -1217,7 +1262,7 @@ func TestResolveNodejsAPI(t *testing.T) {
 			want: &config.NodejsAPI{
 				Path:                "google/cloud/secretmanager/v1",
 				OmitCommonResources: false,
-				AdditionalProtos:    []string{commonProtos, "pkg.proto", "api.proto"},
+				AdditionalProtos:    []string{cloudCommonResourcesProto, "pkg.proto", "api.proto"},
 			},
 		},
 		{

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -519,7 +519,7 @@ func TestRunPostProcessor_RemovesCloudCommonResourcesProto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create staging structure with a .OwlBot.yaml file.
+	// Create staging structure with a common_resources.proto file.
 	stagingBase := filepath.Join(repoRoot, "owl-bot-staging", library.Name, "v1")
 	srcDir := filepath.Join(stagingBase, "src", "v1")
 	if err := os.MkdirAll(srcDir, 0755); err != nil {
@@ -532,15 +532,10 @@ func TestRunPostProcessor_RemovesCloudCommonResourcesProto(t *testing.T) {
 	if err := os.MkdirAll(protoDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(protoDir, "test.proto"), []byte("syntax = \"proto3\";\npackage google.cloud.test.v1;\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(stagingBase, "protos", cloudCommonResourcesProto), []byte("syntax = \"proto3\";\npackage google.cloud;\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	fullResourcesProto := filepath.Join(protoDir, cloudCommonResourcesProto)
-	if err := os.MkdirAll(filepath.Dir(fullResourcesProto), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(fullResourcesProto, []byte("syntax = \"proto3\";\npackage google.cloud;\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Deletes protos/google/cloud/common_resources.proto in the post-processor for Node. We don't want the file to ever exist in the protos directory, but we do need to specify it during generation in many cases.

Fixes #6024