### PR TITLE
fix: ignore skipped checks

### DIFF
--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -281,7 +281,7 @@ func waitForPullRequestReadinessSingleIteration(ctx context.Context, prMetadata 
 			slog.Info(fmt.Sprintf("Check '%s' is not complete", *checkRun.Name))
 			return false, nil
 		}
-		// Ignore skipped checks.
+		// Ignore "skipped" checks, as we can't do anything about them.
 		if checkRun.GetConclusion() == "skipped" {
 			slog.Info(fmt.Sprintf("Check '%s' was skipped", *checkRun.Name))
 			continue

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -281,6 +281,11 @@ func waitForPullRequestReadinessSingleIteration(ctx context.Context, prMetadata 
 			slog.Info(fmt.Sprintf("Check '%s' is not complete", *checkRun.Name))
 			return false, nil
 		}
+		// Ignore skipped checks.
+		if checkRun.GetConclusion() == "skipped" {
+			slog.Info(fmt.Sprintf("Check '%s' was skipped", *checkRun.Name))
+			continue
+		}
 		if checkRun.GetConclusion() != "success" {
 			return false, reportBlockingReason(ctx, prMetadata, fmt.Sprintf("Check '%s' failed", *checkRun.Name), cfg)
 		}

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -283,7 +283,7 @@ func waitForPullRequestReadinessSingleIteration(ctx context.Context, prMetadata 
 		}
 		// Ignore "skipped" checks, as we can't do anything about them.
 		if checkRun.GetConclusion() == "skipped" {
-			slog.Info(fmt.Sprintf("Check '%s' was skipped", *checkRun.Name))
+			slog.Info(fmt.Sprintf("Check '%s' was skipped", checkRun.GetName()))
 			continue
 		}
 		if checkRun.GetConclusion() != "success" {


### PR DESCRIPTION
Ignore skipped checks when polling check status.

Related API docs: https://docs.github.com/en/rest/checks/runs?apiVersion=2026-03-10#list-check-runs-for-a-git-reference

Fixes #6216