### PR TITLE
refactor(sidekick/swift): decompose map helper

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -71,34 +71,9 @@ func (c *codec) annotateField(field *api.Field) error {
 	if err != nil {
 		return err
 	}
-	var packageName string
-	switch field.Typez {
-	case api.TypezMessage:
-		if m, err := lookupMessage(c.Model, field.TypezID); err == nil {
-			if m.IsMap {
-				for _, mf := range m.Fields {
-					if mf.Name == "value" {
-						switch mf.Typez {
-						case api.TypezMessage:
-							if vm, err := lookupMessage(c.Model, mf.TypezID); err == nil {
-								packageName = vm.Package
-							}
-						case api.TypezEnum:
-							if ve, err := lookupEnum(c.Model, mf.TypezID); err == nil {
-								packageName = ve.Package
-							}
-						}
-						break
-					}
-				}
-			} else {
-				packageName = m.Package
-			}
-		}
-	case api.TypezEnum:
-		if e, err := lookupEnum(c.Model, field.TypezID); err == nil {
-			packageName = e.Package
-		}
+	packageName, err := c.fieldPackage(field)
+	if err != nil {
+		return err
 	}
 	annotations := &fieldAnnotations{
 		Name:            camelCase(field.Name),
@@ -129,4 +104,43 @@ func (c *codec) annotateField(field *api.Field) error {
 	}
 	field.Codec = annotations
 	return nil
+}
+
+func (c *codec) fieldPackage(field *api.Field) (string, error) {
+	switch field.Typez {
+	case api.TypezMessage:
+		m, err := lookupMessage(c.Model, field.TypezID)
+		if err != nil {
+			return "", err
+		}
+		if !m.IsMap {
+			return m.Package, nil
+		}
+		fields, err := decomposeMap(m)
+		if err != nil {
+			return "", err
+		}
+		mf := fields.Value
+		switch mf.Typez {
+		case api.TypezMessage:
+			vm, err := lookupMessage(c.Model, mf.TypezID)
+			if err != nil {
+				return "", err
+			}
+			return vm.Package, nil
+		case api.TypezEnum:
+			ve, err := lookupEnum(c.Model, mf.TypezID)
+			if err != nil {
+				return "", err
+			}
+			return ve.Package, nil
+		}
+	case api.TypezEnum:
+		e, err := lookupEnum(c.Model, field.TypezID)
+		if err != nil {
+			return "", err
+		}
+		return e.Package, nil
+	}
+	return "", nil
 }

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -70,23 +70,15 @@ func (c *codec) mapFieldTypeName(m *api.Message) (string, error) {
 }
 
 func (c *codec) mapFieldTypeComponents(m *api.Message) (string, string, error) {
-	var keyField, valueField *api.Field
-	for _, f := range m.Fields {
-		switch f.Name {
-		case "key":
-			keyField = f
-		case "value":
-			valueField = f
-		}
-	}
-	if keyField == nil || valueField == nil {
-		return "", "", fmt.Errorf("map message %q missing key or value field", m.ID)
-	}
-	keyType, err := c.baseFieldTypeName(keyField)
+	kv, err := decomposeMap(m)
 	if err != nil {
 		return "", "", err
 	}
-	valueType, err := c.baseFieldTypeName(valueField)
+	keyType, err := c.baseFieldTypeName(kv.Key)
+	if err != nil {
+		return "", "", err
+	}
+	valueType, err := c.baseFieldTypeName(kv.Value)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/sidekick/swift/map.go
+++ b/internal/sidekick/swift/map.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+type mapFields struct {
+	Key   *api.Field
+	Value *api.Field
+}
+
+// mapFields decomposes a map message into a key and value field
+func decomposeMap(m *api.Message) (*mapFields, error) {
+	var keyField, valueField *api.Field
+	for _, f := range m.Fields {
+		switch f.Name {
+		case "key":
+			keyField = f
+		case "value":
+			valueField = f
+		}
+	}
+	if keyField == nil || valueField == nil {
+		return nil, fmt.Errorf("map message %q missing key or value field", m.ID)
+	}
+	return &mapFields{Key: keyField, Value: valueField}, nil
+}

--- a/internal/sidekick/swift/map.go
+++ b/internal/sidekick/swift/map.go
@@ -25,7 +25,7 @@ type mapFields struct {
 	Value *api.Field
 }
 
-// mapFields decomposes a map message into a key and value field
+// decomposeMap fields the key and value fields for a map message.
 func decomposeMap(m *api.Message) (*mapFields, error) {
 	var keyField, valueField *api.Field
 	for _, f := range m.Fields {


### PR DESCRIPTION
Add a function to decompose a map into its key and value fields. Use the function to create the map's type name and to compute the map's field package.

Towards #5808 