### PR TITLE
fix(librarian): revert pipeline state for failed library releases via deep copy

### DIFF
--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -15,13 +15,14 @@
 package gitrepo
 
 import (
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 func TestGetCommitsForPathsSinceCommit(t *testing.T) {

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -214,7 +214,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 
 	pr := new(PullRequestContent)
 
-	for _, library := range libraries {
+	for i, library := range libraries {
 		// If we've specified a single library to release, skip all the others.
 		if cfg.LibraryID != "" && library.Id != cfg.LibraryID {
 			continue
@@ -258,10 +258,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		}
 
 		// Save the original values of the library state fields, so we can restore them if the release fails.
-		origVersion := library.CurrentVersion
-		origNextVersion := library.NextVersion
-		origLastReleasedCommit := library.LastReleasedCommit
-		origReleaseTimestamp := library.ReleaseTimestamp
+		originalLib := library.deepCopy()
 		// Update the pipeline state to record what we're releasing and when, and to clear the next version field.
 		// Performing this before anything else means that container code can use the pipeline state for the steps
 		// below, if it doesn't want/need to store the version separately.
@@ -275,16 +272,18 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 
 		if err := cc.PrepareLibraryRelease(ctx, cfg, languageRepo.Dir, inputDirectory, library.Id, releaseVersion); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "preparing library release")
+			libraries[i] = originalLib
 			// Clean up any changes before starting the next iteration.
-			if err := rollbackLibraryState(state, library, origVersion, origNextVersion, origLastReleasedCommit, origReleaseTimestamp); err != nil {
+			if err := languageRepo.CleanWorkingTree(); err != nil {
 				return nil, err
 			}
 			continue
 		}
 		if err := cc.BuildLibrary(ctx, cfg, languageRepo.Dir, library.Id); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "building/testing library")
+			libraries[i] = originalLib
 			// Clean up any changes before starting the next iteration.
-			if err := rollbackLibraryState(state, library, origVersion, origNextVersion, origLastReleasedCommit, origReleaseTimestamp); err != nil {
+			if err := languageRepo.CleanWorkingTree(); err != nil {
 				return nil, err
 			}
 			continue
@@ -293,7 +292,8 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 			slog.Info(fmt.Sprintf("Skipping integration tests: %s", cfg.SkipIntegrationTests))
 		} else if err := cc.IntegrationTestLibrary(ctx, cfg, languageRepo.Dir, library.Id); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "integration testing library")
-			if err := rollbackLibraryState(state, library, origVersion, origNextVersion, origLastReleasedCommit, origReleaseTimestamp); err != nil {
+			libraries[i] = originalLib
+			if err := languageRepo.CleanWorkingTree(); err != nil {
 				return nil, err
 			}
 			continue
@@ -442,17 +442,4 @@ func isReleaseWorthy(messages []*CommitMessage, libraryId string) bool {
 		}
 	}
 	return false
-}
-
-func rollbackLibraryState(state *commandState, library *statepb.LibraryState, origVersion, origNextVersion, origLastReleasedCommit string, origReleaseTimestamp *timestamppb.Timestamp) (err error) {
-	library.CurrentVersion = origVersion
-	library.NextVersion = origNextVersion
-	library.LastReleasedCommit = origLastReleasedCommit
-	library.ReleaseTimestamp = origReleaseTimestamp
-	defer func() {
-		if cleanErr := state.languageRepo.CleanWorkingTree(); cleanErr != nil {
-			err = cleanErr
-		}
-	}()
-	return savePipelineState(state)
 }

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -20,7 +20,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -260,7 +259,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		}
 
 		// Save the original values of the library state fields, so we can restore them if the release fails.
-		originalLib := deepCopyLibrary(library)
+		originalLib := proto.Clone(library).(*statepb.LibraryState)
 		// Update the pipeline state to record what we're releasing and when, and to clear the next version field.
 		// Performing this before anything else means that container code can use the pipeline state for the steps
 		// below, if it doesn't want/need to store the version separately.
@@ -444,19 +443,4 @@ func isReleaseWorthy(messages []*CommitMessage, libraryId string) bool {
 		}
 	}
 	return false
-}
-
-func deepCopyLibrary(lib *statepb.LibraryState) *statepb.LibraryState {
-	return &statepb.LibraryState{
-		Id:                        lib.Id,
-		CurrentVersion:            lib.CurrentVersion,
-		NextVersion:               lib.NextVersion,
-		GenerationAutomationLevel: lib.GenerationAutomationLevel,
-		ReleaseAutomationLevel:    lib.ReleaseAutomationLevel,
-		ReleaseTimestamp:          proto.Clone(lib.ReleaseTimestamp).(*timestamppb.Timestamp),
-		LastGeneratedCommit:       lib.LastGeneratedCommit,
-		LastReleasedCommit:        lib.LastReleasedCommit,
-		ApiPaths:                  slices.Clone(lib.ApiPaths),
-		SourcePaths:               slices.Clone(lib.SourcePaths),
-	}
 }

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -444,13 +444,15 @@ func isReleaseWorthy(messages []*CommitMessage, libraryId string) bool {
 	return false
 }
 
-func rollbackLibraryState(state *commandState, library *statepb.LibraryState, origVersion, origNextVersion, origLastReleasedCommit string, origReleaseTimestamp *timestamppb.Timestamp) error {
+func rollbackLibraryState(state *commandState, library *statepb.LibraryState, origVersion, origNextVersion, origLastReleasedCommit string, origReleaseTimestamp *timestamppb.Timestamp) (err error) {
 	library.CurrentVersion = origVersion
 	library.NextVersion = origNextVersion
 	library.LastReleasedCommit = origLastReleasedCommit
 	library.ReleaseTimestamp = origReleaseTimestamp
-	if err := savePipelineState(state); err != nil {
-		return err
-	}
-	return state.languageRepo.CleanWorkingTree()
+	defer func() {
+		if cleanErr := state.languageRepo.CleanWorkingTree(); cleanErr != nil {
+			err = cleanErr
+		}
+	}()
+	return savePipelineState(state)
 }

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -257,6 +257,11 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 			return nil, err
 		}
 
+		// Save the original values of the library state fields, so we can restore them if the release fails.
+		origVersion := library.CurrentVersion
+		origNextVersion := library.NextVersion
+		origLastReleasedCommit := library.LastReleasedCommit
+		origReleaseTimestamp := library.ReleaseTimestamp
 		// Update the pipeline state to record what we're releasing and when, and to clear the next version field.
 		// Performing this before anything else means that container code can use the pipeline state for the steps
 		// below, if it doesn't want/need to store the version separately.
@@ -271,7 +276,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		if err := cc.PrepareLibraryRelease(ctx, cfg, languageRepo.Dir, inputDirectory, library.Id, releaseVersion); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "preparing library release")
 			// Clean up any changes before starting the next iteration.
-			if err := languageRepo.CleanWorkingTree(); err != nil {
+			if err := rollbackLibraryState(state, library, origVersion, origNextVersion, origLastReleasedCommit, origReleaseTimestamp); err != nil {
 				return nil, err
 			}
 			continue
@@ -279,7 +284,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		if err := cc.BuildLibrary(ctx, cfg, languageRepo.Dir, library.Id); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "building/testing library")
 			// Clean up any changes before starting the next iteration.
-			if err := languageRepo.CleanWorkingTree(); err != nil {
+			if err := rollbackLibraryState(state, library, origVersion, origNextVersion, origLastReleasedCommit, origReleaseTimestamp); err != nil {
 				return nil, err
 			}
 			continue
@@ -288,7 +293,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 			slog.Info(fmt.Sprintf("Skipping integration tests: %s", cfg.SkipIntegrationTests))
 		} else if err := cc.IntegrationTestLibrary(ctx, cfg, languageRepo.Dir, library.Id); err != nil {
 			addErrorToPullRequest(pr, library.Id, err, "integration testing library")
-			if err := languageRepo.CleanWorkingTree(); err != nil {
+			if err := rollbackLibraryState(state, library, origVersion, origNextVersion, origLastReleasedCommit, origReleaseTimestamp); err != nil {
 				return nil, err
 			}
 			continue
@@ -437,4 +442,15 @@ func isReleaseWorthy(messages []*CommitMessage, libraryId string) bool {
 		}
 	}
 	return false
+}
+
+func rollbackLibraryState(state *commandState, library *statepb.LibraryState, origVersion, origNextVersion, origLastReleasedCommit string, origReleaseTimestamp *timestamppb.Timestamp) error {
+	library.CurrentVersion = origVersion
+	library.NextVersion = origNextVersion
+	library.LastReleasedCommit = origLastReleasedCommit
+	library.ReleaseTimestamp = origReleaseTimestamp
+	if err := savePipelineState(state); err != nil {
+		return err
+	}
+	return state.languageRepo.CleanWorkingTree()
 }

--- a/internal/librarian/createreleasepr.go
+++ b/internal/librarian/createreleasepr.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -29,6 +30,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/googleapis/librarian/internal/statepb"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -258,7 +260,7 @@ func generateReleaseCommitForEachLibrary(ctx context.Context, state *commandStat
 		}
 
 		// Save the original values of the library state fields, so we can restore them if the release fails.
-		originalLib := library.deepCopy()
+		originalLib := deepCopyLibrary(library)
 		// Update the pipeline state to record what we're releasing and when, and to clear the next version field.
 		// Performing this before anything else means that container code can use the pipeline state for the steps
 		// below, if it doesn't want/need to store the version separately.
@@ -442,4 +444,19 @@ func isReleaseWorthy(messages []*CommitMessage, libraryId string) bool {
 		}
 	}
 	return false
+}
+
+func deepCopyLibrary(lib *statepb.LibraryState) *statepb.LibraryState {
+	return &statepb.LibraryState{
+		Id:                        lib.Id,
+		CurrentVersion:            lib.CurrentVersion,
+		NextVersion:               lib.NextVersion,
+		GenerationAutomationLevel: lib.GenerationAutomationLevel,
+		ReleaseAutomationLevel:    lib.ReleaseAutomationLevel,
+		ReleaseTimestamp:          proto.Clone(lib.ReleaseTimestamp).(*timestamppb.Timestamp),
+		LastGeneratedCommit:       lib.LastGeneratedCommit,
+		LastReleasedCommit:        lib.LastReleasedCommit,
+		ApiPaths:                  slices.Clone(lib.ApiPaths),
+		SourcePaths:               slices.Clone(lib.SourcePaths),
+	}
 }

--- a/internal/statepb/pipeline.pb.go
+++ b/internal/statepb/pipeline.pb.go
@@ -21,12 +21,15 @@
 package statepb
 
 import (
+	reflect "reflect"
+	"slices"
+	sync "sync"
+	unsafe "unsafe"
+
+	"google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (
@@ -311,6 +314,21 @@ func (x *LibraryState) GetSourcePaths() []string {
 		return x.SourcePaths
 	}
 	return nil
+}
+
+func (x *LibraryState) deepCopy() *LibraryState {
+	return &LibraryState{
+		Id:                        x.Id,
+		CurrentVersion:            x.CurrentVersion,
+		NextVersion:               x.NextVersion,
+		GenerationAutomationLevel: x.GenerationAutomationLevel,
+		ReleaseAutomationLevel:    x.ReleaseAutomationLevel,
+		ReleaseTimestamp:          proto.Clone(x.ReleaseTimestamp).(*timestamppb.Timestamp),
+		LastGeneratedCommit:       x.LastGeneratedCommit,
+		LastReleasedCommit:        x.LastReleasedCommit,
+		ApiPaths:                  slices.Clone(x.ApiPaths),
+		SourcePaths:               slices.Clone(x.SourcePaths),
+	}
 }
 
 // Manually-maintained configuration for the pipeline.

--- a/internal/statepb/pipeline.pb.go
+++ b/internal/statepb/pipeline.pb.go
@@ -21,15 +21,12 @@
 package statepb
 
 import (
-	reflect "reflect"
-	"slices"
-	sync "sync"
-	unsafe "unsafe"
-
-	"google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -314,21 +311,6 @@ func (x *LibraryState) GetSourcePaths() []string {
 		return x.SourcePaths
 	}
 	return nil
-}
-
-func (x *LibraryState) deepCopy() *LibraryState {
-	return &LibraryState{
-		Id:                        x.Id,
-		CurrentVersion:            x.CurrentVersion,
-		NextVersion:               x.NextVersion,
-		GenerationAutomationLevel: x.GenerationAutomationLevel,
-		ReleaseAutomationLevel:    x.ReleaseAutomationLevel,
-		ReleaseTimestamp:          proto.Clone(x.ReleaseTimestamp).(*timestamppb.Timestamp),
-		LastGeneratedCommit:       x.LastGeneratedCommit,
-		LastReleasedCommit:        x.LastReleasedCommit,
-		ApiPaths:                  slices.Clone(x.ApiPaths),
-		SourcePaths:               slices.Clone(x.SourcePaths),
-	}
 }
 
 // Manually-maintained configuration for the pipeline.


### PR DESCRIPTION
When creating a release PR, if a library fails to prepare, build, or test during the loop, its working directory changes are reverted on disk, but its in-memory state modifications in `state.pipelineState` were not reverted.

This caused subsequent successful library release commits in the same loop to serialize
and commit the incorrect version updates for the previously failed library.

Fix this by using `proto.Clone` to deep-copy the original library state before modifying it in the loop. If any of the release steps fail, we restore the original library state in the `libraries` slice and clean the working tree, ensuring that no stale version updates are written to `pipeline-state.json`.

Fixes #6299 