### PR TITLE
feat(nodejs): update gapic generator to v4.12.0

### DIFF
--- a/internal/librarian/nodejs/librarian.yaml
+++ b/internal/librarian/nodejs/librarian.yaml
@@ -19,9 +19,9 @@ language: nodejs
 tools:
   pnpm:
     - name: gapic-generator-typescript
-      version: "92b328bd72b7418e5eca12ee0ffc32829daf0a77"
-      package: "https://github.com/googleapis/google-cloud-node/archive/92b328bd72b7418e5eca12ee0ffc32829daf0a77.tar.gz"
-      checksum: "34a49ef9c0ded1e14d8d00a32353048e91656a87ecfe285c15f1f2375016a5c6"
+      version: "gapic-generator-v4.12.0"
+      package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.0.tar.gz"
+      checksum: "7db96e31b8c6ac15d40e92654a731ec7aa2b0a3425708ac68369b374688112e8"
       build:
         - "pnpm install"
         # tsc only compiles TypeScript; the generator also needs templates/


### PR DESCRIPTION
The librarian.yaml file which is used by librarian install for nodejs is updated to use gapic-generator-typescript v4.12.0, with a corresponding sha256 checksum.