### PR TITLE
chore(.github/workflows): java post submit to create issue on failure

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -93,12 +93,10 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/google-cloud-java/sdk-platform-java/hermetic_build/library_generation/owlbot
         run: librarian generate --all
-# TODO: uncomment once Java is migrated to Librarian
-# https://github.com/googleapis/librarian/issues/6176
-# create-issue-on-failure:
-#   needs: [integration]
-#   if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-#   uses: ./.github/workflows/create-issue-on-failure.yaml
-#   with:
-#     language: Java
-#     repository: google-cloud-java
+  create-issue-on-failure:
+    needs: [integration]
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/create-issue-on-failure.yaml
+    with:
+      language: Java
+      repository: google-cloud-java


### PR DESCRIPTION
Start creating issue on failure for java generate all post submit test. We are already using librarian in google-cloud-java (co-exist with hermetic build for the week).

Fixes https://github.com/googleapis/librarian/issues/6176