### PR TITLE
refactor(sidekick/swift): field names helper

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -59,11 +59,7 @@ type fieldAnnotations struct {
 }
 
 func (c *codec) annotateField(field *api.Field) error {
-	fieldType, err := c.fieldTypeName(field)
-	if err != nil {
-		return err
-	}
-	baseFieldType, err := c.baseFieldTypeName(field)
+	parts, err := c.fieldTypeParts(field)
 	if err != nil {
 		return err
 	}
@@ -77,11 +73,11 @@ func (c *codec) annotateField(field *api.Field) error {
 	}
 	annotations := &fieldAnnotations{
 		Name:            camelCase(field.Name),
-		FieldType:       fieldType,
-		BaseFieldType:   baseFieldType,
+		FieldType:       parts.Name,
+		BaseFieldType:   parts.Base,
 		PackageName:     packageName,
 		DocLines:        docLines,
-		InitializerType: fieldType,
+		InitializerType: parts.Name,
 	}
 	// Swift value types (structs) cannot contain recursive references directly because their
 	// size must be known at compile time. To break the cycle, we wrap the reference in a box type
@@ -93,9 +89,9 @@ func (c *codec) annotateField(field *api.Field) error {
 	//    automatically using the native indirect case mechanism.
 	if field.Recursive && field.Singular() && !field.IsOneOf {
 		annotations.Recursive = true
-		annotations.InitializerType = baseFieldType + "?"
-		annotations.BaseFieldType = fmt.Sprintf("%s.Recursive<%s>", wellKnownSwiftPackage, baseFieldType)
-		annotations.FieldType = fmt.Sprintf("%s.Recursive<%s>?", wellKnownSwiftPackage, baseFieldType)
+		annotations.InitializerType = parts.Base + "?"
+		annotations.BaseFieldType = fmt.Sprintf("%s.Recursive<%s>", wellKnownSwiftPackage, parts.Base)
+		annotations.FieldType = annotations.BaseFieldType + "?"
 	}
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -59,7 +59,7 @@ type fieldAnnotations struct {
 }
 
 func (c *codec) annotateField(field *api.Field) error {
-	parts, err := c.fieldTypeParts(field)
+	parts, err := c.fieldTypeName(field)
 	if err != nil {
 		return err
 	}
@@ -73,11 +73,11 @@ func (c *codec) annotateField(field *api.Field) error {
 	}
 	annotations := &fieldAnnotations{
 		Name:            camelCase(field.Name),
-		FieldType:       parts.Name,
+		FieldType:       parts.Full,
 		BaseFieldType:   parts.Base,
 		PackageName:     packageName,
 		DocLines:        docLines,
-		InitializerType: parts.Name,
+		InitializerType: parts.Full,
 	}
 	// Swift value types (structs) cannot contain recursive references directly because their
 	// size must be known at compile time. To break the cycle, we wrap the reference in a box type

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -20,6 +20,67 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
+type BaseTypeNames struct {
+	Base  string
+	Key   string
+	Value string
+}
+
+type fieldTypeNames struct {
+	BaseTypeNames
+	Name string
+}
+
+func (c *codec) fieldTypeParts(field *api.Field) (*fieldTypeNames, error) {
+	base, err := c.fieldTypeBaseParts(field)
+	if err != nil {
+		return nil, err
+	}
+	name := base.Base
+	if field.Optional {
+		name = fmt.Sprintf("%s?", base.Base)
+	}
+	if field.Repeated {
+		name = fmt.Sprintf("[%s]", base.Base)
+	}
+	return &fieldTypeNames{BaseTypeNames: *base, Name: name}, nil
+}
+
+func (c *codec) fieldTypeBaseParts(field *api.Field) (*BaseTypeNames, error) {
+	var base string
+	switch field.Typez {
+	case api.TypezMessage:
+		m, err := lookupMessage(c.Model, field.TypezID)
+		if err != nil {
+			return nil, err
+		}
+		if m.IsMap {
+			return c.mapFieldTypeParts(m)
+		}
+		base, err = c.messageTypeName(m)
+		if err != nil {
+			return nil, err
+		}
+		return &BaseTypeNames{Base: base}, nil
+	case api.TypezEnum:
+		e, err := lookupEnum(c.Model, field.TypezID)
+		if err != nil {
+			return nil, err
+		}
+		base, err = c.enumTypeName(e)
+		if err != nil {
+			return nil, err
+		}
+		return &BaseTypeNames{Base: base}, nil
+	default:
+		base, err := scalarFieldTypeName(field)
+		if err != nil {
+			return nil, err
+		}
+		return &BaseTypeNames{Base: base}, nil
+	}
+}
+
 // fieldTypeName returns the Swift type name for a field.
 //
 // The implementation is pretty simple for primitive types. For message and enum fields it may get more
@@ -47,7 +108,11 @@ func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
 			return "", err
 		}
 		if m.IsMap {
-			return c.mapFieldTypeName(m)
+			parts, err := c.mapFieldTypeParts(m)
+			if err != nil {
+				return "", err
+			}
+			return parts.Base, nil
 		}
 		return c.messageTypeName(m)
 	case api.TypezEnum:
@@ -61,12 +126,17 @@ func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
 	}
 }
 
-func (c *codec) mapFieldTypeName(m *api.Message) (string, error) {
+func (c *codec) mapFieldTypeParts(m *api.Message) (*BaseTypeNames, error) {
 	keyType, valueType, err := c.mapFieldTypeComponents(m)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return fmt.Sprintf("[%s: %s]", keyType, valueType), nil
+	base := fmt.Sprintf("[%s: %s]", keyType, valueType)
+	return &BaseTypeNames{
+		Base:  base,
+		Key:   keyType,
+		Value: valueType,
+	}, nil
 }
 
 func (c *codec) mapFieldTypeComponents(m *api.Message) (string, string, error) {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -81,33 +81,6 @@ func (c *codec) fieldTypeBaseParts(field *api.Field) (*BaseTypeNames, error) {
 	}
 }
 
-// baseFieldTypeName returns the basic Swift type used for a field, excluding "optional" and "repeated" decorations.
-func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
-	switch field.Typez {
-	case api.TypezMessage:
-		m, err := lookupMessage(c.Model, field.TypezID)
-		if err != nil {
-			return "", err
-		}
-		if m.IsMap {
-			parts, err := c.mapFieldTypeParts(m)
-			if err != nil {
-				return "", err
-			}
-			return parts.Base, nil
-		}
-		return c.messageTypeName(m)
-	case api.TypezEnum:
-		e, err := lookupEnum(c.Model, field.TypezID)
-		if err != nil {
-			return "", err
-		}
-		return c.enumTypeName(e)
-	default:
-		return scalarFieldTypeName(field)
-	}
-}
-
 func (c *codec) mapFieldTypeParts(m *api.Message) (*BaseTypeNames, error) {
 	keyType, valueType, err := c.mapFieldTypeComponents(m)
 	if err != nil {
@@ -126,15 +99,15 @@ func (c *codec) mapFieldTypeComponents(m *api.Message) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	keyType, err := c.baseFieldTypeName(kv.Key)
+	key, err := c.fieldTypeParts(kv.Key)
 	if err != nil {
 		return "", "", err
 	}
-	valueType, err := c.baseFieldTypeName(kv.Value)
+	value, err := c.fieldTypeParts(kv.Value)
 	if err != nil {
 		return "", "", err
 	}
-	return keyType, valueType, nil
+	return key.Base, value.Base, nil
 }
 
 func scalarFieldTypeName(field *api.Field) (string, error) {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -36,14 +36,13 @@ func (c *codec) fieldTypeParts(field *api.Field) (*fieldTypeNames, error) {
 	if err != nil {
 		return nil, err
 	}
-	name := base.Base
 	if field.Optional {
-		name = fmt.Sprintf("%s?", base.Base)
+		return &fieldTypeNames{BaseTypeNames: *base, Name: fmt.Sprintf("%s?", base.Base)}, nil
 	}
 	if field.Repeated {
-		name = fmt.Sprintf("[%s]", base.Base)
+		return &fieldTypeNames{BaseTypeNames: *base, Name: fmt.Sprintf("[%s]", base.Base)}, nil
 	}
-	return &fieldTypeNames{BaseTypeNames: *base, Name: name}, nil
+	return &fieldTypeNames{BaseTypeNames: *base, Name: base.Base}, nil
 }
 
 func (c *codec) fieldTypeBaseParts(field *api.Field) (*BaseTypeNames, error) {
@@ -99,11 +98,11 @@ func (c *codec) mapFieldTypeComponents(m *api.Message) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	key, err := c.fieldTypeParts(kv.Key)
+	key, err := c.fieldTypeBaseParts(kv.Key)
 	if err != nil {
 		return "", "", err
 	}
-	value, err := c.fieldTypeParts(kv.Value)
+	value, err := c.fieldTypeBaseParts(kv.Value)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -81,24 +81,6 @@ func (c *codec) fieldTypeBaseParts(field *api.Field) (*BaseTypeNames, error) {
 	}
 }
 
-// fieldTypeName returns the Swift type name for a field.
-//
-// The implementation is pretty simple for primitive types. For message and enum fields it may get more
-// difficult as the name may be in a separate package.
-func (c *codec) fieldTypeName(field *api.Field) (string, error) {
-	baseFieldType, err := c.baseFieldTypeName(field)
-	if err != nil {
-		return "", err
-	}
-	if field.Optional {
-		return fmt.Sprintf("%s?", baseFieldType), nil
-	}
-	if field.Repeated {
-		return fmt.Sprintf("[%s]", baseFieldType), nil
-	}
-	return baseFieldType, nil
-}
-
 // baseFieldTypeName returns the basic Swift type used for a field, excluding "optional" and "repeated" decorations.
 func (c *codec) baseFieldTypeName(field *api.Field) (string, error) {
 	switch field.Typez {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -20,33 +20,31 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
-type BaseTypeNames struct {
+type fieldTypeNames struct {
+	Full  string
 	Base  string
 	Key   string
 	Value string
 }
 
-type fieldTypeNames struct {
-	BaseTypeNames
-	Name string
-}
-
-func (c *codec) fieldTypeParts(field *api.Field) (*fieldTypeNames, error) {
-	base, err := c.fieldTypeBaseParts(field)
+func (c *codec) fieldTypeName(field *api.Field) (*fieldTypeNames, error) {
+	names, err := c.fieldTypeBase(field)
 	if err != nil {
 		return nil, err
 	}
 	if field.Optional {
-		return &fieldTypeNames{BaseTypeNames: *base, Name: fmt.Sprintf("%s?", base.Base)}, nil
+		names.Full = fmt.Sprintf("%s?", names.Base)
+		return names, nil
 	}
 	if field.Repeated {
-		return &fieldTypeNames{BaseTypeNames: *base, Name: fmt.Sprintf("[%s]", base.Base)}, nil
+		names.Full = fmt.Sprintf("[%s]", names.Base)
+		return names, nil
 	}
-	return &fieldTypeNames{BaseTypeNames: *base, Name: base.Base}, nil
+	names.Full = names.Base
+	return names, nil
 }
 
-func (c *codec) fieldTypeBaseParts(field *api.Field) (*BaseTypeNames, error) {
-	var base string
+func (c *codec) fieldTypeBase(field *api.Field) (*fieldTypeNames, error) {
 	switch field.Typez {
 	case api.TypezMessage:
 		m, err := lookupMessage(c.Model, field.TypezID)
@@ -54,39 +52,39 @@ func (c *codec) fieldTypeBaseParts(field *api.Field) (*BaseTypeNames, error) {
 			return nil, err
 		}
 		if m.IsMap {
-			return c.mapFieldTypeParts(m)
+			return c.mapFieldTypeNames(m)
 		}
-		base, err = c.messageTypeName(m)
+		base, err := c.messageTypeName(m)
 		if err != nil {
 			return nil, err
 		}
-		return &BaseTypeNames{Base: base}, nil
+		return &fieldTypeNames{Base: base}, nil
 	case api.TypezEnum:
 		e, err := lookupEnum(c.Model, field.TypezID)
 		if err != nil {
 			return nil, err
 		}
-		base, err = c.enumTypeName(e)
+		base, err := c.enumTypeName(e)
 		if err != nil {
 			return nil, err
 		}
-		return &BaseTypeNames{Base: base}, nil
+		return &fieldTypeNames{Base: base}, nil
 	default:
 		base, err := scalarFieldTypeName(field)
 		if err != nil {
 			return nil, err
 		}
-		return &BaseTypeNames{Base: base}, nil
+		return &fieldTypeNames{Base: base}, nil
 	}
 }
 
-func (c *codec) mapFieldTypeParts(m *api.Message) (*BaseTypeNames, error) {
+func (c *codec) mapFieldTypeNames(m *api.Message) (*fieldTypeNames, error) {
 	keyType, valueType, err := c.mapFieldTypeComponents(m)
 	if err != nil {
 		return nil, err
 	}
 	base := fmt.Sprintf("[%s: %s]", keyType, valueType)
-	return &BaseTypeNames{
+	return &fieldTypeNames{
 		Base:  base,
 		Key:   keyType,
 		Value: valueType,
@@ -98,11 +96,11 @@ func (c *codec) mapFieldTypeComponents(m *api.Message) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	key, err := c.fieldTypeBaseParts(kv.Key)
+	key, err := c.fieldTypeBase(kv.Key)
 	if err != nil {
 		return "", "", err
 	}
-	value, err := c.fieldTypeBaseParts(kv.Value)
+	value, err := c.fieldTypeBase(kv.Value)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -115,11 +115,12 @@ func TestFieldTypeName_BaseMessage(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.baseFieldTypeName(test.field)
+			got, err := c.fieldTypeBaseParts(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, got); diff != "" {
+			want := &BaseTypeNames{Base: test.want}
+			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -174,11 +175,12 @@ func TestFieldTypeName_BaseEnum(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.baseFieldTypeName(test.field)
+			got, err := c.fieldTypeBaseParts(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, got); diff != "" {
+			want := &BaseTypeNames{Base: test.want}
+			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -115,11 +115,11 @@ func TestFieldTypeName_BaseMessage(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.fieldTypeBaseParts(test.field)
+			got, err := c.fieldTypeBase(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := &BaseTypeNames{Base: test.want}
+			want := &fieldTypeNames{Base: test.want}
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -175,11 +175,11 @@ func TestFieldTypeName_BaseEnum(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.fieldTypeBaseParts(test.field)
+			got, err := c.fieldTypeBase(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := &BaseTypeNames{Base: test.want}
+			want := &fieldTypeNames{Base: test.want}
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -212,8 +212,8 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				MessageType: secret,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Secret"},
-				Name:          "Secret?",
+				Base: "Secret",
+				Full: "Secret?",
 			},
 		},
 		{
@@ -224,8 +224,8 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				Optional: true,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Swift.String"},
-				Name:          "Swift.String?",
+				Base: "Swift.String",
+				Full: "Swift.String?",
 			},
 		},
 		{
@@ -236,8 +236,8 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				Optional: true,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Foundation.Data"},
-				Name:          "Foundation.Data?",
+				Base: "Foundation.Data",
+				Full: "Foundation.Data?",
 			},
 		},
 		{
@@ -248,13 +248,13 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				Optional: true,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Swift.Int32"},
-				Name:          "Swift.Int32?",
+				Base: "Swift.Int32",
+				Full: "Swift.Int32?",
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.fieldTypeParts(test.field)
+			got, err := c.fieldTypeName(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -290,8 +290,8 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				MessageType: secret,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Secret"},
-				Name:          "[Secret]",
+				Base: "Secret",
+				Full: "[Secret]",
 			},
 		},
 		{
@@ -302,8 +302,8 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				Repeated: true,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Swift.String"},
-				Name:          "[Swift.String]",
+				Base: "Swift.String",
+				Full: "[Swift.String]",
 			},
 		},
 		{
@@ -314,8 +314,8 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				Repeated: true,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Foundation.Data"},
-				Name:          "[Foundation.Data]",
+				Base: "Foundation.Data",
+				Full: "[Foundation.Data]",
 			},
 		},
 		{
@@ -326,13 +326,13 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				Repeated: true,
 			},
 			want: &fieldTypeNames{
-				BaseTypeNames: BaseTypeNames{Base: "Swift.Int32"},
-				Name:          "[Swift.Int32]",
+				Base: "Swift.Int32",
+				Full: "[Swift.Int32]",
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.fieldTypeParts(test.field)
+			got, err := c.fieldTypeName(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -366,17 +366,15 @@ func TestFieldTypeName_Map(t *testing.T) {
 		ID:      ".test.field1",
 	}
 
-	got, err := c.fieldTypeParts(field)
+	got, err := c.fieldTypeName(field)
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := &fieldTypeNames{
-		BaseTypeNames: BaseTypeNames{
-			Base:  "[Swift.String: Swift.Int32]",
-			Key:   "Swift.String",
-			Value: "Swift.Int32",
-		},
-		Name: "[Swift.String: Swift.Int32]",
+		Full:  "[Swift.String: Swift.Int32]",
+		Base:  "[Swift.String: Swift.Int32]",
+		Key:   "Swift.String",
+		Value: "Swift.Int32",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -198,7 +198,7 @@ func TestFieldTypeName_Optional(t *testing.T) {
 	for _, test := range []struct {
 		name  string
 		field *api.Field
-		want  string
+		want  *fieldTypeNames
 	}{
 		{
 			name: "optional message Secret",
@@ -209,7 +209,10 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				Optional:    true,
 				MessageType: secret,
 			},
-			want: "Secret?",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Secret"},
+				Name:          "Secret?",
+			},
 		},
 		{
 			name: "optional string",
@@ -218,7 +221,10 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				ID:       ".test.field5",
 				Optional: true,
 			},
-			want: "Swift.String?",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Swift.String"},
+				Name:          "Swift.String?",
+			},
 		},
 		{
 			name: "optional bytes",
@@ -227,7 +233,10 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				ID:       ".test.field7",
 				Optional: true,
 			},
-			want: "Foundation.Data?",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Foundation.Data"},
+				Name:          "Foundation.Data?",
+			},
 		},
 		{
 			name: "optional int32",
@@ -236,11 +245,14 @@ func TestFieldTypeName_Optional(t *testing.T) {
 				ID:       ".test.field9",
 				Optional: true,
 			},
-			want: "Swift.Int32?",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Swift.Int32"},
+				Name:          "Swift.Int32?",
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.fieldTypeName(test.field)
+			got, err := c.fieldTypeParts(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -264,7 +276,7 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 	for _, test := range []struct {
 		name  string
 		field *api.Field
-		want  string
+		want  *fieldTypeNames
 	}{
 		{
 			name: "repeated message Secret",
@@ -275,7 +287,10 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				Repeated:    true,
 				MessageType: secret,
 			},
-			want: "[Secret]",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Secret"},
+				Name:          "[Secret]",
+			},
 		},
 		{
 			name: "repeated string",
@@ -284,7 +299,10 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				ID:       ".test.field6",
 				Repeated: true,
 			},
-			want: "[Swift.String]",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Swift.String"},
+				Name:          "[Swift.String]",
+			},
 		},
 		{
 			name: "repeated bytes",
@@ -293,7 +311,10 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				ID:       ".test.field8",
 				Repeated: true,
 			},
-			want: "[Foundation.Data]",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Foundation.Data"},
+				Name:          "[Foundation.Data]",
+			},
 		},
 		{
 			name: "repeated int32",
@@ -302,11 +323,14 @@ func TestFieldTypeName_Repeated(t *testing.T) {
 				ID:       ".test.field10",
 				Repeated: true,
 			},
-			want: "[Swift.Int32]",
+			want: &fieldTypeNames{
+				BaseTypeNames: BaseTypeNames{Base: "Swift.Int32"},
+				Name:          "[Swift.Int32]",
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := c.fieldTypeName(test.field)
+			got, err := c.fieldTypeParts(test.field)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -340,11 +364,18 @@ func TestFieldTypeName_Map(t *testing.T) {
 		ID:      ".test.field1",
 	}
 
-	got, err := c.baseFieldTypeName(field)
+	got, err := c.fieldTypeParts(field)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "[Swift.String: Swift.Int32]"
+	want := &fieldTypeNames{
+		BaseTypeNames: BaseTypeNames{
+			Base:  "[Swift.String: Swift.Int32]",
+			Key:   "Swift.String",
+			Value: "Swift.Int32",
+		},
+		Name: "[Swift.String: Swift.Int32]",
+	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
Add helper types and functions to return the base name and full field type name in a single call. Include the key and value types for maps. That makes the code in `annotateField()` more readable, and maybe add other attributes in the future.

Towards #5808 