### PR TITLE
feat(sidekick/swift): support discovery-based modules

### DIFF
--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -42,9 +42,13 @@ func moduleToModelConfig(library *config.Library, module *config.SwiftModule, sr
 	if library.Swift != nil && len(library.Swift.IncludeList) > 0 {
 		sourceConfig.IncludeList = library.Swift.IncludeList
 	}
+	specFormat := config.SpecProtobuf
+	if library.SpecificationFormat != "" {
+		specFormat = library.SpecificationFormat
+	}
 
 	return &parser.ModelConfig{
-		SpecificationFormat: config.SpecProtobuf,
+		SpecificationFormat: specFormat,
 		SpecificationSource: module.APIPath,
 		Source:              sourceConfig,
 		Codec: map[string]string{

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
@@ -63,22 +64,28 @@ func TestGenerateModule(t *testing.T) {
 func TestModuleToModelConfig(t *testing.T) {
 	src := &sources.Sources{}
 	for _, test := range []struct {
-		name            string
-		lib             *config.Library
-		module          *config.SwiftModule
-		wantIncludeList []string
-		wantCodec       map[string]string
+		name   string
+		lib    *config.Library
+		module *config.SwiftModule
+		want   *parser.ModelConfig
 	}{
 		{
 			name: "no include list",
 			lib: &config.Library{
 				Swift: &config.SwiftPackage{},
 			},
-			module:          &config.SwiftModule{APIPath: "foo"},
-			wantIncludeList: nil,
-			wantCodec: map[string]string{
-				"copyright-year": "",
-				"module":         "true",
+			module: &config.SwiftModule{APIPath: "foo"},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+				},
+				Codec: map[string]string{
+					"copyright-year": "",
+					"module":         "true",
+				},
 			},
 		},
 		{
@@ -88,21 +95,36 @@ func TestModuleToModelConfig(t *testing.T) {
 					IncludeList: []string{"a.proto", "b.proto"},
 				},
 			},
-			module:          &config.SwiftModule{APIPath: "foo"},
-			wantIncludeList: []string{"a.proto", "b.proto"},
-			wantCodec: map[string]string{
-				"copyright-year": "",
-				"module":         "true",
+			module: &config.SwiftModule{APIPath: "foo"},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+					IncludeList: []string{"a.proto", "b.proto"},
+				},
+				Codec: map[string]string{
+					"copyright-year": "",
+					"module":         "true",
+				},
 			},
 		},
 		{
-			name:            "nil swift",
-			lib:             &config.Library{},
-			module:          &config.SwiftModule{APIPath: "foo"},
-			wantIncludeList: nil,
-			wantCodec: map[string]string{
-				"copyright-year": "",
-				"module":         "true",
+			name:   "nil swift",
+			lib:    &config.Library{},
+			module: &config.SwiftModule{APIPath: "foo"},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+				},
+				Codec: map[string]string{
+					"copyright-year": "",
+					"module":         "true",
+				},
 			},
 		},
 		{
@@ -111,20 +133,45 @@ func TestModuleToModelConfig(t *testing.T) {
 				CopyrightYear: "2038",
 				Swift:         &config.SwiftPackage{},
 			},
-			module:          &config.SwiftModule{APIPath: "foo"},
-			wantIncludeList: nil,
-			wantCodec: map[string]string{
-				"copyright-year": "2038",
-				"module":         "true",
+			module: &config.SwiftModule{APIPath: "foo"},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+				},
+				Codec: map[string]string{
+					"copyright-year": "2038",
+					"module":         "true",
+				},
+			},
+		},
+		{
+			name: "discovery",
+			lib: &config.Library{
+				CopyrightYear:       "2038",
+				Swift:               &config.SwiftPackage{},
+				SpecificationFormat: config.SpecDiscovery,
+			},
+			module: &config.SwiftModule{APIPath: "dir/foo.v1.json"},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecDiscovery,
+				SpecificationSource: "dir/foo.v1.json",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+				},
+				Codec: map[string]string{
+					"copyright-year": "2038",
+					"module":         "true",
+				},
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := moduleToModelConfig(test.lib, test.module, src)
-			if diff := cmp.Diff(test.wantIncludeList, got.Source.IncludeList); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(test.wantCodec, got.Codec); diff != "" {
+			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -153,6 +153,7 @@ func TestModuleToModelConfig(t *testing.T) {
 				CopyrightYear:       "2038",
 				Swift:               &config.SwiftPackage{},
 				SpecificationFormat: config.SpecDiscovery,
+				Roots:               []string{"discovery"},
 			},
 			module: &config.SwiftModule{APIPath: "dir/foo.v1.json"},
 			want: &parser.ModelConfig{
@@ -160,7 +161,7 @@ func TestModuleToModelConfig(t *testing.T) {
 				SpecificationSource: "dir/foo.v1.json",
 				Source: &sources.SourceConfig{
 					Sources:     &sources.Sources{},
-					ActiveRoots: []string{"googleapis"},
+					ActiveRoots: []string{"discovery"},
 				},
 				Codec: map[string]string{
 					"copyright-year": "2038",


### PR DESCRIPTION
We need to write Swift tests for the discovery-based generated code. In particular, serialization and deserialization of bytes. This is easier to test if we control the discovery doc, and that recommends using a module.

Towards #5748 