### PR TITLE
feat(nodejs): support requires_billing and codeowner_team in repo-metadata.json

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -369,6 +369,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. This can be overridden at the API level. |
+| `billing_not_required` | bool | Indicates whether the API does NOT require billing. This is typically false. |
 | `bundle_config` | string | Is the path to a GAPIC bundle config file. |
 | `dependencies` | map[string]string | Maps npm package names to version constraints. |
 | `esm` | bool | Indicates that generation should produce ES Modules (ESM) outputs. |
@@ -379,6 +380,7 @@ This document describes the schema for the librarian.yaml.
 | `nodejs_apis` | list of [NodejsAPI](#nodejsapi-configuration) (optional) | Is a list of Node.js-specific API configurations. |
 | `package_name` | string | Is the npm package name (e.g., "@google-cloud/access-approval"). |
 | `client_documentation_override` | string | Allows the client_documentation field in .repo-metadata.json to be overridden from the default that's inferred. |
+| `codeowner_team` | string | Is the GitHub team name of the code owners (e.g. "@googleapis/ml-apis"). |
 
 ## PythonDefault Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -739,6 +739,10 @@ type NodejsPackage struct {
 	// This can be overridden at the API level.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 
+	// BillingNotRequired indicates whether the API does NOT require billing.
+	// This is typically false.
+	BillingNotRequired *bool `yaml:"billing_not_required,omitempty"`
+
 	// BundleConfig is the path to a GAPIC bundle config file.
 	BundleConfig string `yaml:"bundle_config,omitempty"`
 
@@ -771,6 +775,9 @@ type NodejsPackage struct {
 	// ClientDocumentationOverride allows the client_documentation field in
 	// .repo-metadata.json to be overridden from the default that's inferred.
 	ClientDocumentationOverride string `yaml:"client_documentation_override,omitempty"`
+
+	// CodeownerTeam is the GitHub team name of the code owners (e.g. "@googleapis/ml-apis").
+	CodeownerTeam string `yaml:"codeowner_team,omitempty"`
 }
 
 // NodejsAPI represents configuration for a single API within a Node.js package.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -741,7 +741,7 @@ type NodejsPackage struct {
 
 	// BillingNotRequired indicates whether the API does NOT require billing.
 	// This is typically false.
-	BillingNotRequired *bool `yaml:"billing_not_required,omitempty"`
+	BillingNotRequired bool `yaml:"billing_not_required,omitempty"`
 
 	// BundleConfig is the path to a GAPIC bundle config file.
 	BundleConfig string `yaml:"bundle_config,omitempty"`

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -55,21 +55,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
 
-	// Determine requires_billing and codeowner_team.
-	// 1. Default requires_billing to true, and codeownerTeam to empty (matching Java).
-	requiresBilling := true
-	var codeownerTeam string
-
-	// 2. Configuration in librarian.yaml takes absolute precedence.
-	if library.Nodejs != nil {
-		if library.Nodejs.BillingNotRequired != nil && *library.Nodejs.BillingNotRequired {
-			requiresBilling = false
-		}
-		if library.Nodejs.CodeownerTeam != "" {
-			codeownerTeam = library.Nodejs.CodeownerTeam
-		}
-	}
-
 	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
@@ -85,7 +70,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
-	if err := runPostProcessor(ctx, cfg, library, googleapisDir, repoRoot, outdir, requiresBilling, codeownerTeam); err != nil {
+	if err := runPostProcessor(ctx, cfg, library, googleapisDir, repoRoot, outdir); err != nil {
 		return fmt.Errorf("failed to run post processor: %w", err)
 	}
 
@@ -273,7 +258,7 @@ func buildGeneratorArgs(api *config.API, library *config.Library, googleapisDir,
 
 // runPostProcessor combines versioned API outputs from owl-bot-staging/ into
 // the output directory using gapic-node-processing, then compiles protos.
-func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.Library, googleapisDir, repoRoot, outDir string, requiresBilling bool, codeownerTeam string) error {
+func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.Library, googleapisDir, repoRoot, outDir string) error {
 
 	// combine-library wipes the destination directory before writing generated
 	// files (src/, protos/). Save the keep files it would delete, then restore
@@ -342,7 +327,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		return fmt.Errorf("failed to restore copyright year: %w", err)
 	}
 	if !slices.Contains(library.Keep, ".repo-metadata.json") {
-		if err := writeRepoMetadata(cfg, library, googleapisDir, outDir, requiresBilling, codeownerTeam); err != nil {
+		if err := writeRepoMetadata(cfg, library, googleapisDir, outDir); err != nil {
 			return fmt.Errorf("failed to write repo metadata: %w", err)
 		}
 	}
@@ -505,13 +490,25 @@ func replaceCopyrightInDir(dir string, re *regexp.Regexp, replacement []byte) er
 // and all .repo-metadata.json generation once the documentation pipeline is
 // migrated to read from librarian.yaml directly.
 // writeRepoMetadata generates .repo-metadata.json for the library.
-func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDir, outDir string, requiresBilling bool, codeownerTeam string) error {
+func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDir, outDir string) error {
 	if len(library.APIs) == 0 {
 		return nil
 	}
 	metadata, err := repometadata.FromLibrary(cfg, library, googleapisDir)
 	if err != nil {
 		return err
+	}
+
+	// Determine requires_billing and codeowner_team.
+	requiresBilling := true
+	var codeownerTeam string
+	if library.Nodejs != nil {
+		if library.Nodejs.BillingNotRequired {
+			requiresBilling = false
+		}
+		if library.Nodejs.CodeownerTeam != "" {
+			codeownerTeam = library.Nodejs.CodeownerTeam
+		}
 	}
 
 	metadata.RequiresBilling = &requiresBilling

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -54,6 +54,22 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
+
+	// Determine requires_billing and codeowner_team.
+	// 1. Default requires_billing to true, and codeownerTeam to empty (matching Java).
+	requiresBilling := true
+	var codeownerTeam string
+
+	// 2. Configuration in librarian.yaml takes absolute precedence.
+	if library.Nodejs != nil {
+		if library.Nodejs.BillingNotRequired != nil && *library.Nodejs.BillingNotRequired {
+			requiresBilling = false
+		}
+		if library.Nodejs.CodeownerTeam != "" {
+			codeownerTeam = library.Nodejs.CodeownerTeam
+		}
+	}
+
 	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
@@ -69,7 +85,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
-	if err := runPostProcessor(ctx, cfg, library, googleapisDir, repoRoot, outdir); err != nil {
+	if err := runPostProcessor(ctx, cfg, library, googleapisDir, repoRoot, outdir, requiresBilling, codeownerTeam); err != nil {
 		return fmt.Errorf("failed to run post processor: %w", err)
 	}
 
@@ -257,7 +273,7 @@ func buildGeneratorArgs(api *config.API, library *config.Library, googleapisDir,
 
 // runPostProcessor combines versioned API outputs from owl-bot-staging/ into
 // the output directory using gapic-node-processing, then compiles protos.
-func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.Library, googleapisDir, repoRoot, outDir string) error {
+func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.Library, googleapisDir, repoRoot, outDir string, requiresBilling bool, codeownerTeam string) error {
 
 	// combine-library wipes the destination directory before writing generated
 	// files (src/, protos/). Save the keep files it would delete, then restore
@@ -326,7 +342,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		return fmt.Errorf("failed to restore copyright year: %w", err)
 	}
 	if !slices.Contains(library.Keep, ".repo-metadata.json") {
-		if err := writeRepoMetadata(cfg, library, googleapisDir, outDir); err != nil {
+		if err := writeRepoMetadata(cfg, library, googleapisDir, outDir, requiresBilling, codeownerTeam); err != nil {
 			return fmt.Errorf("failed to write repo metadata: %w", err)
 		}
 	}
@@ -489,7 +505,7 @@ func replaceCopyrightInDir(dir string, re *regexp.Regexp, replacement []byte) er
 // and all .repo-metadata.json generation once the documentation pipeline is
 // migrated to read from librarian.yaml directly.
 // writeRepoMetadata generates .repo-metadata.json for the library.
-func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDir, outDir string) error {
+func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDir, outDir string, requiresBilling bool, codeownerTeam string) error {
 	if len(library.APIs) == 0 {
 		return nil
 	}
@@ -497,6 +513,10 @@ func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDi
 	if err != nil {
 		return err
 	}
+
+	metadata.RequiresBilling = &requiresBilling
+	metadata.CodeownerTeam = codeownerTeam
+
 	metadata.DistributionName = DerivePackageName(library)
 	metadata.DefaultVersion = filepath.Base(library.APIs[0].Path)
 	metadata.LibraryType = repometadata.GAPICAutoLibraryType

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -455,7 +455,7 @@ func TestRunPostProcessor(t *testing.T) {
 		Language: config.LanguageNodejs,
 		Repo:     "googleapis/google-cloud-node",
 	}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
 	// Verify that the package staging directory is successfully cleaned up
@@ -500,7 +500,7 @@ func TestRunPostProcessor_RemovesOwlBotYaml(t *testing.T) {
 	}
 
 	cfg := &config.Config{Language: config.LanguageNodejs}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(outDir, ".OwlBot.yaml")); !errors.Is(err, fs.ErrNotExist) {
@@ -540,7 +540,7 @@ func TestRunPostProcessor_RemovesCloudCommonResourcesProto(t *testing.T) {
 	}
 
 	cfg := &config.Config{Language: config.LanguageNodejs}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(outDir, "protos", cloudCommonResourcesProto)); !errors.Is(err, fs.ErrNotExist) {
@@ -604,7 +604,7 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 		Language: config.LanguageNodejs,
 		Repo:     "googleapis/google-cloud-node",
 	}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
 	// Verify package staging directory is cleaned up
@@ -670,7 +670,7 @@ func TestRunPostProcessor_PreservesFiles(t *testing.T) {
 		Language: config.LanguageNodejs,
 		Repo:     "googleapis/google-cloud-node",
 	}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1003,11 +1003,9 @@ func TestWriteRepoMetadata(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name            string
-		library         *config.Library
-		requiresBilling bool
-		codeownerTeam   string
-		want            func() *repometadata.RepoMetadata
+		name    string
+		library *config.Library
+		want    func() *repometadata.RepoMetadata
 	}{
 		{
 			name: "no overrides",
@@ -1015,7 +1013,6 @@ func TestWriteRepoMetadata(t *testing.T) {
 				Name: "google-cloud-secretmanager",
 				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			},
-			requiresBilling: true,
 			want: func() *repometadata.RepoMetadata {
 				w := sample.RepoMetadata()
 				w.DistributionName = "@google-cloud/secretmanager"
@@ -1037,7 +1034,6 @@ func TestWriteRepoMetadata(t *testing.T) {
 					ClientDocumentationOverride: "https://custom.docs.com/ref",
 				},
 			},
-			requiresBilling: true,
 			want: func() *repometadata.RepoMetadata {
 				w := sample.RepoMetadata()
 				w.DistributionName = "@google-cloud/secretmanager"
@@ -1055,9 +1051,10 @@ func TestWriteRepoMetadata(t *testing.T) {
 			library: &config.Library{
 				Name: "google-cloud-secretmanager",
 				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Nodejs: &config.NodejsPackage{
+					CodeownerTeam: "@googleapis/ml-apis",
+				},
 			},
-			requiresBilling: true,
-			codeownerTeam:   "@googleapis/ml-apis",
 			want: func() *repometadata.RepoMetadata {
 				w := sample.RepoMetadata()
 				w.DistributionName = "@google-cloud/secretmanager"
@@ -1076,8 +1073,10 @@ func TestWriteRepoMetadata(t *testing.T) {
 			library: &config.Library{
 				Name: "google-cloud-secretmanager",
 				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Nodejs: &config.NodejsPackage{
+					BillingNotRequired: true,
+				},
 			},
-			requiresBilling: false,
 			want: func() *repometadata.RepoMetadata {
 				w := sample.RepoMetadata()
 				w.DistributionName = "@google-cloud/secretmanager"
@@ -1093,7 +1092,7 @@ func TestWriteRepoMetadata(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
-			if err := writeRepoMetadata(cfg, test.library, absGoogleapisDir, outDir, test.requiresBilling, test.codeownerTeam); err != nil {
+			if err := writeRepoMetadata(cfg, test.library, absGoogleapisDir, outDir); err != nil {
 				t.Fatal(err)
 			}
 			got, err := repometadata.Read(outDir)
@@ -1111,7 +1110,7 @@ func TestWriteRepoMetadata(t *testing.T) {
 func TestWriteRepoMetadata_NoAPIs(t *testing.T) {
 	cfg := &config.Config{Language: config.LanguageNodejs}
 	library := &config.Library{Name: "google-cloud-test"}
-	if err := writeRepoMetadata(cfg, library, "", t.TempDir(), false, ""); err != nil {
+	if err := writeRepoMetadata(cfg, library, "", t.TempDir()); err != nil {
 		t.Errorf("expected nil error for library with no APIs, got: %v", err)
 	}
 }
@@ -1146,7 +1145,7 @@ func TestRunPostProcessor_CustomScripts_RootRelativePath(t *testing.T) {
 		Repo:     "googleapis/google-cloud-node",
 	}
 
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
 		t.Fatal(err)
 	}
 	// The file should have been created at outDir/output.txt

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -455,7 +455,7 @@ func TestRunPostProcessor(t *testing.T) {
 		Language: config.LanguageNodejs,
 		Repo:     "googleapis/google-cloud-node",
 	}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	// Verify that the package staging directory is successfully cleaned up
@@ -500,7 +500,7 @@ func TestRunPostProcessor_RemovesOwlBotYaml(t *testing.T) {
 	}
 
 	cfg := &config.Config{Language: config.LanguageNodejs}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(outDir, ".OwlBot.yaml")); !errors.Is(err, fs.ErrNotExist) {
@@ -540,7 +540,7 @@ func TestRunPostProcessor_RemovesCloudCommonResourcesProto(t *testing.T) {
 	}
 
 	cfg := &config.Config{Language: config.LanguageNodejs}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(outDir, "protos", cloudCommonResourcesProto)); !errors.Is(err, fs.ErrNotExist) {
@@ -604,7 +604,7 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 		Language: config.LanguageNodejs,
 		Repo:     "googleapis/google-cloud-node",
 	}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	// Verify package staging directory is cleaned up
@@ -670,7 +670,7 @@ func TestRunPostProcessor_PreservesFiles(t *testing.T) {
 		Language: config.LanguageNodejs,
 		Repo:     "googleapis/google-cloud-node",
 	}
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1003,9 +1003,11 @@ func TestWriteRepoMetadata(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name    string
-		library *config.Library
-		want    func() *repometadata.RepoMetadata
+		name            string
+		library         *config.Library
+		requiresBilling bool
+		codeownerTeam   string
+		want            func() *repometadata.RepoMetadata
 	}{
 		{
 			name: "no overrides",
@@ -1013,6 +1015,7 @@ func TestWriteRepoMetadata(t *testing.T) {
 				Name: "google-cloud-secretmanager",
 				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 			},
+			requiresBilling: true,
 			want: func() *repometadata.RepoMetadata {
 				w := sample.RepoMetadata()
 				w.DistributionName = "@google-cloud/secretmanager"
@@ -1020,6 +1023,8 @@ func TestWriteRepoMetadata(t *testing.T) {
 				w.Repo = cfg.Repo
 				w.ClientDocumentation = "https://cloud.google.com/nodejs/docs/reference/secretmanager/latest"
 				w.ProductDocumentation = "https://cloud.google.com/secret-manager/docs"
+				rb := true
+				w.RequiresBilling = &rb
 				return w
 			},
 		},
@@ -1032,6 +1037,7 @@ func TestWriteRepoMetadata(t *testing.T) {
 					ClientDocumentationOverride: "https://custom.docs.com/ref",
 				},
 			},
+			requiresBilling: true,
 			want: func() *repometadata.RepoMetadata {
 				w := sample.RepoMetadata()
 				w.DistributionName = "@google-cloud/secretmanager"
@@ -1039,13 +1045,55 @@ func TestWriteRepoMetadata(t *testing.T) {
 				w.Repo = cfg.Repo
 				w.ClientDocumentation = "https://custom.docs.com/ref"
 				w.ProductDocumentation = "https://cloud.google.com/secret-manager/docs"
+				rb := true
+				w.RequiresBilling = &rb
+				return w
+			},
+		},
+		{
+			name: "requires billing true and codeowner team set",
+			library: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+			requiresBilling: true,
+			codeownerTeam:   "@googleapis/ml-apis",
+			want: func() *repometadata.RepoMetadata {
+				w := sample.RepoMetadata()
+				w.DistributionName = "@google-cloud/secretmanager"
+				w.Language = cfg.Language
+				w.Repo = cfg.Repo
+				w.ClientDocumentation = "https://cloud.google.com/nodejs/docs/reference/secretmanager/latest"
+				w.ProductDocumentation = "https://cloud.google.com/secret-manager/docs"
+				rb := true
+				w.RequiresBilling = &rb
+				w.CodeownerTeam = "@googleapis/ml-apis"
+				return w
+			},
+		},
+		{
+			name: "requires billing false",
+			library: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+			requiresBilling: false,
+			want: func() *repometadata.RepoMetadata {
+				w := sample.RepoMetadata()
+				w.DistributionName = "@google-cloud/secretmanager"
+				w.Language = cfg.Language
+				w.Repo = cfg.Repo
+				w.ClientDocumentation = "https://cloud.google.com/nodejs/docs/reference/secretmanager/latest"
+				w.ProductDocumentation = "https://cloud.google.com/secret-manager/docs"
+				rb := false
+				w.RequiresBilling = &rb
 				return w
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
-			if err := writeRepoMetadata(cfg, test.library, absGoogleapisDir, outDir); err != nil {
+			if err := writeRepoMetadata(cfg, test.library, absGoogleapisDir, outDir, test.requiresBilling, test.codeownerTeam); err != nil {
 				t.Fatal(err)
 			}
 			got, err := repometadata.Read(outDir)
@@ -1063,7 +1111,7 @@ func TestWriteRepoMetadata(t *testing.T) {
 func TestWriteRepoMetadata_NoAPIs(t *testing.T) {
 	cfg := &config.Config{Language: config.LanguageNodejs}
 	library := &config.Library{Name: "google-cloud-test"}
-	if err := writeRepoMetadata(cfg, library, "", t.TempDir()); err != nil {
+	if err := writeRepoMetadata(cfg, library, "", t.TempDir(), false, ""); err != nil {
 		t.Errorf("expected nil error for library with no APIs, got: %v", err)
 	}
 }
@@ -1098,7 +1146,7 @@ func TestRunPostProcessor_CustomScripts_RootRelativePath(t *testing.T) {
 		Repo:     "googleapis/google-cloud-node",
 	}
 
-	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir); err != nil {
+	if err := runPostProcessor(t.Context(), cfg, library, "", repoRoot, outDir, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	// The file should have been created at outDir/output.txt

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -57,6 +57,10 @@ type RepoMetadata struct {
 	// A Go specific field.
 	ClientLibraryType string `json:"client_library_type,omitempty"`
 
+	// CodeownerTeam is the GitHub team name of the code owners (e.g. "@googleapis/ml-apis").
+	// A Node.js specific field.
+	CodeownerTeam string `json:"codeowner_team,omitempty"`
+
 	// DefaultVersion is the default API version (e.g., "v1", "v1beta1").
 	DefaultVersion string `json:"default_version,omitempty"`
 
@@ -87,6 +91,10 @@ type RepoMetadata struct {
 
 	// ReleaseLevel is the release level (e.g., "stable", "preview").
 	ReleaseLevel string `json:"release_level,omitempty"`
+
+	// RequiresBilling indicates whether the API requires billing to be enabled.
+	// A Node.js specific field.
+	RequiresBilling *bool `json:"requires_billing,omitempty"`
 
 	// Repo is the repository name (e.g., "googleapis/google-cloud-rust").
 	Repo string `json:"repo,omitempty"`


### PR DESCRIPTION

Introduce formal support for missing metadata fields ( requires_billing  and  codeowner_team ). 

During the migration of  google-cloud-node  packages to Librarian, several PRs were opened where regenerating  .repo-metadata.json  resulted in small regressions because  `requires_billing ` and  `codeowner_team`  were being  deleted.

With this PR, and the corresponding [follow-up configuration updates](https://github.com/googleapis/google-cloud-node/pull/8506) to  google-cloud-node/librarian.yaml , running Librarian on these packages completely resolves the regressions, keeping all legacy billing and codeowner fields intact and cleanly configured in the repository's configuration file.


This directly fixes and unblocks the following active/merged migration PRs:

- [google-cloud-node/#8500](https://github.com/googleapis/google-cloud-node/pull/8500)
- [google-cloud-node/#8499](https://github.com/googleapis/google-cloud-node/pull/8499)
- [google-cloud-node/#8498](https://github.com/googleapis/google-cloud-node/pull/8498)
- [google-cloud-node/#8497](https://github.com/googleapis/google-cloud-node/pull/8497)
- [google-cloud-node/#8496](https://github.com/googleapis/google-cloud-node/pull/8496)
- [google-cloud-node/#8495](https://github.com/googleapis/google-cloud-node/pull/8495)
- [google-cloud-node/#8493](https://github.com/googleapis/google-cloud-node/pull/8493)
- [google-cloud-node/#8492](https://github.com/googleapis/google-cloud-node/pull/8492)
- [google-cloud-node/#8491](https://github.com/googleapis/google-cloud-node/pull/8491)
- [google-cloud-node/#8490](https://github.com/googleapis/google-cloud-node/pull/8490)
- [google-cloud-node/#8488](https://github.com/googleapis/google-cloud-node/pull/8488)
- [google-cloud-node/#8480](https://github.com/googleapis/google-cloud-node/pull/8480)
- [google-cloud-node/#8473](https://github.com/googleapis/google-cloud-node/pull/8473)
- [google-cloud-node/#8472](https://github.com/googleapis/google-cloud-node/pull/8472)
