### PR TITLE
feat(nodejs): add a DefaultVersion field to NodeJSPackage

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -370,6 +370,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. This can be overridden at the API level. |
 | `bundle_config` | string | Is the path to a GAPIC bundle config file. |
+| `default_version` | string | Is the default version of the API to use. When omitted, the version in the first API path is used. |
 | `dependencies` | map[string]string | Maps npm package names to version constraints. |
 | `esm` | bool | Indicates that generation should produce ES Modules (ESM) outputs. |
 | `extra_protoc_parameters` | list of string | Is a list of extra parameters to pass to protoc. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -742,6 +742,10 @@ type NodejsPackage struct {
 	// BundleConfig is the path to a GAPIC bundle config file.
 	BundleConfig string `yaml:"bundle_config,omitempty"`
 
+	// DefaultVersion is the default version of the API to use. When omitted,
+	// the version in the first API path is used.
+	DefaultVersion string `yaml:"default_version,omitempty"`
+
 	// Dependencies maps npm package names to version constraints.
 	Dependencies map[string]string `yaml:"dependencies,omitempty"`
 

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -286,6 +286,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		"combine-library",
 		"--source-path", stagingDir,
 		"--destination-path", outDir,
+		"--default-version", resolveDefaultVersion(library),
 	}
 	if library.Nodejs != nil && library.Nodejs.ESM {
 		combineArgs = append(combineArgs, "--is-esm")
@@ -498,8 +499,8 @@ func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDi
 		return err
 	}
 	metadata.DistributionName = DerivePackageName(library)
-	metadata.DefaultVersion = filepath.Base(library.APIs[0].Path)
 	metadata.LibraryType = repometadata.GAPICAutoLibraryType
+	metadata.DefaultVersion = resolveDefaultVersion(library)
 
 	if strings.HasPrefix(metadata.DistributionName, "@google-cloud/") {
 		pkgSuffix := strings.TrimPrefix(metadata.DistributionName, "@google-cloud/")
@@ -666,6 +667,20 @@ func derivePackageNameFromLibraryName(name string) string {
 // DefaultOutput returns the output path for a library.
 func DefaultOutput(name, defaultOutput string) string {
 	return filepath.Join(defaultOutput, name)
+}
+
+// resolveDefaultVersion returns the default API version (v1, v1beta etc) for
+// a library, using the Node-specific override if present, or the path of the
+// first API otherwise. If the library has no override and no APIs, an empty
+// string is returned.
+func resolveDefaultVersion(library *config.Library) string {
+	if library.Nodejs != nil && library.Nodejs.DefaultVersion != "" {
+		return library.Nodejs.DefaultVersion
+	}
+	if len(library.APIs) == 0 {
+		return ""
+	}
+	return filepath.Base(library.APIs[0].Path)
 }
 
 // TODO(https://github.com/googleapis/google-cloud-node/issues/8149):

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -443,7 +443,10 @@ func TestRunPostProcessor(t *testing.T) {
 	testhelper.RequireCommand(t, "compileProtos")
 
 	repoRoot := t.TempDir()
-	library := &config.Library{Name: "google-cloud-secretmanager"}
+	library := &config.Library{
+		Name: "google-cloud-secretmanager",
+		APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		t.Fatal(err)
@@ -473,7 +476,10 @@ func TestRunPostProcessor_RemovesOwlBotYaml(t *testing.T) {
 	testhelper.RequireCommand(t, "compileProtos")
 
 	repoRoot := t.TempDir()
-	library := &config.Library{Name: "google-cloud-test"}
+	library := &config.Library{
+		Name: "google-cloud-test",
+		APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		t.Fatal(err)
@@ -513,7 +519,10 @@ func TestRunPostProcessor_RemovesCloudCommonResourcesProto(t *testing.T) {
 	testhelper.RequireCommand(t, "compileProtos")
 
 	repoRoot := t.TempDir()
-	library := &config.Library{Name: "google-cloud-test"}
+	library := &config.Library{
+		Name: "google-cloud-test",
+		APIs: []*config.API{{Path: "google/cloud/test/v1"}},
+	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		t.Fatal(err)
@@ -557,6 +566,7 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 	repoRoot := t.TempDir()
 	library := &config.Library{
 		Name: "google-cloud-secretmanager",
+		APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 		Keep: []string{"librarian.js", ".readme-partials.yaml", "README.md"},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
@@ -640,6 +650,7 @@ func TestRunPostProcessor_PreservesFiles(t *testing.T) {
 	repoRoot := t.TempDir()
 	library := &config.Library{
 		Name: "google-cloud-test",
+		APIs: []*config.API{{Path: "google/cloud/test/v1"}},
 		Keep: []string{"README.md", ".readme-partials.yaml", "system-test/.eslintrc.yml"},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
@@ -1042,6 +1053,29 @@ func TestWriteRepoMetadata(t *testing.T) {
 				return w
 			},
 		},
+		{
+			name: "default version override",
+			library: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+					{Path: "google/cloud/secretmanager/v1beta"},
+				},
+				Nodejs: &config.NodejsPackage{
+					DefaultVersion: "v1beta",
+				},
+			},
+			want: func() *repometadata.RepoMetadata {
+				w := sample.RepoMetadata()
+				w.DistributionName = "@google-cloud/secretmanager"
+				w.Language = cfg.Language
+				w.Repo = cfg.Repo
+				w.ClientDocumentation = "https://cloud.google.com/nodejs/docs/reference/secretmanager/latest"
+				w.ProductDocumentation = "https://cloud.google.com/secret-manager/docs"
+				w.DefaultVersion = "v1beta"
+				return w
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
@@ -1076,6 +1110,7 @@ func TestRunPostProcessor_CustomScripts_RootRelativePath(t *testing.T) {
 	repoRoot := t.TempDir()
 	library := &config.Library{
 		Name: "google-cloud-secretmanager",
+		APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 		Keep: []string{"librarian.js"},
 	}
 
@@ -1444,6 +1479,50 @@ func TestRemoveRedundantLinterFiles(t *testing.T) {
 			slices.Sort(got)
 			slices.Sort(test.want)
 
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResolveDefaultVersion(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want string
+	}{
+		{
+			name: "default to first API path",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/test/v3"},
+					{Path: "google/cloud/test/v4"},
+				},
+			},
+			want: "v3",
+		},
+		{
+			name: "no APIs or override",
+			lib:  &config.Library{},
+			want: "",
+		},
+		{
+			name: "override",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/test/v3"},
+					{Path: "google/cloud/test/v4"},
+				},
+				Nodejs: &config.NodejsPackage{
+					DefaultVersion: "v4",
+				},
+			},
+			want: "v4",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := resolveDefaultVersion(test.lib)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Adds a DefaultVersion field to the Node config, which is then written to .repo-metadata.json, overriding the default of "the first API path variant". The combine-libraries part of the post-processor is also provided with the default version to create the appropriate index.ts.

Like Python, our Node packages have the concept of a "default version", which is the API variant which is imported implicitly.

See #6357 for further work we'll need to consider post-migration.