### PR TITLE
feat(sidekick/swift): non-string maps

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -37,6 +37,12 @@ type fieldAnnotations struct {
 	// This is used in the mustache templates, which sometimes need to refer to the underlying type.
 	BaseFieldType string
 
+	// KeyType is the key's Swift type for maps and empty otherwise.
+	KeyType string
+
+	// ValueType is the value's Swift type for maps and empty otherwise.
+	ValueType string
+
 	// PackageName is the name of the package defining the type of this field.
 	PackageName string
 
@@ -58,6 +64,12 @@ type fieldAnnotations struct {
 	InitializerType string
 }
 
+// IsStringKeyed returns true if the field is a map field and the key is a
+// string type.
+func (a *fieldAnnotations) IsStringKeyed() bool {
+	return a.KeyType == "Swift.String"
+}
+
 func (c *codec) annotateField(field *api.Field) error {
 	parts, err := c.fieldTypeName(field)
 	if err != nil {
@@ -71,10 +83,13 @@ func (c *codec) annotateField(field *api.Field) error {
 	if err != nil {
 		return err
 	}
+
 	annotations := &fieldAnnotations{
 		Name:            camelCase(field.Name),
 		FieldType:       parts.Full,
 		BaseFieldType:   parts.Base,
+		KeyType:         parts.Key,
+		ValueType:       parts.Value,
 		PackageName:     packageName,
 		DocLines:        docLines,
 		InitializerType: parts.Full,

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -144,6 +144,10 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 				annotations.DependsOn[dep.Name] = dep
 			}
 			if field.Map && !fieldCodec.IsStringKeyed() {
+				// In ProtoJSON map fields with non-string keys need to be
+				// serialized as JSON objects with key fields. In the generated
+				// Swift code, that requires a custom implementation of the
+				// `Decodable` and `Encodable` protocol.
 				annotations.CustomSerialization = true
 			}
 		}

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -143,6 +143,9 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 				}
 				annotations.DependsOn[dep.Name] = dep
 			}
+			if field.Map && !fieldCodec.IsStringKeyed() {
+				annotations.CustomSerialization = true
+			}
 		}
 	}
 

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -84,6 +84,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     let container = try decoder.container(keyedBy: CodingKeys.self)
     {{#Fields}}
     {{^IsOneOf}}
+    {{#Singular}}
     {{#Optional}}
     self.{{Codec.Name}} = try container.decodeIfPresent({{{Codec.BaseFieldType}}}.self, forKey: .{{Codec.Name}})
     {{/Optional}}
@@ -95,6 +96,28 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
     {{/Codec.Recursive}}
     {{/Optional}}
+    {{/Singular}}
+    {{#Repeated}}
+    self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
+    {{/Repeated}}
+    {{#Map}}
+    {{#Codec.IsStringKeyed}}
+    self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
+    {{/Codec.IsStringKeyed}}
+    {{^Codec.IsStringKeyed}}
+    self.{{Codec.Name}} = try { () throws in
+      let stringKeyed = try container.decode([Swift.String : {{{Codec.ValueType}}}].self, forKey: .{{Codec.Name}})
+      let tuples = try stringKeyed.lazy.map { (key, value) throws -> ({{{Codec.KeyType}}}, {{{Codec.ValueType}}}) in
+        guard let newKey = {{{Codec.KeyType}}}(key) else {
+          throw DecodingError.typeMismatch(
+            {{{Codec.KeyType}}}.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Incorrect type for map key '{{Codec.Name}}'"))
+        }
+        return (newKey, value)
+      }
+      return Dictionary(uniqueKeysWithValues: tuples)
+    }()
+    {{/Codec.IsStringKeyed}}
+    {{/Map}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}
@@ -119,7 +142,24 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     var container = encoder.container(keyedBy: CodingKeys.self)
     {{#Fields}}
     {{^IsOneOf}}
+    {{#Map}}
+    {{#Codec.IsStringKeyed}}
+    {{! string keys have easy encoding }}
     try container.encode(self.{{Codec.Name}}, forKey: .{{Codec.Name}})
+    {{/Codec.IsStringKeyed}}
+    {{^Codec.IsStringKeyed}}
+    do {
+      let stringKeyed = Dictionary(
+        uniqueKeysWithValues: self.{{Codec.Name}}.lazy.map { (Swift.String($0), $1) }
+      )
+      try container.encode(stringKeyed, forKey: .{{Codec.Name}})
+    }
+    {{/Codec.IsStringKeyed}}
+    {{/Map}}
+    {{^Map}}
+    {{! non-maps have easy encoding }}
+    try container.encode(self.{{Codec.Name}}, forKey: .{{Codec.Name}})
+    {{/Map}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}


### PR DESCRIPTION
Protobuf can define maps where the key is not a string. These require custom serialization and deserialization. It may be possible to reduce the size of the generated code, but I cannot find a way at the moment.

Fixes #5808 