### PR TITLE
cleanup(sidekick/swift): remove unused annotation

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -56,12 +56,6 @@ type fieldAnnotations struct {
 
 	// Recursive is true if the field is a recursive reference to another message.
 	Recursive bool
-
-	// InitializerType is the Swift type name of this field as it appears in the initializer signature.
-	//
-	// For recursive fields, this is the unwrapped type with an optional suffix (e.g., `Node?`), rather
-	// than the boxed type (`GoogleCloudWkt.Recursive<Node>?`). For standard fields, it matches `FieldType`.
-	InitializerType string
 }
 
 // IsStringKeyed returns true if the field is a map field and the key is a
@@ -85,14 +79,13 @@ func (c *codec) annotateField(field *api.Field) error {
 	}
 
 	annotations := &fieldAnnotations{
-		Name:            camelCase(field.Name),
-		FieldType:       parts.Full,
-		BaseFieldType:   parts.Base,
-		KeyType:         parts.Key,
-		ValueType:       parts.Value,
-		PackageName:     packageName,
-		DocLines:        docLines,
-		InitializerType: parts.Full,
+		Name:          camelCase(field.Name),
+		FieldType:     parts.Full,
+		BaseFieldType: parts.Base,
+		KeyType:       parts.Key,
+		ValueType:     parts.Value,
+		PackageName:   packageName,
+		DocLines:      docLines,
 	}
 	// Swift value types (structs) cannot contain recursive references directly because their
 	// size must be known at compile time. To break the cycle, we wrap the reference in a box type
@@ -104,7 +97,6 @@ func (c *codec) annotateField(field *api.Field) error {
 	//    automatically using the native indirect case mechanism.
 	if field.Recursive && field.Singular() && !field.IsOneOf {
 		annotations.Recursive = true
-		annotations.InitializerType = parts.Base + "?"
 		annotations.BaseFieldType = fmt.Sprintf("%s.Recursive<%s>", wellKnownSwiftPackage, parts.Base)
 		annotations.FieldType = annotations.BaseFieldType + "?"
 	}

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -74,11 +74,10 @@ func TestAnnotateField(t *testing.T) {
 				t.Fatal(err)
 			}
 			want := &fieldAnnotations{
-				Name:            "secretPayload",
-				DocLines:        []string{"The secret version payload."},
-				FieldType:       test.wantType,
-				BaseFieldType:   test.wantBaseType,
-				InitializerType: test.wantType,
+				Name:          "secretPayload",
+				DocLines:      []string{"The secret version payload."},
+				FieldType:     test.wantType,
+				BaseFieldType: test.wantBaseType,
 			}
 
 			if diff := cmp.Diff(want, field.Codec); diff != "" {
@@ -118,11 +117,10 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 				t.Fatal(err)
 			}
 			want := &fieldAnnotations{
-				Name:            "testField",
-				FieldType:       test.wantType,
-				BaseFieldType:   test.wantType,
-				DocLines:        []string{"Test documentation."},
-				InitializerType: test.wantType,
+				Name:          "testField",
+				FieldType:     test.wantType,
+				BaseFieldType: test.wantType,
+				DocLines:      []string{"Test documentation."},
 			}
 			if diff := cmp.Diff(want, field.Codec); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -165,12 +163,11 @@ func TestAnnotateField_PackageName(t *testing.T) {
 	}
 	got := field.Codec.(*fieldAnnotations)
 	want := &fieldAnnotations{
-		Name:            "externalMessage",
-		FieldType:       "GoogleCloudExternalV1.SomeMessage",
-		BaseFieldType:   "GoogleCloudExternalV1.SomeMessage",
-		PackageName:     "google.cloud.external.v1",
-		DocLines:        []string{"The external message."},
-		InitializerType: "GoogleCloudExternalV1.SomeMessage",
+		Name:          "externalMessage",
+		FieldType:     "GoogleCloudExternalV1.SomeMessage",
+		BaseFieldType: "GoogleCloudExternalV1.SomeMessage",
+		PackageName:   "google.cloud.external.v1",
+		DocLines:      []string{"The external message."},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -258,13 +255,12 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			}
 
 			want := &fieldAnnotations{
-				Name:            "childNode",
-				DocLines:        []string{"Recursive link."},
-				FieldType:       test.wantType,
-				BaseFieldType:   test.wantBaseType,
-				PackageName:     "test",
-				Recursive:       test.wantRecursive,
-				InitializerType: test.wantInitType,
+				Name:          "childNode",
+				DocLines:      []string{"Recursive link."},
+				FieldType:     test.wantType,
+				BaseFieldType: test.wantBaseType,
+				PackageName:   "test",
+				Recursive:     test.wantRecursive,
 			}
 			if test.isOneOf {
 				want.OneOfChecker = test.oneofProperty + "CheckAndSet"

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -183,7 +183,6 @@ func TestAnnotateField_Recursive(t *testing.T) {
 		wantType      string
 		wantBaseType  string
 		wantRecursive bool
-		wantInitType  string
 		oneofProperty string
 	}{
 		{
@@ -194,7 +193,6 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			wantType:      "GoogleCloudWkt.Recursive<Node>?",
 			wantBaseType:  "GoogleCloudWkt.Recursive<Node>",
 			wantRecursive: true,
-			wantInitType:  "Node?",
 		},
 		{
 			name:          "repeated recursive",
@@ -204,7 +202,6 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			wantType:      "[Node]",
 			wantBaseType:  "Node",
 			wantRecursive: false,
-			wantInitType:  "[Node]",
 		},
 		{
 			name:          "oneof recursive",
@@ -214,7 +211,6 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			wantType:      "Node",
 			wantBaseType:  "Node",
 			wantRecursive: false,
-			wantInitType:  "Node",
 			oneofProperty: "alternatives",
 		},
 	} {


### PR DESCRIPTION
We don't need the `InitializerType` annotation because we no longer generate complex initializers.