### PR TITLE
fix(.github/workflows): fix outdated Java tools path in integration job

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -87,7 +87,7 @@ jobs:
         working-directory: google-cloud-java
         run: |
           librarian install
-          echo "$HOME/java_tools/bin" >> $GITHUB_PATH
+          echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Run librarian generate
         working-directory: google-cloud-java
         env:


### PR DESCRIPTION
Updates the integration job in the Java workflow to use the centralized cache path ($HOME/.cache/librarian/bin/java_tools/bin) when updating GITHUB_PATH.

Following https://github.com/googleapis/librarian/pull/6331, this path should be updated same as the test job.