### PR TITLE
refactor(sidekick/swift): `annotateField()` return

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -64,18 +64,18 @@ func (a *fieldAnnotations) IsStringKeyed() bool {
 	return a.KeyType == "Swift.String"
 }
 
-func (c *codec) annotateField(field *api.Field) error {
+func (c *codec) annotateField(field *api.Field) (*fieldAnnotations, error) {
 	parts, err := c.fieldTypeName(field)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	docLines, err := c.formatDocumentation(field.Documentation, field.Scopes())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	packageName, err := c.fieldPackage(field)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	annotations := &fieldAnnotations{
@@ -106,7 +106,7 @@ func (c *codec) annotateField(field *api.Field) error {
 		}
 	}
 	field.Codec = annotations
-	return nil
+	return annotations, nil
 }
 
 func (c *codec) fieldPackage(field *api.Field) (string, error) {

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -129,27 +129,26 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		}
 	}
 	for _, field := range message.Fields {
-		if err := c.annotateField(field); err != nil {
+		fieldCodec, err := c.annotateField(field)
+		if err != nil {
 			return err
 		}
-		if fieldCodec, ok := field.Codec.(*fieldAnnotations); ok {
-			if fieldCodec.Name != field.JSONName {
-				annotations.CustomSerialization = true
+		if fieldCodec.Name != field.JSONName {
+			annotations.CustomSerialization = true
+		}
+		if fieldCodec.PackageName != "" && fieldCodec.PackageName != c.Model.PackageName {
+			dep, err := c.addApiPackageDependency(fieldCodec.PackageName)
+			if err != nil {
+				return err
 			}
-			if fieldCodec.PackageName != "" && fieldCodec.PackageName != c.Model.PackageName {
-				dep, err := c.addApiPackageDependency(fieldCodec.PackageName)
-				if err != nil {
-					return err
-				}
-				annotations.DependsOn[dep.Name] = dep
-			}
-			if field.Map && !fieldCodec.IsStringKeyed() {
-				// In ProtoJSON map fields with non-string keys need to be
-				// serialized as JSON objects with key fields. In the generated
-				// Swift code, that requires a custom implementation of the
-				// `Decodable` and `Encodable` protocol.
-				annotations.CustomSerialization = true
-			}
+			annotations.DependsOn[dep.Name] = dep
+		}
+		if field.Map && !fieldCodec.IsStringKeyed() {
+			// In ProtoJSON map fields with non-string keys need to be
+			// serialized as JSON objects with key fields. In the generated
+			// Swift code, that requires a custom implementation of the
+			// `Decodable` and `Encodable` protocol.
+			annotations.CustomSerialization = true
 		}
 	}
 

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -84,11 +84,8 @@ func TestPathVariables(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{requestMessage}, nil, []*api.Service{})
 	codec := newTestCodec(t, model, nil)
-
-	for _, f := range requestMessage.Fields {
-		if err := codec.annotateField(f); err != nil {
-			t.Fatal(err)
-		}
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
 	}
 
 	for _, test := range []struct {


### PR DESCRIPTION
Return the annotations from `annotateField()` so we can use them in `annotateMessage()` directly without a downcast.

Towards #5748 