### PR TITLE
chore: add instruction to avoid force push in `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ After modifying code, you MUST run these commands:
 - **Lint:** `go tool golangci-lint run`
 - **Tests:** `go test -short ./...` (for fast feedback)
 - **YAML:** `yamlfmt` (if YAML files were touched)
-- **Git:** Never use force push (`git push -f` or `git push --force`). If a branch needs updating, always pull/rebase or merge instead.
+- **Git:** Never use force push (`git push -f` or `git push --force`). 
+  If a branch needs updating, always pull/rebase or merge instead.
 
 Before submitting changes, run the full test suite:
 - **Full Tests:** `go test -race ./...`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ After modifying code, you MUST run these commands:
 - **Lint:** `go tool golangci-lint run`
 - **Tests:** `go test -short ./...` (for fast feedback)
 - **YAML:** `yamlfmt` (if YAML files were touched)
+- **Git:** Never use force push (`git push -f` or `git push --force`). If a branch needs updating, always pull/rebase or merge instead.
 
 Before submitting changes, run the full test suite:
 - **Full Tests:** `go test -race ./...`


### PR DESCRIPTION
Instructs agentic coding assistants working in the repository to never use force push and instead pull/rebase or merge to update branches.