### PR TITLE
fix(internal/postprocessing): return error for missing files in RemoveFile

### DIFF
--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -16,8 +16,6 @@
 package postprocessing
 
 import (
-	"errors"
-	"io/fs"
 	"os"
 
 	"github.com/googleapis/librarian/internal/filesystem"
@@ -31,11 +29,6 @@ func CopyFile(src, dst string) error {
 }
 
 // RemoveFile removes the file at the specified path.
-// It silently ignores errors if the file does not exist.
 func RemoveFile(path string) error {
-	err := os.Remove(path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil
-	}
-	return err
+	return os.Remove(path)
 }

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -73,8 +73,9 @@ func TestRemoveFile(t *testing.T) {
 func TestRemoveFile_NonExistent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nonexistent.txt")
-	if err := RemoveFile(path); err != nil {
-		t.Fatal(err)
+	err := RemoveFile(path)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("RemoveFile() returned unexpected error: got %v, want %v", err, fs.ErrNotExist)
 	}
 }
 


### PR DESCRIPTION
This PR updates RemoveFile so that it returns an error instead of silently skipping if a target file is missing.

Follow-up to #6371