### PR TITLE
feat(internal/postprocessing): add replace and replaceRegex functions

### DIFF
--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -16,6 +16,7 @@
 package postprocessing
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -47,11 +48,12 @@ func Replace(path, original, replacement string) error {
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(string(content), original) {
+	oldBytes := []byte(original)
+	if !bytes.Contains(content, oldBytes) {
 		return fmt.Errorf("%w: %q in file %s", ErrTextNotFound, original, path)
 	}
-	newContent := strings.ReplaceAll(string(content), original, replacement)
-	return os.WriteFile(path, []byte(newContent), 0644)
+	newContent := bytes.ReplaceAll(content, oldBytes, []byte(replacement))
+	return os.WriteFile(path, newContent, 0644)
 }
 
 // ReplaceRegex finds and replaces text in a file using a regular expression.
@@ -73,6 +75,6 @@ func ReplaceRegex(path, pattern, replacement string) error {
 	if !re.Match(content) {
 		return fmt.Errorf("%w: pattern %q in file %s", ErrTextNotFound, pattern, path)
 	}
-	newContent := re.ReplaceAllString(string(content), replacement)
-	return os.WriteFile(path, []byte(newContent), 0644)
+	newContent := re.ReplaceAll(content, []byte(replacement))
+	return os.WriteFile(path, newContent, 0644)
 }

--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -26,8 +26,8 @@ import (
 	"github.com/googleapis/librarian/internal/filesystem"
 )
 
-// ErrTextNotFound is returned when the target text or pattern is not found in the file.
-var ErrTextNotFound = errors.New("text not found")
+// errTextNotFound is returned when the target text or pattern is not found in the file.
+var errTextNotFound = errors.New("text not found")
 
 // CopyFile copies a single file from the src path to the dst path.
 // It acts as a wrapper around filesystem.CopyFile to provide a unified
@@ -50,7 +50,7 @@ func Replace(path, original, replacement string) error {
 	}
 	oldBytes := []byte(original)
 	if !bytes.Contains(content, oldBytes) {
-		return fmt.Errorf("%w: %q in file %s", ErrTextNotFound, original, path)
+		return fmt.Errorf("%w: %q in file %s", errTextNotFound, original, path)
 	}
 	newContent := bytes.ReplaceAll(content, oldBytes, []byte(replacement))
 	return os.WriteFile(path, newContent, 0644)
@@ -62,18 +62,16 @@ func ReplaceRegex(path, pattern, replacement string) error {
 	if !strings.HasPrefix(pattern, "(?") {
 		pattern = "(?m)" + pattern
 	}
-
 	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return err
 	}
-
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	if !re.Match(content) {
-		return fmt.Errorf("%w: pattern %q in file %s", ErrTextNotFound, pattern, path)
+		return fmt.Errorf("%w: pattern %q in file %s", errTextNotFound, pattern, path)
 	}
 	newContent := re.ReplaceAll(content, []byte(replacement))
 	return os.WriteFile(path, newContent, 0644)

--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -16,10 +16,17 @@
 package postprocessing
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/filesystem"
 )
+
+// ErrTextNotFound is returned when the target text or pattern is not found in the file.
+var ErrTextNotFound = errors.New("text not found")
 
 // CopyFile copies a single file from the src path to the dst path.
 // It acts as a wrapper around filesystem.CopyFile to provide a unified
@@ -31,4 +38,41 @@ func CopyFile(src, dst string) error {
 // RemoveFile removes the file at the specified path.
 func RemoveFile(path string) error {
 	return os.Remove(path)
+}
+
+// Replace finds and replaces exact text in a file.
+// It returns an error if the target file does not exist or if the text is not found.
+func Replace(path, original, replacement string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(content), original) {
+		return fmt.Errorf("%w: %q in file %s", ErrTextNotFound, original, path)
+	}
+	newContent := strings.ReplaceAll(string(content), original, replacement)
+	return os.WriteFile(path, []byte(newContent), 0644)
+}
+
+// ReplaceRegex finds and replaces text in a file using a regular expression.
+// It returns an error if the target file does not exist or if the pattern matches no text.
+func ReplaceRegex(path, pattern, replacement string) error {
+	if !strings.HasPrefix(pattern, "(?") {
+		pattern = "(?m)" + pattern
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !re.Match(content) {
+		return fmt.Errorf("%w: pattern %q in file %s", ErrTextNotFound, pattern, path)
+	}
+	newContent := re.ReplaceAllString(string(content), replacement)
+	return os.WriteFile(path, []byte(newContent), 0644)
 }

--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -59,6 +59,7 @@ func Replace(path, original, replacement string) error {
 // ReplaceRegex finds and replaces text in a file using a regular expression.
 // It returns an error if the target file does not exist or if the pattern matches no text.
 func ReplaceRegex(path, pattern, replacement string) error {
+	// Default to multiline mode so ^ and $ match per-line.
 	if !strings.HasPrefix(pattern, "(?") {
 		pattern = "(?m)" + pattern
 	}

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -119,7 +119,7 @@ func TestReplace(t *testing.T) {
 }
 
 func TestReplaceRegex(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		name        string
 		content     string
 		pattern     string
@@ -140,16 +140,14 @@ func TestReplaceRegex(t *testing.T) {
 			replacement: "Number",
 			want:        "Hello Number World",
 		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	} {
+		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 			path := filepath.Join(dir, "test.txt")
-			if err := os.WriteFile(path, []byte(tc.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
 				t.Fatal(err)
 			}
-			if err := ReplaceRegex(path, tc.pattern, tc.replacement); err != nil {
+			if err := ReplaceRegex(path, test.pattern, test.replacement); err != nil {
 				t.Fatal(err)
 			}
 			gotBytes, err := os.ReadFile(path)
@@ -157,51 +155,87 @@ func TestReplaceRegex(t *testing.T) {
 				t.Fatal(err)
 			}
 			got := string(gotBytes)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestReplace_NonExistent(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "nonexistent.txt")
-	err := Replace(path, "old", "new")
-	if !errors.Is(err, fs.ErrNotExist) {
-		t.Errorf("Replace() returned unexpected error: got %v, want %v", err, fs.ErrNotExist)
+func TestReplace_Error(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		content     string
+		original    string
+		replacement string
+		wantErr     error
+	}{
+		{
+			name:        "file does not exist",
+			original:    "old",
+			replacement: "new",
+			wantErr:     fs.ErrNotExist,
+		},
+		{
+			name:        "text not found",
+			content:     "Hello World",
+			original:    "Apple",
+			replacement: "Go",
+			wantErr:     errTextNotFound,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "nonexistent.txt")
+			if test.content != "" {
+				path = filepath.Join(dir, "test.txt")
+				if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := Replace(path, test.original, test.replacement)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Replace() returned unexpected error: got %v, want %v", err, test.wantErr)
+			}
+		})
 	}
 }
 
-func TestReplaceRegex_NonExistent(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "nonexistent.txt")
-	err := ReplaceRegex(path, "old", "new")
-	if !errors.Is(err, fs.ErrNotExist) {
-		t.Errorf("ReplaceRegex() returned unexpected error: got %v, want %v", err, fs.ErrNotExist)
-	}
-}
-
-func TestReplace_NotFound(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(path, []byte("Hello World"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	err := Replace(path, "Apple", "Go")
-	if !errors.Is(err, ErrTextNotFound) {
-		t.Errorf("Replace() returned unexpected error: got %v, want %v", err, ErrTextNotFound)
-	}
-}
-
-func TestReplaceRegex_NotFound(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(path, []byte("Hello World"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	err := ReplaceRegex(path, `\d+`, "Number")
-	if !errors.Is(err, ErrTextNotFound) {
-		t.Errorf("ReplaceRegex() returned unexpected error: got %v, want %v", err, ErrTextNotFound)
+func TestReplaceRegex_Error(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		content     string
+		pattern     string
+		replacement string
+		wantErr     error
+	}{
+		{
+			name:        "file does not exist",
+			pattern:     "old",
+			replacement: "new",
+			wantErr:     fs.ErrNotExist,
+		},
+		{
+			name:        "pattern not found",
+			content:     "Hello World",
+			pattern:     `\d+`,
+			replacement: "Number",
+			wantErr:     errTextNotFound,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "nonexistent.txt")
+			if test.content != "" {
+				path = filepath.Join(dir, "test.txt")
+				if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := ReplaceRegex(path, test.pattern, test.replacement)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("ReplaceRegex() returned unexpected error: got %v, want %v", err, test.wantErr)
+			}
+		})
 	}
 }

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -118,6 +118,7 @@ func TestReplace(t *testing.T) {
 }
 
 func TestReplaceRegex(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name        string
 		content     string

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -101,7 +101,6 @@ func TestReplace(t *testing.T) {
 	original := "World"
 	replacement := "Go"
 	want := "Hello Go"
-
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -142,6 +141,7 @@ func TestReplaceRegex(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			path := filepath.Join(dir, "test.txt")
 			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -93,3 +93,115 @@ func TestRemoveFile_Error(t *testing.T) {
 		t.Errorf("RemoveFile() error = %v, wantErr %v", err, syscall.ENOTEMPTY)
 	}
 }
+
+func TestReplace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	content := "Hello World"
+	original := "World"
+	replacement := "Go"
+	want := "Hello Go"
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Replace(path, original, replacement); err != nil {
+		t.Fatal(err)
+	}
+	gotBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotBytes)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestReplaceRegex(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		pattern     string
+		replacement string
+		want        string
+	}{
+		{
+			name:        "simple replacement",
+			content:     "Hello World",
+			pattern:     "World",
+			replacement: "Go",
+			want:        "Hello Go",
+		},
+		{
+			name:        "regex replacement",
+			content:     "Hello 123 World",
+			pattern:     `\d+`,
+			replacement: "Number",
+			want:        "Hello Number World",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "test.txt")
+			if err := os.WriteFile(path, []byte(tc.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := ReplaceRegex(path, tc.pattern, tc.replacement); err != nil {
+				t.Fatal(err)
+			}
+			gotBytes, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(gotBytes)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReplace_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.txt")
+	err := Replace(path, "old", "new")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("Replace() returned unexpected error: got %v, want %v", err, fs.ErrNotExist)
+	}
+}
+
+func TestReplaceRegex_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.txt")
+	err := ReplaceRegex(path, "old", "new")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ReplaceRegex() returned unexpected error: got %v, want %v", err, fs.ErrNotExist)
+	}
+}
+
+func TestReplace_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("Hello World"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := Replace(path, "Apple", "Go")
+	if !errors.Is(err, ErrTextNotFound) {
+		t.Errorf("Replace() returned unexpected error: got %v, want %v", err, ErrTextNotFound)
+	}
+}
+
+func TestReplaceRegex_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("Hello World"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := ReplaceRegex(path, `\d+`, "Number")
+	if !errors.Is(err, ErrTextNotFound) {
+		t.Errorf("ReplaceRegex() returned unexpected error: got %v, want %v", err, ErrTextNotFound)
+	}
+}


### PR DESCRIPTION
Add the replace and replaceRegex functions to the postprocessing package. They perform exact string and regex replacements in files and return an error if the target text is not found.

Fixes #6297