### PR TITLE
refactor: use strings.CutPrefix in packages

### DIFF
--- a/cmd/config_doc_generate.go
+++ b/cmd/config_doc_generate.go
@@ -314,10 +314,8 @@ func getTypeName(expr ast.Expr) string {
 }
 
 func (d *docData) formatType(typeName string) string {
-	isSlice := strings.HasPrefix(typeName, "[]")
-	cleanType := strings.TrimPrefix(typeName, "[]")
-	isPointer := strings.HasPrefix(cleanType, "*")
-	cleanType = strings.TrimPrefix(cleanType, "*")
+	cleanType, isSlice := strings.CutPrefix(typeName, "[]")
+	cleanType, isPointer := strings.CutPrefix(cleanType, "*")
 	res := cleanType
 	// If it's one of our structs, link it
 	if _, ok := d.structs[cleanType]; ok {

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -170,11 +170,7 @@ func deriveLibraryName(language string, api string) string {
 // error if the API cannot be added (e.g. because it already exists, or the new
 // API is a preview and there is no corresponding stable library).
 func addLibrary(cfg *config.Config, apiPath string) (string, *config.Config, error) {
-	isPreview := strings.HasPrefix(apiPath, "preview/")
-	stablePath := apiPath
-	if isPreview {
-		stablePath = strings.TrimPrefix(apiPath, "preview/")
-	}
+	stablePath, isPreview := strings.CutPrefix(apiPath, "preview/")
 	api := &config.API{Path: stablePath}
 	existingLib := findExistingLibraryForNewAPI(cfg, stablePath)
 	if isPreview {

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -86,8 +86,8 @@ func DefaultLibraryName(api string) string {
 		path = api[:idx]
 	}
 	for _, p := range knownPrefixes {
-		if strings.HasPrefix(path, p) {
-			path = strings.TrimPrefix(path, p)
+		if after, ok := strings.CutPrefix(path, p); ok {
+			path = after
 			break
 		}
 	}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -502,8 +502,7 @@ func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDi
 	metadata.LibraryType = repometadata.GAPICAutoLibraryType
 	metadata.DefaultVersion = resolveDefaultVersion(library)
 
-	if after, ok := strings.CutPrefix(metadata.DistributionName, "@google-cloud/"); ok {
-		pkgSuffix := after
+	if pkgSuffix, ok := strings.CutPrefix(metadata.DistributionName, "@google-cloud/"); ok {
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/nodejs/docs/reference/%s/latest", pkgSuffix)
 	}
 

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -502,8 +502,8 @@ func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDi
 	metadata.LibraryType = repometadata.GAPICAutoLibraryType
 	metadata.DefaultVersion = resolveDefaultVersion(library)
 
-	if strings.HasPrefix(metadata.DistributionName, "@google-cloud/") {
-		pkgSuffix := strings.TrimPrefix(metadata.DistributionName, "@google-cloud/")
+	if after, ok :=strings.CutPrefix(metadata.DistributionName, "@google-cloud/"); ok  {
+		pkgSuffix := after
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/nodejs/docs/reference/%s/latest", pkgSuffix)
 	}
 

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -502,7 +502,7 @@ func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDi
 	metadata.LibraryType = repometadata.GAPICAutoLibraryType
 	metadata.DefaultVersion = resolveDefaultVersion(library)
 
-	if after, ok :=strings.CutPrefix(metadata.DistributionName, "@google-cloud/"); ok  {
+	if after, ok := strings.CutPrefix(metadata.DistributionName, "@google-cloud/"); ok {
 		pkgSuffix := after
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/nodejs/docs/reference/%s/latest", pkgSuffix)
 	}

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -193,10 +193,9 @@ func newLibraryCodec(library *config.Library) map[string]string {
 func extraModulesFromKeep(keep []string) []string {
 	var modules []string
 	for _, k := range keep {
-		if strings.HasPrefix(k, "src/") && strings.HasSuffix(k, ".rs") {
+		if after, ok := strings.CutPrefix(k, "src/"); ok && strings.HasSuffix(k, ".rs") {
 			// Extract module name: "src/errors.rs" -> "errors"
-			module := strings.TrimPrefix(k, "src/")
-			module = strings.TrimSuffix(module, ".rs")
+			module := strings.TrimSuffix(after, ".rs")
 			modules = append(modules, module)
 		}
 	}

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -278,10 +278,11 @@ func (r *Resource) WithSingular(singular string) *Resource {
 // ParseTemplateForTest converts a string literal into a []PathSegment slice for testing purposes.
 func ParseTemplateForTest(template string) []PathSegment {
 	var segments []PathSegment
-	parts := strings.Split(strings.TrimPrefix(template, "//"), "/")
+	trimmed, hasDoubleSlash := strings.CutPrefix(template, "//")
+	parts := strings.Split(trimmed, "/")
 
 	host := parts[0]
-	if strings.HasPrefix(template, "//") {
+	if hasDoubleSlash {
 		host = "//" + parts[0]
 	}
 	segments = append(segments, PathSegment{Literal: host})

--- a/internal/sidekick/language/generate.go
+++ b/internal/sidekick/language/generate.go
@@ -30,8 +30,8 @@ type mustacheProvider struct {
 
 // Get gets the template contents.
 func (p *mustacheProvider) Get(name string) (string, error) {
-	if strings.HasPrefix(name, "/") {
-		return p.impl(strings.TrimPrefix(name, "/") + ".mustache")
+	if suffix, ok := strings.CutPrefix(name, "/"); ok {
+		return p.impl(suffix + ".mustache")
 	}
 	return p.impl(filepath.Join(p.dirname, name) + ".mustache")
 }

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -731,14 +731,12 @@ func enumValueVariantName(e *api.EnumValue) string {
 	// transformation would map it as `INSTANCE_PRIVATE_IPV_6_GOOGLE_ACCESS`.
 	// Note the extra `_` in `IPV_6` in the second case.
 	prefix := toScreamingSnake(e.Parent.Name) + "_"
-	trimmed := strings.TrimPrefix(e.Name, prefix)
-	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
+	if trimmed, ok := strings.CutPrefix(e.Name, prefix); ok && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
 		return toPascal(trimmed)
 	}
 	trimNumbers := regexp.MustCompile(`_([0-9])`)
 	prefix = trimNumbers.ReplaceAllString(prefix, `$1`)
-	trimmed = strings.TrimPrefix(e.Name, prefix)
-	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
+	if trimmed, ok := strings.CutPrefix(e.Name, prefix); ok && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
 		return toPascal(trimmed)
 	}
 	return toPascal(e.Name)

--- a/internal/sidekick/swift/names.go
+++ b/internal/sidekick/swift/names.go
@@ -194,13 +194,11 @@ func pascalCaseNoMangling(s string) string {
 // enumValueCaseName returns the name of the Swift enumeration case for a given enumeration value.
 func enumValueCaseName(e *api.EnumValue) string {
 	prefix := strcase.ToScreamingSnake(e.Parent.Name) + "_"
-	trimmed := strings.TrimPrefix(e.Name, prefix)
-	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
+	if trimmed, ok := strings.CutPrefix(e.Name, prefix); ok && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
 		return camelCase(trimmed)
 	}
 	prefix = trimNumbers.ReplaceAllString(prefix, `$1`)
-	trimmed = strings.TrimPrefix(e.Name, prefix)
-	if strings.HasPrefix(e.Name, prefix) && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
+	if trimmed, ok := strings.CutPrefix(e.Name, prefix); ok && strings.IndexFunc(trimmed, unicode.IsLetter) == 0 {
 		return camelCase(trimmed)
 	}
 	return camelCase(e.Name)

--- a/internal/sidekick/swift/package_name.go
+++ b/internal/sidekick/swift/package_name.go
@@ -24,12 +24,11 @@ import (
 // PackageName returns the package name for the API.
 func PackageName(api *api.API) string {
 	var name string
-	switch {
-	case strings.HasPrefix(api.PackageName, "google.cloud."):
-		name = "Cloud" + pascalPackageName(strings.TrimPrefix(api.PackageName, "google.cloud."))
-	case strings.HasPrefix(api.PackageName, "google."):
-		name = pascalPackageName(strings.TrimPrefix(api.PackageName, "google."))
-	default:
+	if suffix, ok := strings.CutPrefix(api.PackageName, "google.cloud."); ok {
+		name = "Cloud" + pascalPackageName(suffix)
+	} else if suffix, ok := strings.CutPrefix(api.PackageName, "google."); ok {
+		name = pascalPackageName(suffix)
+	} else {
 		name = pascalPackageName(api.PackageName)
 	}
 	return "Google" + name

--- a/tool/cmd/migrate/nodejs.go
+++ b/tool/cmd/migrate/nodejs.go
@@ -229,8 +229,7 @@ func buildNodejsLibrary(googleapisDir, packagesDir, libraryName string) (*config
 	// Read existing .repo-metadata.json if it exists to preserve custom metadata overrides.
 	if meta, err := repometadata.Read(pkgDir); err == nil && meta != nil {
 		var defaultClientDoc string
-		if strings.HasPrefix(pkgJSON.Name, "@google-cloud/") {
-			pkgSuffix := strings.TrimPrefix(pkgJSON.Name, "@google-cloud/")
+		if pkgSuffix, ok := strings.CutPrefix(pkgJSON.Name, "@google-cloud/"); ok {
 			defaultClientDoc = fmt.Sprintf("https://cloud.google.com/nodejs/docs/reference/%s/latest", pkgSuffix)
 		}
 		if meta.ClientDocumentation != "" && meta.ClientDocumentation != defaultClientDoc {


### PR DESCRIPTION
Use `strings.CutPrefix` instead of `strings.HasPrefix` and `strings.TrimPrefix`.

This simplifies the logic and makes it more idiomatic.