### PR TITLE
refactor(internal/librarian/nodejs): extract moveKeep helper and add tests

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -266,18 +266,9 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		return fmt.Errorf("failed to create backup dir: %w", err)
 	}
 	defer os.RemoveAll(backupDir)
-	for _, name := range library.Keep {
-		src := filepath.Join(outDir, name)
-		if _, err := os.Stat(src); err != nil {
-			continue // file doesn't exist, nothing to save
-		}
-		dst := filepath.Join(backupDir, name)
-		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
-			return fmt.Errorf("failed to create backup subdir for %s: %w", name, err)
-		}
-		if err := os.Rename(src, dst); err != nil {
-			return fmt.Errorf("failed to save %s: %w", name, err)
-		}
+	// Backup keep files.
+	if err := moveKeep(library.Keep, outDir, backupDir); err != nil {
+		return err
 	}
 
 	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name)
@@ -293,22 +284,10 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 	if err := command.Run(ctx, "gapic-node-processing", combineArgs...); err != nil {
 		return fmt.Errorf("combine-library: %w", err)
 	}
-
 	// Restore keep files.
-	for _, name := range library.Keep {
-		src := filepath.Join(backupDir, name)
-		if _, err := os.Stat(src); err != nil {
-			continue
-		}
-		dst := filepath.Join(outDir, name)
-		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
-			return fmt.Errorf("failed to create output subdir for %s: %w", name, err)
-		}
-		if err := os.Rename(src, dst); err != nil {
-			return fmt.Errorf("failed to restore %s: %w", name, err)
-		}
+	if err := moveKeep(library.Keep, backupDir, outDir); err != nil {
+		return err
 	}
-
 	// Copy generated samples from staging into the output directory.
 	// combine-library only handles src/ and protos/; samples are generated
 	// by gapic-generator-typescript but left in staging.
@@ -715,4 +694,21 @@ func injectV1SmallExports(outDir string) error {
 	content = updated
 
 	return os.WriteFile(indexPath, []byte(content), 0644)
+}
+
+func moveKeep(files []string, srcDir, dstDir string) error {
+	for _, name := range files {
+		src := filepath.Join(srcDir, name)
+		if _, err := os.Stat(src); err != nil {
+			continue // file doesn't exist, nothing to save
+		}
+		dst := filepath.Join(dstDir, name)
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return fmt.Errorf("failed to create dstDir subdir for %s: %w", name, err)
+		}
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("failed to save %s: %w", name, err)
+		}
+	}
+	return nil
 }

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -704,10 +704,10 @@ func moveKeep(files []string, srcDir, dstDir string) error {
 		}
 		dst := filepath.Join(dstDir, name)
 		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
-			return fmt.Errorf("failed to create dstDir subdir for %s: %w", name, err)
+			return fmt.Errorf("failed to create destination subdirectory for %s: %w", name, err)
 		}
 		if err := os.Rename(src, dst); err != nil {
-			return fmt.Errorf("failed to save %s: %w", name, err)
+			return fmt.Errorf("failed to move %s: %w", name, err)
 		}
 	}
 	return nil

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1528,3 +1528,54 @@ func TestResolveDefaultVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestMoveKeep(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		setup       func(t *testing.T, srcDir string)
+		filesToKeep []string
+		wantFiles   []string
+		unexpected  []string
+	}{
+		{
+			name: "moves existing files successfully",
+			setup: func(t *testing.T, srcDir string) {
+				if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				for _, file := range []string{"file1.txt", "subdir/file2.txt"} {
+					if err := os.WriteFile(filepath.Join(srcDir, file), []byte("content"), 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			filesToKeep: []string{"file1.txt", "subdir/file2.txt"},
+			wantFiles:   []string{"file1.txt", "subdir/file2.txt"},
+		},
+		{
+			name: "skips missing files without error",
+			setup: func(t *testing.T, srcDir string) {
+				if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("content1"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			filesToKeep: []string{"file1.txt", "missing.txt"},
+			wantFiles:   []string{"file1.txt"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			dstDir := t.TempDir()
+			test.setup(t, srcDir)
+			if err := moveKeep(test.filesToKeep, srcDir, dstDir); err != nil {
+				t.Fatal(err)
+			}
+			for _, f := range test.wantFiles {
+				path := filepath.Join(dstDir, f)
+				if _, err := os.Stat(path); err != nil {
+					t.Errorf("file %s does not exist in destination: %v", path, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1575,6 +1576,55 @@ func TestMoveKeep(t *testing.T) {
 				if _, err := os.Stat(path); err != nil {
 					t.Errorf("file %s does not exist in destination: %v", path, err)
 				}
+			}
+		})
+	}
+}
+
+func TestMoveKeep_Errors(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		setup       func(t *testing.T, srcDir, dstDir string)
+		filesToKeep []string
+		wantErr     error
+	}{
+		{
+			name: "mkdir failure when target parent is a regular file",
+			setup: func(t *testing.T, srcDir, dstDir string) {
+				if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(srcDir, "subdir", "file.txt"), []byte("content"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dstDir, "subdir"), []byte("not-a-dir"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			filesToKeep: []string{"subdir/file.txt"},
+			wantErr:     syscall.ENOTDIR,
+		},
+		{
+			name: "rename failure when target is an existing directory",
+			setup: func(t *testing.T, srcDir, dstDir string) {
+				if err := os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("content"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Join(dstDir, "file.txt"), 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			filesToKeep: []string{"file.txt"},
+			wantErr:     os.ErrExist,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			dstDir := t.TempDir()
+			test.setup(t, srcDir, dstDir)
+			err := moveKeep(test.filesToKeep, srcDir, dstDir)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("moveKeep() error = %v, want %v", err, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Extract the file backup and restore logic from `runPostProcessor` into a reusable `moveKeep` helper function.

This reduces duplication and enables isolated unit testing of the keep-file movement behavior.