### PR TITLE
refactor(internal/librarian/nodejs): simplify copyMissingProtos implementation

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -519,12 +519,10 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve googleapis directory: %w", err)
 	}
-
 	lists, err := filepath.Glob(filepath.Join(outDir, "src", "*", "*_proto_list.json"))
 	if err != nil {
 		return fmt.Errorf("failed to glob proto list files: %w", err)
 	}
-
 	for _, listPath := range lists {
 		data, err := os.ReadFile(listPath)
 		if err != nil {
@@ -534,25 +532,18 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 		if err := json.Unmarshal(data, &entries); err != nil {
 			return fmt.Errorf("failed to parse %s: %w", listPath, err)
 		}
-
 		listDir := filepath.Dir(listPath)
 		for _, entry := range entries {
-			absPath := filepath.Join(listDir, entry)
-			absPath = filepath.Clean(absPath)
+			absPath := filepath.Clean(filepath.Join(listDir, entry))
 			if _, err := os.Stat(absPath); err == nil {
 				continue
 			}
 			// Extract the proto-relative path after "protos/".
-			const protosPrefix = "protos/"
-			idx := strings.Index(entry, protosPrefix)
-			if idx < 0 {
+			_, relPath, ok := strings.Cut(entry, "protos/")
+			if !ok {
 				continue
 			}
-			relPath := entry[idx+len(protosPrefix):]
 			srcPath := filepath.Join(googleapisDir, relPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				return fmt.Errorf("failed to create directory for %s: %w", absPath, err)
-			}
 			if err := filesystem.CopyFile(srcPath, absPath); err != nil {
 				return fmt.Errorf("failed to copy %s to %s: %w", srcPath, absPath, err)
 			}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -40,6 +40,7 @@ import (
 
 const (
 	cloudCommonResourcesProto = "google/cloud/common_resources.proto"
+	protosPathPrefix          = "protos/"
 )
 
 // IsMixedLibrary reports whether the library has handwritten code wrapping
@@ -539,7 +540,7 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 				continue
 			}
 			// Extract the proto-relative path after "protos/".
-			_, relPath, ok := strings.Cut(entry, "protos/")
+			_, relPath, ok := strings.Cut(entry, protosPathPrefix)
 			if !ok {
 				continue
 			}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/repometadata"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sources"
@@ -541,7 +542,6 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 			if _, err := os.Stat(absPath); err == nil {
 				continue
 			}
-
 			// Extract the proto-relative path after "protos/".
 			const protosPrefix = "protos/"
 			idx := strings.Index(entry, protosPrefix)
@@ -549,17 +549,12 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 				continue
 			}
 			relPath := entry[idx+len(protosPrefix):]
-
 			srcPath := filepath.Join(googleapisDir, relPath)
-			content, err := os.ReadFile(srcPath)
-			if err != nil {
-				return fmt.Errorf("failed to read source proto %s: %w", srcPath, err)
-			}
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				return fmt.Errorf("failed to create directory for %s: %w", absPath, err)
 			}
-			if err := os.WriteFile(absPath, content, 0644); err != nil {
-				return fmt.Errorf("failed to write proto %s: %w", absPath, err)
+			if err := filesystem.CopyFile(srcPath, absPath); err != nil {
+				return fmt.Errorf("failed to copy %s to %s: %w", srcPath, absPath, err)
 			}
 		}
 	}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -543,6 +543,9 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 			if !ok {
 				continue
 			}
+			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+				return fmt.Errorf("failed to create directory for %s: %w", absPath, err)
+			}
 			srcPath := filepath.Join(googleapisDir, relPath)
 			if err := filesystem.CopyFile(srcPath, absPath); err != nil {
 				return fmt.Errorf("failed to copy %s to %s: %w", srcPath, absPath, err)


### PR DESCRIPTION
Refactor `copyMissingProtos` in generate.go to use the `filesystem.CopyFile` helper instead of manually reading and writing file bytes.

Additionally, replace the manual `strings.Index` and slicing logic with
`strings.Cut` to extract the relative path of missing protos, and clean the joined destination path in a single operation.