### PR TITLE
fix: use `fmt.Fprintf` to replace `WriteString`

### DIFF
--- a/internal/docker/environment.go
+++ b/internal/docker/environment.go
@@ -107,10 +107,10 @@ func (e *EnvironmentProvider) constructEnvironmentFileContent(ctx context.Contex
 		// Finally, write the value if we've got one
 		if present {
 			slog.Info(fmt.Sprintf("Using %s to provide value to container for %s", source, variable.Name))
-			builder.WriteString(fmt.Sprintf("%s=%s\n", variable.Name, value))
+			fmt.Fprintf(&builder, "%s=%s\n", variable.Name, value)
 		} else {
 			slog.Info(fmt.Sprintf("No value to provide to container for '%s'", variable.Name))
-			builder.WriteString(fmt.Sprintf("# No value for %s\n", variable.Name))
+			fmt.Fprintf(&builder, "# No value for %s\n", variable.Name)
 		}
 		continue
 	}

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -458,7 +458,7 @@ func checkPullRequestCommits(ctx context.Context, prMetadata *github.PullRequest
 	}
 
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "At least one library being released may have changed since release PR creation:\n\n")
+	builder.WriteString("At least one library being released may have changed since release PR creation:\n\n")
 	for _, suspectRelease := range suspectReleases {
 		fmt.Fprintf(&builder, "%s: %s\n", suspectRelease.LibraryID, suspectRelease.Reason)
 	}

--- a/internal/librarian/mergereleasepr.go
+++ b/internal/librarian/mergereleasepr.go
@@ -458,9 +458,9 @@ func checkPullRequestCommits(ctx context.Context, prMetadata *github.PullRequest
 	}
 
 	var builder strings.Builder
-	builder.WriteString("At least one library being released may have changed since release PR creation:\n\n")
+	fmt.Fprintf(&builder, "At least one library being released may have changed since release PR creation:\n\n")
 	for _, suspectRelease := range suspectReleases {
-		builder.WriteString(fmt.Sprintf("%s: %s\n", suspectRelease.LibraryID, suspectRelease.Reason))
+		fmt.Fprintf(&builder, "%s: %s\n", suspectRelease.LibraryID, suspectRelease.Reason)
 	}
 	return false, reportBlockingReason(ctx, prMetadata, builder.String(), cfg)
 }

--- a/internal/librarian/pullrequest.go
+++ b/internal/librarian/pullrequest.go
@@ -128,13 +128,11 @@ func formatListAsMarkdown(title string, list []string) string {
 		return ""
 	}
 	var builder strings.Builder
-	builder.WriteString("## ")
-	builder.WriteString(title)
-	builder.WriteString("\n\n")
+	fmt.Fprintf(&builder, "## %s\n\n", title)
 	for _, value := range list {
-		builder.WriteString(fmt.Sprintf("- %s\n", value))
+		fmt.Fprintf(&builder, "- %s\n", value)
 	}
-	builder.WriteString("\n\n")
+	fmt.Fprintf(&builder, "\n\n")
 	return builder.String()
 }
 

--- a/internal/librarian/pullrequest.go
+++ b/internal/librarian/pullrequest.go
@@ -132,7 +132,7 @@ func formatListAsMarkdown(title string, list []string) string {
 	for _, value := range list {
 		fmt.Fprintf(&builder, "- %s\n", value)
 	}
-	fmt.Fprintf(&builder, "\n\n")
+	builder.WriteString("\n\n")
 	return builder.String()
 }
 

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -302,15 +302,18 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 			if strings.HasPrefix(line, PiperPrefix) {
 				piperRevIdLines = append(piperRevIdLines, line)
 			} else {
-				fmt.Fprintf(&builder, "%s\n", line)
+				builder.WriteString(line)
+				builder.WriteString("\n")
 			}
 		}
 	}
 	for _, revIdLine := range piperRevIdLines {
-		fmt.Fprintf(&builder, "%s\n", revIdLine)
+		builder.WriteString(revIdLine)
+		builder.WriteString("\n")
 	}
 	for _, sourceLinkLine := range sourceLinkLines {
-		fmt.Fprintf(&builder, "%s\n", sourceLinkLine)
+		builder.WriteString(sourceLinkLine)
+		builder.WriteString("\n")
 	}
 	return builder.String()
 }

--- a/internal/librarian/updateapis.go
+++ b/internal/librarian/updateapis.go
@@ -289,10 +289,7 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 	var builder strings.Builder
 
 	// Start the commit with a line on its own saying what's being regenerated.
-	builder.WriteString(fmt.Sprintf("regen: Regenerate %s at API commit %s", libraryID, commits[0].Hash.String()[0:7]))
-	builder.WriteString("\n")
-	builder.WriteString("\n")
-
+	fmt.Fprintf(&builder, "regen: Regenerate %s at API commit %s\n\n", libraryID, commits[0].Hash.String()[0:7])
 	piperRevIdLines := []string{}
 	sourceLinkLines := []string{}
 	// Consume the commits in reverse order, so that they're in normal chronological order,
@@ -305,19 +302,15 @@ func createCommitMessage(libraryID string, commits []*gitrepo.Commit) string {
 			if strings.HasPrefix(line, PiperPrefix) {
 				piperRevIdLines = append(piperRevIdLines, line)
 			} else {
-				builder.WriteString(line)
-				builder.WriteString("\n")
+				fmt.Fprintf(&builder, "%s\n", line)
 			}
-
 		}
 	}
 	for _, revIdLine := range piperRevIdLines {
-		builder.WriteString(revIdLine)
-		builder.WriteString("\n")
+		fmt.Fprintf(&builder, "%s\n", revIdLine)
 	}
 	for _, sourceLinkLine := range sourceLinkLines {
-		builder.WriteString(sourceLinkLine)
-		builder.WriteString("\n")
+		fmt.Fprintf(&builder, "%s\n", sourceLinkLine)
 	}
 	return builder.String()
 }


### PR DESCRIPTION
Use `fmt.Fprint` to replace `builder.WriteString(fmt.Sprintf()`, this will fix errors in unit tests.

Fixes #6388