### PR TITLE
refactor(sidekick/swift): simplify encoding/decoding

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -56,12 +56,62 @@ type fieldAnnotations struct {
 
 	// Recursive is true if the field is a recursive reference to another message.
 	Recursive bool
+
+	// Decoding controls how the field is decoded.
+	Decoding DecodingStyle
+
+	// Encoding controls how the field is encoded.
+	Encoding EncodingStyle
 }
+
+type DecodingStyle int
+type EncodingStyle int
+
+const (
+	DecodingSimple DecodingStyle = iota
+	DecodingOptional
+	DecodingMapCustomKey
+)
+
+const (
+	EncodingSimple EncodingStyle = iota
+	EncodingMapCustomKey
+)
 
 // IsStringKeyed returns true if the field is a map field and the key is a
 // string type.
 func (a *fieldAnnotations) IsStringKeyed() bool {
 	return a.KeyType == "Swift.String"
+}
+
+// IsDecodingSimple is used in mustache templates, where it is not possible to
+// compare a field to a constant.
+func (a *fieldAnnotations) IsDecodingSimple() bool {
+	return a.Decoding == DecodingSimple
+}
+
+// IsDecodingOptional is used in mustache templates, where it is not possible to
+// compare a field to a constant.
+func (a *fieldAnnotations) IsDecodingOptional() bool {
+	return a.Decoding == DecodingOptional
+}
+
+// IsDecodingMapCustomKey is used in mustache templates, where it is not
+// possible to compare a field to a constant.
+func (a *fieldAnnotations) IsDecodingMapCustomKey() bool {
+	return a.Decoding == DecodingMapCustomKey
+}
+
+// IsEncodingSimple is used in mustache templates, where it is not possible to
+// compare a field to a constant.
+func (a *fieldAnnotations) IsEncodingSimple() bool {
+	return a.Encoding == EncodingSimple
+}
+
+// IsEncodingMapCustomKey is used in mustache templates, where it is not
+// possible to compare a field to a constant.
+func (a *fieldAnnotations) IsEncodingMapCustomKey() bool {
+	return a.Encoding == EncodingMapCustomKey
 }
 
 func (c *codec) annotateField(field *api.Field) (*fieldAnnotations, error) {
@@ -86,6 +136,8 @@ func (c *codec) annotateField(field *api.Field) (*fieldAnnotations, error) {
 		ValueType:     parts.Value,
 		PackageName:   packageName,
 		DocLines:      docLines,
+		Decoding:      DecodingSimple,
+		Encoding:      EncodingSimple,
 	}
 	// Swift value types (structs) cannot contain recursive references directly because their
 	// size must be known at compile time. To break the cycle, we wrap the reference in a box type
@@ -99,6 +151,14 @@ func (c *codec) annotateField(field *api.Field) (*fieldAnnotations, error) {
 		annotations.Recursive = true
 		annotations.BaseFieldType = fmt.Sprintf("%s.Recursive<%s>", wellKnownSwiftPackage, parts.Base)
 		annotations.FieldType = annotations.BaseFieldType + "?"
+		annotations.Decoding = DecodingOptional
+	}
+	if field.Map && !annotations.IsStringKeyed() {
+		annotations.Decoding = DecodingMapCustomKey
+		annotations.Encoding = EncodingMapCustomKey
+	}
+	if field.Optional {
+		annotations.Decoding = DecodingOptional
 	}
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -64,17 +64,32 @@ type fieldAnnotations struct {
 	Encoding EncodingStyle
 }
 
+// DecodingStyle defines an enumeration for decoding fields.
 type DecodingStyle int
+
+// EncodingStyle defines an enumeration for encoding fields.
 type EncodingStyle int
 
 const (
+	// DecodingSimple means that the field is decoded using a simple `.decode()`
+	// call.
 	DecodingSimple DecodingStyle = iota
+
+	// DecodingOptional means that the field is decoded using a
+	// `.decodeIfPresent()` call.
 	DecodingOptional
+
+	// DecodingMapCustomKey means that the field is a map, with non-string keys
+	// and requires mapping through a string-keyed temporary.
 	DecodingMapCustomKey
 )
 
 const (
+	// EncodingSimple means that the field is encoded using a simple `.encode()` call.
 	EncodingSimple EncodingStyle = iota
+
+	// EncodingMapCustomKey means that the field is a map, with non-string keys
+	// and requires mapping through a string-keyed temporary.
 	EncodingMapCustomKey
 )
 

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -24,32 +24,38 @@ import (
 
 func TestAnnotateField(t *testing.T) {
 	for _, test := range []struct {
-		name         string
-		optional     bool
-		repeated     bool
-		wantType     string
-		wantBaseType string
+		name     string
+		optional bool
+		repeated bool
+		want     *fieldAnnotations
 	}{
 		{
-			name:         "regular",
-			optional:     false,
-			repeated:     false,
-			wantType:     "Swift.String",
-			wantBaseType: "Swift.String",
+			name:     "regular",
+			optional: false,
+			repeated: false,
+			want: &fieldAnnotations{
+				FieldType:     "Swift.String",
+				BaseFieldType: "Swift.String",
+			},
 		},
 		{
-			name:         "optional",
-			optional:     true,
-			repeated:     false,
-			wantType:     "Swift.String?",
-			wantBaseType: "Swift.String",
+			name:     "optional",
+			optional: true,
+			repeated: false,
+			want: &fieldAnnotations{
+				FieldType:     "Swift.String?",
+				BaseFieldType: "Swift.String",
+				Decoding:      DecodingOptional,
+			},
 		},
 		{
-			name:         "repeated",
-			optional:     false,
-			repeated:     true,
-			wantType:     "[Swift.String]",
-			wantBaseType: "Swift.String",
+			name:     "repeated",
+			optional: false,
+			repeated: true,
+			want: &fieldAnnotations{
+				FieldType:     "[Swift.String]",
+				BaseFieldType: "Swift.String",
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -73,14 +79,10 @@ func TestAnnotateField(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			want := &fieldAnnotations{
-				Name:          "secretPayload",
-				DocLines:      []string{"The secret version payload."},
-				FieldType:     test.wantType,
-				BaseFieldType: test.wantBaseType,
-			}
+			test.want.Name = "secretPayload"
+			test.want.DocLines = []string{"The secret version payload."}
 
-			if diff := cmp.Diff(want, field.Codec); diff != "" {
+			if diff := cmp.Diff(test.want, field.Codec); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -180,38 +182,43 @@ func TestAnnotateField_Recursive(t *testing.T) {
 		optional      bool
 		repeated      bool
 		isOneOf       bool
-		wantType      string
-		wantBaseType  string
-		wantRecursive bool
 		oneofProperty string
+		want          *fieldAnnotations
 	}{
 		{
-			name:          "singular optional recursive",
-			optional:      true,
-			repeated:      false,
-			isOneOf:       false,
-			wantType:      "GoogleCloudWkt.Recursive<Node>?",
-			wantBaseType:  "GoogleCloudWkt.Recursive<Node>",
-			wantRecursive: true,
+			name:     "singular optional recursive",
+			optional: true,
+			repeated: false,
+			isOneOf:  false,
+			want: &fieldAnnotations{
+				FieldType:     "GoogleCloudWkt.Recursive<Node>?",
+				BaseFieldType: "GoogleCloudWkt.Recursive<Node>",
+				Recursive:     true,
+				Decoding:      DecodingOptional,
+			},
 		},
 		{
-			name:          "repeated recursive",
-			optional:      false,
-			repeated:      true,
-			isOneOf:       false,
-			wantType:      "[Node]",
-			wantBaseType:  "Node",
-			wantRecursive: false,
+			name:     "repeated recursive",
+			optional: false,
+			repeated: true,
+			isOneOf:  false,
+			want: &fieldAnnotations{
+				FieldType:     "[Node]",
+				BaseFieldType: "Node",
+				Recursive:     false,
+			},
 		},
 		{
 			name:          "oneof recursive",
 			optional:      false,
 			repeated:      false,
 			isOneOf:       true,
-			wantType:      "Node",
-			wantBaseType:  "Node",
-			wantRecursive: false,
 			oneofProperty: "alternatives",
+			want: &fieldAnnotations{
+				FieldType:     "Node",
+				BaseFieldType: "Node",
+				Recursive:     false,
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -250,19 +257,14 @@ func TestAnnotateField_Recursive(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			want := &fieldAnnotations{
-				Name:          "childNode",
-				DocLines:      []string{"Recursive link."},
-				FieldType:     test.wantType,
-				BaseFieldType: test.wantBaseType,
-				PackageName:   "test",
-				Recursive:     test.wantRecursive,
-			}
+			test.want.Name = "childNode"
+			test.want.DocLines = []string{"Recursive link."}
+			test.want.PackageName = "test"
 			if test.isOneOf {
-				want.OneOfChecker = test.oneofProperty + "CheckAndSet"
+				test.want.OneOfChecker = test.oneofProperty + "CheckAndSet"
 			}
 
-			if diff := cmp.Diff(want, field.Codec); diff != "" {
+			if diff := cmp.Diff(test.want, field.Codec); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/sidekick/swift/templates/common/field_decode.mustache
+++ b/internal/sidekick/swift/templates/common/field_decode.mustache
@@ -25,7 +25,8 @@ self.{{Codec.Name}} = try { () throws in
   let tuples = try stringKeyed.lazy.map { (key, value) throws -> ({{{Codec.KeyType}}}, {{{Codec.ValueType}}}) in
     guard let newKey = {{{Codec.KeyType}}}(key) else {
       throw DecodingError.typeMismatch(
-        {{{Codec.KeyType}}}.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Incorrect type for map key '{{Codec.Name}}'"))
+        {{{Codec.KeyType}}}.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Incorrect type for map key '{{Codec.Name}}'")
+      )
     }
     return (newKey, value)
   }

--- a/internal/sidekick/swift/templates/common/field_decode.mustache
+++ b/internal/sidekick/swift/templates/common/field_decode.mustache
@@ -1,0 +1,34 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{#Codec.IsDecodingSimple}}
+self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
+{{/Codec.IsDecodingSimple}}
+{{#Codec.IsDecodingOptional}}
+self.{{Codec.Name}} = try container.decodeIfPresent({{{Codec.BaseFieldType}}}.self, forKey: .{{Codec.Name}})
+{{/Codec.IsDecodingOptional}}
+{{#Codec.IsDecodingMapCustomKey}}
+self.{{Codec.Name}} = try { () throws in
+  let stringKeyed = try container.decode([Swift.String : {{{Codec.ValueType}}}].self, forKey: .{{Codec.Name}})
+  let tuples = try stringKeyed.lazy.map { (key, value) throws -> ({{{Codec.KeyType}}}, {{{Codec.ValueType}}}) in
+    guard let newKey = {{{Codec.KeyType}}}(key) else {
+      throw DecodingError.typeMismatch(
+        {{{Codec.KeyType}}}.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Incorrect type for map key '{{Codec.Name}}'"))
+    }
+    return (newKey, value)
+  }
+  return Dictionary(uniqueKeysWithValues: tuples)
+}()
+{{/Codec.IsDecodingMapCustomKey}}

--- a/internal/sidekick/swift/templates/common/field_decode.mustache
+++ b/internal/sidekick/swift/templates/common/field_decode.mustache
@@ -25,8 +25,7 @@ self.{{Codec.Name}} = try { () throws in
   let tuples = try stringKeyed.lazy.map { (key, value) throws -> ({{{Codec.KeyType}}}, {{{Codec.ValueType}}}) in
     guard let newKey = {{{Codec.KeyType}}}(key) else {
       throw DecodingError.typeMismatch(
-        {{{Codec.KeyType}}}.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Incorrect type for map key '{{Codec.Name}}'")
-      )
+        {{{Codec.KeyType}}}.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Incorrect type for map key '{{Codec.Name}}'"))
     }
     return (newKey, value)
   }

--- a/internal/sidekick/swift/templates/common/field_encode.mustache
+++ b/internal/sidekick/swift/templates/common/field_encode.mustache
@@ -1,0 +1,26 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{#Codec.IsEncodingSimple}}
+try container.encode(self.{{Codec.Name}}, forKey: .{{Codec.Name}})
+{{/Codec.IsEncodingSimple}}
+{{#Codec.IsEncodingMapCustomKey}}
+do {
+    let stringKeyed = Dictionary(
+    uniqueKeysWithValues: self.{{Codec.Name}}.lazy.map { (Swift.String($0), $1) }
+    )
+    try container.encode(stringKeyed, forKey: .{{Codec.Name}})
+}
+{{/Codec.IsEncodingMapCustomKey}}

--- a/internal/sidekick/swift/templates/common/field_encode.mustache
+++ b/internal/sidekick/swift/templates/common/field_encode.mustache
@@ -18,9 +18,9 @@ try container.encode(self.{{Codec.Name}}, forKey: .{{Codec.Name}})
 {{/Codec.IsEncodingSimple}}
 {{#Codec.IsEncodingMapCustomKey}}
 do {
-    let stringKeyed = Dictionary(
+  let stringKeyed = Dictionary(
     uniqueKeysWithValues: self.{{Codec.Name}}.lazy.map { (Swift.String($0), $1) }
-    )
-    try container.encode(stringKeyed, forKey: .{{Codec.Name}})
+  )
+  try container.encode(stringKeyed, forKey: .{{Codec.Name}})
 }
 {{/Codec.IsEncodingMapCustomKey}}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -84,40 +84,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     let container = try decoder.container(keyedBy: CodingKeys.self)
     {{#Fields}}
     {{^IsOneOf}}
-    {{#Singular}}
-    {{#Optional}}
-    self.{{Codec.Name}} = try container.decodeIfPresent({{{Codec.BaseFieldType}}}.self, forKey: .{{Codec.Name}})
-    {{/Optional}}
-    {{^Optional}}
-    {{#Codec.Recursive}}
-    self.{{Codec.Name}} = try container.decodeIfPresent({{{Codec.BaseFieldType}}}.self, forKey: .{{Codec.Name}})
-    {{/Codec.Recursive}}
-    {{^Codec.Recursive}}
-    self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
-    {{/Codec.Recursive}}
-    {{/Optional}}
-    {{/Singular}}
-    {{#Repeated}}
-    self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
-    {{/Repeated}}
-    {{#Map}}
-    {{#Codec.IsStringKeyed}}
-    self.{{Codec.Name}} = try container.decode({{{Codec.FieldType}}}.self, forKey: .{{Codec.Name}})
-    {{/Codec.IsStringKeyed}}
-    {{^Codec.IsStringKeyed}}
-    self.{{Codec.Name}} = try { () throws in
-      let stringKeyed = try container.decode([Swift.String : {{{Codec.ValueType}}}].self, forKey: .{{Codec.Name}})
-      let tuples = try stringKeyed.lazy.map { (key, value) throws -> ({{{Codec.KeyType}}}, {{{Codec.ValueType}}}) in
-        guard let newKey = {{{Codec.KeyType}}}(key) else {
-          throw DecodingError.typeMismatch(
-            {{{Codec.KeyType}}}.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Incorrect type for map key '{{Codec.Name}}'"))
-        }
-        return (newKey, value)
-      }
-      return Dictionary(uniqueKeysWithValues: tuples)
-    }()
-    {{/Codec.IsStringKeyed}}
-    {{/Map}}
+    {{> /templates/common/field_decode}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}
@@ -142,24 +109,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     var container = encoder.container(keyedBy: CodingKeys.self)
     {{#Fields}}
     {{^IsOneOf}}
-    {{#Map}}
-    {{#Codec.IsStringKeyed}}
-    {{! string keys have easy encoding }}
-    try container.encode(self.{{Codec.Name}}, forKey: .{{Codec.Name}})
-    {{/Codec.IsStringKeyed}}
-    {{^Codec.IsStringKeyed}}
-    do {
-      let stringKeyed = Dictionary(
-        uniqueKeysWithValues: self.{{Codec.Name}}.lazy.map { (Swift.String($0), $1) }
-      )
-      try container.encode(stringKeyed, forKey: .{{Codec.Name}})
-    }
-    {{/Codec.IsStringKeyed}}
-    {{/Map}}
-    {{^Map}}
-    {{! non-maps have easy encoding }}
-    try container.encode(self.{{Codec.Name}}, forKey: .{{Codec.Name}})
-    {{/Map}}
+    {{> /templates/common/field_encode}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}


### PR DESCRIPTION
Use enums and some predicates to generate the code. Not awesome, but less finicky.

Towards #5748 