### PR TITLE
fix(librarian/internal/java): preserve released_version for non-snapshot versions during tidy

### DIFF
--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -100,12 +100,7 @@ func Tidy(library *config.Library) (*config.Library, error) {
 		if library.Java.GroupID == defaultGroupID {
 			library.Java.GroupID = ""
 		}
-		if library.Java.ReleasedVersion != "" {
-			derived, err := deriveLastReleasedVersion(library.Version)
-			if err == nil && library.Java.ReleasedVersion == derived {
-				library.Java.ReleasedVersion = ""
-			}
-		}
+		tidyReleasedVersion(library)
 		empty, err := yaml.Empty(library.Java)
 		if err != nil {
 			return nil, err
@@ -230,4 +225,26 @@ func deriveLastReleasedVersion(v string) (string, error) {
 	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "SNAPSHOT")
 	sv.Prerelease = strings.TrimSuffix(sv.Prerelease, "-")
 	return sv.String(), nil
+}
+
+// isSnapshot reports whether the version represents a SNAPSHOT release.
+func isSnapshot(v string) bool {
+	sv, err := semver.Parse(v)
+	return err == nil && strings.HasSuffix(sv.Prerelease, "SNAPSHOT")
+}
+
+// tidyReleasedVersion clears the Java module's released_version if it can be
+// derived from the library version. It only tidies when the current library
+// version is a SNAPSHOT.
+func tidyReleasedVersion(library *config.Library) {
+	if library.Java.ReleasedVersion == "" {
+		return
+	}
+	if !isSnapshot(library.Version) {
+		return
+	}
+	derived, err := deriveLastReleasedVersion(library.Version)
+	if err == nil && library.Java.ReleasedVersion == derived {
+		library.Java.ReleasedVersion = ""
+	}
 }

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -484,6 +484,23 @@ func TestTidy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "do not tidy released version if version is not a snapshot",
+			lib: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.2.0",
+				},
+			},
+			want: &config.Library{
+				Name:    "secretmanager",
+				Version: "1.2.0",
+				Java: &config.JavaModule{
+					ReleasedVersion: "1.2.0",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := Tidy(test.lib)


### PR DESCRIPTION
During `librarian tidy`, if a library version is a released version (non-snapshot, e.g. `0.82.1`), the `released_version` field was being removed from the configuration because it matched the derived version, which defeats the purpose of  specifying a `released_version` in these patch version releases.

Fix this by only tidying `released_version` if the current version is a SNAPSHOT. Non-snapshot (released) versions will retain their explicit `released_version` in the config, which ensures correctness during subsequent snapshot version development and major/minor bumps. Note that minor`released_version` like `0.82.0` are also preserved with logic, so that it works as expected in case of manual major version bump to 1.0.0-SNAPSHOT.

Fixes https://github.com/googleapis/librarian/issues/6425