### PR TITLE
feat(internal/librarian/python): update gapic-generator to 1.35.0

### DIFF
--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -19,7 +19,7 @@ language: python
 tools:
   pip:
     - name: gapic-generator
-      version: "1.34.1"
+      version: "1.35.0"
     - name: nox
       version: "2025.11.12"
     - name: ruff


### PR DESCRIPTION
The version of gapic-generator in the embedded librarian.yaml (used by librarian install) is updated to v1.35.0. This will bump the minimum version of Protobuf to 6.33.5 to address `CVE-2026-0994` (See https://github.com/googleapis/google-cloud-python/pull/17349).