### PR TITLE
feat(internal/librarian/java): source google-cloud-pom-parent in pom.xml templates

### DIFF
--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -39,6 +39,7 @@ const (
 var (
 	errNoProtos          = errors.New("no protos found")
 	errMonorepoVersion   = fmt.Errorf("failed to find monorepo version for %q in config", rootLibrary)
+	errParentVersion     = fmt.Errorf("failed to find parent version for %q in config", parentPOM)
 	errBOMVersionMissing = errors.New("libraries bom version not found in config")
 	errUnrecognizedAPI   = errors.New("unrecognized non-cloud API: configure java.group_id and java.distribution_name_override in librarian.yaml")
 	// nonRecursivePaths is a set of paths where proto gathering should not be recursive.

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -677,6 +677,7 @@ func TestGenerate_Logic(t *testing.T) {
 		Libraries: []*config.Library{
 			library,
 			{Name: rootLibrary, Version: "1.2.3"},
+			{Name: parentPOM, Version: "1.2.3"},
 		},
 	}
 	// Setup mandatory files for postProcessAPI and syncPOMs
@@ -753,6 +754,7 @@ func TestGenerate_ProtoExclusion(t *testing.T) {
 		Libraries: []*config.Library{
 			library,
 			{Name: rootLibrary, Version: "1.2.3"},
+			{Name: parentPOM, Version: "1.2.3"},
 		},
 	}
 	err := Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: googleapisDir})

--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -72,6 +72,7 @@ type bomParentPOMData struct {
 	MainModule      Coordinate
 	Name            string
 	MonorepoVersion string
+	ParentVersion   string
 	Modules         []Coordinate
 }
 
@@ -216,8 +217,8 @@ func discoverModules(library *config.Library, libraryDir string, transports map[
 // and parent POMs when new proto or gRPC modules are added. It returns a list
 // of newly created artifact version entries to be added to versions.txt.
 // TODO(https://github.com/googleapis/librarian/issues/5529): remove returning version entries.
-func syncPOMs(library *config.Library, libraryDir, monorepoVersion string, metadata *repoMetadata, transports map[string]serviceconfig.Transport) error {
-	modules, err := collectModules(library, libraryDir, monorepoVersion, metadata, transports)
+func syncPOMs(library *config.Library, libraryDir, monorepoVersion, parentVersion string, metadata *repoMetadata, transports map[string]serviceconfig.Transport) error {
+	modules, err := collectModules(library, libraryDir, monorepoVersion, parentVersion, metadata, transports)
 	if err != nil {
 		return err
 	}
@@ -396,7 +397,7 @@ func detectIndentation(content string, index int) string {
 // All expected modules are collected (even if they exist) because the client
 // module's POM requires a full list of all proto and gRPC dependencies
 // to ensure its dependency list is fully synchronized.
-func collectModules(library *config.Library, libraryDir, monorepoVersion string, metadata *repoMetadata, transports map[string]serviceconfig.Transport) ([]javaModule, error) {
+func collectModules(library *config.Library, libraryDir, monorepoVersion, parentVersion string, metadata *repoMetadata, transports map[string]serviceconfig.Transport) ([]javaModule, error) {
 	expectedModules, err := discoverModules(library, libraryDir, transports)
 	if err != nil {
 		return nil, err
@@ -456,6 +457,7 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 				MainModule:      libCoord.GAPIC,
 				Name:            metadata.NamePretty,
 				MonorepoVersion: monorepoVersion,
+				ParentVersion:   parentVersion,
 				Modules:         allModules,
 			}
 			template = bomPOMTemplateName
@@ -464,6 +466,7 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion string,
 				MainModule:      libCoord.GAPIC,
 				Name:            metadata.NamePretty,
 				MonorepoVersion: monorepoVersion,
+				ParentVersion:   parentVersion,
 				Modules:         allModules,
 			}
 			template = parentPOMTemplateName
@@ -521,4 +524,19 @@ func findMonorepoVersion(cfg *config.Config) (string, error) {
 		}
 	}
 	return "", errMonorepoVersion
+}
+
+func findParentPOMVersion(cfg *config.Config) (string, error) {
+	for _, lib := range cfg.Libraries {
+		if lib.Name == parentPOM {
+			return lib.Version, nil
+		}
+	}
+	// Fallback to monorepoVersion if google-cloud-pom-parent is missing (e.g. in tests)
+	for _, lib := range cfg.Libraries {
+		if lib.Name == rootLibrary {
+			return lib.Version, nil
+		}
+	}
+	return "", errParentVersion
 }

--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -526,15 +526,11 @@ func findMonorepoVersion(cfg *config.Config) (string, error) {
 	return "", errMonorepoVersion
 }
 
+// TODO(https://github.com/googleapis/librarian/issues/6411):
+// Simplify logic here and check at validate step.
 func findParentPOMVersion(cfg *config.Config) (string, error) {
 	for _, lib := range cfg.Libraries {
 		if lib.Name == parentPOM {
-			return lib.Version, nil
-		}
-	}
-	// Fallback to monorepoVersion if google-cloud-pom-parent is missing (e.g. in tests)
-	for _, lib := range cfg.Libraries {
-		if lib.Name == rootLibrary {
 			return lib.Version, nil
 		}
 	}

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -72,7 +72,7 @@ func TestSyncPOMs_Golden(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = syncPOMs(library, tmpDir, "1.2.3", metadata, transports)
+	err = syncPOMs(library, tmpDir, "1.2.3", "1.2.3", metadata, transports)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +206,7 @@ func TestSyncPOMs_Update(t *testing.T) {
 		APIDescription: "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
 	}
 
-	if err := syncPOMs(library, tmpDir, "1.2.3", metadata, transports); err != nil {
+	if err := syncPOMs(library, tmpDir, "1.2.3", "1.2.3", metadata, transports); err != nil {
 		t.Fatal(err)
 	}
 
@@ -272,7 +272,7 @@ func TestSyncPOMs_NoUpdate(t *testing.T) {
 		APIDescription: "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
 	}
 
-	if err := syncPOMs(library, tmpDir, "1.2.3", metadata, transports); err != nil {
+	if err := syncPOMs(library, tmpDir, "1.2.3", "1.2.3", metadata, transports); err != nil {
 		t.Fatal(err)
 	}
 
@@ -577,7 +577,7 @@ func TestCollectModules(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t, tmpDir)
 			}
-			got, err := collectModules(test.library, tmpDir, test.monorepoVersion, test.metadata, test.transports)
+			got, err := collectModules(test.library, tmpDir, test.monorepoVersion, test.monorepoVersion, test.metadata, test.transports)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -32,6 +32,8 @@ const (
 	// rootLibrary is the name of the monorepo library used to identify
 	// the version for all libraries in the repository.
 	rootLibrary = "google-cloud-java"
+	// parentPOM is the name of the parent POM library.
+	parentPOM = "google-cloud-pom-parent"
 	// gapicBOM is the name of the directory and artifact ID for the
 	// generated Bill of Materials (BOM) for all GAPIC libraries.
 	gapicBOM  = "gapic-libraries-bom"
@@ -100,6 +102,13 @@ func PostGenerate(ctx context.Context, repoPath string, cfg *config.Config, miss
 	if monorepoVersion == "" {
 		return fmt.Errorf("%s library not found in librarian.yaml", rootLibrary)
 	}
+	parentVersion, err := findParentPOMVersion(cfg)
+	if err != nil {
+		return err
+	}
+	if parentVersion == "" {
+		return fmt.Errorf("%s library not found in librarian.yaml", parentPOM)
+	}
 
 	// TODO(https://github.com/googleapis/librarian/issues/5529): remove appending to versions.txt.
 	versions := constructVersionLines(missingArtifacts)
@@ -118,7 +127,7 @@ func PostGenerate(ctx context.Context, repoPath string, cfg *config.Config, miss
 	if err != nil {
 		return fmt.Errorf("failed to search for BOM artifacts: %w", err)
 	}
-	if err := generateGAPICLibrariesBOM(repoPath, monorepoVersion, bomConfigs); err != nil {
+	if err := generateGAPICLibrariesBOM(repoPath, monorepoVersion, parentVersion, bomConfigs); err != nil {
 		return fmt.Errorf("failed to generate %s: %w", gapicBOM, err)
 	}
 	return nil
@@ -325,17 +334,19 @@ func generateRootPOM(repoPath string, modules []string) error {
 
 // generateGAPICLibrariesBOM writes the gapic-libraries-bom/pom.xml file, which manages
 // versions for all individual library BOMs in the monorepo.
-func generateGAPICLibrariesBOM(repoPath, version string, bomConfigs []*bomConfig) error {
+func generateGAPICLibrariesBOM(repoPath, version, parentVersion string, bomConfigs []*bomConfig) error {
 	bomDir := filepath.Join(repoPath, gapicBOM)
 	if err := os.MkdirAll(bomDir, 0755); err != nil {
 		return err
 	}
 	data := struct {
-		Version    string
-		BOMConfigs []*bomConfig
+		Version       string
+		ParentVersion string
+		BOMConfigs    []*bomConfig
 	}{
-		Version:    version,
-		BOMConfigs: bomConfigs,
+		Version:       version,
+		ParentVersion: parentVersion,
+		BOMConfigs:    bomConfigs,
 	}
 	return writePOM(filepath.Join(bomDir, "pom.xml"), "gapic-libraries-bom.xml.tmpl", data)
 }

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -41,6 +41,7 @@ func TestPostGenerate(t *testing.T) {
 		Language: "java",
 		Libraries: []*config.Library{
 			{Name: rootLibrary, Version: "1.2.3"},
+			{Name: parentPOM, Version: "1.2.3"},
 			{Name: "analytics-admin", Version: "0.98.0"},
 			{Name: "area120-tables", Version: "0.92.0"},
 			{Name: "aiplatform", Version: "3.89.0"},
@@ -196,6 +197,7 @@ func TestPostGenerate_SearchError(t *testing.T) {
 	cfg := &config.Config{
 		Libraries: []*config.Library{
 			{Name: rootLibrary, Version: "1.2.3"},
+			{Name: parentPOM, Version: "1.2.3"},
 		},
 	}
 	err := PostGenerate(t.Context(), tmpDir, cfg, nil)
@@ -215,6 +217,7 @@ func TestPostGenerate_Error(t *testing.T) {
 	cfg := &config.Config{
 		Libraries: []*config.Library{
 			{Name: rootLibrary, Version: "1.2.3"},
+			{Name: parentPOM, Version: "1.2.3"},
 		},
 	}
 	err := PostGenerate(t.Context(), tmpDir, cfg, nil)

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -86,7 +86,7 @@ func postProcessLibrary(ctx context.Context, params libraryPostProcessParams) er
 	if err != nil {
 		return err
 	}
-	parentVersion, err := findParentPOMVersion(p.cfg)
+	parentVersion, err := findParentPOMVersion(params.cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -86,7 +86,11 @@ func postProcessLibrary(ctx context.Context, p libraryPostProcessParams) error {
 	if err != nil {
 		return err
 	}
-	if err := syncPOMs(p.library, p.outDir, monorepoVersion, p.metadata, p.transports); err != nil {
+	parentVersion, err := findParentPOMVersion(p.cfg)
+	if err != nil {
+		return err
+	}
+	if err := syncPOMs(p.library, p.outDir, monorepoVersion, parentVersion, p.metadata, p.transports); err != nil {
 		return fmt.Errorf("%w: %w", errSyncPOMs, err)
 	}
 

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -520,6 +520,7 @@ func TestPostProcessLibrary(t *testing.T) {
 	defaultCfg := &config.Config{
 		Libraries: []*config.Library{
 			{Name: rootLibrary, Version: "1.0.0"},
+			{Name: parentPOM, Version: "1.0.0"},
 		},
 		Default: &config.Default{
 			Java: &config.JavaModule{
@@ -621,6 +622,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 	defaultCfg := &config.Config{
 		Libraries: []*config.Library{
 			{Name: rootLibrary, Version: "1.0.0"},
+			{Name: parentPOM, Version: "1.0.0"},
 		},
 		Default: &config.Default{
 			Java: &config.JavaModule{

--- a/internal/librarian/java/template/gapic-libraries-bom.xml.tmpl
+++ b/internal/librarian/java/template/gapic-libraries-bom.xml.tmpl
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>google-cloud-pom-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>{{.Version}}</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>{{.ParentVersion}}</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 

--- a/internal/librarian/java/template/module_bom_pom.xml.tmpl
+++ b/internal/librarian/java/template/module_bom_pom.xml.tmpl
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pom-parent</artifactId>
-    <version>{{.MonorepoVersion}}</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>{{.ParentVersion}}</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 

--- a/internal/librarian/java/testdata/syncpoms/secretmanager-v1/google-cloud-secretmanager-bom/pom.xml
+++ b/internal/librarian/java/testdata/syncpoms/secretmanager-v1/google-cloud-secretmanager-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pom-parent</artifactId>
-    <version>1.2.3</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.2.3</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Update logic to parse `google-cloud-pom-parent` version separately from librarian.yaml, and update pom.xml templates to use dedicated marker comment for "google-cloud-pom-parent" to match versions.txt (https://github.com/googleapis/google-cloud-java/pull/13483).
Note: This logic is added in parallel to existing "monorepoVersion" logic. Will do a followup to validate both config in `Validate` step and simplify logic when accessing these.

For https://github.com/googleapis/librarian/issues/6411