### PR TITLE
feat(sidekick/swift): `bytes` for discovery docs

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -62,6 +62,13 @@ type fieldAnnotations struct {
 
 	// Encoding controls how the field is encoded.
 	Encoding EncodingStyle
+
+	// UrlSafeValue is true if the value is a `bytes` and should be serialized
+	// and deserialized using URL-safe encoding.
+	UrlSafeValue bool
+
+	// Model points to the annotations for the model.
+	Model *modelAnnotations
 }
 
 // DecodingStyle defines an enumeration for decoding fields.
@@ -129,7 +136,7 @@ func (a *fieldAnnotations) IsEncodingMapCustomKey() bool {
 	return a.Encoding == EncodingMapCustomKey
 }
 
-func (c *codec) annotateField(field *api.Field) (*fieldAnnotations, error) {
+func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*fieldAnnotations, error) {
 	parts, err := c.fieldTypeName(field)
 	if err != nil {
 		return nil, err
@@ -153,6 +160,7 @@ func (c *codec) annotateField(field *api.Field) (*fieldAnnotations, error) {
 		DocLines:      docLines,
 		Decoding:      DecodingSimple,
 		Encoding:      EncodingSimple,
+		Model:         model,
 	}
 	// Swift value types (structs) cannot contain recursive references directly because their
 	// size must be known at compile time. To break the cycle, we wrap the reference in a box type
@@ -178,6 +186,14 @@ func (c *codec) annotateField(field *api.Field) (*fieldAnnotations, error) {
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {
 			annotations.OneOfChecker = oneofAnn.Checker
+		}
+	}
+	if c.UrlSafeForBytes {
+		if field.Typez == api.TypezBytes {
+			annotations.UrlSafeValue = true
+		}
+		if field.Map && annotations.ValueType == "Foundation.Data" {
+			annotations.UrlSafeValue = true
 		}
 	}
 	field.Codec = annotations

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -88,6 +88,117 @@ func TestAnnotateField(t *testing.T) {
 	}
 }
 
+func TestAnnotateField_Discovery(t *testing.T) {
+	mapMessage := &api.Message{
+		Name:  "map<string, bytes>",
+		ID:    "$map<string, bytes>",
+		IsMap: true,
+		Fields: []*api.Field{
+			{Name: "key", JSONName: "key", Typez: api.TypezString},
+			{Name: "value", JSONName: "value", Typez: api.TypezBytes},
+		},
+	}
+
+	for _, test := range []struct {
+		name  string
+		input *api.Field
+		want  *fieldAnnotations
+	}{
+		{
+			name: "regular",
+			input: &api.Field{
+				Name:  "name",
+				ID:    ".test.Message.name",
+				Typez: api.TypezBytes,
+			},
+			want: &fieldAnnotations{
+				FieldType:     "Foundation.Data",
+				BaseFieldType: "Foundation.Data",
+				UrlSafeValue:  true,
+			},
+		},
+		{
+			name: "regular string",
+			input: &api.Field{
+				Name:  "name",
+				ID:    ".test.Message.name",
+				Typez: api.TypezString,
+			},
+			want: &fieldAnnotations{
+				FieldType:     "Swift.String",
+				BaseFieldType: "Swift.String",
+			},
+		},
+		{
+			name: "optional",
+			input: &api.Field{
+				Name:     "name",
+				ID:       ".test.Message.name",
+				Optional: true,
+				Typez:    api.TypezBytes,
+			},
+			want: &fieldAnnotations{
+				FieldType:     "Foundation.Data?",
+				BaseFieldType: "Foundation.Data",
+				UrlSafeValue:  true,
+				Decoding:      DecodingOptional,
+			},
+		},
+		{
+			name: "repeated",
+			input: &api.Field{
+				Name:     "name",
+				ID:       ".test.Message.name",
+				Repeated: true,
+				Typez:    api.TypezBytes,
+			},
+			want: &fieldAnnotations{
+				FieldType:     "[Foundation.Data]",
+				BaseFieldType: "Foundation.Data",
+				UrlSafeValue:  true,
+			},
+		},
+		{
+			name: "map",
+			input: &api.Field{
+				Name:    "name",
+				ID:      ".test.Message.name",
+				Typez:   api.TypezMessage,
+				TypezID: mapMessage.ID,
+				Map:     true,
+			},
+			want: &fieldAnnotations{
+				FieldType:     "[Swift.String: Foundation.Data]",
+				BaseFieldType: "[Swift.String: Foundation.Data]",
+				KeyType:       "Swift.String",
+				ValueType:     "Foundation.Data",
+				UrlSafeValue:  true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			msg := &api.Message{
+				Name:    "Message",
+				ID:      ".test.Message",
+				Package: "test",
+				Fields:  []*api.Field{test.input},
+			}
+			test.input.Parent = msg
+			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+			model.AddMessage(mapMessage)
+			codec := newTestCodec(t, model, map[string]string{})
+			codec.UrlSafeForBytes = true
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(test.want, test.input.Codec, cmpopts.IgnoreFields(fieldAnnotations{}, "Name", "DocLines", "Model")); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAnnotateField_TypeNames(t *testing.T) {
 	for _, test := range []struct {
 		name     string

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
@@ -79,10 +80,8 @@ func TestAnnotateField(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			test.want.Name = "secretPayload"
-			test.want.DocLines = []string{"The secret version payload."}
 
-			if diff := cmp.Diff(test.want, field.Codec); diff != "" {
+			if diff := cmp.Diff(test.want, field.Codec, cmpopts.IgnoreFields(fieldAnnotations{}, "Name", "DocLines", "Model")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -123,6 +122,7 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 				FieldType:     test.wantType,
 				BaseFieldType: test.wantType,
 				DocLines:      []string{"Test documentation."},
+				Model:         model.Codec.(*modelAnnotations),
 			}
 			if diff := cmp.Diff(want, field.Codec); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -170,6 +170,7 @@ func TestAnnotateField_PackageName(t *testing.T) {
 		BaseFieldType: "GoogleCloudExternalV1.SomeMessage",
 		PackageName:   "google.cloud.external.v1",
 		DocLines:      []string{"The external message."},
+		Model:         model.Codec.(*modelAnnotations),
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -218,6 +219,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 				FieldType:     "Node",
 				BaseFieldType: "Node",
 				Recursive:     false,
+				OneOfChecker:  "alternativesCheckAndSet",
 			},
 		},
 	} {
@@ -257,14 +259,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			test.want.Name = "childNode"
-			test.want.DocLines = []string{"Recursive link."}
-			test.want.PackageName = "test"
-			if test.isOneOf {
-				test.want.OneOfChecker = test.oneofProperty + "CheckAndSet"
-			}
-
-			if diff := cmp.Diff(test.want, field.Codec); diff != "" {
+			if diff := cmp.Diff(test.want, field.Codec, cmpopts.IgnoreFields(fieldAnnotations{}, "Name", "DocLines", "PackageName", "Model")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -129,7 +129,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		}
 	}
 	for _, field := range message.Fields {
-		fieldCodec, err := c.annotateField(field)
+		fieldCodec, err := c.annotateField(field, model)
 		if err != nil {
 			return err
 		}

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -85,6 +85,10 @@ type codec struct {
 
 	// If true, these traits are enabled by default.
 	DefaultTraits []string
+
+	// If true, bytes need to be serialized and deserialized using the URL-safe
+	// base64 alphabet.
+	UrlSafeForBytes bool
 }
 
 func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPackage, outdir string) (*codec, error) {
@@ -112,6 +116,7 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 		RootName:           "googleapis",
 		ApiPackages:        map[string]*Dependency{},
 		DependenciesByName: map[string]*Dependency{},
+		UrlSafeForBytes:    cfg.SpecificationFormat == config.SpecDiscovery,
 	}
 	if swiftCfg != nil {
 		for _, d := range swiftCfg.Dependencies {

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -25,29 +25,62 @@ import (
 )
 
 func TestParseOptions(t *testing.T) {
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year":        "2038",
-			"package-name-override": "GoogleCloudBigtable",
-			"root-name":             "test-root",
-		},
-	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
-	got, err := newCodec(model, cfg, nil, ".")
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := &codec{
-		GenerationYear:     "2038",
-		PackageName:        "GoogleCloudBigtable",
-		MonorepoRoot:       ".",
-		RootName:           "test-root",
-		Model:              model,
-		ApiPackages:        map[string]*Dependency{},
-		DependenciesByName: map[string]*Dependency{},
-	}
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(api.API{})); diff != "" {
-		t.Errorf("mismatch in codec (-want, +got)\n:%s", diff)
+	for _, test := range []struct {
+		name string
+		cfg  *parser.ModelConfig
+		want *codec
+	}{
+		{
+			name: "baseline",
+			cfg: &parser.ModelConfig{
+				Codec: map[string]string{
+					"copyright-year":        "2038",
+					"package-name-override": "GoogleCloudBigtable",
+					"root-name":             "test-root",
+				},
+			},
+			want: &codec{
+				GenerationYear:     "2038",
+				PackageName:        "GoogleCloudBigtable",
+				MonorepoRoot:       ".",
+				RootName:           "test-root",
+				Model:              model,
+				ApiPackages:        map[string]*Dependency{},
+				DependenciesByName: map[string]*Dependency{},
+			},
+		},
+		{
+			name: "discovery",
+			cfg: &parser.ModelConfig{
+				Codec: map[string]string{
+					"copyright-year":        "2038",
+					"package-name-override": "GoogleCloudComputeV1",
+					"root-name":             "test-root",
+				},
+				SpecificationFormat: config.SpecDiscovery,
+			},
+			want: &codec{
+				GenerationYear:     "2038",
+				PackageName:        "GoogleCloudComputeV1",
+				MonorepoRoot:       ".",
+				RootName:           "test-root",
+				Model:              model,
+				ApiPackages:        map[string]*Dependency{},
+				DependenciesByName: map[string]*Dependency{},
+				UrlSafeForBytes:    true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := newCodec(model, test.cfg, nil, ".")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(api.API{})); diff != "" {
+				t.Errorf("mismatch (-want, +got)\n:%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/sidekick/swift/templates/common/field_decode_url_safe.mustache
+++ b/internal/sidekick/swift/templates/common/field_decode_url_safe.mustache
@@ -26,7 +26,7 @@ if let s = try container.decodeIfPresent(Swift.String.self, forKey: .{{Codec.Nam
 {{/Optional}}
 {{^Optional}}
 do {
-  let s = container.decode(Swift.String.self, forKey: .{{Codec.Name}})
+  let s = try container.decode(Swift.String.self, forKey: .{{Codec.Name}})
   guard let v = {{Codec.Model.WktPackage}}._DiscoveryBase64.decode(s) else {
     throw DecodingError.dataCorrupted(
       DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected url-safe encoded value")

--- a/internal/sidekick/swift/templates/common/field_decode_url_safe.mustache
+++ b/internal/sidekick/swift/templates/common/field_decode_url_safe.mustache
@@ -1,0 +1,65 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{#Singular}}
+{{#Optional}}
+if let s = try container.decodeIfPresent(Swift.String.self, forKey: .{{Codec.Name}}) {
+  guard let v = {{Codec.Model.WktPackage}}._DiscoveryBase64.decode(s) else {
+    throw DecodingError.dataCorrupted(
+      DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected url-safe encoded value")
+    )
+  }
+  self.{{Codec.Name}} = v
+}
+{{/Optional}}
+{{^Optional}}
+do {
+  let s = container.decode(Swift.String.self, forKey: .{{Codec.Name}})
+  guard let v = {{Codec.Model.WktPackage}}._DiscoveryBase64.decode(s) else {
+    throw DecodingError.dataCorrupted(
+      DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected url-safe encoded value")
+    )
+  }
+  self.{{Codec.Name}} = v
+}
+{{/Optional}}
+{{/Singular}}
+{{#Repeated}}
+do {
+  let strings = try container.decode([Swift.String].self, forKey: .{{Codec.Name}})
+  self.{{Codec.Name}} = try strings.map {
+    guard let v = {{Codec.Model.WktPackage}}._DiscoveryBase64.decode($0) else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected url-safe encoded value")
+      )
+    }
+    return v
+  }
+}
+{{/Repeated}}
+{{#Map}}
+{{! Discovery-based services only have string-key maps, we only need to map the values }}
+do {
+  let strings = try container.decode([Swift.String:Swift.String].self, forKey: .{{Codec.Name}})
+  self.{{Codec.Name}} = try strings.mapValues {
+    guard let v = {{Codec.Model.WktPackage}}._DiscoveryBase64.decode($0) else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected url-safe encoded value")
+      )
+    }
+    return v
+  }
+}
+{{/Map}}

--- a/internal/sidekick/swift/templates/common/field_encode_url_safe.mustache
+++ b/internal/sidekick/swift/templates/common/field_encode_url_safe.mustache
@@ -1,0 +1,43 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{#Singular}}
+{{#Optional}}
+if let v = {{Codec.Name}} {
+    try container.encode(
+    {{Codec.Model.WktPackage}}._DiscoveryBase64.encode(v), forKey: .{{Codec.Name}}
+    )
+}
+{{/Optional}}
+{{^Optional}}
+try container.encode(
+  {{Codec.Model.WktPackage}}._DiscoveryBase64.encode({{Codec.Name}}), forKey: .{{Codec.Name}}
+)
+{{/Optional}}
+{{/Singular}}
+{{#Repeated}}
+try container.encode(
+  {{Codec.Name}}.map { {{Codec.Model.WktPackage}}._DiscoveryBase64.encode($0) }, forKey: .{{Codec.Name}}
+)
+{{/Repeated}}
+{{#Map}}
+{{! Discovery-based services only have string-key maps, we only need to map the values }}
+do {
+  let transformed = self.{{Codec.Name}}.mapValues {
+    {{Codec.Model.WktPackage}}._DiscoveryBase64.encode($0)
+  }
+  try container.encode(transformed, forKey: .{{Codec.Name}})
+}
+{{/Map}}

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -84,7 +84,12 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     let container = try decoder.container(keyedBy: CodingKeys.self)
     {{#Fields}}
     {{^IsOneOf}}
+    {{^Codec.UrlSafeValue}}
     {{> /templates/common/field_decode}}
+    {{/Codec.UrlSafeValue}}
+    {{#Codec.UrlSafeValue}}
+    {{> /templates/common/field_decode_url_safe}}
+    {{/Codec.UrlSafeValue}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}
@@ -109,7 +114,12 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
     var container = encoder.container(keyedBy: CodingKeys.self)
     {{#Fields}}
     {{^IsOneOf}}
+    {{^Codec.UrlSafeValue}}
     {{> /templates/common/field_encode}}
+    {{/Codec.UrlSafeValue}}
+    {{#Codec.UrlSafeValue}}
+    {{> /templates/common/field_encode_url_safe}}
+    {{/Codec.UrlSafeValue}}
     {{/IsOneOf}}
     {{/Fields}}
     {{#OneOfs}}


### PR DESCRIPTION
Discovery docs use a different base64-encoding for `bytes`. This adds support for optional, required, repeated, and map fields of `bytes` type in discovery-based APIs.

Fixes #5748 