### PR TITLE
feat(sidekick/swift): improve snippet body

### DIFF
--- a/internal/sidekick/swift/templates/snippet/method_request_body.mustache
+++ b/internal/sidekick/swift/templates/snippet/method_request_body.mustache
@@ -38,7 +38,7 @@ limitations under the License.
   {{/IsMessageResourceName}}
   {{^IsMessageResourceName}}
   {{#MessageField}}
-    $0.{{Codec.Name}} = {{MessageField.Codec.BaseFieldType}}() /* .with { ... } */
+    $0.{{Codec.Name}} = {{Codec.BaseFieldType}}() /* .with { ... } */
   {{/MessageField}}
   {{/IsMessageResourceName}}
   {{#UpdateMaskField}}

--- a/internal/sidekick/swift/templates/snippet/method_request_body.mustache
+++ b/internal/sidekick/swift/templates/snippet/method_request_body.mustache
@@ -24,19 +24,27 @@ limitations under the License.
 }}
 {{InputType.Codec.Name}}()
   {{#SampleInfo}}
-  {{#IsRequestResourceName}}
-  .with { $0.{{Codec.Name}} = "{{Codec.FormatString}}" }
-  {{/IsRequestResourceName}}
-  {{#IsMessageResourceName}}
   .with {
+  {{#IsRequestResourceName}}
+    $0.{{Codec.Name}} = "{{Codec.FormatString}}"
+  {{/IsRequestResourceName}}
+  {{#ResourceIDField}}
+    $0.{{Codec.Name}} = "[replace with a valid ID]"
+  {{/ResourceIDField}}
+  {{#IsMessageResourceName}}
     $0.{{MessageField.Codec.Name}} = {{MessageField.Codec.BaseFieldType}}().with {
       $0.{{Codec.Name}} = "{{Codec.FormatString}}"
     }
-  }
+  {{/IsMessageResourceName}}
+  {{^IsMessageResourceName}}
+  {{#MessageField}}
+    $0.{{Codec.Name}} = {{MessageField.Codec.BaseFieldType}}() /* .with { ... } */
+  {{/MessageField}}
   {{/IsMessageResourceName}}
   {{#UpdateMaskField}}
-  .with { $0.{{Codec.Name}} = {{Service.Codec.Model.WktPackage}}.FieldMask(paths: ["field.path1", "field.path2"]) }
+    $0.{{Codec.Name}} = {{Service.Codec.Model.WktPackage}}.FieldMask(paths: ["field.path1", "field.path2"])
   {{/UpdateMaskField}}
+  }
   {{/SampleInfo}}
   {{^SampleInfo}}
   /* set fields using .with { $0... } */


### PR DESCRIPTION
Make the body more readable by using a single `.with{}` call for all the fields.

For AIP-standard `Create*()` and `Update*()` requests we can show how the body field is initialized.