### PR TITLE
fix(golang): fix onboarding versionless paths

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -271,7 +271,10 @@ func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api 
 			return "", nil, err
 		}
 		existingLib.APIs = append(existingLib.APIs, api)
-	case config.LanguageGo, config.LanguageJava, config.LanguageNodejs:
+	case config.LanguageGo:
+		existingLib.APIs = append(existingLib.APIs, api)
+		existingLib = golang.Add(existingLib)
+	case config.LanguageJava, config.LanguageNodejs:
 		existingLib.APIs = append(existingLib.APIs, api)
 	default:
 		return "", nil, fmt.Errorf("%w: %s", errLibraryAlreadyExists, existingLib.Name)

--- a/internal/librarian/golang/add.go
+++ b/internal/librarian/golang/add.go
@@ -14,14 +14,56 @@
 
 package golang
 
-import "github.com/googleapis/librarian/internal/config"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+)
 
 // defaultVersion is the first version used for a new library.
 // This is set on the initial `librarian add` for a new API.
 const defaultVersion = "0.0.0"
 
-// Add initializes a new Go library with default values.
+// Add initializes a Go library with default values.
 func Add(lib *config.Library) *config.Library {
-	lib.Version = defaultVersion
+	if lib.Version == "" {
+		lib.Version = defaultVersion
+	}
+	for _, api := range lib.APIs {
+		addGoAPI(api)
+	}
 	return lib
+}
+
+// addGoAPI initializes Go-specific API configuration when adding a new API.
+// It populates the ImportPath and sets ProtoOnly to true if the API path
+// is versionless (does not contain a version segment like "v1"). It does
+// nothing for versioned API paths.
+func addGoAPI(api *config.API) {
+	if serviceconfig.ExtractVersion(api.Path) != "" {
+		return
+	}
+	if api.Go != nil {
+		return
+	}
+	importPath := deriveVersionlessImportPath(api.Path)
+	api.Go = &config.GoAPI{
+		ImportPath: importPath,
+		ProtoOnly:  true,
+	}
+}
+
+func deriveVersionlessImportPath(apiPath string) string {
+	apiPath = strings.TrimPrefix(apiPath, "google/cloud/")
+	apiPath = strings.TrimPrefix(apiPath, "google/")
+	idx := strings.LastIndex(apiPath, "/")
+	var leaf string
+	if idx == -1 {
+		leaf = apiPath
+	} else {
+		leaf = apiPath[idx+1:]
+	}
+	return fmt.Sprintf("%s/%spb", apiPath, leaf)
 }

--- a/internal/librarian/golang/add_test.go
+++ b/internal/librarian/golang/add_test.go
@@ -22,10 +22,43 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	lib := &config.Library{}
-	want := &config.Library{Version: defaultVersion}
-	got := Add(lib)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want *config.Library
+	}{
+		{
+			name: "versioned api",
+			lib: &config.Library{
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+			want: &config.Library{
+				Version: defaultVersion,
+				APIs:    []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+		},
+		{
+			name: "versionless api",
+			lib: &config.Library{
+				APIs: []*config.API{{Path: "google/shopping/type"}},
+			},
+			want: &config.Library{
+				Version: defaultVersion,
+				APIs: []*config.API{{
+					Path: "google/shopping/type",
+					Go: &config.GoAPI{
+						ImportPath: "shopping/type/typepb",
+						ProtoOnly:  true,
+					},
+				}},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Add(test.lib)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/librarian/golang/bump_test.go
+++ b/internal/librarian/golang/bump_test.go
@@ -283,7 +283,7 @@ func TestBump_Error(t *testing.T) {
 				Name: "test-lib",
 				APIs: []*config.API{
 					{
-						Path: "google/example/common",
+						Path: "google/v1",
 					},
 				},
 			},

--- a/internal/librarian/golang/module_test.go
+++ b/internal/librarian/golang/module_test.go
@@ -151,6 +151,30 @@ func TestFill(t *testing.T) {
 			},
 		},
 		{
+			name: "fill defaults for versionless/type-only api",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{{
+					Path: "google/cloud/secretmanager/type",
+					Go: &config.GoAPI{
+						ImportPath: "secretmanager/type/typepb",
+						ProtoOnly:  true,
+					},
+				}},
+			},
+			want: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{{
+					Path: "google/cloud/secretmanager/type",
+					Go: &config.GoAPI{
+						ImportPath: "secretmanager/type/typepb",
+						ProtoOnly:  true,
+					},
+				}},
+				Go: &config.GoModule{},
+			},
+		},
+		{
 			name: "no API",
 			library: &config.Library{
 				Name: "auth",


### PR DESCRIPTION
When faced with a version-less, typically type-only API path, we default to `ProtoOnly = true` and we derive the `ImportPath` based on the common pattern of using the API path and repeating the leaf segment with a `pb` suffix e.g. `google/shopping/type` -> `shopping/type/typepb` (this is a real example). This can always be fixed at onboarding time, but the default should be something reasonable to avoid friction.

Fixes #6306