### PR TITLE
feat(postprocessing): implement Java method deletion

### DIFF
--- a/internal/postprocessing/delete.go
+++ b/internal/postprocessing/delete.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
 )
 
 var (
@@ -36,8 +38,13 @@ var (
 
 // DeleteMethod deletes a method from a Java file.
 // It handles brace counting to remove the entire method body.
+//
+// Note: funcName must be the full method declaration line (including modifiers
+// and return type, e.g., "public static void foo()") to avoid matching a substring
+// of another method name (e.g., "foo()" matching inside "afoo()").
+// TODO: Enforce word boundaries during matching as a safety net against accidental substring matches.
 func DeleteMethod(path, funcName, language string) error {
-	if language != "java" {
+	if language != config.LanguageJava {
 		return fmt.Errorf("%w: %s", errUnsupportedLanguage, language)
 	}
 	if !strings.Contains(funcName, "(") || !strings.Contains(funcName, ")") {
@@ -62,13 +69,11 @@ func DeleteMethod(path, funcName, language string) error {
 	}
 	finalStart, finalEnd := adjustDeleteBounds(data, idx, closeBraceIdx+1)
 	newContent := append(data[:finalStart], data[finalEnd:]...)
-	if err := os.WriteFile(path, newContent, 0644); err != nil {
-		return fmt.Errorf("writing updated file: %w", err)
-	}
-	return nil
+	return os.WriteFile(path, newContent, 0644)
 }
 
-// cleanJavaCode replaces comments and strings with equal-length spaces to keep offsets.
+// cleanJavaCode replaces comments, strings, and char literals with spaces.
+// This prevents brace count mismatch while keeping the original offsets.
 func cleanJavaCode(content []byte) []byte {
 	return javaCleanRegex.ReplaceAllFunc(content, func(match []byte) []byte {
 		return bytes.Repeat([]byte(" "), len(match))
@@ -77,11 +82,10 @@ func cleanJavaCode(content []byte) []byte {
 
 // findOpeningBrace returns the index of the first '{' after start, or error if ';' is found first.
 func findOpeningBrace(cleaned []byte, start int) (int, error) {
-	for i := start; i < len(cleaned); i++ {
-		c := cleaned[i]
+	for i, c := range cleaned[start:] {
 		switch c {
 		case '{':
-			return i, nil
+			return start + i, nil
 		case ';':
 			return -1, errOpeningBraceNotFound
 		}
@@ -92,30 +96,49 @@ func findOpeningBrace(cleaned []byte, start int) (int, error) {
 // findClosingBrace returns the index of the matching closing brace.
 func findClosingBrace(cleaned []byte, openBraceIdx int) (int, error) {
 	braceCount := 1
-	for i := openBraceIdx + 1; i < len(cleaned); i++ {
-		c := cleaned[i]
+	start := openBraceIdx + 1
+	for i, c := range cleaned[start:] {
 		switch c {
 		case '{':
 			braceCount++
 		case '}':
 			braceCount--
 			if braceCount == 0 {
-				return i, nil
+				return start + i, nil
 			}
 		}
 	}
 	return -1, errClosingBraceNotFound
 }
 
-// adjustDeleteBounds expands the delete range to remove entire lines if the method is on its own lines.
+// adjustDeleteBounds adjusts the delete range [start, end) to include the entire line(s)
+// if the method is the only content on those lines.
+//
+// Examples:
+// - For a block method on its own lines:
+//
+//	class T {
+//	    void m() {
+//	    }
+//	}
+//
+//	If deleting "void m() {\n    }", it returns bounds for "    void m() {\n    }\n"
+//	to remove the leading indentation and trailing newline.
+//
+// - For an inline method:
+//
+//	class T { void m() {} void o() {} }
+//
+//	If deleting "void m() {}", it returns the exact bounds of "void m() {}"
+//	to preserve "void o() {}".
 func adjustDeleteBounds(content []byte, start, end int) (int, int) {
 	startLineIdx := 0
-	if lastNL := bytes.LastIndexByte(content[:start], '\n'); lastNL != -1 {
-		startLineIdx = lastNL + 1
+	if lastNl := bytes.LastIndexByte(content[:start], '\n'); lastNl != -1 {
+		startLineIdx = lastNl + 1
 	}
 	endLineIdx := len(content)
-	if nextNL := bytes.IndexByte(content[end:], '\n'); nextNL != -1 {
-		endLineIdx = end + nextNL
+	if nextNl := bytes.IndexByte(content[end:], '\n'); nextNl != -1 {
+		endLineIdx = end + nextNl
 	}
 	if len(bytes.TrimSpace(content[startLineIdx:start])) == 0 && len(bytes.TrimSpace(content[end:endLineIdx])) == 0 {
 		finalEnd := endLineIdx

--- a/internal/postprocessing/delete.go
+++ b/internal/postprocessing/delete.go
@@ -15,6 +15,7 @@
 package postprocessing
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -46,9 +47,8 @@ func DeleteMethod(path, funcName, language string) error {
 	if err != nil {
 		return fmt.Errorf("reading file: %w", err)
 	}
-	content := string(data)
-	cleaned := cleanJavaCode(content)
-	idx := strings.Index(cleaned, funcName)
+	cleaned := cleanJavaCode(data)
+	idx := bytes.Index(cleaned, []byte(funcName))
 	if idx == -1 {
 		return fmt.Errorf("%w %q in %s", errMethodNotFound, funcName, path)
 	}
@@ -60,23 +60,23 @@ func DeleteMethod(path, funcName, language string) error {
 	if err != nil {
 		return fmt.Errorf("deleting method %s: %w", funcName, err)
 	}
-	finalStart, finalEnd := adjustDeleteBounds(content, idx, closeBraceIdx+1)
-	newContent := content[:finalStart] + content[finalEnd:]
-	if err := os.WriteFile(path, []byte(newContent), 0644); err != nil {
+	finalStart, finalEnd := adjustDeleteBounds(data, idx, closeBraceIdx+1)
+	newContent := append(data[:finalStart], data[finalEnd:]...)
+	if err := os.WriteFile(path, newContent, 0644); err != nil {
 		return fmt.Errorf("writing updated file: %w", err)
 	}
 	return nil
 }
 
 // cleanJavaCode replaces comments and strings with equal-length spaces to keep offsets.
-func cleanJavaCode(content string) string {
-	return javaCleanRegex.ReplaceAllStringFunc(content, func(match string) string {
-		return strings.Repeat(" ", len(match))
+func cleanJavaCode(content []byte) []byte {
+	return javaCleanRegex.ReplaceAllFunc(content, func(match []byte) []byte {
+		return bytes.Repeat([]byte(" "), len(match))
 	})
 }
 
-// findOpeningBrace returns the index of the first `{` after start, or error if `;` is found first.
-func findOpeningBrace(cleaned string, start int) (int, error) {
+// findOpeningBrace returns the index of the first '{' after start, or error if ';' is found first.
+func findOpeningBrace(cleaned []byte, start int) (int, error) {
 	for i := start; i < len(cleaned); i++ {
 		c := cleaned[i]
 		switch c {
@@ -90,7 +90,7 @@ func findOpeningBrace(cleaned string, start int) (int, error) {
 }
 
 // findClosingBrace returns the index of the matching closing brace.
-func findClosingBrace(cleaned string, openBraceIdx int) (int, error) {
+func findClosingBrace(cleaned []byte, openBraceIdx int) (int, error) {
 	braceCount := 1
 	for i := openBraceIdx + 1; i < len(cleaned); i++ {
 		c := cleaned[i]
@@ -108,16 +108,16 @@ func findClosingBrace(cleaned string, openBraceIdx int) (int, error) {
 }
 
 // adjustDeleteBounds expands the delete range to remove entire lines if the method is on its own lines.
-func adjustDeleteBounds(content string, start, end int) (int, int) {
+func adjustDeleteBounds(content []byte, start, end int) (int, int) {
 	startLineIdx := 0
-	if lastNL := strings.LastIndexByte(content[:start], '\n'); lastNL != -1 {
+	if lastNL := bytes.LastIndexByte(content[:start], '\n'); lastNL != -1 {
 		startLineIdx = lastNL + 1
 	}
 	endLineIdx := len(content)
-	if nextNL := strings.IndexByte(content[end:], '\n'); nextNL != -1 {
+	if nextNL := bytes.IndexByte(content[end:], '\n'); nextNL != -1 {
 		endLineIdx = end + nextNL
 	}
-	if strings.TrimSpace(content[startLineIdx:start]) == "" && strings.TrimSpace(content[end:endLineIdx]) == "" {
+	if len(bytes.TrimSpace(content[startLineIdx:start])) == 0 && len(bytes.TrimSpace(content[end:endLineIdx])) == 0 {
 		finalEnd := endLineIdx
 		if finalEnd < len(content) {
 			finalEnd++

--- a/internal/postprocessing/delete.go
+++ b/internal/postprocessing/delete.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postprocessing
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	errUnsupportedLanguage  = errors.New("unsupported language")
+	errMethodNotFound       = errors.New("method not found")
+	errOpeningBraceNotFound = errors.New("opening brace not found")
+	errClosingBraceNotFound = errors.New("closing brace not found")
+	errInvalidSignature     = errors.New("invalid method signature")
+	// javaCleanRegex matches Java text blocks, double-quoted strings, char literals,
+	// block comments, and line comments.
+	javaCleanRegex = regexp.MustCompile(`"""[\s\S]*?"""|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|/\*[\s\S]*?\*/|//.*`)
+)
+
+// DeleteMethod deletes a method from a Java file.
+// It handles brace counting to remove the entire method body.
+func DeleteMethod(path, funcName, language string) error {
+	if language != "java" {
+		return fmt.Errorf("%w: %s", errUnsupportedLanguage, language)
+	}
+	if !strings.Contains(funcName, "(") || !strings.Contains(funcName, ")") {
+		return fmt.Errorf("%w: %q (must contain parameter list in parentheses)", errInvalidSignature, funcName)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+	content := string(data)
+	cleaned := cleanJavaCode(content)
+	idx := strings.Index(cleaned, funcName)
+	if idx == -1 {
+		return fmt.Errorf("%w %q in %s", errMethodNotFound, funcName, path)
+	}
+	openBraceIdx, err := findOpeningBrace(cleaned, idx+len(funcName))
+	if err != nil {
+		return fmt.Errorf("deleting method %s: %w", funcName, err)
+	}
+	closeBraceIdx, err := findClosingBrace(cleaned, openBraceIdx)
+	if err != nil {
+		return fmt.Errorf("deleting method %s: %w", funcName, err)
+	}
+	finalStart, finalEnd := adjustDeleteBounds(content, idx, closeBraceIdx+1)
+	newContent := content[:finalStart] + content[finalEnd:]
+	if err := os.WriteFile(path, []byte(newContent), 0644); err != nil {
+		return fmt.Errorf("writing updated file: %w", err)
+	}
+	return nil
+}
+
+// cleanJavaCode replaces comments and strings with equal-length spaces to keep offsets.
+func cleanJavaCode(content string) string {
+	return javaCleanRegex.ReplaceAllStringFunc(content, func(match string) string {
+		return strings.Repeat(" ", len(match))
+	})
+}
+
+// findOpeningBrace returns the index of the first `{` after start, or error if `;` is found first.
+func findOpeningBrace(cleaned string, start int) (int, error) {
+	for i := start; i < len(cleaned); i++ {
+		c := cleaned[i]
+		switch c {
+		case '{':
+			return i, nil
+		case ';':
+			return -1, errOpeningBraceNotFound
+		}
+	}
+	return -1, errOpeningBraceNotFound
+}
+
+// findClosingBrace returns the index of the matching closing brace.
+func findClosingBrace(cleaned string, openBraceIdx int) (int, error) {
+	braceCount := 1
+	for i := openBraceIdx + 1; i < len(cleaned); i++ {
+		c := cleaned[i]
+		switch c {
+		case '{':
+			braceCount++
+		case '}':
+			braceCount--
+			if braceCount == 0 {
+				return i, nil
+			}
+		}
+	}
+	return -1, errClosingBraceNotFound
+}
+
+// adjustDeleteBounds expands the delete range to remove entire lines if the method is on its own lines.
+func adjustDeleteBounds(content string, start, end int) (int, int) {
+	startLineIdx := 0
+	if lastNL := strings.LastIndexByte(content[:start], '\n'); lastNL != -1 {
+		startLineIdx = lastNL + 1
+	}
+	endLineIdx := len(content)
+	if nextNL := strings.IndexByte(content[end:], '\n'); nextNL != -1 {
+		endLineIdx = end + nextNL
+	}
+	if strings.TrimSpace(content[startLineIdx:start]) == "" && strings.TrimSpace(content[end:endLineIdx]) == "" {
+		finalEnd := endLineIdx
+		if finalEnd < len(content) {
+			finalEnd++
+		}
+		return startLineIdx, finalEnd
+	}
+	return start, end
+}

--- a/internal/postprocessing/delete.go
+++ b/internal/postprocessing/delete.go
@@ -42,7 +42,8 @@ var (
 // Note: funcName must be the full method declaration line (including modifiers
 // and return type, e.g., "public static void foo()") to avoid matching a substring
 // of another method name (e.g., "foo()" matching inside "afoo()").
-// TODO: Enforce word boundaries during matching as a safety net against accidental substring matches.
+// TODO(https://github.com/googleapis/librarian/issues/6298): Enforce word boundaries
+// during matching as a safety net against accidental substring matches.
 func DeleteMethod(path, funcName, language string) error {
 	if language != config.LanguageJava {
 		return fmt.Errorf("%w: %s", errUnsupportedLanguage, language)

--- a/internal/postprocessing/delete_test.go
+++ b/internal/postprocessing/delete_test.go
@@ -308,13 +308,7 @@ func TestAdjustDeleteBounds(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			content := []byte(test.content)
 			start := strings.Index(test.content, test.startSub)
-			if start == -1 {
-				t.Fatalf("startSub %q not found in content", test.startSub)
-			}
 			endRelative := strings.Index(test.content[start:], test.endSub)
-			if endRelative == -1 {
-				t.Fatalf("endSub %q not found after start in content", test.endSub)
-			}
 			end := start + endRelative + len(test.endSub)
 			gotStart, gotEnd := adjustDeleteBounds(content, start, end)
 			got := string(content[gotStart:gotEnd])

--- a/internal/postprocessing/delete_test.go
+++ b/internal/postprocessing/delete_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postprocessing
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDeleteMethod(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		content  string
+		funcName string
+		language string
+		want     string
+	}{
+		{
+			name: "simple method",
+			content: `package com.example;
+class Test {
+    public void myMethod() {
+        System.out.println("hello");
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name: "nested braces",
+			content: `package com.example;
+class Test {
+    public void myMethod() {
+        if (true) {
+            System.out.println("nested");
+        }
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name: "braces in strings",
+			content: `package com.example;
+class Test {
+    public void myMethod() {
+        System.out.println(" { ");
+        System.out.println(" } ");
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name: "braces in comments",
+			content: `package com.example;
+class Test {
+    public void myMethod() {
+        // {
+        /* } */
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name: "escaped backslash before quote",
+			content: `package com.example;
+class Test {
+    public void myMethod() {
+        System.out.println("value \\");
+        if (true) {
+             System.out.println("inside if");
+        }
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name: "annotation with braces",
+			content: `package com.example;
+class Test {
+    @MyAnnotation(keys = {"a", "b"})
+    public void myMethod() {
+        System.out.println("hello");
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    @MyAnnotation(keys = {"a", "b"})
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name: "java text block",
+			content: `package com.example;
+class Test {
+    public void myMethod() {
+        String block = """
+            {
+            }
+            """;
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name: "signature in comment first",
+			content: `package com.example;
+class Test {
+    // Deprecated: public void myMethod() is no longer used
+    public void myMethod() {
+        System.out.println("hello");
+    }
+    public void otherMethod() {
+    }
+}`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+    // Deprecated: public void myMethod() is no longer used
+    public void otherMethod() {
+    }
+}`,
+		},
+		{
+			name:     "same line delete exact range only",
+			content:  "class Test { public void myMethod() { System.out.println(\"hello\"); } public void otherMethod() {} }",
+			funcName: "public void myMethod()",
+			language: "java",
+			want:     "class Test {  public void otherMethod() {} }",
+		},
+		{
+			name: "method followed by class closing brace on same line",
+			content: `package com.example;
+class Test {
+    public void myMethod() {} }`,
+			funcName: "public void myMethod()",
+			language: "java",
+			want: `package com.example;
+class Test {
+     }`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "test.java")
+			if err := os.WriteFile(tmpFile, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := DeleteMethod(tmpFile, test.funcName, test.language); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(tmpFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, string(got)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeleteMethod_Error(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		content  string
+		funcName string
+		language string
+		wantErr  error
+	}{
+		{
+			name:     "function not found",
+			content:  "class T { void o() {} }",
+			funcName: "void m()",
+			language: "java",
+			wantErr:  errMethodNotFound,
+		},
+		{
+			name:     "unsupported language",
+			content:  "def m(): pass",
+			funcName: "def m()",
+			language: "python",
+			wantErr:  errUnsupportedLanguage,
+		},
+		{
+			name:     "opening brace not found",
+			content:  "class T { void m(); void o() {} }",
+			funcName: "void m()",
+			language: "java",
+			wantErr:  errOpeningBraceNotFound,
+		},
+		{
+			name:     "invalid signature",
+			content:  "class T { void m() {} }",
+			funcName: "void m",
+			language: "java",
+			wantErr:  errInvalidSignature,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "test.java")
+			if err := os.WriteFile(tmpFile, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			err := DeleteMethod(tmpFile, test.funcName, test.language)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("DeleteMethod(%q, %q, %q) error = %v, wantErr %v", tmpFile, test.funcName, test.language, err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/postprocessing/delete_test.go
+++ b/internal/postprocessing/delete_test.go
@@ -318,7 +318,6 @@ func TestAdjustDeleteBounds(t *testing.T) {
 			end := start + endRelative + len(test.endSub)
 
 			gotStart, gotEnd := adjustDeleteBounds(content, start, end)
-
 			got := string(content[gotStart:gotEnd])
 			if diff := cmp.Diff(test.wantDeleted, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/postprocessing/delete_test.go
+++ b/internal/postprocessing/delete_test.go
@@ -316,7 +316,6 @@ func TestAdjustDeleteBounds(t *testing.T) {
 				t.Fatalf("endSub %q not found after start in content", test.endSub)
 			}
 			end := start + endRelative + len(test.endSub)
-
 			gotStart, gotEnd := adjustDeleteBounds(content, start, end)
 			got := string(content[gotStart:gotEnd])
 			if diff := cmp.Diff(test.wantDeleted, got); diff != "" {

--- a/internal/postprocessing/delete_test.go
+++ b/internal/postprocessing/delete_test.go
@@ -18,17 +18,18 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestDeleteMethod(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name     string
 		content  string
 		funcName string
-		language string
 		want     string
 	}{
 		{
@@ -42,7 +43,6 @@ class Test {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     public void otherMethod() {
@@ -62,26 +62,25 @@ class Test {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     public void otherMethod() {
     }
 }`,
 		},
+		// This test has an unbalanced '{' in a string.
+		// It passes because cleanJavaCode strips strings before brace counting.
 		{
 			name: "braces in strings",
 			content: `package com.example;
 class Test {
     public void myMethod() {
         System.out.println(" { ");
-        System.out.println(" } ");
     }
     public void otherMethod() {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     public void otherMethod() {
@@ -100,7 +99,6 @@ class Test {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     public void otherMethod() {
@@ -121,7 +119,6 @@ class Test {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     public void otherMethod() {
@@ -140,7 +137,6 @@ class Test {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     @MyAnnotation(keys = {"a", "b"})
@@ -162,7 +158,6 @@ class Test {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     public void otherMethod() {
@@ -181,7 +176,6 @@ class Test {
     }
 }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
     // Deprecated: public void myMethod() is no longer used
@@ -193,7 +187,6 @@ class Test {
 			name:     "same line delete exact range only",
 			content:  "class Test { public void myMethod() { System.out.println(\"hello\"); } public void otherMethod() {} }",
 			funcName: "public void myMethod()",
-			language: "java",
 			want:     "class Test {  public void otherMethod() {} }",
 		},
 		{
@@ -202,18 +195,18 @@ class Test {
 class Test {
     public void myMethod() {} }`,
 			funcName: "public void myMethod()",
-			language: "java",
 			want: `package com.example;
 class Test {
      }`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			tmpFile := filepath.Join(t.TempDir(), "test.java")
 			if err := os.WriteFile(tmpFile, []byte(test.content), 0644); err != nil {
 				t.Fatal(err)
 			}
-			if err := DeleteMethod(tmpFile, test.funcName, test.language); err != nil {
+			if err := DeleteMethod(tmpFile, test.funcName, "java"); err != nil {
 				t.Fatal(err)
 			}
 			got, err := os.ReadFile(tmpFile)
@@ -228,6 +221,7 @@ class Test {
 }
 
 func TestDeleteMethod_Error(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name     string
 		content  string
@@ -263,8 +257,16 @@ func TestDeleteMethod_Error(t *testing.T) {
 			language: "java",
 			wantErr:  errInvalidSignature,
 		},
+		{
+			name:     "closing brace not found",
+			content:  "class T { void m() { System.out.println();",
+			funcName: "void m()",
+			language: "java",
+			wantErr:  errClosingBraceNotFound,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			tmpFile := filepath.Join(t.TempDir(), "test.java")
 			if err := os.WriteFile(tmpFile, []byte(test.content), 0644); err != nil {
 				t.Fatal(err)
@@ -272,6 +274,54 @@ func TestDeleteMethod_Error(t *testing.T) {
 			err := DeleteMethod(tmpFile, test.funcName, test.language)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("DeleteMethod(%q, %q, %q) error = %v, wantErr %v", tmpFile, test.funcName, test.language, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestAdjustDeleteBounds(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		content     string
+		startSub    string
+		endSub      string
+		wantDeleted string
+	}{
+		{
+			name: "method on its own lines",
+			content: `class T {
+    void m() {
+    }
+}`,
+			startSub:    "void m()",
+			endSub:      "}",
+			wantDeleted: "    void m() {\n    }\n",
+		},
+		{
+			name:        "inline method",
+			content:     "class T { void m() {} void o() {} }",
+			startSub:    "void m()",
+			endSub:      "}",
+			wantDeleted: "void m() {}",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			content := []byte(test.content)
+			start := strings.Index(test.content, test.startSub)
+			if start == -1 {
+				t.Fatalf("startSub %q not found in content", test.startSub)
+			}
+			endRelative := strings.Index(test.content[start:], test.endSub)
+			if endRelative == -1 {
+				t.Fatalf("endSub %q not found after start in content", test.endSub)
+			}
+			end := start + endRelative + len(test.endSub)
+
+			gotStart, gotEnd := adjustDeleteBounds(content, start, end)
+
+			got := string(content[gotStart:gotEnd])
+			if diff := cmp.Diff(test.wantDeleted, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This change adds DeleteMethod to internal/postprocessing as part of issue #6298. It uses regex pre-cleaning and brace tracking to safely delete Java method bodies.

For #6298