### PR TITLE
fix(sdk.yaml): enable java sql v1beta4 dual transport

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -2322,8 +2322,6 @@
     - java
     - nodejs
     - python
-  transports:
-    java: grpc
 - path: google/cloud/storagebatchoperations/v1
   description: Cloud Storage Batch Operations is a Cloud Storage capability that lets you perform operations on billions of objects in a serverless manner.
   languages:


### PR DESCRIPTION
Removes `java` specific config forcing generation of only a `grpc` transport client for SQL v1beta4, thus enabling the default dual transport grpc+rest client generation. API producer initiated change in http://cl/931245278.