### PR TITLE
feat(internal/librarian/nodejs): extract sample metadata for node readme

### DIFF
--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -16,6 +16,7 @@ package nodejs
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -49,7 +50,7 @@ func findSampleMetadata(output string) ([]sampleMetadata, error) {
 		}
 		metadata = append(metadata, sampleMetadata{
 			name:     extractSampleName(d.Name()),
-			filePath: filepath.Join(repoURLPrefix, path),
+			filePath: fmt.Sprintf("%s/%s", repoURLPrefix, path),
 		})
 		return nil
 	})

--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -49,7 +49,7 @@ func findSampleMetadata(output string) ([]sampleMetadata, error) {
 			return nil
 		}
 		metadata = append(metadata, sampleMetadata{
-			name:     extractSampleName(d.Name()),
+			name: extractSampleName(d.Name()),
 			// use string concat and filepath.ToSlash because we need a url format
 			// path to use in markdown file.
 			filePath: fmt.Sprintf("%s/%s", repoURLPrefix, filepath.ToSlash(path)),

--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 )
 
-const repoURLPrefix = "https://github.com/googleapis/google-cloud-node/blob/main/packages"
+const repoURLPrefix = "https://github.com/googleapis/google-cloud-node/blob/main"
 
 var (
 	errorFindSampleMetadata = errors.New("error finding sample metadata")

--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -50,7 +50,7 @@ func findSampleMetadata(output string) ([]sampleMetadata, error) {
 		}
 		metadata = append(metadata, sampleMetadata{
 			name:     extractSampleName(d.Name()),
-			filePath: fmt.Sprintf("%s/%s", repoURLPrefix, path),
+			filePath: fmt.Sprintf("%s/%s", repoURLPrefix, filepath.ToSlash(path)),
 		})
 		return nil
 	})

--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const repoURLPrefix = "https://github.com/googleapis/google-cloud-node/blob/main/packages"
+
+var samplePathPrefix = filepath.Join("samples", "generated")
+
+type sampleMetadata struct {
+	name     string
+	filePath string
+}
+
+func findSampleMetadata(output string) ([]sampleMetadata, error) {
+	samplesPath := filepath.Join(output, samplePathPrefix)
+	var metadata []sampleMetadata
+	if _, err := os.Stat(samplesPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return metadata, nil
+		}
+		return nil, err
+	}
+	err := filepath.WalkDir(samplesPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".js" {
+			return nil
+		}
+		metadata = append(metadata, sampleMetadata{
+			name:     extractSampleName(d.Name()),
+			filePath: filepath.Join(repoURLPrefix, path),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return metadata, nil
+}
+
+func extractSampleName(name string) string {
+	name = strings.TrimSuffix(name, ".js")
+	idx := strings.Index(name, ".")
+	if idx != -1 {
+		name = name[idx+1:]
+	}
+	return strings.ReplaceAll(name, "_", " ")
+}

--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -25,7 +25,10 @@ import (
 
 const repoURLPrefix = "https://github.com/googleapis/google-cloud-node/blob/main/packages"
 
-var samplePathPrefix = filepath.Join("samples", "generated")
+var (
+	errorFindSampleMetadata = errors.New("error finding sample metadata")
+	samplePathPrefix        = filepath.Join("samples", "generated")
+)
 
 type sampleMetadata struct {
 	name     string
@@ -57,7 +60,7 @@ func findSampleMetadata(output string) ([]sampleMetadata, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", errorFindSampleMetadata, err)
 	}
 	return metadata, nil
 }

--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -50,6 +50,8 @@ func findSampleMetadata(output string) ([]sampleMetadata, error) {
 		}
 		metadata = append(metadata, sampleMetadata{
 			name:     extractSampleName(d.Name()),
+			// use string concat and filepath.ToSlash because we need a url format
+			// path to use in markdown file.
 			filePath: fmt.Sprintf("%s/%s", repoURLPrefix, filepath.ToSlash(path)),
 		})
 		return nil

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -83,11 +83,11 @@ func TestFindSampleMetadata(t *testing.T) {
 				return []sampleMetadata{
 					{
 						name:     "nested sample",
-						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/packages/%s/samples/generated/sub/v1.nested_sample.js", dir),
+						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/%s/samples/generated/sub/v1.nested_sample.js", dir),
 					},
 					{
 						name:     "do something",
-						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/packages/%s/samples/generated/v2.do_something.js", dir),
+						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/%s/samples/generated/v2.do_something.js", dir),
 					},
 				}
 			},

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -16,6 +16,7 @@ package nodejs
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -84,11 +85,11 @@ func TestFindSampleMetadata(t *testing.T) {
 				return []sampleMetadata{
 					{
 						name:     "nested sample",
-						filePath: filepath.Join(repoURLPrefix, filepath.Join(generatedDir, "sub/v1.nested_sample.js")),
+						filePath: fmt.Sprintf("%s/%s/sub/v1.nested_sample.js", repoURLPrefix, generatedDir),
 					},
 					{
 						name:     "do something",
-						filePath: filepath.Join(repoURLPrefix, filepath.Join(generatedDir, "v2.do_something.js")),
+						filePath: fmt.Sprintf("%s/%s/v2.do_something.js", repoURLPrefix, generatedDir),
 					},
 				}
 			},

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -81,15 +81,14 @@ func TestFindSampleMetadata(t *testing.T) {
 				}
 			},
 			want: func(dir string) []sampleMetadata {
-				generatedDir := filepath.Join(dir, "samples", "generated")
 				return []sampleMetadata{
 					{
 						name:     "nested sample",
-						filePath: fmt.Sprintf("%s/%s/sub/v1.nested_sample.js", repoURLPrefix, generatedDir),
+						filePath: fmt.Sprintf("%s/%s/samples/generated/sub/v1.nested_sample.js", repoURLPrefix, dir),
 					},
 					{
 						name:     "do something",
-						filePath: fmt.Sprintf("%s/%s/v2.do_something.js", repoURLPrefix, generatedDir),
+						filePath: fmt.Sprintf("%s/%s/samples/generated/v2.do_something.js", repoURLPrefix, dir),
 					},
 				}
 			},

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -17,7 +17,6 @@ package nodejs
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -122,7 +121,8 @@ func TestFindSampleMetadata_Error(t *testing.T) {
 	t.Cleanup(func() {
 		_ = os.Chmod(unreadableSubdir, 0755)
 	})
-	if _, err := findSampleMetadata(tmpDir); !errors.Is(err, fs.ErrPermission) {
-		t.Errorf("expected permission error, got: %v", err)
+	_, err := findSampleMetadata(tmpDir)
+	if !errors.Is(err, errorFindSampleMetadata) {
+		t.Errorf("findSampleMetadata() error = %v, wantErr %v", err, errorFindSampleMetadata)
 	}
 }

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -15,6 +15,8 @@
 package nodejs
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,5 +106,23 @@ func TestFindSampleMetadata(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestFindSampleMetadata_Error(t *testing.T) {
+	tmpDir := t.TempDir()
+	generatedDir := filepath.Join(tmpDir, "samples", "generated")
+	if err := os.MkdirAll(generatedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	unreadableSubdir := filepath.Join(generatedDir, "unreadable")
+	if err := os.MkdirAll(unreadableSubdir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(unreadableSubdir, 0755)
+	})
+	if _, err := findSampleMetadata(tmpDir); !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("expected permission error, got: %v", err)
 	}
 }

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -83,11 +83,11 @@ func TestFindSampleMetadata(t *testing.T) {
 				return []sampleMetadata{
 					{
 						name:     "nested sample",
-						filePath: fmt.Sprintf("%s/%s/samples/generated/sub/v1.nested_sample.js", repoURLPrefix, dir),
+						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/packages/%s/samples/generated/sub/v1.nested_sample.js", dir),
 					},
 					{
 						name:     "do something",
-						filePath: fmt.Sprintf("%s/%s/samples/generated/v2.do_something.js", repoURLPrefix, dir),
+						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/packages/%s/samples/generated/v2.do_something.js", dir),
 					},
 				}
 			},

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractSampleName(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "v1beta1.some_sample.js", want: "some sample"},
+		{input: "foo_bar.js", want: "foo bar"},
+	} {
+		t.Run(test.input, func(t *testing.T) {
+			got := extractSampleName(test.input)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindSampleMetadata(t *testing.T) {
+	type fileInfo struct {
+		path    string
+		content string
+	}
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+		want  func(dir string) []sampleMetadata
+	}{
+		{
+			name: "no samples directory",
+			setup: func(t *testing.T, dir string) {
+				// Do nothing
+			},
+			want: func(dir string) []sampleMetadata {
+				return nil
+			},
+		},
+		{
+			name: "collects and filters samples",
+			setup: func(t *testing.T, dir string) {
+				generatedDir := filepath.Join(dir, "samples", "generated")
+				files := []fileInfo{
+					{path: "v2.do_something.js", content: "console.log('do something');"},
+					{path: "ignored.ts", content: "console.log('typescript');"},
+					{path: "sub/v1.nested_sample.js", content: "console.log('nested');"},
+				}
+				for _, file := range files {
+					fullPath := filepath.Join(generatedDir, file.path)
+					if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(fullPath, []byte(file.content), 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			want: func(dir string) []sampleMetadata {
+				generatedDir := filepath.Join(dir, "samples", "generated")
+				return []sampleMetadata{
+					{
+						name:     "nested sample",
+						filePath: filepath.Join(repoURLPrefix, filepath.Join(generatedDir, "sub/v1.nested_sample.js")),
+					},
+					{
+						name:     "do something",
+						filePath: filepath.Join(repoURLPrefix, filepath.Join(generatedDir, "v2.do_something.js")),
+					},
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			test.setup(t, tmpDir)
+			got, err := findSampleMetadata(tmpDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := test.want(tmpDir)
+			if diff := cmp.Diff(want, got, cmp.AllowUnexported(sampleMetadata{})); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Functionality is added to scan and collect metadata from generated Node.js sample files during the post-processing phase.

This metadata is gathered using directory traversal and is intended to be used for dynamically generating sample listings in library README files.

Implement helper function first and create main function in follow ups.

For #6442