### PR TITLE
fix(librarian): print errors on failure

### DIFF
--- a/cmd/librarian/main.go
+++ b/cmd/librarian/main.go
@@ -25,7 +25,7 @@ import (
 func main() {
 	ctx := context.Background()
 	if err := librarian.Run(ctx, os.Args...); err != nil {
-		fmt.Fprintf(os.Stderr, "librarian: %v", err)
+		fmt.Fprintf(os.Stderr, "librarian: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/librarian/main.go
+++ b/cmd/librarian/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/googleapis/librarian/internal/librarian"
@@ -25,6 +25,7 @@ import (
 func main() {
 	ctx := context.Background()
 	if err := librarian.Run(ctx, os.Args...); err != nil {
-		log.Fatalf("librarian: %v", err)
+		fmt.Fprintf(os.Stderr, "librarian: %v", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Librarian was using `log.Fatalf()` to report errors. Sometimes `log.Fatalf()` seems to print nothing, which is not very useful.

Use `fmt.Fprintf()` and `os.Exit()` as a simpler way to print any errors.

Motivated by #6455 