### PR TITLE
feat(sidekick): parse method signatures

### DIFF
--- a/internal/sidekick/api/method_signature.go
+++ b/internal/sidekick/api/method_signature.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/sidekick/api/method_signature.go
+++ b/internal/sidekick/api/method_signature.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// MethodSignature defines an alternative signature for the method.
+//
+// Some methods include annotations to generate additional overloads for the
+// corresponding generated code. That is, while most generators emit a single
+// function for each RPC, these annotations may define additional overloads for
+// the same RPC.
+//
+// These overloads select a subset of the fields in the request message, and the
+// generator emits a function for each list.
+type MethodSignature struct {
+	// Names define the list of field names from the request message included in
+	// this signature.
+	Names []string
+
+	// Fields define the list of fields from the request message included in
+	// this signature.
+	//
+	// This is initialized in the cross-reference phase, as the fields may not
+	// exist when the method is first parsed.
+	Fields []*Field
+
+	// Method cross-references the method containing this signature.
+	//
+	// This is useful in mustache templates, as the template can access the
+	// method and the method's annotations from within a signature.
+	Method *Method
+}

--- a/internal/sidekick/api/model.go
+++ b/internal/sidekick/api/model.go
@@ -457,6 +457,8 @@ type Method struct {
 	// SampleInfo may contain sample generation information for this method,
 	// usually if it is an AIP conforming metho.
 	SampleInfo *SampleInfo
+	// Signatures defines alternative signatures (overloads) for the method.
+	Signatures []*MethodSignature
 	// Codec contains language specific annotations.
 	Codec any
 }

--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -73,6 +73,16 @@ func CrossReference(model *API) error {
 		if m.OperationInfo != nil {
 			m.OperationInfo.Method = m
 		}
+		for _, signature := range m.Signatures {
+			signature.Method = m
+			for _, name := range signature.Names {
+				idx := slices.IndexFunc(input.Fields, func(f *Field) bool { return f.Name == name })
+				if idx == -1 {
+					return fmt.Errorf("cannot find field %s in method signature for method %s", name, m.ID)
+				}
+				signature.Fields = append(signature.Fields, input.Fields[idx])
+			}
+		}
 	}
 	for s := range model.AllServices() {
 		s.Model = model

--- a/internal/sidekick/parser/discovery/lro_test.go
+++ b/internal/sidekick/parser/discovery/lro_test.go
@@ -64,6 +64,7 @@ func TestLroAnnotations(t *testing.T) {
 		DiscoveryLro: &api.DiscoveryLro{
 			PollingPathParameters: []string{"project", "zone"},
 		},
+		Signatures: []*api.MethodSignature{{Names: []string{"project", "zone", "body"}}},
 	}
 	got := model.Method(want.ID)
 	if got == nil {

--- a/internal/sidekick/parser/discovery/methods.go
+++ b/internal/sidekick/parser/discovery/methods.go
@@ -107,6 +107,10 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 		fieldNames[field.Name] = true
 	}
 
+	// Every discovery-based method has one additional signature formed by the
+	// path parameters, in the order specified by the discovery doc.
+	signature := &api.MethodSignature{Names: input.ParameterOrder}
+
 	bodyPathField := ""
 	if bodyID != ".google.protobuf.Empty" {
 		name, err := bodyFieldName(fieldNames)
@@ -124,6 +128,8 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 		}
 		requestMessage.Fields = append(requestMessage.Fields, body)
 		bodyPathField = name
+		// The body, if present, is required for signature requests.
+		signature.Names = append(signature.Names, name)
 	}
 
 	method := &api.Method{
@@ -138,6 +144,7 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 			Bindings:      []*api.PathBinding{binding},
 			BodyFieldPath: bodyPathField,
 		},
+		Signatures: []*api.MethodSignature{signature},
 		APIVersion: input.APIVersion,
 	}
 	return method, nil

--- a/internal/sidekick/parser/discovery/methods_test.go
+++ b/internal/sidekick/parser/discovery/methods_test.go
@@ -54,11 +54,13 @@ func TestMakeServiceMethods(t *testing.T) {
 			},
 			BodyFieldPath: "",
 		},
+		Signatures: []*api.MethodSignature{{Names: []string{"project", "zone"}}},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 }
+
 func TestMakeServiceMethodsReturnsEmpty(t *testing.T) {
 	model, err := ComputeDisco(t, nil)
 	if err != nil {
@@ -94,6 +96,7 @@ func TestMakeServiceMethodsReturnsEmpty(t *testing.T) {
 			},
 			BodyFieldPath: "",
 		},
+		Signatures: []*api.MethodSignature{{Names: []string{"project", "zone", "operation"}}},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
@@ -132,6 +135,7 @@ func TestMakeServiceMethodsDeprecated(t *testing.T) {
 			},
 			BodyFieldPath: "body",
 		},
+		Signatures: []*api.MethodSignature{{Names: []string{"project", "body"}}},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/parser/discovery/services_test.go
+++ b/internal/sidekick/parser/discovery/services_test.go
@@ -61,6 +61,7 @@ func TestService(t *testing.T) {
 					},
 					BodyFieldPath: "",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"project", "zone"}}},
 			},
 			{
 				ID:            "..zones.list",
@@ -89,6 +90,7 @@ func TestService(t *testing.T) {
 					},
 					BodyFieldPath: "",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"project"}}},
 			},
 		},
 	}

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -549,6 +549,10 @@ func processMethod(model *api.API, m *descriptorpb.MethodDescriptorProto, mFQN, 
 		return nil, fmt.Errorf("cannot parse routing annotations for %q: %w", mFQN, err)
 	}
 	outputTypeID := m.GetOutputType()
+	signatures, err := protobufMethodSignatures(m)
+	if err != nil {
+		return nil, err
+	}
 	method := &api.Method{
 		ID:                  mFQN,
 		PathInfo:            pathInfo,
@@ -563,6 +567,7 @@ func processMethod(model *api.API, m *descriptorpb.MethodDescriptorProto, mFQN, 
 		ReturnsEmpty:        outputTypeID == ".google.protobuf.Empty",
 		SourceServiceID:     serviceID,
 		APIVersion:          apiVersion,
+		Signatures:          signatures,
 	}
 	model.AddMethod(method)
 	return method, nil

--- a/internal/sidekick/parser/protobuf_method_signature.go
+++ b/internal/sidekick/parser/protobuf_method_signature.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	ann "google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func protobufMethodSignatures(m *descriptorpb.MethodDescriptorProto) ([]*api.MethodSignature, error) {
+	var signatures []*api.MethodSignature
+
+	extensionId := ann.E_MethodSignature
+	if !proto.HasExtension(m.GetOptions(), extensionId) {
+		return signatures, nil
+	}
+	ext, ok := proto.GetExtension(m.GetOptions(), extensionId).([]string)
+	if !ok {
+		return nil, fmt.Errorf("invalid signature type for %v", m.Name)
+	}
+	for _, signature := range ext {
+		if signature == "" {
+			continue
+		}
+		// TODO(https://github.com/googleapis/librarian/issues/6460) - support sub-message fields.
+		if strings.ContainsRune(signature, '.') {
+			continue
+		}
+		var names []string
+		for name := range strings.SplitSeq(signature, ",") {
+			names = append(names, strings.TrimSpace(name))
+		}
+		signatures = append(signatures, &api.MethodSignature{Names: names})
+	}
+	return signatures, nil
+}

--- a/internal/sidekick/parser/protobuf_method_signature_test.go
+++ b/internal/sidekick/parser/protobuf_method_signature_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func TestProtobuf_Signatures(t *testing.T) {
+	requireProtoc(t)
+	serviceConfig := &serviceconfig.Service{
+		Name:  "secretmanager.googleapis.com",
+		Title: "Secret Manager API",
+	}
+
+	got, err := makeAPIForProtobuf(serviceConfig, newTestCodeGeneratorRequest(t, "method_signatures.proto"))
+	if err != nil {
+		t.Fatalf("Failed to make API for Protobuf %v", err)
+	}
+	if err := api.CrossReference(got); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ".test.CreateFooRequest"
+	gotMessage := got.Message(id)
+	if gotMessage == nil {
+		t.Fatalf("Cannot find message %s in API State", id)
+	}
+	var names []string
+	for _, f := range gotMessage.Fields {
+		names = append(names, f.Name)
+	}
+	if diff := cmp.Diff([]string{"parent", "foo_id", "flags"}, names); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+
+	id = ".test.Service.CreateFoo"
+	gotMethod := got.Method(id)
+	if gotMethod == nil {
+		t.Fatalf("Cannot find method %s in API State", id)
+	}
+	wantSignatures := []*api.MethodSignature{
+		{
+			Names:  []string{"parent", "foo_id", "flags"},
+			Fields: gotMessage.Fields,
+		},
+		{
+			Names:  []string{"foo_id", "parent"},
+			Fields: []*api.Field{gotMessage.Fields[1], gotMessage.Fields[0]},
+		},
+		{
+			Names:  []string{"parent", "flags"},
+			Fields: []*api.Field{gotMessage.Fields[0], gotMessage.Fields[2]},
+		},
+	}
+
+	// Use IgnoreFields() to avoid recursive testing of the Field->Message->Fields cycle.
+	if diff := cmp.Diff(
+		wantSignatures,
+		gotMethod.Signatures,
+		cmpopts.IgnoreFields(api.MethodSignature{}, "Method"),
+		cmpopts.IgnoreFields(api.Field{}, "Parent")); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/parser/protobuf_mixin_test.go
+++ b/internal/sidekick/parser/protobuf_mixin_test.go
@@ -238,6 +238,7 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 			},
 			BodyFieldPath: "*",
 		},
+		Signatures: []*api.MethodSignature{{Names: []string{"name"}}},
 	})
 }
 
@@ -326,6 +327,7 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 			},
 			BodyFieldPath: "*",
 		},
+		Signatures: []*api.MethodSignature{{Names: []string{"name"}}},
 	})
 	got := test.Message(".google.protobuf.Empty")
 	if got == nil {

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -913,6 +913,7 @@ func TestProtobuf_Service(t *testing.T) {
 					},
 					BodyFieldPath: "",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"name"}}},
 			},
 			{
 				Name:            "CreateFoo",
@@ -936,6 +937,7 @@ func TestProtobuf_Service(t *testing.T) {
 					},
 					BodyFieldPath: "foo",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent", "foo_id", "foo"}}},
 			},
 			{
 				Name:            "DeleteFoo",
@@ -1049,6 +1051,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					},
 					BodyFieldPath: "bar",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent", "foo_id", "bar"}}},
 			},
 			{
 				Name:            "AddBar",
@@ -1074,6 +1077,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					},
 					BodyFieldPath: "*",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent", "payload"}}},
 			},
 		},
 	})
@@ -1176,6 +1180,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					JSONName: "pageToken",
 					Behavior: []api.FieldBehavior{api.FieldBehaviorOptional},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooWithMaxResultsInt32",
@@ -1204,6 +1209,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					JSONName: "pageToken",
 					Behavior: []api.FieldBehavior{api.FieldBehaviorOptional},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooWithMaxResultsUInt32",
@@ -1232,6 +1238,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					JSONName: "pageToken",
 					Behavior: []api.FieldBehavior{api.FieldBehaviorOptional},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooWithMaxResultsUInt32Value",
@@ -1260,6 +1267,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					JSONName: "pageToken",
 					Behavior: []api.FieldBehavior{api.FieldBehaviorOptional},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooWithMaxResultsInt32Value",
@@ -1288,6 +1296,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					JSONName: "pageToken",
 					Behavior: []api.FieldBehavior{api.FieldBehaviorOptional},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooWithMaxResultsIncorrectMessageType",
@@ -1309,6 +1318,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 						},
 					},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooMissingNextPageToken",
@@ -1330,6 +1340,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 						},
 					},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooMissingPageSize",
@@ -1351,6 +1362,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 						},
 					},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooMissingPageToken",
@@ -1372,6 +1384,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 						},
 					},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 			{
 				Name:            "ListFooMissingRepeatedItemToken",
@@ -1393,6 +1406,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 						},
 					},
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"parent"}}},
 			},
 		},
 	})
@@ -1569,6 +1583,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					},
 					BodyFieldPath: "*",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"name"}}},
 			},
 		},
 	})

--- a/internal/sidekick/parser/testdata/method_signatures.proto
+++ b/internal/sidekick/parser/testdata/method_signatures.proto
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/protobuf/timestamp.proto";
+
+// A service to unit test parsing of method signatures.
+service Service {
+  // Creates a new `Foo` resource. `Foo`s are containers for `Bar`s.
+  //
+  // Shows how a `body: "${field}"` option works.
+  rpc CreateFoo(CreateFooRequest) returns (Foo) {
+    option (google.api.http) = {post: "/v1/{parent=projects/*}/foos"};
+    option (google.api.method_signature) = "parent,foo_id,flags";
+    // Not realistic, but good to test out-of-order fields and subsets.
+    option (google.api.method_signature) = "foo_id,parent";
+    // Yes, to my surprise, some protos use spaces.
+    option (google.api.method_signature) = "parent, flags";
+    // Some APIs set the method signature to nothing, which seems silly.
+    option (google.api.method_signature) = "";
+    // TODO(https://github.com/googleapis/librarian/issues/6460) - support sub-message fields.
+    option (google.api.method_signature) = "root.display_name";
+  }
+}
+
+// Request message for `CreateFoo`.
+message CreateFooRequest {
+  // The resource name of the project to associate with the
+  // [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`.
+  string parent = 1;
+
+  // This must be unique within the project.
+  string foo_id = 2;
+
+  // Initial flags.
+  repeated string flags = 3;
+}
+
+// The `Foo` resource.
+message Foo {
+  // The resource name of `Foo`, in the format `projects/{project}/foos/{foo}`.
+  string name = 1;
+
+  repeated string flags = 2;
+}


### PR DESCRIPTION
In some languages (and soon in Swift) we want to generate multiple overloads per-RPC, as some RPCs can be invoked with one or two string fields. An overload can request a couple of strings, or maybe a few strings and a body message, with is a better DX than the full request as input.

For protobuf-based APIs, the `method_signature` annotation defines such overloads.

For discovery-based APIs, the path parameters define an obvious overload.

----

Towards #5930, fixes #6457.  Is not exactly the same as #6451, it adds some checks for empty method signatures, skips method signatures with sub-message fields, and adds test cases for them.  Manually tested on `google-cloud-rust`.
