### PR TITLE
fix(surfer): print errors on failure

### DIFF
--- a/cmd/surfer/main.go
+++ b/cmd/surfer/main.go
@@ -17,7 +17,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/googleapis/librarian/internal/surfer"
@@ -26,6 +26,7 @@ import (
 func main() {
 	ctx := context.Background()
 	if err := surfer.Run(ctx, os.Args...); err != nil {
-		log.Fatal(err)
+		fmt.Fprintf(os.Stderr, "surfer: %v\n", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The surfer command is updated to report errors using `fmt.Fprintf` and `os.Exit` instead of `log.Fatal`.

Previously, surfer relied on the legacy log package. Because the global logger is configured using `slog.SetDefault` to filter logs below `LevelWarn` by default, standard log messages—which map to LevelInfo—were silently discarded. This caused the tool to exit with a non-zero status without displaying any error output.

Also see https://github.com/googleapis/librarian/pull/6458.