### PR TITLE
chore(.github/workflow): print debug log when running generate -all in java integration

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -92,7 +92,7 @@ jobs:
         working-directory: google-cloud-java
         env:
           PYTHONPATH: ${{ github.workspace }}/google-cloud-java/sdk-platform-java/hermetic_build/library_generation/owlbot
-        run: librarian generate --all
+        run: librarian generate -v --all
   create-issue-on-failure:
     needs: [integration]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
In java integration workflow, use `-v` to print debug logging when running librarian generate -all. 
For future fails like https://github.com/googleapis/librarian/issues/6446, print more useful info via github action log.