### PR TITLE
fix(internal/librarian/nodejs):  path leak during generte_readme

### DIFF
--- a/internal/librarian/nodejs/generate_readme.go
+++ b/internal/librarian/nodejs/generate_readme.go
@@ -36,6 +36,7 @@ type sampleMetadata struct {
 }
 
 func findSampleMetadata(output string) ([]sampleMetadata, error) {
+	output = filepath.Clean(output)
 	samplesPath := filepath.Join(output, samplePathPrefix)
 	var metadata []sampleMetadata
 	if _, err := os.Stat(samplesPath); err != nil {
@@ -44,6 +45,7 @@ func findSampleMetadata(output string) ([]sampleMetadata, error) {
 		}
 		return nil, err
 	}
+	repoRoot := filepath.Dir(filepath.Dir(output))
 	err := filepath.WalkDir(samplesPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -51,11 +53,13 @@ func findSampleMetadata(output string) ([]sampleMetadata, error) {
 		if d.IsDir() || filepath.Ext(path) != ".js" {
 			return nil
 		}
+		relPath, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
 		metadata = append(metadata, sampleMetadata{
-			name: extractSampleName(d.Name()),
-			// use string concat and filepath.ToSlash because we need a url format
-			// path to use in markdown file.
-			filePath: fmt.Sprintf("%s/%s", repoURLPrefix, filepath.ToSlash(path)),
+			name:     extractSampleName(d.Name()),
+			filePath: repoURLPrefix + "/" + filepath.ToSlash(relPath),
 		})
 		return nil
 	})

--- a/internal/librarian/nodejs/generate_readme_test.go
+++ b/internal/librarian/nodejs/generate_readme_test.go
@@ -16,7 +16,6 @@ package nodejs
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,22 +47,21 @@ func TestFindSampleMetadata(t *testing.T) {
 	}
 	for _, test := range []struct {
 		name  string
-		setup func(t *testing.T, dir string)
-		want  func(dir string) []sampleMetadata
+		setup func(t *testing.T, dir string) string
+		want  []sampleMetadata
 	}{
 		{
 			name: "no samples directory",
-			setup: func(t *testing.T, dir string) {
-				// Do nothing
+			setup: func(t *testing.T, dir string) string {
+				return filepath.Join(dir, "packages", "my-package")
 			},
-			want: func(dir string) []sampleMetadata {
-				return nil
-			},
+			want: nil,
 		},
 		{
 			name: "collects and filters samples",
-			setup: func(t *testing.T, dir string) {
-				generatedDir := filepath.Join(dir, "samples", "generated")
+			setup: func(t *testing.T, dir string) string {
+				pkgDir := filepath.Join(dir, "packages", "my-package")
+				generatedDir := filepath.Join(pkgDir, "samples", "generated")
 				files := []fileInfo{
 					{path: "v2.do_something.js", content: "console.log('do something');"},
 					{path: "ignored.ts", content: "console.log('typescript');"},
@@ -78,30 +76,28 @@ func TestFindSampleMetadata(t *testing.T) {
 						t.Fatal(err)
 					}
 				}
+				return pkgDir
 			},
-			want: func(dir string) []sampleMetadata {
-				return []sampleMetadata{
-					{
-						name:     "nested sample",
-						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/%s/samples/generated/sub/v1.nested_sample.js", dir),
-					},
-					{
-						name:     "do something",
-						filePath: fmt.Sprintf("https://github.com/googleapis/google-cloud-node/blob/main/%s/samples/generated/v2.do_something.js", dir),
-					},
-				}
+			want: []sampleMetadata{
+				{
+					name:     "nested sample",
+					filePath: "https://github.com/googleapis/google-cloud-node/blob/main/packages/my-package/samples/generated/sub/v1.nested_sample.js",
+				},
+				{
+					name:     "do something",
+					filePath: "https://github.com/googleapis/google-cloud-node/blob/main/packages/my-package/samples/generated/v2.do_something.js",
+				},
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			test.setup(t, tmpDir)
-			got, err := findSampleMetadata(tmpDir)
+			targetDir := test.setup(t, tmpDir)
+			got, err := findSampleMetadata(targetDir)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := test.want(tmpDir)
-			if diff := cmp.Diff(want, got, cmp.AllowUnexported(sampleMetadata{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(sampleMetadata{})); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
When `librarian` post-processes a generated client library (e.g., `packages/google-cloud-vision`), `library.Output` is resolved to an absolute path for working directory safety. When `filepath.WalkDir` navigates this directory, it passes absolute disk file paths (`/workspace/google-cloud-node/packages/...`) to the callback.

When we appended this walk path to `repoURLPrefix`, we generated Markdown hyperlinks that leaked local continuous integration working folder paths:
```text
https://github.com/googleapis/google-cloud-node/blob/main/packages//workspace/google-cloud-node/packages/google-cloud-vision/samples/generated/v1/foo.js
```

> NOTE: The previous unit tests failed to catch this defect because the test computed expected URLs at runtime using the exact same dynamic path manipulation logic as the implementation. 
