### PR TITLE
feat(sidekick/swift): generate method signature overloads

### DIFF
--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -76,6 +76,11 @@ func (ann *methodAnnotations) HasQueryParams() bool {
 	return len(ann.QueryParams) != 0
 }
 
+// PlainRPC returns true if the method is not a pagination or LRO
+func (ann *methodAnnotations) PlainRPC() bool {
+	return ann.LRO == nil && ann.Pagination == nil
+}
+
 func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) error {
 	if method.InputType != nil {
 		if err := c.annotateMessage(method.InputType, modelAnn); err != nil {

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -76,7 +76,7 @@ func (ann *methodAnnotations) HasQueryParams() bool {
 	return len(ann.QueryParams) != 0
 }
 
-// PlainRPC returns true if the method is not a pagination or LRO
+// PlainRPC returns true if the method is not a pagination or LRO.
 func (ann *methodAnnotations) PlainRPC() bool {
 	return ann.LRO == nil && ann.Pagination == nil
 }

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -163,6 +163,9 @@ func TestAnnotateMethod(t *testing.T) {
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
+			if !got.PlainRPC() {
+				t.Errorf("mismatch for PlainRPC()")
+			}
 		})
 	}
 }
@@ -361,6 +364,9 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
+	if gotMethod.PlainRPC() {
+		t.Errorf("mismatch for PlainRPC()")
+	}
 
 	// Verify request message annotations
 	gotRequest := inputType.Codec.(*messageAnnotations)
@@ -468,6 +474,9 @@ func TestAnnotateMethod_LRO(t *testing.T) {
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
+	if gotMethod.PlainRPC() {
+		t.Errorf("mismatch for PlainRPC()")
+	}
 }
 
 func TestAnnotateMethod_LRO_Empty(t *testing.T) {
@@ -535,5 +544,8 @@ func TestAnnotateMethod_LRO_Empty(t *testing.T) {
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
+	}
+	if gotMethod.PlainRPC() {
+		t.Errorf("mismatch for PlainRPC()")
 	}
 }

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -164,7 +164,7 @@ func TestAnnotateMethod(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if !got.PlainRPC() {
-				t.Errorf("mismatch for PlainRPC()")
+				t.Errorf("got.PlainRPC() == true, want false\ngot=%+v", got)
 			}
 		})
 	}
@@ -365,7 +365,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 	if gotMethod.PlainRPC() {
-		t.Errorf("mismatch for PlainRPC()")
+		t.Errorf("gotMethod.PlainRPC() == false, want true\ngotMethod=%+v", gotMethod)
 	}
 
 	// Verify request message annotations
@@ -475,7 +475,7 @@ func TestAnnotateMethod_LRO(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if gotMethod.PlainRPC() {
-		t.Errorf("mismatch for PlainRPC()")
+		t.Errorf("gotMethod.PlainRPC() == false, want true\ngotMethod=%+v", gotMethod)
 	}
 }
 
@@ -546,6 +546,6 @@ func TestAnnotateMethod_LRO_Empty(t *testing.T) {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 	if gotMethod.PlainRPC() {
-		t.Errorf("mismatch for PlainRPC()")
+		t.Errorf("gotMethod.PlainRPC() == false, want true\ngotMethod=%+v", gotMethod)
 	}
 }

--- a/internal/sidekick/swift/templates/common/method_signature/lro_overload.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/lro_overload.mustache
@@ -1,0 +1,20 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{Method.Codec.Name}}(
+  {{#Fields}}
+  {{Codec.Name}}: {{Codec.FieldType}},
+  {{/Fields}}
+) async throws -> any GoogleCloudGax.PollableOperation<{{Codec.LRO.ReturnType}}>

--- a/internal/sidekick/swift/templates/common/method_signature/lro_overload.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/lro_overload.mustache
@@ -17,4 +17,4 @@ limitations under the License.
   {{#Fields}}
   {{Codec.Name}}: {{Codec.FieldType}},
   {{/Fields}}
-) async throws -> any GoogleCloudGax.PollableOperation<{{Codec.LRO.ReturnType}}>
+) async throws -> any GoogleCloudGax.PollableOperation<{{Method.Codec.LRO.ReturnType}}>

--- a/internal/sidekick/swift/templates/common/method_signature/overload.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/overload.mustache
@@ -17,4 +17,4 @@ limitations under the License.
   {{#Fields}}
   {{Codec.Name}}: {{Codec.FieldType}},
   {{/Fields}}
-) async throws{{^Method.ReturnsEmpty}} -> {{Method.Codec.ReturnType}}{{/Method.ReturnsEmpty}}
+) async throws{{^Method.Codec.ReturnsEmpty}} -> {{Method.Codec.ReturnType}}{{/Method.Codec.ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/common/method_signature/overload.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/overload.mustache
@@ -1,0 +1,20 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{Method.Codec.Name}}(
+  {{#Fields}}
+  {{Codec.Name}}: {{Codec.FieldType}},
+  {{/Fields}}
+) async throws{{^Method.ReturnsEmpty}} -> {{Method.Codec.ReturnType}}{{/Method.ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/common/method_signature/overload.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/overload.mustache
@@ -17,4 +17,4 @@ limitations under the License.
   {{#Fields}}
   {{Codec.Name}}: {{Codec.FieldType}},
   {{/Fields}}
-) async throws{{^Method.Codec.ReturnsEmpty}} -> {{Method.Codec.ReturnType}}{{/Method.Codec.ReturnsEmpty}}
+) async throws{{^Method.ReturnsEmpty}} -> {{Method.Codec.ReturnType}}{{/Method.ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/common/method_signature/pagination_overload.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/pagination_overload.mustache
@@ -1,0 +1,20 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{Method.Codec.Name}}(
+  {{#Fields}}
+  {{Codec.Name}}: {{Codec.FieldType}},
+  {{/Fields}}
+) throws -> any AsyncSequence<{{Method.OutputType.Codec.PageableItemType}}, Swift.Error>

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -207,12 +207,12 @@ extension {{Codec.Name}} {
       $0.{{Codec.Name}} = {{Codec.Name}}
       {{/Fields}}
     }
-    {{#Method.Codec.ReturnsEmpty}}
+    {{#Method.ReturnsEmpty}}
     try await self.{{Codec.Name}}(request: request)
-    {{/Method.Codec.ReturnsEmpty}}
-    {{^Method.Codec.ReturnsEmpty}}
+    {{/Method.ReturnsEmpty}}
+    {{^Method.ReturnsEmpty}}
     return try await self.{{Codec.Name}}(request: request)
-    {{/Method.Codec.ReturnsEmpty}}
+    {{/Method.ReturnsEmpty}}
   }
   {{/Signatures}}
   {{/Codec.PlainRPC}}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -46,17 +46,37 @@ public protocol {{Codec.Name}} {
   ///
   /// @Snippet(path: "{{Service.Name}}_{{Name}}")
   func {{> /templates/common/method_signature/request}}
+  {{#Codec.PlainRPC}}
+  {{#Signatures}}
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  func {{> /templates/common/method_signature/overload}}
+  {{/Signatures}}
+  {{/Codec.PlainRPC}}
   {{#Codec.Pagination}}
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
   func {{> /templates/common/method_signature/pagination}}
+  {{#Signatures}}
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  func {{> /templates/common/method_signature/pagination_overload}}
+  {{/Signatures}}
   {{/Codec.Pagination}}
   {{#Codec.LRO}}
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
   func {{> /templates/common/method_signature/lro}}
+  {{#Signatures}}
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  func {{> /templates/common/method_signature/lro_overload}}
+  {{/Signatures}}
   {{/Codec.LRO}}
   {{/Codec.RestMethods}}
 
@@ -178,6 +198,24 @@ extension {{Codec.Name}} {
   public func {{> /templates/common/method_signature/request_options}} {
     throw GoogleCloudGax.RequestError.unimplemented
   }
+  {{#Codec.PlainRPC}}
+  {{#Signatures}}
+
+  public func {{> /templates/common/method_signature/overload}} {
+    let request = {{Method.InputType.Codec.Name}}().with {
+      {{#Fields}}
+      $0.{{Codec.Name}} = {{Codec.Name}}
+      {{/Fields}}
+    }
+    {{#Method.Codec.ReturnsEmpty}}
+    try await self.{{Codec.Name}}(request: request)
+    {{/Method.Codec.ReturnsEmpty}}
+    {{^Method.Codec.ReturnsEmpty}}
+    return try await self.{{Codec.Name}}(request: request)
+    {{/Method.Codec.ReturnsEmpty}}
+  }
+  {{/Signatures}}
+  {{/Codec.PlainRPC}}
   {{#Codec.Pagination}}
 
   public func {{> /templates/common/method_signature/pagination}} {
@@ -190,6 +228,17 @@ extension {{Codec.Name}} {
     }
     return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
   }
+  {{#Signatures}}
+
+  public func {{> /templates/common/method_signature/pagination_overload}} {
+    let request = {{Method.InputType.Codec.Name}}().with {
+      {{#Fields}}
+      $0.{{Codec.Name}} = {{Codec.Name}}
+      {{/Fields}}
+    }
+    return try self.{{Codec.Name}}(byItem: request)
+  }
+  {{/Signatures}}
   {{/Codec.Pagination}}
   {{#Codec.LRO}}
 
@@ -203,6 +252,17 @@ extension {{Codec.Name}} {
     }
     return GoogleCloudGax._PollableOperationImpl(initialState: .init(done: false, result: nil), poll: poll)
   }
+  {{#Signatures}}
+
+  public func {{> /templates/common/method_signature/lro_overload}} {
+    let request = {{Method.InputType.Codec.Name}}().with {
+      {{#Fields}}
+      $0.{{Codec.Name}} = {{Codec.Name}}
+      {{/Fields}}
+    }
+    return try await self.{{Codec.Name}}(withPolling: request)
+  }
+  {{/Signatures}}
   {{/Codec.LRO}}
   {{/Codec.RestMethods}}
 }

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -208,10 +208,10 @@ extension {{Codec.Name}} {
       {{/Fields}}
     }
     {{#Method.ReturnsEmpty}}
-    try await self.{{Codec.Name}}(request: request)
+    try await self.{{Method.Codec.Name}}(request: request)
     {{/Method.ReturnsEmpty}}
     {{^Method.ReturnsEmpty}}
-    return try await self.{{Codec.Name}}(request: request)
+    return try await self.{{Method.Codec.Name}}(request: request)
     {{/Method.ReturnsEmpty}}
   }
   {{/Signatures}}


### PR DESCRIPTION
Generate overloads for RPCs that have method signatures.

Fixes #5930 
