### PR TITLE
feat(internal/librarian/java): support alternate_headers for monolithc libraries

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -153,7 +153,7 @@ func postProcessAPI(ctx context.Context, params postProcessParams) error {
 }
 
 func addHeaders(params postProcessParams, dirs []string) error {
-	if params.javaAPI.Monolithic {
+	if params.javaAPI.Monolithic && (params.library.Java == nil || params.library.Java.AlternateHeaders == "") {
 		return nil
 	}
 	for _, dir := range dirs {

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -505,6 +505,20 @@ func TestPostProcessAPI_AlternateHeaders(t *testing.T) {
 	if !bytes.HasPrefix(got, []byte(wantHeader)) {
 		t.Errorf("mismatch got = %q, want %q", got, wantHeader)
 	}
+	if err := os.WriteFile(grpcFile, []byte("package com.test;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	params.javaAPI.Monolithic = true
+	if err := addHeaders(params, []string{gRPCDir}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = os.ReadFile(grpcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(got, []byte(wantHeader)) {
+		t.Errorf("monolithic mismatch got = %q, want %q", got, wantHeader)
+	}
 }
 
 func TestCopyProtos_Success(t *testing.T) {


### PR DESCRIPTION
Final F/U PR described in https://github.com/googleapis/librarian/pull/6311. This PR "flips the switch" so that if a library has alternate_headers, we should see it in the library. Otherwise keeps other monolithic libraries stable.

Fixes https://github.com/googleapis/librarian/issues/6178