### PR TITLE
feat(internal/postprocessing): implement Java method deprecation

### DIFF
--- a/internal/postprocessing/deprecate.go
+++ b/internal/postprocessing/deprecate.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postprocessing
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+var (
+	errEmptyDeprecationMessage = errors.New("deprecation message is required and cannot be empty")
+	errAmbiguousDeprecation    = errors.New("ambiguous deprecation")
+	errMethodAlreadyDeprecated = errors.New("method is already deprecated")
+)
+
+type methodHeader struct {
+	hasDeprecated      bool
+	hasJavadoc         bool
+	hasDeprecatedTag   bool
+	javadocEndIdx      int
+	firstAnnotationIdx int
+}
+
+// DeprecateMethod deprecates a Java method by adding the @Deprecated annotation
+// and appending a @deprecated tag in its Javadoc block.
+//
+// Note: funcName must be the complete, single-line method signature declaration
+// (including modifiers and return type, e.g., "public void foo()"). Matching is
+// done via exact substring search, so any spacing or formatting mismatch will fail.
+func DeprecateMethod(path, funcName, deprecationMessage, language string) error {
+	if language != config.LanguageJava {
+		return fmt.Errorf("%w: %s", errUnsupportedLanguage, language)
+	}
+	if !strings.Contains(funcName, "(") || !strings.Contains(funcName, ")") {
+		return fmt.Errorf("%w: %q", errInvalidSignature, funcName)
+	}
+	if strings.TrimSpace(deprecationMessage) == "" {
+		return fmt.Errorf("%w for method %q in %s", errEmptyDeprecationMessage, funcName, path)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	cleaned := cleanJavaCode(content)
+	boundsList, err := findMethodBounds(content, cleaned, funcName)
+	if err != nil {
+		return fmt.Errorf("deprecating method %s in %s: %w", funcName, path, err)
+	}
+	if len(boundsList) > 1 {
+		return fmt.Errorf("%w: multiple methods found matching signature %q in %s", errAmbiguousDeprecation, funcName, path)
+	}
+	lines := bytes.Split(content, []byte("\n"))
+	sigLineIdx := bytes.Count(content[:boundsList[0].start], []byte("\n"))
+	header := analyzeMethodHeader(lines, sigLineIdx)
+	if header.hasDeprecated && header.hasDeprecatedTag {
+		return fmt.Errorf("%w: method %q in %s", errMethodAlreadyDeprecated, funcName, path)
+	}
+	indentation := extractLineIndentation(lines[sigLineIdx])
+	lines = annotateMethod(lines, sigLineIdx, indentation, header)
+	lines = addJavadocTag(lines, indentation, header, "deprecated", deprecationMessage)
+	return os.WriteFile(path, bytes.Join(lines, []byte("\n")), 0644)
+}
+
+// analyzeMethodHeader scans the lines above a method signature to identify existing Javadoc and annotations.
+func analyzeMethodHeader(lines [][]byte, sigLineIdx int) methodHeader {
+	header := methodHeader{
+		firstAnnotationIdx: sigLineIdx,
+		javadocEndIdx:      -1,
+	}
+	idx := sigLineIdx - 1
+	for idx >= 0 {
+		line := bytes.TrimSpace(lines[idx])
+		if bytes.HasPrefix(line, []byte("@")) {
+			if string(line) == "@Deprecated" || bytes.HasPrefix(line, []byte("@Deprecated(")) {
+				header.hasDeprecated = true
+			}
+			header.firstAnnotationIdx = idx
+			idx--
+			continue
+		}
+		break
+	}
+	if idx >= 0 {
+		line := bytes.TrimSpace(lines[idx])
+		if bytes.HasSuffix(line, []byte("*/")) {
+			header.hasJavadoc = true
+			header.javadocEndIdx = idx
+			header.hasDeprecatedTag = hasTagInJavadoc(lines, idx, "deprecated")
+		}
+	}
+	return header
+}
+
+// annotateMethod prepends the @Deprecated annotation above the method signature if not already present.
+func annotateMethod(lines [][]byte, sigLineIdx int, indentation []byte, header methodHeader) [][]byte {
+	if header.hasDeprecated {
+		return lines
+	}
+	annotationLine := fmt.Appendf(nil, "%s@Deprecated", indentation)
+	return slices.Insert(lines, sigLineIdx, annotationLine)
+}
+
+// addJavadocTag adds the @deprecated tag to the method's Javadoc block, creating one if it doesn't exist.
+func addJavadocTag(lines [][]byte, indentation []byte, header methodHeader, tagName, tagMessage string) [][]byte {
+	if !header.hasJavadoc {
+		newJavadoc := [][]byte{
+			fmt.Appendf(nil, "%s/**", indentation),
+			fmt.Appendf(nil, "%s * @%s %s", indentation, tagName, tagMessage),
+			fmt.Appendf(nil, "%s */", indentation),
+		}
+		return slices.Insert(lines, header.firstAnnotationIdx, newJavadoc...)
+	}
+	if header.hasDeprecatedTag {
+		return lines
+	}
+	tagLine := fmt.Appendf(nil, "%s * @%s %s", indentation, tagName, tagMessage)
+	return slices.Insert(lines, header.javadocEndIdx, tagLine)
+}
+
+func extractLineIndentation(line []byte) []byte {
+	trimmed := bytes.TrimLeft(line, " \t")
+	return line[:len(line)-len(trimmed)]
+}
+
+func hasTagInJavadoc(lines [][]byte, javadocEndIdx int, tagName string) bool {
+	tagBytes := []byte("@" + tagName)
+	for i := javadocEndIdx; i >= 0; i-- {
+		line := bytes.TrimSpace(lines[i])
+		if bytes.Contains(line, tagBytes) {
+			return true
+		}
+		if bytes.HasPrefix(line, []byte("/**")) {
+			break
+		}
+	}
+	return false
+}

--- a/internal/postprocessing/deprecate.go
+++ b/internal/postprocessing/deprecate.go
@@ -73,7 +73,7 @@ func DeprecateMethod(path, funcName, deprecationMessage, language string) error 
 	if header.hasDeprecated && header.hasDeprecatedTag {
 		return fmt.Errorf("%w: method %q in %s", errMethodAlreadyDeprecated, funcName, path)
 	}
-	indentation := extractLineIndentation(lines[sigLineIdx])
+	indentation := trimLineIndentation(lines[sigLineIdx])
 	lines = annotateMethod(lines, sigLineIdx, indentation, header)
 	lines = addJavadocTag(lines, indentation, header, "deprecated", deprecationMessage)
 	return os.WriteFile(path, bytes.Join(lines, []byte("\n")), 0644)
@@ -86,6 +86,7 @@ func analyzeMethodHeader(lines [][]byte, sigLineIdx int) methodHeader {
 		javadocEndIdx:      -1,
 	}
 	idx := sigLineIdx - 1
+	// Scan past annotations, checking if the method is deprecated.
 	for idx >= 0 {
 		line := bytes.TrimSpace(lines[idx])
 		if bytes.HasPrefix(line, []byte("@")) {
@@ -98,6 +99,7 @@ func analyzeMethodHeader(lines [][]byte, sigLineIdx int) methodHeader {
 		}
 		break
 	}
+	// Check if the line immediately above annotations is the end of Javadoc.
 	if idx >= 0 {
 		line := bytes.TrimSpace(lines[idx])
 		if bytes.HasSuffix(line, []byte("*/")) {
@@ -149,7 +151,7 @@ func makeNewJavadoc(indentation []byte, tagName, tagMessage string, inner []byte
 	return doc
 }
 
-func extractLineIndentation(line []byte) []byte {
+func trimLineIndentation(line []byte) []byte {
 	trimmed := bytes.TrimLeft(line, " \t")
 	return line[:len(line)-len(trimmed)]
 }

--- a/internal/postprocessing/deprecate.go
+++ b/internal/postprocessing/deprecate.go
@@ -89,7 +89,7 @@ func analyzeMethodHeader(lines [][]byte, sigLineIdx int) methodHeader {
 	for idx >= 0 {
 		line := bytes.TrimSpace(lines[idx])
 		if bytes.HasPrefix(line, []byte("@")) {
-			if string(line) == "@Deprecated" || bytes.HasPrefix(line, []byte("@Deprecated(")) {
+			if bytes.Equal(line, []byte("@Deprecated")) || bytes.HasPrefix(line, []byte("@Deprecated(")) {
 				header.hasDeprecated = true
 			}
 			header.firstAnnotationIdx = idx
@@ -120,19 +120,33 @@ func annotateMethod(lines [][]byte, sigLineIdx int, indentation []byte, header m
 
 // addJavadocTag adds the @deprecated tag to the method's Javadoc block, creating one if it doesn't exist.
 func addJavadocTag(lines [][]byte, indentation []byte, header methodHeader, tagName, tagMessage string) [][]byte {
-	if !header.hasJavadoc {
-		newJavadoc := [][]byte{
-			fmt.Appendf(nil, "%s/**", indentation),
-			fmt.Appendf(nil, "%s * @%s %s", indentation, tagName, tagMessage),
-			fmt.Appendf(nil, "%s */", indentation),
-		}
-		return slices.Insert(lines, header.firstAnnotationIdx, newJavadoc...)
-	}
 	if header.hasDeprecatedTag {
 		return lines
 	}
+	if !header.hasJavadoc {
+		newJavadoc := makeNewJavadoc(indentation, tagName, tagMessage, nil)
+		return slices.Insert(lines, header.firstAnnotationIdx, newJavadoc...)
+	}
+	line := bytes.TrimSpace(lines[header.javadocEndIdx])
+	if bytes.HasPrefix(line, []byte("/**")) {
+		inner := bytes.TrimSpace(bytes.TrimSuffix(bytes.TrimPrefix(line, []byte("/**")), []byte("*/")))
+		newJavadoc := makeNewJavadoc(indentation, tagName, tagMessage, inner)
+		return slices.Replace(lines, header.javadocEndIdx, header.javadocEndIdx+1, newJavadoc...)
+	}
 	tagLine := fmt.Appendf(nil, "%s * @%s %s", indentation, tagName, tagMessage)
 	return slices.Insert(lines, header.javadocEndIdx, tagLine)
+}
+
+func makeNewJavadoc(indentation []byte, tagName, tagMessage string, inner []byte) [][]byte {
+	doc := [][]byte{
+		fmt.Appendf(nil, "%s/**", indentation),
+		fmt.Appendf(nil, "%s * @%s %s", indentation, tagName, tagMessage),
+		fmt.Appendf(nil, "%s */", indentation),
+	}
+	if len(inner) > 0 {
+		doc = slices.Insert(doc, 1, fmt.Appendf(nil, "%s * %s", indentation, inner))
+	}
+	return doc
 }
 
 func extractLineIndentation(line []byte) []byte {

--- a/internal/postprocessing/deprecate_test.go
+++ b/internal/postprocessing/deprecate_test.go
@@ -303,3 +303,129 @@ public class TestClass {
 		})
 	}
 }
+
+func TestAddJavadocTag(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name        string
+		lines       []string
+		indentation string
+		header      methodHeader
+		tagName     string
+		tagMessage  string
+		wantLines   []string
+	}{
+		{
+			name: "no javadoc",
+			lines: []string{
+				"  public void foo() {",
+				"  }",
+			},
+			indentation: "  ",
+			header: methodHeader{
+				hasJavadoc:         false,
+				firstAnnotationIdx: 0,
+			},
+			tagName:    "deprecated",
+			tagMessage: "use bar",
+			wantLines: []string{
+				"  /**",
+				"   * @deprecated use bar",
+				"   */",
+				"  public void foo() {",
+				"  }",
+			},
+		},
+		{
+			name: "existing Javadoc without tag",
+			lines: []string{
+				"  /**",
+				"   * Hello world",
+				"   */",
+				"  public void foo() {",
+				"  }",
+			},
+			indentation: "  ",
+			header: methodHeader{
+				hasJavadoc:       true,
+				javadocEndIdx:    2,
+				hasDeprecatedTag: false,
+			},
+			tagName:    "deprecated",
+			tagMessage: "use bar",
+			wantLines: []string{
+				"  /**",
+				"   * Hello world",
+				"   * @deprecated use bar",
+				"   */",
+				"  public void foo() {",
+				"  }",
+			},
+		},
+		{
+			name: "existing Javadoc with tag",
+			lines: []string{
+				"  /**",
+				"   * @deprecated use bar",
+				"   */",
+				"  public void foo() {",
+				"  }",
+			},
+			indentation: "  ",
+			header: methodHeader{
+				hasJavadoc:       true,
+				javadocEndIdx:    2,
+				hasDeprecatedTag: true,
+			},
+			tagName:    "deprecated",
+			tagMessage: "use bar",
+			wantLines: []string{
+				"  /**",
+				"   * @deprecated use bar",
+				"   */",
+				"  public void foo() {",
+				"  }",
+			},
+		},
+		{
+			name: "single-line Javadoc",
+			lines: []string{
+				"  /** Hello world */",
+				"  public void foo() {",
+				"  }",
+			},
+			indentation: "  ",
+			header: methodHeader{
+				hasJavadoc:       true,
+				javadocEndIdx:    0,
+				hasDeprecatedTag: false,
+			},
+			tagName:    "deprecated",
+			tagMessage: "use bar",
+			wantLines: []string{
+				"  /**",
+				"   * Hello world",
+				"   * @deprecated use bar",
+				"   */",
+				"  public void foo() {",
+				"  }",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			inputBytes := make([][]byte, len(test.lines))
+			for i, l := range test.lines {
+				inputBytes[i] = []byte(l)
+			}
+			gotBytes := addJavadocTag(inputBytes, []byte(test.indentation), test.header, test.tagName, test.tagMessage)
+			gotLines := make([]string, len(gotBytes))
+			for i, b := range gotBytes {
+				gotLines[i] = string(b)
+			}
+			if diff := cmp.Diff(test.wantLines, gotLines); diff != "" {
+				t.Errorf("addJavadocTag() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/postprocessing/deprecate_test.go
+++ b/internal/postprocessing/deprecate_test.go
@@ -153,6 +153,33 @@ public class TestClass {
 }
 `,
 		},
+		{
+			name: "method with single-line javadoc",
+			inputContent: `package com.google.example;
+
+public class TestClass {
+  /** Formats a name. */
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+			funcName:           "public static String formatName(String name)",
+			deprecationMessage: "Please use {@link #anotherMethod()} instead",
+			wantContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * Formats a name.
+   * @deprecated Please use {@link #anotherMethod()} instead
+   */
+  @Deprecated
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/postprocessing/deprecate_test.go
+++ b/internal/postprocessing/deprecate_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postprocessing
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestDeprecateMethod(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name               string
+		inputContent       string
+		funcName           string
+		deprecationMessage string
+		wantContent        string
+	}{
+		{
+			name: "simple method without javadoc and annotations",
+			inputContent: `package com.google.example;
+
+public class TestClass {
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+			funcName:           "public static String formatName(String name)",
+			deprecationMessage: "Please use {@link #anotherMethod()} instead",
+			wantContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * @deprecated Please use {@link #anotherMethod()} instead
+   */
+  @Deprecated
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+		},
+		{
+			name: "method with existing annotations but no javadoc",
+			inputContent: `package com.google.example;
+
+public class TestClass {
+  @BetaApi
+  @SuppressWarnings("unchecked")
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+			funcName:           "public static String formatName(String name)",
+			deprecationMessage: "Please use {@link #anotherMethod()} instead",
+			wantContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * @deprecated Please use {@link #anotherMethod()} instead
+   */
+  @BetaApi
+  @SuppressWarnings("unchecked")
+  @Deprecated
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+		},
+		{
+			name: "method with existing javadoc but no annotations",
+			inputContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * Formats a name.
+   *
+   * @param name the name to format
+   * @return the formatted name
+   */
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+			funcName:           "public static String formatName(String name)",
+			deprecationMessage: "Please use {@link #anotherMethod()} instead",
+			wantContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * Formats a name.
+   *
+   * @param name the name to format
+   * @return the formatted name
+   * @deprecated Please use {@link #anotherMethod()} instead
+   */
+  @Deprecated
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+		},
+		{
+			name: "method with existing javadoc and existing annotations",
+			inputContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * Formats a name.
+   */
+  @BetaApi
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+			funcName:           "public static String formatName(String name)",
+			deprecationMessage: "Please use {@link #anotherMethod()} instead",
+			wantContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * Formats a name.
+   * @deprecated Please use {@link #anotherMethod()} instead
+   */
+  @BetaApi
+  @Deprecated
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			filePath := filepath.Join(tmpDir, "TestClass.java")
+			if err := os.WriteFile(filePath, []byte(test.inputContent), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := DeprecateMethod(filePath, test.funcName, test.deprecationMessage, config.LanguageJava); err != nil {
+				t.Fatal(err)
+			}
+			gotBytes, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.wantContent, string(gotBytes)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeprecateMethod_Error(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name               string
+		inputContent       string
+		funcName           string
+		deprecationMessage string
+		language           string
+		wantErr            error
+	}{
+		{
+			name:               "unsupported language",
+			inputContent:       "public void foo() {}",
+			funcName:           "public void foo()",
+			deprecationMessage: "use bar",
+			language:           "python",
+			wantErr:            errUnsupportedLanguage,
+		},
+		{
+			name:               "invalid method signature",
+			inputContent:       "public void foo() {}",
+			funcName:           "public void foo",
+			deprecationMessage: "use bar",
+			language:           config.LanguageJava,
+			wantErr:            errInvalidSignature,
+		},
+		{
+			name:               "empty deprecation message",
+			inputContent:       "public void foo() {}",
+			funcName:           "public void foo()",
+			deprecationMessage: "   ",
+			language:           config.LanguageJava,
+			wantErr:            errEmptyDeprecationMessage,
+		},
+		{
+			name: "method not found",
+			inputContent: `public class TestClass {
+  public void bar() {}
+}
+`,
+			funcName:           "public void foo()",
+			deprecationMessage: "use bar",
+			language:           config.LanguageJava,
+			wantErr:            errMethodNotFound,
+		},
+		{
+			name: "ambiguous matches in a file",
+			inputContent: `package com.google.example;
+
+public class TestClass {
+  public static String formatName(String name) {
+    return name;
+  }
+
+  public static class Inner {
+    public static String formatName(String name) {
+      return "inner-" + name;
+    }
+  }
+}
+`,
+			funcName:           "public static String formatName(String name)",
+			deprecationMessage: "Please use {@link #anotherMethod()} instead",
+			language:           config.LanguageJava,
+			wantErr:            errAmbiguousDeprecation,
+		},
+		{
+			name: "method already deprecated with tag and annotation",
+			inputContent: `package com.google.example;
+
+public class TestClass {
+  /**
+   * Formats a name.
+   * @deprecated Please use {@link #anotherMethod()} instead
+   */
+  @Deprecated
+  public static String formatName(String name) {
+    return name;
+  }
+}
+`,
+			funcName:           "public static String formatName(String name)",
+			deprecationMessage: "Please use {@link #anotherMethod()} instead",
+			language:           config.LanguageJava,
+			wantErr:            errMethodAlreadyDeprecated,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			filePath := filepath.Join(tmpDir, "TestClass.java")
+			if err := os.WriteFile(filePath, []byte(test.inputContent), 0644); err != nil {
+				t.Fatal(err)
+			}
+			err := DeprecateMethod(filePath, test.funcName, test.deprecationMessage, test.language)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("DeprecateMethod(%q, %q, %q, %q) error = %v, wantErr %v", filePath, test.funcName, test.deprecationMessage, test.language, err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds the DeprecateMethod function to support deprecating Java methods. The function inserts the @Deprecated annotation and the Javadoc @deprecated tag into the target Java file.

For #6298