### PR TITLE
test(.github/workflows/java): cache maven and librarian tools to speed up test execution

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -61,12 +61,13 @@ jobs:
             sudo apt-get update && sudo apt-get install -y maven
           fi
           mvn -version
+      - name: Add Java tools to PATH
+        run: echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Run librarian install
         if: steps.cache-tools.outputs.cache-hit != 'true'
         working-directory: google-cloud-java
         run: |
           librarian install
-          echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Debug - List Java tools directory
         run: |
           echo "=== 1. CHECKING PATH ENVIRONMENT VARIABLE ==="

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -47,7 +47,7 @@ jobs:
           path: |
             ~/.cache/librarian
             venv
-          key: librarian-java-tools-v1-{{ runner.os }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
+          key: librarian-java-tools-v1-${{ runner.os }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
       - name: Create Python virtual environment
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: python3 -m venv venv
@@ -71,11 +71,11 @@ jobs:
         run: |
           echo "=== 1. CHECKING PATH ENVIRONMENT VARIABLE ==="
           echo "PATH is: $PATH"
-          
+
           echo "=== 2. CHECKING WRAPPER SCRIPT CONTENT & LINE ENDINGS ==="
           # cat -v will show carriage returns (\r) as ^M
           cat -v "$HOME/.cache/librarian/bin/java_tools/bin/google-java-format"
-          
+
           echo "=== 3. TRYING TO EXECUTE BY ABSOLUTE PATH ==="
           # This will isolate if the issue is the PATH or the file shebang
           if "$HOME/.cache/librarian/bin/java_tools/bin/google-java-format" --version; then

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -30,13 +30,34 @@ jobs:
         with:
           repository: googleapis/google-cloud-java
           path: google-cloud-java
+          sparse-checkout: |
+            librarian.yaml
+            sdk-platform-java
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"
+          cache: "maven"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Cache Librarian Tools & Venv
+        id: cache-tools
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/librarian
+            venv
+          key: librarian-java-tools-${{ runner.os }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
+      - name: Create Python virtual environment
+        if: steps.cache-tools.outputs.cache-hit != 'true'
+        run: python3 -m venv venv
+      - name: Activate virtual environment
+        run: echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
       - name: Verify Java and Maven installation
+        if: steps.cache-tools.outputs.cache-hit != 'true'
         run: |
           java -version
           if ! command -v mvn &> /dev/null; then
@@ -44,10 +65,11 @@ jobs:
           fi
           mvn -version
       - name: Run librarian install
+        if: steps.cache-tools.outputs.cache-hit != 'true'
         working-directory: google-cloud-java
-        run: |
-          librarian install
-          echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
+        run: librarian install
+      - name: Add Java tools to PATH
+        run: echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Verify tools
         run: |
           protoc --version

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -30,9 +30,6 @@ jobs:
         with:
           repository: googleapis/google-cloud-java
           path: google-cloud-java
-          sparse-checkout: |
-            librarian.yaml
-            sdk-platform-java
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@v4

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -67,6 +67,25 @@ jobs:
         run: |
           librarian install
           echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
+      - name: Debug - List Java tools directory
+        run: |
+          echo "=== CHECKING PATHS ==="
+          echo "Workspace: $GITHUB_WORKSPACE"
+          echo "Home: $HOME"
+          echo "=== CHECKING JAVA TOOLS BIN ==="
+          if [ -d "$HOME/.cache/librarian/bin/java_tools/bin" ]; then
+            echo "Directory exists! Listing contents:"
+            ls -la "$HOME/.cache/librarian/bin/java_tools/bin"
+          else
+            echo "Directory DOES NOT exist!"
+          fi
+          echo "=== CHECKING LIBRARIAN CACHE ROOT ==="
+          if [ -d "$HOME/.cache/librarian" ]; then
+            echo "Librarian cache root exists! Listing:"
+            find "$HOME/.cache/librarian" -maxdepth 4
+          else
+            echo "Librarian cache root DOES NOT exist!"
+          fi
       - name: Verify tools
         run: |
           protoc --version

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -20,8 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
-    # TODO(https://github.com/googleapis/librarian/issues/6482): Speed this up and lower to 5 minutes.
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-librarian

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -68,22 +68,6 @@ jobs:
         working-directory: google-cloud-java
         run: |
           librarian install
-      - name: Debug - List Java tools directory
-        run: |
-          echo "=== 1. CHECKING PATH ENVIRONMENT VARIABLE ==="
-          echo "PATH is: $PATH"
-
-          echo "=== 2. CHECKING WRAPPER SCRIPT CONTENT & LINE ENDINGS ==="
-          # cat -v will show carriage returns (\r) as ^M
-          cat -v "$HOME/.cache/librarian/bin/java_tools/bin/google-java-format"
-
-          echo "=== 3. TRYING TO EXECUTE BY ABSOLUTE PATH ==="
-          # This will isolate if the issue is the PATH or the file shebang
-          if "$HOME/.cache/librarian/bin/java_tools/bin/google-java-format" --version; then
-            echo "Execution by absolute path succeeded!"
-          else
-            echo "Execution by absolute path failed with exit code $?"
-          fi
       - name: Verify tools
         run: |
           protoc --version

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -67,9 +67,9 @@ jobs:
       - name: Run librarian install
         if: steps.cache-tools.outputs.cache-hit != 'true'
         working-directory: google-cloud-java
-        run: librarian install
-      - name: Add Java tools to PATH
-        run: echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
+        run: |
+          librarian install
+          echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Verify tools
         run: |
           protoc --version

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -47,7 +47,7 @@ jobs:
           path: |
             ~/.cache/librarian
             venv
-          key: librarian-java-tools-${{ runner.os }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
+          key: librarian-java-tools-v1-{{ runner.os }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
       - name: Create Python virtual environment
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: python3 -m venv venv

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -69,22 +69,19 @@ jobs:
           echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Debug - List Java tools directory
         run: |
-          echo "=== CHECKING PATHS ==="
-          echo "Workspace: $GITHUB_WORKSPACE"
-          echo "Home: $HOME"
-          echo "=== CHECKING JAVA TOOLS BIN ==="
-          if [ -d "$HOME/.cache/librarian/bin/java_tools/bin" ]; then
-            echo "Directory exists! Listing contents:"
-            ls -la "$HOME/.cache/librarian/bin/java_tools/bin"
+          echo "=== 1. CHECKING PATH ENVIRONMENT VARIABLE ==="
+          echo "PATH is: $PATH"
+          
+          echo "=== 2. CHECKING WRAPPER SCRIPT CONTENT & LINE ENDINGS ==="
+          # cat -v will show carriage returns (\r) as ^M
+          cat -v "$HOME/.cache/librarian/bin/java_tools/bin/google-java-format"
+          
+          echo "=== 3. TRYING TO EXECUTE BY ABSOLUTE PATH ==="
+          # This will isolate if the issue is the PATH or the file shebang
+          if "$HOME/.cache/librarian/bin/java_tools/bin/google-java-format" --version; then
+            echo "Execution by absolute path succeeded!"
           else
-            echo "Directory DOES NOT exist!"
-          fi
-          echo "=== CHECKING LIBRARIAN CACHE ROOT ==="
-          if [ -d "$HOME/.cache/librarian" ]; then
-            echo "Librarian cache root exists! Listing:"
-            find "$HOME/.cache/librarian" -maxdepth 4
-          else
-            echo "Librarian cache root DOES NOT exist!"
+            echo "Execution by absolute path failed with exit code $?"
           fi
       - name: Verify tools
         run: |


### PR DESCRIPTION
Optimizes the `Java / tests` workflow in `java.yaml` to prevent timeouts by introducing caching for built dependencies and tools:

- Enable Maven dependency caching (`cache: "maven"`) in `setup-java`.
- Set up a Python virtual environment (`venv`) to isolate and cache pip-installed dependencies like `synthtool`.
- Use `actions/cache` to cache both the compiled Java tools (`~/.cache/librarian`) and the Python virtual environment (`venv`).
- Make the Java/Maven verification and `librarian install` steps conditional on a cache miss, skipping them entirely when tools are restored from cache.

Future test idea speedup: to do `sparse-checkout`, we could change `buildLocalMavenProject` to extract the parent directory of the local project (e.g., sdk-platform-java) and run the mvn command from inside that directory, so that we don't need to check out the whole repo and mvn doesn't have to validate the whole repo when running.

Fixes #6482 