### PR TITLE
feat(sidekick/rust): add condition to include `google-cloud-lro` as dependency

### DIFF
--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -385,7 +385,7 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
 		// not save us any computations.
 
 		for _, m := range s.Methods {
-			if m.OperationInfo != nil || m.DiscoveryLro != nil {
+			if m.OperationInfo != nil || m.DiscoveryLro != nil || m.IsLroPoller {
 				hasLROs = true
 			}
 			if len(m.AutoPopulated) != 0 {

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -385,7 +385,7 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
 		// not save us any computations.
 
 		for _, m := range s.Methods {
-			if m.OperationInfo != nil || m.DiscoveryLro != nil || m.IsLroPoller {
+			if m.OperationInfo != nil || m.IsLroPoller {
 				hasLROs = true
 			}
 			if len(m.AutoPopulated) != 0 {


### PR DESCRIPTION
Include the `google-cloud-lro` dependency in a generated crate's `Cargo.toml` if any of its methods are configured as LRO pollers (`IsLroPoller`).