### PR TITLE
feat(sidekick/swift): qualified names for requests

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -58,8 +58,8 @@ type messageAnnotations struct {
 	// imported with the mixin, e.g. `import GoogleCloudIamV1` imports the IAM
 	// mixin request types.
 	//
-	// For discovery-based APIs the request are synthetic and generated within a
-	// scope. They need to be fully qualified.
+	// For discovery-based APIs, the request are synthetic and generated within
+	// a scope. They need to be fully qualified.
 	ParameterTypeName string
 }
 

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -51,6 +51,16 @@ type messageAnnotations struct {
 	// service that needs them is enabled. Messages that do not map to any
 	// service use " && ".
 	GatedOp string
+
+	// The message type name when it appears as a method parameter name.
+	//
+	// Most of the time the request types are in the package namespace, or are
+	// imported with the mixin, e.g. `import GoogleCloudIamV1` imports the IAM
+	// mixin request types.
+	//
+	// For discovery-based APIs the request are synthetic and generated within a
+	// scope. They need to be fully qualifed.
+	ParameterTypeName string
 }
 
 // MessageImports returns the list of dependencies for this message.
@@ -97,6 +107,10 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if len(message.Fields) != 0 {
 		sampleField = camelCase(message.Fields[0].Name)
 	}
+	parameterTypeName, err := c.messageTypeName(message)
+	if err != nil {
+		return err
+	}
 	annotations := &messageAnnotations{
 		Name:                pascalCase(message.Name),
 		DocLines:            docLines,
@@ -105,6 +119,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		CustomSerialization: len(message.OneOfs) > 0,
 		DependsOn:           map[string]*Dependency{},
 		SampleField:         sampleField,
+		ParameterTypeName:   parameterTypeName,
 	}
 
 	// Ensure the entire package depends on the package this message belongs to.

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -59,7 +59,7 @@ type messageAnnotations struct {
 	// mixin request types.
 	//
 	// For discovery-based APIs the request are synthetic and generated within a
-	// scope. They need to be fully qualifed.
+	// scope. They need to be fully qualified.
 	ParameterTypeName string
 }
 

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -46,6 +46,7 @@ func TestAnnotateMessage(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Secret",
 				CustomSerialization: false,
 				SampleField:         "secretKey",
+				ParameterTypeName:   "Secret",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -63,6 +64,7 @@ func TestAnnotateMessage(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Protocol",
 				CustomSerialization: false,
 				SampleField:         "<placeholder>",
+				ParameterTypeName:   "Protocol_",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -79,6 +81,7 @@ func TestAnnotateMessage(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.WithOneof",
 				CustomSerialization: true,
 				SampleField:         "<placeholder>",
+				ParameterTypeName:   "WithOneof",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -97,6 +100,7 @@ func TestAnnotateMessage(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.WithCustomJSON",
 				CustomSerialization: true,
 				SampleField:         "secretKey",
+				ParameterTypeName:   "WithCustomJSON",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -122,6 +126,7 @@ func TestAnnotateMessage(t *testing.T) {
 				PageableItemField:   "secretKey",
 				PageableItemType:    "SecretKey",
 				SampleField:         "secretKey",
+				ParameterTypeName:   "WithPagination",
 			},
 			wantImports: []string{"GoogleCloudGax", "GoogleCloudWkt"},
 		},
@@ -338,9 +343,10 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 	// Verify annotations on request message
 	gotRequest := inputType.Codec.(*messageAnnotations)
 	wantRequest := &messageAnnotations{
-		Name:        "ListSecretsRequest",
-		TypeURL:     "type.googleapis.com/google.cloud.secretmanager.v1.ListSecretsRequest",
-		SampleField: "pageSize",
+		Name:              "ListSecretsRequest",
+		TypeURL:           "type.googleapis.com/google.cloud.secretmanager.v1.ListSecretsRequest",
+		SampleField:       "pageSize",
+		ParameterTypeName: "ListSecretsRequest",
 	}
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
@@ -359,6 +365,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		PageableItemField:   "secrets",
 		PageableItemType:    "Secret",
 		SampleField:         "secrets",
+		ParameterTypeName:   "ListSecretsResponse",
 	}
 	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
@@ -408,9 +415,10 @@ func TestAnnotateMessage_RecursiveNested(t *testing.T) {
 
 	gotOuter := outerMessage.Codec.(*messageAnnotations)
 	wantOuter := &messageAnnotations{
-		Name:        "OuterMessage",
-		TypeURL:     "type.googleapis.com/google.cloud.secretmanager.v1.OuterMessage",
-		SampleField: "<placeholder>",
+		Name:              "OuterMessage",
+		TypeURL:           "type.googleapis.com/google.cloud.secretmanager.v1.OuterMessage",
+		SampleField:       "<placeholder>",
+		ParameterTypeName: "OuterMessage",
 	}
 	if diff := cmp.Diff(wantOuter, gotOuter, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -181,6 +181,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Secret",
 				CustomSerialization: false,
 				SampleField:         "field",
+				ParameterTypeName:   "Secret",
 			},
 		},
 		{
@@ -198,6 +199,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Secret",
 				CustomSerialization: true,
 				SampleField:         "field",
+				ParameterTypeName:   "Secret",
 			},
 		},
 		{
@@ -215,6 +217,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Secret",
 				CustomSerialization: true,
 				SampleField:         "field",
+				ParameterTypeName:   "Secret",
 			},
 		},
 		{
@@ -232,6 +235,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Secret",
 				CustomSerialization: true,
 				SampleField:         "field",
+				ParameterTypeName:   "Secret",
 			},
 		},
 		{
@@ -256,6 +260,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Secret",
 				CustomSerialization: true,
 				SampleField:         "field",
+				ParameterTypeName:   "Secret",
 			},
 		},
 	} {

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -26,14 +26,16 @@ import (
 func TestAnnotateMethod(t *testing.T) {
 	keyField := &api.Field{Name: "key", ID: ".test.Request.key", Typez: api.TypezString}
 	inputType := &api.Message{
-		Name:   "Request",
-		ID:     ".test.Request",
-		Fields: []*api.Field{keyField},
+		Name:    "Request",
+		ID:      ".test.Request",
+		Package: "test",
+		Fields:  []*api.Field{keyField},
 	}
 	keyField.Parent = inputType
 	outputType := &api.Message{
-		Name: "Response",
-		ID:   ".test.Response",
+		Name:    "Response",
+		ID:      ".test.Response",
+		Package: "test",
 		Fields: []*api.Field{
 			{Name: "value", ID: ".test.Request.value", Typez: api.TypezString},
 		},
@@ -64,7 +66,7 @@ func TestAnnotateMethod(t *testing.T) {
 				DocLines:       []string{"Gets a thing.", "", "Test multiple comment lines.", ""},
 				HTTPMethod:     "GET",
 				HasBody:        false,
-				ReturnType:     "Response",
+				ReturnType:     "GoogleTest.Response",
 			},
 		},
 		{
@@ -88,7 +90,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HasBody:        true,
 				IsBodyWildcard: false,
 				BodyField:      "key",
-				ReturnType:     "Response",
+				ReturnType:     "GoogleTest.Response",
 			},
 		},
 		{
@@ -111,7 +113,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HTTPMethod:     "POST",
 				HasBody:        true,
 				IsBodyWildcard: true,
-				ReturnType:     "Response",
+				ReturnType:     "GoogleTest.Response",
 			},
 		},
 		{
@@ -136,7 +138,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HTTPMethod:     "GET",
 				HasBody:        false,
 				QueryParams:    []*api.Field{keyField},
-				ReturnType:     "Response",
+				ReturnType:     "GoogleTest.Response",
 			},
 		},
 	} {
@@ -148,6 +150,7 @@ func TestAnnotateMethod(t *testing.T) {
 			service := &api.Service{
 				Name:    "TestService",
 				ID:      ".test.TestService",
+				Package: "test",
 				Methods: []*api.Method{test.method},
 			}
 			model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -148,7 +148,6 @@ func TestAnnotateMethod(t *testing.T) {
 			service := &api.Service{
 				Name:    "TestService",
 				ID:      ".test.TestService",
-				Package: "test",
 				Methods: []*api.Method{test.method},
 			}
 			model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})
@@ -371,9 +370,10 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 	// Verify request message annotations
 	gotRequest := inputType.Codec.(*messageAnnotations)
 	wantRequest := &messageAnnotations{
-		Name:        "ListRequest",
-		TypeURL:     "type.googleapis.com/test.ListRequest",
-		SampleField: "pageSize",
+		Name:              "ListRequest",
+		TypeURL:           "type.googleapis.com/test.ListRequest",
+		SampleField:       "pageSize",
+		ParameterTypeName: "ListRequest",
 	}
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
@@ -392,6 +392,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		PageableItemField:   "items",
 		PageableItemType:    "Item",
 		SampleField:         "items",
+		ParameterTypeName:   "ListResponse",
 	}
 	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -175,7 +175,8 @@ func TestGenerateService_Delegation(t *testing.T) {
 func TestGenerateService_SnippetFiles(t *testing.T) {
 	outDir := t.TempDir()
 
-	dummyMessage := &api.Message{Name: "DummyMessage"}
+	packageName := "google.cloud.test.v1"
+	dummyMessage := &api.Message{Name: "DummyMessage", Package: packageName}
 	iam := &api.Service{
 		Name: "IAM",
 		Methods: []*api.Method{
@@ -202,7 +203,7 @@ func TestGenerateService_SnippetFiles(t *testing.T) {
 	}
 
 	model := api.NewTestAPI([]*api.Message{dummyMessage}, nil, []*api.Service{iam, secretManager})
-	model.PackageName = "google.cloud.test.v1"
+	model.PackageName = packageName
 
 	cfg := &parser.ModelConfig{
 		Codec: map[string]string{

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -86,7 +86,7 @@ func TestGenerateService_StubStructure(t *testing.T) {
 	got := extractBlock(t, contentStr, `  protocol ProtocolStub {`, "\n"+`  }`)
 	want := `  protocol ProtocolStub {
     func getThing(
-    request: Request, options: GoogleCloudGax.RequestOptions
+    request: SomeTestPackage.Request, options: GoogleCloudGax.RequestOptions
 ) async throws -> SomeTestPackage.Response
 
   }`

--- a/internal/sidekick/swift/templates/common/logging.swift.mustache
+++ b/internal/sidekick/swift/templates/common/logging.swift.mustache
@@ -73,7 +73,7 @@ extension Clients {
         request: request,
         options: options,
         name: "{{Codec.Name}}",
-        action: { (r: {{InputType.Codec.Name}}, o: GoogleCloudGax.RequestOptions) async throws ->
+        action: { (r: {{InputType.Codec.ParameterTypeName}}, o: GoogleCloudGax.RequestOptions) async throws ->
             {{^ReturnsEmpty}}{{Codec.ReturnType}}{{/ReturnsEmpty}}
             {{#ReturnsEmpty}}Void{{/ReturnsEmpty}} in
               return try await self.inner.{{Codec.Name}}(request: r, options: o)

--- a/internal/sidekick/swift/templates/common/method_signature/lro.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/lro.mustache
@@ -13,4 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{Codec.Name}}(withPolling: {{InputType.Codec.Name}}) async throws -> any GoogleCloudGax.PollableOperation<{{Codec.LRO.ReturnType}}>
+{{Codec.Name}}(withPolling: {{InputType.Codec.ParameterTypeName}}) async throws -> any GoogleCloudGax.PollableOperation<{{Codec.LRO.ReturnType}}>

--- a/internal/sidekick/swift/templates/common/method_signature/lro_options.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/lro_options.mustache
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 {{Codec.Name}}(
-    withPolling: {{InputType.Codec.Name}}, options: GoogleCloudGax.RequestOptions
+    withPolling: {{InputType.Codec.ParameterTypeName}}, options: GoogleCloudGax.RequestOptions
 ) async throws -> any GoogleCloudGax.PollableOperation<{{Codec.LRO.ReturnType}}>

--- a/internal/sidekick/swift/templates/common/method_signature/pagination.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/pagination.mustache
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 {{Codec.Name}}(
-  byItem: {{InputType.Codec.Name}}
+  byItem: {{InputType.Codec.ParameterTypeName}}
 ) throws -> any AsyncSequence<{{OutputType.Codec.PageableItemType}}, Swift.Error>

--- a/internal/sidekick/swift/templates/common/method_signature/pagination_options.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/pagination_options.mustache
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 {{Codec.Name}}(
-    byItem: {{InputType.Codec.Name}}, options: GoogleCloudGax.RequestOptions
+    byItem: {{InputType.Codec.ParameterTypeName}}, options: GoogleCloudGax.RequestOptions
 ) throws -> any AsyncSequence<{{OutputType.Codec.PageableItemType}}, Swift.Error>

--- a/internal/sidekick/swift/templates/common/method_signature/request.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/request.mustache
@@ -13,4 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{Codec.Name}}(request: {{InputType.Codec.Name}}) async throws{{^ReturnsEmpty}} -> {{Codec.ReturnType}}{{/ReturnsEmpty}}
+{{Codec.Name}}(request: {{InputType.Codec.ParameterTypeName}}) async throws{{^ReturnsEmpty}} -> {{Codec.ReturnType}}{{/ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/common/method_signature/request_options.mustache
+++ b/internal/sidekick/swift/templates/common/method_signature/request_options.mustache
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 {{Codec.Name}}(
-    request: {{InputType.Codec.Name}}, options: GoogleCloudGax.RequestOptions
+    request: {{InputType.Codec.ParameterTypeName}}, options: GoogleCloudGax.RequestOptions
 ) async throws{{^ReturnsEmpty}} -> {{Codec.ReturnType}}{{/ReturnsEmpty}}

--- a/internal/sidekick/swift/templates/common/retry.swift.mustache
+++ b/internal/sidekick/swift/templates/common/retry.swift.mustache
@@ -66,7 +66,7 @@ extension Clients {
         request: request,
         options: options,
         idempotent: {{Codec.Idempotent}},
-        action: { (r: {{InputType.Codec.Name}}, o: GoogleCloudGax.RequestOptions) async throws ->
+        action: { (r: {{InputType.Codec.ParameterTypeName}}, o: GoogleCloudGax.RequestOptions) async throws ->
             {{^ReturnsEmpty}}{{Codec.ReturnType}}{{/ReturnsEmpty}}
             {{#ReturnsEmpty}}Void{{/ReturnsEmpty}} in
               return try await self.inner.{{Codec.Name}}(request: r, options: o)

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -202,7 +202,7 @@ extension {{Codec.Name}} {
   {{#Signatures}}
 
   public func {{> /templates/common/method_signature/overload}} {
-    let request = {{Method.InputType.Codec.Name}}().with {
+    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
       {{#Fields}}
       $0.{{Codec.Name}} = {{Codec.Name}}
       {{/Fields}}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -231,7 +231,7 @@ extension {{Codec.Name}} {
   {{#Signatures}}
 
   public func {{> /templates/common/method_signature/pagination_overload}} {
-    let request = {{Method.InputType.Codec.Name}}().with {
+    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
       {{#Fields}}
       $0.{{Codec.Name}} = {{Codec.Name}}
       {{/Fields}}
@@ -255,7 +255,7 @@ extension {{Codec.Name}} {
   {{#Signatures}}
 
   public func {{> /templates/common/method_signature/lro_overload}} {
-    let request = {{Method.InputType.Codec.Name}}().with {
+    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
       {{#Fields}}
       $0.{{Codec.Name}} = {{Codec.Name}}
       {{/Fields}}

--- a/internal/sidekick/swift/templates/snippet/method_request_body.mustache
+++ b/internal/sidekick/swift/templates/snippet/method_request_body.mustache
@@ -22,7 +22,7 @@ limitations under the License.
   Conceptually there is a `list response = try await client.<<MethodName>>( ... )` around this
   partial.
 }}
-{{InputType.Codec.Name}}()
+{{InputType.Codec.ParameterTypeName}}()
   {{#SampleInfo}}
   .with {
   {{#IsRequestResourceName}}


### PR DESCRIPTION
In discovery-based services the requests will be nested messages. We need to generate code that fully qualifies the request type, like we do for fields. This requires new annotations for the messages.

Fixes #6493 