### PR TITLE
Revert "feat(internal/librarian/java): remove redundant keep items in librarian.yaml"

### DIFF
--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -85,9 +85,6 @@ func cleanPatterns(library *config.Library) map[string]bool {
 	}
 	for _, api := range library.APIs {
 		javaAPI := api.Java
-		if javaAPI == nil {
-			javaAPI = &config.JavaAPI{}
-		}
 		version := filepath.Base(api.Path)
 		apiCoordinates := DeriveAPICoordinates(libraryCoordinates, version, javaAPI)
 		if apiCoordinates.Proto.ArtifactID != "" && shouldGenerateProto(javaAPI) {
@@ -176,29 +173,16 @@ func isDefaultPreserved(path string) bool {
 	return itTestRegexp.MatchString(path) || versionRegexp.MatchString(path)
 }
 
-// isManualFile checks if the file at the given path is manually maintained.
-func isManualFile(path string, name string) (bool, error) {
-	if slices.Contains(generatedNonJavaFiles, name) {
-		return false, nil
-	}
-	if filepath.Ext(path) != ".java" {
-		return true, nil
-	}
-	hasGenMarker, err := hasMarker(path)
-	if err != nil {
-		return false, err
-	}
-	return !hasGenMarker, nil
-}
-
 // shouldCleanMarkerPath returns true if the file at path should be cleaned based on
 // its name or whether it contains the auto-generated marker.
 func shouldCleanMarkerPath(path string, d os.DirEntry) (bool, error) {
-	isManual, err := isManualFile(path, d.Name())
-	if err != nil {
-		return false, err
+	if slices.Contains(generatedNonJavaFiles, d.Name()) {
+		return true, nil
 	}
-	return !isManual, nil
+	if filepath.Ext(path) != ".java" {
+		return false, nil
+	}
+	return hasMarker(path)
 }
 
 // hasMarker checks if the file at path contains the auto-generated marker.

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -89,10 +89,7 @@ func Fill(library *config.Library) (*config.Library, error) {
 // Tidy tidies the Java-specific configuration for a library by removing default
 // values.
 func Tidy(library *config.Library) (*config.Library, error) {
-	if _, err := Fill(library); err != nil {
-		return nil, err
-	}
-	library.Keep = tidyKeep(library)
+	library.Keep = tidyKeep(library.Keep)
 	if library.Output == deriveOutput(library.Name) {
 		library.Output = ""
 	}
@@ -146,17 +143,14 @@ func Tidy(library *config.Library) (*config.Library, error) {
 }
 
 // tidyKeep removes default files from the library's keep configuration.
-func tidyKeep(library *config.Library) []string {
-	if len(library.Keep) == 0 {
+func tidyKeep(keep []string) []string {
+	if len(keep) == 0 {
 		return nil
 	}
 	var filteredKeepPaths []string
-	for _, keepPath := range library.Keep {
+	for _, keepPath := range keep {
 		keepPathSlash := filepath.ToSlash(keepPath)
 		if isDefaultPreserved(keepPathSlash) {
-			continue
-		}
-		if isInGAPICModule(library, keepPath) {
 			continue
 		}
 		filteredKeepPaths = append(filteredKeepPaths, keepPath)
@@ -167,20 +161,6 @@ func tidyKeep(library *config.Library) []string {
 		return nil
 	}
 	return filteredKeepPaths
-}
-
-// isInGAPICModule checks if the given keepPath belongs to a generated GAPIC module of the library.
-func isInGAPICModule(library *config.Library, keepPath string) bool {
-	keepPathSlash := filepath.ToSlash(keepPath)
-	for pattern, isGAPIC := range cleanPatterns(library) {
-		if isGAPIC {
-			moduleName, _, _ := strings.Cut(filepath.ToSlash(pattern), "/")
-			if strings.HasPrefix(keepPathSlash, moduleName+"/") {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 var (

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -446,6 +446,9 @@ func TestTidy(t *testing.T) {
 					},
 				},
 				Keep: []string{
+					"google-cloud-vision/src/main/resources/META-INF/native-image/reflect-config.json",
+					"google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java",
+					"google-cloud-vision/src/test/resources/placeholder.txt",
 					"proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ImageName.java",
 				},
 			},
@@ -644,25 +647,15 @@ func TestTidyKeep(t *testing.T) {
 				"proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ImageName.java",
 			},
 			want: []string{
+				"google-cloud-vision/src/main/resources/META-INF/native-image/reflect-config.json",
+				"google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java",
+				"google-cloud-vision/src/test/resources/placeholder.txt",
 				"proto-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ImageName.java",
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			lib := &config.Library{
-				Name: "vision",
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/vision/v1",
-					},
-				},
-				Java: &config.JavaModule{
-					GroupID:    "com.google.cloud",
-					ArtifactID: "google-cloud-vision",
-				},
-				Keep: test.keep,
-			}
-			got := tidyKeep(lib)
+			got := tidyKeep(test.keep)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Reverts googleapis/librarian#6291 due to regression in which tidy removes too many files, many of which are necessary.

Fixes https://github.com/googleapis/librarian/issues/6510