### PR TITLE
fix(internal/librarian/nodejs): correct product doc link in readme template

### DIFF
--- a/internal/librarian/nodejs/template/_README.md.txt
+++ b/internal/librarian/nodejs/template/_README.md.txt
@@ -18,7 +18,7 @@ A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
 * [{{.Name}} API Nodejs Client API Reference]({{.ClientDoc}})
-* [{{.Name}} API Documentation]({{.ProductDoc}}/overview)
+* [{{.Name}} API Documentation]({{.ProductDoc}})
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].

--- a/internal/librarian/nodejs/testdata/generate_readme/with_partials/google-cloud-secretmanager/README.md
+++ b/internal/librarian/nodejs/testdata/generate_readme/with_partials/google-cloud-secretmanager/README.md
@@ -21,7 +21,7 @@ A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
 * [Secret Manager API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/secret-manager/latest)
-* [Secret Manager API Documentation](https://cloud.google.com/secret-manager/docs/overview)
+* [Secret Manager API Documentation](https://cloud.google.com/secret-manager/docs)
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].

--- a/internal/librarian/nodejs/testdata/generate_readme/without_partials/google-cloud-secretmanager/README.md
+++ b/internal/librarian/nodejs/testdata/generate_readme/without_partials/google-cloud-secretmanager/README.md
@@ -17,7 +17,7 @@ A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
 * [Secret Manager API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/secret-manager/latest)
-* [Secret Manager API Documentation](https://cloud.google.com/secret-manager/docs/overview)
+* [Secret Manager API Documentation](https://cloud.google.com/secret-manager/docs)
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].


### PR DESCRIPTION
The product documentation link in the README template is corrected by removing the redundant trailing "/overview" path suffix.

For #6442