### PR TITLE
feat(internal/librarian/nodejs): generate README in Node library

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -34,7 +34,6 @@ import (
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sources"
-	"github.com/googleapis/librarian/internal/yaml"
 )
 
 const (
@@ -309,8 +308,12 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 			return fmt.Errorf("librarian.js failed: %w", err)
 		}
 	}
-	if err := generateReadme(ctx, outDir); err != nil {
-		return err
+	// TODO(https://github.com/googleapis/librarian/issues/6442): remove this if block
+	// once all readme are generated in google-cloud-node.
+	if !slices.Contains(library.Keep, "README.md") {
+		if err := generateReadme(cfg, library, googleapisDir, outDir); err != nil {
+			return fmt.Errorf("failed to generate README.md: %w", err)
+		}
 	}
 	if err := removeRedundantLinterFiles(library, outDir); err != nil {
 		return fmt.Errorf("failed to remove redundant linter files: %w", err)
@@ -366,38 +369,6 @@ func movePackageFromStaging(ctx context.Context, library *config.Library, repoRo
 	}
 	if err := os.RemoveAll(stagingDir); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to remove package staging: %w", err)
-	}
-	return nil
-}
-
-// generateReadme generates the README.md file in the package root, replacing
-// any introduction and body specified in .readme-partials.yaml.
-func generateReadme(ctx context.Context, outDir string) error {
-	readmePartials := filepath.Join(outDir, ".readme-partials.yaml")
-	if _, err := os.Stat(readmePartials); err == nil {
-		type partials struct {
-			Introduction string `yaml:"introduction"`
-			Body         string `yaml:"body"`
-		}
-		p, err := yaml.Read[partials](readmePartials)
-		if err != nil {
-			return fmt.Errorf("failed to parse %s: %w", readmePartials, err)
-		}
-		for name, replacement := range map[string]string{
-			"introduction": p.Introduction,
-			"body":         p.Body,
-		} {
-			if replacement == "" {
-				continue
-			}
-			if err := command.RunInDir(ctx, outDir, "npx", "gapic-node-processing", "generate-readme",
-				fmt.Sprintf("--source-path=%s", outDir),
-				fmt.Sprintf("--string-to-replace=[//]: # \"partials.%s\"", name),
-				fmt.Sprintf("--replacement-string=%s", replacement),
-			); err != nil {
-				return fmt.Errorf("generate-readme (%s) failed: %w", name, err)
-			}
-		}
 	}
 	return nil
 }

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -626,7 +626,7 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 	library := &config.Library{
 		Name: "google-cloud-secretmanager",
 		APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
-		Keep: []string{"librarian.js", ".readme-partials.yaml", "README.md"},
+		Keep: []string{"librarian.js", ".readme-partials.yaml"},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
@@ -653,22 +653,14 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(protoContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-
 	librarianJS := filepath.Join(outDir, "librarian.js")
 	if err := os.WriteFile(librarianJS, []byte("const fs = require('fs');\nfs.writeFileSync('librarian-ran.txt', 'yes');\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-
-	readmePath := filepath.Join(outDir, "README.md")
-	if err := os.WriteFile(readmePath, []byte("Some Title\n[//]: # \"partials.introduction\"\n[//]: # \"partials.body\"\nFooter"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
 	readmePartials := filepath.Join(outDir, ".readme-partials.yaml")
 	if err := os.WriteFile(readmePartials, []byte("introduction: 'intro text'\nbody: 'body text'"), 0644); err != nil {
 		t.Fatal(err)
 	}
-
 	cfg := &config.Config{
 		Language: config.LanguageNodejs,
 		Repo:     "googleapis/google-cloud-node",
@@ -684,11 +676,10 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repoRoot, "owl-bot-staging")); err != nil {
 		t.Error("expected top-level owl-bot-staging directory to remain intact")
 	}
-
 	if _, err := os.Stat(filepath.Join(repoRoot, "librarian-ran.txt")); err != nil {
 		t.Errorf("expected librarian.js to run and create librarian-ran.txt in repoRoot: %v", err)
 	}
-
+	readmePath := filepath.Join(outDir, "README.md")
 	content, err := os.ReadFile(readmePath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/librarian/nodejs/readme.go
+++ b/internal/librarian/nodejs/readme.go
@@ -55,7 +55,7 @@ type sampleMetadata struct {
 	FilePath string
 }
 
-func generateReadmeNew(cfg *config.Config, library *config.Library, googleapisDir, output string) (err error) {
+func generateReadme(cfg *config.Config, library *config.Library, googleapisDir, output string) (err error) {
 	metadata, err := generateRepoMetadata(cfg, library, googleapisDir)
 	if err != nil {
 		return err

--- a/internal/librarian/nodejs/readme_test.go
+++ b/internal/librarian/nodejs/readme_test.go
@@ -80,7 +80,7 @@ func TestGenerateReadme(t *testing.T) {
 			if test.setup != nil {
 				test.setup(output)
 			}
-			if err := generateReadmeNew(cfg, library, absGoogleapisDir, output); err != nil {
+			if err := generateReadme(cfg, library, absGoogleapisDir, output); err != nil {
 				t.Fatal(err)
 			}
 			got, err := os.ReadFile(filepath.Join(output, "README.md"))
@@ -160,7 +160,7 @@ func TestGenerateReadme_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outputDir := test.output(t)
-			err := generateReadmeNew(cfg, test.library, test.googleapisDir, outputDir)
+			err := generateReadme(cfg, test.library, test.googleapisDir, outputDir)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("expected error %v, got %v", test.wantErr, err)
 			}


### PR DESCRIPTION
The new pure Go-based README generator is fully integrated into the Node.js post processing generation pipeline, completely replacing the old external script-based generator.

The generator now creates the package `README.md` from the embedded Go text template during the post-processing phase, unless the `README.md` is explicitly listed in the library's keep configuration to preserve hand-written versions.

This feature will not bring changes to `README.md` in google-cloud-node since `README.md` is in the default keep list. We will gradually rollout this feature after the partial migration is done.

For https://github.com/googleapis/librarian/issues/6442