### PR TITLE
chore(internal/librarian/nodejs): remove symlink workarounds for issue 6313

### DIFF
--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -41,12 +41,8 @@ func TestInstall(t *testing.T) {
 	genDir := filepath.Join(cache,
 		repo+"@"+tool.Version,
 		gapicGeneratorSubdir)
-	// TODO(https://github.com/googleapis/librarian/issues/6313):
-	// this can be just "templates", "protos" once the workaround in
-	// librarian.yaml is removed.
 	for _, sub := range []string{
-		"templates/cjs/typescript_gapic",
-		"templates/esm/typescript_gapic",
+		"templates",
 		"protos",
 	} {
 		if err := os.MkdirAll(filepath.Join(genDir, sub), 0o755); err != nil {

--- a/internal/librarian/nodejs/librarian.yaml
+++ b/internal/librarian/nodejs/librarian.yaml
@@ -27,12 +27,6 @@ tools:
         # tsc only compiles TypeScript; the generator also needs templates/
         # and protos/ in build/ (resolved via __dirname at runtime).
         - "./node_modules/.bin/tsc"
-        # Recreate the symlinks that are in the tarball, as fetch doesn't handle them
-        # at the moment.
-        # TODO(https://github.com/googleapis/librarian/issues/6313):
-        # remove this workaround when the issue is fixed.
-        - "ln -sf package.json templates/cjs/typescript_gapic/package.json.njk"
-        - "ln -sf package.json templates/esm/typescript_gapic/package.json.njk"
         - "cp -a templates protos build/"
         # Pass the full directory name into "pnpm add" so that the generator
         # is registered with the name "gapic-generator-typescript" rather than


### PR DESCRIPTION
The temporary build-step workarounds and associated TODO comments for the symlink extraction issue are removed from the Node.js installer tool configuration and its unit tests.

Since native symlink extraction is now supported by the fetch package, the manual symlink creation steps in the generator build configuration are no longer necessary, and the test mock setup is simplified.

Fixes https://github.com/googleapis/librarian/issues/6313