### PR TITLE
fix(sidekick/swift): UrlSafe requires custom serialization

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -133,7 +133,14 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		if err != nil {
 			return err
 		}
-		if fieldCodec.Name != field.JSONName {
+		if fieldCodec.Name != field.JSONName || fieldCodec.UrlSafeValue {
+			annotations.CustomSerialization = true
+		}
+		if field.Map && !fieldCodec.IsStringKeyed() {
+			// In ProtoJSON map fields with non-string keys need to be
+			// serialized as JSON objects with key fields. In the generated
+			// Swift code, that requires a custom implementation of the
+			// `Decodable` and `Encodable` protocol.
 			annotations.CustomSerialization = true
 		}
 		if fieldCodec.PackageName != "" && fieldCodec.PackageName != c.Model.PackageName {
@@ -142,13 +149,6 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 				return err
 			}
 			annotations.DependsOn[dep.Name] = dep
-		}
-		if field.Map && !fieldCodec.IsStringKeyed() {
-			// In ProtoJSON map fields with non-string keys need to be
-			// serialized as JSON objects with key fields. In the generated
-			// Swift code, that requires a custom implementation of the
-			// `Decodable` and `Encodable` protocol.
-			annotations.CustomSerialization = true
 		}
 	}
 

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -145,6 +145,133 @@ func TestAnnotateMessage(t *testing.T) {
 	}
 }
 
+func TestAnnotateMessage_Discovery(t *testing.T) {
+	mapMessage := &api.Message{
+		Name:  "map<string, bytes>",
+		ID:    "$map<string, bytes>",
+		IsMap: true,
+		Fields: []*api.Field{
+			{Name: "key", JSONName: "key", Typez: api.TypezString},
+			{Name: "value", JSONName: "value", Typez: api.TypezBytes},
+		},
+	}
+
+	for _, test := range []struct {
+		name    string
+		message *api.Message
+		want    *messageAnnotations
+	}{
+		{
+			name: "simple",
+			message: &api.Message{
+				Name:    "Secret",
+				ID:      ".test.Secret",
+				Package: "test",
+				Fields: []*api.Field{
+					{Name: "field", JSONName: "field", ID: ".test.Secret.field", Typez: api.TypezString},
+				},
+			},
+			want: &messageAnnotations{
+				Name:                "Secret",
+				TypeURL:             "type.googleapis.com/test.Secret",
+				CustomSerialization: false,
+				SampleField:         "field",
+			},
+		},
+		{
+			name: "required",
+			message: &api.Message{
+				Name:    "Secret",
+				ID:      ".test.Secret",
+				Package: "test",
+				Fields: []*api.Field{
+					{Name: "field", JSONName: "field", ID: ".test.Secret.field", Typez: api.TypezBytes},
+				},
+			},
+			want: &messageAnnotations{
+				Name:                "Secret",
+				TypeURL:             "type.googleapis.com/test.Secret",
+				CustomSerialization: true,
+				SampleField:         "field",
+			},
+		},
+		{
+			name: "optional",
+			message: &api.Message{
+				Name:    "Secret",
+				ID:      ".test.Secret",
+				Package: "test",
+				Fields: []*api.Field{
+					{Name: "field", JSONName: "field", ID: ".test.Secret.field", Typez: api.TypezBytes, Optional: true},
+				},
+			},
+			want: &messageAnnotations{
+				Name:                "Secret",
+				TypeURL:             "type.googleapis.com/test.Secret",
+				CustomSerialization: true,
+				SampleField:         "field",
+			},
+		},
+		{
+			name: "repeated",
+			message: &api.Message{
+				Name:    "Secret",
+				ID:      ".test.Secret",
+				Package: "test",
+				Fields: []*api.Field{
+					{Name: "field", JSONName: "field", ID: ".test.Secret.field", Typez: api.TypezBytes, Repeated: true},
+				},
+			},
+			want: &messageAnnotations{
+				Name:                "Secret",
+				TypeURL:             "type.googleapis.com/test.Secret",
+				CustomSerialization: true,
+				SampleField:         "field",
+			},
+		},
+		{
+			name: "map",
+			message: &api.Message{
+				Name:    "Secret",
+				ID:      ".test.Secret",
+				Package: "test",
+				Fields: []*api.Field{
+					{
+						Name:     "field",
+						JSONName: "field",
+						ID:       ".test.Secret.field",
+						Typez:    api.TypezMessage,
+						TypezID:  mapMessage.ID,
+						Map:      true,
+					},
+				},
+			},
+			want: &messageAnnotations{
+				Name:                "Secret",
+				TypeURL:             "type.googleapis.com/test.Secret",
+				CustomSerialization: true,
+				SampleField:         "field",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, f := range test.message.Fields {
+				f.Parent = test.message
+			}
+			model := api.NewTestAPI([]*api.Message{test.message}, []*api.Enum{}, []*api.Service{})
+			model.AddMessage(mapMessage)
+			codec := newTestCodec(t, model, map[string]string{})
+			codec.UrlSafeForBytes = true
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
+				t.Errorf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAnnotateMessage_Pagination(t *testing.T) {
 	pageSizeField := &api.Field{Name: "page_size", JSONName: "pageSize", Typez: api.TypezInt32}
 	pageTokenField := &api.Field{Name: "page_token", JSONName: "pageToken", Typez: api.TypezString}


### PR DESCRIPTION
Sidekick needs to generate a custom `encode()` and a custom initializer for messages when any field is url-safe encoded.

Fixes #5748 