### PR TITLE
fix(internal/librarian/nodejs): preserve non-empty api-level configs

### DIFF
--- a/internal/librarian/nodejs/tidy.go
+++ b/internal/librarian/nodejs/tidy.go
@@ -21,15 +21,25 @@ import (
 
 // Tidy tidies configuration for a library.
 func Tidy(lib *config.Library) (*config.Library, error) {
-	if lib.Nodejs == nil {
-		return lib, nil
+	for _, api := range lib.APIs {
+		if api.Nodejs != nil {
+			empty, err := yaml.Empty(api.Nodejs)
+			if err != nil {
+				return nil, err
+			}
+			if empty {
+				api.Nodejs = nil
+			}
+		}
 	}
-	empty, err := yaml.Empty(lib.Nodejs)
-	if err != nil {
-		return nil, err
-	}
-	if empty {
-		lib.Nodejs = nil
+	if lib.Nodejs != nil {
+		empty, err := yaml.Empty(lib.Nodejs)
+		if err != nil {
+			return nil, err
+		}
+		if empty {
+			lib.Nodejs = nil
+		}
 	}
 	return lib, nil
 }


### PR DESCRIPTION
When normalizing library configurations with librarian tidy, explicit nodejs configurations declared on individual APIs are omitted.

This modifies nodejs normalization to iterate over all APIs in a library and preserve non-empty api-level nodejs blocks