### PR TITLE
feat(sidekick/swift): handle clashing names

### DIFF
--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -89,6 +89,21 @@ type codec struct {
 	// If true, bytes need to be serialized and deserialized using the URL-safe
 	// base64 alphabet.
 	UrlSafeForBytes bool
+
+	// Tracks generated files, considering case-insensitive filesystems.
+	//
+	// The generated file names are based on message, enum, and service names.
+	// When using case-insensitive filesystems (such as APFS on macOS, or NTFS
+	// on Windows) this can result in filename clashes when two messages differ
+	// only in case, such as `HTTPCheckName` vs. `HttpCheckName`.
+	//
+	// Furthermore, Swift requires all the files in a package to have different
+	// names, even if they are in different subdirectories.
+	//
+	// The codec uses this map to disambiguate names, the number of clashes for
+	// each (lowercased) name are tracked in this hash, and if necessary, the
+	// output file is disambiguated by prepending `${Counter}` to the name.
+	GeneratedFiles map[string]int
 }
 
 func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPackage, outdir string) (*codec, error) {

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -102,7 +102,7 @@ type codec struct {
 	//
 	// The codec uses this map to disambiguate names, the number of clashes for
 	// each (lowercased) name are tracked in this hash, and if necessary, the
-	// output file is disambiguated by prepending `${Counter}` to the name.
+	// output file is disambiguated by appending `+${Counter}` to the name.
 	GeneratedFiles map[string]int
 }
 

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -102,7 +102,7 @@ type codec struct {
 	//
 	// The codec uses this map to disambiguate names, the number of clashes for
 	// each (lowercased) name are tracked in this hash, and if necessary, the
-	// output file is disambiguated by appending `+${Counter}` to the name.
+	// output file is disambiguated by appending `+${Counter}` to the basename.
 	GeneratedFiles map[string]int
 }
 

--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -20,6 +20,7 @@ import (
 	"embed"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
@@ -72,22 +73,36 @@ func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.Mo
 	return language.GenerateFromModel(outdir, model, provider, generatedFiles)
 }
 
-func (c *codec) outputPath(elem ...string) string {
-	if c.Module {
-		return filepath.Join(elem...)
+func (c *codec) swiftFilename(basename string) string {
+	name := basename + ".swift"
+	key := strings.ToLower(basename)
+	if c.GeneratedFiles == nil {
+		c.GeneratedFiles = map[string]int{key: 0}
+	} else {
+		count, ok := c.GeneratedFiles[key]
+		if !ok {
+			c.GeneratedFiles[key] = 0
+		} else {
+			c.GeneratedFiles[key] = count + 1
+			// This can only deal with 1000 conflicts on the same name. If we
+			// ever have more, we need to have a serious discussion with the
+			// API team that produced that many conflicts.
+			name = fmt.Sprintf("%s+%03d.swift", basename, count)
+		}
+
 	}
-	full := make([]string, 0, len(elem)+2)
-	full = append(full, "Sources", c.PackageName)
-	full = append(full, elem...)
-	return filepath.Join(full...)
+	if c.Module {
+		return name
+	}
+	return filepath.Join("Sources", c.PackageName, name)
 }
 
 func (c *codec) generateMessages(outdir string, model *api.API, provider language.TemplateProvider) error {
 	for _, m := range model.Messages {
-		output := c.outputPath(m.Name + ".swift")
+		output := c.swiftFilename(m.Name)
 		template := "templates/common/message_file.swift.mustache"
 		if m.ServicePlaceholder {
-			output = c.outputPath(m.Name + "+Requests.swift")
+			output = c.swiftFilename(m.Name + "+Requests")
 			template = "templates/common/placeholder_file.swift.mustache"
 		}
 		generated := language.GeneratedFile{
@@ -105,7 +120,7 @@ func (c *codec) generateEnums(outdir string, model *api.API, provider language.T
 	for _, e := range model.Enums {
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/common/enum_file.swift.mustache",
-			OutputPath:   c.outputPath(e.Name + ".swift"),
+			OutputPath:   c.swiftFilename(e.Name),
 		}
 		if err := language.GenerateEnum(outdir, e, provider, generated); err != nil {
 			return err
@@ -118,7 +133,7 @@ func (c *codec) generateServices(outdir string, model *api.API, provider languag
 	for _, s := range model.Services {
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/common/service.swift.mustache",
-			OutputPath:   c.outputPath(s.Name + ".swift"),
+			OutputPath:   c.swiftFilename(s.Name),
 		}
 		if err := language.GenerateService(outdir, s, provider, generated); err != nil {
 			return err
@@ -133,13 +148,13 @@ func (c *codec) generateStubs(outdir string, model *api.API, provider language.T
 			suffix   string
 			template string
 		}{
-			{suffix: "Stub.swift", template: "templates/common/stub.swift.mustache"},
-			{suffix: "Logging.swift", template: "templates/common/logging.swift.mustache"},
-			{suffix: "Retry.swift", template: "templates/common/retry.swift.mustache"},
+			{suffix: "+Stub", template: "templates/common/stub.swift.mustache"},
+			{suffix: "+Logging", template: "templates/common/logging.swift.mustache"},
+			{suffix: "+Retry", template: "templates/common/retry.swift.mustache"},
 		} {
 			generated := language.GeneratedFile{
 				TemplatePath: stub.template,
-				OutputPath:   c.outputPath("Clients", s.Name+stub.suffix),
+				OutputPath:   c.swiftFilename(s.Name + stub.suffix),
 			}
 			if err := language.GenerateService(outdir, s, provider, generated); err != nil {
 				return err
@@ -180,7 +195,7 @@ func (c *codec) generateClients(outdir string, model *api.API, provider language
 	}
 	generated := language.GeneratedFile{
 		TemplatePath: "templates/common/clients.swift.mustache",
-		OutputPath:   c.outputPath("Clients.swift"),
+		OutputPath:   c.swiftFilename("Clients"),
 	}
 	return language.GenerateFromModel(outdir, model, provider, []language.GeneratedFile{generated})
 }

--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -166,6 +166,21 @@ func (c *codec) generateStubs(outdir string, model *api.API, provider language.T
 
 func (c *codec) generateSnippets(outdir string, model *api.API, provider language.TemplateProvider) error {
 	for _, s := range model.Services {
+		// If two services differ only in case (such as `fooService` and
+		// `FooService`), then this might generate clashing filenames in
+		// filesystems that are case insensitive.
+		//
+		// This seems unlikely: the services are always in a flat namespace, and
+		// they always use consistent naming conventions. We have only found
+		// clashes between messages and services or between messages, not
+		// between two services.
+		//
+		// Furthermore, fixing the problem would require changing the generated
+		// code, as the name of the snippet file is referenced in the generated
+		// comments. The effort to fix that does not seem worthwhile given how
+		// unlikely is the problem.
+		//
+		// If I (coryan@) am wrong, we can fix the generator at that time.
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/common/client_snippet.swift.mustache",
 			OutputPath:   filepath.Join("Snippets", s.Name+"Quickstart.swift"),

--- a/internal/sidekick/swift/generate_enum_swift_test.go
+++ b/internal/sidekick/swift/generate_enum_swift_test.go
@@ -34,7 +34,14 @@ func TestGenerateEnum_Files(t *testing.T) {
 	kind.Values = []*api.EnumValue{{Name: "KIND_UNSPECIFIED", Number: 0, Parent: kind}}
 	kind.UniqueNumberValues = kind.Values
 
-	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{color, kind}, []*api.Service{})
+	clash0 := &api.Enum{Name: "ClashName", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.ClashName"}
+	clash0.Values = []*api.EnumValue{{Name: "CLASH_UNSPECIFIED", Number: 0, Parent: clash0}}
+	clash0.UniqueNumberValues = clash0.Values
+	clash1 := &api.Enum{Name: "clashName", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.clashName"}
+	clash1.Values = []*api.EnumValue{{Name: "CLASH_UNSPECIFIED", Number: 0, Parent: clash1}}
+	clash1.UniqueNumberValues = clash1.Values
+
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{color, kind, clash0, clash1}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 
 	cfg := &parser.ModelConfig{
@@ -48,7 +55,13 @@ func TestGenerateEnum_Files(t *testing.T) {
 	}
 
 	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
-	for _, expected := range []string{"Color.swift", "Kind.swift"} {
+	want := []string{
+		"Color.swift",
+		"Kind.swift",
+		"ClashName.swift",
+		"clashName+000.swift",
+	}
+	for _, expected := range want {
 		filename := filepath.Join(expectedDir, expected)
 		if _, err := os.Stat(filename); err != nil {
 			t.Error(err)

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -44,8 +44,11 @@ func TestGenerateMessage_Files(t *testing.T) {
 
 	secret := &api.Message{Name: "Secret", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.Secret"}
 	volume := &api.Message{Name: "Volume", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.Volume"}
+	clash0 := &api.Message{Name: "HttpHealthCheck", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.HttpHealthCheck"}
+	clash1 := &api.Message{Name: "HTTPHealthCheck", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.HTTPHealthCheck"}
+	clash2 := &api.Message{Name: "httpHealthCheck", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.httpHealthCheck"}
 
-	model := api.NewTestAPI([]*api.Message{secret, volume}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{secret, volume, clash0, clash1, clash2}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 
 	cfg := &parser.ModelConfig{
@@ -59,7 +62,14 @@ func TestGenerateMessage_Files(t *testing.T) {
 	}
 
 	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
-	for _, expected := range []string{"Secret.swift", "Volume.swift"} {
+	want := []string{
+		"Secret.swift",
+		"Volume.swift",
+		"HttpHealthCheck.swift",
+		"HTTPHealthCheck+000.swift",
+		"httpHealthCheck+001.swift",
+	}
+	for _, expected := range want {
 		filename := filepath.Join(expectedDir, expected)
 		if _, err := os.Stat(filename); err != nil {
 			t.Error(err)

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -31,11 +31,15 @@ import (
 func TestGenerateService_Files(t *testing.T) {
 	outDir := t.TempDir()
 
-	iam := &api.Service{Name: "IAM"}
-	secretManager := &api.Service{Name: "SecretManagerService"}
+	// We need explicit Package and ID fields because we generate both messages
+	// and services.
+	iam := &api.Service{Name: "IAM", Package: "test", ID: ".test.IAM"}
+	secretManager := &api.Service{Name: "SecretManagerService", Package: "test", ID: ".test.SecretManagerService"}
+	clash0 := &api.Message{Name: "InstanceSettings", Package: "test", ID: ".test.InstanceSettings"}
+	clash1 := &api.Service{Name: "instanceSettings", Package: "test", ID: ".test.instanceSettings"}
 
-	model := api.NewTestAPI(nil, nil, []*api.Service{iam, secretManager})
-	model.PackageName = "google.cloud.test.v1"
+	model := api.NewTestAPI([]*api.Message{clash0}, nil, []*api.Service{iam, secretManager, clash1})
+	model.PackageName = "test"
 
 	cfg := &parser.ModelConfig{
 		Codec: map[string]string{
@@ -47,14 +51,19 @@ func TestGenerateService_Files(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedDir := filepath.Join(outDir, "Sources", "GoogleCloudTestV1")
+	expectedDir := filepath.Join(outDir, "Sources", "GoogleTest")
 	wantFiles := []string{
 		"IAM.swift",
-		"SecretManagerService.swift",
 		"Clients.swift",
-		"Clients/SecretManagerServiceStub.swift",
-		"Clients/SecretManagerServiceLogging.swift",
-		"Clients/SecretManagerServiceRetry.swift",
+		"SecretManagerService.swift",
+		"SecretManagerService+Stub.swift",
+		"SecretManagerService+Logging.swift",
+		"SecretManagerService+Retry.swift",
+		"InstanceSettings.swift",
+		"instanceSettings+000.swift",
+		"instanceSettings+Stub.swift",
+		"instanceSettings+Logging.swift",
+		"instanceSettings+Retry.swift",
 	}
 	for _, expected := range wantFiles {
 		filename := filepath.Join(expectedDir, expected)
@@ -435,7 +444,7 @@ func TestGenerateService_PathParameters(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			filename := filepath.Join(outDir, "Sources", "GoogleCloudSecretmanagerV1", "Clients", "SecretManagerServiceStub.swift")
+			filename := filepath.Join(outDir, "Sources", "GoogleCloudSecretmanagerV1", "SecretManagerService+Stub.swift")
 			content, err := os.ReadFile(filename)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -76,7 +76,7 @@ func TestGenerateService_StubStructure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	filename := filepath.Join(outDir, "Sources", "GoogleCloudTestV1", "Clients", "ProtocolStub.swift")
+	filename := filepath.Join(outDir, "Sources", "GoogleCloudTestV1", "Protocol+Stub.swift")
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
@@ -190,7 +190,7 @@ func TestGenerateService_QueryParameters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	filename := filepath.Join(outDir, "Sources", "GoogleTest", "Clients", "ServiceStub.swift")
+	filename := filepath.Join(outDir, "Sources", "GoogleTest", "Service+Stub.swift")
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Filenames must be unique on case-insensitive filesystems.

Swift also requires the basename to be unique, so I removed the `Clients/` intermediate directory because it was solving the problem of filename clashes, but not Swift source clashes.

Fixes #6542 and fixes #6541 