### PR TITLE
feat(internal/librarian/java): add production sample filter

### DIFF
--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -16,7 +16,7 @@ package java
 
 import (
 	"errors"
-  "path/filepath"
+	"path/filepath"
 	"regexp"
 	"strings"
 )

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -32,9 +32,10 @@ func decamelize(value string) string {
 }
 
 // isProductionSample reports whether the given entry represents a production Java source file
-// located under a standard "/src/main/java/" path.
+// located under a standard "src/main/java" path.
 func isProductionSample(d os.DirEntry, path string) bool {
+	slashed := filepath.ToSlash(path)
 	return !d.IsDir() &&
-		strings.HasSuffix(path, ".java") &&
-		strings.Contains(filepath.ToSlash(path), "/src/main/java/")
+		strings.HasSuffix(slashed, ".java") &&
+		(strings.HasPrefix(slashed, "src/main/java/") || strings.Contains(slashed, "/src/main/java/"))
 }

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -15,6 +15,8 @@
 package java
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -27,4 +29,12 @@ var (
 // decamelize converts CamelCase string to space-separated string (e.g. "CamelCase" -> "Camel Case").
 func decamelize(value string) string {
 	return strings.TrimSpace(camelCaseRegexp.ReplaceAllString(value, `$1 $2`))
+}
+
+// isProductionSample reports whether the given entry represents a production Java source file
+// located under a standard "/src/main/java/" path.
+func isProductionSample(d os.DirEntry, path string) bool {
+	return !d.IsDir() &&
+		strings.HasSuffix(path, ".java") &&
+		strings.Contains(filepath.ToSlash(path), "/src/main/java/")
 }

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -15,7 +15,6 @@
 package java
 
 import (
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -31,11 +30,10 @@ func decamelize(value string) string {
 	return strings.TrimSpace(camelCaseRegexp.ReplaceAllString(value, `$1 $2`))
 }
 
-// isProductionSample reports whether the given entry represents a production Java source file
+// isProductionSample reports whether the given path represents a production Java source file
 // located under a standard "src/main/java" path.
-func isProductionSample(d os.DirEntry, path string) bool {
+func isProductionSample(path string) bool {
 	slashed := filepath.ToSlash(path)
-	return !d.IsDir() &&
-		strings.HasSuffix(slashed, ".java") &&
+	return strings.HasSuffix(slashed, ".java") &&
 		(strings.HasPrefix(slashed, "src/main/java/") || strings.Contains(slashed, "/src/main/java/"))
 }

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -15,7 +15,6 @@
 package java
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -62,56 +61,35 @@ func TestDecamelize(t *testing.T) {
 	}
 }
 
-// mockDirEntry is a mock implementation of os.DirEntry for testing.
-type mockDirEntry struct {
-	isDir bool
-}
-
-func (m mockDirEntry) Name() string               { return "" }
-func (m mockDirEntry) IsDir() bool                { return m.isDir }
-func (m mockDirEntry) Type() os.FileMode          { return 0 }
-func (m mockDirEntry) Info() (os.FileInfo, error) { return nil, nil }
-
 func TestIsProductionSample(t *testing.T) {
 	for _, test := range []struct {
-		name  string
-		entry mockDirEntry
-		path  string
-		want  bool
+		name string
+		path string
+		want bool
 	}{
 		{
-			name:  "valid production sample",
-			entry: mockDirEntry{isDir: false},
-			path:  "samples/src/main/java/com/example/Sample.java",
-			want:  true,
+			name: "valid production sample",
+			path: "samples/src/main/java/com/example/Sample.java",
+			want: true,
 		},
 		{
-			name:  "valid production sample at root",
-			entry: mockDirEntry{isDir: false},
-			path:  "src/main/java/com/example/Sample.java",
-			want:  true,
+			name: "valid production sample at root",
+			path: "src/main/java/com/example/Sample.java",
+			want: true,
 		},
 		{
-			name:  "directory instead of file",
-			entry: mockDirEntry{isDir: true},
-			path:  "samples/src/main/java",
-			want:  false,
+			name: "non-java file",
+			path: "samples/src/main/java/README.md",
+			want: false,
 		},
 		{
-			name:  "non-java file",
-			entry: mockDirEntry{isDir: false},
-			path:  "samples/src/main/java/README.md",
-			want:  false,
-		},
-		{
-			name:  "not in src/main/java",
-			entry: mockDirEntry{isDir: false},
-			path:  "samples/src/test/java/com/example/Sample.java",
-			want:  false,
+			name: "not in src/main/java",
+			path: "samples/src/test/java/com/example/Sample.java",
+			want: false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := isProductionSample(test.entry, test.path)
+			got := isProductionSample(test.path)
 			if got != test.want {
 				t.Errorf("isProductionSample() = %t, want %t", got, test.want)
 			}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -54,6 +55,57 @@ func TestDecamelize(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := decamelize(test.input)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// mockDirEntry is a mock implementation of os.DirEntry for testing.
+type mockDirEntry struct {
+	isDir bool
+}
+
+func (m mockDirEntry) Name() string               { return "" }
+func (m mockDirEntry) IsDir() bool                { return m.isDir }
+func (m mockDirEntry) Type() os.FileMode          { return 0 }
+func (m mockDirEntry) Info() (os.FileInfo, error) { return nil, nil }
+
+func TestIsProductionSample(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		entry mockDirEntry
+		path  string
+		want  bool
+	}{
+		{
+			name:  "valid production sample",
+			entry: mockDirEntry{isDir: false},
+			path:  "samples/src/main/java/com/example/Sample.java",
+			want:  true,
+		},
+		{
+			name:  "directory instead of file",
+			entry: mockDirEntry{isDir: true},
+			path:  "samples/src/main/java",
+			want:  false,
+		},
+		{
+			name:  "non-java file",
+			entry: mockDirEntry{isDir: false},
+			path:  "samples/src/main/java/README.md",
+			want:  false,
+		},
+		{
+			name:  "not in src/main/java",
+			entry: mockDirEntry{isDir: false},
+			path:  "samples/src/test/java/com/example/Sample.java",
+			want:  false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := isProductionSample(test.entry, test.path)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -86,6 +86,12 @@ func TestIsProductionSample(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "valid production sample at root",
+			entry: mockDirEntry{isDir: false},
+			path:  "src/main/java/com/example/Sample.java",
+			want:  true,
+		},
+		{
 			name:  "directory instead of file",
 			entry: mockDirEntry{isDir: true},
 			path:  "samples/src/main/java",
@@ -106,8 +112,8 @@ func TestIsProductionSample(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := isProductionSample(test.entry, test.path)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
+			if got != test.want {
+				t.Errorf("isProductionSample() = %t, want %t", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
Adds 'isProductionSample' helper to identify production Java source files under '/src/main/java/', with unit tests.

For #6515