### PR TITLE
feat(internal/librarian/java): add title override extractor

### DIFF
--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 )
@@ -22,9 +23,37 @@ import (
 var (
 	// Matches lowercase/digit followed by uppercase (e.g., "FooBar" -> "Foo Bar").
 	camelCaseRegexp = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+
+	// reTitle matches a "sample-metadata:" marker followed immediately by a "title:" line on the next comment line.
+	reTitle = regexp.MustCompile(`sample-metadata:\s*\n\s*(?://|#)\s*title:\s*(.*)`)
+
+	// errMissingTitle indicates the "title:" line is missing immediately following "sample-metadata:".
+	errMissingTitle = errors.New("missing title line immediately following sample-metadata")
+
+	// errEmptyTitle indicates the extracted title value is empty.
+	errEmptyTitle = errors.New("title value cannot be empty")
 )
 
 // decamelize converts CamelCase string to space-separated string (e.g. "CamelCase" -> "Camel Case").
 func decamelize(value string) string {
 	return strings.TrimSpace(camelCaseRegexp.ReplaceAllString(value, `$1 $2`))
+}
+
+// extractTitle extracts and validates the title override from Java comment blocks.
+// It expects a "title:" line to immediately follow the "sample-metadata:" marker.
+// Returns an error if the marker is present but the title line is missing, malformed, or empty.
+func extractTitle(content string) (string, error) {
+	if !strings.Contains(content, "sample-metadata:") {
+		return "", nil
+	}
+	matches := reTitle.FindStringSubmatch(content)
+	if len(matches) < 2 {
+		return "", errMissingTitle
+	}
+	// Trim surrounding whitespace, quotes, and carriage returns.
+	title := strings.Trim(matches[1], " \t\"'\r\n")
+	if title == "" {
+		return "", errEmptyTitle
+	}
+	return title, nil
 }

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -56,6 +57,88 @@ func TestDecamelize(t *testing.T) {
 			got := decamelize(test.input)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractTitle(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "success with standard comment",
+			content: `// sample-metadata:
+//   title: Standard Title`,
+			want: "Standard Title",
+		},
+		{
+			name: "success with indented comment",
+			content: `//   sample-metadata:
+//     title: Indented Title`,
+			want: "Indented Title",
+		},
+		{
+			name: "success with single quotes",
+			content: `// sample-metadata:
+//   title: 'Single Quotes Title'`,
+			want: "Single Quotes Title",
+		},
+		{
+			name: "success with double quotes",
+			content: `// sample-metadata:
+//   title: "Double Quotes Title"`,
+			want: "Double Quotes Title",
+		},
+		{
+			name:    "success with windows carriage returns",
+			content: "// sample-metadata:\r\n//   title: Windows Title\r\n",
+			want:    "Windows Title",
+		},
+		{
+			name: "no metadata block present",
+			content: `// This is a standard java file.
+public class Normal {}`,
+			want: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := extractTitle(test.content)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractTitle_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+		wantErr error
+	}{
+		{
+			name: "missing title line returns error",
+			content: `// sample-metadata:
+//   description: No title line immediately following!`,
+			wantErr: errMissingTitle,
+		},
+		{
+			name: "empty title value returns error",
+			content: `// sample-metadata:
+//   title: ""`,
+			wantErr: errEmptyTitle,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, gotErr := extractTitle(test.content)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("extractTitle() error = %v, wantErr %v", gotErr, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Adds 'extractTitle' to extract 'sample-metadata:' titles. It returns an error if the title is missing or empty.

For #6515