### PR TITLE
feat(internal/librarian/python): update gapic-generator to 1.36.0

### DIFF
--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -19,7 +19,7 @@ language: python
 tools:
   pip:
     - name: gapic-generator
-      version: "1.35.0"
+      version: "1.36.0"
     - name: nox
       version: "2025.11.12"
     - name: ruff


### PR DESCRIPTION
The version of gapic-generator in the embedded librarian.yaml (used by librarian install) is updated to v1.36.0. This adds Python 3.15 pre-release testing to generated libraries to prepare for the [Python 3.15 release in October](https://peps.python.org/pep-0790/#schedule).