### PR TITLE
chore(internal/librarian/nodejs): add helper function to generate `index.ts`

### DIFF
--- a/internal/librarian/nodejs/index.go
+++ b/internal/librarian/nodejs/index.go
@@ -50,7 +50,7 @@ func findVersion(output string) ([]versionAndClient, error) {
 			return nil, err
 		}
 		matches := clientExportRegex.FindAllStringSubmatch(string(content), -1)
-		if len(matches) == 0 {
+		if len(matches) != 1 {
 			return nil, errClientNotFound
 		}
 		versions = append(versions, versionAndClient{

--- a/internal/librarian/nodejs/index.go
+++ b/internal/librarian/nodejs/index.go
@@ -49,13 +49,13 @@ func findVersion(output string) ([]versionAndClient, error) {
 		if err != nil {
 			return nil, err
 		}
-		matches := clientExportRegex.FindAllStringSubmatch(string(content), -1)
+		matches := clientExportRegex.FindAllSubmatch(content, -1)
 		if len(matches) != 1 {
 			return nil, errClientNotFound
 		}
 		versions = append(versions, versionAndClient{
 			Version: e.Name(),
-			Client:  matches[0][1],
+			Client:  string(matches[0][1]),
 		})
 	}
 	return versions, nil

--- a/internal/librarian/nodejs/index.go
+++ b/internal/librarian/nodejs/index.go
@@ -32,7 +32,7 @@ type versionAndClient struct {
 	Client  string
 }
 
-func findVersion(output string) ([]versionAndClient, error) {
+func findVersionAndClient(output string) ([]versionAndClient, error) {
 	output = filepath.Clean(output)
 	srcDir := filepath.Join(output, "src")
 	entries, err := os.ReadDir(srcDir)

--- a/internal/librarian/nodejs/index.go
+++ b/internal/librarian/nodejs/index.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	versionRegex      = regexp.MustCompile(`^(v\d+(_\d+)*)`)
-	clientExportRegex = regexp.MustCompile(`export\s*\{\s*([A-Za-z0-9_]+)\s*\}\s*from\s*['"][^'"]+['"]`)
+	clientExportRegex = regexp.MustCompile(`export\s*\{\s*([A-Za-z0-9_]+Client)\s*\}\s*from\s*['"][^'"]+['"]`)
 	errNoClientFound  = errors.New("do not find client export in index")
 )
 
@@ -49,13 +49,13 @@ func findVersion(output string) ([]versionAndClient, error) {
 		if err != nil {
 			return nil, err
 		}
-		matches := clientExportRegex.FindStringSubmatch(string(content))
-		if len(matches) != 1 {
+		matches := clientExportRegex.FindAllStringSubmatch(string(content), -1)
+		if len(matches) == 0 {
 			return nil, errNoClientFound
 		}
 		versions = append(versions, versionAndClient{
 			Version: e.Name(),
-			Client:  matches[1],
+			Client:  matches[0][1],
 		})
 	}
 	return versions, nil

--- a/internal/librarian/nodejs/index.go
+++ b/internal/librarian/nodejs/index.go
@@ -32,6 +32,8 @@ type versionAndClient struct {
 	Client  string
 }
 
+// findVersionAndClient scans the package source directory to discover API versions
+// and their corresponding exported service client names.
 func findVersionAndClient(output string) ([]versionAndClient, error) {
 	output = filepath.Clean(output)
 	srcDir := filepath.Join(output, "src")

--- a/internal/librarian/nodejs/index.go
+++ b/internal/librarian/nodejs/index.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var (
+	versionRegex      = regexp.MustCompile(`^(v\d+(_\d+)*)`)
+	clientExportRegex = regexp.MustCompile(`export\s*\{\s*([A-Za-z0-9_]+)\s*\}\s*from\s*['"][^'"]+['"]`)
+	errNoClientFound  = errors.New("do not find client export in index")
+)
+
+type versionAndClient struct {
+	Version string
+	Client  string
+}
+
+func findVersion(output string) ([]versionAndClient, error) {
+	output = filepath.Clean(output)
+	srcDir := filepath.Join(output, "src")
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return nil, err
+	}
+	var versions []versionAndClient
+	for _, e := range entries {
+		if !e.IsDir() || !versionRegex.MatchString(e.Name()) {
+			continue
+		}
+		versionIndex := filepath.Join(srcDir, e.Name(), "index.ts")
+		content, err := os.ReadFile(versionIndex)
+		if err != nil {
+			return nil, err
+		}
+		matches := clientExportRegex.FindStringSubmatch(string(content))
+		if len(matches) != 1 {
+			return nil, errNoClientFound
+		}
+		versions = append(versions, versionAndClient{
+			Version: e.Name(),
+			Client:  matches[1],
+		})
+	}
+	return versions, nil
+}

--- a/internal/librarian/nodejs/index.go
+++ b/internal/librarian/nodejs/index.go
@@ -24,7 +24,7 @@ import (
 var (
 	versionRegex      = regexp.MustCompile(`^(v\d+(_\d+)*)`)
 	clientExportRegex = regexp.MustCompile(`export\s*\{\s*([A-Za-z0-9_]+Client)\s*\}\s*from\s*['"][^'"]+['"]`)
-	errNoClientFound  = errors.New("do not find client export in index")
+	errClientNotFound = errors.New("client not found in index.ts")
 )
 
 type versionAndClient struct {
@@ -51,7 +51,7 @@ func findVersion(output string) ([]versionAndClient, error) {
 		}
 		matches := clientExportRegex.FindAllStringSubmatch(string(content), -1)
 		if len(matches) == 0 {
-			return nil, errNoClientFound
+			return nil, errClientNotFound
 		}
 		versions = append(versions, versionAndClient{
 			Version: e.Name(),

--- a/internal/librarian/nodejs/index_test.go
+++ b/internal/librarian/nodejs/index_test.go
@@ -15,6 +15,7 @@
 package nodejs
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,6 +99,44 @@ func TestFindVersion(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(versionAndClient{})); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindVersion_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		setup   func(t *testing.T, dir string)
+		wantErr error
+	}{
+		{
+			name: "missing src dir",
+			setup: func(t *testing.T, dir string) {
+				// Do nothing
+			},
+			wantErr: os.ErrNotExist,
+		},
+		{
+			name: "missing client export in index.ts",
+			setup: func(t *testing.T, dir string) {
+				v1Dir := filepath.Join(dir, "src", "v1")
+				if err := os.MkdirAll(v1Dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(v1Dir, "index.ts"), []byte("export const foo = 'bar';"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: errNoClientFound,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			test.setup(t, tmpDir)
+			_, err := findVersion(tmpDir)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("findVersion() error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/nodejs/index_test.go
+++ b/internal/librarian/nodejs/index_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestFindVersion(t *testing.T) {
+func TestFindVersionAndClient(t *testing.T) {
 	for _, test := range []struct {
 		name  string
 		setup func(t *testing.T, dir string)
@@ -93,7 +93,7 @@ func TestFindVersion(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			test.setup(t, tmpDir)
-			got, err := findVersion(tmpDir)
+			got, err := findVersionAndClient(tmpDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -104,7 +104,7 @@ func TestFindVersion(t *testing.T) {
 	}
 }
 
-func TestFindVersion_Error(t *testing.T) {
+func TestFindVersionAndClient_Error(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		setup   func(t *testing.T, dir string)
@@ -134,9 +134,9 @@ func TestFindVersion_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			test.setup(t, tmpDir)
-			_, err := findVersion(tmpDir)
+			_, err := findVersionAndClient(tmpDir)
 			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("findVersion() error = %v, wantErr %v", err, test.wantErr)
+				t.Fatalf("findVersionAndClient() error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/nodejs/index_test.go
+++ b/internal/librarian/nodejs/index_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFindVersion(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+		want  []versionAndClient
+	}{
+		{
+			name: "valid single version",
+			setup: func(t *testing.T, dir string) {
+				v1Dir := filepath.Join(dir, "src", "v1")
+				if err := os.MkdirAll(v1Dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				content := "export { AppConnectionsServiceClient } from './app_connections_service_client';\n"
+				if err := os.WriteFile(filepath.Join(v1Dir, "index.ts"), []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []versionAndClient{
+				{Version: "v1", Client: "AppConnectionsServiceClient"},
+			},
+		},
+		{
+			name: "valid multiple versions",
+			setup: func(t *testing.T, dir string) {
+				v1Dir := filepath.Join(dir, "src", "v1")
+				v1beta1Dir := filepath.Join(dir, "src", "v1beta1")
+				for _, d := range []string{v1Dir, v1beta1Dir} {
+					if err := os.MkdirAll(d, 0755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := os.WriteFile(filepath.Join(v1Dir, "index.ts"), []byte("export { ClientV1Client } from './client';"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(v1beta1Dir, "index.ts"), []byte("export { ClientV1Beta1Client } from './client';"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []versionAndClient{
+				{Version: "v1", Client: "ClientV1Client"},
+				{Version: "v1beta1", Client: "ClientV1Beta1Client"},
+			},
+		},
+		{
+			name: "ignores non-version dirs",
+			setup: func(t *testing.T, dir string) {
+				v1Dir := filepath.Join(dir, "src", "v1")
+				helpersDir := filepath.Join(dir, "src", "helpers")
+				if err := os.MkdirAll(v1Dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(helpersDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(v1Dir, "index.ts"), []byte("export { ClientV1Client } from './client';"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(helpersDir, "index.ts"), []byte("export { Helper } from './helper';"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []versionAndClient{
+				{Version: "v1", Client: "ClientV1Client"},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			test.setup(t, tmpDir)
+			got, err := findVersion(tmpDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(versionAndClient{})); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/nodejs/index_test.go
+++ b/internal/librarian/nodejs/index_test.go
@@ -128,7 +128,7 @@ func TestFindVersion_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantErr: errNoClientFound,
+			wantErr: errClientNotFound,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Add helper function to find version and client in `src/{api version}/index.ts`.

For #6514