### PR TITLE
chore(internal/serviceconfig): rename api-allowlist-schema to sdk-yaml-schema

### DIFF
--- a/doc/sdk-yaml-schema.md
+++ b/doc/sdk-yaml-schema.md
@@ -1,6 +1,6 @@
-# API Allowlist Schema
+# API Schema
 
-This document describes the schema for the API Allowlist.
+This document describes the schema for the API configuration.
 
 ## API Configuration
 

--- a/doc/sdk-yaml-schema.md
+++ b/doc/sdk-yaml-schema.md
@@ -1,6 +1,6 @@
-# API Schema
+# API Allowlist Schema
 
-This document describes the schema for the API configuration.
+This document describes the schema for the API Allowlist.
 
 ## API Configuration
 

--- a/doc/sdk-yaml-schema.md
+++ b/doc/sdk-yaml-schema.md
@@ -1,6 +1,6 @@
-# API Allowlist Schema
+# SDK YAML Schema
 
-This document describes the schema for the API Allowlist.
+This document describes the schema for the SDK YAML.
 
 ## API Configuration
 

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags configdocgen ../../cmd/config_doc_generate.go -input . -output ../../doc/api-allowlist-schema.md -root API -root-title API -title "API Allowlist"
+//go:generate go run -tags configdocgen ../../cmd/config_doc_generate.go -input . -output ../../doc/sdk-yaml-schema.md -root API -root-title API -title "API Allowlist"
 
 package serviceconfig
 

--- a/internal/serviceconfig/api.go
+++ b/internal/serviceconfig/api.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run -tags configdocgen ../../cmd/config_doc_generate.go -input . -output ../../doc/sdk-yaml-schema.md -root API -root-title API -title "API Allowlist"
+//go:generate go run -tags configdocgen ../../cmd/config_doc_generate.go -input . -output ../../doc/sdk-yaml-schema.md -root API -root-title API -title "SDK YAML"
 
 package serviceconfig
 


### PR DESCRIPTION
Rename `doc/api-allowlist-schema.md` to `doc/sdk-yaml-schema.md`.

Fixes https://github.com/googleapis/librarian/issues/6540