### PR TITLE
ci: add contents: read permission to create-issue-on-failure jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       issues: write
     needs: [legacylibrarian, test]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -50,6 +50,7 @@ jobs:
   create-issue-on-failure:
     needs: [integration]
     permissions:
+      contents: read
       issues: write
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/create-issue-on-failure.yaml

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -121,6 +121,7 @@ jobs:
   create-issue-on-failure:
     needs: [integration]
     permissions:
+      contents: read
       issues: write
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/create-issue-on-failure.yaml

--- a/.github/workflows/sidekick.yaml
+++ b/.github/workflows/sidekick.yaml
@@ -66,6 +66,7 @@ jobs:
   create-issue-on-failure:
     needs: [test, integration]
     permissions:
+      contents: read
       issues: write
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/create-issue-on-failure.yaml

--- a/.github/workflows/sidekick.yaml
+++ b/.github/workflows/sidekick.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Display Go version
         run: go version
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable as of 2026-06-26
       - name: Display Cargo version
         run: cargo version
       - name: Display rustc version
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable as of 2026-06-26
       - uses: ./.github/actions/install-taplo
       - name: Checkout google-cloud-rust
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
Fixes https://github.com/googleapis/librarian/issues/6555

Also, the Git SHA for `dtolnay/rust-toolchain@stable` was incorrect. It's 29eef336d9b2848a0b548edc03f92a220660cdb8 for its stable branch as of today. (The wrong value was for its "v1" tag, We were specifying the stable branch before https://github.com/googleapis/librarian/pull/6544)
