### PR TITLE
refactor(internal/fetch): rename helper functions in fetch.go

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -287,13 +287,13 @@ func tarballLink(githubDownload string, repo *RepoRef, sha string) string {
 }
 
 // Download downloads a file from the given url to the target path, verifying
-// its SHA256 checksum matches expectedSha256. It retries up to
+// its SHA256 checksum matches expectedSHA256. It retries up to
 // maxDownloadRetries times with exponential backoff on failure.
-func Download(ctx context.Context, target, url, expectedSha256 string) error {
+func Download(ctx context.Context, target, url, expectedSHA256 string) error {
 	if fileExists(target) {
 		return nil
 	}
-	if expectedSha256 == "" {
+	if expectedSHA256 == "" {
 		return errMissingSHA256
 	}
 	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
@@ -319,8 +319,8 @@ func Download(ctx context.Context, target, url, expectedSha256 string) error {
 	if err != nil {
 		return err
 	}
-	if sha != expectedSha256 {
-		return fmt.Errorf("%w: expected=%s, got=%s", errChecksumMismatch, expectedSha256, sha)
+	if sha != expectedSHA256 {
+		return fmt.Errorf("%w: expected=%s, got=%s", errChecksumMismatch, expectedSHA256, sha)
 	}
 	return os.Rename(tempPath, target)
 }

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -392,11 +392,9 @@ func fileExists(name string) bool {
 	return stat.Mode().IsRegular()
 }
 
+// stripTopLevelDir removes the top-level directory prefix (such as "{repo}-{commit}/")
+// that GitHub automatically adds to repository archive entries.
 func stripTopLevelDir(name string) (string, bool) {
-	// When GitHub creates a tarball archive of a repository, it wraps all
-	// the files in a top-level directory named in the format
-	// "{repo}-{commit}/". Remove the GitHub top-level "repo-<commit>/"
-	// prefix.
 	parts := strings.SplitN(name, "/", 2)
 	if len(parts) == 2 {
 		return parts[1], true

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -128,7 +128,7 @@ func Repo(ctx context.Context, repo, commit, expectedSHA256 string) (string, err
 				if err := os.MkdirAll(outDir, 0755); err != nil {
 					return "", fmt.Errorf("failed creating %q: %w", outDir, err)
 				}
-				if err := ExtractTarball(tgz, outDir, filter); err == nil {
+				if err := ExtractTarball(tgz, outDir, stripTopLevelDir); err == nil {
 					return outDir, nil
 				}
 			}
@@ -149,7 +149,7 @@ func Repo(ctx context.Context, repo, commit, expectedSHA256 string) (string, err
 	if err := Download(ctx, tgz, sourceURL, expectedSHA256); err != nil {
 		return "", err
 	}
-	if err := ExtractTarball(tgz, outDir, filter); err != nil {
+	if err := ExtractTarball(tgz, outDir, stripTopLevelDir); err != nil {
 		return "", fmt.Errorf("failed to extract tarball: %w", err)
 	}
 	return outDir, nil
@@ -392,7 +392,7 @@ func fileExists(name string) bool {
 	return stat.Mode().IsRegular()
 }
 
-func filter(name string) (string, bool) {
+func stripTopLevelDir(name string) (string, bool) {
 	// When GitHub creates a tarball archive of a repository, it wraps all
 	// the files in a top-level directory named in the format
 	// "{repo}-{commit}/". Remove the GitHub top-level "repo-<commit>/"

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -128,7 +128,7 @@ func Repo(ctx context.Context, repo, commit, expectedSHA256 string) (string, err
 				if err := os.MkdirAll(outDir, 0755); err != nil {
 					return "", fmt.Errorf("failed creating %q: %w", outDir, err)
 				}
-				if err := extractTarball(tgz, outDir); err == nil {
+				if err := ExtractTarball(tgz, outDir, filter); err == nil {
 					return outDir, nil
 				}
 			}
@@ -146,10 +146,10 @@ func Repo(ctx context.Context, repo, commit, expectedSHA256 string) (string, err
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		return "", fmt.Errorf("failed creating %q: %w", outDir, err)
 	}
-	if err := download(ctx, tgz, sourceURL, expectedSHA256); err != nil {
+	if err := Download(ctx, tgz, sourceURL, expectedSHA256); err != nil {
 		return "", err
 	}
-	if err := extractTarball(tgz, outDir); err != nil {
+	if err := ExtractTarball(tgz, outDir, filter); err != nil {
 		return "", fmt.Errorf("failed to extract tarball: %w", err)
 	}
 	return outDir, nil
@@ -286,10 +286,10 @@ func tarballLink(githubDownload string, repo *RepoRef, sha string) string {
 	return fmt.Sprintf("%s/%s/%s/archive/%s.tar.gz", githubDownload, repo.Org, repo.Name, sha)
 }
 
-// download downloads a file from the given url to the target path, verifying
+// Download downloads a file from the given url to the target path, verifying
 // its SHA256 checksum matches expectedSha256. It retries up to
 // maxDownloadRetries times with exponential backoff on failure.
-func download(ctx context.Context, target, url, expectedSha256 string) error {
+func Download(ctx context.Context, target, url, expectedSha256 string) error {
 	if fileExists(target) {
 		return nil
 	}
@@ -392,9 +392,20 @@ func fileExists(name string) bool {
 	return stat.Mode().IsRegular()
 }
 
-// extractTarball extracts a gzipped tarball to the specified directory,
-// stripping the top-level directory prefix that GitHub adds to tarballs.
-func extractTarball(tarballPath, destDir string) error {
+func filter(name string) (string, bool) {
+	// When GitHub creates a tarball archive of a repository, it wraps all
+	// the files in a top-level directory named in the format
+	// "{repo}-{commit}/". Remove the GitHub top-level "repo-<commit>/"
+	// prefix.
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) == 2 {
+		return parts[1], true
+	}
+	return "", false
+}
+
+// ExtractTarball extracts a gzipped tarball to the specified directory.
+func ExtractTarball(tarballPath, destDir string, filter func(string) (string, bool)) error {
 	f, err := os.Open(tarballPath)
 	if err != nil {
 		return err
@@ -417,18 +428,10 @@ func extractTarball(tarballPath, destDir string) error {
 			return err
 		}
 
-		// When GitHub creates a tarball archive of a repository, it wraps all
-		// the files in a top-level directory named in the format
-		// "{repo}-{commit}/". Remove the GitHub top-level "repo-<commit>/"
-		// prefix.
-		name := hdr.Name
-		parts := strings.SplitN(name, "/", 2)
-		if len(parts) == 2 {
-			name = parts[1]
-		} else {
+		name, ok := filter(hdr.Name)
+		if !ok {
 			continue
 		}
-
 		target := filepath.Join(destDir, name)
 		switch hdr.Typeflag {
 		case tar.TypeDir:

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -404,6 +404,9 @@ func stripTopLevelDir(name string) (string, bool) {
 
 // ExtractTarball extracts a gzipped tarball to the specified directory.
 func ExtractTarball(tarballPath, destDir string, filter func(string) (string, bool)) error {
+	if filter == nil {
+		filter = func(name string) (string, bool) { return name, true }
+	}
 	f, err := os.Open(tarballPath)
 	if err != nil {
 		return err

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -446,7 +446,7 @@ func TestDownload_TgzExists(t *testing.T) {
 	if err := os.WriteFile(target, tarball.Contents, 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := download(t.Context(), target, "https://unused/placeholder.tar.gz", tarball.Sha256); err != nil {
+	if err := Download(t.Context(), target, "https://unused/placeholder.tar.gz", tarball.Sha256); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -464,7 +464,7 @@ func TestDownload_NeedsDownload(t *testing.T) {
 	defer server.Close()
 
 	expected := path.Join(testDir, "new-file")
-	if err := download(t.Context(), expected, server.URL+"/placeholder.tar.gz", tarball.Sha256); err != nil {
+	if err := Download(t.Context(), expected, server.URL+"/placeholder.tar.gz", tarball.Sha256); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(expected)
@@ -488,7 +488,7 @@ func TestDownload_ChecksumMismatch(t *testing.T) {
 	target := path.Join(testDir, "target-file")
 	wrongSha := "0000000000000000000000000000000000000000000000000000000000000000"
 
-	err := download(t.Context(), target, server.URL+"/test.tar.gz", wrongSha)
+	err := Download(t.Context(), target, server.URL+"/test.tar.gz", wrongSha)
 	if !errors.Is(err, errChecksumMismatch) {
 		t.Fatalf("expected errChecksumMismatch, got: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestDownload_ContextCanceled(t *testing.T) {
 		cancel()
 	}()
 
-	err := download(ctx, target, server.URL+"/test.tar.gz", "any-sha")
+	err := Download(ctx, target, server.URL+"/test.tar.gz", "any-sha")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got: %v", err)
 	}
@@ -557,7 +557,7 @@ func TestExtractTarball(t *testing.T) {
 	}
 
 	destDir := t.TempDir()
-	if err := extractTarball(tarballPath, destDir); err != nil {
+	if err := ExtractTarball(tarballPath, destDir, filter); err != nil {
 		t.Fatal(err)
 	}
 
@@ -760,7 +760,7 @@ func TestExtractTarball_Error(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := extractTarball(test.tarballPath(t), test.dest(t))
+			err := ExtractTarball(test.tarballPath(t), test.dest(t), filter)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("got error %v, want %v", err, test.wantErr)
 			}
@@ -803,7 +803,7 @@ func TestExtractTarball_PathError(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := extractTarball(test.tarballPath(t), test.dest(t))
+			err := ExtractTarball(test.tarballPath(t), test.dest(t), filter)
 			var pathErr *fs.PathError
 			if !errors.As(err, &pathErr) {
 				t.Fatalf("got error %v, want *fs.PathError", err)
@@ -834,7 +834,8 @@ func TestDownload_Error(t *testing.T) {
 			},
 			sha:     "any-sha",
 			wantErr: true,
-		}, {
+		},
+		{
 			name: "cannot create parent directory",
 			target: func(t *testing.T) string {
 				// Create a read-only directory to trigger a permission error.
@@ -860,9 +861,9 @@ func TestDownload_Error(t *testing.T) {
 			t.Cleanup(func() {
 				defaultBackoff = 10 * time.Second
 			})
-			err := download(context.Background(), test.target(t), test.url(t), test.sha)
+			err := Download(context.Background(), test.target(t), test.url(t), test.sha)
 			if (err != nil) != test.wantErr {
-				t.Errorf("download() error = %v, wantErr %v", err, test.wantErr)
+				t.Errorf("Download() error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}
@@ -870,7 +871,7 @@ func TestDownload_Error(t *testing.T) {
 
 func TestDownload_EmptySha(t *testing.T) {
 	target := path.Join(t.TempDir(), "target")
-	err := download(t.Context(), target, "https://any-url", "")
+	err := Download(t.Context(), target, "https://any-url", "")
 	if !errors.Is(err, errMissingSHA256) {
 		t.Errorf("expected errMissingSHA256, got: %v", err)
 	}
@@ -980,7 +981,7 @@ func TestDownload_RetryErrorIncludesLastFailure(t *testing.T) {
 	defer server.Close()
 
 	target := path.Join(t.TempDir(), "target-file")
-	err := download(t.Context(), target, server.URL+"/test.tar.gz", "any-sha")
+	err := Download(t.Context(), target, server.URL+"/test.tar.gz", "any-sha")
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -1011,7 +1012,7 @@ func TestDownload_RetrySucceeds(t *testing.T) {
 	defer server.Close()
 
 	target := path.Join(t.TempDir(), "target-file")
-	if err := download(t.Context(), target, server.URL+"/test.tar.gz", tarball.Sha256); err != nil {
+	if err := Download(t.Context(), target, server.URL+"/test.tar.gz", tarball.Sha256); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1114,7 +1115,7 @@ func TestExtractTarball_Symlink(t *testing.T) {
 	}
 
 	destDir := t.TempDir()
-	if err := extractTarball(tarballPath, destDir); err != nil {
+	if err := ExtractTarball(tarballPath, destDir, filter); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -557,7 +557,7 @@ func TestExtractTarball(t *testing.T) {
 	}
 
 	destDir := t.TempDir()
-	if err := ExtractTarball(tarballPath, destDir, filter); err != nil {
+	if err := ExtractTarball(tarballPath, destDir, stripTopLevelDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -760,7 +760,7 @@ func TestExtractTarball_Error(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := ExtractTarball(test.tarballPath(t), test.dest(t), filter)
+			err := ExtractTarball(test.tarballPath(t), test.dest(t), stripTopLevelDir)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("got error %v, want %v", err, test.wantErr)
 			}
@@ -803,7 +803,7 @@ func TestExtractTarball_PathError(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := ExtractTarball(test.tarballPath(t), test.dest(t), filter)
+			err := ExtractTarball(test.tarballPath(t), test.dest(t), stripTopLevelDir)
 			var pathErr *fs.PathError
 			if !errors.As(err, &pathErr) {
 				t.Fatalf("got error %v, want *fs.PathError", err)
@@ -1115,7 +1115,7 @@ func TestExtractTarball_Symlink(t *testing.T) {
 	}
 
 	destDir := t.TempDir()
-	if err := ExtractTarball(tarballPath, destDir, filter); err != nil {
+	if err := ExtractTarball(tarballPath, destDir, stripTopLevelDir); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Export functions in `fetch` package and create `filter` function when extracting tarball.

Preparations to implement `protoc` installation.

For #6558