### PR TITLE
feat(internal/librarian/java): add sample directory walker and extractor

### DIFF
--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -16,6 +16,9 @@ package java
 
 import (
 	"errors"
+	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -35,6 +38,82 @@ var (
 	errEmptyTitle = errors.New("title value cannot be empty")
 )
 
+// CodeSample represents a Java code sample and its metadata for README generation.
+type CodeSample struct {
+	Title string
+	File  string
+}
+
+func ExtractSamples(dir string) ([]CodeSample, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("dir cannot be empty")
+	}
+	files, err := collectSampleFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+	var samples []CodeSample
+	for _, file := range files {
+		sample, err := parseCodeSample(dir, file)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, sample)
+	}
+	return samples, nil
+}
+
+// collectSampleFiles recursively traverses dir/samples to find production Java sample files.
+func collectSampleFiles(dir string) ([]string, error) {
+	samplesDir := filepath.Join(dir, "samples")
+	var files []string
+	err := filepath.WalkDir(samplesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		// Skip directories and non-regular files.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		// Get relative path of file and filter for only Java files in src/main/java/ production trees.
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if isProductionSample(rel) {
+			files = append(files, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk samples directory: %w", err)
+	}
+	return files, nil
+}
+
+// parseCodeSample reads a Java sample file and constructs a CodeSample struct with its title and relative path.
+func parseCodeSample(dir, file string) (CodeSample, error) {
+	// Derive default human-readable title by stripping extension and converting CamelCase to space-separated words.
+	base := strings.TrimSuffix(filepath.Base(file), ".java")
+	title := decamelize(base)
+	titleOverride, err := extractTitle(filepath.Join(dir, file))
+	if err != nil {
+		return CodeSample{}, fmt.Errorf("failed to extract title from %s: %w", file, err)
+	}
+	if titleOverride != "" {
+		title = titleOverride
+	}
+	return CodeSample{
+		Title: title,
+		// Normalize path separators to forward slashes for Markdown links in README.
+		File: filepath.ToSlash(file),
+	}, nil
+}
+
 // decamelize converts CamelCase string to space-separated string (e.g. "CamelCase" -> "Camel Case").
 func decamelize(value string) string {
 	return strings.TrimSpace(camelCaseRegexp.ReplaceAllString(value, `$1 $2`))
@@ -48,10 +127,15 @@ func isProductionSample(path string) bool {
 		(strings.HasPrefix(slashed, "src/main/java/") || strings.Contains(slashed, "/src/main/java/"))
 }
 
-// extractTitle extracts and validates the title override from Java comment blocks.
+// extractTitle reads a file to extract and validate any title override from Java comment blocks.
 // It expects a "title:" line to immediately follow the "sample-metadata:" marker.
 // Returns an error if the marker is present but the title line is missing, malformed, or empty.
-func extractTitle(content string) (string, error) {
+func extractTitle(filePath string) (string, error) {
+	contentBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read sample file: %w", err)
+	}
+	content := string(contentBytes)
 	if !strings.Contains(content, "sample-metadata:") {
 		return "", nil
 	}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -16,6 +16,9 @@ package java
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -91,8 +94,8 @@ func TestIsProductionSample(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := isProductionSample(test.path)
-			if got != test.want {
-				t.Errorf("isProductionSample() = %t, want %t", got, test.want)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -141,7 +144,11 @@ public class Normal {}`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := extractTitle(test.content)
+			tmpPath := filepath.Join(t.TempDir(), "Sample.java")
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := extractTitle(tmpPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -172,9 +179,133 @@ func TestExtractTitle_Error(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, gotErr := extractTitle(test.content)
+			tmpPath := filepath.Join(t.TempDir(), "Sample.java")
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			_, gotErr := extractTitle(tmpPath)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("extractTitle() error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractSamples(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		setupFiles func(t *testing.T, dir string)
+		want       []CodeSample
+	}{
+		{
+			name: "missing samples directory",
+			setupFiles: func(t *testing.T, dir string) {
+				// Do nothing, tempDir is empty.
+			},
+			want: nil,
+		},
+		{
+			name: "extract successfully",
+			setupFiles: func(t *testing.T, dir string) {
+				samplesDir := filepath.Join(dir, "samples", "src", "main", "java")
+				if err := os.MkdirAll(samplesDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				file1 := filepath.Join(samplesDir, "RequesterPays.java")
+				content1 := `// sample-metadata:
+//   title: Custom Title Override
+public class RequesterPays {}`
+				if err := os.WriteFile(file1, []byte(content1), 0644); err != nil {
+					t.Fatal(err)
+				}
+				file2 := filepath.Join(samplesDir, "DemoSample.java")
+				content2 := `public class DemoSample {}`
+				if err := os.WriteFile(file2, []byte(content2), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []CodeSample{
+				{
+					Title: "Demo Sample",
+					File:  "samples/src/main/java/DemoSample.java",
+				},
+				{
+					Title: "Custom Title Override",
+					File:  "samples/src/main/java/RequesterPays.java",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			test.setupFiles(t, tempDir)
+
+			samples, err := ExtractSamples(tempDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, samples); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractSamples_Error(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		emptyDir  bool
+		content   string
+		wantErr   error
+		errString string
+	}{
+		{
+			name:      "error on empty directory",
+			emptyDir:  true,
+			errString: "dir cannot be empty",
+		},
+		{
+			name: "error on empty title override",
+			content: `// sample-metadata:
+//   title: ""
+public class Invalid {}`,
+			wantErr: errEmptyTitle,
+		},
+		{
+			name: "error on capitalized Title",
+			content: `// sample-metadata:
+//   Title: Capitalized Title
+public class Invalid {}`,
+			wantErr: errMissingTitle,
+		},
+		{
+			name: "error on missing title line immediately following sample-metadata",
+			content: `// sample-metadata:
+//   description: missing title line
+public class Invalid {}`,
+			wantErr: errMissingTitle,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.emptyDir {
+				_, err := ExtractSamples("")
+				if err == nil || !strings.Contains(err.Error(), test.errString) {
+					t.Errorf("ExtractSamples(\"\") err = %v, want substring %q", err, test.errString)
+				}
+				return
+			}
+			tempDir := t.TempDir()
+			samplesDir := filepath.Join(tempDir, "samples", "src", "main", "java")
+			if err := os.MkdirAll(samplesDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			file := filepath.Join(samplesDir, "Sample.java")
+			if err := os.WriteFile(file, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := ExtractSamples(tempDir)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("ExtractSamples() err = %v, want %v", err, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Adds `CodeSample` struct, directory walker (`collectSampleFiles`), and comment parser (`parseCodeSample`, `ExtractSamples`) to locate and extract Java code samples for README generation.

### Testing & Verification
- Unit tests added: `TestExtractSamples` and `TestExtractSamples_Error`.
- Ran `go test -short ./internal/librarian/java/...` — passed.