### PR TITLE
feat(sidekick/swift): swap client vs. protocol

### DIFF
--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -143,7 +143,7 @@ func TestAnnotateMessage(t *testing.T) {
 				TypeURL:             "type.googleapis.com/test.Service",
 				CustomSerialization: false,
 				SampleField:         "<placeholder>",
-				ParameterTypeName:   "Clients.ServiceClient",
+				ParameterTypeName:   "ServiceClient",
 				PlaceholderName:     "ServiceClient",
 			},
 			wantImports: []string{"GoogleCloudWkt"},
@@ -315,7 +315,7 @@ func TestAnnotateMessage_DiscoveryRequests(t *testing.T) {
 				Name:              "GetRequest",
 				TypeURL:           "type.googleapis.com/test.Service.getRequest",
 				SampleField:       "<placeholder>",
-				ParameterTypeName: "Clients.ServiceClient.GetRequest",
+				ParameterTypeName: "ServiceClient.GetRequest",
 			},
 		},
 		{
@@ -326,7 +326,7 @@ func TestAnnotateMessage_DiscoveryRequests(t *testing.T) {
 				Name:              "ListRequest",
 				TypeURL:           "type.googleapis.com/test.Protocol.listRequest",
 				SampleField:       "<placeholder>",
-				ParameterTypeName: "Clients.ProtocolClient.ListRequest",
+				ParameterTypeName: "ProtocolClient.ListRequest",
 			},
 		},
 	} {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -147,7 +147,7 @@ func scalarFieldTypeName(field *api.Field) (string, error) {
 func (c *codec) messageTypeName(m *api.Message) (string, error) {
 	name := pascalCase(m.Name)
 	if m.ServicePlaceholder {
-		name = "Clients." + pascalCase(m.Name+"Client")
+		name = pascalCase(m.Name + "Client")
 	}
 	if m.Parent == nil {
 		prefix, err := c.externalTypePrefix(m.Package)

--- a/internal/sidekick/swift/generate_pagination_swift_test.go
+++ b/internal/sidekick/swift/generate_pagination_swift_test.go
@@ -155,18 +155,18 @@ func verifyGeneratedMapService(t *testing.T, outDir string) {
 	contentStr := string(content)
 
 	gotMethodOverload := extractBlock(t, contentStr, `  public func listSecrets(
-    byItem: `, "\n    }")
+    byItem: `, "\n  }")
 	wantMethodOverload := `  public func listSecrets(
     byItem: ListSecretsRequest, options: GoogleCloudGax.RequestOptions
 ) throws -> any AsyncSequence<(Swift.String, Secret), Swift.Error>
  {
-      let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
-        var request = byItem
-        request.pageToken = token
-        return try await self.listSecrets(request: request, options: options)
-      }
-      return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
-    }`
+    let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
+      var request = byItem
+      request.pageToken = token
+      return try await self.listSecrets(request: request, options: options)
+    }
+    return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
+  }`
 	if diff := cmp.Diff(wantMethodOverload, gotMethodOverload); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -100,9 +100,8 @@ func TestGenerateServiceSwift_SnippetReference(t *testing.T) {
 	}
 	contentStr := string(content)
 
-	gotBlock := extractBlock(t, contentStr, "/// @Snippet", "public protocol Protocol_ {")
-	wantBlock := `/// @Snippet(path: "ProtocolQuickstart")
-public protocol Protocol_ {`
+	gotBlock := extractBlock(t, contentStr, "public protocol ", "{")
+	wantBlock := `public protocol ProtocolProtocol {`
 	if diff := cmp.Diff(wantBlock, gotBlock); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -173,8 +172,8 @@ func TestGenerateService_Delegation(t *testing.T) {
 	contentStr := string(content)
 
 	for _, want := range []string{
-		"let inner: any IAMStub",
-		"var inner: any IAMStub = try IAMTransport(options)",
+		"let inner: any Clients.IAMStub",
+		"var inner: any Clients.IAMStub = try Clients.IAMTransport(options)",
 		"try await self.inner.createRole(request: request, options: options)",
 	} {
 		if !strings.Contains(contentStr, want) {
@@ -579,18 +578,18 @@ func verifyGeneratedService(t *testing.T, outDir string) {
 	contentStr := string(content)
 
 	gotMethodOverload := extractBlock(t, contentStr, `  public func listSecrets(
-    byItem: ListSecretsRequest, options: `, "\n    }")
+    byItem: ListSecretsRequest, options: `, "\n  }")
 	wantMethodOverload := `  public func listSecrets(
     byItem: ListSecretsRequest, options: GoogleCloudGax.RequestOptions
 ) throws -> any AsyncSequence<Secret, Swift.Error>
  {
-      let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
-        var request = byItem
-        request.pageToken = token
-        return try await self.listSecrets(request: request, options: options)
-      }
-      return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
-    }`
+    let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
+      var request = byItem
+      request.pageToken = token
+      return try await self.listSecrets(request: request, options: options)
+    }
+    return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
+  }`
 	if diff := cmp.Diff(wantMethodOverload, gotMethodOverload); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -956,7 +955,7 @@ func TestGenerateDiscoveryService_Files(t *testing.T) {
 			}
 
 			// Verify it contains an extension to the right Clients.$ServiceName type.
-			wantExtension := fmt.Appendf(nil, "extension Clients.%sClient {", test.serviceName)
+			wantExtension := fmt.Appendf(nil, "extension %sClient {", test.serviceName)
 			if !bytes.Contains(content, wantExtension) {
 				t.Errorf("expected extension %q in %s, got:\n%s", wantExtension, filename, content)
 			}

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -954,7 +954,7 @@ func TestGenerateDiscoveryService_Files(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Verify it contains an extension to the right Clients.$ServiceName type.
+			// Verify it contains an extension to the right ${ServiceName}Client type.
 			wantExtension := fmt.Appendf(nil, "extension %sClient {", test.serviceName)
 			if !bytes.Contains(content, wantExtension) {
 				t.Errorf("expected extension %q in %s, got:\n%s", wantExtension, filename, content)

--- a/internal/sidekick/swift/templates/common/client_protocol.mustache
+++ b/internal/sidekick/swift/templates/common/client_protocol.mustache
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 extension Clients {
-  /// A Swift protocol to mock `{{Service.Codec.ClientName}}`.
+  /// A Swift protocol to mock `{{Codec.ClientName}}`.
   ///
-  /// To mock `{{Service.Codec.ClientName}}` change your functions to receive
+  /// To mock `{{Codec.ClientName}}` change your functions to receive
   /// `some {{Codec.StubPrefix}}Protocol` or `any {{Codec.StubPrefix}}Protocol`
   /// and pass a mock implementation in your tests.
   public protocol {{Codec.StubPrefix}}Protocol {

--- a/internal/sidekick/swift/templates/common/client_protocol.mustache
+++ b/internal/sidekick/swift/templates/common/client_protocol.mustache
@@ -1,0 +1,143 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+extension Clients {
+  /// A Swift protocol to mock `{{Service.Codec.ClientName}}`.
+  ///
+  /// To mock `{{Service.Codec.ClientName}}` change your functions to receive
+  /// `some {{Codec.StubPrefix}}Protocol` or `any {{Codec.StubPrefix}}Protocol`
+  /// and pass a mock implementation in your tests.
+  public protocol {{Codec.StubPrefix}}Protocol {
+    {{#Codec.RestMethods}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/request}}
+    {{#Codec.PlainRPC}}
+    {{#Signatures}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/overload}}
+    {{/Signatures}}
+    {{/Codec.PlainRPC}}
+    {{#Codec.Pagination}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/pagination}}
+    {{#Signatures}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/pagination_overload}}
+    {{/Signatures}}
+    {{/Codec.Pagination}}
+    {{#Codec.LRO}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/lro}}
+    {{#Signatures}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/lro_overload}}
+    {{/Signatures}}
+    {{/Codec.LRO}}
+    {{/Codec.RestMethods}}
+
+    {{#Codec.RestMethods}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/request_options}}
+    {{#Codec.Pagination}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/pagination_options}}
+    {{/Codec.Pagination}}
+    {{#Codec.LRO}}
+    /// See `{{Service.Codec.ClientName}}.{{Codec.Name}}`.
+    func {{> /templates/common/method_signature/lro_options}}
+    {{/Codec.LRO}}
+    {{/Codec.RestMethods}}
+  }
+}
+
+// Default implementations
+extension Clients.{{Codec.StubPrefix}}Protocol {
+  {{#Codec.RestMethods}}
+
+  public func {{> /templates/common/method_signature/request}} {
+    try await self.{{Codec.Name}}(request: request, options: .init())
+  }
+
+  public func {{> /templates/common/method_signature/request_options}} {
+    throw GoogleCloudGax.RequestError.unimplemented
+  }
+  {{#Codec.PlainRPC}}
+  {{#Signatures}}
+
+  public func {{> /templates/common/method_signature/overload}} {
+    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
+      {{#Fields}}
+      $0.{{Codec.Name}} = {{Codec.Name}}
+      {{/Fields}}
+    }
+    {{#Method.ReturnsEmpty}}
+    try await self.{{Method.Codec.Name}}(request: request)
+    {{/Method.ReturnsEmpty}}
+    {{^Method.ReturnsEmpty}}
+    return try await self.{{Method.Codec.Name}}(request: request)
+    {{/Method.ReturnsEmpty}}
+  }
+  {{/Signatures}}
+  {{/Codec.PlainRPC}}
+  {{#Codec.Pagination}}
+
+  public func {{> /templates/common/method_signature/pagination}} {
+    try self.{{Codec.Name}}(byItem: byItem, options: .init())
+  }
+
+  public func {{> /templates/common/method_signature/pagination_options}} {
+    let listRpc = { (token: String) async throws -> {{Codec.ReturnType}} in
+      throw GoogleCloudGax.RequestError.unimplemented
+    }
+    return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
+  }
+  {{#Signatures}}
+
+  public func {{> /templates/common/method_signature/pagination_overload}} {
+    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
+      {{#Fields}}
+      $0.{{Codec.Name}} = {{Codec.Name}}
+      {{/Fields}}
+    }
+    return try self.{{Codec.Name}}(byItem: request)
+  }
+  {{/Signatures}}
+  {{/Codec.Pagination}}
+  {{#Codec.LRO}}
+
+  public func {{> /templates/common/method_signature/lro}} {
+    try await self.{{Codec.Name}}(withPolling: withPolling, options: .init())
+  }
+
+  public func {{> /templates/common/method_signature/lro_options}} {
+    let poll = { () async throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
+      throw GoogleCloudGax.RequestError.unimplemented
+    }
+    return GoogleCloudGax._PollableOperationImpl(initialState: .init(done: false, result: nil), poll: poll)
+  }
+  {{#Signatures}}
+
+  public func {{> /templates/common/method_signature/lro_overload}} {
+    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
+      {{#Fields}}
+      $0.{{Codec.Name}} = {{Codec.Name}}
+      {{/Fields}}
+    }
+    return try await self.{{Codec.Name}}(withPolling: request)
+  }
+  {{/Signatures}}
+  {{/Codec.LRO}}
+  {{/Codec.RestMethods}}
+}

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -32,7 +32,7 @@ import {{.}}
 {{/Codec.SnippetImports}}
 
 func sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: String, {{/Codec.Parameters}}{{/Codec.QuickstartMethod.SampleInfo}}) async throws {
-  let client = try {{Codec.PackageName}}.Clients.{{Codec.ClientName}}()
+  let client = try {{Codec.PackageName}}.{{Codec.ClientName}}()
   {{#Codec.QuickstartMethod}}
   {{> /templates/snippet/generic}}
   {{/Codec.QuickstartMethod}}

--- a/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
@@ -31,7 +31,7 @@ import {{Service.Codec.PackageName}}
 import {{.}}
 {{/Service.Codec.SnippetImports}}
 
-func sample(client: some {{Service.Codec.Name}}{{#SampleInfo}}{{#Codec.Parameters}}, {{.}}: String{{/Codec.Parameters}}{{/SampleInfo}}) async throws {
+func sample(client: {{Service.Codec.ClientName}}{{#SampleInfo}}{{#Codec.Parameters}}, {{.}}: String{{/Codec.Parameters}}{{/SampleInfo}}) async throws {
   {{> /templates/snippet/generic}}
 }
 // snippet.hide
@@ -40,7 +40,7 @@ func sample(client: some {{Service.Codec.Name}}{{#SampleInfo}}{{#Codec.Parameter
 struct SnippetRunner {
     static func main() async throws {
         do {
-            let client = try {{Service.Codec.PackageName}}.Clients.{{Service.Codec.ClientName}}()
+            let client = try {{Service.Codec.PackageName}}.{{Service.Codec.ClientName}}()
             try await sample(client: client{{#SampleInfo}}{{#Codec.Parameters}}, {{.}}: "[placeholder]"{{/Codec.Parameters}}{{/SampleInfo}})
         } catch {
             print("Error: \(error)")

--- a/internal/sidekick/swift/templates/common/placeholder.mustache
+++ b/internal/sidekick/swift/templates/common/placeholder.mustache
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-extension Clients.{{Codec.PlaceholderName}} {
+extension {{Codec.PlaceholderName}} {
   {{#Messages}}
 
   {{> /templates/common/message}}

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -38,234 +38,97 @@ import {{.}}
 {{/Codec.DocLines}}
 ///
 /// @Snippet(path: "{{Name}}Quickstart")
-public protocol {{Codec.Name}} {
+public class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol {
+  let inner: any Clients.{{Codec.StubPrefix}}Stub
+
+  /// Creates a new `{{Codec.ClientName}}` instance.
+  public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {
+    var inner: any Clients.{{Codec.StubPrefix}}Stub = try Clients.{{Codec.StubPrefix}}Transport(options)
+    inner = Clients.{{Codec.StubPrefix}}Retry(inner, options: options)
+    if let logger = options.logger {
+      inner = Clients.{{Codec.StubPrefix}}Logging(inner, logger: logger)
+    }
+    self.inner = inner
+  }
   {{#Codec.RestMethods}}
+
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
   ///
   /// @Snippet(path: "{{Service.Name}}_{{Name}}")
-  func {{> /templates/common/method_signature/request}}
-  {{#Codec.PlainRPC}}
-  {{#Signatures}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  func {{> /templates/common/method_signature/overload}}
-  {{/Signatures}}
-  {{/Codec.PlainRPC}}
-  {{#Codec.Pagination}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  func {{> /templates/common/method_signature/pagination}}
-  {{#Signatures}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  func {{> /templates/common/method_signature/pagination_overload}}
-  {{/Signatures}}
-  {{/Codec.Pagination}}
-  {{#Codec.LRO}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  func {{> /templates/common/method_signature/lro}}
-  {{#Signatures}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  func {{> /templates/common/method_signature/lro_overload}}
-  {{/Signatures}}
-  {{/Codec.LRO}}
-  {{/Codec.RestMethods}}
-
-  {{#Codec.RestMethods}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  ///
-  /// @Snippet(path: "{{Service.Name}}_{{Name}}")
-  func {{> /templates/common/method_signature/request_options}}
-  {{#Codec.Pagination}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  func {{> /templates/common/method_signature/pagination_options}}
-  {{/Codec.Pagination}}
-  {{#Codec.LRO}}
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  func {{> /templates/common/method_signature/lro_options}}
-  {{/Codec.LRO}}
-  {{/Codec.RestMethods}}
-}
-
-extension Clients {
-  /// The recommended implementation for ``{{Codec.Name}}``.
-  public class {{Codec.ClientName}}: {{Codec.Name}} {
-    let inner: any {{Codec.StubPrefix}}Stub
-
-    /// Creates a new `{{Codec.ClientName}}` instance.
-    public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {
-      var inner: any {{Codec.StubPrefix}}Stub = try {{Codec.StubPrefix}}Transport(options)
-      inner = {{Codec.StubPrefix}}Retry(inner, options: options)
-      if let logger = options.logger {
-        inner = {{Codec.StubPrefix}}Logging(inner, logger: logger)
-      }
-      self.inner = inner
-    }
-    {{#Codec.RestMethods}}
-
-    /// See `{{Service.Codec.Name}}.{{Codec.Name}}`
-    public func {{> /templates/common/method_signature/request_options}} {
-        try await self.inner.{{Codec.Name}}(request: request, options: options)
-    }
-    {{#Codec.Pagination}}
-
-    {{#Codec.DocLines}}
-    /// {{{.}}}
-    {{/Codec.DocLines}}
-    public func {{> /templates/common/method_signature/pagination_options}} {
-      let listRpc = { (token: String) async throws -> {{Codec.ReturnType}} in
-        var request = byItem
-        request.pageToken = token
-        return try await self.{{Codec.Name}}(request: request, options: options)
-      }
-      return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
-    }
-    {{/Codec.Pagination}}
-    {{#Codec.LRO}}
-
-    {{#Codec.DocLines}}
-    /// {{{.}}}
-    {{/Codec.DocLines}}
-    public func {{> /templates/common/method_signature/lro_options}} {
-      let extractStatus = { (op: {{Codec.ReturnType}}) throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
-        guard op.done else {
-          return .init(done: false, result: nil)
-        }
-
-        switch op.result {
-        {{#Codec.LRO.ResponseIsEmpty}}
-        case .response:
-          return .init(done: true, result: .success(()))
-        {{/Codec.LRO.ResponseIsEmpty}}
-        {{^Codec.LRO.ResponseIsEmpty}}
-        case .response(let anyValue):
-          guard let anyValueUnwrapped = anyValue else {
-            return .init(done: true, result: .failure(GoogleCloudGax.RequestError.binding("Operation completed but response value was missing")))
-          }
-          let response = try {{Codec.LRO.ReturnType}}(fromAny: anyValueUnwrapped)
-          return .init(done: true, result: .success(response))
-        {{/Codec.LRO.ResponseIsEmpty}}
-        case .error(let status):
-          guard let statusUnwrapped = status else {
-            return .init(done: true, result: .failure(GoogleCloudGax.RequestError.binding("Operation completed but error value was missing")))
-          }
-          let error = GoogleCloudGax.RequestError.service(
-            GoogleCloudGax.ServiceError(code: GoogleRpc.Code(intValue: Int(statusUnwrapped.code)), message: statusUnwrapped.message))
-          return .init(done: true, result: .failure(error))
-        case .none:
-          return .init(
-            done: true,
-            result: .failure(
-              GoogleCloudGax.RequestError.binding("Operation completed but result was missing")))
-        }
-      }
-      let rawOp = try await self.{{Codec.Name}}(request: withPolling, options: options)
-      let initialState = try extractStatus(rawOp)
-      let poll = { () async throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
-        let op = try await self.getOperation(request: .init().with { $0.name = rawOp.name }, options: options)
-        return try extractStatus(op)
-      }
-      return GoogleCloudGax._PollableOperationImpl(initialState: initialState, poll: poll)
-    }
-    {{/Codec.LRO}}
-    {{/Codec.RestMethods}}
-  }
-}
-
-// Default implementations
-extension {{Codec.Name}} {
-  {{#Codec.RestMethods}}
-
-  public func {{> /templates/common/method_signature/request}} {
-    try await self.{{Codec.Name}}(request: request, options: .init())
-  }
-
   public func {{> /templates/common/method_signature/request_options}} {
-    throw GoogleCloudGax.RequestError.unimplemented
+      try await self.inner.{{Codec.Name}}(request: request, options: options)
   }
-  {{#Codec.PlainRPC}}
-  {{#Signatures}}
-
-  public func {{> /templates/common/method_signature/overload}} {
-    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
-      {{#Fields}}
-      $0.{{Codec.Name}} = {{Codec.Name}}
-      {{/Fields}}
-    }
-    {{#Method.ReturnsEmpty}}
-    try await self.{{Method.Codec.Name}}(request: request)
-    {{/Method.ReturnsEmpty}}
-    {{^Method.ReturnsEmpty}}
-    return try await self.{{Method.Codec.Name}}(request: request)
-    {{/Method.ReturnsEmpty}}
-  }
-  {{/Signatures}}
-  {{/Codec.PlainRPC}}
   {{#Codec.Pagination}}
 
-  public func {{> /templates/common/method_signature/pagination}} {
-    try self.{{Codec.Name}}(byItem: byItem, options: .init())
-  }
-
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  ///
+  /// @Snippet(path: "{{Service.Name}}_{{Name}}")
   public func {{> /templates/common/method_signature/pagination_options}} {
     let listRpc = { (token: String) async throws -> {{Codec.ReturnType}} in
-      throw GoogleCloudGax.RequestError.unimplemented
+      var request = byItem
+      request.pageToken = token
+      return try await self.{{Codec.Name}}(request: request, options: options)
     }
     return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
   }
-  {{#Signatures}}
-
-  public func {{> /templates/common/method_signature/pagination_overload}} {
-    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
-      {{#Fields}}
-      $0.{{Codec.Name}} = {{Codec.Name}}
-      {{/Fields}}
-    }
-    return try self.{{Codec.Name}}(byItem: request)
-  }
-  {{/Signatures}}
   {{/Codec.Pagination}}
   {{#Codec.LRO}}
 
-  public func {{> /templates/common/method_signature/lro}} {
-    try await self.{{Codec.Name}}(withPolling: withPolling, options: .init())
-  }
-
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  ///
+  /// @Snippet(path: "{{Service.Name}}_{{Name}}")
   public func {{> /templates/common/method_signature/lro_options}} {
-    let poll = { () async throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
-      throw GoogleCloudGax.RequestError.unimplemented
-    }
-    return GoogleCloudGax._PollableOperationImpl(initialState: .init(done: false, result: nil), poll: poll)
-  }
-  {{#Signatures}}
+    let extractStatus = { (op: {{Codec.ReturnType}}) throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
+      guard op.done else {
+        return .init(done: false, result: nil)
+      }
 
-  public func {{> /templates/common/method_signature/lro_overload}} {
-    let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
-      {{#Fields}}
-      $0.{{Codec.Name}} = {{Codec.Name}}
-      {{/Fields}}
+      switch op.result {
+      {{#Codec.LRO.ResponseIsEmpty}}
+      case .response:
+        return .init(done: true, result: .success(()))
+      {{/Codec.LRO.ResponseIsEmpty}}
+      {{^Codec.LRO.ResponseIsEmpty}}
+      case .response(let anyValue):
+        guard let anyValueUnwrapped = anyValue else {
+          return .init(done: true, result: .failure(GoogleCloudGax.RequestError.binding("Operation completed but response value was missing")))
+        }
+        let response = try {{Codec.LRO.ReturnType}}(fromAny: anyValueUnwrapped)
+        return .init(done: true, result: .success(response))
+      {{/Codec.LRO.ResponseIsEmpty}}
+      case .error(let status):
+        guard let statusUnwrapped = status else {
+          return .init(done: true, result: .failure(GoogleCloudGax.RequestError.binding("Operation completed but error value was missing")))
+        }
+        let error = GoogleCloudGax.RequestError.service(
+          GoogleCloudGax.ServiceError(code: GoogleRpc.Code(intValue: Int(statusUnwrapped.code)), message: statusUnwrapped.message))
+        return .init(done: true, result: .failure(error))
+      case .none:
+        return .init(
+          done: true,
+          result: .failure(
+            GoogleCloudGax.RequestError.binding("Operation completed but result was missing")))
+      }
     }
-    return try await self.{{Codec.Name}}(withPolling: request)
+    let rawOp = try await self.{{Codec.Name}}(request: withPolling, options: options)
+    let initialState = try extractStatus(rawOp)
+    let poll = { () async throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
+      let op = try await self.getOperation(request: .init().with { $0.name = rawOp.name }, options: options)
+      return try extractStatus(op)
+    }
+    return GoogleCloudGax._PollableOperationImpl(initialState: initialState, poll: poll)
   }
-  {{/Signatures}}
   {{/Codec.LRO}}
   {{/Codec.RestMethods}}
 }
+
+{{> /templates/common/client_protocol}}
 {{#Codec.IsGated}}
 #endif
 {{/Codec.IsGated}}


### PR DESCRIPTION
Move the client struct to the top-level namespace. At the same time, move the protocol to the nested `Clients` namespace.

This makes the client libraries easier to use, as most applications only interact with the client type, which now has a shorter name.

Fixes #6202 