### PR TITLE
chore(actions): update version comments and specify setup-dart release version

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Display Go version
         run: go version
       - name: Install Dart SDK
-        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: 3.9.0
       - name: Display Dart version

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.12"
       - name: Cache Librarian Tools & Venv
         id: cache-tools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/librarian

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo "npm=$(npm config get prefix)" >> "$GITHUB_OUTPUT"
       - name: "Install Node.js dependencies (restore cache)"
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: tools-cache
         with:
           path: |


### PR DESCRIPTION
This commit fixes some inconsistent version comments for commit SHAs, and specifies the latest release's commit SHA for setup-dart. Dependabot should be able to keep this up to date by updating to the commit SHA for newer releases when they are available.
