### PR TITLE
fix(internal/librarian): gracefully handle nil defaults in applyDefaults

### DIFF
--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -299,7 +299,11 @@ func applyDefaults(language string, lib *config.Library, defaults *config.Defaul
 		if len(lib.APIs) > 0 {
 			apiPath = lib.APIs[0].Path
 		}
-		lib.Output = defaultOutput(language, lib.Name, apiPath, defaults.Output)
+		var defaultOut string
+		if defaults != nil {
+			defaultOut = defaults.Output
+		}
+		lib.Output = defaultOutput(language, lib.Name, apiPath, defaultOut)
 	}
 	return fillLibraryDefaults(language, fillDefaults(lib, defaults))
 }

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -636,6 +636,7 @@ func TestApplyDefaults(t *testing.T) {
 		apis        []*config.API
 		wantOutput  string
 		wantAPIPath string
+		nilDefaults bool
 	}{
 		{
 			name:       "empty output derives path from api",
@@ -690,6 +691,12 @@ func TestApplyDefaults(t *testing.T) {
 			language:   config.LanguageGo,
 			wantOutput: "src/generated/google-cloud-secretmanager-v1",
 		},
+		{
+			name:        "nil defaults is handled safely",
+			language:    config.LanguageGo,
+			nilDefaults: true,
+			wantOutput:  "google-cloud-secretmanager-v1",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			lib := &config.Library{
@@ -698,8 +705,11 @@ func TestApplyDefaults(t *testing.T) {
 				APIs:   test.apis,
 				Rust:   test.rust,
 			}
-			defaults := &config.Default{
-				Output: "src/generated",
+			var defaults *config.Default
+			if !test.nilDefaults {
+				defaults = &config.Default{
+					Output: "src/generated",
+				}
 			}
 			got, err := applyDefaults(test.language, lib, defaults)
 			if err != nil {


### PR DESCRIPTION
The applyDefaults function is updated to safely handle a nil defaults parameter to avoid a runtime nil pointer panic when attempting to access defaults.Output.

A test case is added to verify this safety.
