### PR TITLE
refactor(internal/librarian/java): accept file path in extractTitle

### DIFF
--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -16,6 +16,8 @@ package java
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -48,10 +50,16 @@ func isProductionSample(path string) bool {
 		(strings.HasPrefix(slashed, "src/main/java/") || strings.Contains(slashed, "/src/main/java/"))
 }
 
-// extractTitle extracts and validates the title override from Java comment blocks.
+// extractTitle reads a file from disk and extracts the title override from Java comment blocks.
 // It expects a "title:" line to immediately follow the "sample-metadata:" marker.
-// Returns an error if the marker is present but the title line is missing, malformed, or empty.
-func extractTitle(content string) (string, error) {
+// Returns an error if the file cannot be read, or if the marker is present but the title line
+// is missing, malformed, or empty.
+func extractTitle(filePath string) (string, error) {
+	contentBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+	content := string(contentBytes)
 	if !strings.Contains(content, "sample-metadata:") {
 		return "", nil
 	}

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -59,10 +59,10 @@ func extractTitle(filePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)
 	}
-	content := string(contentBytes)
-	if !strings.Contains(content, "sample-metadata:") {
+	if !bytes.Contains(contentBytes, []byte("sample-metadata:")) {
 		return "", nil
 	}
+	content := string(contentBytes)
 	matches := reTitle.FindStringSubmatch(content)
 	if len(matches) < 2 {
 		return "", errMissingTitle

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -16,6 +16,8 @@ package java
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -141,7 +143,11 @@ public class Normal {}`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := extractTitle(test.content)
+			tmpPath := filepath.Join(t.TempDir(), "Sample.java")
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := extractTitle(tmpPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -172,7 +178,11 @@ func TestExtractTitle_Error(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, gotErr := extractTitle(test.content)
+			tmpPath := filepath.Join(t.TempDir(), "Sample.java")
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			_, gotErr := extractTitle(tmpPath)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("extractTitle() error = %v, wantErr %v", gotErr, test.wantErr)
 			}


### PR DESCRIPTION
Accept file path in extractTitle to read file content from disk directly. Update unit tests to use t.TempDir().

Follow-up to #6546