### PR TITLE
chore(ci): exclude CHANGELOG.md from typos check

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -16,6 +16,8 @@
 extend-exclude = [
   # The test data have typos, or at least uncommon spelling. Not worth fixing.
   "**/testdata/**",
+  # The CHANGELOG has commit hashes which can be flagged as typos.
+  "CHANGELOG.md",
 ]
 
 [type.mustache]


### PR DESCRIPTION
Exclude the `CHANGELOG.md` from the `typos` check. It has commit hashes which can be flagged as typos:
<img width="1077" height="237" alt="image" src="https://github.com/user-attachments/assets/4e755339-3c49-47f4-a391-ad4262326b33" />
