### PR TITLE
chore(internal/librarian): add extractZip helper for protoc installation

### DIFF
--- a/internal/librarian/protoc.go
+++ b/internal/librarian/protoc.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// extractZip extracts a ZIP archive to the specified directory.
+func extractZip(zipPath, destDir string, filter func(string) (string, bool)) error {
+	if filter == nil {
+		filter = func(name string) (string, bool) { return name, true }
+	}
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	for _, file := range r.File {
+		cleanPath := filepath.Clean(file.Name)
+		if cleanPath != filepath.Join("bin", "protoc") ||
+			!strings.HasPrefix(cleanPath, "include"+string(filepath.Separator)) {
+			continue
+		}
+		target := filepath.Join(destDir, cleanPath)
+		// Check for Zip Slip vulnerability (directory traversal)
+		rel, err := filepath.Rel(destDir, target)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return fmt.Errorf("illegal file path in zip: %s", file.Name)
+		}
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, file.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, file.Mode())
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return err
+		}
+		out.Close()
+		rc.Close()
+	}
+	return nil
+}

--- a/internal/librarian/protoc.go
+++ b/internal/librarian/protoc.go
@@ -24,10 +24,7 @@ import (
 )
 
 // extractZip extracts a ZIP archive to the specified directory.
-func extractZip(zipPath, destDir string, filter func(string) (string, bool)) error {
-	if filter == nil {
-		filter = func(name string) (string, bool) { return name, true }
-	}
+func extractZip(zipPath, destDir string) error {
 	r, err := zip.OpenReader(zipPath)
 	if err != nil {
 		return err
@@ -35,7 +32,7 @@ func extractZip(zipPath, destDir string, filter func(string) (string, bool)) err
 	defer r.Close()
 	for _, file := range r.File {
 		cleanPath := filepath.Clean(file.Name)
-		if cleanPath != filepath.Join("bin", "protoc") ||
+		if !strings.HasPrefix(cleanPath, "bin"+string(filepath.Separator)) &&
 			!strings.HasPrefix(cleanPath, "include"+string(filepath.Separator)) {
 			continue
 		}

--- a/internal/librarian/protoc.go
+++ b/internal/librarian/protoc.go
@@ -55,18 +55,15 @@ func extractZip(zipPath, destDir string) error {
 		if err != nil {
 			return err
 		}
+		defer rc.Close()
 		out, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, file.Mode())
 		if err != nil {
-			rc.Close()
 			return err
 		}
+		defer out.Close()
 		if _, err := io.Copy(out, rc); err != nil {
-			out.Close()
-			rc.Close()
 			return err
 		}
-		out.Close()
-		rc.Close()
 	}
 	return nil
 }

--- a/internal/librarian/protoc.go
+++ b/internal/librarian/protoc.go
@@ -36,34 +36,36 @@ func extractZip(zipPath, destDir string) error {
 			!strings.HasPrefix(cleanPath, "include"+string(filepath.Separator)) {
 			continue
 		}
-		target := filepath.Join(destDir, cleanPath)
-		// Check for Zip Slip vulnerability (directory traversal)
-		rel, err := filepath.Rel(destDir, target)
-		if err != nil || strings.HasPrefix(rel, "..") {
-			return fmt.Errorf("illegal file path in zip: %s", file.Name)
-		}
-		if file.FileInfo().IsDir() {
-			if err := os.MkdirAll(target, file.Mode()); err != nil {
-				return err
-			}
-			continue
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-			return err
-		}
-		rc, err := file.Open()
-		if err != nil {
-			return err
-		}
-		defer rc.Close()
-		out, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, file.Mode())
-		if err != nil {
-			return err
-		}
-		defer out.Close()
-		if _, err := io.Copy(out, rc); err != nil {
+		if err := unzipFile(file, destDir, cleanPath); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func unzipFile(file *zip.File, destDir, cleanPath string) error {
+	target := filepath.Join(destDir, cleanPath)
+	// Check for Zip Slip vulnerability (directory traversal)
+	rel, err := filepath.Rel(destDir, target)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("illegal file path in zip: %s", file.Name)
+	}
+	if file.FileInfo().IsDir() {
+		return os.MkdirAll(target, file.Mode())
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return err
+	}
+	rc, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, file.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, rc)
+	return err
 }

--- a/internal/librarian/protoc_test.go
+++ b/internal/librarian/protoc_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractZip(t *testing.T) {
+	mockZip, err := createMockZip(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zipPath := filepath.Join(t.TempDir(), "mock.zip")
+	if err := os.WriteFile(zipPath, mockZip, 0644); err != nil {
+		t.Fatal(err)
+	}
+	destDir := t.TempDir()
+	if err := extractZip(zipPath, destDir); err != nil {
+		t.Fatal(err)
+	}
+	expectedFiles := []string{
+		filepath.Join(destDir, "bin", "protoc"),
+		filepath.Join(destDir, "include", "google", "protobuf", "any.proto"),
+	}
+	for _, expected := range expectedFiles {
+		if _, err := os.Stat(expected); err != nil {
+			t.Errorf("expected file %q was not extracted: %v", expected, err)
+		}
+	}
+
+	unexpectedFiles := []string{
+		filepath.Join(destDir, "some_other_file.txt"),
+	}
+	for _, unexpected := range unexpectedFiles {
+		if _, err := os.Stat(unexpected); err == nil {
+			t.Errorf("unexpected file %q exists in destination directory", unexpected)
+		}
+	}
+}
+
+func createMockZip(t *testing.T) ([]byte, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+
+	files := []struct {
+		Name, Body string
+	}{
+		{"bin/protoc", "mock protoc binary"},
+		{"include/google/protobuf/any.proto", "mock any proto"},
+		{"some_other_file.txt", "should be ignored"},
+	}
+
+	for _, file := range files {
+		f, err := w.Create(file.Name)
+		if err != nil {
+			return nil, err
+		}
+		_, err = f.Write([]byte(file.Body))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/librarian/protoc_test.go
+++ b/internal/librarian/protoc_test.go
@@ -59,7 +59,6 @@ func createMockZip(t *testing.T) ([]byte, error) {
 	t.Helper()
 	var buf bytes.Buffer
 	w := zip.NewWriter(&buf)
-
 	files := []struct {
 		Name, Body string
 	}{
@@ -67,7 +66,6 @@ func createMockZip(t *testing.T) ([]byte, error) {
 		{"include/google/protobuf/any.proto", "mock any proto"},
 		{"some_other_file.txt", "should be ignored"},
 	}
-
 	for _, file := range files {
 		f, err := w.Create(file.Name)
 		if err != nil {
@@ -78,7 +76,6 @@ func createMockZip(t *testing.T) ([]byte, error) {
 			return nil, err
 		}
 	}
-
 	if err := w.Close(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add an extractZip helper function to the internal/librarian package to extract precompiled `protoc` ZIP archives to a destination directory.

This helper extracts only the protoc binary (inside the bin folder) and the protocol buffer header files (inside the include folder), ignoring other auxiliary files in the archive.

For #6558