### PR TITLE
feat(sidekick/discovery): signatures without path params

### DIFF
--- a/internal/sidekick/parser/discovery/methods.go
+++ b/internal/sidekick/parser/discovery/methods.go
@@ -107,9 +107,18 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 		fieldNames[field.Name] = true
 	}
 
-	// Every discovery-based method has one additional signature formed by the
-	// path parameters, in the order specified by the discovery doc.
-	signature := &api.MethodSignature{Names: input.ParameterOrder}
+	// Methods without path parameters don't get an overload. Typically one of
+	// the query parameter is "required" for them. Otherwise the request is some
+	// kind of singleton, these are sufficiently rare that missing the
+	// convenience overload is not a big problem.
+	var signature *api.MethodSignature
+	signatures := []*api.MethodSignature{}
+	if len(input.ParameterOrder) != 0 {
+		// If there are path parameters, then create an additional signature
+		// formed by them, in the order specified by the discovery doc.
+		signature = &api.MethodSignature{Names: input.ParameterOrder}
+		signatures = append(signatures, signature)
+	}
 
 	bodyPathField := ""
 	if bodyID != ".google.protobuf.Empty" {
@@ -128,8 +137,10 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 		}
 		requestMessage.Fields = append(requestMessage.Fields, body)
 		bodyPathField = name
-		// The body, if present, is required for signature requests.
-		signature.Names = append(signature.Names, name)
+		if signature != nil {
+			// The body, if present, is required for signature requests.
+			signature.Names = append(signature.Names, name)
+		}
 	}
 
 	method := &api.Method{
@@ -144,7 +155,7 @@ func makeMethod(model *api.API, parent *api.Message, doc *document, input *metho
 			Bindings:      []*api.PathBinding{binding},
 			BodyFieldPath: bodyPathField,
 		},
-		Signatures: []*api.MethodSignature{signature},
+		Signatures: signatures,
 		APIVersion: input.APIVersion,
 	}
 	return method, nil

--- a/internal/sidekick/parser/discovery/methods_test.go
+++ b/internal/sidekick/parser/discovery/methods_test.go
@@ -94,7 +94,7 @@ func TestMakeServiceMethods(t *testing.T) {
 				t.Fatalf("expected method %s in the API model", test.id)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/parser/discovery/methods_test.go
+++ b/internal/sidekick/parser/discovery/methods_test.go
@@ -27,37 +27,76 @@ func TestMakeServiceMethods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id := "..zones.get"
-	got := model.Method(id)
-	if got == nil {
-		t.Fatalf("expected method %s in the API model", id)
-	}
-	want := &api.Method{
-		ID:            "..zones.get",
-		Name:          "get",
-		Documentation: "Returns the specified Zone resource.",
-		InputTypeID:   "..zones.getRequest",
-		OutputTypeID:  "..Zone",
-		PathInfo: &api.PathInfo{
-			Bindings: []*api.PathBinding{
-				{
-					Verb: "GET",
-					PathTemplate: (&api.PathTemplate{}).
-						WithLiteral("compute").
-						WithLiteral("v1").
-						WithLiteral("projects").
-						WithVariableNamed("project").
-						WithLiteral("zones").
-						WithVariableNamed("zone"),
-					QueryParameters: map[string]bool{},
+	for _, test := range []struct {
+		id   string
+		want *api.Method
+	}{
+		{
+			id: "..zones.get",
+			want: &api.Method{
+				ID:            "..zones.get",
+				Name:          "get",
+				Documentation: "Returns the specified Zone resource.",
+				InputTypeID:   "..zones.getRequest",
+				OutputTypeID:  "..Zone",
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: (&api.PathTemplate{}).
+								WithLiteral("compute").
+								WithLiteral("v1").
+								WithLiteral("projects").
+								WithVariableNamed("project").
+								WithLiteral("zones").
+								WithVariableNamed("zone"),
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "",
 				},
+				Signatures: []*api.MethodSignature{{Names: []string{"project", "zone"}}},
 			},
-			BodyFieldPath: "",
 		},
-		Signatures: []*api.MethodSignature{{Names: []string{"project", "zone"}}},
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		{
+			id: "..firewallPolicies.insert",
+			want: &api.Method{
+				ID:            "..firewallPolicies.insert",
+				Name:          "insert",
+				Documentation: "Creates a new policy in the specified project using the data included in the request.",
+				InputTypeID:   "..firewallPolicies.insertRequest",
+				OutputTypeID:  "..Operation",
+				PathInfo: &api.PathInfo{
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "POST",
+							PathTemplate: (&api.PathTemplate{}).
+								WithLiteral("compute").
+								WithLiteral("v1").
+								WithLiteral("locations").
+								WithLiteral("global").
+								WithLiteral("firewallPolicies"),
+							QueryParameters: map[string]bool{
+								"parentId":  true,
+								"requestId": true,
+							},
+						},
+					},
+					BodyFieldPath: "body",
+				},
+				Signatures: []*api.MethodSignature{},
+			},
+		},
+	} {
+		t.Run(test.id, func(t *testing.T) {
+			got := model.Method(test.id)
+			if got == nil {
+				t.Fatalf("expected method %s in the API model", test.id)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
For discovery-based services, most methods get a method signature with all the path parameters. This does not work for methods without any path parameters. Such methods typically require one or more query parameters, and there is no way to tell which ones are required.

Fixes #6567 