### PR TITLE
cleanup(sidekick): follow test guidelines

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -230,10 +230,10 @@ func TestRunStreaming(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.wantOut, outBuf.String()); diff != "" {
-				t.Errorf("mismatch of stdout (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.wantErr, errBuf.String()); diff != "" {
-				t.Errorf("mismatch of stderr (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -110,7 +110,7 @@ func TestFilesChangedSuccess(t *testing.T) {
 	}
 	want := []string{path.Join("src", "storage", "src", "lib.rs")}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -137,7 +137,7 @@ func TestFilterNoFilter(t *testing.T) {
 	got := filesFilter(nil, input)
 	want := input
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -163,7 +163,7 @@ func TestFilterBasic(t *testing.T) {
 		"src/generated/cloud/secretmanager/v1/src/model.rs",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -181,7 +181,7 @@ func TestFilterSomeGlobs(t *testing.T) {
 	}, input)
 	want := []string{}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -263,7 +263,7 @@ func TestShowFileAtRemoteBranch(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(testhelper.ReadmeContents, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -315,7 +315,7 @@ func TestShowFileAtRevision(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/api/apitest/apitest.go
+++ b/internal/sidekick/api/apitest/apitest.go
@@ -28,15 +28,15 @@ func CheckMessage(t *testing.T, got *api.Message, want *api.Message) {
 	t.Helper()
 	// Checking Parent, Messages, Fields, and OneOfs requires special handling.
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Message{}, "Fields", "OneOfs", "Parent", "Messages", "Enums", "Resource")); diff != "" {
-		t.Errorf("message attributes mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	less := func(a, b *api.Field) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(want.Fields, got.Fields, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("field mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	// Ignore parent because types are cyclic
 	if diff := cmp.Diff(want.OneOfs, got.OneOfs, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("oneofs mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -44,11 +44,11 @@ func CheckMessage(t *testing.T, got *api.Message, want *api.Message) {
 func CheckEnum(t *testing.T, got api.Enum, want api.Enum) {
 	t.Helper()
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Enum{}, "Values", "UniqueNumberValues", "Parent")); diff != "" {
-		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	less := func(a, b *api.EnumValue) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(want.Values, got.Values, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -56,11 +56,11 @@ func CheckEnum(t *testing.T, got api.Enum, want api.Enum) {
 func CheckService(t *testing.T, got *api.Service, want *api.Service) {
 	t.Helper()
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Service{}, "Methods")); diff != "" {
-		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	less := func(a, b *api.Method) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(want.Methods, got.Methods, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -80,6 +80,6 @@ func CheckMethod(t *testing.T, service *api.Service, name string, want *api.Meth
 		t.Errorf("missing method %s", name)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched data for method %s (-want, +got):\n%s", name, diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/api/dependencies_test.go
+++ b/internal/sidekick/api/dependencies_test.go
@@ -71,7 +71,7 @@ func TestFindDependenciesEnumFields(t *testing.T) {
 	// Note that `MessageWithEnumField` is not included.
 	want := []string{".test.OrphanEnum"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// Verify that a message with an enum field depends on the enum.
@@ -81,7 +81,7 @@ func TestFindDependenciesEnumFields(t *testing.T) {
 	}
 	want = []string{".test.OrphanEnum", ".test.MessageWithEnumField"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -110,7 +110,7 @@ func TestFindDependenciesNestedEnum(t *testing.T) {
 	}
 	want := []string{parent, child}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got, err = FindDependencies(model, []string{parent})
@@ -119,7 +119,7 @@ func TestFindDependenciesNestedEnum(t *testing.T) {
 	}
 	want = []string{parent}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -169,7 +169,7 @@ func TestFindDependenciesNestedMessage(t *testing.T) {
 			t.Fatal(err)
 		}
 		if diff := cmp.Diff(test.Want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-			t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 
 	}
@@ -205,7 +205,7 @@ func TestFindDependenciesMessage(t *testing.T) {
 	}
 	want := []string{".test.MessageWithMessageField", ".test.Orphan"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got, err = FindDependencies(model, []string{".test.Orphan"})
@@ -215,7 +215,7 @@ func TestFindDependenciesMessage(t *testing.T) {
 	// Note that `MessageWithMessageField` is not included.
 	want = []string{".test.Orphan"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -244,7 +244,7 @@ func TestFindDependenciesHandlesCycles1(t *testing.T) {
 	}
 	want := []string{".test.Recursive"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -294,7 +294,7 @@ func TestFindDependenciesHandlesCycles2(t *testing.T) {
 		}
 		want := []string{".test.A", ".test.B"}
 		if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-			t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -346,7 +346,7 @@ func TestFindDependenciesHandlesCycles3(t *testing.T) {
 		}
 		want := []string{".test.Triangle2.Triangle1", ".test.Triangle2", ".test.Triangle3"}
 		if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-			t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -394,7 +394,7 @@ func TestFindDependenciesMethod(t *testing.T) {
 	// Note that `Sibling` is not included
 	want := []string{".test.Service", ".test.Service.Method", ".test.Request", ".test.Response"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// Verify that messages don't imply methods
@@ -404,7 +404,7 @@ func TestFindDependenciesMethod(t *testing.T) {
 	}
 	want = []string{".test.Request"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -452,7 +452,7 @@ func TestFindDependenciesLroMethod(t *testing.T) {
 	}
 	want := []string{".test.Service", ".test.Service.Lro", ".test.Empty", ".test.OpMetadata", ".test.OpResponse"}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -557,7 +557,7 @@ func TestFindDependenciesService(t *testing.T) {
 		".test.Enum",
 	}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got, err = FindDependencies(model, []string{".test.Service", ".test.OtherService"})
@@ -579,7 +579,7 @@ func TestFindDependenciesService(t *testing.T) {
 		".test.OtherResponse",
 	}
 	if diff := cmp.Diff(want, flatten(got), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/api/discovery_test.go
+++ b/internal/sidekick/api/discovery_test.go
@@ -34,12 +34,12 @@ func TestLroServices(t *testing.T) {
 	}
 	got := d.LroServices()
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("LroServices() mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestPathParameters(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		name  string
 		input *Poller
 		want  []string
@@ -59,12 +59,11 @@ func TestPathParameters(t *testing.T) {
 			input: &Poller{Prefix: "a/{b}"},
 			want:  []string{"b"},
 		},
-	}
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.input.PathParameters()
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("PathParameters(%q) mismatch (-want +got):\n%s", test.input.Prefix, diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/api/documentation_test.go
+++ b/internal/sidekick/api/documentation_test.go
@@ -82,7 +82,7 @@ func TestPatchCommentsMessage(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(m0.Documentation, Want); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -203,7 +203,7 @@ func TestPatchCommentsField(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(f0.Documentation, Want); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -227,7 +227,7 @@ func TestPatchCommentsEnum(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(e0.Documentation, Want); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -257,7 +257,7 @@ func TestPatchCommentsEnumValue(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(v0.Documentation, Want); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -281,7 +281,7 @@ func TestPatchCommentsService(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(s0.Documentation, Want); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -310,6 +310,6 @@ func TestPatchCommentsMethod(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(m0.Documentation, Want); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -54,7 +54,7 @@ func TestRoutingCombosSimpleOr(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, method.RoutingCombos()); diff != "" {
-		t.Errorf("Incorrect routing combos (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -92,7 +92,7 @@ func TestRoutingCombosSimpleAnd(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, method.RoutingCombos()); diff != "" {
-		t.Errorf("Incorrect routing combos (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -161,7 +161,7 @@ func TestRoutingCombosFull(t *testing.T) {
 		make_combo(va3, vb2, vc1),
 	}
 	if diff := cmp.Diff(want, method.RoutingCombos()); diff != "" {
-		t.Errorf("Incorrect routing combos (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -229,7 +229,7 @@ func TestPathTemplateBuilder(t *testing.T) {
 		Verb: verb,
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("bad builder result (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/api/pagination_test.go
+++ b/internal/sidekick/api/pagination_test.go
@@ -90,7 +90,7 @@ func TestPageSimple(t *testing.T) {
 		PageableItem:  response.Fields[1],
 	}
 	if diff := cmp.Diff(want, response.Pagination); diff != "" {
-		t.Errorf("mismatch, (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -175,7 +175,7 @@ func TestPageWithOverride(t *testing.T) {
 		PageableItem:  response.Fields[2],
 	}
 	if diff := cmp.Diff(want, response.Pagination); diff != "" {
-		t.Errorf("mismatch, (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -429,7 +429,7 @@ func TestPaginationRequestPageSizeSuccess(t *testing.T) {
 		}
 		got := paginationRequestPageSize(response)
 		if diff := cmp.Diff(response.Fields[0], got); diff != "" {
-			t.Errorf("mismatch (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -559,7 +559,7 @@ func TestPaginationResponseItemMatching(t *testing.T) {
 		}
 		got := paginationResponseItem(nil, "package.Service.List", response)
 		if diff := cmp.Diff(response.Fields[0], got); diff != "" {
-			t.Errorf("mismatch (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -594,7 +594,7 @@ func TestPaginationResponseItemMatchingMany(t *testing.T) {
 		}
 		got := paginationResponseItem(nil, "package.Service.List", response)
 		if diff := cmp.Diff(response.Fields[0], got); diff != "" {
-			t.Errorf("mismatch (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -620,7 +620,7 @@ func TestPaginationResponseItemMatchingPreferRepeatedOverMap(t *testing.T) {
 	}
 	got := paginationResponseItem(nil, "package.Service.List", response)
 	if diff := cmp.Diff(response.Fields[1], got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/api/resource_name_heuristic_test.go
+++ b/internal/sidekick/api/resource_name_heuristic_test.go
@@ -162,7 +162,7 @@ func TestBuildHeuristicVocabulary(t *testing.T) {
 			}
 			got := BuildHeuristicVocabulary(model)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("BuildHeuristicVocabulary() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/api/scopes_test.go
+++ b/internal/sidekick/api/scopes_test.go
@@ -29,7 +29,7 @@ func TestScopesService(t *testing.T) {
 	got := service.Scopes()
 	want := []string{"test.Service", "test"}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched service.Scopes() (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -50,13 +50,13 @@ func TestScopesMessage(t *testing.T) {
 	got := parent.Scopes()
 	want := []string{"test.Parent", "test"}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched parent.Scopes() (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got = child.Scopes()
 	want = []string{"test.Parent.Child", "test.Parent", "test"}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched child.Scopes() (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -70,7 +70,7 @@ func TestScopesEnum(t *testing.T) {
 	got := enum.Scopes()
 	want := []string{"test.Enum", "test"}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched enum.Scopes() (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -91,7 +91,7 @@ func TestScopesEnumInMessage(t *testing.T) {
 	got := child.Scopes()
 	want := []string{"test.Parent.Child", "test.Parent", "test"}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched child.Scopes() (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -111,7 +111,7 @@ func TestScopesEnumValue(t *testing.T) {
 	got := enumValue.Scopes()
 	want := []string{"test.Enum", "test"}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched enum.Scopes() (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -138,7 +138,7 @@ func TestScopesEnumValueInMessage(t *testing.T) {
 	got := enumValue.Scopes()
 	want := []string{"test.Parent.Enum", "test.Parent", "test"}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched child.Scopes() (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/api/service_dependencies_test.go
+++ b/internal/sidekick/api/service_dependencies_test.go
@@ -123,7 +123,7 @@ func TestFindServiceDependencies(t *testing.T) {
 	got := FindServiceDependencies(model, ".test.NotFound")
 	want := &ServiceDependencies{}
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got = FindServiceDependencies(model, ".test.Service1")
@@ -132,7 +132,7 @@ func TestFindServiceDependencies(t *testing.T) {
 		Enums:    []string{".test.SomeEnum"},
 	}
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got = FindServiceDependencies(model, ".test.Service2")
@@ -140,6 +140,6 @@ func TestFindServiceDependencies(t *testing.T) {
 		Messages: []string{".test.Empty", ".test.OpMetadata", ".test.OpResponse"},
 	}
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/api/skip_test.go
+++ b/internal/sidekick/api/skip_test.go
@@ -46,7 +46,7 @@ func TestSkipMessages(t *testing.T) {
 	want := []*Message{m0, m2}
 
 	if diff := cmp.Diff(want, model.Messages); diff != "" {
-		t.Errorf("mismatch in messages (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -75,7 +75,7 @@ func TestSkipEnums(t *testing.T) {
 	want := []*Enum{e0, e2}
 
 	if diff := cmp.Diff(want, model.Enums); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestSkipNestedMessages(t *testing.T) {
 	})
 	want := []*Message{m0}
 	if diff := cmp.Diff(want, m2.Messages); diff != "" {
-		t.Errorf("mismatch in messages (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -137,7 +137,7 @@ func TestSkipNestedEnums(t *testing.T) {
 
 	want := []*Enum{e0, e2}
 	if diff := cmp.Diff(want, m.Enums); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -166,7 +166,7 @@ func TestSkipServices(t *testing.T) {
 	want := []*Service{s0, s2}
 
 	if diff := cmp.Diff(want, model.Services, cmpopts.IgnoreFields(Service{}, "Model")); diff != "" {
-		t.Errorf("mismatch in services (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -208,7 +208,7 @@ func TestSkipMethods(t *testing.T) {
 
 	wantServices := []*Service{s0, s1, s2}
 	if diff := cmp.Diff(wantServices, model.Services, cmpopts.IgnoreFields(Service{}, "Model")); diff != "" {
-		t.Errorf("mismatch in services (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	wantMethods := []*Method{
@@ -222,7 +222,7 @@ func TestSkipMethods(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(wantMethods, s1.Methods); diff != "" {
-		t.Errorf("mismatch in methods (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -270,7 +270,7 @@ func TestIncludeNestedEnums(t *testing.T) {
 
 	want := []*Enum{e0}
 	if diff := cmp.Diff(want, m.Enums, cmpopts.IgnoreFields(Message{}, "Enums")); diff != "" {
-		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -297,7 +297,7 @@ func TestIncludeNestedMessages(t *testing.T) {
 	})
 	want := []*Message{m0}
 	if diff := cmp.Diff(want, m2.Messages, cmpopts.IgnoreFields(Message{}, "Messages")); diff != "" {
-		t.Errorf("mismatch in messages (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -373,7 +373,7 @@ func TestIncludeMethods(t *testing.T) {
 
 	wantServices := []*Service{s1}
 	if diff := cmp.Diff(wantServices, model.Services, cmpopts.IgnoreFields(Method{}, methodIgnoreFields...), cmpopts.IgnoreFields(Service{}, "Model", "QuickstartMethod")); diff != "" {
-		t.Errorf("mismatch in services (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	wantMethods := []*Method{
@@ -387,6 +387,6 @@ func TestIncludeMethods(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(wantMethods, s1.Methods, cmpopts.IgnoreFields(Method{}, methodIgnoreFields...)); diff != "" {
-		t.Errorf("mismatch in methods (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -286,7 +286,7 @@ func TestEnrichSamplesEnumValues(t *testing.T) {
 
 			got := enum.ValuesForExamples
 			if diff := cmp.Diff(tc.wantExamples, got, cmpopts.IgnoreFields(EnumValue{}, "Parent")); diff != "" {
-				t.Errorf("mismatch in ValuesForExamples (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -413,7 +413,7 @@ func TestEnrichSamplesOneOfExampleField(t *testing.T) {
 
 			got := group.ExampleField
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("mismatch in ExampleField (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1144,7 +1144,7 @@ func TestAIPStandardGetInfo(t *testing.T) {
 			enrichMethodSamples(tc.method)
 			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1277,7 +1277,7 @@ func TestAIPStandardDeleteInfo(t *testing.T) {
 			enrichMethodSamples(tc.method)
 			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1418,7 +1418,7 @@ func TestAIPStandardUndeleteInfo(t *testing.T) {
 			enrichMethodSamples(tc.method)
 			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1516,7 +1516,7 @@ func TestAIPStandardCreateInfo(t *testing.T) {
 			enrichMethodSamples(tc.method)
 			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1642,7 +1642,7 @@ func TestAIPStandardUpdateInfo(t *testing.T) {
 			enrichMethodSamples(tc.method)
 			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1776,7 +1776,7 @@ func TestAIPStandardListInfo(t *testing.T) {
 			enrichMethodSamples(tc.method)
 			got := tc.method.SampleInfo
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("SampleInfo() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1826,7 +1826,7 @@ func TestFindBestResourceFieldByType(t *testing.T) {
 			msg := &Message{Fields: tc.fields}
 			got := findBestResourceFieldByType(msg, f.model, targetType)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("findBestResourceFieldByType() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1881,7 +1881,7 @@ func TestFindBestResourceFieldBySingular(t *testing.T) {
 			msg := &Message{Fields: tc.fields}
 			got := findBestResourceFieldBySingular(msg, f.model, targetSingular)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("findBestResourceFieldBySingular() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1942,7 +1942,7 @@ func TestFindBestParentFieldByType(t *testing.T) {
 			msg := &Message{Fields: tc.fields}
 			got := findBestParentFieldByType(msg, childType)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("findBestParentFieldByType() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2132,7 +2132,7 @@ func TestFindBodyField(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := findBodyField(tc.message, tc.pathInfo, tc.targetType, tc.singular)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("findBodyField() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2166,7 +2166,7 @@ func TestFindResourceIDField(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := findResourceIDField(tc.message, tc.singular)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("findResourceIDField() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2237,7 +2237,7 @@ func TestFindQuickstartMethod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := findQuickstartMethod(tc.service)
 			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Method{}, "Service", "Model")); diff != "" {
-				t.Errorf("findQuickstartMethod() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2285,7 +2285,7 @@ func TestFindQuickstartService(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := findQuickstartService(tc.api)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("findQuickstartService() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/dart/annotate_test.go
+++ b/internal/sidekick/dart/annotate_test.go
@@ -15,6 +15,7 @@
 package dart
 
 import (
+	"fmt"
 	"maps"
 	"slices"
 	"testing"
@@ -50,10 +51,10 @@ func TestAnnotateModel(t *testing.T) {
 	codec := model.Codec.(*modelAnnotations)
 
 	if diff := cmp.Diff("google_cloud_test", codec.PackageName); diff != "" {
-		t.Errorf("mismatch in Codec.PackageName (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff("test.dart", codec.MainFileNameWithExtension); diff != "" {
-		t.Errorf("mismatch in Codec.MainFileNameWithExtension (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -105,7 +106,7 @@ func TestAnnotateModel_FakeList(t *testing.T) {
 
 	want := "FakeAccessApprovalService, FakeSecretManagerService"
 	if diff := cmp.Diff(want, codec.FakeList); diff != "" {
-		t.Errorf("mismatch in Codec.FakeList (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -121,7 +122,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("src/buffers.dart", codec.MainFileNameWithExtension); diff != "" {
-					t.Errorf("mismatch in Codec.MainFileNameWithExtension (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -130,7 +131,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("google-cloud-type", codec.PackageName); diff != "" {
-					t.Errorf("mismatch in Codec.PackageName (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -139,7 +140,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff([]string{"mockito", "test"}, codec.DevDependencies); diff != "" {
-					t.Errorf("mismatch in Codec.PackageName (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -165,7 +166,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 				if diff := cmp.Diff([]string{
 					"export 'package:google_cloud_gax/gax.dart' show Any",
 					"export 'package:google_cloud_gax/gax.dart' show Status"}, codec.Exports); diff != "" {
-					t.Errorf("mismatch in Codec.Exports (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -186,7 +187,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("1.2.3", codec.PackageVersion); diff != "" {
-					t.Errorf("mismatch in Codec.PackageVersion (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -195,7 +196,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("src/test.p.dart", codec.PartFileReference); diff != "" {
-					t.Errorf("mismatch in Codec.PartFileReference (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -204,7 +205,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("> [!TIP] Still beta!", codec.ReadMeAfterTitleText); diff != "" {
-					t.Errorf("mismatch in Codec.ReadMeAfterTitleText (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -213,7 +214,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("## Getting Started\n...", codec.ReadMeQuickstartText); diff != "" {
-					t.Errorf("mismatch in Codec.ReadMeQuickstartText (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -222,7 +223,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("http://example.com/repo", codec.RepositoryURL); diff != "" {
-					t.Errorf("mismatch in Codec.RepositoryURL (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -231,7 +232,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 			func(t *testing.T, am *annotateModel) {
 				codec := model.Codec.(*modelAnnotations)
 				if diff := cmp.Diff("http://example.com/issues", codec.IssueTrackerURL); diff != "" {
-					t.Errorf("mismatch in Codec.IssueTrackerURL (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -243,7 +244,7 @@ func TestAnnotateModel_Options(t *testing.T) {
 					"google_cloud_protobuf": "^7.8.9",
 					"http":                  "1.2.0"},
 					am.dependencyConstraints); diff != "" {
-					t.Errorf("mismatch in annotateModel.dependencyConstraints (-want, +got)\n:%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -628,7 +629,7 @@ func TestCalculateImports(t *testing.T) {
 			got := calculateImports(deps, test.packageName, test.mainFileName)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch in calculateImports (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -914,7 +915,7 @@ func TestBuildQueryLines_Primitives(t *testing.T) {
 
 			got := annotate.buildQueryLines([]string{}, "result.", false, "", test.field)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -979,7 +980,7 @@ func TestBuildQueryLines_Enums(t *testing.T) {
 		t.Run(test.enumField.Name, func(t *testing.T) {
 			got := annotate.buildQueryLines([]string{}, "result.", false, "", test.enumField)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch in TestBuildQueryLinesEnums (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1046,7 +1047,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		"if (result.message1?.state case final $1? when $1.isNotDefault) 'message1.state': $1.value",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got = annotate.buildQueryLines([]string{}, "result.", false, "", messageField2)
@@ -1055,7 +1056,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		"if (result.message2?.dataCrc32C case final $1?) 'message2.dataCrc32c': '${$1}'",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// nested messages
@@ -1065,7 +1066,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		"if (result.message3?.fieldMask case final $1?) 'message3.fieldMask': $1.toJson()",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// custom encoded messages
@@ -1074,7 +1075,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		"if (result.fieldMask case final $1?) 'fieldMask': $1.toJson()",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got = annotate.buildQueryLines([]string{}, "result.", false, "", durationField)
@@ -1082,7 +1083,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		"if (result.duration case final $1?) 'duration': $1.toJson()",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got = annotate.buildQueryLines([]string{}, "result.", false, "", timestampField)
@@ -1090,7 +1091,7 @@ func TestBuildQueryLines_Messages(t *testing.T) {
 		"if (result.time case final $1?) 'time': $1.toJson()",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1349,7 +1350,7 @@ func TestCreateFromJsonLine(t *testing.T) {
 
 			got := annotate.createFromJsonLine(test.field, codec.Required)
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch in TestBuildQueryLines (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1721,7 +1722,7 @@ func TestToJson(t *testing.T) {
 			annotate.annotateField(test.field)
 			got := test.field.Codec.(*fieldAnnotation).ToJson
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch in TestToJson (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1796,25 +1797,30 @@ func TestAnnotateEnum(t *testing.T) {
 			wantValueAnnotations: []wantedValueAnnotation{{"NAME"}, {"name"}},
 		},
 	} {
-		annotate.annotateEnum(test.enum)
-		codec := test.enum.Codec.(*enumAnnotation)
-		gotEnumName := codec.Name
-		gotEnumDefaultValue := codec.DefaultValue
+		t.Run(test.wantEnumName, func(t *testing.T) {
+			annotate.annotateEnum(test.enum)
+			codec := test.enum.Codec.(*enumAnnotation)
+			gotEnumName := codec.Name
+			gotEnumDefaultValue := codec.DefaultValue
 
-		if diff := cmp.Diff(test.wantEnumName, gotEnumName); diff != "" {
-			t.Errorf("mismatch in TestAnnotateEnum(%q) (-want, +got)\n:%s", test.enum.Name, diff)
-		}
-		if diff := cmp.Diff(test.wantEnumDefaultValue, gotEnumDefaultValue); diff != "" {
-			t.Errorf("mismatch in TestAnnotateEnum(%q) (-want, +got)\n:%s", test.enum.Name, diff)
-		}
-
-		for i, value := range test.enum.Values {
-			wantValueAnnotation := test.wantValueAnnotations[i]
-			gotValueAnnotation := value.Codec.(*enumValueAnnotation)
-			if diff := cmp.Diff(wantValueAnnotation.wantValueName, gotValueAnnotation.Name); diff != "" {
-				t.Errorf("mismatch in TestAnnotateEnum(%q) [value annotation %d] (-want, +got)\n:%s", test.enum.Name, i, diff)
+			if diff := cmp.Diff(test.wantEnumName, gotEnumName); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
-		}
+			if diff := cmp.Diff(test.wantEnumDefaultValue, gotEnumDefaultValue); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+
+			for i, value := range test.enum.Values {
+				testName := fmt.Sprintf("TestAnnotateEnum(%q) [value annotation %d]", test.enum.Name, i)
+				t.Run(testName, func(t *testing.T) {
+					wantValueAnnotation := test.wantValueAnnotations[i]
+					gotValueAnnotation := value.Codec.(*enumValueAnnotation)
+					if diff := cmp.Diff(wantValueAnnotation.wantValueName, gotValueAnnotation.Name); diff != "" {
+						t.Errorf("mismatch (-want +got):\n%s", diff)
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -2069,7 +2075,7 @@ func TestAnnotateField(t *testing.T) {
 			got.ToJson = ""
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch in TestAnnotateField(-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/dart/dart_test.go
+++ b/internal/sidekick/dart/dart_test.go
@@ -510,7 +510,7 @@ We want to respect whitespace at the beginning, because it important in Markdown
 	}
 	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -520,13 +520,13 @@ func TestFormatDocCommentsEmpty(t *testing.T) {
 	want := []string{}
 	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestFormatDocCommentsTrimTrailingSpaces(t *testing.T) {
 	input := `The next line contains spaces.
-  
+
 This line has trailing spaces.  `
 
 	want := []string{
@@ -536,7 +536,7 @@ This line has trailing spaces.  `
 	}
 	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -554,7 +554,7 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
 	}
 	got := formatDocComments(input, nil)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -603,7 +603,7 @@ is set to true, this field will contain the sentiment for the sentence.`,
 			gotLines := formatDocComments(test.input, nil)
 			got := strings.Join(gotLines, "\n")
 			if diff := cmp.Diff(test.output, got); diff != "" {
-				t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/language/codec_test.go
+++ b/internal/sidekick/language/codec_test.go
@@ -64,7 +64,7 @@ func TestQueryParams(t *testing.T) {
 	want := []*api.Field{field1, field2}
 	less := func(a, b *api.Field) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -83,7 +83,7 @@ func TestPathParams(t *testing.T) {
 	}
 	want := []*api.Field{sample.CreateRequest().Fields[0]}
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	got, err = PathParams(sample.MethodUpdate(), test)
@@ -92,7 +92,7 @@ func TestPathParams(t *testing.T) {
 	}
 	want = []*api.Field{sample.UpdateRequest().Fields[0]}
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -100,7 +100,7 @@ func TestFilterSlice(t *testing.T) {
 	got := FilterSlice([]string{"a.1", "b.1", "a.2", "b.2"}, func(s string) bool { return strings.HasPrefix(s, "a.") })
 	want := []string{"a.1", "a.2"}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched FilterSlice result (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -108,7 +108,7 @@ func TestMapSlice(t *testing.T) {
 	got := MapSlice([]string{"a", "aa", "aaa"}, func(s string) int { return len(s) })
 	want := []int{1, 2, 3}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatched FilterSlice result (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/language/walk_templates_dir_test.go
+++ b/internal/sidekick/language/walk_templates_dir_test.go
@@ -35,6 +35,6 @@ func TestWalkDir(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched config from LoadConfig (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/parser/disco_test.go
+++ b/internal/sidekick/parser/disco_test.go
@@ -125,7 +125,7 @@ func TestDisco_ParsePagination(t *testing.T) {
 		Optional: true,
 	}
 	if diff := cmp.Diff(wantPagination, got.Pagination, cmpopts.IgnoreFields(api.Field{}, "Documentation")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -152,7 +152,7 @@ func TestDisco_ParsePaginationAggregate(t *testing.T) {
 		Optional: true,
 	}
 	if diff := cmp.Diff(wantPagination, got.Pagination, cmpopts.IgnoreFields(api.Field{}, "Documentation")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/parser/discovery/discovery_test.go
+++ b/internal/sidekick/parser/discovery/discovery_test.go
@@ -55,7 +55,7 @@ func TestInfo(t *testing.T) {
 		Revision:    "20250810",
 	}
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums"), cmpopts.IgnoreUnexported(api.API{})); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -77,7 +77,7 @@ func TestServiceConfigOverridesInfo(t *testing.T) {
 		PackageName: "google.cloud.secretmanager.v1",
 	}
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums"), cmpopts.IgnoreUnexported(api.API{})); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if len(sc.Apis) != 2 {
 		t.Fatalf("expected 2 APIs in service config")
@@ -192,7 +192,7 @@ func TestDeprecatedField(t *testing.T) {
 		Optional:      true,
 	}
 	if diff := cmp.Diff(wantField, gotField, cmpopts.IgnoreFields(api.Field{}, "Parent")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/parser/discovery/enum_field_test.go
+++ b/internal/sidekick/parser/discovery/enum_field_test.go
@@ -117,7 +117,7 @@ func TestMakeEnumFields(t *testing.T) {
 	apitest.CheckMessage(t, message, want)
 	wantEnums := []*api.Enum{wantEnum}
 	if diff := cmp.Diff(wantEnums, message.Enums, cmpopts.IgnoreFields(api.Enum{}, "Parent"), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -202,7 +202,7 @@ func TestMakeEnumFieldsDeprecated(t *testing.T) {
 	apitest.CheckMessage(t, message, want)
 	wantEnums := []*api.Enum{wantEnum}
 	if diff := cmp.Diff(wantEnums, message.Enums, cmpopts.IgnoreFields(api.Enum{}, "Parent"), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -308,7 +308,7 @@ func TestMakeEnumFieldsWithDeprecatedValues(t *testing.T) {
 	apitest.CheckMessage(t, message, want)
 	wantEnums := []*api.Enum{wantEnum}
 	if diff := cmp.Diff(wantEnums, message.Enums, cmpopts.IgnoreFields(api.Enum{}, "Parent"), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/parser/discovery/inline_object_field_test.go
+++ b/internal/sidekick/parser/discovery/inline_object_field_test.go
@@ -64,7 +64,7 @@ func TestMaybeInlineObject(t *testing.T) {
 		TypezID:       ".package.Message.inline",
 	}
 	if diff := cmp.Diff(wantField, field); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	wantInlineMessage := &api.Message{
@@ -149,7 +149,7 @@ func TestArrayWithInlineObject(t *testing.T) {
 		TypezID:       ".package.Message.arrayWithObject",
 	}
 	if diff := cmp.Diff(wantField, field); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	wantInlineMessage := &api.Message{

--- a/internal/sidekick/parser/discovery/lro_test.go
+++ b/internal/sidekick/parser/discovery/lro_test.go
@@ -71,7 +71,7 @@ func TestLroAnnotations(t *testing.T) {
 		t.Fatalf("missing method %s in model", want.ID)
 	}
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Method{}, "Documentation")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// The parser should have injected a mixin method.
@@ -105,7 +105,7 @@ func TestLroAnnotations(t *testing.T) {
 		t.Fatalf("missing method %s in model", wantMixin.ID)
 	}
 	if diff := cmp.Diff(wantMixin, gotMixin, cmpopts.IgnoreFields(api.Method{}, "Documentation", "Service")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/parser/discovery/map_field_test.go
+++ b/internal/sidekick/parser/discovery/map_field_test.go
@@ -322,7 +322,7 @@ func TestMapScalarTypes(t *testing.T) {
 			},
 		}
 		if diff := cmp.Diff(wantFields, message.Fields, cmpopts.IgnoreFields(api.Field{}, "TypezID")); diff != "" {
-			t.Errorf("mismatch (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 			continue
 		}
 		mapMessage := model.Message(message.Fields[0].TypezID)
@@ -342,7 +342,7 @@ func TestMapScalarTypes(t *testing.T) {
 			TypezID: test.WantTypeID,
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("mismatch on value field (-want, +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/internal/sidekick/parser/discovery/methods_test.go
+++ b/internal/sidekick/parser/discovery/methods_test.go
@@ -138,7 +138,7 @@ func TestMakeServiceMethodsReturnsEmpty(t *testing.T) {
 		Signatures: []*api.MethodSignature{{Names: []string{"project", "zone", "operation"}}},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -177,7 +177,7 @@ func TestMakeServiceMethodsDeprecated(t *testing.T) {
 		Signatures: []*api.MethodSignature{{Names: []string{"project", "body"}}},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/parser/discovery/uritemplate_test.go
+++ b/internal/sidekick/parser/discovery/uritemplate_test.go
@@ -53,14 +53,15 @@ func TestParseUriTemplateSuccess(t *testing.T) {
 			WithVariable(api.NewPathVariable("resource").WithAllowReserved().WithMatchRecursive()).
 			WithVerb("getIamPolicy")},
 	} {
-		got, err := ParseUriTemplate(test.input)
-		if err != nil {
-			t.Errorf("expected a successful parse with input=%s, err=%v", test.input, err)
-			continue
-		}
-		if diff := cmp.Diff(test.want, got, cmpopts.EquateEmpty()); diff != "" {
-			t.Errorf("mismatch [%s] (-want, +got):\n%s", test.input, diff)
-		}
+		t.Run(test.input, func(t *testing.T) {
+			got, err := ParseUriTemplate(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -78,9 +79,11 @@ func TestParseUriTemplateError(t *testing.T) {
 		{"dns/v1/{+resource}:verb/should/not/have/slashes"},
 		{"dns/v1/{+emptyVerb}:"},
 	} {
-		if got, err := ParseUriTemplate(test.input); err == nil {
-			t.Errorf("expected a parsing error with input=%s, got=%v", test.input, got)
-		}
+		t.Run(test.input, func(t *testing.T) {
+			if got, err := ParseUriTemplate(test.input); err == nil {
+				t.Fatalf("expected error, got=%v", got)
+			}
+		})
 	}
 }
 
@@ -95,17 +98,18 @@ func TestParseExpression(t *testing.T) {
 		{"{abc_012}", "abc_012"},
 		{"{abc_012}/foo/{bar}", "abc_012"},
 	} {
-		gotSegment, gotWidth, err := parseExpression(test.input)
-		if err != nil {
-			t.Errorf("expected a successful parse with input=%s, err=%v", test.input, err)
-			continue
-		}
-		if diff := cmp.Diff(&api.PathSegment{Variable: api.NewPathVariable(test.want).WithMatch()}, gotSegment); diff != "" {
-			t.Errorf("mismatch [%s] (-want, +got):\n%s", test.input, diff)
-		}
-		if len(test.want)+2 != gotWidth {
-			t.Errorf("mismatch want=%d, got=%d", len(test.want), gotWidth)
-		}
+		t.Run(test.input, func(t *testing.T) {
+			gotSegment, gotWidth, err := parseExpression(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(&api.PathSegment{Variable: api.NewPathVariable(test.want).WithMatch()}, gotSegment); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			if len(test.want)+2 != gotWidth {
+				t.Errorf("mismatch want=%d, got=%d", len(test.want), gotWidth)
+			}
+		})
 	}
 }
 
@@ -136,17 +140,18 @@ func TestParseLiteral(t *testing.T) {
 		{"abcde/f", "abcde"},
 		{"abcdef", "abcdef"},
 	} {
-		gotSegment, gotWidth, err := parseLiteral(test.input)
-		if err != nil {
-			t.Errorf("expected a successful parse with input=%s, err=%v", test.input, err)
-			continue
-		}
-		if diff := cmp.Diff(&api.PathSegment{Literal: test.want}, gotSegment); diff != "" {
-			t.Errorf("mismatch [%s] (-want, +got):\n%s", test.input, diff)
-		}
-		if len(test.want) != gotWidth {
-			t.Errorf("mismatch want=%d, got=%d", len(test.want), gotWidth)
-		}
+		t.Run(test.input, func(t *testing.T) {
+			gotSegment, gotWidth, err := parseLiteral(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(&api.PathSegment{Literal: test.want}, gotSegment); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			if len(test.want) != gotWidth {
+				t.Errorf("mismatch want=%d, got=%d", len(test.want), gotWidth)
+			}
+		})
 	}
 }
 

--- a/internal/sidekick/parser/mixin_test.go
+++ b/internal/sidekick/parser/mixin_test.go
@@ -47,7 +47,7 @@ func TestProtobuf_ForceLongrunning(t *testing.T) {
 	}
 	gotMethods, gotDescriptors := loadMixins(sc, true)
 	if diff := cmp.Diff(wantMethods, gotMethods); diff != "" {
-		t.Errorf("mismatched operations (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	names := map[string]bool{}
@@ -68,7 +68,7 @@ func TestProtobuf_ForceLongrunningNoRules(t *testing.T) {
 	}
 	gotMethods, gotDescriptors := loadMixins(sc, true)
 	if diff := cmp.Diff(wantMethods, gotMethods); diff != "" {
-		t.Errorf("mismatched operations (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	names := map[string]bool{}

--- a/internal/sidekick/parser/openapi_test.go
+++ b/internal/sidekick/parser/openapi_test.go
@@ -717,7 +717,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 	wantService.Name = "Service"
 	wantService.ID = "..Service"
 	if diff := cmp.Diff(wantService, service, cmpopts.IgnoreFields(api.Service{}, "Methods")); diff != "" {
-		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	apitest.CheckMethod(t, service, "ListLocations", &api.Method{
@@ -1156,7 +1156,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 	}
 	wantField := []*api.Field{request_id, request_id_explicit}
 	if diff := cmp.Diff(wantField, method.AutoPopulated); diff != "" {
-		t.Errorf("incorrect auto-populated fields on method (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/parser/protobuf_imports_test.go
+++ b/internal/sidekick/parser/protobuf_imports_test.go
@@ -33,7 +33,7 @@ func TestProtobufImportsSync(t *testing.T) {
 	sort.Strings(g3Names)
 
 	if diff := cmp.Diff(ossNames, g3Names); diff != "" {
-		t.Errorf("protobuf_imports_oss.go and protobuf_imports_google3.go are out of sync (-oss +g3):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -548,10 +548,10 @@ func TestProtobuf_UniqueEnumValues(t *testing.T) {
 
 	less := func(a, b *api.EnumValue) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(fullList, withAlias.Values, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("enum values mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(uniqueList, withAlias.UniqueNumberValues, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("enum values mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1132,7 +1132,7 @@ func TestProtobuf_TrimLeadingSpacesInDocumentation(t *testing.T) {
 
 	got := trimLeadingSpacesInDocumentation(input)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in trimLeadingSpacesInDocumentation (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1755,7 +1755,7 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 	}
 	want := []*api.Field{request_id, request_id_optional, request_id_with_field_behavior}
 	if diff := cmp.Diff(want, method.AutoPopulated); diff != "" {
-		t.Errorf("incorrect auto-populated fields on method (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1919,7 +1919,7 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 			t.Fatalf("Expected ResourceDefinition for 'library.googleapis.com/Shelf' not found")
 		}
 		if diff := cmp.Diff(shelfResourceDef, foundShelf, cmpopts.IgnoreFields(api.Resource{}, "Self", "Codec", "Plural", "Singular")); diff != "" {
-			t.Errorf("ResourceDefinition (Shelf) mismatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 
 		// Verify Book
@@ -1952,7 +1952,7 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 		// Note: Book resource has 'Self' populated because it's a message resource.
 		// Ignoring Self/Codec for comparison.
 		if diff := cmp.Diff(bookResourceDef, foundBook, cmpopts.IgnoreFields(api.Resource{}, "Self", "Codec")); diff != "" {
-			t.Errorf("ResourceDefinition (Book) mismatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -1997,7 +1997,7 @@ func TestProtobuf_ResourceAnnotations(t *testing.T) {
 		}
 
 		if diff := cmp.Diff(wantBookResource, bookMessage.Resource, cmpopts.IgnoreFields(api.Resource{}, "Self", "Codec")); diff != "" {
-			t.Errorf("Book message Resource mismatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 
 		apitest.CheckMessage(t, bookMessage, &api.Message{

--- a/internal/sidekick/parser/routing_info_test.go
+++ b/internal/sidekick/parser/routing_info_test.go
@@ -252,7 +252,7 @@ func TestExamples(t *testing.T) {
 				t.Fatalf("Cannot find method %s in API State", test.methodID)
 			}
 			if diff := cmp.Diff(test.want, got.Routing); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -531,7 +531,7 @@ func TestParseRoutingPathSpecSuccess(t *testing.T) {
 		t.Run(test.path, func(t *testing.T) {
 			got, width := parseRoutingPathSpec(test.path)
 			if diff := cmp.Diff(test.wantSegments, got.Segments); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s\n", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if test.path[width:] != test.wantTrailer {
 				t.Errorf("trailer segment mismatch, want=%s, got=%s", test.wantTrailer, test.path[width:])

--- a/internal/sidekick/protobuf/input_files_test.go
+++ b/internal/sidekick/protobuf/input_files_test.go
@@ -51,7 +51,7 @@ func TestBasic(t *testing.T) {
 		filepath.ToSlash(path.Join(testdataDir, source, "service.proto")),
 	}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -75,6 +75,6 @@ func TestIncludeList(t *testing.T) {
 		filepath.ToSlash(path.Join(testdataDir, source, "resources.proto")),
 	}
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
-		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/rust/bigquery_test.go
+++ b/internal/sidekick/rust/bigquery_test.go
@@ -111,7 +111,7 @@ func TestBigQueryFiltering(t *testing.T) {
 	// "output_only" and "skip" must be skipped; "foo" must be present.
 	want := []string{"foo"}
 	if diff := cmp.Diff(want, fieldNames); diff != "" {
-		t.Errorf("unexpected field list (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/rust_prost/annotate_test.go
+++ b/internal/sidekick/rust_prost/annotate_test.go
@@ -52,7 +52,7 @@ func TestModelAnnotations(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, model.Codec, cmpopts.IgnoreFields(modelAnnotations{}, "BoilerPlate")); diff != "" {
-		t.Errorf("mismatch in model annotations (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -88,7 +88,7 @@ func TestServiceAnnotations(t *testing.T) {
 		t.Fatalf("cannot find service %s", ".google.cloud.workflows.v1.Workflows")
 	}
 	if diff := cmp.Diff(want, got.Codec); diff != "" {
-		t.Errorf("mismatch in service annotations (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -130,6 +130,6 @@ func TestMethodAnnotations(t *testing.T) {
 		t.Fatalf("cannot find service %s", ".google.cloud.workflows.v1.Workflows.GetWorkflow")
 	}
 	if diff := cmp.Diff(want, got.Codec); diff != "" {
-		t.Errorf("mismatch in method annotations (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/rust_prost/codec_test.go
+++ b/internal/sidekick/rust_prost/codec_test.go
@@ -43,6 +43,6 @@ func TestParseOptions(t *testing.T) {
 		RootName:       "test-root",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in codec (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -119,6 +119,6 @@ func TestAnnotateEnumValue_Aliases(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in Values (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -159,10 +159,10 @@ func TestAnnotateMessage(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.wantImports, test.message.Codec.(*messageAnnotations).MessageImports()); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -294,7 +294,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -349,7 +349,7 @@ func TestAnnotateMessage_DiscoveryRequests(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, test.request.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-				t.Errorf("mismatch (-want, +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -427,11 +427,11 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		ParameterTypeName: "ListSecretsRequest",
 	}
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantRequestImports := []string{"GoogleCloudWkt"}
 	if diff := cmp.Diff(wantRequestImports, gotRequest.MessageImports()); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// Verify annotations on response message
@@ -446,11 +446,11 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		ParameterTypeName:   "ListSecretsResponse",
 	}
 	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantResponseImports := []string{"GoogleCloudGax", "GoogleCloudWkt"}
 	if diff := cmp.Diff(wantResponseImports, gotResponse.MessageImports()); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -499,12 +499,12 @@ func TestAnnotateMessage_RecursiveNested(t *testing.T) {
 		ParameterTypeName: "OuterMessage",
 	}
 	if diff := cmp.Diff(wantOuter, gotOuter, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	wantImports := []string{"GoogleCloudGax", "GoogleCloudWkt"}
 	if diff := cmp.Diff(wantImports, gotOuter.MessageImports()); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -364,7 +364,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		ReturnType: "GoogleTest.ListResponse",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if gotMethod.PlainRPC() {
 		t.Errorf("gotMethod.PlainRPC() == false, want true\ngotMethod=%+v", gotMethod)
@@ -379,11 +379,11 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		ParameterTypeName: "ListRequest",
 	}
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantRequestImports := []string{"GoogleCloudWkt"}
 	if diff := cmp.Diff(wantRequestImports, gotRequest.MessageImports()); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	// Verify response message annotations
@@ -398,12 +398,12 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		ParameterTypeName:   "ListResponse",
 	}
 	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	// Response type is a paginated response which depends on gax
 	wantResponseImports := []string{"GoogleCloudGax", "GoogleCloudWkt"}
 	if diff := cmp.Diff(wantResponseImports, gotResponse.MessageImports()); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -547,7 +547,7 @@ func TestAnnotateMethod_LRO_Empty(t *testing.T) {
 		ReturnType: "GoogleTest.Operation",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
-		t.Errorf("mismatch (-want, +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	if gotMethod.PlainRPC() {
 		t.Errorf("gotMethod.PlainRPC() == false, want true\ngotMethod=%+v", gotMethod)

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -78,7 +78,7 @@ func TestParseOptions(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(api.API{})); diff != "" {
-				t.Errorf("mismatch (-want, +got)\n:%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -105,14 +105,14 @@ func TestNewCodec_WithSwiftCfg(t *testing.T) {
 		{SwiftDependency: swiftCfg.Dependencies[1]},
 	}
 	if diff := cmp.Diff(wantDeps, got.Dependencies); diff != "" {
-		t.Errorf("mismatch in Dependencies (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	wantApiPackages := map[string]*Dependency{
 		"google.cloud.location": {SwiftDependency: swiftCfg.Dependencies[1]},
 	}
 	if diff := cmp.Diff(wantApiPackages, got.ApiPackages); diff != "" {
-		t.Errorf("mismatch in ApiPackages (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/swift/format_documentation_test.go
+++ b/internal/sidekick/swift/format_documentation_test.go
@@ -56,7 +56,7 @@ func TestFormatDocumentation(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("formatDocumentation() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -83,6 +83,6 @@ func TestFormatDocumentationWithLinks(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("formatDocumentation() mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -152,7 +152,7 @@ func TestPathVariables(t *testing.T) {
 				return
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("pathVariables() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -318,7 +318,7 @@ func TestNewPathVariable(t *testing.T) {
 				return
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("newPathVariable() mismatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/swift/generate_package_swift_test.go
+++ b/internal/sidekick/swift/generate_package_swift_test.go
@@ -73,7 +73,7 @@ func TestGeneratePackageSwift_WithDependencies(t *testing.T) {
     .package(path: "../../packages/wkt"),
   ],`
 	if diff := cmp.Diff(wantPackageDeps, gotPackageDeps); diff != "" {
-		t.Errorf("mismatch in package dependencies (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
 	gotTargetDeps := extractBlock(t, contentStr, "      dependencies: [", "\n      ]")
@@ -83,7 +83,7 @@ func TestGeneratePackageSwift_WithDependencies(t *testing.T) {
         .product(name: "wkt", package: "wkt"),
       ]`
 	if diff := cmp.Diff(wantTargetDeps, gotTargetDeps); diff != "" {
-		t.Errorf("mismatch in target dependencies (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/swift/lookup_test.go
+++ b/internal/sidekick/swift/lookup_test.go
@@ -30,7 +30,7 @@ func TestLookupMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(msg, got); diff != "" {
-		t.Errorf("lookupMessage() mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -52,7 +52,7 @@ func TestLookupEnum(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(enum, got); diff != "" {
-		t.Errorf("lookupEnum() mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -78,7 +78,7 @@ func TestLookupField(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(field, got); diff != "" {
-		t.Errorf("lookupField() mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
I got tired of refactoring code only to be told I was not following the guidelines in `howwewritego.md`. Change all the `t.Errorf(, diff)` to use the prescribed format.