### PR TITLE
feat(internal/librarian/java): add code snippet extraction helpers for README rendering

### DIFF
--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -242,7 +242,7 @@ func extractSnippetsFromFile(file string) (map[string][]string, error) {
 			name := openMatch[1]
 			openSnippets[name] = true
 			if _, exists := snippetLines[name]; !exists {
-				snippetLines[name] = []string{}
+				snippetLines[name] = nil
 			}
 			continue
 		}

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -191,6 +191,7 @@ func collectSnippetFiles(dir string) ([]string, error) {
 		if !d.Type().IsRegular() {
 			return nil
 		}
+		// Include .xml files since non-POM configs (e.g., logback.xml) also contain snippets.
 		ext := filepath.Ext(path)
 		if ext == ".java" || ext == ".xml" {
 			files = append(files, path)

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -26,6 +27,11 @@ import (
 )
 
 var (
+	openSnippetRegex  = regexp.MustCompile(`\[START ([a-zA-Z0-9_-]+)\]`)
+	closeSnippetRegex = regexp.MustCompile(`\[END ([a-zA-Z0-9_-]+)\]`)
+	openExcludeRegex  = regexp.MustCompile(`\[START_EXCLUDE\]`)
+	closeExcludeRegex = regexp.MustCompile(`\[END_EXCLUDE\]`)
+
 	// Matches lowercase/digit followed by uppercase (e.g., "FooBar" -> "Foo Bar").
 	camelCaseRegexp = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 
@@ -40,6 +46,9 @@ var (
 
 	// errEmptyDir indicates the provided directory path is empty.
 	errEmptyDir = errors.New("dir cannot be empty")
+
+	// errEmptyFile indicates an empty file path was provided.
+	errEmptyFile = errors.New("file cannot be empty")
 )
 
 // codeSample represents a discovered Java code sample along with its derived title.
@@ -156,4 +165,97 @@ func extractTitle(filePath string) (string, error) {
 		return "", errEmptyTitle
 	}
 	return title, nil
+}
+
+// collectSnippetFiles recursively scans dir/samples for Java and XML files containing snippets.
+func collectSnippetFiles(dir string) ([]string, error) {
+	samplesDir := filepath.Join(dir, "samples")
+	if _, err := os.Stat(samplesDir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to stat samples directory: %w", err)
+	}
+	var files []string
+	err := filepath.WalkDir(samplesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "test" || (d.Name() == "generated" && filepath.Base(filepath.Dir(path)) == "snippets") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if ext == ".java" || ext == ".xml" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk samples directory: %w", err)
+	}
+	return files, nil
+}
+
+// extractSnippetsFromFile parses a single file to return a map of tagged code snippets.
+// Reads code between START and END markers while omitting EXCLUDE blocks.
+// START and END markers must be named (e.g. [START <name>]).
+func extractSnippetsFromFile(file string) (map[string][]string, error) {
+	if file == "" {
+		return nil, errEmptyFile
+	}
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", file, err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	// 10 MB sanity limit to protect system memory.
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+	// Scan through file line by line and capture all open snippets.
+	// More than one open block might exist for a given line, so we
+	// need to track open snippets in a map.
+	snippetLines := make(map[string][]string)
+	openSnippets := make(map[string]bool)
+	excluding := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if openExcludeRegex.MatchString(line) {
+			excluding = true
+			continue
+		}
+		if closeExcludeRegex.MatchString(line) {
+			excluding = false
+			continue
+		}
+		if excluding {
+			continue
+		}
+		openMatch := openSnippetRegex.FindStringSubmatch(line)
+		closeMatch := closeSnippetRegex.FindStringSubmatch(line)
+		if len(openMatch) > 1 {
+			name := openMatch[1]
+			openSnippets[name] = true
+			if _, exists := snippetLines[name]; !exists {
+				snippetLines[name] = []string{}
+			}
+			continue
+		}
+		if len(closeMatch) > 1 {
+			delete(openSnippets, closeMatch[1])
+			continue
+		}
+		for s := range openSnippets {
+			snippetLines[s] = append(snippetLines[s], line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed scanning file %s: %w", file, err)
+	}
+	return snippetLines, nil
 }

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -182,6 +182,7 @@ func collectSnippetFiles(dir string) ([]string, error) {
 			return err
 		}
 		if d.IsDir() {
+			// Skip unit test directories and generated snippet output directories.
 			if d.Name() == "test" || (d.Name() == "generated" && filepath.Base(filepath.Dir(path)) == "snippets") {
 				return filepath.SkipDir
 			}
@@ -203,8 +204,24 @@ func collectSnippetFiles(dir string) ([]string, error) {
 }
 
 // extractSnippetsFromFile parses a single file to return a map of tagged code snippets.
-// Reads code between START and END markers while omitting EXCLUDE blocks.
-// START and END markers must be named (e.g. [START <name>]).
+// Code between [START <name>] and [END <name>] tags is captured line by line.
+// Any code inside [START_EXCLUDE] and [END_EXCLUDE] blocks is omitted.
+// Example:
+//
+//	Input file content:
+//	  // [START my_snippet]
+//	  void run() {
+//	    // [START_EXCLUDE]
+//	    secretInit();
+//	    // [END_EXCLUDE]
+//	    doWork();
+//	  }
+//	  // [END my_snippet]
+//
+//	Resulting map entry for "my_snippet":
+//	  void run() {
+//	    doWork();
+//	  }
 func extractSnippetsFromFile(file string) (map[string][]string, error) {
 	if file == "" {
 		return nil, errEmptyFile
@@ -219,12 +236,13 @@ func extractSnippetsFromFile(file string) (map[string][]string, error) {
 	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
 	// Scan through file line by line and capture all open snippets.
 	// More than one open block might exist for a given line, so we
-	// need to track open snippets in a map.
+	// need openSnippets to track currently active snippet blocks by name
 	snippetLines := make(map[string][]string)
 	openSnippets := make(map[string]bool)
 	excluding := false
 	for scanner.Scan() {
 		line := scanner.Text()
+		// Check for exclusion blocks first; code within EXCLUDE tags is completely skipped.
 		if openExcludeRegex.MatchString(line) {
 			excluding = true
 			continue
@@ -236,6 +254,7 @@ func extractSnippetsFromFile(file string) (map[string][]string, error) {
 		if excluding {
 			continue
 		}
+		// Check for snippet start/end tags. Tag lines themselves are not saved.
 		openMatch := openSnippetRegex.FindStringSubmatch(line)
 		closeMatch := closeSnippetRegex.FindStringSubmatch(line)
 		if len(openMatch) > 1 {
@@ -250,6 +269,7 @@ func extractSnippetsFromFile(file string) (map[string][]string, error) {
 			delete(openSnippets, closeMatch[1])
 			continue
 		}
+		// Append this line of code to every snippet block currently open.
 		for s := range openSnippets {
 			snippetLines[s] = append(snippetLines[s], line)
 		}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -16,6 +16,7 @@ package java
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -472,6 +473,157 @@ func TestExtractTitle_Error(t *testing.T) {
 			_, gotErr := extractTitle(tmpPath)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("extractTitle() error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestCollectSnippetFiles(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		setupFiles func(t *testing.T, dir string)
+		want       []string
+	}{
+		{
+			name: "missing samples directory returns nil",
+			setupFiles: func(t *testing.T, dir string) {
+				// Empty directory.
+			},
+			want: nil,
+		},
+		{
+			name: "collects java and xml files while ignoring excluded directories",
+			setupFiles: func(t *testing.T, dir string) {
+				validJavaDir := filepath.Join(dir, "samples", "src", "main", "java")
+				validXMLDir := filepath.Join(dir, "samples", "src", "main", "resources")
+				testDir := filepath.Join(dir, "samples", "src", "test", "java")
+				genDir := filepath.Join(dir, "samples", "snippets", "generated")
+				if err := os.MkdirAll(validJavaDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(validXMLDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(testDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(genDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(validJavaDir, "Sample.java"), []byte("public class Sample {}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(validXMLDir, "pom.xml"), []byte("<project></project>"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(validJavaDir, "README.md"), []byte("# Ignore"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(testDir, "TestSample.java"), []byte("public class TestSample {}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(genDir, "GenSnippet.java"), []byte("public class GenSnippet {}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []string{
+				filepath.Join("samples", "src", "main", "java", "Sample.java"),
+				filepath.Join("samples", "src", "main", "resources", "pom.xml"),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			test.setupFiles(t, tempDir)
+
+			got, err := collectSnippetFiles(tempDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var relGot []string
+			for _, p := range got {
+				rel, err := filepath.Rel(tempDir, p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				relGot = append(relGot, rel)
+			}
+			if diff := cmp.Diff(test.want, relGot); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractSnippetsFromFile(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+		want    map[string][]string
+	}{
+		{
+			name: "extracts snippets and respects exclude blocks",
+			content: `public class Example {
+  // [START my_snippet]
+  public void run() {
+    // [START_EXCLUDE]
+    secretInit();
+    // [END_EXCLUDE]
+    doWork();
+  }
+  // [END my_snippet]
+}`,
+			want: map[string][]string{
+				"my_snippet": {
+					"  public void run() {",
+					"    doWork();",
+					"  }",
+				},
+			},
+		},
+		{
+			name:    "no snippets in file",
+			content: "public class Simple {}",
+			want:    map[string][]string{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpPath := filepath.Join(t.TempDir(), "SampleSnippet.java")
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := extractSnippetsFromFile(tmpPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractSnippetsFromFile_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		file    string
+		wantErr error
+	}{
+		{
+			name:    "empty file parameter returns error",
+			file:    "",
+			wantErr: errEmptyFile,
+		},
+		{
+			name:    "non-existent file returns error",
+			file:    "non-existent-file.java",
+			wantErr: fs.ErrNotExist,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := extractSnippetsFromFile(test.file)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("extractSnippetsFromFile(%q) error = %v, wantErr %v", test.file, err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -656,6 +656,7 @@ func TestExtractSnippetsFromFile_Error(t *testing.T) {
 			file:    "",
 			wantErr: errEmptyFile,
 		},
+		// Triggers os.Open error when target file does not exist on disk.
 		{
 			name:    "non-existent file returns error",
 			file:    "non-existent-file.java",

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -498,17 +498,10 @@ func TestCollectSnippetFiles(t *testing.T) {
 				validXMLDir := filepath.Join(dir, "samples", "src", "main", "resources")
 				testDir := filepath.Join(dir, "samples", "src", "test", "java")
 				genDir := filepath.Join(dir, "samples", "snippets", "generated")
-				if err := os.MkdirAll(validJavaDir, 0755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.MkdirAll(validXMLDir, 0755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.MkdirAll(testDir, 0755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.MkdirAll(genDir, 0755); err != nil {
-					t.Fatal(err)
+				for _, d := range []string{validJavaDir, validXMLDir, testDir, genDir} {
+					if err := os.MkdirAll(d, 0755); err != nil {
+						t.Fatal(err)
+					}
 				}
 				if err := os.WriteFile(filepath.Join(validJavaDir, "Sample.java"), []byte("public class Sample {}"), 0644); err != nil {
 					t.Fatal(err)
@@ -556,6 +549,7 @@ func TestCollectSnippetFiles(t *testing.T) {
 }
 
 func TestExtractSnippetsFromFile(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name    string
 		content string
@@ -582,12 +576,60 @@ func TestExtractSnippetsFromFile(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple independent snippets in single file",
+			content: `public class Multi {
+  // [START first]
+  void a() {}
+  // [END first]
+  // [START second]
+  void b() {}
+  // [END second]
+}`,
+			want: map[string][]string{
+				"first": {
+					"  void a() {}",
+				},
+				"second": {
+					"  void b() {}",
+				},
+			},
+		},
+		{
+			name: "nested snippets with exclude block",
+			content: `public class Nested {
+  // [START outer]
+  void start() {
+    // [START inner]
+    doInner();
+    // [START_EXCLUDE]
+    logDebug();
+    // [END_EXCLUDE]
+    finishInner();
+    // [END inner]
+  }
+  // [END outer]
+}`,
+			want: map[string][]string{
+				"outer": {
+					"  void start() {",
+					"    doInner();",
+					"    finishInner();",
+					"  }",
+				},
+				"inner": {
+					"    doInner();",
+					"    finishInner();",
+				},
+			},
+		},
+		{
 			name:    "no snippets in file",
 			content: "public class Simple {}",
 			want:    map[string][]string{},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			tmpPath := filepath.Join(t.TempDir(), "SampleSnippet.java")
 			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Add collectSnippetFiles and extractSnippetsFromFile helpers to scan Java and XML sample files for code snippets. Add unit tests in readme_test.go.

For #6515