### PR TITLE
fix(internal/librarian/java): exclude google-cloud-bom and libraries-bom when generating gapic-libraries-bom/pom.xml

### DIFF
--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -49,6 +49,8 @@ var (
 	// excludedBOMs is a set of artifact IDs to exclude from the generated GAPIC BOM.
 	excludedBOMs = map[string]bool{
 		"google-cloud-bigtable-deps-bom": true,
+		"google-cloud-bom":               true,
+		"libraries-bom":                  true,
 	}
 	ignoredDirs = map[string]bool{
 		gapicBOM:                   true,

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -137,6 +137,16 @@ func verifyBOM(t *testing.T, path string, wantVersion string, wantDeps []bomDepe
 	}) {
 		t.Errorf("%s should NOT contain google-cloud-bigtable-deps-bom", path)
 	}
+	if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
+		return d.ArtifactID == "google-cloud-bom"
+	}) {
+		t.Errorf("%s should NOT contain google-cloud-bom", path)
+	}
+	if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
+		return d.ArtifactID == "libraries-bom"
+	}) {
+		t.Errorf("%s should NOT contain libraries-bom", path)
+	}
 }
 
 func TestSearchForJavaModules(t *testing.T) {

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -126,26 +126,15 @@ func verifyBOM(t *testing.T, path string, wantVersion string, wantDeps []bomDepe
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	// Verify that libraries like java-maps-places are excluded because their
-	// GroupID (com.google.maps) is not in the allowed groupInclusions list.
-	if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
-		return d.ArtifactID == "google-maps-places-bom"
-	}) {
-		t.Errorf("%s should NOT contain google-maps-places-bom", path)
-	}
-	if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
-		return d.ArtifactID == "google-cloud-bigtable-deps-bom"
-	}) {
-		t.Errorf("%s should NOT contain google-cloud-bigtable-deps-bom", path)
-	}
-	if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
-		return d.ArtifactID == "google-cloud-bom"
-	}) {
-		t.Errorf("%s should NOT contain google-cloud-bom", path)
-	}
-	if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
-		return d.ArtifactID == "libraries-bom"
-	}) {
-		t.Errorf("%s should NOT contain libraries-bom", path)
+	// GroupID (com.google.maps) is not in the allowed groupInclusions list, and
+	// other BOMs explicitly excluded in excludedBOMs are also absent.
+	for _, excluded := range []string{"google-maps-places-bom",
+		"google-cloud-bigtable-deps-bom", "google-cloud-bom", "libraries-bom"} {
+		if slices.ContainsFunc(p.Dependencies, func(d bomDependency) bool {
+			return d.ArtifactID == excluded
+		}) {
+			t.Errorf("%s should NOT contain %s", path, excluded)
+		}
 	}
 }
 


### PR DESCRIPTION
Exclude google-cloud-bom and libraries-bom when generating gapic-libraries-bom/pom.xml. This is needed because  https://github.com/googleapis/google-cloud-java/pull/13498 added new modules, among them are these two BOMs.

Fixes https://github.com/googleapis/librarian/issues/6600
For https://github.com/googleapis/google-cloud-java/issues/13609