### PR TITLE
feat(internal/librarian/nodejs): add metadata_name_override and name_pretty_override support

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -364,6 +364,8 @@ This document describes the schema for the librarian.yaml.
 | `nodejs_apis` | list of [NodejsAPI](#nodejsapi-configuration) (optional) | Is a list of Node.js-specific API configurations. |
 | `package_name` | string | Is the npm package name (e.g., "@google-cloud/access-approval"). |
 | `client_documentation_override` | string | Allows the client_documentation field in .repo-metadata.json to be overridden from the default that's inferred. |
+| `metadata_name_override` | string | Allows the name field in .repo-metadata.json to be overridden. |
+| `name_pretty_override` | string | Allows the name_pretty field in .repo-metadata.json to be overridden. |
 
 ## PythonDefault Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -777,6 +777,12 @@ type NodejsPackage struct {
 	// ClientDocumentationOverride allows the client_documentation field in
 	// .repo-metadata.json to be overridden from the default that's inferred.
 	ClientDocumentationOverride string `yaml:"client_documentation_override,omitempty"`
+
+	// MetadataNameOverride allows the name field in .repo-metadata.json to be overridden.
+	MetadataNameOverride string `yaml:"metadata_name_override,omitempty"`
+
+	// NamePrettyOverride allows the name_pretty field in .repo-metadata.json to be overridden.
+	NamePrettyOverride string `yaml:"name_pretty_override,omitempty"`
 }
 
 // NodejsAPI represents configuration for a single API within a Node.js package.

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -674,6 +674,12 @@ func mergeNodejs(dst, src *config.NodejsPackage) *config.NodejsPackage {
 	if src.ClientDocumentationOverride != "" {
 		res.ClientDocumentationOverride = src.ClientDocumentationOverride
 	}
+	if src.MetadataNameOverride != "" {
+		res.MetadataNameOverride = src.MetadataNameOverride
+	}
+	if src.NamePrettyOverride != "" {
+		res.NamePrettyOverride = src.NamePrettyOverride
+	}
 	return &res
 }
 

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1125,6 +1125,28 @@ func TestWriteRepoMetadata(t *testing.T) {
 				return w
 			},
 		},
+		{
+			name: "metadata name and name pretty overrides",
+			library: &config.Library{
+				Name: "google-cloud-dialogflow-cx",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Nodejs: &config.NodejsPackage{
+					MetadataNameOverride: "dialogflow-cx",
+					NamePrettyOverride:   "Dialogflow CX API",
+				},
+			},
+			want: func() *repometadata.RepoMetadata {
+				w := sample.RepoMetadata()
+				w.DistributionName = "@google-cloud/dialogflow-cx"
+				w.Language = cfg.Language
+				w.Repo = cfg.Repo
+				w.ClientDocumentation = "https://cloud.google.com/nodejs/docs/reference/dialogflow-cx/latest"
+				w.ProductDocumentation = "https://cloud.google.com/secret-manager/docs"
+				w.Name = "dialogflow-cx"
+				w.NamePretty = "Dialogflow CX API"
+				return w
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()

--- a/internal/librarian/nodejs/repometadata.go
+++ b/internal/librarian/nodejs/repometadata.go
@@ -35,8 +35,16 @@ func generateRepoMetadata(cfg *config.Config, library *config.Library, googleapi
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/nodejs/docs/reference/%s/latest", pkgSuffix)
 	}
 
-	if library.Nodejs != nil && library.Nodejs.ClientDocumentationOverride != "" {
-		metadata.ClientDocumentation = library.Nodejs.ClientDocumentationOverride
+	if library.Nodejs != nil {
+		if library.Nodejs.ClientDocumentationOverride != "" {
+			metadata.ClientDocumentation = library.Nodejs.ClientDocumentationOverride
+		}
+		if library.Nodejs.MetadataNameOverride != "" {
+			metadata.Name = library.Nodejs.MetadataNameOverride
+		}
+		if library.Nodejs.NamePrettyOverride != "" {
+			metadata.NamePretty = library.Nodejs.NamePrettyOverride
+		}
 	}
 
 	if strings.HasPrefix(metadata.ProductDocumentation, "https://cloud.google.com/") {


### PR DESCRIPTION
This pull request adds  metadata_name_override  and  name_pretty_override  configuration fields to  NodejsPackage  in  librarian.yaml .

Currently, Librarian infers  name  and  name_pretty  in  `.repo-metadata.json`  directly from the backend service config ( api.ShortName  and  api.Title ). When multiple packages share a single service
authority (e.g.,  @google-cloud/dialogflow  and  @google-cloud/dialogflow-cx  both generating from  dialogflow.googleapis.com ), Librarian overwrites both  `.repo-metadata.json`  files with identical
values ( "dialogflow"  /  "Dialogflow" ), causing config collisions.

Adding these override fields aligns Node.js with Java ( name_pretty_override ) and Python ( metadata_name_override ), allowing packages with shared service authorities to explicitly preserve their unique
metadata names.

For #6453