### PR TITLE
feat(librarian/swift): use discovery config

### DIFF
--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
+	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	sidekickswift "github.com/googleapis/librarian/internal/sidekick/swift"
 	"github.com/googleapis/librarian/internal/sources"
@@ -74,8 +75,8 @@ func camelLibraryName(api string) string {
 	return name.String()
 }
 
-func libraryToModelConfig(library *config.Library, api *config.API, src *sources.Sources) (*parser.ModelConfig, error) {
-	svcConfig, err := serviceconfig.Find(src.Googleapis, api.Path, config.LanguageSwift)
+func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sources.Sources) (*parser.ModelConfig, error) {
+	svcConfig, err := serviceconfig.Find(src.Googleapis, apiCfg.Path, config.LanguageSwift)
 	if err != nil {
 		return nil, err
 	}
@@ -89,15 +90,29 @@ func libraryToModelConfig(library *config.Library, api *config.API, src *sources
 		specFormat = library.SpecificationFormat
 	}
 
-	return &parser.ModelConfig{
+	modelCfg := &parser.ModelConfig{
 		Language:            config.LanguageSwift,
 		SpecificationFormat: specFormat,
 		ServiceConfig:       svcConfig.ServiceConfig,
-		SpecificationSource: api.Path,
+		SpecificationSource: apiCfg.Path,
 		Source:              sourceConfig,
 		Codec: map[string]string{
 			"copyright-year": library.CopyrightYear,
 			"version":        library.Version,
 		},
-	}, nil
+	}
+	if library.Swift != nil && library.Swift.Discovery != nil {
+		pollers := make([]*api.Poller, len(library.Swift.Discovery.Pollers))
+		for i, poller := range library.Swift.Discovery.Pollers {
+			pollers[i] = &api.Poller{
+				Prefix:   poller.Prefix,
+				MethodID: poller.MethodID,
+			}
+		}
+		modelCfg.Discovery = &api.Discovery{
+			OperationID: library.Swift.Discovery.OperationID,
+			Pollers:     pollers,
+		}
+	}
+	return modelCfg, nil
 }

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/testhelper"
@@ -204,6 +205,49 @@ func TestLibraryToModelConfig(t *testing.T) {
 				Codec:               map[string]string{"copyright-year": "2038", "version": "1.2.3"},
 				Source: &sources.SourceConfig{
 					ActiveRoots: []string{"discovery", "googleapis"},
+				},
+			},
+		},
+		{
+			name: "discovery config with LRO",
+			library: &config.Library{
+				Name:                "google-cloud-compute-v1",
+				CopyrightYear:       "2038",
+				Version:             "1.2.3",
+				Roots:               []string{"discovery", "googleapis"},
+				SpecificationFormat: config.SpecDiscovery,
+				Swift: &config.SwiftPackage{
+					Discovery: &config.SwiftDiscovery{
+						OperationID: ".google.cloud.compute.v1.",
+						Pollers: []config.SwiftPoller{
+							{
+								Prefix:   "compute/v1/projects/{project}/zones/{zone}",
+								MethodID: ".google.cloud.compute.v1.zoneOperations.get",
+							},
+						},
+					},
+				},
+			},
+			api: &config.API{
+				Path: "discoveries/compute.v1.json",
+			},
+			want: &parser.ModelConfig{
+				Language:            config.LanguageSwift,
+				SpecificationFormat: config.SpecDiscovery,
+				SpecificationSource: "discoveries/compute.v1.json",
+				ServiceConfig:       "google/cloud/compute/v1/compute_v1.yaml",
+				Codec:               map[string]string{"copyright-year": "2038", "version": "1.2.3"},
+				Source: &sources.SourceConfig{
+					ActiveRoots: []string{"discovery", "googleapis"},
+				},
+				Discovery: &api.Discovery{
+					OperationID: ".google.cloud.compute.v1.",
+					Pollers: []*api.Poller{
+						{
+							Prefix:   "compute/v1/projects/{project}/zones/{zone}",
+							MethodID: ".google.cloud.compute.v1.zoneOperations.get",
+						},
+					},
 				},
 			},
 		},

--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -361,11 +361,11 @@ func sortOneOfFieldForExamples(f1, f2 *Field) int {
 }
 
 func enrichMethodSamples(m *Method) {
-	m.IsSimple = m.Pagination == nil &&
-		!m.ClientSideStreaming && !m.ServerSideStreaming &&
-		m.OperationInfo == nil && m.DiscoveryLro == nil
-
-	m.IsLRO = m.OperationInfo != nil
+	// Methods with AIP-151 LRO annotations *OR* discovery LRO annotations are LROs.
+	m.IsLRO = m.OperationInfo != nil || m.DiscoveryLro != nil
+	m.IsStreaming = m.ClientSideStreaming || m.ServerSideStreaming
+	// A simple method is not paginated, not streaming and not an LRO.
+	m.IsSimple = m.Pagination == nil && !m.IsStreaming && !m.IsLRO
 
 	if m.SourceServiceID == ".google.longrunning.Operations" &&
 		m.Name == "GetOperation" &&
@@ -380,8 +380,6 @@ func enrichMethodSamples(m *Method) {
 	m.LongRunningReturnsEmpty = m.LongRunningResponseType != nil && m.LongRunningResponseType.ID == ".google.protobuf.Empty"
 
 	m.IsList = m.OutputType != nil && m.OutputType.Pagination != nil
-
-	m.IsStreaming = m.ClientSideStreaming || m.ServerSideStreaming
 
 	if m.SampleInfo = aipStandardGetInfo(m); m.SampleInfo != nil {
 		m.IsAIPStandardGet = true

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -672,7 +672,7 @@ func TestIsSimpleMethod(t *testing.T) {
 }
 
 func TestIsLRO(t *testing.T) {
-	testCases := []struct {
+	for _, test := range []struct {
 		name   string
 		method *Method
 		want   bool
@@ -687,12 +687,16 @@ func TestIsLRO(t *testing.T) {
 			method: &Method{OperationInfo: &OperationInfo{}},
 			want:   true,
 		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			enrichMethodSamples(tc.method)
-			if got := tc.method.IsLRO; got != tc.want {
-				t.Errorf("IsLRO() = %v, want %v", got, tc.want)
+		{
+			name:   "LRO method is discovery LRO",
+			method: &Method{DiscoveryLro: &DiscoveryLro{}},
+			want:   true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			enrichMethodSamples(test.method)
+			if got := test.method.IsLRO; got != test.want {
+				t.Errorf("IsLRO() = %v, want %v", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
Use the discovery configuration to generate `getOperation()` mixins in discovery-based APIs.

Towards #5271 

Verified that this has no effect on Rust and Swift.