### PR TITLE
fix(rust): tidy empty rust blocks

### DIFF
--- a/internal/librarian/rust/tidy.go
+++ b/internal/librarian/rust/tidy.go
@@ -18,12 +18,21 @@ import (
 	"slices"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/yaml"
 )
 
 // Tidy tidies the Rust-specific configuration for a library.
 func Tidy(lib *config.Library) (*config.Library, error) {
 	if lib.Rust != nil && lib.Rust.Modules != nil {
 		lib.Rust.Modules = slices.DeleteFunc(lib.Rust.Modules, isEmptyModule)
+	}
+
+	empty, err := yaml.Empty(lib.Rust)
+	if err != nil {
+		return nil, err
+	}
+	if empty {
+		lib.Rust = nil
 	}
 
 	return lib, nil

--- a/internal/librarian/rust/tidy_test.go
+++ b/internal/librarian/rust/tidy_test.go
@@ -17,14 +17,15 @@ package rust
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func TestTidyLanguageConfig_Rust(t *testing.T) {
+func TestTidy(t *testing.T) {
 	for _, test := range []struct {
-		name        string
-		lib         *config.Library
-		wantNumMods int
+		name string
+		lib  *config.Library
+		want *config.RustCrate
 	}{
 		{
 			name: "empty_module_removed",
@@ -44,7 +45,15 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 					},
 				},
 			},
-			wantNumMods: 1, // Modules should be removed
+			want: &config.RustCrate{
+				Modules: []*config.RustModule{
+					{
+						Output:   "src/storage/src/generated/protos/storage",
+						APIPath:  "google/storage/v2",
+						Template: "prost",
+					},
+				},
+			},
 		},
 		{
 			name: "storage_module_not_removed",
@@ -60,7 +69,23 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 					},
 				},
 			},
-			wantNumMods: 1, // Rust storage module should NOT be removed
+			want: &config.RustCrate{
+				Modules: []*config.RustModule{
+					{
+						Output:   "src/storage/src/generated/protos/storage",
+						Template: "storage",
+					},
+				},
+			},
+		},
+		{
+			name: "empty_rust_removed",
+			lib: &config.Library{
+				Name:   "google-cloud-storage",
+				Output: "src/storage",
+				Rust:   &config.RustCrate{},
+			},
+			want: nil,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -68,8 +93,8 @@ func TestTidyLanguageConfig_Rust(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(got.Rust.Modules) != test.wantNumMods {
-				t.Fatalf("wrong number of modules")
+			if diff := cmp.Diff(test.want, got.Rust); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
If a `lib.Rust` (struct _pointer_) is initialized to an empty struct value, set `lib.Rust` to `nil` as part of `rust.Tidy`. Achieve this by literally serializing the value and comparing it to `{}`, as provided by our `yaml.Empty` API.

This will fix a number of empty blocks already checked into google-cloud-rust: https://github.com/googleapis/google-cloud-rust/commit/6592b1b5411e402ef1b98265d0067a6127768652.

Also refactors the test to be more aligned with our principles/easier to extend.

Fixes #6599