### PR TITLE
feat(internal/librarian/java): add Java README rendering without snippets

### DIFF
--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -159,12 +159,12 @@ func renderREADME(params libraryPostProcessParams, keepSet map[string]bool) erro
 		Monorepo:          true,
 		BOMVersion:        bomVersion,
 	}
-	var buf strings.Builder
+	var buf bytes.Buffer
 	if err := readmeTmplParsed.Execute(&buf, data); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
 	}
 	outputPath := filepath.Join(params.outDir, "README.md")
-	return os.WriteFile(outputPath, []byte(buf.String()), 0644)
+	return os.WriteFile(outputPath, buf.Bytes(), 0644)
 }
 
 // extractSamples locates production Java sample files and returns parsed codeSample structs

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -29,11 +29,13 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
 const (
 	readmePartialsFile = ".readme-partials.yaml"
+	readmeFile         = "README.md"
 )
 
 var (
@@ -102,31 +104,15 @@ type readmeData struct {
 // renderREADME generates README.md using the embedded Markdown template.
 // Skips if keepSet protects README.md.
 func renderREADME(params libraryPostProcessParams, keepSet map[string]bool) error {
-	if keepSet["README.md"] {
+	if keepSet[readmeFile] {
 		return nil
 	}
-	if params.outDir == "" {
-		return errEmptyDir
+	if err := validateReadmeParams(params); err != nil {
+		return err
 	}
-	if params.metadata == nil {
-		return errNilMetadata
-	}
-	if params.library == nil {
-		return errNilLibrary
-	}
-	if params.cfg == nil {
-		return errNilConfig
-	}
-
-	var libraryVersion string
-	if params.library.Java != nil && params.library.Java.ReleasedVersion != "" {
-		libraryVersion = params.library.Java.ReleasedVersion
-	} else {
-		var err error
-		libraryVersion, err = deriveLastReleasedVersion(params.library.Version)
-		if err != nil {
-			return fmt.Errorf("failed to derive library version: %w", err)
-		}
+	libraryVersion, err := getLibraryVersion(params.library)
+	if err != nil {
+		return err
 	}
 	bomVersion, err := findBOMVersion(params.cfg)
 	if err != nil {
@@ -136,12 +122,9 @@ func renderREADME(params libraryPostProcessParams, keepSet map[string]bool) erro
 	if err != nil {
 		return err
 	}
-	groupID, artifactID := parseGroupIDArtifactID(params.metadata.DistributionName)
+	groupID, artifactID := getGroupIDArtifactID(params)
 	repoShort := parseRepoShortName(params.metadata.Repo)
-	minJavaVersion := params.metadata.MinJavaVersion
-	if minJavaVersion == 0 {
-		minJavaVersion = 8
-	}
+	minJavaVersion := getMinJavaVersion(params.metadata)
 	samples, err := extractSamples(params.outDir)
 	if err != nil {
 		return fmt.Errorf("failed to extract samples: %w", err)
@@ -163,8 +146,50 @@ func renderREADME(params libraryPostProcessParams, keepSet map[string]bool) erro
 	if err := readmeTmplParsed.Execute(&buf, data); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
 	}
-	outputPath := filepath.Join(params.outDir, "README.md")
+	outputPath := filepath.Join(params.outDir, readmeFile)
 	return os.WriteFile(outputPath, buf.Bytes(), 0644)
+}
+
+// validateReadmeParams validates that required parameters are present before rendering README.md.
+func validateReadmeParams(params libraryPostProcessParams) error {
+	if params.outDir == "" {
+		return errEmptyDir
+	}
+	if params.metadata == nil {
+		return errNilMetadata
+	}
+	if params.library == nil {
+		return errNilLibrary
+	}
+	if params.cfg == nil {
+		return errNilConfig
+	}
+	return nil
+}
+
+func getLibraryVersion(lib *config.Library) (string, error) {
+	if lib.Java != nil && lib.Java.ReleasedVersion != "" {
+		return lib.Java.ReleasedVersion, nil
+	}
+	ver, err := deriveLastReleasedVersion(lib.Version)
+	if err != nil {
+		return "", fmt.Errorf("failed to derive library version: %w", err)
+	}
+	return ver, nil
+}
+
+func getGroupIDArtifactID(params libraryPostProcessParams) (string, string) {
+	if params.library.Java != nil && params.library.Java.GroupID != "" && params.library.Java.ArtifactID != "" {
+		return params.library.Java.GroupID, params.library.Java.ArtifactID
+	}
+	return parseGroupIDArtifactID(params.metadata.DistributionName)
+}
+
+func getMinJavaVersion(meta *repoMetadata) int {
+	if meta == nil || meta.MinJavaVersion == 0 {
+		return 8
+	}
+	return meta.MinJavaVersion
 }
 
 // extractSamples locates production Java sample files and returns parsed codeSample structs

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -17,6 +17,7 @@ package java
 import (
 	"bufio"
 	"bytes"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -24,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"text/template"
 	"unicode"
 	"unicode/utf8"
 
@@ -35,6 +37,10 @@ const (
 )
 
 var (
+	//go:embed template/README.md.go.tmpl
+	readmeTmpl       string
+	readmeTmplParsed = template.Must(template.New("README").Parse(readmeTmpl))
+
 	openSnippetRegex  = regexp.MustCompile(`\[START ([a-zA-Z0-9_-]+)\]`)
 	closeSnippetRegex = regexp.MustCompile(`\[END ([a-zA-Z0-9_-]+)\]`)
 	openExcludeRegex  = regexp.MustCompile(`\[START_EXCLUDE\]`)
@@ -60,12 +66,105 @@ var (
 
 	// errInvalidYAML indicates the YAML file syntax is invalid or cannot be unmarshaled.
 	errInvalidYAML = errors.New("invalid yaml syntax")
+
+	// errNilMetadata indicates a nil repoMetadata pointer was provided.
+	errNilMetadata = errors.New("metadata cannot be nil")
+
+	// errNilLibrary indicates a nil Library pointer was provided.
+	errNilLibrary = errors.New("library cannot be nil")
+
+	// errNilConfig indicates a nil Config pointer was provided.
+	errNilConfig = errors.New("cfg cannot be nil")
 )
 
 // codeSample represents a discovered Java code sample along with its derived title.
 type codeSample struct {
 	Title string
 	File  string
+}
+
+// readmeData represents the top-level template execution context passed to README.md.go.tmpl.
+type readmeData struct {
+	Repo              *repoMetadata
+	Samples           []codeSample
+	MinJavaVersion    int
+	Partials          map[string]interface{}
+	Snippets          map[string]string
+	GroupID           string
+	ArtifactID        string
+	Version           string
+	RepoShort         string
+	MigratedSplitRepo bool
+	Monorepo          bool
+	BOMVersion        string
+}
+
+// renderREADME generates README.md using the embedded Markdown template.
+// Skips if keepSet protects README.md.
+func renderREADME(params libraryPostProcessParams, keepSet map[string]bool) error {
+	if keepSet["README.md"] {
+		return nil
+	}
+	if params.outDir == "" {
+		return errEmptyDir
+	}
+	if params.metadata == nil {
+		return errNilMetadata
+	}
+	if params.library == nil {
+		return errNilLibrary
+	}
+	if params.cfg == nil {
+		return errNilConfig
+	}
+
+	var libraryVersion string
+	if params.library.Java != nil && params.library.Java.ReleasedVersion != "" {
+		libraryVersion = params.library.Java.ReleasedVersion
+	} else {
+		var err error
+		libraryVersion, err = deriveLastReleasedVersion(params.library.Version)
+		if err != nil {
+			return fmt.Errorf("failed to derive library version: %w", err)
+		}
+	}
+	bomVersion, err := findBOMVersion(params.cfg)
+	if err != nil {
+		return fmt.Errorf("failed to find BOM version: %w", err)
+	}
+	partials, err := loadReadmePartials(params.outDir)
+	if err != nil {
+		return err
+	}
+	groupID, artifactID := parseGroupIDArtifactID(params.metadata.DistributionName)
+	repoShort := parseRepoShortName(params.metadata.Repo)
+	minJavaVersion := params.metadata.MinJavaVersion
+	if minJavaVersion == 0 {
+		minJavaVersion = 8
+	}
+	samples, err := extractSamples(params.outDir)
+	if err != nil {
+		return fmt.Errorf("failed to extract samples: %w", err)
+	}
+	data := readmeData{
+		Repo:              params.metadata,
+		Samples:           samples,
+		MinJavaVersion:    minJavaVersion,
+		Partials:          partials,
+		GroupID:           groupID,
+		ArtifactID:        artifactID,
+		Version:           libraryVersion,
+		RepoShort:         repoShort,
+		MigratedSplitRepo: false,
+		Monorepo:          true,
+		BOMVersion:        bomVersion,
+	}
+	var buf strings.Builder
+	if err := readmeTmplParsed.Execute(&buf, data); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+	outputPath := filepath.Join(params.outDir, "README.md")
+	return os.WriteFile(outputPath, []byte(buf.String()), 0644)
 }
 
 // extractSamples locates production Java sample files and returns parsed codeSample structs

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -19,7 +19,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -891,22 +890,16 @@ func TestRenderREADME(t *testing.T) {
 	defaultBOMVersion := "1.0.0-BOM"
 	defaultLibraryVersion := "1.2.3-LIB"
 	for _, test := range []struct {
-		name              string
-		metadata          *repoMetadata
-		keepSet           map[string]bool
-		setupFiles        func(t *testing.T, dir string)
-		wantSubstrings    []string
-		wantNotSubstrings []string
-		wantContent       string
+		name        string
+		metadata    *repoMetadata
+		keepSet     map[string]bool
+		setupFiles  func(t *testing.T, dir string)
+		goldenFile  string
+		wantContent string
 	}{
 		{
-			name: "renders standard README without partials",
-			wantSubstrings: []string{
-				"# Google My API Client for Java",
-				"<groupId>com.google.cloud</groupId>",
-				"<artifactId>google-cloud-myapi</artifactId>",
-				"<version>1.2.3-LIB</version>",
-			},
+			name:       "renders standard README without partials",
+			goldenFile: filepath.Join("testdata", "readme", "standard.golden"),
 		},
 		{
 			name: "renders README with loaded partial overrides",
@@ -917,10 +910,7 @@ func TestRenderREADME(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantSubstrings: []string{
-				"# Google My API Client for Java",
-				"This is a great API.",
-			},
+			goldenFile: filepath.Join("testdata", "readme", "partials.golden"),
 		},
 		{
 			name:    "skips rendering if README.md is in keep list",
@@ -968,21 +958,29 @@ func TestRenderREADME(t *testing.T) {
 				t.Fatal(err)
 			}
 			content := string(outputBytes)
+			if test.goldenFile != "" {
+				if *update {
+					if err := os.MkdirAll(filepath.Dir(test.goldenFile), 0755); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(test.goldenFile, outputBytes, 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
+				wantBytes, err := os.ReadFile(test.goldenFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if diff := cmp.Diff(string(wantBytes), content); diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+				return
+			}
 			if test.wantContent != "" {
 				if diff := cmp.Diff(test.wantContent, content); diff != "" {
 					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 				return
-			}
-			for _, want := range test.wantSubstrings {
-				if !strings.Contains(content, want) {
-					t.Errorf("generated README missing expected substring %q", want)
-				}
-			}
-			for _, notWant := range test.wantNotSubstrings {
-				if strings.Contains(content, notWant) {
-					t.Errorf("generated README contains unexpected substring %q", notWant)
-				}
 			}
 		})
 	}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -890,12 +890,10 @@ func TestRenderREADME(t *testing.T) {
 	defaultBOMVersion := "1.0.0-BOM"
 	defaultLibraryVersion := "1.2.3-LIB"
 	for _, test := range []struct {
-		name        string
-		metadata    *repoMetadata
-		keepSet     map[string]bool
-		setupFiles  func(t *testing.T, dir string)
-		goldenFile  string
-		wantContent string
+		name       string
+		metadata   *repoMetadata
+		setupFiles func(t *testing.T, dir string)
+		goldenFile string
 	}{
 		{
 			name:       "renders standard README without partials",
@@ -911,18 +909,6 @@ func TestRenderREADME(t *testing.T) {
 				}
 			},
 			goldenFile: filepath.Join("testdata", "readme", "partials.golden"),
-		},
-		{
-			name:    "skips rendering if README.md is in keep list",
-			keepSet: map[string]bool{"README.md": true},
-			setupFiles: func(t *testing.T, dir string) {
-				path := filepath.Join(dir, "README.md")
-				content := "Custom README content"
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
-			wantContent: "Custom README content",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -948,8 +934,7 @@ func TestRenderREADME(t *testing.T) {
 				},
 				metadata: meta,
 			}
-			err := renderREADME(params, test.keepSet)
-			if err != nil {
+			if err := renderREADME(params, nil); err != nil {
 				t.Fatal(err)
 			}
 			outputPath := filepath.Join(dir, "README.md")
@@ -957,32 +942,42 @@ func TestRenderREADME(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			content := string(outputBytes)
-			if test.goldenFile != "" {
-				if *update {
-					if err := os.MkdirAll(filepath.Dir(test.goldenFile), 0755); err != nil {
-						t.Fatal(err)
-					}
-					if err := os.WriteFile(test.goldenFile, outputBytes, 0644); err != nil {
-						t.Fatal(err)
-					}
-				}
-				wantBytes, err := os.ReadFile(test.goldenFile)
-				if err != nil {
+			if *update {
+				if err := os.MkdirAll(filepath.Dir(test.goldenFile), 0755); err != nil {
 					t.Fatal(err)
 				}
-				if diff := cmp.Diff(string(wantBytes), content); diff != "" {
-					t.Errorf("mismatch (-want +got):\n%s", diff)
+				if err := os.WriteFile(test.goldenFile, outputBytes, 0644); err != nil {
+					t.Fatal(err)
 				}
-				return
 			}
-			if test.wantContent != "" {
-				if diff := cmp.Diff(test.wantContent, content); diff != "" {
-					t.Errorf("mismatch (-want +got):\n%s", diff)
-				}
-				return
+			wantBytes, err := os.ReadFile(test.goldenFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(string(wantBytes), string(outputBytes)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestRenderREADME_KeepSet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "README.md")
+	wantContent := "Custom README content"
+	if err := os.WriteFile(path, []byte(wantContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	params := libraryPostProcessParams{outDir: dir}
+	if err := renderREADME(params, map[string]bool{readmeFile: true}); err != nil {
+		t.Fatal(err)
+	}
+	gotBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(wantContent, string(gotBytes)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -19,9 +19,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestExtractSamples(t *testing.T) {
@@ -874,6 +876,159 @@ func TestExtractSnippetsFromFile_Error(t *testing.T) {
 			_, err := extractSnippetsFromFile(test.file)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("extractSnippetsFromFile(%q) error = %v, wantErr %v", test.file, err, test.wantErr)
+			}
+		})
+	}
+}
+func TestRenderREADME(t *testing.T) {
+	defaultMetadata := &repoMetadata{
+		NamePretty:       "My API",
+		DistributionName: "com.google.cloud:google-cloud-myapi",
+		Repo:             "googleapis/google-cloud-java",
+		APIShortname:     "myapi",
+		MinJavaVersion:   8,
+	}
+	defaultBOMVersion := "1.0.0-BOM"
+	defaultLibraryVersion := "1.2.3-LIB"
+	for _, test := range []struct {
+		name              string
+		metadata          *repoMetadata
+		keepSet           map[string]bool
+		setupFiles        func(t *testing.T, dir string)
+		wantSubstrings    []string
+		wantNotSubstrings []string
+		wantContent       string
+	}{
+		{
+			name: "renders standard README without partials",
+			wantSubstrings: []string{
+				"# Google My API Client for Java",
+				"<groupId>com.google.cloud</groupId>",
+				"<artifactId>google-cloud-myapi</artifactId>",
+				"<version>1.2.3-LIB</version>",
+			},
+		},
+		{
+			name: "renders README with loaded partial overrides",
+			setupFiles: func(t *testing.T, dir string) {
+				path := filepath.Join(dir, readmePartialsFile)
+				content := `about: "This is a great API."`
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSubstrings: []string{
+				"# Google My API Client for Java",
+				"This is a great API.",
+			},
+		},
+		{
+			name:    "skips rendering if README.md is in keep list",
+			keepSet: map[string]bool{"README.md": true},
+			setupFiles: func(t *testing.T, dir string) {
+				path := filepath.Join(dir, "README.md")
+				content := "Custom README content"
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantContent: "Custom README content",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if test.setupFiles != nil {
+				test.setupFiles(t, dir)
+			}
+			meta := test.metadata
+			if meta == nil {
+				meta = defaultMetadata
+			}
+			params := libraryPostProcessParams{
+				outDir: dir,
+				library: &config.Library{
+					Version: defaultLibraryVersion,
+				},
+				cfg: &config.Config{
+					Default: &config.Default{
+						Java: &config.JavaDefault{
+							LibrariesBOMVersion: defaultBOMVersion,
+						},
+					},
+				},
+				metadata: meta,
+			}
+			err := renderREADME(params, test.keepSet)
+			if err != nil {
+				t.Fatalf("renderREADME() unexpected error: %v", err)
+			}
+			outputPath := filepath.Join(dir, "README.md")
+			outputBytes, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatalf("failed reading generated README: %v", err)
+			}
+			content := string(outputBytes)
+			if test.wantContent != "" {
+				if diff := cmp.Diff(test.wantContent, content); diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+				return
+			}
+			for _, want := range test.wantSubstrings {
+				if !strings.Contains(content, want) {
+					t.Errorf("generated README missing expected substring %q", want)
+				}
+			}
+			for _, notWant := range test.wantNotSubstrings {
+				if strings.Contains(content, notWant) {
+					t.Errorf("generated README contains unexpected substring %q", notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderREADME_Error(t *testing.T) {
+	validMeta := &repoMetadata{Repo: "repo", DistributionName: "com.google.cloud:google-cloud-foo"}
+	validLib := &config.Library{Version: "1.2.3"}
+	validCfg := &config.Config{Default: &config.Default{Java: &config.JavaDefault{LibrariesBOMVersion: "1.0.0"}}}
+	for _, test := range []struct {
+		name    string
+		params  libraryPostProcessParams
+		keepSet map[string]bool
+		wantErr error
+	}{
+		{
+			name:    "empty directory returns error",
+			params:  libraryPostProcessParams{outDir: "", metadata: validMeta, library: validLib, cfg: validCfg},
+			wantErr: errEmptyDir,
+		},
+		{
+			name:    "nil metadata returns error",
+			params:  libraryPostProcessParams{outDir: "dir", metadata: nil, library: validLib, cfg: validCfg},
+			wantErr: errNilMetadata,
+		},
+		{
+			name:    "nil library returns error",
+			params:  libraryPostProcessParams{outDir: "dir", metadata: validMeta, library: nil, cfg: validCfg},
+			wantErr: errNilLibrary,
+		},
+		{
+			name:    "nil config returns error",
+			params:  libraryPostProcessParams{outDir: "dir", metadata: validMeta, library: validLib, cfg: nil},
+			wantErr: errNilConfig,
+		},
+		{
+			name:    "keepSet protecting README.md exits early without error even with nil pointers",
+			params:  libraryPostProcessParams{outDir: "", metadata: nil, library: nil, cfg: nil},
+			keepSet: map[string]bool{"README.md": true},
+			wantErr: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := renderREADME(test.params, test.keepSet)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("renderREADME() error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -960,12 +960,12 @@ func TestRenderREADME(t *testing.T) {
 			}
 			err := renderREADME(params, test.keepSet)
 			if err != nil {
-				t.Fatalf("renderREADME() unexpected error: %v", err)
+				t.Fatal(err)
 			}
 			outputPath := filepath.Join(dir, "README.md")
 			outputBytes, err := os.ReadFile(outputPath)
 			if err != nil {
-				t.Fatalf("failed reading generated README: %v", err)
+				t.Fatal(err)
 			}
 			content := string(outputBytes)
 			if test.wantContent != "" {

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -1018,12 +1018,6 @@ func TestRenderREADME_Error(t *testing.T) {
 			params:  libraryPostProcessParams{outDir: "dir", metadata: validMeta, library: validLib, cfg: nil},
 			wantErr: errNilConfig,
 		},
-		{
-			name:    "keepSet protecting README.md exits early without error even with nil pointers",
-			params:  libraryPostProcessParams{outDir: "", metadata: nil, library: nil, cfg: nil},
-			keepSet: map[string]bool{"README.md": true},
-			wantErr: nil,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := renderREADME(test.params, test.keepSet)

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -891,7 +891,6 @@ func TestRenderREADME(t *testing.T) {
 	defaultLibraryVersion := "1.2.3-LIB"
 	for _, test := range []struct {
 		name       string
-		metadata   *repoMetadata
 		setupFiles func(t *testing.T, dir string)
 		goldenFile string
 	}{
@@ -916,10 +915,6 @@ func TestRenderREADME(t *testing.T) {
 			if test.setupFiles != nil {
 				test.setupFiles(t, dir)
 			}
-			meta := test.metadata
-			if meta == nil {
-				meta = defaultMetadata
-			}
 			params := libraryPostProcessParams{
 				outDir: dir,
 				library: &config.Library{
@@ -932,7 +927,7 @@ func TestRenderREADME(t *testing.T) {
 						},
 					},
 				},
-				metadata: meta,
+				metadata: defaultMetadata,
 			}
 			if err := renderREADME(params, nil); err != nil {
 				t.Fatal(err)

--- a/internal/librarian/java/template/README.md.go.tmpl
+++ b/internal/librarian/java/template/README.md.go.tmpl
@@ -1,0 +1,255 @@
+# Google {{ .Repo.NamePretty }} Client for Java
+
+Java idiomatic client for [{{ .Repo.NamePretty }}][product-docs].
+
+[![Maven][maven-version-image]][maven-version-link]
+![Stability][stability-image]
+
+- [Product Documentation][product-docs]
+- [Client Library Documentation][javadocs]
+
+{{ if and .Partials .Partials.DeprecationWarning }}{{ .Partials.DeprecationWarning }}
+{{ else if eq .Repo.ReleaseLevel "preview" }}> Note: This client is a work-in-progress, and may occasionally
+> make backwards-incompatible changes.
+
+{{ end }}{{ if .MigratedSplitRepo }}:bus: In October 2022, this library has moved to
+[google-cloud-java/{{ .Repo.RepoShort }}](
+https://github.com/googleapis/google-cloud-java/tree/main/{{ .Repo.RepoShort }}).
+This repository will be archived in the future.
+Future releases will appear in the new repository (https://github.com/googleapis/google-cloud-java/releases).
+The Maven artifact coordinates (`{{ .GroupID }}:{{ .ArtifactID }}`) remain the same.
+{{ end }}
+## Quickstart
+
+{{ if and .Snippets (index .Snippets (print .Repo.APIShortname "_install_with_bom")) -}}
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
+
+```xml
+{{ index .Snippets (print .Repo.APIShortname "_install_with_bom") }}
+```
+
+If you are using Maven without the BOM, add this to your dependencies:
+{{ else if and .Monorepo (or (eq .GroupID "com.google.cloud") (eq .GroupID "com.google.analytics") (eq .GroupID "com.google.area120")) }}
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>{{ .BOMVersion }}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>{{ .GroupID }}</groupId>
+    <artifactId>{{ .ArtifactID }}</artifactId>
+  </dependency>
+</dependencies>
+```
+
+If you are using Maven without the BOM, add this to your dependencies:
+{{ else }}If you are using Maven, add this to your pom.xml file:
+{{ end }}
+
+```xml
+{{ if and .Snippets (index .Snippets (print .Repo.APIShortname "_install_without_bom")) -}}
+{{ index .Snippets (print .Repo.APIShortname "_install_without_bom") }}
+{{- else -}}
+<dependency>
+  <groupId>{{ .GroupID }}</groupId>
+  <artifactId>{{ .ArtifactID }}</artifactId>
+  <version>{{ .Version }}</version>
+</dependency>
+{{- end }}
+```
+
+{{ if and .Snippets (index .Snippets (print .Repo.APIShortname "_install_with_bom")) -}}
+If you are using Gradle 5.x or later, add this to your dependencies:
+
+```Groovy
+implementation platform('com.google.cloud:libraries-bom:{{ .BOMVersion }}')
+
+implementation '{{ .GroupID }}:{{ .ArtifactID }}'
+```
+{{ end }}If you are using Gradle without BOM, add this to your dependencies:
+
+```Groovy
+implementation '{{ .GroupID }}:{{ .ArtifactID }}:{{ .Version }}'
+```
+
+If you are using SBT, add this to your dependencies:
+
+```Scala
+libraryDependencies += "{{ .GroupID }}" % "{{ .ArtifactID }}" % "{{ .Version }}"
+```
+
+## Authentication
+
+See the [Authentication][authentication] section in the base directory's README.
+
+## Authorization
+
+The client application making API calls must be granted [authorization scopes][auth-scopes] required for the desired {{ .Repo.NamePretty }} APIs, and the authenticated principal must have the [IAM role(s)][predefined-iam-roles] required to access GCP resources using the {{ .Repo.NamePretty }} API calls.
+
+## Getting Started
+
+### Prerequisites
+
+You will need a [Google Cloud Platform Console][developer-console] project with the {{ .Repo.NamePretty }} [API enabled][enable-api].
+{{ if .Repo.RequiresBilling }}You will need to [enable billing][enable-billing] to use Google {{ .Repo.NamePretty }}.{{ end }}
+[Follow these instructions][create-project] to get your project set up. You will also need to set up the local development environment by
+[installing the Google Cloud Command Line Interface][cloud-cli] and running the following commands in command line:
+`gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
+
+### Installation and setup
+
+You'll need to obtain the `{{ .ArtifactID }}` library.  See the [Quickstart](#quickstart) section
+to add `{{ .ArtifactID }}` as a dependency in your code.
+
+## About {{ .Repo.NamePretty }}
+
+{{ if and .Partials .Partials.About }}
+{{ .Partials.About }}
+{{ else }}
+[{{ .Repo.NamePretty }}][product-docs] {{ .Repo.APIDescription }}
+
+See the [{{ .Repo.NamePretty }} client library docs][javadocs] to learn how to
+use this {{ .Repo.NamePretty }} Client Library.
+{{ end -}}
+{{ if and .Partials .Partials.CustomContent }}
+
+{{ .Partials.CustomContent }}
+{{ end }}
+
+{{ if .Samples }}
+## Samples
+
+Samples are in the [`samples/`](https://github.com/{{ .Repo.Repo }}/tree/main/samples) directory.
+
+| Sample                      | Source Code                       | Try it |
+| --------------------------- | --------------------------------- | ------ |
+{{ range .Samples }}| {{ .Title }} | [source code](https://github.com/{{ $.Repo.Repo }}/blob/main/{{ .File }}) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/{{ $.Repo.Repo }}&page=editor&open_in_editor={{ .File }}) |
+{{ end }}
+{{ end }}
+
+{{ if not .Samples }}
+
+{{ end -}}
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document][troubleshooting].
+
+{{ if .Repo.Transport }}## Transport
+
+{{ if eq .Repo.Transport "grpc" }}{{ .Repo.NamePretty }} uses gRPC for the transport layer.
+{{ else if or (eq .Repo.Transport "http") (eq .Repo.Transport "rest") }}{{ .Repo.NamePretty }} uses HTTP/JSON for the transport layer.
+{{ else if or (eq .Repo.Transport "both") (eq .Repo.Transport "grpc+rest") }}{{ .Repo.NamePretty }} uses both gRPC and HTTP/JSON for the transport layer.
+{{ end }}
+{{ end }}## Supported Java Versions
+
+Java {{ .MinJavaVersion }} or above is required for using this client.
+
+Google's Java client libraries,
+[Google Cloud Client Libraries][cloudlibs]
+and
+[Google Cloud API Libraries][apilibs],
+follow the
+[Oracle Java SE support roadmap][oracle]
+(see the Oracle Java SE Product Releases section).
+
+### For new development
+
+In general, new feature development occurs with support for the lowest Java
+LTS version covered by  Oracle's Premier Support (which typically lasts 5 years
+from initial General Availability). If the minimum required JVM for a given
+library is changed, it is accompanied by a [semver][semver] major release.
+
+Java 11 and (in September 2021) Java 17 are the best choices for new
+development.
+
+### Keeping production systems current
+
+Google tests its client libraries with all current LTS versions covered by
+Oracle's Extended Support (which typically lasts 8 years from initial
+General Availability).
+
+#### Legacy support
+
+Google's client libraries support legacy versions of Java runtimes with long
+term stable libraries that don't receive feature updates on a best efforts basis
+as it may not be possible to backport all patches.
+
+Google provides updates on a best efforts basis to apps that continue to use
+Java 7, though apps might need to upgrade to current versions of the library
+that supports their JVM.
+
+#### Where to find specific information
+
+The latest versions and the supported Java versions are identified on
+the individual GitHub repository `github.com/GoogleAPIs/java-SERVICENAME`
+and on [google-cloud-java][g-c-j].
+
+## Versioning
+
+{{- if and .Partials .Partials.Versioning }}
+{{ .Partials.Versioning }}
+{{ else }}
+This library follows [Semantic Versioning](http://semver.org/).
+
+{{ if eq .Repo.ReleaseLevel "preview" }}
+It is currently in major version zero (``0.y.z``), which means that anything may change at any time
+and the public API should not be considered stable.
+{{ end }}{{ end }}
+
+## Contributing
+
+{{ if and .Partials .Partials.Contributing }}
+{{ .Partials.Contributing }}
+{{ else }}
+Contributions to this library are always welcome and highly encouraged.
+
+See [CONTRIBUTING][contributing] for more information how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in
+this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more
+information.
+{{ end }}
+
+## License
+
+Apache 2.0 - See [LICENSE][license] for more information.
+
+Java is a registered trademark of Oracle and/or its affiliates.
+
+[product-docs]: {{ .Repo.ProductDocumentation }}
+[javadocs]: {{ .Repo.ClientDocumentation }}
+[stability-image]: https://img.shields.io/badge/stability-{{ if eq .Repo.ReleaseLevel "stable" }}stable-green{{ else if eq .Repo.ReleaseLevel "preview" }}preview-yellow{{ else }}unknown-red{{ end }}
+[maven-version-image]: https://img.shields.io/maven-central/v/{{ .GroupID }}/{{ .ArtifactID }}.svg
+[maven-version-link]: https://central.sonatype.com/artifact/{{ .GroupID }}/{{ .ArtifactID }}/{{ .Version }}
+[authentication]: https://github.com/googleapis/google-cloud-java#authentication
+[auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
+[predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles
+[iam-policy]: https://cloud.google.com/iam/docs/overview#cloud-iam-policy
+[developer-console]: https://console.developers.google.com/
+[create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+[cloud-cli]: https://cloud.google.com/cli
+[troubleshooting]: https://github.com/googleapis/google-cloud-java/blob/main/TROUBLESHOOTING.md
+[contributing]: https://github.com/{{ .Repo.Repo }}/blob/main/CONTRIBUTING.md
+[code-of-conduct]: https://github.com/{{ .Repo.Repo }}/blob/main/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[license]: https://github.com/{{ .Repo.Repo }}/blob/main/LICENSE
+{{ if .Repo.RequiresBilling }}[enable-billing]: https://cloud.google.com/apis/docs/getting-started#enabling_billing{{ end }}
+{{ if .Repo.APIID }}[enable-api]: https://console.cloud.google.com/flows/enableapi?apiid={{ .Repo.APIID }}{{ end }}
+[libraries-bom]: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+
+[semver]: https://semver.org/
+[cloudlibs]: https://cloud.google.com/apis/docs/client-libraries-explained
+[apilibs]: https://cloud.google.com/apis/docs/client-libraries-explained#google_api_client_libraries
+[oracle]: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
+[g-c-j]: http://github.com/googleapis/google-cloud-java

--- a/internal/librarian/java/testdata/readme/partials.golden
+++ b/internal/librarian/java/testdata/readme/partials.golden
@@ -1,0 +1,190 @@
+# Google My API Client for Java
+
+Java idiomatic client for [My API][product-docs].
+
+[![Maven][maven-version-image]][maven-version-link]
+![Stability][stability-image]
+
+- [Product Documentation][product-docs]
+- [Client Library Documentation][javadocs]
+
+
+## Quickstart
+
+
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>1.0.0-BOM</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-myapi</artifactId>
+  </dependency>
+</dependencies>
+```
+
+If you are using Maven without the BOM, add this to your dependencies:
+
+
+```xml
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-myapi</artifactId>
+  <version>1.2.3-LIB</version>
+</dependency>
+```
+
+If you are using Gradle without BOM, add this to your dependencies:
+
+```Groovy
+implementation 'com.google.cloud:google-cloud-myapi:1.2.3-LIB'
+```
+
+If you are using SBT, add this to your dependencies:
+
+```Scala
+libraryDependencies += "com.google.cloud" % "google-cloud-myapi" % "1.2.3-LIB"
+```
+
+## Authentication
+
+See the [Authentication][authentication] section in the base directory's README.
+
+## Authorization
+
+The client application making API calls must be granted [authorization scopes][auth-scopes] required for the desired My API APIs, and the authenticated principal must have the [IAM role(s)][predefined-iam-roles] required to access GCP resources using the My API API calls.
+
+## Getting Started
+
+### Prerequisites
+
+You will need a [Google Cloud Platform Console][developer-console] project with the My API [API enabled][enable-api].
+
+[Follow these instructions][create-project] to get your project set up. You will also need to set up the local development environment by
+[installing the Google Cloud Command Line Interface][cloud-cli] and running the following commands in command line:
+`gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
+
+### Installation and setup
+
+You'll need to obtain the `google-cloud-myapi` library.  See the [Quickstart](#quickstart) section
+to add `google-cloud-myapi` as a dependency in your code.
+
+## About My API
+
+
+This is a great API.
+
+
+
+
+
+
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document][troubleshooting].
+
+## Supported Java Versions
+
+Java 8 or above is required for using this client.
+
+Google's Java client libraries,
+[Google Cloud Client Libraries][cloudlibs]
+and
+[Google Cloud API Libraries][apilibs],
+follow the
+[Oracle Java SE support roadmap][oracle]
+(see the Oracle Java SE Product Releases section).
+
+### For new development
+
+In general, new feature development occurs with support for the lowest Java
+LTS version covered by  Oracle's Premier Support (which typically lasts 5 years
+from initial General Availability). If the minimum required JVM for a given
+library is changed, it is accompanied by a [semver][semver] major release.
+
+Java 11 and (in September 2021) Java 17 are the best choices for new
+development.
+
+### Keeping production systems current
+
+Google tests its client libraries with all current LTS versions covered by
+Oracle's Extended Support (which typically lasts 8 years from initial
+General Availability).
+
+#### Legacy support
+
+Google's client libraries support legacy versions of Java runtimes with long
+term stable libraries that don't receive feature updates on a best efforts basis
+as it may not be possible to backport all patches.
+
+Google provides updates on a best efforts basis to apps that continue to use
+Java 7, though apps might need to upgrade to current versions of the library
+that supports their JVM.
+
+#### Where to find specific information
+
+The latest versions and the supported Java versions are identified on
+the individual GitHub repository `github.com/GoogleAPIs/java-SERVICENAME`
+and on [google-cloud-java][g-c-j].
+
+## Versioning
+This library follows [Semantic Versioning](http://semver.org/).
+
+
+
+## Contributing
+
+
+Contributions to this library are always welcome and highly encouraged.
+
+See [CONTRIBUTING][contributing] for more information how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in
+this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more
+information.
+
+
+## License
+
+Apache 2.0 - See [LICENSE][license] for more information.
+
+Java is a registered trademark of Oracle and/or its affiliates.
+
+[product-docs]: 
+[javadocs]: 
+[stability-image]: https://img.shields.io/badge/stability-unknown-red
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-myapi.svg
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-myapi/1.2.3-LIB
+[authentication]: https://github.com/googleapis/google-cloud-java#authentication
+[auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
+[predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles
+[iam-policy]: https://cloud.google.com/iam/docs/overview#cloud-iam-policy
+[developer-console]: https://console.developers.google.com/
+[create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+[cloud-cli]: https://cloud.google.com/cli
+[troubleshooting]: https://github.com/googleapis/google-cloud-java/blob/main/TROUBLESHOOTING.md
+[contributing]: https://github.com/googleapis/google-cloud-java/blob/main/CONTRIBUTING.md
+[code-of-conduct]: https://github.com/googleapis/google-cloud-java/blob/main/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[license]: https://github.com/googleapis/google-cloud-java/blob/main/LICENSE
+
+
+[libraries-bom]: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+
+[semver]: https://semver.org/
+[cloudlibs]: https://cloud.google.com/apis/docs/client-libraries-explained
+[apilibs]: https://cloud.google.com/apis/docs/client-libraries-explained#google_api_client_libraries
+[oracle]: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
+[g-c-j]: http://github.com/googleapis/google-cloud-java

--- a/internal/librarian/java/testdata/readme/standard.golden
+++ b/internal/librarian/java/testdata/readme/standard.golden
@@ -1,0 +1,193 @@
+# Google My API Client for Java
+
+Java idiomatic client for [My API][product-docs].
+
+[![Maven][maven-version-image]][maven-version-link]
+![Stability][stability-image]
+
+- [Product Documentation][product-docs]
+- [Client Library Documentation][javadocs]
+
+
+## Quickstart
+
+
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>1.0.0-BOM</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-myapi</artifactId>
+  </dependency>
+</dependencies>
+```
+
+If you are using Maven without the BOM, add this to your dependencies:
+
+
+```xml
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-myapi</artifactId>
+  <version>1.2.3-LIB</version>
+</dependency>
+```
+
+If you are using Gradle without BOM, add this to your dependencies:
+
+```Groovy
+implementation 'com.google.cloud:google-cloud-myapi:1.2.3-LIB'
+```
+
+If you are using SBT, add this to your dependencies:
+
+```Scala
+libraryDependencies += "com.google.cloud" % "google-cloud-myapi" % "1.2.3-LIB"
+```
+
+## Authentication
+
+See the [Authentication][authentication] section in the base directory's README.
+
+## Authorization
+
+The client application making API calls must be granted [authorization scopes][auth-scopes] required for the desired My API APIs, and the authenticated principal must have the [IAM role(s)][predefined-iam-roles] required to access GCP resources using the My API API calls.
+
+## Getting Started
+
+### Prerequisites
+
+You will need a [Google Cloud Platform Console][developer-console] project with the My API [API enabled][enable-api].
+
+[Follow these instructions][create-project] to get your project set up. You will also need to set up the local development environment by
+[installing the Google Cloud Command Line Interface][cloud-cli] and running the following commands in command line:
+`gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
+
+### Installation and setup
+
+You'll need to obtain the `google-cloud-myapi` library.  See the [Quickstart](#quickstart) section
+to add `google-cloud-myapi` as a dependency in your code.
+
+## About My API
+
+
+[My API][product-docs] 
+
+See the [My API client library docs][javadocs] to learn how to
+use this My API Client Library.
+
+
+
+
+
+
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document][troubleshooting].
+
+## Supported Java Versions
+
+Java 8 or above is required for using this client.
+
+Google's Java client libraries,
+[Google Cloud Client Libraries][cloudlibs]
+and
+[Google Cloud API Libraries][apilibs],
+follow the
+[Oracle Java SE support roadmap][oracle]
+(see the Oracle Java SE Product Releases section).
+
+### For new development
+
+In general, new feature development occurs with support for the lowest Java
+LTS version covered by  Oracle's Premier Support (which typically lasts 5 years
+from initial General Availability). If the minimum required JVM for a given
+library is changed, it is accompanied by a [semver][semver] major release.
+
+Java 11 and (in September 2021) Java 17 are the best choices for new
+development.
+
+### Keeping production systems current
+
+Google tests its client libraries with all current LTS versions covered by
+Oracle's Extended Support (which typically lasts 8 years from initial
+General Availability).
+
+#### Legacy support
+
+Google's client libraries support legacy versions of Java runtimes with long
+term stable libraries that don't receive feature updates on a best efforts basis
+as it may not be possible to backport all patches.
+
+Google provides updates on a best efforts basis to apps that continue to use
+Java 7, though apps might need to upgrade to current versions of the library
+that supports their JVM.
+
+#### Where to find specific information
+
+The latest versions and the supported Java versions are identified on
+the individual GitHub repository `github.com/GoogleAPIs/java-SERVICENAME`
+and on [google-cloud-java][g-c-j].
+
+## Versioning
+This library follows [Semantic Versioning](http://semver.org/).
+
+
+
+## Contributing
+
+
+Contributions to this library are always welcome and highly encouraged.
+
+See [CONTRIBUTING][contributing] for more information how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in
+this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more
+information.
+
+
+## License
+
+Apache 2.0 - See [LICENSE][license] for more information.
+
+Java is a registered trademark of Oracle and/or its affiliates.
+
+[product-docs]: 
+[javadocs]: 
+[stability-image]: https://img.shields.io/badge/stability-unknown-red
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-myapi.svg
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-myapi/1.2.3-LIB
+[authentication]: https://github.com/googleapis/google-cloud-java#authentication
+[auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
+[predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles
+[iam-policy]: https://cloud.google.com/iam/docs/overview#cloud-iam-policy
+[developer-console]: https://console.developers.google.com/
+[create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+[cloud-cli]: https://cloud.google.com/cli
+[troubleshooting]: https://github.com/googleapis/google-cloud-java/blob/main/TROUBLESHOOTING.md
+[contributing]: https://github.com/googleapis/google-cloud-java/blob/main/CONTRIBUTING.md
+[code-of-conduct]: https://github.com/googleapis/google-cloud-java/blob/main/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[license]: https://github.com/googleapis/google-cloud-java/blob/main/LICENSE
+
+
+[libraries-bom]: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+
+[semver]: https://semver.org/
+[cloudlibs]: https://cloud.google.com/apis/docs/client-libraries-explained
+[apilibs]: https://cloud.google.com/apis/docs/client-libraries-explained#google_api_client_libraries
+[oracle]: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
+[g-c-j]: http://github.com/googleapis/google-cloud-java


### PR DESCRIPTION
Add renderREADME helper function and README.md.go.tmpl template to render Java client library READMEs without snippets using metadata, partials, and BOM version extraction. Add unit tests in readme_test.go.

For #6515