### PR TITLE
feat(internal/librarian/php): add skeleton code for PHP client library generation

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -263,6 +263,20 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 			})
 		}
 		return g.Wait()
+	case config.LanguagePhp:
+		g, gctx := errgroup.WithContext(ctx)
+		for _, library := range libraries {
+			g.Go(func() error {
+				if err := php.Generate(gctx, cfg, library, src); err != nil {
+					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+				}
+				if err := php.Format(gctx, library); err != nil {
+					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
+				}
+				return nil
+			})
+		}
+		return g.Wait()
 	case config.LanguagePython:
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {
@@ -297,20 +311,6 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 			}
 		}
 		return rust.UpdateWorkspace(ctx)
-	case config.LanguagePhp:
-		g, gctx := errgroup.WithContext(ctx)
-		for _, library := range libraries {
-			g.Go(func() error {
-				if err := php.Generate(gctx, cfg, library, src); err != nil {
-					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
-				}
-				if err := php.Format(gctx, library); err != nil {
-					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
-				}
-				return nil
-			})
-		}
-		return g.Wait()
 	case config.LanguageSwift:
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
@@ -158,6 +159,8 @@ func cleanLibraries(language string, libraries []*config.Library) error {
 			err = java.Clean(library)
 		case config.LanguageNodejs:
 			err = nodejs.Clean(library)
+		case config.LanguagePhp:
+			err = php.Clean(library)
 		case config.LanguagePython:
 			err = python.Clean(library)
 		case config.LanguageRust:
@@ -294,6 +297,20 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 			}
 		}
 		return rust.UpdateWorkspace(ctx)
+	case config.LanguagePhp:
+		g, gctx := errgroup.WithContext(ctx)
+		for _, library := range libraries {
+			g.Go(func() error {
+				if err := php.Generate(gctx, cfg, library, src); err != nil {
+					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+				}
+				if err := php.Format(gctx, library); err != nil {
+					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
+				}
+				return nil
+			})
+		}
+		return g.Wait()
 	case config.LanguageSwift:
 		g, gctx := errgroup.WithContext(ctx)
 		for _, library := range libraries {

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package php provides functionality for generating and releasing PHP client
-// libraries.
+// Package php provides PHP specific functionality for librarian.
 package php
 
 import (
@@ -35,7 +34,8 @@ func Format(ctx context.Context, library *config.Library) error {
 	return nil
 }
 
-// Clean cleans the generated PHP library.
+// Clean removes all generated code from beneath the given library's
+// output directory.
 func Clean(library *config.Library) error {
 	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP cleaning
 	return nil

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package php provides functionality for generating and releasing PHP client
+// libraries.
+package php
+
+import (
+	"context"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+// Generate generates a PHP client library.
+func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP generation
+	return nil
+}
+
+// Format formats a generated PHP library.
+func Format(ctx context.Context, library *config.Library) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP formatting
+	return nil
+}
+
+// Clean cleans the generated PHP library.
+func Clean(library *config.Library) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP cleaning
+	return nil
+}


### PR DESCRIPTION
A PHP sub-package is introduced under internal/librarian/php, defining Generate, Clean, and Format stubs.
Librarian is updated to integrate PHP into the cleanLibraries and generateLibraries generation steps.

For https://github.com/googleapis/librarian/issues/6629