### PR TITLE
build(docker): remove librarian install nodejs step from Dockerfile

### DIFF
--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -62,6 +62,12 @@ ARG GO_GOIMPORTS_VERSION=latest
 # NodeJS dependency versions
 ARG NODEJS_PROTOC_VERSION=33.2
 ARG NODEJS_PROTOC_CHECKSUM=8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5
+ARG NODEJS_GAPIC_GENERATOR_VERSION=gapic-generator-v4.12.1
+ARG NODEJS_GAPIC_GENERATOR_CHECKSUM=477e4a9b3442457667846bd5c629d1c059e7caf2d5a3ebce95da626a2d42ea80
+ARG NODEJS_GAPIC_NODE_PROCESSING_VERSION=0.1.8
+ARG NODEJS_GAPIC_TOOLS_VERSION=1.0.6
+ARG NODEJS_PROTOBUFJS_CLI_VERSION=1.2.0
+ARG NODEJS_PROTOBUFJS_VERSION=7.5.8
 
 # Java dependency versions
 ARG JAVA_PROTOC_VERSION=33.2
@@ -246,6 +252,12 @@ ARG NODEJS_NVM_VERSION
 ARG NODEJS_NVM_CHECKSUM
 ARG NODEJS_NODE_VERSION
 ARG NODEJS_PNPM_VERSION
+ARG NODEJS_GAPIC_GENERATOR_VERSION
+ARG NODEJS_GAPIC_GENERATOR_CHECKSUM
+ARG NODEJS_GAPIC_NODE_PROCESSING_VERSION
+ARG NODEJS_GAPIC_TOOLS_VERSION
+ARG NODEJS_PROTOBUFJS_CLI_VERSION
+ARG NODEJS_PROTOBUFJS_VERSION
 
 # Node requires libatomic but doesn't install it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -284,9 +296,6 @@ RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
     echo "${NODEJS_PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip
 
-# Install all the tools that Librarian needs for Node generation.
-RUN PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true /app/librarian install nodejs -v
-
 # Allow normal users to read /root (as the generator is installed
 # in /root/.cache, for example)
 RUN chmod a+x /root
@@ -302,6 +311,24 @@ RUN chmod a+x /root
 # nvm from Librarian. We're only using it to set up the right version of Node.
 RUN ln -s /root/.nvm/versions/node/$(nvm current) /root/.nvm/versions/node/current 
 ENV PATH=$PATH:/root/.nvm/versions/node/current/bin
+
+# Install Node generation tools
+RUN PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm add -g \
+        gapic-node-processing@${NODEJS_GAPIC_NODE_PROCESSING_VERSION} \
+        gapic-tools@${NODEJS_GAPIC_TOOLS_VERSION} \
+        protobufjs-cli@${NODEJS_PROTOBUFJS_CLI_VERSION} \
+        protobufjs@${NODEJS_PROTOBUFJS_VERSION} && \
+    curl -fsSL --retry 5 --retry-delay 15 -o /tmp/generator.tar.gz \
+        https://github.com/googleapis/google-cloud-node/archive/${NODEJS_GAPIC_GENERATOR_VERSION}.tar.gz && \
+    echo "${NODEJS_GAPIC_GENERATOR_CHECKSUM} /tmp/generator.tar.gz" | sha256sum -c - && \
+    mkdir -p /tmp/generator && \
+    tar -xzf /tmp/generator.tar.gz -C /tmp/generator --strip-components=1 && \
+    cd /tmp/generator/core/generator/gapic-generator-typescript && \
+    pnpm install && \
+    ./node_modules/.bin/tsc && \
+    cp -a templates protos build/ && \
+    PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm add -g "$PWD" && \
+    rm -rf /tmp/generator /tmp/generator.tar.gz
 
 # ============== Java Stage ==============
 ARG JAVA_PYTHON_VERSION

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -311,6 +311,10 @@ RUN chmod a+x /root
 # nvm from Librarian. We're only using it to set up the right version of Node.
 RUN ln -s /root/.nvm/versions/node/$(nvm current) /root/.nvm/versions/node/current 
 ENV PATH=$PATH:/root/.nvm/versions/node/current/bin
+ENV PNPM_CONFIG_GLOBAL_BIN_DIR=/root/.nvm/versions/node/current/bin
+ENV PNPM_CONFIG_GLOBAL_DIR=/root/.nvm/versions/node/current/pnpm-global
+ENV PNPM_CONFIG_STORE_DIR=/root/.nvm/versions/node/current/pnpm-store
+ENV PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true
 
 # Install Node generation tools
 RUN PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm add -g \


### PR DESCRIPTION
Explicitly install Node.js generation tools in `cmd/librarian/Dockerfile` as part of https://github.com/googleapis/librarian/issues/6509.

This replaces the previous `/app/librarian install nodejs -v` step (which required reading `librarian.yaml` in the working directory) with explicit installation of Node.js generation tools matching the versions in `google-cloud-node/librarian.yaml`. This follows Go and Java's style where we don't use `librarian install` in Dockerfile.

### Tool Installation Details
* `gapic-generator-typescript` is **not published to the npm registry** (it lives inside the `google-cloud-node` monorepo under `core/generator/gapic-generator-typescript`). It is fetched from the release archive tarball, compiled (`tsc`), assembled with its required `templates/` and `protos/` assets, and installed globally via `pnpm add -g "$PWD"`.
* `gapic-node-processing`, `gapic-tools`, `protobufjs-cli`, and `protobufjs` are installed globally via `pnpm add -g`.

### Verification

1. **Docker Image Build**:
   ```bash
   docker build --target nodejs -t librarian:nodejs -f cmd/librarian/Dockerfile .
   ```
   *Result*: Built successfully.

2. **Installed Binaries Verification**:
   ```bash
   docker run --rm --entrypoint /bin/bash librarian:nodejs -c "gapic-generator-typescript --version && gapic-node-processing --version && pbjs --version"
   ```
   *Output*:
   ```
   suztomo@suztomo:~/librarian-2026/google-cloud-java$ docker run --rm --entrypoint /bin/bash librarian:nodejs -c "gapic-generator-typescript --version && gapic-node-processing --version && pbjs --version"
   4.12.0
   0.1.8
   protobuf.js v1.2.0 CLI for JavaScript
   ...
   ```
   *Installed binaries verified inside container*:
   - `gapic-generator-typescript` (`v4.12.0`)
   - `gapic-node-processing` (`v0.1.8`)
   - `gapic-tools` (`compileProtos`, `listProtos`, `minifyProtoJson`, `prepublishProtos`)
   - `protobufjs-cli` / `protobufjs` (`pbjs`, `pbts`)