### PR TITLE
build(docker): remove redundant PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS inline env vars

### DIFF
--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -332,7 +332,9 @@ RUN pnpm add -g \
     pnpm install && \
     ./node_modules/.bin/tsc && \
     cp -a templates protos build/ && \
-    pnpm add -g "$PWD" && \
+    node -e "const fs = require('fs'); const f = 'package.json'; const p = JSON.parse(fs.readFileSync(f)); p.dependencies['google-gax'] = p.devDependencies['google-gax']; delete p.devDependencies['google-gax']; fs.writeFileSync(f, JSON.stringify(p, null, 2))" && \
+    pnpm pack && \
+    pnpm add -g ./*.tgz && \
     rm -rf /tmp/generator /tmp/generator.tar.gz
 
 # ============== Java Stage ==============

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -317,7 +317,7 @@ ENV PNPM_CONFIG_STORE_DIR=/root/.nvm/versions/node/current/pnpm-store
 ENV PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true
 
 # Install Node generation tools
-RUN PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm add -g \
+RUN pnpm add -g \
         gapic-node-processing@${NODEJS_GAPIC_NODE_PROCESSING_VERSION} \
         gapic-tools@${NODEJS_GAPIC_TOOLS_VERSION} \
         protobufjs-cli@${NODEJS_PROTOBUFJS_CLI_VERSION} \
@@ -331,7 +331,7 @@ RUN PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm add -g \
     pnpm install && \
     ./node_modules/.bin/tsc && \
     cp -a templates protos build/ && \
-    PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm add -g "$PWD" && \
+    pnpm add -g "$PWD" && \
     rm -rf /tmp/generator /tmp/generator.tar.gz
 
 # ============== Java Stage ==============

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -326,6 +326,10 @@ RUN pnpm add -g \
     curl -fsSL --retry 5 --retry-delay 15 -o /tmp/generator.tar.gz \
         https://github.com/googleapis/google-cloud-node/archive/${NODEJS_GAPIC_GENERATOR_VERSION}.tar.gz && \
     echo "${NODEJS_GAPIC_GENERATOR_CHECKSUM} /tmp/generator.tar.gz" | sha256sum -c - && \
+    # The generator is installed in /opt (rather than a transient /tmp) and linked via
+    # `pnpm add -g` to preserve its node_modules. This is necessary because google-gax is
+    # defined as a devDependency in the generator but is required at startup. Deleting the
+    # source directory would break the global installation with MODULE_NOT_FOUND.
     mkdir -p /opt/gapic-generator-typescript && \
     tar -xzf /tmp/generator.tar.gz -C /opt/gapic-generator-typescript --strip-components=4 google-cloud-node-${NODEJS_GAPIC_GENERATOR_VERSION}/core/generator/gapic-generator-typescript && \
     rm /tmp/generator.tar.gz && \

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -311,6 +311,7 @@ RUN chmod a+x /root
 # nvm from Librarian. We're only using it to set up the right version of Node.
 RUN ln -s /root/.nvm/versions/node/$(nvm current) /root/.nvm/versions/node/current 
 ENV PATH=$PATH:/root/.nvm/versions/node/current/bin
+ENV PNPM_HOME=/root/.nvm/versions/node/current
 ENV PNPM_CONFIG_GLOBAL_BIN_DIR=/root/.nvm/versions/node/current/bin
 ENV PNPM_CONFIG_GLOBAL_DIR=/root/.nvm/versions/node/current/pnpm-global
 ENV PNPM_CONFIG_STORE_DIR=/root/.nvm/versions/node/current/pnpm-store

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -326,16 +326,14 @@ RUN pnpm add -g \
     curl -fsSL --retry 5 --retry-delay 15 -o /tmp/generator.tar.gz \
         https://github.com/googleapis/google-cloud-node/archive/${NODEJS_GAPIC_GENERATOR_VERSION}.tar.gz && \
     echo "${NODEJS_GAPIC_GENERATOR_CHECKSUM} /tmp/generator.tar.gz" | sha256sum -c - && \
-    mkdir -p /tmp/generator && \
-    tar -xzf /tmp/generator.tar.gz -C /tmp/generator --strip-components=1 && \
-    cd /tmp/generator/core/generator/gapic-generator-typescript && \
+    mkdir -p /opt/gapic-generator-typescript && \
+    tar -xzf /tmp/generator.tar.gz -C /opt/gapic-generator-typescript --strip-components=4 google-cloud-node-${NODEJS_GAPIC_GENERATOR_VERSION}/core/generator/gapic-generator-typescript && \
+    rm /tmp/generator.tar.gz && \
+    cd /opt/gapic-generator-typescript && \
     pnpm install && \
     ./node_modules/.bin/tsc && \
     cp -a templates protos build/ && \
-    node -e "const fs = require('fs'); const f = 'package.json'; const p = JSON.parse(fs.readFileSync(f)); p.dependencies['google-gax'] = p.devDependencies['google-gax']; delete p.devDependencies['google-gax']; fs.writeFileSync(f, JSON.stringify(p, null, 2))" && \
-    pnpm pack && \
-    pnpm add -g ./*.tgz && \
-    rm -rf /tmp/generator /tmp/generator.tar.gz
+    pnpm add -g "$PWD"
 
 # ============== Java Stage ==============
 ARG JAVA_PYTHON_VERSION


### PR DESCRIPTION
Remove redundant `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true` inline variables in `cmd/librarian/Dockerfile` since it is already set as a global `ENV` variable. 

Additionally explicitly defines `PNPM_HOME=/root/.nvm/versions/node/current` to fix pnpm global path validation failures.

### Why `PNPM_HOME=/root/.nvm/versions/node/current` was chosen
This matches the logic in our Node.js installation helper where `PNPM_HOME` is set to the parent of the resolved `node` bin directory (so that `PNPM_HOME/bin` points directly to the `node` bin directory which is already in `PATH`):
https://github.com/googleapis/librarian/blob/7569927/internal/librarian/nodejs/install.go#L91-L94

Without `PNPM_HOME`, the build failed with the following error during `pnpm add -g`:
```
[ERROR] The configured global bin directory "/root/.local/share/pnpm/bin" is not in PATH
Run "pnpm setup" to update your shell configuration.
```

### Installation in `/opt` and Linking
To prevent broken symlinks and missing runtime dependencies (specifically `google-gax`, which is a `devDependency` in `package.json` but required at startup to resolve proto paths), the generator is extracted and built in a permanent directory: `/opt/gapic-generator-typescript`. 

We then run `pnpm add -g "$PWD"` inside that directory. This links the global command to `/opt/...` and preserves its `node_modules` (including `google-gax` installed during build time), mirroring the behavior of the Go `librarian install` helper.

This also resolves the cosmetic version resolution issue where `yargs` was showing the version of `nvm` (`0.40.4`) instead of the generator because it was resolving the parent directories of the global bin. It now correctly resolves the generator's `package.json` version (`4.12.1`).

### Verification

1. **Docker Image Build**:
   ```bash
   docker build --target nodejs -t librarian:nodejs -f cmd/librarian/Dockerfile .
   ```
   *Result*: Built successfully (no cache).

2. **Installed Binaries Verification**:
   We verify that the installed tools are executable and correctly configured in `PATH` (exiting with 0):

   ```bash
   docker run --rm --entrypoint /bin/bash librarian:nodejs -c "gapic-generator-typescript --version && gapic-node-processing --version && which pbjs"
   ```
   *Output*:
   ```
   4.12.1
   0.1.8
   /root/.nvm/versions/node/v22.23.1/bin/pbjs
   ```

For https://github.com/googleapis/librarian/issues/6509