### PR TITLE
refactor(internal/librarian/java): define struct for syncPOMs inputs

### DIFF
--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -84,6 +84,15 @@ type javaModule struct {
 	template     string
 }
 
+type syncPOMsParams struct {
+	library         *config.Library
+	libraryDir      string
+	monorepoVersion string
+	parentVersion   string
+	metadata        *repoMetadata
+	transports      map[string]serviceconfig.Transport
+}
+
 type moduleKind int
 
 const (
@@ -216,8 +225,8 @@ func discoverModules(library *config.Library, libraryDir string, transports map[
 // and parent POMs when new proto or gRPC modules are added. It returns a list
 // of newly created artifact version entries to be added to versions.txt.
 // TODO(https://github.com/googleapis/librarian/issues/5529): remove returning version entries.
-func syncPOMs(library *config.Library, libraryDir, monorepoVersion, parentVersion string, metadata *repoMetadata, transports map[string]serviceconfig.Transport) error {
-	modules, err := collectModules(library, libraryDir, monorepoVersion, parentVersion, metadata, transports)
+func syncPOMs(params syncPOMsParams) error {
+	modules, err := collectModules(params)
 	if err != nil {
 		return err
 	}
@@ -394,14 +403,14 @@ func detectIndentation(content string, index int) string {
 // All expected modules are collected (even if they exist) because the client
 // module's POM requires a full list of all proto and gRPC dependencies
 // to ensure its dependency list is fully synchronized.
-func collectModules(library *config.Library, libraryDir, monorepoVersion, parentVersion string, metadata *repoMetadata, transports map[string]serviceconfig.Transport) ([]javaModule, error) {
-	expectedModules, err := discoverModules(library, libraryDir, transports)
+func collectModules(params syncPOMsParams) ([]javaModule, error) {
+	expectedModules, err := discoverModules(params.library, params.libraryDir, params.transports)
 	if err != nil {
 		return nil, err
 	}
-	libCoord := deriveLibraryCoordinates(library)
-	protoModules := make([]coordinate, 0, len(library.APIs))
-	gRPCModules := make([]coordinate, 0, len(library.APIs))
+	libCoord := deriveLibraryCoordinates(params.library)
+	protoModules := make([]coordinate, 0, len(params.library.APIs))
+	gRPCModules := make([]coordinate, 0, len(params.library.APIs))
 	// At most one client module per library; slice used for variadic append.
 	var clientModule []coordinate
 	for _, m := range expectedModules {
@@ -431,7 +440,7 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion, parent
 				GRPC:           m.APICoords.GRPC,
 				Parent:         libCoord.Parent,
 				MainArtifactID: libCoord.GAPIC.ArtifactID,
-				Version:        library.Version,
+				Version:        params.library.Version,
 			}
 			if m.Kind == kindProto {
 				template = protoPOMTemplateName
@@ -441,9 +450,9 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion, parent
 		case kindClient:
 			templateData = clientPOMData{
 				Client:       m.Coordinate,
-				Version:      library.Version,
-				Name:         metadata.NamePretty,
-				Description:  metadata.APIDescription,
+				Version:      params.library.Version,
+				Name:         params.metadata.NamePretty,
+				Description:  params.metadata.APIDescription,
 				Parent:       libCoord.Parent,
 				ProtoModules: protoModules,
 				GRPCModules:  gRPCModules,
@@ -452,18 +461,18 @@ func collectModules(library *config.Library, libraryDir, monorepoVersion, parent
 		case kindBOM:
 			templateData = bomParentPOMData{
 				MainModule:      libCoord.GAPIC,
-				Name:            metadata.NamePretty,
-				MonorepoVersion: monorepoVersion,
-				ParentVersion:   parentVersion,
+				Name:            params.metadata.NamePretty,
+				MonorepoVersion: params.monorepoVersion,
+				ParentVersion:   params.parentVersion,
 				Modules:         allModules,
 			}
 			template = bomPOMTemplateName
 		case kindParent:
 			templateData = bomParentPOMData{
 				MainModule:      libCoord.GAPIC,
-				Name:            metadata.NamePretty,
-				MonorepoVersion: monorepoVersion,
-				ParentVersion:   parentVersion,
+				Name:            params.metadata.NamePretty,
+				MonorepoVersion: params.monorepoVersion,
+				ParentVersion:   params.parentVersion,
 				Modules:         allModules,
 			}
 			template = parentPOMTemplateName

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -71,7 +71,14 @@ func TestSyncPOMs_Golden(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = syncPOMs(library, tmpDir, "1.2.3", "1.2.3", metadata, transports)
+	err = syncPOMs(syncPOMsParams{
+		library:         library,
+		libraryDir:      tmpDir,
+		monorepoVersion: "1.2.3",
+		parentVersion:   "1.2.3",
+		metadata:        metadata,
+		transports:      transports,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +212,14 @@ func TestSyncPOMs_Update(t *testing.T) {
 		APIDescription: "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
 	}
 
-	if err := syncPOMs(library, tmpDir, "1.2.3", "1.2.3", metadata, transports); err != nil {
+	if err := syncPOMs(syncPOMsParams{
+		library:         library,
+		libraryDir:      tmpDir,
+		monorepoVersion: "1.2.3",
+		parentVersion:   "1.2.3",
+		metadata:        metadata,
+		transports:      transports,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -271,7 +285,14 @@ func TestSyncPOMs_NoUpdate(t *testing.T) {
 		APIDescription: "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
 	}
 
-	if err := syncPOMs(library, tmpDir, "1.2.3", "1.2.3", metadata, transports); err != nil {
+	if err := syncPOMs(syncPOMsParams{
+		library:         library,
+		libraryDir:      tmpDir,
+		monorepoVersion: "1.2.3",
+		parentVersion:   "1.2.3",
+		metadata:        metadata,
+		transports:      transports,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -576,7 +597,14 @@ func TestCollectModules(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t, tmpDir)
 			}
-			got, err := collectModules(test.library, tmpDir, test.monorepoVersion, test.monorepoVersion, test.metadata, test.transports)
+			got, err := collectModules(syncPOMsParams{
+				library:         test.library,
+				libraryDir:      tmpDir,
+				monorepoVersion: test.monorepoVersion,
+				parentVersion:   test.monorepoVersion,
+				metadata:        test.metadata,
+				transports:      test.transports,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -90,7 +90,14 @@ func postProcessLibrary(ctx context.Context, params libraryPostProcessParams) er
 	if err != nil {
 		return err
 	}
-	if err := syncPOMs(params.library, params.outDir, monorepoVersion, parentVersion, params.metadata, params.transports); err != nil {
+	if err := syncPOMs(syncPOMsParams{
+		library:         params.library,
+		libraryDir:      params.outDir,
+		monorepoVersion: monorepoVersion,
+		parentVersion:   parentVersion,
+		metadata:        params.metadata,
+		transports:      params.transports,
+	}); err != nil {
 		return fmt.Errorf("%w: %w", errSyncPOMs, err)
 	}
 


### PR DESCRIPTION
The syncPOMs and collectModules functions are refactored to take a new syncPOMsParams struct instead of six individual arguments.

This reduces the parameter list length and improves the readability and maintainability of the POM synchronization code.

Fixes https://github.com/googleapis/librarian/issues/6439