### PR TITLE
refactor(repometadata): add Transport field to shared RepoMetadata

### DIFF
--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -101,6 +101,7 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, sourceDir s
 		ProductDocumentation: sharedMetadata.ProductDocumentation,
 		APIDescription:       sharedMetadata.APIDescription,
 		ReleaseLevel:         sharedMetadata.ReleaseLevel,
+		Transport:            sharedMetadata.Transport,
 		Language:             config.LanguageJava,
 		Repo:                 sharedMetadata.Repo,
 		RepoShort:            fmt.Sprintf("%s-%s", config.LanguageJava, library.Name),
@@ -160,11 +161,5 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, sourceDir s
 		artifactID := parts[len(parts)-1]
 		metadata.ClientDocumentation = fmt.Sprintf("https://cloud.google.com/java/docs/reference/%s/latest/overview", artifactID)
 	}
-	// transport
-	apiCfg, err := serviceconfig.Find(sourceDir, library.APIs[0].Path, config.LanguageJava)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find api config: %w", err)
-	}
-	metadata.Transport = apiCfg.RepoMetadataTransport(config.LanguageJava, library)
 	return metadata, nil
 }

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -131,6 +131,10 @@ func FromLibrary(cfg *config.Config, library *config.Library, googleapisDir stri
 
 // fromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
 func fromAPI(cfg *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
+	var transport string
+	if cfg.Language == config.LanguageJava {
+		transport = api.RepoMetadataTransport(cfg.Language, library)
+	}
 	return &RepoMetadata{
 		APIDescription:       api.Description,
 		APIID:                api.ServiceName,
@@ -143,14 +147,7 @@ func fromAPI(cfg *config.Config, api *serviceconfig.API, library *config.Library
 		ProductDocumentation: extractBaseProductURL(api.DocumentationURI),
 		ReleaseLevel:         api.ReleaseLevel(cfg.Language, library.Version),
 		Repo:                 cfg.Repo,
-		Transport: func() string {
-			switch cfg.Language {
-			case config.LanguageJava:
-				return api.RepoMetadataTransport(cfg.Language, library)
-			default:
-				return ""
-			}
-		}(),
+		Transport:            transport,
 	}
 }
 

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -91,6 +91,9 @@ type RepoMetadata struct {
 
 	// Repo is the repository name (e.g., "googleapis/google-cloud-rust").
 	Repo string `json:"repo,omitempty"`
+
+	// Transport is the transport protocol used by the library (e.g. "grpc", "rest").
+	Transport string `json:"transport,omitempty"`
 }
 
 // FromLibrary creates a RepoMetadata from a specific library in a
@@ -107,6 +110,7 @@ type RepoMetadata struct {
 // - ProductDocumentation
 // - ReleaseLevel
 // - Repo
+// - Transport (Java only)
 //
 // Any other fields required by the caller's language should be populated by the
 // caller before writing to disk.
@@ -126,19 +130,27 @@ func FromLibrary(cfg *config.Config, library *config.Library, googleapisDir stri
 }
 
 // fromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
-func fromAPI(config *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
+func fromAPI(cfg *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
 	return &RepoMetadata{
 		APIDescription:       api.Description,
 		APIID:                api.ServiceName,
 		APIShortname:         api.ShortName,
 		DistributionName:     library.Name,
 		IssueTracker:         api.NewIssueURI,
-		Language:             config.Language,
+		Language:             cfg.Language,
 		Name:                 api.ShortName,
 		NamePretty:           cleanTitle(api.Title),
 		ProductDocumentation: extractBaseProductURL(api.DocumentationURI),
-		ReleaseLevel:         api.ReleaseLevel(config.Language, library.Version),
-		Repo:                 config.Repo,
+		ReleaseLevel:         api.ReleaseLevel(cfg.Language, library.Version),
+		Repo:                 cfg.Repo,
+		Transport: func() string {
+			switch cfg.Language {
+			case config.LanguageJava:
+				return api.RepoMetadataTransport(cfg.Language, library)
+			default:
+				return ""
+			}
+		}(),
 	}
 }
 


### PR DESCRIPTION
Adds the `Transport` field to the shared `repometadata.RepoMetadata` struct, which is populated conditionally for the Java language. Java's local repoMetadata struct is updated to reuse this shared field.

No change to generated code expected as the value of the  transport  field is derived using the exact same underlying logic for Java, and for other languages is skipped during serialization.

Fixes https://github.com/googleapis/librarian/issues/4877