### PR TITLE
feat(internal/config): add declarative postprocessing config schema

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -137,6 +137,50 @@ This document describes the schema for the librarian.yaml.
 | `python` | [PythonPackage](#pythonpackage-configuration) (optional) | Contains Python-specific library configuration. |
 | `rust` | [RustCrate](#rustcrate-configuration) (optional) | Contains Rust-specific library configuration. |
 | `swift` | [SwiftPackage](#swiftpackage-configuration) (optional) | Contains Swift-specific library configuration. |
+| `postprocess` | [Postprocess](#postprocess-configuration) (optional) | Contains post-processing operations executed after code generation. |
+
+## Postprocess Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `replace` | list of [ReplaceConfig](#replaceconfig-configuration) | Contains literal string replacement rules. |
+| `replace_regex` | list of [ReplaceRegexConfig](#replaceregexconfig-configuration) | Contains regular expression replacement rules. |
+| `copy_file` | list of [CopyConfig](#copyconfig-configuration) | Contains file copy rules. |
+| `remove_file` | list of string | Contains glob patterns of files to remove. |
+| `method_operations` | list of [MethodOperation](#methodoperation-configuration) | Contains method-level operations (`delete`, `duplicate`, `deprecate`). |
+
+## MethodOperation Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `path` | string | Specifies the relative file path to modify. |
+| `action` | string | Specifies the operation (`delete`, `duplicate`, or `deprecate`). |
+| `func_name` | string | Specifies the target method name. |
+| `new_name` | string | Specifies the new method name for duplicate operations. |
+| `deprecation_message` | string | Specifies the deprecation message for deprecate operations. |
+
+## ReplaceConfig Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `path` | string | Specifies the relative file path or glob pattern to modify. |
+| `original` | string | Specifies the exact string to find. |
+| `replacement` | string | Specifies the replacement string. |
+
+## ReplaceRegexConfig Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `path` | string | Specifies the relative file path or glob pattern to modify. |
+| `pattern` | string | Specifies the regular expression pattern to find. |
+| `replacement` | string | Specifies the replacement string. |
+
+## CopyConfig Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `src` | string | Specifies the source file path relative to the staging directory. |
+| `dst` | string | Specifies the destination file path relative to the library root. |
 
 ## API Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -125,6 +125,7 @@ This document describes the schema for the librarian.yaml.
 | `title_override` | string | Overrides the title used in README generation. |
 | `keep` | list of string | Lists files and directories to preserve during regeneration. These represent critical custom handwritten files (e.g., package.json, custom configs, and handwritten tests) and semi-handmade documentation files (README.md, CHANGELOG.md, .readme-partials.yaml) that are not natively generated from proto schemas but are strictly required by the post-processor's markdown generation and release tracking passes. |
 | `output` | string | Is the directory where code is written. This overrides Default.Output. |
+| `postprocess` | [Postprocess](#postprocess-configuration) (optional) | Contains post-processing operations executed after code generation. |
 | `roots` | list of string | Specifies the source roots to use for generation. Defaults to googleapis. |
 | `skip_generate` | bool | Disables code generation for this library. |
 | `skip_release` | bool | Disables release for this library. |
@@ -137,7 +138,6 @@ This document describes the schema for the librarian.yaml.
 | `python` | [PythonPackage](#pythonpackage-configuration) (optional) | Contains Python-specific library configuration. |
 | `rust` | [RustCrate](#rustcrate-configuration) (optional) | Contains Rust-specific library configuration. |
 | `swift` | [SwiftPackage](#swiftpackage-configuration) (optional) | Contains Swift-specific library configuration. |
-| `postprocess` | [Postprocess](#postprocess-configuration) (optional) | Contains post-processing operations executed after code generation. |
 
 ## Postprocess Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -335,6 +335,78 @@ type Library struct {
 
 	// Swift contains Swift-specific library configuration.
 	Swift *SwiftPackage `yaml:"swift,omitempty"`
+
+	// Postprocess contains post-processing operations executed after code generation.
+	Postprocess *Postprocess `yaml:"postprocess,omitempty"`
+}
+
+// Postprocess represents post-processing configuration options integrated into librarian.yaml.
+type Postprocess struct {
+	// Replace contains literal string replacement rules.
+	Replace []ReplaceConfig `yaml:"replace,omitempty"`
+
+	// ReplaceRegex contains regular expression replacement rules.
+	ReplaceRegex []ReplaceRegexConfig `yaml:"replace_regex,omitempty"`
+
+	// CopyFile contains file copy rules.
+	CopyFile []CopyConfig `yaml:"copy_file,omitempty"`
+
+	// RemoveFile contains glob patterns of files to remove.
+	RemoveFile []string `yaml:"remove_file,omitempty"`
+
+	// MethodOperations contains method-level operations (`delete`, `duplicate`, `deprecate`).
+	MethodOperations []MethodOperation `yaml:"method_operations,omitempty"`
+}
+
+// MethodOperation represents a method-level operation like delete, duplicate, or deprecate.
+type MethodOperation struct {
+	// Path specifies the relative file path to modify.
+	Path string `yaml:"path"`
+
+	// Action specifies the operation (`delete`, `duplicate`, or `deprecate`).
+	Action string `yaml:"action"`
+
+	// FuncName specifies the target method name.
+	FuncName string `yaml:"func_name"`
+
+	// NewName specifies the new method name for duplicate operations.
+	NewName string `yaml:"new_name,omitempty"`
+
+	// DeprecationMessage specifies the deprecation message for deprecate operations.
+	DeprecationMessage string `yaml:"deprecation_message,omitempty"`
+}
+
+// ReplaceConfig represents a replacement rule.
+type ReplaceConfig struct {
+	// Path specifies the relative file path or glob pattern to modify.
+	Path string `yaml:"path"`
+
+	// Original specifies the exact string to find.
+	Original string `yaml:"original"`
+
+	// Replacement specifies the replacement string.
+	Replacement string `yaml:"replacement"`
+}
+
+// ReplaceRegexConfig represents a regex replacement rule.
+type ReplaceRegexConfig struct {
+	// Path specifies the relative file path or glob pattern to modify.
+	Path string `yaml:"path"`
+
+	// Pattern specifies the regular expression pattern to find.
+	Pattern string `yaml:"pattern"`
+
+	// Replacement specifies the replacement string.
+	Replacement string `yaml:"replacement"`
+}
+
+// CopyConfig represents a file copy rule.
+type CopyConfig struct {
+	// Src specifies the source file path relative to the staging directory.
+	Src string `yaml:"src"`
+
+	// Dst specifies the destination file path relative to the library root.
+	Dst string `yaml:"dst"`
 }
 
 // API describes an API to include in a library.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,6 +297,9 @@ type Library struct {
 	// Default.Output.
 	Output string `yaml:"output,omitempty"`
 
+	// Postprocess contains post-processing operations executed after code generation.
+	Postprocess *Postprocess `yaml:"postprocess,omitempty"`
+
 	// Roots specifies the source roots to use for generation. Defaults to googleapis.
 	Roots []string `yaml:"roots,omitempty"`
 
@@ -335,9 +338,6 @@ type Library struct {
 
 	// Swift contains Swift-specific library configuration.
 	Swift *SwiftPackage `yaml:"swift,omitempty"`
-
-	// Postprocess contains post-processing operations executed after code generation.
-	Postprocess *Postprocess `yaml:"postprocess,omitempty"`
 }
 
 // Postprocess represents post-processing configuration options integrated into librarian.yaml.


### PR DESCRIPTION
Add declarative configuration structs for postprocessing operations in config.go and auto-generate updated schema tables in config-schema.md.

For #6516