### PR TITLE
fix(java): tidy default released version

### DIFF
--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -240,6 +240,10 @@ func tidyReleasedVersion(library *config.Library) {
 	if library.Java.ReleasedVersion == "" {
 		return
 	}
+	if library.Java.ReleasedVersion == defaultReleasedVersion {
+		library.Java.ReleasedVersion = ""
+		return
+	}
 	if !isSnapshot(library.Version) {
 		return
 	}

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -468,6 +468,18 @@ func TestTidy(t *testing.T) {
 			},
 		},
 		{
+			name: "tidy released version if default",
+			lib: &config.Library{
+				Name: "secretmanager",
+				Java: &config.JavaModule{
+					ReleasedVersion: defaultReleasedVersion,
+				},
+			},
+			want: &config.Library{
+				Name: "secretmanager",
+			},
+		},
+		{
 			name: "do not tidy released version if different from derived",
 			lib: &config.Library{
 				Name:    "secretmanager",


### PR DESCRIPTION
Tidy the `java.released_version` if it was set to the default of `0.0.0`.

[Noticed this being serialized](https://github.com/noahdietz/google-cloud-java/commit/85e200be74ec1c42c63e833993b67029a2247a97) while testing a diff change.