### PR TITLE
chore: add skeleton code for Ruby client library generation

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
 	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
+	"github.com/googleapis/librarian/internal/librarian/ruby"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
 	"github.com/googleapis/librarian/internal/sources"
@@ -163,6 +164,8 @@ func cleanLibraries(language string, libraries []*config.Library) error {
 			err = php.Clean(library)
 		case config.LanguagePython:
 			err = python.Clean(library)
+		case config.LanguageRuby:
+			err = ruby.Clean(library)
 		case config.LanguageRust:
 			keep, keepErr := rust.Keep(library)
 			if keepErr != nil {
@@ -285,6 +288,20 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 				// separate generation and formatting for Python.
 				if err := python.Generate(gctx, cfg, library, src); err != nil {
 					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+				}
+				return nil
+			})
+		}
+		return g.Wait()
+	case config.LanguageRuby:
+		g, gctx := errgroup.WithContext(ctx)
+		for _, library := range libraries {
+			g.Go(func() error {
+				if err := ruby.Generate(gctx, cfg, library, src); err != nil {
+					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
+				}
+				if err := ruby.Format(gctx, library); err != nil {
+					return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
 				}
 				return nil
 			})

--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ruby provides Ruby specific functionality for librarian.
 package ruby
 
 import (

--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ruby provides Ruby specific functionality for librarian.
+package ruby
+
+import (
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// Clean removes all generated code from beneath the given library's
+// output directory.
+func Clean(library *config.Library) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6657): implement Ruby cleaning
+	return nil
+}

--- a/internal/librarian/ruby/format.go
+++ b/internal/librarian/ruby/format.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ruby provides Ruby specific functionality for librarian.
 package ruby
 
 import (

--- a/internal/librarian/ruby/format.go
+++ b/internal/librarian/ruby/format.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ruby provides Ruby specific functionality for librarian.
+package ruby
+
+import (
+	"context"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// Format formats a generated Ruby library.
+func Format(ctx context.Context, library *config.Library) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6633): implement Ruby formatting
+	return nil
+}

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ruby provides Ruby specific functionality for librarian.
+package ruby
+
+import (
+	"context"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+// Generate generates a Ruby client library.
+func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6633): implement Ruby generation
+	return nil
+}


### PR DESCRIPTION
Add the internal/librarian/ruby package with initial stub implementations for Generate, Format, and Clean.

Wire up the Ruby language case in `internal/librarian/generate.go` and `clean.go` so librarian can handle Ruby libraries as generation and formatting capabilities are built out.

For https://github.com/googleapis/librarian/issues/6633