### PR TITLE
refactor(internal/librarian/php): split clean and format into separate files

### DIFF
--- a/internal/librarian/php/clean.go
+++ b/internal/librarian/php/clean.go
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package php provides PHP specific functionality for librarian.
 package php
 
 import (
-	"context"
-
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/sources"
 )
 
-// Generate generates a PHP client library.
-func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
-	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP generation
+// Clean removes all generated code from beneath the given library's
+// output directory.
+func Clean(library *config.Library) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6659): implement PHP cleaning
 	return nil
 }

--- a/internal/librarian/php/format.go
+++ b/internal/librarian/php/format.go
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package php provides PHP specific functionality for librarian.
 package php
 
 import (
 	"context"
 
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/sources"
 )
 
-// Generate generates a PHP client library.
-func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
-	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP generation
+// Format formats a generated PHP library.
+func Format(ctx context.Context, library *config.Library) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP formatting
 	return nil
 }


### PR DESCRIPTION
Move the Clean and Format functions from `generate.go` into dedicated `clean.go` and `format.go` files within `internal/librarian/php` to align with the package structure used across other language modules.

This change can also let us work in the implementations in parallel.