### PR TITLE
feat(internal/librarian/java): add logging-logback to legacy BOMs

### DIFF
--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -60,9 +60,10 @@ var (
 		"google-cloud-pom-parent":  true,
 		"google-cloud-shared-deps": true,
 	}
-	dnsBOM          = legacyBOM{"java-dns", "com.google.cloud", "google-cloud-dns"}
-	notificationBOM = legacyBOM{"java-notification", "com.google.cloud", "google-cloud-notification"}
-	grafeasBOM      = legacyBOM{"java-grafeas", "io.grafeas", "grafeas"}
+	dnsBOM            = legacyBOM{"java-dns", "com.google.cloud", "google-cloud-dns"}
+	notificationBOM   = legacyBOM{"java-notification", "com.google.cloud", "google-cloud-notification"}
+	loggingLogbackBOM = legacyBOM{"java-logging-logback", "com.google.cloud", "google-cloud-logging-logback"}
+	grafeasBOM        = legacyBOM{"java-grafeas", "io.grafeas", "grafeas"}
 )
 
 // legacyBOM represents a library that does not have a -bom module
@@ -217,7 +218,7 @@ func searchForBOMArtifacts(repoPath string) ([]*bomConfig, error) {
 		configs = append(configs, moduleConfigs...)
 	}
 
-	legacies, err := collectLegacyBOMs(repoPath, dnsBOM, notificationBOM)
+	legacies, err := collectLegacyBOMs(repoPath, dnsBOM, notificationBOM, loggingLogbackBOM)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -59,7 +59,7 @@ func TestPostGenerate(t *testing.T) {
 	if !strings.Contains(rootPOMContent, "<version>0.201.0</version>") {
 		t.Errorf("root pom.xml missing correct version, got:\n%s", rootPOMContent)
 	}
-	modules := []string{"java-analytics-admin", "java-area120-tables", "java-aiplatform", "java-grafeas", "java-dns", "java-notification"}
+	modules := []string{"java-analytics-admin", "java-area120-tables", "java-aiplatform", "java-grafeas", "java-dns", "java-notification", "java-logging-logback"}
 	for _, mod := range modules {
 		if !strings.Contains(rootPOMContent, "<module>"+mod+"</module>") {
 			t.Errorf("root pom.xml missing module %s", mod)
@@ -71,6 +71,7 @@ func TestPostGenerate(t *testing.T) {
 		{GroupID: "com.google.area120", ArtifactID: "google-area120-tables-bom", Version: "0.92.0", Type: "pom", Scope: "import"},
 		{GroupID: "com.google.cloud", ArtifactID: "google-cloud-aiplatform-bom", Version: "3.89.0", Type: "pom", Scope: "import"},
 		{GroupID: "com.google.cloud", ArtifactID: "google-cloud-dns", Version: "2.86.0", Type: "", Scope: ""},
+		{GroupID: "com.google.cloud", ArtifactID: "google-cloud-logging-logback", Version: "0.143.0-alpha-SNAPSHOT", Type: "", Scope: ""},
 		{GroupID: "com.google.cloud", ArtifactID: "google-cloud-notification", Version: "0.206.0", Type: "", Scope: ""},
 		{GroupID: "io.grafeas", ArtifactID: "grafeas", Version: "1.2.3", Type: "", Scope: ""},
 	}

--- a/internal/librarian/java/testdata/postgenerate/java-logging-logback/pom.xml
+++ b/internal/librarian/java/testdata/postgenerate/java-logging-logback/pom.xml
@@ -1,0 +1,5 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-logging-logback</artifactId>
+  <version>0.143.0-alpha-SNAPSHOT</version>
+</project>


### PR DESCRIPTION
 The java-logging-logback module is added as a legacy BOM in the GAPIC Bill of Materials generation. This allows the google-cloud-logging-logback artifact be included when generating the gapic-libraries-bom/pom.xml.

Fixes https://github.com/googleapis/librarian/issues/6668
For https://github.com/googleapis/google-cloud-java/issues/13672