### PR TITLE
test(internal/librarian/php): add unit tests and configure ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests and check coverage
         run: |
           go run ./tool/cmd/coverage -target=80 \
-            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|python|rust|swift)|internal/sidekick|internal/sample|internal/testhelper')
+            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|php|python|rust|swift)|internal/sidekick|internal/sample|internal/testhelper')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: PHP
+on: [push, pull_request, merge_group]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-librarian
+      - name: Run tests
+        run: go run ./tool/cmd/coverage ./internal/librarian/php

--- a/internal/librarian/php/clean_test.go
+++ b/internal/librarian/php/clean_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestClean(t *testing.T) {
+	lib := &config.Library{}
+
+	if err := Clean(lib); err != nil {
+		t.Errorf("Clean() returned error: %v", err)
+	}
+}

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -15,34 +15,13 @@
 package php
 
 import (
-	"context"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/sources"
 )
 
-func TestGenerate(t *testing.T) {
-	ctx := context.Background()
-	cfg := &config.Config{}
-	lib := &config.Library{}
-	src := &sources.Sources{}
-
-	if err := Generate(ctx, cfg, lib, src); err != nil {
-		t.Errorf("Generate() returned error: %v", err)
-	}
-}
-
-func TestClean(t *testing.T) {
-	lib := &config.Library{}
-
-	if err := Clean(lib); err != nil {
-		t.Errorf("Clean() returned error: %v", err)
-	}
-}
-
 func TestFormat(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lib := &config.Library{}
 
 	if err := Format(ctx, lib); err != nil {

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+func TestGenerate(t *testing.T) {
+	ctx := t.Context()
+	cfg := &config.Config{}
+	lib := &config.Library{}
+	src := &sources.Sources{}
+
+	if err := Generate(ctx, cfg, lib, src); err != nil {
+		t.Errorf("Generate() returned error: %v", err)
+	}
+}

--- a/internal/librarian/php/php_test.go
+++ b/internal/librarian/php/php_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"context"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+func TestGenerate(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.Config{}
+	lib := &config.Library{}
+	src := &sources.Sources{}
+
+	if err := Generate(ctx, cfg, lib, src); err != nil {
+		t.Errorf("Generate() returned error: %v", err)
+	}
+}
+
+func TestClean(t *testing.T) {
+	lib := &config.Library{}
+
+	if err := Clean(lib); err != nil {
+		t.Errorf("Clean() returned error: %v", err)
+	}
+}
+
+func TestFormat(t *testing.T) {
+	ctx := context.Background()
+	lib := &config.Library{}
+
+	if err := Format(ctx, lib); err != nil {
+		t.Errorf("Format() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Set up GitHub Actions workflow for the PHP package to run the unit tests. Placeholder unit tests are added to the php package to test the stubbed Generate, Clean, and Format functions.

For https://github.com/googleapis/librarian/issues/6629