### PR TITLE
fix(internal/librarian/java): remove excluded_poms from repometadata

### DIFF
--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -51,8 +51,6 @@ type repoMetadata struct {
 	APIReference string `json:"api_reference,omitempty"`
 	// Java-specific field.
 	CodeownerTeam string `json:"codeowner_team,omitempty"`
-	// Java-specific field.
-	ExcludedPOMs string `json:"excluded_poms,omitempty"`
 	IssueTracker string `json:"issue_tracker,omitempty"`
 	// Java-specific field.
 	RestDocumentation string `json:"rest_documentation,omitempty"`
@@ -145,7 +143,6 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, sourceDir s
 		metadata.APIReference = library.Java.APIReference
 		metadata.CodeownerTeam = library.Java.CodeownerTeam
 		metadata.ExtraVersionedModules = library.Java.ExtraVersionedModules
-		metadata.ExcludedPOMs = strings.Join(library.Java.ExcludedPOMs, ",")
 		metadata.MinJavaVersion = library.Java.MinJavaVersion
 		metadata.RecommendedPackage = library.Java.RecommendedPackage
 		metadata.RestDocumentation = library.Java.RestDocumentation

--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -51,7 +51,7 @@ type repoMetadata struct {
 	APIReference string `json:"api_reference,omitempty"`
 	// Java-specific field.
 	CodeownerTeam string `json:"codeowner_team,omitempty"`
-	IssueTracker string `json:"issue_tracker,omitempty"`
+	IssueTracker  string `json:"issue_tracker,omitempty"`
 	// Java-specific field.
 	RestDocumentation string `json:"rest_documentation,omitempty"`
 	// Java-specific field.


### PR DESCRIPTION
The java-specific field ExcludedPOMs is removed from the repoMetadata struct and its population is disabled in .repo-metadata.json.

This field is no longer required in .repo-metadata.json once migrated to librarian generate, and its omission cleans up the generated output.

For https://github.com/googleapis/librarian/issues/6099