### PR TITLE
feat(internal/librarian/nodejs): use cache and bin directories for nodejs install

### DIFF
--- a/internal/librarian/debug.go
+++ b/internal/librarian/debug.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
+	"github.com/googleapis/librarian/internal/librarian/nodejs"
 	"github.com/urfave/cli/v3"
 )
 
@@ -58,6 +59,7 @@ func runEnv(w io.Writer) error {
 	buildDir := dirOrErr(cache.BinDirectory())
 	goToolsDir := dirOrErr(golang.InstallDir())
 	javaToolsDir := dirOrErr(java.InstallDir())
+	nodejsToolsDir := dirOrErr(nodejs.InstallDir())
 	var b strings.Builder
 	fmt.Fprintf(&b, "LIBRARIAN_CACHE=%s\n", cacheDir)
 	fmt.Fprintf(&b, "LIBRARIAN_BIN=%s\n", buildDir)
@@ -65,6 +67,7 @@ func runEnv(w io.Writer) error {
 	fmt.Fprintln(&b, "Language-specific tool installation directories:")
 	fmt.Fprintf(&b, "  golang: %s\n", goToolsDir)
 	fmt.Fprintf(&b, "  java: %s\n", javaToolsDir)
+	fmt.Fprintf(&b, "  nodejs: %s\n", nodejsToolsDir)
 	_, err := io.WriteString(w, b.String())
 	return err
 }

--- a/internal/librarian/debug_test.go
+++ b/internal/librarian/debug_test.go
@@ -37,7 +37,7 @@ func TestRunEnv(t *testing.T) {
 		fmt.Sprintf("LIBRARIAN_BIN=%s", binDir),
 		fmt.Sprintf("golang: %s", filepath.Join(binDir, "go_tools")),
 		fmt.Sprintf("java: %s", filepath.Join(binDir, "java_tools")),
-		fmt.Sprintf("nodejs: %s", binDir),
+		fmt.Sprintf("nodejs: %s", filepath.Join(binDir, "nodejs_tools")),
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {

--- a/internal/librarian/debug_test.go
+++ b/internal/librarian/debug_test.go
@@ -37,6 +37,7 @@ func TestRunEnv(t *testing.T) {
 		fmt.Sprintf("LIBRARIAN_BIN=%s", binDir),
 		fmt.Sprintf("golang: %s", filepath.Join(binDir, "go_tools")),
 		fmt.Sprintf("java: %s", filepath.Join(binDir, "java_tools")),
+		fmt.Sprintf("nodejs: %s", binDir),
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {
@@ -61,6 +62,7 @@ func TestRunEnv_Error(t *testing.T) {
 		"LIBRARIAN_BIN=<error:",
 		"golang: <error:",
 		"java: <error:",
+		"nodejs: <error:",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -119,8 +119,12 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err != nil {
 		return err
 	}
+	toolsEnv, err := getToolsEnv()
+	if err != nil {
+		return err
+	}
 	cmdArgs := append(args[1:], protos...)
-	return command.RunInDir(ctx, googleapisDir, args[0], cmdArgs...)
+	return command.RunInDirWithEnv(ctx, googleapisDir, toolsEnv, args[0], cmdArgs...)
 }
 
 // resolveNodejsAPI returns the Node.js-specific configuration for the given API,
@@ -292,7 +296,12 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 	}
 	runArgs := append([]string{protoDir}, compileArgs...)
 
-	if err := command.RunInDir(ctx, outDir, "compileProtos", runArgs...); err != nil {
+	toolsEnv, err := getToolsEnv()
+	if err != nil {
+		return err
+	}
+
+	if err := command.RunInDirWithEnv(ctx, outDir, toolsEnv, "compileProtos", runArgs...); err != nil {
 		return fmt.Errorf("failed to compile protos: %w", err)
 	}
 
@@ -304,7 +313,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 	// of the gapic-generator-typescript
 	librarianScript := filepath.Join(outDir, "librarian.js")
 	if _, err := os.Stat(librarianScript); err == nil {
-		if err := command.RunInDir(ctx, repoRoot, "node", librarianScript); err != nil {
+		if err := command.RunInDirWithEnv(ctx, repoRoot, toolsEnv, "node", librarianScript); err != nil {
 			return fmt.Errorf("librarian.js failed: %w", err)
 		}
 	}
@@ -354,7 +363,11 @@ func movePackageFromStaging(ctx context.Context, library *config.Library, repoRo
 	if library.Nodejs != nil && library.Nodejs.ESM {
 		combineArgs = append(combineArgs, "--is-esm")
 	}
-	if err := command.Run(ctx, "gapic-node-processing", combineArgs...); err != nil {
+	toolsEnv, err := getToolsEnv()
+	if err != nil {
+		return err
+	}
+	if err := command.RunWithEnv(ctx, toolsEnv, "gapic-node-processing", combineArgs...); err != nil {
 		return fmt.Errorf("combine-library: %w", err)
 	}
 	// Restore keep files.

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -35,7 +35,10 @@ const (
 	gapicGeneratorSubdir = "core/generator/gapic-generator-typescript"
 )
 
-var errNoToolsSpecified = errors.New("no tools.pnpm field specified in configuration")
+var (
+	errNoToolsSpecified  = errors.New("no tools.pnpm field specified in configuration")
+	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
+)
 
 // Install installs Node.js tool dependencies.
 func Install(ctx context.Context, tools *config.Tools) error {
@@ -161,7 +164,7 @@ func installPNPMToolFromSource(ctx context.Context, env []string, tool *config.P
 func repoFromPackageURL(packageURL string) (string, error) {
 	parts := strings.SplitN(packageURL, "/archive/", 2)
 	if len(parts) != 2 {
-		return "", fmt.Errorf("cannot extract repo from package URL %q", packageURL)
+		return "", fmt.Errorf("%w %q", errCannotExtractRepo, packageURL)
 	}
 	return strings.TrimPrefix(parts[0], "https://"), nil
 }

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -38,6 +38,8 @@ const (
 var (
 	errNoToolsSpecified  = errors.New("no tools.pnpm field specified in configuration")
 	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
+	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
+	errMissingPackageURL = errors.New("has build steps but no package URL")
 )
 
 // Install installs Node.js tool dependencies.
@@ -48,7 +50,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 
 	for _, cmd := range []string{"node", "pnpm"} {
 		if _, err := exec.LookPath(cmd); err != nil {
-			return fmt.Errorf("%s is not installed or not in PATH, which is required for Node.js tool installation: %w", cmd, err)
+			return fmt.Errorf("%s %w: %w", cmd, errMissingExecutable, err)
 		}
 	}
 
@@ -137,7 +139,7 @@ func runPNPMBuildCmd(ctx context.Context, dir string, env []string, cmdStr strin
 
 func installPNPMToolFromSource(ctx context.Context, env []string, tool *config.PNPMTool) error {
 	if tool.Package == "" {
-		return fmt.Errorf("pnpm tool %s has build steps but no package URL", tool.Name)
+		return fmt.Errorf("pnpm tool %s %w", tool.Name, errMissingPackageURL)
 	}
 	repo, err := repoFromPackageURL(tool.Package)
 	if err != nil {

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -89,9 +89,18 @@ func InstallDir() (string, error) {
 	return filepath.Abs(filepath.Join(dir, toolsDir))
 }
 
+// getBinDir returns the directory where Node.js tool executables are stored.
+func getBinDir() (string, error) {
+	installDir, err := InstallDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(installDir, "bin"), nil
+}
+
 // getToolsEnv returns an environment map with the Node.js tools bin directory prepended to PATH.
 func getToolsEnv() (map[string]string, error) {
-	binDir, err := InstallDir()
+	binDir, err := getBinDir()
 	if err != nil {
 		return nil, err
 	}
@@ -110,13 +119,17 @@ func getPNPMEnv() ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve librarian cache directory: %w", err)
 	}
-	binDir, err := InstallDir()
+	installDir, err := InstallDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve librarian install directory: %w", err)
+	}
+	binDir, err := getBinDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve librarian bin directory: %w", err)
 	}
 
 	env := os.Environ()
-	env = append(env, "PNPM_HOME="+binDir)
+	env = append(env, "PNPM_HOME="+installDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -110,7 +110,7 @@ func getPNPMEnv() ([]string, error) {
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
-	env = append(env, "PATH="+binDir+":"+os.Getenv("PATH"))
+	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil
 }
 

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -15,7 +15,6 @@
 package nodejs
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -24,14 +23,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/fetch"
 )
 
-// gapicGeneratorSubdir is the sub-directory within the
-// google-cloud-node repo that contains the gapic-generator-typescript
-// source.
-const gapicGeneratorSubdir = "core/generator/gapic-generator-typescript"
+const (
+	// gapicGeneratorSubdir is the sub-directory within the
+	// google-cloud-node repo that contains the gapic-generator-typescript
+	// source.
+	gapicGeneratorSubdir = "core/generator/gapic-generator-typescript"
+)
 
 var errNoToolsSpecified = errors.New("no tools.pnpm field specified in configuration")
 
@@ -47,7 +49,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		}
 	}
 
-	env, err := getPNPMEnv(ctx)
+	env, err := getPNPMEnv()
 	if err != nil {
 		return err
 	}
@@ -71,32 +73,44 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	return nil
 }
 
-// getPNPMEnv resolves Node's global installation bin prefix path dynamically
-// and constructs a transient environment variable block to configure pnpm.
+// InstallDir gets the directory where tools should be installed.
+func InstallDir() (string, error) {
+	return cache.BinDirectory()
+}
+
+// getToolsEnv returns an environment map with the Node.js tools bin directory prepended to PATH.
+func getToolsEnv() (map[string]string, error) {
+	binDir, err := InstallDir()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"PATH": binDir}, nil
+}
+
+// getPNPMEnv constructs a transient environment variable block to configure pnpm.
 //
-// This redirects all globally-installed pnpm binaries, virtual stores, and
-// content-addressable storage caches to be nested under the Node prefix folder.
+// This redirects all globally-installed pnpm binaries to LIBRARIAN_BIN, and
+// virtual stores / content-addressable storage caches to LIBRARIAN_CACHE.
 // This enables complete environment caching and restore on CI runners,
 // while permanently avoiding persistent side-effects on the host machine
 // (it does not modify the user's personal ~/.config/pnpm/rc files).
-func getPNPMEnv(ctx context.Context) ([]string, error) {
-	binOut, err := commandOutput(ctx, "node", "-e", "console.log(require('path').dirname(process.execPath))")
+func getPNPMEnv() ([]string, error) {
+	cacheDir, err := cache.Directory()
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve node bin directory: %w", err)
+		return nil, fmt.Errorf("failed to resolve librarian cache directory: %w", err)
 	}
-	globalBin := strings.TrimSpace(binOut)
-
-	// In pnpm v11+, globally installed binaries are stored in PNPM_HOME/bin.
-	// We want them to be stored directly in globalBin (node's bin directory).
-	// See https://pnpm.io/blog/releases/11.0#isolated-global-virtual-store-global-installs
-	pnpmHome := filepath.Dir(globalBin)
+	binDir, err := InstallDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve librarian bin directory: %w", err)
+	}
 
 	env := os.Environ()
-	env = append(env, "PNPM_HOME="+pnpmHome)
-	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+globalBin)
-	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(globalBin, "pnpm-global"))
-	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(globalBin, "pnpm-store"))
+	env = append(env, "PNPM_HOME="+filepath.Dir(binDir))
+	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
+	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
+	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
+	env = append(env, "PATH="+binDir+":"+os.Getenv("PATH"))
 	return env, nil
 }
 
@@ -116,14 +130,6 @@ func runPNPMBuildCmd(ctx context.Context, dir string, env []string, cmdStr strin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-func commandOutput(ctx context.Context, name string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	return out.String(), err
 }
 
 func installPNPMToolFromSource(ctx context.Context, env []string, tool *config.PNPMTool) error {

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -33,6 +33,8 @@ const (
 	// google-cloud-node repo that contains the gapic-generator-typescript
 	// source.
 	gapicGeneratorSubdir = "core/generator/gapic-generator-typescript"
+
+	toolsDir = "nodejs_tools"
 )
 
 var (
@@ -80,7 +82,11 @@ func Install(ctx context.Context, tools *config.Tools) error {
 
 // InstallDir gets the directory where tools should be installed.
 func InstallDir() (string, error) {
-	return cache.BinDirectory()
+	dir, err := cache.BinDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Join(dir, toolsDir))
 }
 
 // getToolsEnv returns an environment map with the Node.js tools bin directory prepended to PATH.
@@ -110,7 +116,7 @@ func getPNPMEnv() ([]string, error) {
 	}
 
 	env := os.Environ()
-	env = append(env, "PNPM_HOME="+filepath.Dir(binDir))
+	env = append(env, "PNPM_HOME="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -237,27 +237,47 @@ func TestRepoFromPackageURL_Error(t *testing.T) {
 }
 
 func TestInstallDir(t *testing.T) {
-	binDir := t.TempDir()
-	t.Setenv("LIBRARIAN_BIN", binDir)
-	got, err := InstallDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(binDir, "nodejs_tools")
-	if got != want {
-		t.Errorf("InstallDir() = %q, want %q", got, want)
+	for _, test := range []struct {
+		name string
+	}{
+		{
+			name: "returns nodejs_tools directory under LIBRARIAN_BIN",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			t.Setenv("LIBRARIAN_BIN", binDir)
+			got, err := InstallDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := filepath.Join(binDir, "nodejs_tools")
+			if got != want {
+				t.Errorf("InstallDir() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
 func TestGetToolsEnv(t *testing.T) {
-	binDir := t.TempDir()
-	t.Setenv("LIBRARIAN_BIN", binDir)
-	env, err := getToolsEnv()
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(binDir, "nodejs_tools", "bin")
-	if got := env["PATH"]; got != want {
-		t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, want)
+	for _, test := range []struct {
+		name string
+	}{
+		{
+			name: "returns PATH with nodejs_tools bin directory",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			t.Setenv("LIBRARIAN_BIN", binDir)
+			env, err := getToolsEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := filepath.Join(binDir, "nodejs_tools", "bin")
+			if got := env["PATH"]; got != want {
+				t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, want)
+			}
+		})
 	}
 }

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -48,6 +48,8 @@ func TestInstall(t *testing.T) {
 	// without downloading the tarball over the network.
 	cache := t.TempDir()
 	t.Setenv("LIBRARIAN_CACHE", cache)
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
 	genDir := filepath.Join(cache,
 		repo+"@"+tool.Version,
 		gapicGeneratorSubdir)
@@ -82,11 +84,6 @@ esac
 exit 0
 `
 	nodeStub := `#!/bin/sh
-case "$*" in
-    *dirname*)
-        echo "/usr/local/bin"
-        ;;
-esac
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
@@ -99,6 +96,30 @@ exit 0
 
 	if err := Install(t.Context(), tools); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestInstallDir(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
+	got, err := InstallDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != binDir {
+		t.Errorf("InstallDir() = %q, want %q", got, binDir)
+	}
+}
+
+func TestGetToolsEnv(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
+	env, err := getToolsEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := env["PATH"]; got != binDir {
+		t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, binDir)
 	}
 }
 

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -196,13 +196,31 @@ func TestRepoFromPackageURL(t *testing.T) {
 		name       string
 		packageURL string
 		want       string
-		wantErr    error
 	}{
 		{
 			name:       "valid archive url",
 			packageURL: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
 			want:       "github.com/googleapis/google-cloud-node",
 		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := repoFromPackageURL(test.packageURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("repoFromPackageURL(%q) = %q, want %q", test.packageURL, got, test.want)
+			}
+		})
+	}
+}
+
+func TestRepoFromPackageURL_Error(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		packageURL string
+		wantErr    error
+	}{
 		{
 			name:       "invalid archive url",
 			packageURL: "https://github.com/googleapis/google-cloud-node/invalid",
@@ -210,12 +228,9 @@ func TestRepoFromPackageURL(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := repoFromPackageURL(test.packageURL)
+			_, err := repoFromPackageURL(test.packageURL)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("repoFromPackageURL(%q) error = %v, wantErr = %v", test.packageURL, err, test.wantErr)
-			}
-			if got != test.want {
-				t.Errorf("repoFromPackageURL(%q) = %q, want %q", test.packageURL, got, test.want)
 			}
 		})
 	}

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -256,7 +256,7 @@ func TestGetToolsEnv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join(binDir, "nodejs_tools")
+	want := filepath.Join(binDir, "nodejs_tools", "bin")
 	if got := env["PATH"]; got != want {
 		t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, want)
 	}

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -174,6 +174,7 @@ func TestInstall_Error(t *testing.T) {
 			setup: func(t *testing.T) {
 				stubExecutables(t)
 			},
+			wantErr: errCannotExtractRepo,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -197,7 +198,7 @@ func TestRepoFromPackageURL(t *testing.T) {
 		name       string
 		packageURL string
 		want       string
-		wantErr    bool
+		wantErr    error
 	}{
 		{
 			name:       "valid archive url",
@@ -207,12 +208,12 @@ func TestRepoFromPackageURL(t *testing.T) {
 		{
 			name:       "invalid archive url",
 			packageURL: "https://github.com/googleapis/google-cloud-node/invalid",
-			wantErr:    true,
+			wantErr:    errCannotExtractRepo,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := repoFromPackageURL(test.packageURL)
-			if (err != nil) != test.wantErr {
+			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("repoFromPackageURL(%q) error = %v, wantErr = %v", test.packageURL, err, test.wantErr)
 			}
 			if got != test.want {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -23,53 +23,15 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func TestInstall(t *testing.T) {
-	tools := &config.Tools{
-		PNPM: []*config.PNPMTool{
-			{
-				Name:    "gapic-generator-typescript",
-				Version: "4.12.1",
-				Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
-				Build: []string{
-					"pnpm install",
-					"./node_modules/.bin/tsc",
-					"cp -a templates protos build/",
-				},
-			},
-		},
-	}
-	tool := tools.PNPM[0]
-	repo, err := repoFromPackageURL(tool.Package)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Pre-populate the fetch cache so fetch.Repo returns immediately
-	// without downloading the tarball over the network.
-	cache := t.TempDir()
-	t.Setenv("LIBRARIAN_CACHE", cache)
-	binDir := t.TempDir()
-	t.Setenv("LIBRARIAN_BIN", binDir)
-	genDir := filepath.Join(cache,
-		repo+"@"+tool.Version,
-		gapicGeneratorSubdir)
-	for _, sub := range []string{
-		"templates",
-		"protos",
-	} {
-		if err := os.MkdirAll(filepath.Join(genDir, sub), 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	// Stub pnpm and node. The pnpm stub also creates
-	// node_modules/.bin/tsc in the working directory during 'pnpm install'
-	// so the subsequent "./node_modules/.bin/tsc" build step finds an executable.
+func stubExecutables(t *testing.T) {
+	t.Helper()
 	bin := t.TempDir()
 	pnpmStub := `#!/bin/sh
 # Assert that transient environmental variables are set dynamically for process lifetime
-if [ -z "$PNPM_HOME" ] || [ -z "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] || [ -z "$PNPM_CONFIG_GLOBAL_DIR" ] || [ -z "$PNPM_CONFIG_STORE_DIR" ] || \
-   [ -z "$PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS" ]; then
+if [ -n "$PNPM_HOME" ] && [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] && [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] && [ -n "$PNPM_CONFIG_STORE_DIR" ] && \
+   [ -n "$PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS" ]; then
+    :
+else
     echo "Error: Required transient PNPM environment variables are missing!" >&2
     exit 1
 fi
@@ -79,6 +41,8 @@ case "$*" in
         mkdir -p node_modules/.bin
         printf '#!/bin/sh\nmkdir -p build\n' > node_modules/.bin/tsc
         chmod +x node_modules/.bin/tsc
+        ;;
+    *add\ -g*)
         ;;
 esac
 exit 0
@@ -93,9 +57,168 @@ exit 0
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
 
-	if err := Install(t.Context(), tools); err != nil {
-		t.Fatal(err)
+func TestInstall(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		tools *config.Tools
+		setup func(t *testing.T)
+	}{
+		{
+			name: "source build tool",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "gapic-generator-typescript",
+						Version: "4.12.1",
+						Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
+						Build: []string{
+							"pnpm install",
+							"./node_modules/.bin/tsc",
+							"cp -a templates protos build/",
+						},
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				cache := t.TempDir()
+				t.Setenv("LIBRARIAN_CACHE", cache)
+				binDir := t.TempDir()
+				t.Setenv("LIBRARIAN_BIN", binDir)
+				genDir := filepath.Join(cache,
+					"github.com/googleapis/google-cloud-node@4.12.1",
+					gapicGeneratorSubdir)
+				for _, sub := range []string{"templates", "protos"} {
+					if err := os.MkdirAll(filepath.Join(genDir, sub), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				stubExecutables(t)
+			},
+		},
+		{
+			name: "non-build tool",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "gapic-node-processing",
+						Version: "0.1.8",
+					},
+					{
+						Name:    "custom-pkg",
+						Package: "custom-pkg@1.0.0",
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				stubExecutables(t)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			if err := Install(t.Context(), test.tools); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestInstall_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tools   *config.Tools
+		setup   func(t *testing.T)
+		wantErr error
+	}{
+		{
+			name:    "nil tools",
+			tools:   nil,
+			wantErr: errNoToolsSpecified,
+		},
+		{
+			name:    "empty tools",
+			tools:   &config.Tools{},
+			wantErr: errNoToolsSpecified,
+		},
+		{
+			name:  "missing node or pnpm in path",
+			tools: &config.Tools{PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
+			setup: func(t *testing.T) {
+				t.Setenv("PATH", t.TempDir())
+			},
+		},
+		{
+			name: "missing package url for build tool",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{Name: "tool", Build: []string{"echo 1"}},
+				},
+			},
+			setup: func(t *testing.T) {
+				stubExecutables(t)
+			},
+		},
+		{
+			name: "invalid package url for build tool",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
+				},
+			},
+			setup: func(t *testing.T) {
+				stubExecutables(t)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			err := Install(t.Context(), test.tools)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
+				}
+			} else if err == nil {
+				t.Fatal("Install() expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestRepoFromPackageURL(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		packageURL string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "valid archive url",
+			packageURL: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
+			want:       "github.com/googleapis/google-cloud-node",
+		},
+		{
+			name:       "invalid archive url",
+			packageURL: "https://github.com/googleapis/google-cloud-node/invalid",
+			wantErr:    true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := repoFromPackageURL(test.packageURL)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("repoFromPackageURL(%q) error = %v, wantErr = %v", test.packageURL, err, test.wantErr)
+			}
+			if got != test.want {
+				t.Errorf("repoFromPackageURL(%q) = %q, want %q", test.packageURL, got, test.want)
+			}
+		})
 	}
 }
 
@@ -120,31 +243,5 @@ func TestGetToolsEnv(t *testing.T) {
 	}
 	if got := env["PATH"]; got != binDir {
 		t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, binDir)
-	}
-}
-
-func TestInstall_Error(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		tools   *config.Tools
-		wantErr error
-	}{
-		{
-			name:    "nil tools",
-			tools:   nil,
-			wantErr: errNoToolsSpecified,
-		},
-		{
-			name:    "empty tools",
-			tools:   &config.Tools{},
-			wantErr: errNoToolsSpecified,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			err := Install(t.Context(), test.tools)
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("Install() err = %v, wantErr = %v", err, test.wantErr)
-			}
-		})
 	}
 }

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -184,12 +184,8 @@ func TestInstall_Error(t *testing.T) {
 				test.setup(t)
 			}
 			err := Install(t.Context(), test.tools)
-			if test.wantErr != nil {
-				if !errors.Is(err, test.wantErr) {
-					t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
-				}
-			} else if err == nil {
-				t.Fatal("Install() expected error, got nil")
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -152,6 +152,7 @@ func TestInstall_Error(t *testing.T) {
 			setup: func(t *testing.T) {
 				t.Setenv("PATH", t.TempDir())
 			},
+			wantErr: errMissingExecutable,
 		},
 		{
 			name: "missing package url for build tool",
@@ -163,6 +164,7 @@ func TestInstall_Error(t *testing.T) {
 			setup: func(t *testing.T) {
 				stubExecutables(t)
 			},
+			wantErr: errMissingPackageURL,
 		},
 		{
 			name: "invalid package url for build tool",

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -243,8 +243,9 @@ func TestInstallDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != binDir {
-		t.Errorf("InstallDir() = %q, want %q", got, binDir)
+	want := filepath.Join(binDir, "nodejs_tools")
+	if got != want {
+		t.Errorf("InstallDir() = %q, want %q", got, want)
 	}
 }
 
@@ -255,7 +256,8 @@ func TestGetToolsEnv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := env["PATH"]; got != binDir {
-		t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, binDir)
+	want := filepath.Join(binDir, "nodejs_tools")
+	if got := env["PATH"]; got != want {
+		t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Update NodeJS tool installation to use `$LIBRARIAN_BIN/nodejs_tools` for installed executables (aligning with `go_tools` and `java_tools`) and `LIBRARIAN_CACHE` for downloaded `google-cloud-node` repository and pnpm cache/store.

Fixes https://github.com/googleapis/librarian/issues/6678

- Installs Node.js tools in `$LIBRARIAN_BIN/nodejs_tools/bin` (with `PNPM_HOME=$LIBRARIAN_BIN/nodejs_tools` and `PNPM_CONFIG_GLOBAL_BIN_DIR=$LIBRARIAN_BIN/nodejs_tools/bin`).
- Prepends `$LIBRARIAN_BIN/nodejs_tools/bin` to `PATH` during tool installation and generation to prevent `pnpm` warnings/errors about global bin directory not in `PATH`.
- Declares sentinel errors (`errMissingExecutable`, `errMissingPackageURL`, `errCannotExtractRepo`) evaluated with `errors.Is`.
- Table-driven tests in `internal/librarian/nodejs/install_test.go` use a `pnpm` shell script stub. The stub handles `pnpm add -g` for non-build tool installations and asserts that required transient environment variables (`PNPM_HOME`, `PNPM_CONFIG_GLOBAL_BIN_DIR`, `PNPM_CONFIG_GLOBAL_DIR`, `PNPM_CONFIG_STORE_DIR`, and `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS`) are present during execution.

<details>

<summary>I ran `librarian install` and the executables are installed in the cache folder.</summary>

```
suztomo@suztomo:~/librarian-2026/google-cloud-node$ rm $(which pbjs)
suztomo@suztomo:~/librarian-2026/google-cloud-node$ which gapic-node-processing
/usr/local/google/home/suztomo/.nvm/versions/node/v22.22.3/bin/gapic-node-processing
suztomo@suztomo:~/librarian-2026/google-cloud-node$ rm $(which gapic-node-processing)
suztomo@suztomo:~/librarian-2026/google-cloud-node$ which gapic-generator-java
suztomo@suztomo:~/librarian-2026/google-cloud-node$ which gapic-generator-typescript
/usr/local/google/home/suztomo/.nvm/versions/node/v22.22.3/bin/gapic-generator-typescript
suztomo@suztomo:~/librarian-2026/google-cloud-node$ rm $(which gapic-generator-typescript)
suztomo@suztomo:~/librarian-2026/google-cloud-node$ /tmp/librarian install
Already up to date
...

Done in 1s using pnpm v11.10.0
suztomo@suztomo:~/librarian-2026/google-cloud-node$ which gapic-generator-typescript
suztomo@suztomo:~/librarian-2026/google-cloud-node$ /tmp/librarian debug env
LIBRARIAN_CACHE=/usr/local/google/home/suztomo/.cache/librarian
LIBRARIAN_BIN=/usr/local/google/home/suztomo/.cache/librarian/bin

Language-specific tool installation directories:
  golang: /usr/local/google/home/suztomo/.cache/librarian/bin/go_tools
  java: /usr/local/google/home/suztomo/.cache/librarian/bin/java_tools
  nodejs: /usr/local/google/home/suztomo/.cache/librarian/bin/nodejs_tools
suztomo@suztomo:~/librarian-2026/google-cloud-node$ export PATH=$PATH:/usr/local/google/home/suztomo/.cache/librarian/bin/nodejs_tools/bin
suztomo@suztomo:~/librarian-2026/google-cloud-node$ which gapic-generator-typescript
/usr/local/google/home/suztomo/.cache/librarian/bin/nodejs_tools/bin/gapic-generator-typescript
```

<details>

<summary>I ran generate without setting the PATH. Librarian used the bin directory.</summary>

```
suztomo@suztomo:~/librarian-2026/google-cloud-node$ which gapic-node-processing
suztomo@suztomo:~/librarian-2026/google-cloud-node$ /tmp/librarian generate google-cloud-agentregistry
suztomo@suztomo:~/librarian-2026/google-cloud-node$ git diff |head -30
diff --git a/packages/google-cloud-agentregistry/protos/protos.js b/packages/google-cloud-agentregistry/protos/protos.js
index e8aaa3ea7c..6154bd8bc0 100644
--- a/packages/google-cloud-agentregistry/protos/protos.js
+++ b/packages/google-cloud-agentregistry/protos/protos.js
@@ -28,7 +28,7 @@
     var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
     
     // Exported root namespace
-    var $root = $protobuf.roots._google_cloud_agentregistry_protos || ($protobuf.roots._google_cloud_agentregistry_protos = {});
+    var $root = $protobuf.roots["_google_cloud_agentregistry_protos"] || ($protobuf.roots["_google_cloud_agentregistry_protos"] = {});
     
     $root.google = (function() {
     
@@ -230,9:13 @@
                          * @param {$protobuf.Writer} [writer] Writer to encode to
                          * @returns {$protobuf.Writer} Writer
                          */
-                        Agent.encode = function encode(message, writer) {
+                        Agent.encode = function encode(message, writer, q) {
                             if (!writer)
                                 writer = $Writer.create();
+                            if (q === undefined)
+                                q = 0;
+                            if (q > $util.recursionLimit)
+                                throw Error("max depth exceeded");
                             if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             if (message.agentId != null && Object.hasOwnProperty.call(message, "agentId"))
@@ -247,23 +251,23 @@
                                 writer.uint32(/* id 7, wireType 2 =*/58).string(message.version);
```

</details>
