### PR TITLE
refactor(internal/repometadata): move recommended package logic

### DIFF
--- a/internal/librarian/java/repometadata.go
+++ b/internal/librarian/java/repometadata.go
@@ -105,6 +105,7 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, sourceDir s
 		APIID:                sharedMetadata.APIID,
 		LibraryType:          repometadata.GAPICAutoLibraryType,
 		RequiresBilling:      true,
+		RecommendedPackage:   sharedMetadata.RecommendedPackage,
 	}
 
 	// Java-specific overrides and optional fields
@@ -144,7 +145,6 @@ func deriveRepoMetadata(cfg *config.Config, library *config.Library, sourceDir s
 		metadata.CodeownerTeam = library.Java.CodeownerTeam
 		metadata.ExtraVersionedModules = library.Java.ExtraVersionedModules
 		metadata.MinJavaVersion = library.Java.MinJavaVersion
-		metadata.RecommendedPackage = library.Java.RecommendedPackage
 		metadata.RestDocumentation = library.Java.RestDocumentation
 		metadata.RpcDocumentation = library.Java.RpcDocumentation
 	}

--- a/internal/librarian/java/repometadata_test.go
+++ b/internal/librarian/java/repometadata_test.go
@@ -172,6 +172,31 @@ func TestDeriveRepoMetadata_Overrides(t *testing.T) {
 				RequiresBilling:      true,
 			},
 		},
+		{
+			name: "recommended package",
+			java: &config.JavaModule{
+				ArtifactID:         "google-cloud-secretmanager",
+				GroupID:            "com.google.cloud",
+				RecommendedPackage: "com.google.cloud.secretmanager.v1",
+			},
+			want: &repoMetadata{
+				APIShortname:         "secretmanager",
+				NamePretty:           wantNamePretty,
+				ProductDocumentation: wantProductDoc,
+				APIDescription:       wantAPIDescription,
+				ClientDocumentation:  "https://cloud.google.com/java/docs/reference/google-cloud-secretmanager/latest/overview",
+				ReleaseLevel:         "stable",
+				Transport:            "grpc+rest",
+				Language:             "java",
+				Repo:                 "googleapis/google-cloud-java",
+				RepoShort:            "java-secretmanager",
+				DistributionName:     "com.google.cloud:google-cloud-secretmanager",
+				APIID:                "secretmanager.googleapis.com",
+				LibraryType:          "GAPIC_AUTO",
+				RequiresBilling:      true,
+				RecommendedPackage:   "com.google.cloud.secretmanager.v1",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			library := &config.Library{

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -94,6 +94,10 @@ type RepoMetadata struct {
 
 	// Transport is the transport protocol used by the library (e.g. "grpc", "rest").
 	Transport string `json:"transport,omitempty"`
+
+	// RecommendedPackage is the recommended package name.
+	// A Java-specific field.
+	RecommendedPackage string `json:"recommended_package,omitempty"`
 }
 
 // FromLibrary creates a RepoMetadata from a specific library in a
@@ -132,8 +136,12 @@ func FromLibrary(cfg *config.Config, library *config.Library, googleapisDir stri
 // fromAPI generates the .repo-metadata.json file from a serviceconfig.API and library information.
 func fromAPI(cfg *config.Config, api *serviceconfig.API, library *config.Library) *RepoMetadata {
 	var transport string
+	var recommendedPackage string
 	if cfg.Language == config.LanguageJava {
 		transport = api.RepoMetadataTransport(cfg.Language, library)
+		if library.Java != nil {
+			recommendedPackage = library.Java.RecommendedPackage
+		}
 	}
 	return &RepoMetadata{
 		APIDescription:       api.Description,
@@ -148,6 +156,7 @@ func fromAPI(cfg *config.Config, api *serviceconfig.API, library *config.Library
 		ReleaseLevel:         api.ReleaseLevel(cfg.Language, library.Version),
 		Repo:                 cfg.Repo,
 		Transport:            transport,
+		RecommendedPackage:   recommendedPackage,
 	}
 }
 

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -65,6 +65,31 @@ func TestFromLibrary(t *testing.T) {
 				APIDescription:   "Defines types and an abstract service to handle long-running operations.\n\n[Long-running operations] are a common pattern to handle methods that may take\na significant amount of time to execute. Many Google APIs return an `Operation`\nmessage (defined in this package) that are roughly analogous to a future. The\noperation will eventually complete, though it may still return an error on\ncompletion. The client libraries provide helpers to simplify polling of these\noperations.\n\n[Long-running operations]: https://google.aip.dev/151",
 			},
 		},
+		{
+			name: "java configuration",
+			library: &config.Library{
+				Name: "google-cloud-secretmanager-v1",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Java: &config.JavaModule{
+					RecommendedPackage: "com.google.cloud.secretmanager.v1",
+				},
+			},
+			want: &RepoMetadata{
+				Name:                 "secretmanager",
+				NamePretty:           "Secret Manager",
+				ProductDocumentation: "https://cloud.google.com/secret-manager/",
+				IssueTracker:         "https://issuetracker.google.com/issues/new?component=784854&template=1380926",
+				ReleaseLevel:         "stable",
+				Language:             config.LanguageJava,
+				Repo:                 "googleapis/google-cloud-java",
+				DistributionName:     "google-cloud-secretmanager-v1",
+				APIID:                "secretmanager.googleapis.com",
+				APIShortname:         "secretmanager",
+				APIDescription:       "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
+				RecommendedPackage:   "com.google.cloud.secretmanager.v1",
+				Transport:            "grpc+rest",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()


### PR DESCRIPTION
The RecommendedPackage configuration mapping logic for Java libraries is moved from the language-specific Java package to the shared repometadata package. This is a step towards removing the java specific layer of repometadata.

This is java specific field, used for CloudRAD doc generation. It is set for 8 hybrid libraries. So google-cloud-java/librarian.yaml is the right place for it.

Fixes https://github.com/googleapis/librarian/issues/6285?issue=googleapis%7Clibrarian%7C6694