### PR TITLE
feat(swift): add protobuf generation support

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -571,7 +571,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `output` | string | Is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated"). |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
-| `module_type` | string | Is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC). |
+| `module_type` | string | Is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty/"default" for standard GAPIC). |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include. This is typically reserved for special cases to avoid generating unused/dead code. For example, in Storage we need Protobuf gencode for a subset of the protos in the google/type directory. This code is private to the package (google-cloud-storage in Rust, GoogleCloudStorage in Swift). All other files in google/type would be dead code. |
 | `module_path` | string | Is the module import path or target containing stubs (used by convert-swift). |
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -572,7 +572,7 @@ This document describes the schema for the librarian.yaml.
 | `output` | string | Is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated"). |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
 | `module_type` | string | Is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC). |
-| `include_list` | list of string | Is a subset of proto files under the target API path to include. This is typically reserved for special cases (e.g., resolving dependency issues or compiling subsets of shared proto namespaces) and should not be used for standard libraries. |
+| `include_list` | list of string | Is a subset of proto files under the target API path to include. This is typically reserved for special cases to avoid generating unused/dead code. For example, in Storage we need Protobuf gencode for a subset of the protos in the google/type directory. This code is private to the package (google-cloud-storage in Rust, GoogleCloudStorage in Swift). All other files in google/type would be dead code. |
 | `module_path` | string | Is the module import path or target containing stubs (used by convert-swift). |
 
 ## SwiftPackage Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -571,7 +571,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `output` | string | Is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated"). |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
-| `template` | string | Is the generation template to use (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC). |
+| `module_type` | string | Is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC). |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include. |
 | `module_path` | string | Is the module import path or target containing stubs (used by convert-swift). |
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -571,6 +571,9 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `output` | string | Is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated"). |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
+| `template` | string | Is the generation template to use (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC). |
+| `include_list` | list of string | Is a subset of proto files under the target API path to include. |
+| `module_path` | string | Is the module import path or target containing stubs (used by convert-swift). |
 
 ## SwiftPackage Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -572,7 +572,7 @@ This document describes the schema for the librarian.yaml.
 | `output` | string | Is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated"). |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
 | `module_type` | string | Is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC). |
-| `include_list` | list of string | Is a subset of proto files under the target API path to include. |
+| `include_list` | list of string | Is a subset of proto files under the target API path to include. This is typically reserved for special cases (e.g., resolving dependency issues or compiling subsets of shared proto namespaces) and should not be used for standard libraries. |
 | `module_path` | string | Is the module import path or target containing stubs (used by convert-swift). |
 
 ## SwiftPackage Configuration

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -109,7 +109,7 @@ type SwiftModule struct {
 	// APIPath is the proto path to generate from (e.g., "google/storage/v2").
 	APIPath string `yaml:"api_path"`
 
-	// ModuleType is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC).
+	// ModuleType is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty/"default" for standard GAPIC).
 	ModuleType string `yaml:"module_type,omitempty"`
 
 	// IncludeList is a subset of proto files under the target API path to include.

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -113,6 +113,8 @@ type SwiftModule struct {
 	ModuleType string `yaml:"module_type,omitempty"`
 
 	// IncludeList is a subset of proto files under the target API path to include.
+	// This is typically reserved for special cases (e.g., resolving dependency issues or
+	// compiling subsets of shared proto namespaces) and should not be used for standard libraries.
 	IncludeList []string `yaml:"include_list,omitempty"`
 
 	// ModulePath is the module import path or target containing stubs (used by convert-swift).

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -109,8 +109,8 @@ type SwiftModule struct {
 	// APIPath is the proto path to generate from (e.g., "google/storage/v2").
 	APIPath string `yaml:"api_path"`
 
-	// Template is the generation template to use (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC).
-	Template string `yaml:"template,omitempty"`
+	// ModuleType is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC).
+	ModuleType string `yaml:"module_type,omitempty"`
 
 	// IncludeList is a subset of proto files under the target API path to include.
 	IncludeList []string `yaml:"include_list,omitempty"`

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -113,8 +113,10 @@ type SwiftModule struct {
 	ModuleType string `yaml:"module_type,omitempty"`
 
 	// IncludeList is a subset of proto files under the target API path to include.
-	// This is typically reserved for special cases (e.g., resolving dependency issues or
-	// compiling subsets of shared proto namespaces) and should not be used for standard libraries.
+	// This is typically reserved for special cases to avoid generating unused/dead code.
+	// For example, in Storage we need Protobuf gencode for a subset of the protos in the google/type
+	// directory. This code is private to the package (google-cloud-storage in Rust, GoogleCloudStorage
+	// in Swift). All other files in google/type would be dead code.
 	IncludeList []string `yaml:"include_list,omitempty"`
 
 	// ModulePath is the module import path or target containing stubs (used by convert-swift).

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -108,6 +108,15 @@ type SwiftModule struct {
 
 	// APIPath is the proto path to generate from (e.g., "google/storage/v2").
 	APIPath string `yaml:"api_path"`
+
+	// Template is the generation template to use (e.g., "swift-protobuf", "convert-swift", or empty for standard GAPIC).
+	Template string `yaml:"template,omitempty"`
+
+	// IncludeList is a subset of proto files under the target API path to include.
+	IncludeList []string `yaml:"include_list,omitempty"`
+
+	// ModulePath is the module import path or target containing stubs (used by convert-swift).
+	ModulePath string `yaml:"module_path,omitempty"`
 }
 
 // SwiftDiscovery contains discovery-specific configuration for LRO polling.

--- a/internal/librarian/swift/compile_protobufs.go
+++ b/internal/librarian/swift/compile_protobufs.go
@@ -68,10 +68,6 @@ func compileProtobufs(ctx context.Context, library *config.Library, module *conf
 	for _, r := range sourceConfig.ActiveRoots {
 		addImport(sourceConfig.Root(r))
 	}
-	addImport(src.Googleapis)
-	addImport(src.ProtobufSrc)
-	addImport(src.Showcase)
-	addImport(src.Conformance)
 
 	args := []string{
 		"--swift_out=Visibility=Public:" + module.Output,

--- a/internal/librarian/swift/compile_protobufs.go
+++ b/internal/librarian/swift/compile_protobufs.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+func compileProtobufs(ctx context.Context, library *config.Library, module *config.SwiftModule, src *sources.Sources) error {
+	if err := os.MkdirAll(module.Output, 0755); err != nil {
+		return err
+	}
+
+	sourceConfig := sources.NewSourceConfig(src, library.Roots)
+	apiPathAbs := sourceConfig.ResolveDir(module.APIPath)
+
+	var protoFiles []string
+	if len(module.IncludeList) > 0 {
+		for _, file := range module.IncludeList {
+			protoFiles = append(protoFiles, filepath.Join(apiPathAbs, file))
+		}
+	} else {
+		entries, err := os.ReadDir(apiPathAbs)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".proto") {
+				protoFiles = append(protoFiles, filepath.Join(apiPathAbs, entry.Name()))
+			}
+		}
+	}
+
+	if len(protoFiles) == 0 {
+		return fmt.Errorf("no proto files found in %s", apiPathAbs)
+	}
+
+	importsMap := make(map[string]bool)
+	var protoImports []string
+
+	addImport := func(path string) {
+		if path != "" && !importsMap[path] {
+			importsMap[path] = true
+			protoImports = append(protoImports, "-I", path)
+		}
+	}
+
+	for _, r := range sourceConfig.ActiveRoots {
+		addImport(sourceConfig.Root(r))
+	}
+	addImport(src.Googleapis)
+	addImport(src.ProtobufSrc)
+	addImport(src.Showcase)
+	addImport(src.Conformance)
+
+	args := []string{
+		"--swift_out=Visibility=Public:" + module.Output,
+		"--grpc-swift_out=Visibility=Public:" + module.Output,
+	}
+	args = append(args, protoImports...)
+	args = append(args, protoFiles...)
+
+	return command.Run(ctx, "protoc", args...)
+}

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -31,7 +31,13 @@ import (
 func generateModule(ctx context.Context, library *config.Library, src *sources.Sources) error {
 	for _, module := range library.Swift.Modules {
 		switch module.Template {
-		case "", "gapic":
+		case "swift-protobuf":
+			if err := compileProtobufs(ctx, library, module, src); err != nil {
+				return err
+			}
+		case "convert-swift":
+			return fmt.Errorf("template %q is not yet supported", module.Template)
+		case "":
 			modelConfig := moduleToModelConfig(library, module, src)
 			model, err := parser.CreateModel(modelConfig)
 			if err != nil {
@@ -40,12 +46,8 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 			if err := sidekickswift.Generate(ctx, model, module.Output, modelConfig, library.Swift); err != nil {
 				return err
 			}
-		case "swift-protobuf":
-			if err := compileProtobufs(ctx, library, module, src); err != nil {
-				return err
-			}
 		default:
-			return fmt.Errorf("unsupported template %q for module %q", module.Template, module.Output)
+			return fmt.Errorf("unknown template %q", module.Template)
 		}
 	}
 	return nil

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -33,7 +33,7 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 			}
 		case "convert-swift":
 			return fmt.Errorf("module type %q is not yet supported", module.ModuleType)
-		case "":
+		case "", "default":
 			modelConfig := moduleToModelConfig(library, module, src)
 			model, err := parser.CreateModel(modelConfig)
 			if err != nil {
@@ -48,8 +48,6 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 	}
 	return nil
 }
-
-
 
 func moduleToModelConfig(library *config.Library, module *config.SwiftModule, src *sources.Sources) *parser.ModelConfig {
 	sourceConfig := sources.NewSourceConfig(src, library.Roots)

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -16,6 +16,7 @@ package swift
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,12 +31,7 @@ import (
 func generateModule(ctx context.Context, library *config.Library, src *sources.Sources) error {
 	for _, module := range library.Swift.Modules {
 		switch module.Template {
-		case "swift-protobuf":
-			if err := compileProtobufs(ctx, library, module, src); err != nil {
-				return err
-			}
-		default:
-			// Fall back to standard GAPIC generation
+		case "", "gapic":
 			modelConfig := moduleToModelConfig(library, module, src)
 			model, err := parser.CreateModel(modelConfig)
 			if err != nil {
@@ -44,6 +40,12 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 			if err := sidekickswift.Generate(ctx, model, module.Output, modelConfig, library.Swift); err != nil {
 				return err
 			}
+		case "swift-protobuf":
+			if err := compileProtobufs(ctx, library, module, src); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported template %q for module %q", module.Template, module.Output)
 		}
 	}
 	return nil

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -16,7 +16,11 @@ package swift
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	sidekickswift "github.com/googleapis/librarian/internal/sidekick/swift"
@@ -25,16 +29,81 @@ import (
 
 func generateModule(ctx context.Context, library *config.Library, src *sources.Sources) error {
 	for _, module := range library.Swift.Modules {
-		modelConfig := moduleToModelConfig(library, module, src)
-		model, err := parser.CreateModel(modelConfig)
-		if err != nil {
-			return err
-		}
-		if err := sidekickswift.Generate(ctx, model, module.Output, modelConfig, library.Swift); err != nil {
-			return err
+		switch module.Template {
+		case "swift-protobuf":
+			if err := compileProtobufs(ctx, library, module, src); err != nil {
+				return err
+			}
+		default:
+			// Fall back to standard GAPIC generation
+			modelConfig := moduleToModelConfig(library, module, src)
+			model, err := parser.CreateModel(modelConfig)
+			if err != nil {
+				return err
+			}
+			if err := sidekickswift.Generate(ctx, model, module.Output, modelConfig, library.Swift); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+func compileProtobufs(ctx context.Context, library *config.Library, module *config.SwiftModule, src *sources.Sources) error {
+	if err := os.MkdirAll(module.Output, 0755); err != nil {
+		return err
+	}
+
+	sourceConfig := sources.NewSourceConfig(src, library.Roots)
+	apiPathAbs := sourceConfig.ResolveDir(module.APIPath)
+
+	var protoFiles []string
+	if len(module.IncludeList) > 0 {
+		for _, file := range module.IncludeList {
+			protoFiles = append(protoFiles, filepath.Join(apiPathAbs, file))
+		}
+	} else {
+		entries, err := os.ReadDir(apiPathAbs)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".proto") {
+				protoFiles = append(protoFiles, filepath.Join(apiPathAbs, entry.Name()))
+			}
+		}
+	}
+
+	if len(protoFiles) == 0 {
+		return nil
+	}
+
+	importsMap := make(map[string]bool)
+	var protoImports []string
+
+	addImport := func(path string) {
+		if path != "" && !importsMap[path] {
+			importsMap[path] = true
+			protoImports = append(protoImports, "-I", path)
+		}
+	}
+
+	for _, r := range sourceConfig.ActiveRoots {
+		addImport(sourceConfig.Root(r))
+	}
+	addImport(src.Googleapis)
+	addImport(src.ProtobufSrc)
+	addImport(src.Showcase)
+	addImport(src.Conformance)
+
+	args := []string{
+		"--swift_out=Visibility=Public:" + module.Output,
+		"--grpc-swift_out=Visibility=Public:" + module.Output,
+	}
+	args = append(args, protoImports...)
+	args = append(args, protoFiles...)
+
+	return command.Run(ctx, "protoc", args...)
 }
 
 func moduleToModelConfig(library *config.Library, module *config.SwiftModule, src *sources.Sources) *parser.ModelConfig {

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -30,13 +30,13 @@ import (
 
 func generateModule(ctx context.Context, library *config.Library, src *sources.Sources) error {
 	for _, module := range library.Swift.Modules {
-		switch module.Template {
+		switch module.ModuleType {
 		case "swift-protobuf":
 			if err := compileProtobufs(ctx, library, module, src); err != nil {
 				return err
 			}
 		case "convert-swift":
-			return fmt.Errorf("template %q is not yet supported", module.Template)
+			return fmt.Errorf("module type %q is not yet supported", module.ModuleType)
 		case "":
 			modelConfig := moduleToModelConfig(library, module, src)
 			model, err := parser.CreateModel(modelConfig)
@@ -47,7 +47,7 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 				return err
 			}
 		default:
-			return fmt.Errorf("unknown template %q", module.Template)
+			return fmt.Errorf("unknown module type %q", module.ModuleType)
 		}
 	}
 	return nil

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -79,7 +79,7 @@ func compileProtobufs(ctx context.Context, library *config.Library, module *conf
 	}
 
 	if len(protoFiles) == 0 {
-		return nil
+		return fmt.Errorf("no proto files found in %s", apiPathAbs)
 	}
 
 	importsMap := make(map[string]bool)

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -17,11 +17,7 @@ package swift
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	sidekickswift "github.com/googleapis/librarian/internal/sidekick/swift"
@@ -53,62 +49,7 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 	return nil
 }
 
-func compileProtobufs(ctx context.Context, library *config.Library, module *config.SwiftModule, src *sources.Sources) error {
-	if err := os.MkdirAll(module.Output, 0755); err != nil {
-		return err
-	}
 
-	sourceConfig := sources.NewSourceConfig(src, library.Roots)
-	apiPathAbs := sourceConfig.ResolveDir(module.APIPath)
-
-	var protoFiles []string
-	if len(module.IncludeList) > 0 {
-		for _, file := range module.IncludeList {
-			protoFiles = append(protoFiles, filepath.Join(apiPathAbs, file))
-		}
-	} else {
-		entries, err := os.ReadDir(apiPathAbs)
-		if err != nil {
-			return err
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".proto") {
-				protoFiles = append(protoFiles, filepath.Join(apiPathAbs, entry.Name()))
-			}
-		}
-	}
-
-	if len(protoFiles) == 0 {
-		return fmt.Errorf("no proto files found in %s", apiPathAbs)
-	}
-
-	importsMap := make(map[string]bool)
-	var protoImports []string
-
-	addImport := func(path string) {
-		if path != "" && !importsMap[path] {
-			importsMap[path] = true
-			protoImports = append(protoImports, "-I", path)
-		}
-	}
-
-	for _, r := range sourceConfig.ActiveRoots {
-		addImport(sourceConfig.Root(r))
-	}
-	addImport(src.Googleapis)
-	addImport(src.ProtobufSrc)
-	addImport(src.Showcase)
-	addImport(src.Conformance)
-
-	args := []string{
-		"--swift_out=Visibility=Public:" + module.Output,
-		"--grpc-swift_out=Visibility=Public:" + module.Output,
-	}
-	args = append(args, protoImports...)
-	args = append(args, protoFiles...)
-
-	return command.Run(ctx, "protoc", args...)
-}
 
 func moduleToModelConfig(library *config.Library, module *config.SwiftModule, src *sources.Sources) *parser.ModelConfig {
 	sourceConfig := sources.NewSourceConfig(src, library.Roots)

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -46,6 +46,11 @@ func TestGenerateModule(t *testing.T) {
 			APIPath: "google/type",
 			Output:  filepath.Join(outDir, "ProtoJSON"),
 		},
+		{
+			APIPath:    "google/type",
+			Output:     filepath.Join(outDir, "ProtoJSONDefault"),
+			ModuleType: "default",
+		},
 	}
 	src := &sources.Sources{
 		Googleapis: googleapisDir,
@@ -58,6 +63,11 @@ func TestGenerateModule(t *testing.T) {
 
 	expectedFile := filepath.Join(outDir, "ProtoJSON", "Expr.swift")
 	if _, err := os.Stat(expectedFile); err != nil {
+		t.Error(err)
+	}
+
+	expectedDefaultFile := filepath.Join(outDir, "ProtoJSONDefault", "Expr.swift")
+	if _, err := os.Stat(expectedDefaultFile); err != nil {
 		t.Error(err)
 	}
 }

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -17,6 +17,7 @@ package swift
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -241,5 +242,39 @@ func TestGenerateModule_UnsupportedModuleType(t *testing.T) {
 	expectedErr := `module type "convert-swift" is not yet supported`
 	if err.Error() != expectedErr {
 		t.Errorf("got error %q, want %q", err.Error(), expectedErr)
+	}
+}
+
+func TestGenerateModule_NoProtos(t *testing.T) {
+	library := &config.Library{
+		Name:          "NoProtosModule",
+		CopyrightYear: "2038",
+		Swift:         defaultSwiftConfig(t),
+		Output:        t.TempDir(),
+	}
+	googleapisDir := t.TempDir()
+	emptyAPIPath := "google/empty"
+	if err := os.MkdirAll(filepath.Join(googleapisDir, emptyAPIPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	library.Swift.Modules = []*config.SwiftModule{
+		{
+			APIPath:    emptyAPIPath,
+			Output:     filepath.Join(library.Output, "ProtoJSON"),
+			ModuleType: "swift-protobuf",
+		},
+	}
+	src := &sources.Sources{
+		Googleapis: googleapisDir,
+	}
+	cfg := &config.Config{}
+
+	err := Generate(t.Context(), cfg, library, src)
+	if err == nil {
+		t.Fatal("Generate did not return an error when no proto files were found")
+	}
+	if !strings.Contains(err.Error(), "no proto files found in") {
+		t.Errorf("got error %q, want it to contain 'no proto files found in'", err.Error())
 	}
 }

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -79,9 +79,9 @@ func TestGenerateModule_SwiftProtobuf(t *testing.T) {
 	}
 	library.Swift.Modules = []*config.SwiftModule{
 		{
-			APIPath:  "google/type",
-			Output:   filepath.Join(outDir, "ProtoJSON"),
-			Template: "swift-protobuf",
+			APIPath:    "google/type",
+			Output:     filepath.Join(outDir, "ProtoJSON"),
+			ModuleType: "swift-protobuf",
 		},
 	}
 	src := &sources.Sources{
@@ -217,7 +217,7 @@ func TestModuleToModelConfig(t *testing.T) {
 	}
 }
 
-func TestGenerateModule_UnsupportedTemplate(t *testing.T) {
+func TestGenerateModule_UnsupportedModuleType(t *testing.T) {
 	library := &config.Library{
 		Name:          "UnsupportedModule",
 		CopyrightYear: "2038",
@@ -226,9 +226,9 @@ func TestGenerateModule_UnsupportedTemplate(t *testing.T) {
 	}
 	library.Swift.Modules = []*config.SwiftModule{
 		{
-			APIPath:  "google/type",
-			Output:   filepath.Join(library.Output, "ProtoJSON"),
-			Template: "convert-swift",
+			APIPath:    "google/type",
+			Output:     filepath.Join(library.Output, "ProtoJSON"),
+			ModuleType: "convert-swift",
 		},
 	}
 	src := &sources.Sources{}
@@ -236,9 +236,9 @@ func TestGenerateModule_UnsupportedTemplate(t *testing.T) {
 
 	err := Generate(t.Context(), cfg, library, src)
 	if err == nil {
-		t.Fatal("Generate did not return an error for unsupported template 'convert-swift'")
+		t.Fatal("Generate did not return an error for unsupported module type 'convert-swift'")
 	}
-	expectedErr := `template "convert-swift" is not yet supported`
+	expectedErr := `module type "convert-swift" is not yet supported`
 	if err.Error() != expectedErr {
 		t.Errorf("got error %q, want %q", err.Error(), expectedErr)
 	}

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -61,6 +61,44 @@ func TestGenerateModule(t *testing.T) {
 	}
 }
 
+func TestGenerateModule_SwiftProtobuf(t *testing.T) {
+	testhelper.RequireCommand(t, "protoc")
+	testhelper.RequireCommand(t, "protoc-gen-swift")
+	testhelper.RequireCommand(t, "protoc-gen-grpc-swift")
+
+	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outDir := t.TempDir()
+	library := &config.Library{
+		Name:          "GoogleTypeModule",
+		CopyrightYear: "2038",
+		Swift:         defaultSwiftConfig(t),
+		Output:        outDir,
+	}
+	library.Swift.Modules = []*config.SwiftModule{
+		{
+			APIPath:  "google/type",
+			Output:   filepath.Join(outDir, "ProtoJSON"),
+			Template: "swift-protobuf",
+		},
+	}
+	src := &sources.Sources{
+		Googleapis: googleapisDir,
+	}
+	cfg := &config.Config{}
+
+	if err := Generate(t.Context(), cfg, library, src); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFile := filepath.Join(outDir, "ProtoJSON", "google", "type", "expr.pb.swift")
+	if _, err := os.Stat(expectedFile); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestModuleToModelConfig(t *testing.T) {
 	src := &sources.Sources{}
 	for _, test := range []struct {

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -216,3 +216,30 @@ func TestModuleToModelConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateModule_UnsupportedTemplate(t *testing.T) {
+	library := &config.Library{
+		Name:          "UnsupportedModule",
+		CopyrightYear: "2038",
+		Swift:         defaultSwiftConfig(t),
+		Output:        t.TempDir(),
+	}
+	library.Swift.Modules = []*config.SwiftModule{
+		{
+			APIPath:  "google/type",
+			Output:   filepath.Join(library.Output, "ProtoJSON"),
+			Template: "convert-swift",
+		},
+	}
+	src := &sources.Sources{}
+	cfg := &config.Config{}
+
+	err := Generate(t.Context(), cfg, library, src)
+	if err == nil {
+		t.Fatal("Generate did not return an error for unsupported template 'convert-swift'")
+	}
+	expectedErr := `template "convert-swift" is not yet supported`
+	if err.Error() != expectedErr {
+		t.Errorf("got error %q, want %q", err.Error(), expectedErr)
+	}
+}


### PR DESCRIPTION
This change introduces support for generating raw Swift Protobuf and gRPC-Swift stub files directly using protoc, bypassing the standard GAPIC client generation when requested. This is done by adding a new "swift-protobuf" template option to the Swift module configuration.

Produces the following: https://depot.code.corp.goog/experimental/google-cloud-swift/pull/300 

Issue: https://github.com/googleapis/google-cloud-swift/issues/452 