### PR TITLE
fix(internal/librarian): preserve maven and protoc configuration during tidy

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -226,7 +226,11 @@ func tidyLanguageConfig(lib *config.Library, cfg *config.Config) (*config.Librar
 
 // isToolsEmpty returns true if the tools configuration is empty.
 func isToolsEmpty(tools *config.Tools) bool {
-	return len(tools.Cargo) == 0 && len(tools.PNPM) == 0 && len(tools.Pip) == 0 && len(tools.Go) == 0
+	return len(tools.Cargo) == 0 &&
+		len(tools.PNPM) == 0 &&
+		len(tools.Pip) == 0 &&
+		len(tools.Go) == 0 &&
+		tools.Protoc == nil
 }
 
 // isDefaultEmpty returns true if the default configuration is empty.

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -227,9 +227,10 @@ func tidyLanguageConfig(lib *config.Library, cfg *config.Config) (*config.Librar
 // isToolsEmpty returns true if the tools configuration is empty.
 func isToolsEmpty(tools *config.Tools) bool {
 	return len(tools.Cargo) == 0 &&
-		len(tools.PNPM) == 0 &&
-		len(tools.Pip) == 0 &&
 		len(tools.Go) == 0 &&
+		len(tools.Maven) == 0 &&
+		len(tools.Pip) == 0 &&
+		len(tools.PNPM) == 0 &&
 		tools.Protoc == nil
 }
 

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -755,7 +755,20 @@ func TestTidy_UnusedSections(t *testing.T) {
 			wantDefault: &config.Default{Output: "output"},
 		},
 		{
-			name: "protoc version and sha256 preserved",
+			name: "maven preserved",
+			cfg: &config.Config{
+				Language: config.LanguageJava,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Commit: "commit"},
+				},
+				Tools:   &config.Tools{Maven: []*config.MavenTool{{Name: "artifact", Version: "1.2.3"}}},
+				Default: &config.Default{},
+			},
+			wantTools:   &config.Tools{Maven: []*config.MavenTool{{Name: "artifact", Version: "1.2.3"}}},
+			wantDefault: nil,
+		},
+		{
+			name: "protoc preserved",
 			cfg: &config.Config{
 				Language: config.LanguageRust,
 				Sources: &config.Sources{

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -725,8 +725,8 @@ func TestTidy_UnusedSections(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		cfg         *config.Config
-		wantTools   bool
-		wantDefault bool
+		wantTools   *config.Tools
+		wantDefault *config.Default
 	}{
 		{
 			name: "empty sections removed",
@@ -738,8 +738,8 @@ func TestTidy_UnusedSections(t *testing.T) {
 				Tools:   &config.Tools{},
 				Default: &config.Default{},
 			},
-			wantTools:   false,
-			wantDefault: false,
+			wantTools:   nil,
+			wantDefault: nil,
 		},
 		{
 			name: "non-empty sections preserved",
@@ -751,8 +751,21 @@ func TestTidy_UnusedSections(t *testing.T) {
 				Tools:   &config.Tools{Cargo: []*config.CargoTool{{Name: "taplo", Version: "1.0"}}},
 				Default: &config.Default{Output: "output"},
 			},
-			wantTools:   true,
-			wantDefault: true,
+			wantTools:   &config.Tools{Cargo: []*config.CargoTool{{Name: "taplo", Version: "1.0"}}},
+			wantDefault: &config.Default{Output: "output"},
+		},
+		{
+			name: "protoc version and sha256 preserved",
+			cfg: &config.Config{
+				Language: config.LanguageRust,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Commit: "commit"},
+				},
+				Tools:   &config.Tools{Protoc: &config.Protoc{Version: "33.2", SHA256: "123abc"}},
+				Default: &config.Default{},
+			},
+			wantTools:   &config.Tools{Protoc: &config.Protoc{Version: "33.2", SHA256: "123abc"}},
+			wantDefault: nil,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -764,11 +777,11 @@ func TestTidy_UnusedSections(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if (got.Tools != nil) != test.wantTools {
-				t.Errorf("Tools present = %v, want %v", got.Tools != nil, test.wantTools)
+			if diff := cmp.Diff(test.wantTools, got.Tools); diff != "" {
+				t.Errorf("Tools mismatch (-want +got):\n%s", diff)
 			}
-			if (got.Default != nil) != test.wantDefault {
-				t.Errorf("Default present = %v, want %v", got.Default != nil, test.wantDefault)
+			if diff := cmp.Diff(test.wantDefault, got.Default); diff != "" {
+				t.Errorf("Default mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Ensure that librarian tidy does not remove the tools section from a configuration file when only maven or protoc is defined under tools.

Previously, `isToolsEmpty` only checked for Cargo, PNPM, Pip, and Go tool definitions, treating a tools section containing only a protoc configuration as empty and stripping it.

For #6558