### PR TITLE
feat(internal/librarian/php): add inital PHP client library generator

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -24,6 +24,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+      - name: Setup PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.31.1
+        with:
+          php-version: '8.2'
+          extensions: mbstring, xml, bcmath
       - uses: ./.github/actions/setup-librarian
       - name: Run tests
         run: go run ./tool/cmd/coverage ./internal/librarian/php

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -30,5 +30,7 @@ jobs:
           php-version: '8.2'
           extensions: mbstring, xml, bcmath
       - uses: ./.github/actions/setup-librarian
+      - name: Install dependencies
+        run: librarian install php
       - name: Run tests
         run: go run ./tool/cmd/coverage ./internal/librarian/php

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -3,5 +3,7 @@
 # The workaround requires keeping blank lines between top-level keys in
 # secretmanager_v1.yaml, which the default yamlfmt settings would otherwise strip.
 # We exclude the file here to prevent yamlfmt from formatting it.
+# TODO(https://github.com/googleapis/gapic-generator-php/issues/837): determine to remove
+# this workaround or adjust testdata to keep blank lines.
 exclude:
   - "internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml"

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,7 @@
+# The PHP generator (gapic-generator-php) has a preprocessor bug (fixYaml)
+# that incorrectly indents top-level keys if they immediately follow indented blocks.
+# The workaround requires keeping blank lines between top-level keys in
+# secretmanager_v1.yaml, which the default yamlfmt settings would otherwise strip.
+# We exclude the file here to prevent yamlfmt from formatting it.
+exclude:
+  - "internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml"

--- a/.yamlfmtignore
+++ b/.yamlfmtignore
@@ -1,5 +1,0 @@
-# The PHP generator (gapic-generator-php) has a preprocessor bug (fixYaml)
-# that incorrectly indents top-level keys if they immediately follow indented blocks.
-# The workaround requires keeping blank lines between top-level keys,
-# which the default yamlfmt settings would otherwise strip.
-internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml

--- a/.yamlfmtignore
+++ b/.yamlfmtignore
@@ -1,0 +1,5 @@
+# The PHP generator (gapic-generator-php) has a preprocessor bug (fixYaml)
+# that incorrectly indents top-level keys if they immediately follow indented blocks.
+# The workaround requires keeping blank lines between top-level keys,
+# which the default yamlfmt settings would otherwise strip.
+internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/protoc"
@@ -118,6 +119,8 @@ Examples:
 				return java.Install(ctx, tools)
 			case config.LanguageNodejs:
 				return nodejs.Install(ctx, tools)
+			case config.LanguagePhp:
+				return php.Install(ctx, tools)
 			case config.LanguagePython:
 				return python.Install(ctx)
 			case config.LanguageRust:

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -27,15 +27,9 @@ import (
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/fetch"
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sources"
-)
-
-const (
-	generatorVersion = "v1.21.2"
-	generatorSHA256  = "29635b02c6e505fe31cba2f88ae999f00d2710fe1d65cb7cad521a82e7c5a518"
 )
 
 // Generate generates a PHP client library.
@@ -208,52 +202,4 @@ func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigPath s
 	}
 
 	return opts
-}
-
-// installGenerator fetches the PHP generator and installs its Composer dependencies.
-// TODO(https://github.com/googleapis/librarian/issues/6630): remove after install command is ready.
-func installGenerator(ctx context.Context) (string, error) {
-	phpPath, err := exec.LookPath("php")
-	if err != nil {
-		return "", fmt.Errorf("php is required on host to run PHP generator: %w", err)
-	}
-
-	repo := "github.com/googleapis/gapic-generator-php"
-	generatorDir, err := fetch.Repo(ctx, repo, generatorVersion, generatorSHA256)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch PHP generator: %w", err)
-	}
-	// Ensure Composer dependencies are installed
-	vendorDir := filepath.Join(generatorDir, "vendor")
-	if _, err := os.Stat(vendorDir); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return "", err
-		}
-		if _, err := exec.LookPath("composer"); err == nil {
-			if err := command.RunInDir(ctx, generatorDir, "composer", "install"); err != nil {
-				return "", fmt.Errorf("failed to run composer install: %w", err)
-			}
-		} else {
-			composerPhar := filepath.Join(generatorDir, "rules_php_gapic", "resources", "composer.phar")
-			if _, err := os.Stat(composerPhar); err == nil {
-				if err := command.RunInDir(ctx, generatorDir, phpPath, composerPhar, "install"); err != nil {
-					return "", fmt.Errorf("failed to run composer.phar install: %w", err)
-				}
-			} else {
-				return "", fmt.Errorf("neither system composer nor composer.phar was found")
-			}
-		}
-	}
-
-	// Write wrapper script
-	wrapperPath := filepath.Join(generatorDir, "wrapper.sh")
-	wrapperContent := fmt.Sprintf(`#!/bin/bash
-exec %q -d display_errors=stderr -d memory_limit=1024M %q --side_loaded_root_dir "$GOOGLEAPIS_DIR" "$@"
-`, phpPath, filepath.Join(generatorDir, "src/Main.php"))
-
-	if err := os.WriteFile(wrapperPath, []byte(wrapperContent), 0755); err != nil {
-		return "", fmt.Errorf("failed to write wrapper script: %w", err)
-	}
-
-	return generatorDir, nil
 }

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -225,7 +225,10 @@ func installGenerator(ctx context.Context) (string, error) {
 	}
 	// Ensure Composer dependencies are installed
 	vendorDir := filepath.Join(generatorDir, "vendor")
-	if _, err := os.Stat(vendorDir); os.IsNotExist(err) {
+	if _, err := os.Stat(vendorDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
 		composerPhar := filepath.Join(generatorDir, "rules_php_gapic", "resources", "composer.phar")
 		if _, err := os.Stat(composerPhar); err == nil {
 			if err := command.RunInDir(ctx, generatorDir, phpPath, composerPhar, "install"); err != nil {

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -229,17 +229,18 @@ func installGenerator(ctx context.Context) (string, error) {
 		if !errors.Is(err, os.ErrNotExist) {
 			return "", err
 		}
-		composerPhar := filepath.Join(generatorDir, "rules_php_gapic", "resources", "composer.phar")
-		if _, err := os.Stat(composerPhar); err == nil {
-			if err := command.RunInDir(ctx, generatorDir, phpPath, composerPhar, "install"); err != nil {
-				return "", fmt.Errorf("failed to run composer.phar install: %w", err)
-			}
-		} else {
-			if _, err := exec.LookPath("composer"); err != nil {
-				return "", fmt.Errorf("neither composer.phar nor system composer was found: %w", err)
-			}
+		if _, err := exec.LookPath("composer"); err == nil {
 			if err := command.RunInDir(ctx, generatorDir, "composer", "install"); err != nil {
 				return "", fmt.Errorf("failed to run composer install: %w", err)
+			}
+		} else {
+			composerPhar := filepath.Join(generatorDir, "rules_php_gapic", "resources", "composer.phar")
+			if _, err := os.Stat(composerPhar); err == nil {
+				if err := command.RunInDir(ctx, generatorDir, phpPath, composerPhar, "install"); err != nil {
+					return "", fmt.Errorf("failed to run composer.phar install: %w", err)
+				}
+			} else {
+				return "", fmt.Errorf("neither system composer nor composer.phar was found")
 			}
 		}
 	}

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -42,11 +42,14 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		return fmt.Errorf("failed to find protoc: %w", err)
 	}
 
-	// Fetch PHP generator and install dependencies
-	// Temp step, remove once install is ready
-	generatorDir, err := installGenerator(ctx)
+	// Locate PHP generator
+	generatorDir, err := generatorDir(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to locate PHP generator: %w", err)
+	}
+	wrapperPath := filepath.Join(generatorDir, "wrapper.sh")
+	if _, err := os.Stat(wrapperPath); err != nil {
+		return fmt.Errorf("PHP generator wrapper not found (did you run 'librarian install'?): %w", err)
 	}
 
 	// Setup sandbox staging dir
@@ -60,7 +63,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		}
 	}()
 
-	wrapperPath := filepath.Join(generatorDir, "wrapper.sh")
 	outputZipPath := filepath.Join(tempDir, "output.zip")
 	srcCfg := sources.NewSourceConfig(src, library.Roots)
 	for _, api := range library.APIs {

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -17,13 +17,239 @@ package php
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/fetch"
+	"github.com/googleapis/librarian/internal/filesystem"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sources"
 )
 
+const (
+	generatorVersion = "v1.21.2"
+	generatorSHA256  = "29635b02c6e505fe31cba2f88ae999f00d2710fe1d65cb7cad521a82e7c5a518"
+)
+
 // Generate generates a PHP client library.
-func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
-	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP generation
+func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) (err error) {
+	if len(library.APIs) == 0 {
+		return fmt.Errorf("no apis configured for library %q", library.Name)
+	}
+	protocPath, err := exec.LookPath("protoc")
+	if err != nil {
+		return fmt.Errorf("failed to find protoc: %w", err)
+	}
+
+	// Fetch PHP generator and install dependencies
+	// Temp step, remove once install is ready
+	generatorDir, err := installGenerator(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Setup sandbox staging dir
+	tempDir, err := os.MkdirTemp("", "librarian-php-")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cleanupErr := os.RemoveAll(tempDir); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+	}()
+
+	wrapperPath := filepath.Join(generatorDir, "wrapper.sh")
+	outputZipPath := filepath.Join(tempDir, "output.zip")
+	srcCfg := sources.NewSourceConfig(src, library.Roots)
+	for _, api := range library.APIs {
+		params := &generateAPIParams{
+			api:           api,
+			library:       library,
+			srcCfg:        srcCfg,
+			wrapperPath:   wrapperPath,
+			outputZipPath: outputZipPath,
+			protocPath:    protocPath,
+		}
+		if err := generateAPI(ctx, params); err != nil {
+			return err
+		}
+		// Cleanup output zip for subsequent APIs in the same library package
+		_ = os.Remove(outputZipPath)
+	}
+
 	return nil
+}
+
+type generateAPIParams struct {
+	api           *config.API
+	library       *config.Library
+	srcCfg        *sources.SourceConfig
+	wrapperPath   string
+	outputZipPath string
+	protocPath    string
+}
+
+// generateAPI generates a single target API by resolving its service config, gathering
+// all target proto files, and executing the PHP generator plugin via protoc.
+// It extracts the resulting ZIP archive directly to the library output directory.
+func generateAPI(ctx context.Context, params *generateAPIParams) error {
+	googleapisDir := params.srcCfg.Root("googleapis")
+	// Resolve service config files
+	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, params.api.Path)
+	if err != nil {
+		return err
+	}
+	apiMetadata, err := serviceconfig.Find(googleapisDir, params.api.Path, config.LanguagePhp)
+	if err != nil {
+		return err
+	}
+	opts := gapicOpts(params.api, apiMetadata, grpcConfigPath)
+
+	// Gather target protos
+	var targetProtos []string
+	apiDir := filepath.Join(googleapisDir, params.api.Path)
+	protos, err := gatherProtos(apiDir)
+	if err != nil {
+		return err
+	}
+	targetProtos = append(targetProtos, protos...)
+	// Always include common resources if present
+	commonResources := filepath.Join(googleapisDir, "google/cloud/common_resources.proto")
+	if _, err := os.Stat(commonResources); err == nil {
+		targetProtos = append(targetProtos, commonResources)
+	}
+	if len(targetProtos) == 0 {
+		return fmt.Errorf("no target protos found for API %s", params.api.Path)
+	}
+	// Build protoc command arguments
+	gapicOutArg := fmt.Sprintf("--gapic_out=%s:%s", strings.Join(opts, ","), params.outputZipPath)
+	protocArgs := []string{
+		"--experimental_allow_proto3_optional",
+		"--plugin=protoc-gen-gapic=" + params.wrapperPath,
+		gapicOutArg,
+	}
+
+	// Append active root directories as include paths (-I) to resolve proto imports.
+	for _, root := range params.srcCfg.ActiveRoots {
+		if r := params.srcCfg.Root(root); r != "" {
+			protocArgs = append(protocArgs, "-I", r)
+		}
+	}
+	protocArgs = append(protocArgs, targetProtos...)
+	// Run compilation
+	if err := command.RunWithEnv(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, params.protocPath, protocArgs...); err != nil {
+		return fmt.Errorf("failed to generate PHP API %s: %w", params.api.Path, err)
+	}
+
+	// Extract output
+	outDir := params.library.Output
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory %s: %w", outDir, err)
+	}
+	if err := filesystem.Unzip(ctx, params.outputZipPath, outDir); err != nil {
+		return fmt.Errorf("failed to extract generated output to %s: %w", outDir, err)
+	}
+
+	return nil
+}
+
+// gatherProtos walks the directory tree recursively from root and returns
+// a sorted list of absolute paths for all found proto files.
+func gatherProtos(root string) ([]string, error) {
+	var protos []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Type().IsRegular() && filepath.Ext(path) == ".proto" {
+			protos = append(protos, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(protos)
+	return protos, nil
+}
+
+func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigPath string) []string {
+	transport := serviceconfig.GRPCRest
+	if apiMetadata != nil {
+		transport = apiMetadata.Transport(config.LanguagePhp)
+	}
+	opts := []string{"metadata", "transport=" + string(transport)}
+	migrationMode := "NEW_SURFACE_ONLY"
+	if api.PHP != nil && api.PHP.MigrationMode != "" {
+		migrationMode = api.PHP.MigrationMode
+	}
+	opts = append(opts, "migration-mode="+migrationMode)
+	if apiMetadata != nil && apiMetadata.HasRESTNumericEnums(config.LanguagePhp) {
+		opts = append(opts, "rest-numeric-enums")
+	}
+	opts = append(opts, "generate-snippets")
+
+	if grpcConfigPath != "" {
+		opts = append(opts, "grpc_service_config="+grpcConfigPath)
+	}
+	if apiMetadata != nil && apiMetadata.ServiceConfig != "" {
+		opts = append(opts, "service_yaml="+apiMetadata.ServiceConfig)
+	}
+
+	return opts
+}
+
+// installGenerator fetches the PHP generator and installs its Composer dependencies.
+// TODO(https://github.com/googleapis/librarian/issues/6630): remove after install command is ready.
+func installGenerator(ctx context.Context) (string, error) {
+	phpPath, err := exec.LookPath("php")
+	if err != nil {
+		return "", fmt.Errorf("php is required on host to run PHP generator: %w", err)
+	}
+
+	repo := "github.com/googleapis/gapic-generator-php"
+	generatorDir, err := fetch.Repo(ctx, repo, generatorVersion, generatorSHA256)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch PHP generator: %w", err)
+	}
+	// Ensure Composer dependencies are installed
+	vendorDir := filepath.Join(generatorDir, "vendor")
+	if _, err := os.Stat(vendorDir); os.IsNotExist(err) {
+		composerPhar := filepath.Join(generatorDir, "rules_php_gapic", "resources", "composer.phar")
+		if _, err := os.Stat(composerPhar); err == nil {
+			if err := command.RunInDir(ctx, generatorDir, phpPath, composerPhar, "install"); err != nil {
+				return "", fmt.Errorf("failed to run composer.phar install: %w", err)
+			}
+		} else {
+			if _, err := exec.LookPath("composer"); err != nil {
+				return "", fmt.Errorf("neither composer.phar nor system composer was found: %w", err)
+			}
+			if err := command.RunInDir(ctx, generatorDir, "composer", "install"); err != nil {
+				return "", fmt.Errorf("failed to run composer install: %w", err)
+			}
+		}
+	}
+
+	// Write wrapper script
+	wrapperPath := filepath.Join(generatorDir, "wrapper.sh")
+	wrapperContent := fmt.Sprintf(`#!/bin/bash
+exec %q -d display_errors=stderr -d memory_limit=1024M %q --side_loaded_root_dir "$GOOGLEAPIS_DIR" "$@"
+`, phpPath, filepath.Join(generatorDir, "src/Main.php"))
+
+	if err := os.WriteFile(wrapperPath, []byte(wrapperContent), 0755); err != nil {
+		return "", fmt.Errorf("failed to write wrapper script: %w", err)
+	}
+
+	return generatorDir, nil
 }

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -15,19 +15,55 @@
 package php
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sources"
+	"github.com/googleapis/librarian/internal/testhelper"
 )
 
 func TestGenerate(t *testing.T) {
-	ctx := t.Context()
-	cfg := &config.Config{}
-	lib := &config.Library{}
-	src := &sources.Sources{}
+	if testing.Short() {
+		t.Skip("skipping slow integration test")
+	}
+	testhelper.RequireCommand(t, "php")
+	testhelper.RequireCommand(t, "protoc")
 
-	if err := Generate(ctx, cfg, lib, src); err != nil {
-		t.Errorf("Generate() returned error: %v", err)
+	// Use mock googleapis checked in as test data
+	googleapisDir := "../../testdata/googleapis"
+	absGoogleapis, err := filepath.Abs(googleapisDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := t.TempDir()
+	library := &config.Library{
+		Name:   "secretmanager",
+		Output: filepath.Join(repoRoot, "output"),
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		Language: config.LanguagePhp,
+	}
+
+	err = Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: absGoogleapis})
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Verify output
+	outputDirs := []string{"src", "tests", "samples", "fragments"}
+	for _, dir := range outputDirs {
+		p := filepath.Join(library.Output, dir)
+		if stat, err := os.Stat(p); err != nil || !stat.IsDir() {
+			t.Errorf("expected directory %s to exist and be a directory", p)
+		}
 	}
 }

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -28,8 +28,8 @@ func TestGenerate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow integration test")
 	}
-	testhelper.RequireCommand(t, "php")
 	testhelper.RequireCommand(t, "protoc")
+	requirePHPGenerator(t)
 
 	// Use mock googleapis checked in as test data
 	googleapisDir := "../../testdata/googleapis"
@@ -65,5 +65,19 @@ func TestGenerate(t *testing.T) {
 		if stat, err := os.Stat(p); err != nil || !stat.IsDir() {
 			t.Errorf("expected directory %s to exist and be a directory", p)
 		}
+	}
+}
+
+func requirePHPGenerator(t *testing.T) {
+	t.Helper()
+	testhelper.RequireCommand(t, "php")
+
+	genDir, err := generatorDir(t.Context())
+	if err != nil {
+		t.Skipf("skipping test: failed to locate PHP generator: %v", err)
+	}
+	wrapperPath := filepath.Join(genDir, "wrapper.sh")
+	if _, err := os.Stat(wrapperPath); err != nil {
+		t.Skip("skipping test: PHP generator is not installed (run 'librarian install php' first)")
 	}
 }

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -39,7 +39,6 @@ func TestGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	repoRoot := t.TempDir()
 	library := &config.Library{
 		Name:   "secretmanager",
@@ -50,16 +49,13 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 	}
-
 	cfg := &config.Config{
 		Language: config.LanguagePhp,
 	}
-
 	err = Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: absGoogleapis})
 	if err != nil {
-		t.Fatalf("Generate failed: %v", err)
+		t.Fatal(err)
 	}
-
 	// Verify output
 	outputDirs := []string{"src", "tests", "samples", "fragments"}
 	for _, dir := range outputDirs {
@@ -73,7 +69,6 @@ func TestGenerate(t *testing.T) {
 func requirePHPGenerator(t *testing.T) {
 	t.Helper()
 	testhelper.RequireCommand(t, "php")
-
 	genDir, err := generatorDir(t.Context())
 	if err != nil {
 		t.Skipf("skipping test: failed to locate PHP generator: %v", err)
@@ -104,12 +99,10 @@ func TestGatherProtos(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-
 	got, err := gatherProtos(tmp)
 	if err != nil {
 		t.Fatalf("gatherProtos failed: %v", err)
 	}
-
 	want := []string{
 		filepath.Join(tmp, "a.proto"),
 		filepath.Join(tmp, "sub/b.proto"),
@@ -174,11 +167,10 @@ func TestGapicOpts(t *testing.T) {
 			want: []string{"metadata", "transport=rest", "migration-mode=NEW_SURFACE_ONLY", "rest-numeric-enums", "generate-snippets"},
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := gapicOpts(tt.api, tt.apiMetadata, tt.grpcConfigPath)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := gapicOpts(test.api, test.apiMetadata, test.grpcConfigPath)
+			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -19,7 +19,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
@@ -79,5 +81,106 @@ func requirePHPGenerator(t *testing.T) {
 	wrapperPath := filepath.Join(genDir, "wrapper.sh")
 	if _, err := os.Stat(wrapperPath); err != nil {
 		t.Skip("skipping test: PHP generator is not installed (run 'librarian install php' first)")
+	}
+}
+
+func TestGatherProtos(t *testing.T) {
+	tmp := t.TempDir()
+	files := []struct {
+		path    string
+		isProto bool
+	}{
+		{"a.proto", true},
+		{"sub/b.proto", true},
+		{"c.txt", false},
+		{"sub/d.proto", true},
+	}
+	for _, f := range files {
+		p := filepath.Join(tmp, f.path)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(""), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := gatherProtos(tmp)
+	if err != nil {
+		t.Fatalf("gatherProtos failed: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(tmp, "a.proto"),
+		filepath.Join(tmp, "sub/b.proto"),
+		filepath.Join(tmp, "sub/d.proto"),
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGapicOpts(t *testing.T) {
+	tests := []struct {
+		name           string
+		api            *config.API
+		apiMetadata    *serviceconfig.API
+		grpcConfigPath string
+		want           []string
+	}{
+		{
+			name: "defaults",
+			api:  &config.API{},
+			want: []string{"metadata", "transport=grpc+rest", "migration-mode=NEW_SURFACE_ONLY", "generate-snippets"},
+		},
+		{
+			name: "custom migration mode",
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					MigrationMode: "MIGRATING",
+				},
+			},
+			want: []string{"metadata", "transport=grpc+rest", "migration-mode=MIGRATING", "generate-snippets"},
+		},
+		{
+			name: "with grpc config and service yaml",
+			api:  &config.API{},
+			apiMetadata: &serviceconfig.API{
+				ServiceConfig: "service.yaml",
+			},
+			grpcConfigPath: "grpc_config.json",
+			want: []string{
+				"metadata", "transport=grpc+rest", "migration-mode=NEW_SURFACE_ONLY", "rest-numeric-enums", "generate-snippets",
+				"grpc_service_config=grpc_config.json",
+				"service_yaml=service.yaml",
+			},
+		},
+		{
+			name: "skip rest numeric enums",
+			api:  &config.API{},
+			apiMetadata: &serviceconfig.API{
+				SkipRESTNumericEnums: []string{"php"},
+			},
+			want: []string{"metadata", "transport=grpc+rest", "migration-mode=NEW_SURFACE_ONLY", "generate-snippets"},
+		},
+		{
+			name: "custom transport",
+			api:  &config.API{},
+			apiMetadata: &serviceconfig.API{
+				Transports: map[string]serviceconfig.Transport{
+					"php": serviceconfig.Transport("rest"),
+				},
+			},
+			want: []string{"metadata", "transport=rest", "migration-mode=NEW_SURFACE_ONLY", "rest-numeric-enums", "generate-snippets"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gapicOpts(tt.api, tt.apiMetadata, tt.grpcConfigPath)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/fetch"
+)
+
+const (
+	generatorVersion = "v1.21.2"
+	generatorSHA256  = "29635b02c6e505fe31cba2f88ae999f00d2710fe1d65cb7cad521a82e7c5a518"
+)
+
+// Install installs the PHP generator tool dependencies.
+func Install(ctx context.Context, tools *config.Tools) error {
+	if tools != nil {
+		return nil
+	}
+	_, err := installGenerator(ctx)
+	return err
+}
+
+// installGenerator is a temp function for testing purposes.
+// TODO(https://github.com/googleapis/librarian/issues/6630): remove after install command is ready.
+func installGenerator(ctx context.Context) (string, error) {
+	phpPath, err := exec.LookPath("php")
+	if err != nil {
+		return "", fmt.Errorf("failed to find php: %w", err)
+	}
+
+	repo := "github.com/googleapis/gapic-generator-php"
+	generatorDir, err := fetch.Repo(ctx, repo, generatorVersion, generatorSHA256)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch PHP generator: %w", err)
+	}
+	// Ensure Composer dependencies are installed
+	vendorDir := filepath.Join(generatorDir, "vendor")
+	if _, err := os.Stat(vendorDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		if _, err := exec.LookPath("composer"); err == nil {
+			if err := command.RunInDir(ctx, generatorDir, "composer", "install"); err != nil {
+				return "", fmt.Errorf("failed to run composer install: %w", err)
+			}
+		} else {
+			composerPhar := filepath.Join(generatorDir, "rules_php_gapic", "resources", "composer.phar")
+			if _, err := os.Stat(composerPhar); err == nil {
+				if err := command.RunInDir(ctx, generatorDir, phpPath, composerPhar, "install"); err != nil {
+					return "", fmt.Errorf("failed to run composer.phar install: %w", err)
+				}
+			} else {
+				return "", fmt.Errorf("neither system composer nor composer.phar was found")
+			}
+		}
+	}
+	return generatorDir, nil
+}

--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -41,6 +41,10 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	return err
 }
 
+func generatorDir(ctx context.Context) (string, error) {
+	return fetch.Repo(ctx, "github.com/googleapis/gapic-generator-php", generatorVersion, generatorSHA256)
+}
+
 // installGenerator is a temp function for testing purposes.
 // TODO(https://github.com/googleapis/librarian/issues/6630): remove after install command is ready.
 func installGenerator(ctx context.Context) (string, error) {
@@ -49,10 +53,9 @@ func installGenerator(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to find php: %w", err)
 	}
 
-	repo := "github.com/googleapis/gapic-generator-php"
-	generatorDir, err := fetch.Repo(ctx, repo, generatorVersion, generatorSHA256)
+	generatorDir, err := generatorDir(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch PHP generator: %w", err)
+		return "", err
 	}
 	// Ensure Composer dependencies are installed
 	vendorDir := filepath.Join(generatorDir, "vendor")
@@ -75,5 +78,15 @@ func installGenerator(ctx context.Context) (string, error) {
 			}
 		}
 	}
+	// Write wrapper script
+	wrapperPath := filepath.Join(generatorDir, "wrapper.sh")
+	wrapperContent := fmt.Sprintf(`#!/bin/bash
+exec %q -d display_errors=stderr -d memory_limit=1024M %q --side_loaded_root_dir "$GOOGLEAPIS_DIR" "$@"
+`, phpPath, filepath.Join(generatorDir, "src/Main.php"))
+
+	if err := os.WriteFile(wrapperPath, []byte(wrapperContent), 0755); err != nil {
+		return "", fmt.Errorf("failed to write wrapper script: %w", err)
+	}
+
 	return generatorDir, nil
 }

--- a/internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
+++ b/internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
@@ -18,6 +18,7 @@ title: Secret Manager API
 apis:
   - name: google.cloud.location.Locations
   - name: google.cloud.secretmanager.v1.SecretManagerService
+
 documentation:
   summary: |-
     Stores sensitive data such as API keys, passwords, and certificates.
@@ -28,12 +29,14 @@ documentation:
       description: Gets information about a location.
     - selector: google.cloud.location.Locations.ListLocations
       description: Lists information about the supported locations for this service.
+
 http:
   rules:
     - selector: google.cloud.location.Locations.GetLocation
       get: '/v1/{name=projects/*/locations/*}'
     - selector: google.cloud.location.Locations.ListLocations
       get: '/v1/{name=projects/*}/locations'
+
 authentication:
   rules:
     - selector: google.cloud.location.Locations.GetLocation
@@ -48,6 +51,7 @@ authentication:
       oauth:
         canonical_scopes: |-
           https://www.googleapis.com/auth/cloud-platform
+
 publishing:
   new_issue_uri: https://issuetracker.google.com/issues/new?component=784854&template=1380926
   documentation_uri: https://cloud.google.com/secret-manager/docs/overview
@@ -90,4 +94,5 @@ publishing:
         common:
           destinations:
             - PACKAGE_MANAGER
+
   proto_reference_documentation_uri: https://cloud.google.com/secret-manager/docs/reference/rpc

--- a/tool/cmd/coverage/main.go
+++ b/tool/cmd/coverage/main.go
@@ -47,6 +47,8 @@ const defaultTarget = 80
 var targets = map[string]float64{
 	// TODO(https://github.com/googleapis/librarian/issues/4664): raise to 80.
 	"internal/librarian/nodejs": 73,
+	// TODO(https://github.com/googleapis/librarian/issues/6705: raise to 80.
+	"internal/librarian/php": 70,
 }
 
 func main() {

--- a/tool/cmd/coverage/main.go
+++ b/tool/cmd/coverage/main.go
@@ -48,7 +48,7 @@ var targets = map[string]float64{
 	// TODO(https://github.com/googleapis/librarian/issues/4664): raise to 80.
 	"internal/librarian/nodejs": 73,
 	// TODO(https://github.com/googleapis/librarian/issues/6705: raise to 80.
-	"internal/librarian/php": 70,
+	"internal/librarian/php": 60,
 }
 
 func main() {


### PR DESCRIPTION
An initial implementation of the PHP client library generator is added to librarian. The goal of this change is to enable executing the PHP GAPIC generator as a protoc plugin from librarian's generation path.

The generator setup downloads the PHP generator codebase, installs its Composer dependencies, and generates a wrapper script that delegates compilation to the Main.php entrypoint. (Will remove this setup in followups)
Compilation parameters such as transport settings, numeric enums, and migration modes are automatically derived and passed during execution.

For  https://github.com/googleapis/librarian/issues/6629