### PR TITLE
feat(sidekick/parser): correct LRO poller service

### DIFF
--- a/internal/sidekick/parser/discovery/lro.go
+++ b/internal/sidekick/parser/discovery/lro.go
@@ -50,6 +50,10 @@ func lroAnnotations(model *api.API, discoveryConfig *api.Discovery) error {
 		if svcMixin == nil {
 			continue
 		}
+		sourceID := ""
+		if l := strings.LastIndex(svcMixin.ID, "."); l != -1 {
+			sourceID = svcMixin.ID[0:l]
+		}
 		method := &api.Method{
 			Name:            "getOperation",
 			ID:              fmt.Sprintf("%s.getOperation", svc.ID),
@@ -62,8 +66,7 @@ func lroAnnotations(model *api.API, discoveryConfig *api.Discovery) error {
 			Routing:         svcMixin.Routing,
 			AutoPopulated:   svcMixin.AutoPopulated,
 			Service:         svc,
-			SourceService:   svcMixin.Service,
-			SourceServiceID: svcMixin.SourceServiceID,
+			SourceServiceID: sourceID,
 			IsLroPoller:     true,
 		}
 		svc.Methods = append(svc.Methods, method)

--- a/internal/sidekick/parser/discovery/lro_test.go
+++ b/internal/sidekick/parser/discovery/lro_test.go
@@ -76,11 +76,12 @@ func TestLroAnnotations(t *testing.T) {
 
 	// The parser should have injected a mixin method.
 	wantMixin := &api.Method{
-		ID:           "..instances.getOperation",
-		Name:         "getOperation",
-		InputTypeID:  "..zoneOperations.getRequest",
-		OutputTypeID: "..Operation",
-		IsLroPoller:  true,
+		ID:              "..instances.getOperation",
+		Name:            "getOperation",
+		InputTypeID:     "..zoneOperations.getRequest",
+		OutputTypeID:    "..Operation",
+		SourceServiceID: "..zoneOperations",
+		IsLroPoller:     true,
 		PathInfo: &api.PathInfo{
 			Bindings: []*api.PathBinding{
 				{


### PR DESCRIPTION
For discovery-based APIs the LRO pollers are mixins: the poller method is injected into the service with LROs. The parser was trying to set the source service, but it did not work because the `SourceService` pointer is not initialized when the parser runs. We need to initialize the `SourceServiceID`.

Fixes #6691 