### PR TITLE
feat(sidekick/swift): traits with dependencies

### DIFF
--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -37,7 +37,11 @@ type modelAnnotations struct {
 
 // traitDefinition provides information about each package trait.
 //
-// In Swift, we define a package trait per-service
+// In Swift, a library may be configured to generate a package trait
+// per-service. Some services depend on request types that are only available if
+// other services are enabled. In other words, if the trait for service A is
+// defined, then the trait for service B may need to be defined because A uses
+// types from B.
 type traitDefinition struct {
 	// The name of this trait.
 	Name string

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -19,7 +19,6 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
-	"strings"
 
 	"github.com/googleapis/librarian/internal/license"
 )
@@ -107,11 +106,11 @@ func (c *codec) annotateModel() error {
 			enabledTraits = append(enabledTraits, c.traitName(svc))
 		}
 		slices.Sort(enabledTraits)
-		new := &traitDefinition{
+		trait := &traitDefinition{
 			Name:          c.traitName(service),
 			EnabledTraits: enabledTraits,
 		}
-		allTraits = append(allTraits, new)
+		allTraits = append(allTraits, trait)
 	}
 	if !c.PerServiceTraits {
 		// The maximum (15) was chosen more or less arbitrarily circa 2026-05. At
@@ -125,7 +124,7 @@ func (c *codec) annotateModel() error {
 	// will lack any feature gates, but may depend on messages that do.
 	// Change them to work only if all features are enabled.
 	slices.SortFunc(allTraits, func(a, b *traitDefinition) int {
-		return strings.Compare(a.Name, b.Name)
+		return cmp.Compare(a.Name, b.Name)
 	})
 	annotations.AllTraits = allTraits
 	allTraitNames := make([]string, 0, len(allTraits))

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/license"
 )
@@ -32,7 +33,17 @@ type modelAnnotations struct {
 	WktPackage       string
 	PerServiceTraits bool
 	DefaultTraits    []string
-	AllTraits        []string
+	AllTraits        []*traitDefinition
+}
+
+// traitDefinition provides information about each package trait.
+//
+// In Swift, we define a package trait per-service
+type traitDefinition struct {
+	// The name of this trait.
+	Name string
+	// The set of additional traits enabled by the service's trait.
+	EnabledTraits []string
 }
 
 // HasDependencies returns true if the package has dependencies on other packages.
@@ -41,6 +52,11 @@ type modelAnnotations struct {
 // dependencies.
 func (ann *modelAnnotations) HasDependencies() bool {
 	return len(ann.DependsOn) != 0
+}
+
+// EnablesOtherTraits returns true if this service's trait enables other traits too.
+func (ann *traitDefinition) EnablesOtherTraits() bool {
+	return len(ann.EnabledTraits) != 0
 }
 
 // Dependencies returns the list of dependencies for this package.
@@ -80,12 +96,22 @@ func (c *codec) annotateModel() error {
 	}
 	// The services are annotated last because the annotation assumes messages
 	// and enums are already annotated.
-	allTraits := make([]string, 0, len(c.Model.Services))
+	allTraits := make([]*traitDefinition, 0, len(c.Model.Services))
 	for _, service := range c.Model.Services {
-		if err := c.annotateService(service, annotations); err != nil {
+		ann, err := c.annotateService(service, annotations)
+		if err != nil {
 			return err
 		}
-		allTraits = append(allTraits, c.traitName(service))
+		var enabledTraits []string
+		for _, svc := range ann.RequiredServices {
+			enabledTraits = append(enabledTraits, c.traitName(svc))
+		}
+		slices.Sort(enabledTraits)
+		new := &traitDefinition{
+			Name:          c.traitName(service),
+			EnabledTraits: enabledTraits,
+		}
+		allTraits = append(allTraits, new)
 	}
 	if !c.PerServiceTraits {
 		// The maximum (15) was chosen more or less arbitrarily circa 2026-05. At
@@ -98,8 +124,14 @@ func (c *codec) annotateModel() error {
 	// Rarely, some messages and enums are not used by any service. These
 	// will lack any feature gates, but may depend on messages that do.
 	// Change them to work only if all features are enabled.
-	slices.Sort(allTraits)
+	slices.SortFunc(allTraits, func(a, b *traitDefinition) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	annotations.AllTraits = allTraits
+	allTraitNames := make([]string, 0, len(allTraits))
+	for _, t := range allTraits {
+		allTraitNames = append(allTraitNames, t.Name)
+	}
 	for msg := range c.Model.AllMessages() {
 		if msg.Codec == nil {
 			continue
@@ -109,7 +141,7 @@ func (c *codec) annotateModel() error {
 			continue
 		}
 		annotation.GatedOp = " && "
-		annotation.GatedBy = allTraits
+		annotation.GatedBy = allTraitNames
 	}
 	for enum := range c.Model.AllEnums() {
 		if enum.Codec == nil {
@@ -120,7 +152,7 @@ func (c *codec) annotateModel() error {
 			continue
 		}
 		annotation.GatedOp = " && "
-		annotation.GatedBy = allTraits
+		annotation.GatedBy = allTraitNames
 	}
 	return nil
 }

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -273,10 +273,10 @@ func TestModelAnnotations_Pagination(t *testing.T) {
 }
 
 func TestModelAnnotations_Gating(t *testing.T) {
-	model := makeGatedTestModel()
+	model := makeRequiredServicesTestModel()
 	codec := newTestCodec(t, model, nil)
 	codec.PerServiceTraits = true
-	codec.DefaultTraits = []string{"Service1"}
+	codec.DefaultTraits = []string{"TestService"}
 
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
@@ -288,8 +288,8 @@ func TestModelAnnotations_Gating(t *testing.T) {
 	}
 
 	wantAllTraits := []*traitDefinition{
-		{Name: "Service1"},
-		{Name: "Service2"},
+		{Name: "TestService", EnabledTraits: []string{"ZoneOperations"}},
+		{Name: "ZoneOperations"},
 	}
 	if diff := cmp.Diff(wantAllTraits, ann.AllTraits); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -299,7 +299,7 @@ func TestModelAnnotations_Gating(t *testing.T) {
 		t.Error("expected HasTraits() to be true")
 	}
 
-	if diff := cmp.Diff([]string{"Service1"}, ann.DefaultTraits); diff != "" {
+	if diff := cmp.Diff([]string{"TestService"}, ann.DefaultTraits); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -287,7 +287,10 @@ func TestModelAnnotations_Gating(t *testing.T) {
 		t.Fatalf("expected model.Codec to be *modelAnnotations, got %T", model.Codec)
 	}
 
-	wantAllTraits := []string{"Service1", "Service2"}
+	wantAllTraits := []*traitDefinition{
+		{Name: "Service1"},
+		{Name: "Service2"},
+	}
 	if diff := cmp.Diff(wantAllTraits, ann.AllTraits); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -34,6 +34,12 @@ type serviceAnnotations struct {
 	Model            *modelAnnotations
 	DependsOn        map[string]*Dependency
 	IsGated          bool
+
+	// Any additional services required by this service.
+	//
+	// Typically this happens on discovery-based APIs where services with LROs
+	// depend on request messages provided by the service that can poll the LRO.
+	RequiredServices map[string]*api.Service
 }
 
 // ServiceImports returns the list of dependencies for this service.
@@ -66,18 +72,22 @@ func (ann *serviceAnnotations) SnippetImports() []string {
 	return result
 }
 
-func (c *codec) annotateService(service *api.Service, model *modelAnnotations) error {
+func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (*serviceAnnotations, error) {
 	docLines, err := c.formatDocumentation(service.Documentation, service.Scopes())
 	if err != nil {
-		return err
+		return nil, err
 	}
+	requiredServices := make(map[string]*api.Service)
 	var restMethods []*api.Method
 	for _, method := range service.Methods {
 		if isGeneratedMethod(method) {
 			if err := c.annotateMethod(method, model); err != nil {
-				return err
+				return nil, err
 			}
 			restMethods = append(restMethods, method)
+			if method.IsLroPoller {
+				requiredServices[method.SourceService.ID] = method.SourceService
+			}
 		}
 	}
 	var quickstartMethod *api.Method
@@ -85,8 +95,9 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 		quickstartMethod = service.QuickstartMethod
 	}
 
+	name := pascalCase(service.Name)
 	annotations := &serviceAnnotations{
-		Name:             pascalCase(service.Name),
+		Name:             name,
 		ClientName:       pascalCase(service.Name + "Client"),
 		StubPrefix:       pascalCaseNoMangling(service.Name),
 		HostnameShort:    strings.TrimSuffix(service.DefaultHost, ".googleapis.com"),
@@ -96,7 +107,10 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 		QuickstartMethod: quickstartMethod,
 		Model:            model,
 		DependsOn:        map[string]*Dependency{},
-		IsGated:          c.PerServiceTraits,
+	}
+	if c.PerServiceTraits {
+		annotations.IsGated = true
+		annotations.RequiredServices = requiredServices
 	}
 
 	// Iterate through the list of all dependencies declared in librarian.yaml
@@ -108,7 +122,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 		}
 		if p.RequiredByServices {
 			if _, err := c.addDependency(p); err != nil {
-				return err
+				return nil, err
 			}
 			annotations.DependsOn[p.Name] = p
 		}
@@ -117,7 +131,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 	// Services always depend on well known types
 	wktDep, err := c.addApiPackageDependency(wellKnownProtobufPackage)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	annotations.DependsOn[wktDep.Name] = wktDep
 
@@ -126,7 +140,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 			if method.InputType.Package != c.Model.PackageName {
 				dep, err := c.addApiPackageDependency(method.InputType.Package)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				if dep != nil {
 					annotations.DependsOn[dep.Name] = dep
@@ -137,7 +151,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 			if method.OutputType.Package != c.Model.PackageName {
 				dep, err := c.addApiPackageDependency(method.OutputType.Package)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				if dep != nil {
 					annotations.DependsOn[dep.Name] = dep
@@ -148,7 +162,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 			// LROs depend on PollableOperation package
 			lroDep, err := c.addPackageDependency(lroSwiftPackage)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if lroDep != nil {
 				annotations.DependsOn[lroDep.Name] = lroDep
@@ -157,7 +171,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 			// LRO error mapping relies on GoogleRpc.Code, so we depend on GoogleRpc package
 			rpcDep, err := c.addApiPackageDependency("google.rpc")
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if rpcDep != nil {
 				annotations.DependsOn[rpcDep.Name] = rpcDep
@@ -166,12 +180,12 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 			// Ensure we have the necessary dependencies for the LRO response and metadata types.
 			respMsg, err := lookupMessage(c.Model, method.OperationInfo.ResponseTypeID)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if respMsg.Package != c.Model.PackageName {
 				dep, err := c.addApiPackageDependency(respMsg.Package)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				if dep != nil {
 					annotations.DependsOn[dep.Name] = dep
@@ -179,12 +193,12 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 			}
 			metaMsg, err := lookupMessage(c.Model, method.OperationInfo.MetadataTypeID)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if metaMsg.Package != c.Model.PackageName {
 				dep, err := c.addApiPackageDependency(metaMsg.Package)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				if dep != nil {
 					annotations.DependsOn[dep.Name] = dep
@@ -194,7 +208,10 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) e
 	}
 
 	service.Codec = annotations
-	return c.addFeatureAnnotations(service)
+	if err := c.addFeatureAnnotations(service); err != nil {
+		return nil, err
+	}
+	return annotations, nil
 }
 
 func isGeneratedMethod(method *api.Method) bool {

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -85,7 +85,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (
 				return nil, err
 			}
 			restMethods = append(restMethods, method)
-			if method.IsLroPoller {
+			if method.IsLroPoller && method.SourceService != nil {
 				requiredServices[method.SourceService.ID] = method.SourceService
 			}
 		}

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -248,56 +248,7 @@ func TestAnnotateService_Gating(t *testing.T) {
 }
 
 func TestAnnotateService_RequiredServices(t *testing.T) {
-	inputType := &api.Message{
-		Name:    "GetOperationRequest",
-		ID:      ".test.GetOperationRequest",
-		Package: "test",
-	}
-	outputType := &api.Message{
-		Name:    "Operation",
-		ID:      ".test.Operation",
-		Package: "test",
-	}
-	sourceMethod := &api.Method{
-		Name:         "GetOperation",
-		ID:           ".test.zoneOperations",
-		IsLroPoller:  true,
-		InputTypeID:  inputType.ID,
-		InputType:    inputType,
-		OutputTypeID: outputType.ID,
-		OutputType:   outputType,
-		PathInfo: &api.PathInfo{
-			Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
-		},
-	}
-	sourceService := &api.Service{
-		Name:    "zoneOperations",
-		ID:      ".test.zoneOperations",
-		Package: "test",
-		Methods: []*api.Method{sourceMethod},
-	}
-	sourceMethod.Service = sourceService
-	method := &api.Method{
-		Name:            sourceMethod.Name,
-		ID:              ".test.TestService",
-		IsLroPoller:     true,
-		SourceService:   sourceService,
-		SourceServiceID: sourceService.ID,
-		PathInfo:        sourceMethod.PathInfo,
-		InputTypeID:     sourceMethod.InputTypeID,
-		InputType:       sourceMethod.InputType,
-		OutputTypeID:    sourceMethod.OutputTypeID,
-		OutputType:      sourceMethod.OutputType,
-	}
-	targetService := &api.Service{
-		Name:    "TestService",
-		ID:      ".test.TestService",
-		Package: "test",
-		Methods: []*api.Method{method},
-	}
-	method.Service = targetService
-
-	model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{sourceService, targetService})
+	model := makeRequiredServicesTestModel()
 	codec := newTestCodec(t, model, nil)
 	codec.PerServiceTraits = true
 
@@ -305,15 +256,23 @@ func TestAnnotateService_RequiredServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	targetService := model.Service(".test.TestService")
+	if targetService == nil {
+		t.Fatalf("missing target service .test.zoneOperations")
+	}
 	targetCodec, ok := targetService.Codec.(*serviceAnnotations)
 	if !ok {
 		t.Fatalf("expected targetService.Codec to be *serviceAnnotations, got %T", targetService.Codec)
 	}
 
+	sourceService := model.Service(".test.zoneOperations")
+	if sourceService == nil {
+		t.Fatalf("missing source service .test.zoneOperations")
+	}
 	wantRequired := map[string]*api.Service{
 		sourceService.ID: sourceService,
 	}
-	if diff := cmp.Diff(wantRequired, targetCodec.RequiredServices); diff != "" {
+	if diff := cmp.Diff(wantRequired, targetCodec.RequiredServices, cmpopts.IgnoreFields(api.Method{}, "Model"), cmpopts.IgnoreFields(api.Service{}, "Model")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -247,6 +247,77 @@ func TestAnnotateService_Gating(t *testing.T) {
 	}
 }
 
+func TestAnnotateService_RequiredServices(t *testing.T) {
+	inputType := &api.Message{
+		Name:    "GetOperationRequest",
+		ID:      ".test.GetOperationRequest",
+		Package: "test",
+	}
+	outputType := &api.Message{
+		Name:    "Operation",
+		ID:      ".test.Operation",
+		Package: "test",
+	}
+	sourceMethod := &api.Method{
+		Name:         "GetOperation",
+		ID:           ".test.zoneOperations",
+		IsLroPoller:  true,
+		InputTypeID:  inputType.ID,
+		InputType:    inputType,
+		OutputTypeID: outputType.ID,
+		OutputType:   outputType,
+		PathInfo: &api.PathInfo{
+			Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
+		},
+	}
+	sourceService := &api.Service{
+		Name:    "zoneOperations",
+		ID:      ".test.zoneOperations",
+		Package: "test",
+		Methods: []*api.Method{sourceMethod},
+	}
+	sourceMethod.Service = sourceService
+	method := &api.Method{
+		Name:            sourceMethod.Name,
+		ID:              ".test.TestService",
+		IsLroPoller:     true,
+		SourceService:   sourceService,
+		SourceServiceID: sourceService.ID,
+		PathInfo:        sourceMethod.PathInfo,
+		InputTypeID:     sourceMethod.InputTypeID,
+		InputType:       sourceMethod.InputType,
+		OutputTypeID:    sourceMethod.OutputTypeID,
+		OutputType:      sourceMethod.OutputType,
+	}
+	targetService := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.TestService",
+		Package: "test",
+		Methods: []*api.Method{method},
+	}
+	method.Service = targetService
+
+	model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{sourceService, targetService})
+	codec := newTestCodec(t, model, nil)
+	codec.PerServiceTraits = true
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	targetCodec, ok := targetService.Codec.(*serviceAnnotations)
+	if !ok {
+		t.Fatalf("expected targetService.Codec to be *serviceAnnotations, got %T", targetService.Codec)
+	}
+
+	wantRequired := map[string]*api.Service{
+		sourceService.ID: sourceService,
+	}
+	if diff := cmp.Diff(wantRequired, targetCodec.RequiredServices); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestAnnotateService_LRO(t *testing.T) {
 	inputType := &api.Message{
 		Name:    "Request",

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -206,3 +206,59 @@ func makeGatedTestModel() *api.API {
 	api.CrossReference(model)
 	return model
 }
+
+func makeRequiredServicesTestModel() *api.API {
+	inputType := &api.Message{
+		Name:    "GetOperationRequest",
+		ID:      ".test.GetOperationRequest",
+		Package: "test",
+	}
+	outputType := &api.Message{
+		Name:    "Operation",
+		ID:      ".test.Operation",
+		Package: "test",
+	}
+	sourceMethod := &api.Method{
+		Name:         "GetOperation",
+		ID:           ".test.zoneOperations.GetOperation",
+		IsLroPoller:  false,
+		InputTypeID:  inputType.ID,
+		InputType:    inputType,
+		OutputTypeID: outputType.ID,
+		OutputType:   outputType,
+		PathInfo: &api.PathInfo{
+			Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
+		},
+	}
+	sourceService := &api.Service{
+		Name:    "zoneOperations",
+		ID:      ".test.zoneOperations",
+		Package: "test",
+		Methods: []*api.Method{sourceMethod},
+	}
+	sourceMethod.Service = sourceService
+	method := &api.Method{
+		Name:            sourceMethod.Name,
+		ID:              ".test.TestService.GetOperation",
+		IsLroPoller:     true,
+		SourceService:   sourceService,
+		SourceServiceID: sourceService.ID,
+		PathInfo:        sourceMethod.PathInfo,
+		InputTypeID:     sourceMethod.InputTypeID,
+		InputType:       sourceMethod.InputType,
+		OutputTypeID:    sourceMethod.OutputTypeID,
+		OutputType:      sourceMethod.OutputType,
+	}
+	targetService := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.TestService",
+		Package: "test",
+		Methods: []*api.Method{method},
+	}
+	method.Service = targetService
+
+	model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{sourceService, targetService})
+	model.PackageName = "test"
+	api.CrossReference(model)
+	return model
+}

--- a/internal/sidekick/swift/templates/package/Package.swift.mustache
+++ b/internal/sidekick/swift/templates/package/Package.swift.mustache
@@ -33,7 +33,16 @@ let package = Package(
   {{#Codec.HasTraits}}
   traits: [
     {{#Codec.AllTraits}}
-    .trait(name: "{{{.}}}"),
+    .trait(
+      name: "{{Name}}",
+      {{#EnablesOtherTraits}}
+      enabledTraits: [
+        {{#EnabledTraits}}
+        "{{{.}}}",
+        {{/EnabledTraits}}
+      ]
+      {{/EnablesOtherTraits}}
+    ),
     {{/Codec.AllTraits}}
     .default(enabledTraits: [
         {{#Codec.DefaultTraits}}


### PR DESCRIPTION
Add support to automatically enable one package trait (where trait == "enable only one service of compute") when another trait is enabled.

This will be used in discovery LROs where enabling a service requires that the LRO poller service is also enabled, as the types related to the poller live in that service.

Fixes #6691 