### PR TITLE
feat(internal/postprocessing): add Apply pipeline runner and tests

### DIFF
--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -47,6 +47,29 @@ var (
 	errSameSourceAndDestination = errors.New("src and dst must be different")
 )
 
+// Apply executes all configured post-processing operations against outDir in sequential order.
+func Apply(outDir string, cfg *config.Postprocess) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := CopyFiles(outDir, cfg.CopyFile); err != nil {
+		return fmt.Errorf("failed to copy files: %w", err)
+	}
+	if err := RemoveFiles(outDir, cfg.RemoveFile); err != nil {
+		return fmt.Errorf("failed to remove files: %w", err)
+	}
+	if err := ReplaceAll(outDir, cfg.Replace); err != nil {
+		return fmt.Errorf("failed to replace all: %w", err)
+	}
+	if err := ReplaceRegexAll(outDir, cfg.ReplaceRegex); err != nil {
+		return fmt.Errorf("failed to replace regex all: %w", err)
+	}
+	if err := ApplyMethodOperations(outDir, cfg.MethodOperations); err != nil {
+		return fmt.Errorf("failed to apply method operations: %w", err)
+	}
+	return nil
+}
+
 // Replace finds and replaces exact text in a file.
 // It returns an error if the target file does not exist or if the text is not found.
 func Replace(path, original, replacement string) error {

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -27,6 +27,147 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+func TestApply(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := "package com.example;\n\npublic class Foo {\n\tpublic void oldFunc() {}\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "Foo.java"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "to_delete.txt"), []byte("delete me"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Postprocess{
+		CopyFile: []config.CopyConfig{
+			{Src: "Foo.java", Dst: "CopiedFoo.java"},
+		},
+		RemoveFile: []string{"to_delete.txt"},
+		Replace: []config.ReplaceConfig{
+			{Path: "Foo.java", Original: "oldFunc", Replacement: "newFunc"},
+		},
+		ReplaceRegex: []config.ReplaceRegexConfig{
+			{Path: "Foo.java", Pattern: `public class (\w+)`, Replacement: "public class Bar"},
+		},
+		MethodOperations: []config.MethodOperation{
+			{Path: "Foo.java", Action: "delete", FuncName: "public void newFunc()"},
+		},
+	}
+	if err := Apply(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	wantFiles := map[string]string{
+		"CopiedFoo.java": "package com.example;\n\npublic class Foo {\n\tpublic void oldFunc() {}\n}\n",
+		"Foo.java":       "package com.example;\n\npublic class Bar {\n}\n",
+	}
+	if diff := cmp.Diff(wantFiles, readDirFiles(t, dir)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestApply_NilOrEmptyConfig(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cfg  *config.Postprocess
+	}{
+		{
+			name: "nil config",
+			cfg:  nil,
+		},
+		{
+			name: "empty config",
+			cfg:  &config.Postprocess{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := Apply(dir, test.cfg); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestApply_Error(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		setup   func(t *testing.T, dir string)
+		cfg     *config.Postprocess
+		wantErr error
+	}{
+		{
+			name: "copy fails - nonexistent source",
+			cfg: &config.Postprocess{
+				CopyFile: []config.CopyConfig{
+					{Src: "nonexistent.txt", Dst: "dst.txt"},
+				},
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "remove fails - pattern matches no files",
+			cfg: &config.Postprocess{
+				RemoveFile: []string{"nonexistent/*.java"},
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "replace fails - text not found",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			cfg: &config.Postprocess{
+				Replace: []config.ReplaceConfig{
+					{Path: "file.txt", Original: "missing", Replacement: "world"},
+				},
+			},
+			wantErr: errTextNotFound,
+		},
+		{
+			name: "replace regex fails - pattern not matched",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			cfg: &config.Postprocess{
+				ReplaceRegex: []config.ReplaceRegexConfig{
+					{Path: "file.txt", Pattern: `\d+`, Replacement: "123"},
+				},
+			},
+			wantErr: errTextNotFound,
+		},
+		{
+			name: "method operation fails - unsupported action",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "Test.java"), []byte("class Test {}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			cfg: &config.Postprocess{
+				MethodOperations: []config.MethodOperation{
+					{Path: "Test.java", Action: "invalid_action", FuncName: "void foo()"},
+				},
+			},
+			wantErr: errUnsupportedMethodAction,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, dir)
+			}
+			gotErr := Apply(dir, test.cfg)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("Apply() error = %v, wantErr %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestReplace(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -30,13 +30,10 @@ import (
 func TestApply(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	content := "package com.example;\n\npublic class Foo {\n\tpublic void oldFunc() {}\n}\n"
-	if err := os.WriteFile(filepath.Join(dir, "Foo.java"), []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "to_delete.txt"), []byte("delete me"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	createFiles(t, dir, map[string]string{
+		"Foo.java":      "package com.example;\n\npublic class Foo {\n\tpublic void oldFunc() {}\n}\n",
+		"to_delete.txt": "delete me",
+	})
 	cfg := &config.Postprocess{
 		CopyFile: []config.CopyConfig{
 			{Src: "Foo.java", Dst: "CopiedFoo.java"},
@@ -91,7 +88,7 @@ func TestApply_Error(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
 		name    string
-		setup   func(t *testing.T, dir string)
+		files   map[string]string
 		cfg     *config.Postprocess
 		wantErr error
 	}{
@@ -112,12 +109,8 @@ func TestApply_Error(t *testing.T) {
 			wantErr: fs.ErrNotExist,
 		},
 		{
-			name: "replace fails - text not found",
-			setup: func(t *testing.T, dir string) {
-				if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
+			name:  "replace fails - text not found",
+			files: map[string]string{"file.txt": "hello"},
 			cfg: &config.Postprocess{
 				Replace: []config.ReplaceConfig{
 					{Path: "file.txt", Original: "missing", Replacement: "world"},
@@ -126,12 +119,8 @@ func TestApply_Error(t *testing.T) {
 			wantErr: errTextNotFound,
 		},
 		{
-			name: "replace regex fails - pattern not matched",
-			setup: func(t *testing.T, dir string) {
-				if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
+			name:  "replace regex fails - pattern not matched",
+			files: map[string]string{"file.txt": "hello"},
 			cfg: &config.Postprocess{
 				ReplaceRegex: []config.ReplaceRegexConfig{
 					{Path: "file.txt", Pattern: `\d+`, Replacement: "123"},
@@ -140,12 +129,8 @@ func TestApply_Error(t *testing.T) {
 			wantErr: errTextNotFound,
 		},
 		{
-			name: "method operation fails - unsupported action",
-			setup: func(t *testing.T, dir string) {
-				if err := os.WriteFile(filepath.Join(dir, "Test.java"), []byte("class Test {}"), 0644); err != nil {
-					t.Fatal(err)
-				}
-			},
+			name:  "method operation fails - unsupported action",
+			files: map[string]string{"Test.java": "class Test {}"},
 			cfg: &config.Postprocess{
 				MethodOperations: []config.MethodOperation{
 					{Path: "Test.java", Action: "invalid_action", FuncName: "void foo()"},
@@ -157,9 +142,7 @@ func TestApply_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
-			if test.setup != nil {
-				test.setup(t, dir)
-			}
+			createFiles(t, dir, test.files)
 			gotErr := Apply(dir, test.cfg)
 			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("Apply() error = %v, wantErr %v", gotErr, test.wantErr)


### PR DESCRIPTION
Add Apply function to execute sequential post-processing operations (Copy, Remove, Replace, ReplaceRegex, MethodOperations) against a directory, along with unit and integration tests.

For #6516