### PR TITLE
chore(internal/librarian/ruby): add tool installation directory helpers

### DIFF
--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/cache"
+)
+
+const toolsDir = "ruby_tools"
+
+// InstallDir gets the directory where tools should be installed.
+func InstallDir() (string, error) {
+	dir, err := cache.BinDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Join(dir, toolsDir))
+}
+
+// getBinDir returns the directory where Ruby tool executables are stored.
+func getBinDir() (string, error) {
+	installDir, err := InstallDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(installDir, "bin"), nil
+}

--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -31,8 +31,8 @@ func InstallDir() (string, error) {
 	return filepath.Abs(filepath.Join(dir, toolsDir))
 }
 
-// getBinDir returns the directory where Ruby tool executables are stored.
-func getBinDir() (string, error) {
+// binDir returns the directory where Ruby tool executables are stored.
+func binDir() (string, error) {
 	installDir, err := InstallDir()
 	if err != nil {
 		return "", err

--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -15,6 +15,7 @@
 package ruby
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/cache"
@@ -28,7 +29,11 @@ func InstallDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Abs(filepath.Join(dir, toolsDir))
+	absDir, err := filepath.Abs(filepath.Join(dir, toolsDir))
+	if err != nil {
+		return "", fmt.Errorf("failed to get install directory: %w", err)
+	}
+	return filepath.Join(absDir, toolsDir), nil
 }
 
 // binDir returns the directory where Ruby tool executables are stored.

--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -33,7 +33,7 @@ func InstallDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get install directory: %w", err)
 	}
-	return filepath.Join(absDir, toolsDir), nil
+	return absDir, nil
 }
 
 // binDir returns the directory where Ruby tool executables are stored.

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -31,3 +31,16 @@ func TestInstallDir(t *testing.T) {
 		t.Errorf("InstallDir() = %q, want %q", got, want)
 	}
 }
+
+func TestGetBinDir(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
+	got, err := getBinDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(binDir, "ruby_tools", "bin")
+	if got != want {
+		t.Errorf("getBinDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -32,15 +32,15 @@ func TestInstallDir(t *testing.T) {
 	}
 }
 
-func TestGetBinDir(t *testing.T) {
-	binDir := t.TempDir()
-	t.Setenv("LIBRARIAN_BIN", binDir)
-	got, err := getBinDir()
+func TestBinDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", dir)
+	got, err := binDir()
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join(binDir, "ruby_tools", "bin")
+	want := filepath.Join(dir, "ruby_tools", "bin")
 	if got != want {
-		t.Errorf("getBinDir() = %q, want %q", got, want)
+		t.Errorf("binDir() = %q, want %q", got, want)
 	}
 }

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallDir(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
+	got, err := InstallDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(binDir, "ruby_tools")
+	if got != want {
+		t.Errorf("InstallDir() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Add `InstallDir` and `binDir` functions to the internal/librarian/ruby package to determine where Ruby tools and executables should be installed.

This provides the foundation for managing Ruby tool installations within Librarian's cached binary directory.

For https://github.com/googleapis/librarian/issues/6634