### PR TITLE
feat(internal/librarian/php): add tool installation directory helpers

### DIFF
--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -49,7 +49,11 @@ func InstallDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Abs(filepath.Join(dir, toolsDir))
+	absDir, err := filepath.Abs(filepath.Join(dir, toolsDir))
+	if err != nil {
+		return "", fmt.Errorf("failed to get install directory: %w", err)
+	}
+	return absDir, nil
 }
 
 // binDir gets the directory where PHP tool executables are stored.

--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/fetch"
@@ -30,6 +31,7 @@ import (
 const (
 	generatorVersion = "v1.21.2"
 	generatorSHA256  = "29635b02c6e505fe31cba2f88ae999f00d2710fe1d65cb7cad521a82e7c5a518"
+	toolsDir         = "php_tools"
 )
 
 // Install installs the PHP generator tool dependencies.
@@ -41,8 +43,22 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	return err
 }
 
-func generatorDir(ctx context.Context) (string, error) {
-	return fetch.Repo(ctx, "github.com/googleapis/gapic-generator-php", generatorVersion, generatorSHA256)
+// InstallDir gets the directory where tools should be installed.
+func InstallDir() (string, error) {
+	dir, err := cache.BinDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Join(dir, toolsDir))
+}
+
+// getBinDir returns the directory where PHP tool executables are stored.
+func getBinDir() (string, error) {
+	installDir, err := InstallDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(installDir, "bin"), nil
 }
 
 // installGenerator is a temp function for testing purposes.
@@ -89,4 +105,8 @@ exec %q -d display_errors=stderr -d memory_limit=1024M %q --side_loaded_root_dir
 	}
 
 	return generatorDir, nil
+}
+
+func generatorDir(ctx context.Context) (string, error) {
+	return fetch.Repo(ctx, "github.com/googleapis/gapic-generator-php", generatorVersion, generatorSHA256)
 }

--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -52,8 +52,8 @@ func InstallDir() (string, error) {
 	return filepath.Abs(filepath.Join(dir, toolsDir))
 }
 
-// getBinDir returns the directory where PHP tool executables are stored.
-func getBinDir() (string, error) {
+// binDir gets the directory where PHP tool executables are stored.
+func binDir() (string, error) {
 	installDir, err := InstallDir()
 	if err != nil {
 		return "", err

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallDir(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
+	got, err := InstallDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(binDir, "php_tools")
+	if got != want {
+		t.Errorf("InstallDir() = %q, want %q", got, want)
+	}
+}
+
+func TestBinDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", dir)
+	got, err := binDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "php_tools", "bin")
+	if got != want {
+		t.Errorf("binDir() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Add `InstallDir `and b`inDir` functions to the internal/librarian/php package to determine where PHP tools and executables should be installed.

This provides the foundation for managing PHP tool installations within Librarian's cached binary directory.

For #6630