### PR TITLE
feat(internal/gem): add gem package to install Ruby gem tools

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -39,6 +39,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `cargo` | list of [CargoTool](#cargotool-configuration) (optional) | Defines tools to install via cargo. |
 | `go` | list of [GoTool](#gotool-configuration) (optional) | Defines tools to install via go. |
+| `gem` | list of [GemTool](#gemtool-configuration) (optional) | Defines tools to install via gem. |
 | `maven` | list of [MavenTool](#maventool-configuration) (optional) | Defines tools to install via Maven. |
 | `pip` | list of [PipTool](#piptool-configuration) (optional) | Defines tools to install via pip. |
 | `pnpm` | list of [PNPMTool](#pnpmtool-configuration) (optional) | Defines tools to install via pnpm. |
@@ -49,6 +50,13 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `name` | string | Is the cargo package name. |
+| `version` | string | Is the version to install. |
+
+## GemTool Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | string | Is the gem name. |
 | `version` | string | Is the version to install. |
 
 ## GoTool Configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,7 @@ type CargoTool struct {
 	Version string `yaml:"version"`
 }
 
+// GemTool defines a tool to install via gem.
 type GemTool struct {
 	// Name is the gem name.
 	Name string `yaml:"name"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,9 @@ type Tools struct {
 	// Go defines tools to install via go.
 	Go []*GoTool `yaml:"go,omitempty"`
 
+	// Gem defines tools to install via gem.
+	Gem []*GemTool `yaml:"gem,omitempty"`
+
 	// Maven defines tools to install via Maven.
 	Maven []*MavenTool `yaml:"maven,omitempty"`
 
@@ -116,6 +119,14 @@ type Tools struct {
 // CargoTool defines a tool to install via cargo.
 type CargoTool struct {
 	// Name is the cargo package name.
+	Name string `yaml:"name"`
+
+	// Version is the version to install.
+	Version string `yaml:"version"`
+}
+
+type GemTool struct {
+	// Name is the gem name.
 	Name string `yaml:"name"`
 
 	// Version is the version to install.

--- a/internal/gem/gem.go
+++ b/internal/gem/gem.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gem provides utility functions for installing Ruby gems via gem.
+package gem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+var (
+	// errInstall indicates a failure to install gem packages.
+	errInstall    = errors.New("failed to install ruby gems")
+	errInvalidGem = errors.New("invalid gem tool")
+)
+
+// Install installs a list of gem tools into the environment.
+func Install(ctx context.Context, tools []*config.GemTool) error {
+	for _, tool := range tools {
+		if tool == nil || tool.Name == "" || tool.Version == "" {
+			return fmt.Errorf("%w: missing name or version", errInvalidGem)
+		}
+		args := []string{"install", tool.Name, "-v", tool.Version}
+		if err := command.RunStreaming(ctx, "gem", args...); err != nil {
+			return fmt.Errorf("%w: %w", errInstall, err)
+		}
+	}
+	return nil
+}

--- a/internal/gem/gem.go
+++ b/internal/gem/gem.go
@@ -26,17 +26,20 @@ import (
 
 var (
 	// errInstall indicates a failure to install gem packages.
-	errInstall    = errors.New("failed to install ruby gems")
+	errInstall = errors.New("failed to install ruby gems")
+	// errInvalidGem indicates an invalid gem tool.
 	errInvalidGem = errors.New("invalid gem tool")
 )
 
 // Install installs a list of gem tools into the environment.
 func Install(ctx context.Context, tools []*config.GemTool) error {
 	for _, tool := range tools {
-		if tool == nil || tool.Name == "" || tool.Version == "" {
-			return fmt.Errorf("%w: missing name or version", errInvalidGem)
+		if tool.Name == "" || tool.Version == "" {
+			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidGem, tool)
 		}
-		args := []string{"install", tool.Name, "-v", tool.Version}
+		// Skip the generation of the local documentation to make installation faster
+		// and use less disk space.
+		args := []string{"install", tool.Name, "-v", tool.Version, "--no-document"}
 		if err := command.RunStreaming(ctx, "gem", args...); err != nil {
 			return fmt.Errorf("%w: %w", errInstall, err)
 		}

--- a/internal/gem/gem_test.go
+++ b/internal/gem/gem_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gem
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestInstall(t *testing.T) {
+	tmpDir := t.TempDir()
+	stubLogPath := filepath.Join(tmpDir, "gem_invocations.log")
+	stubContent := fmt.Sprintf(`#!/bin/sh
+echo "gem $@" >> %q
+`, stubLogPath)
+	stubDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(stubDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	stubPath := filepath.Join(stubDir, "gem")
+	if err := os.WriteFile(stubPath, []byte(stubContent), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir)
+	for _, test := range []struct {
+		name    string
+		tools   []*config.GemTool
+		wantLog string
+	}{
+		{
+			name: "install gem with version",
+			tools: []*config.GemTool{
+				{Name: "rubocop", Version: "1.50.0"},
+			},
+			wantLog: "gem install rubocop -v 1.50.0",
+		},
+		{
+			name: "install multiple gems",
+			tools: []*config.GemTool{
+				{Name: "rubocop", Version: "1.50.0"},
+				{Name: "rake", Version: "13.0.6"},
+			},
+			wantLog: "gem install rubocop -v 1.50.0\ngem install rake -v 13.0.6",
+		},
+		{
+			name:    "empty or nil tools",
+			tools:   []*config.GemTool{},
+			wantLog: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_ = os.Remove(stubLogPath)
+			if err := Install(t.Context(), test.tools); err != nil {
+				t.Fatal(err)
+			}
+			data, _ := os.ReadFile(stubLogPath)
+			gotLog := strings.TrimSpace(string(data))
+			if diff := cmp.Diff(test.wantLog, gotLog); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestInstall_Error(t *testing.T) {
+	tmpDir := t.TempDir()
+	stubDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(stubDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	stubPath := filepath.Join(stubDir, "gem")
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name    string
+		tools   []*config.GemTool
+		setup   func(t *testing.T)
+		wantErr error
+	}{
+		{
+			name: "gem command fails",
+			tools: []*config.GemTool{
+				{Name: "failgem", Version: "1.0.0"},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("PATH", stubDir)
+			},
+			wantErr: errInstall,
+		},
+		{
+			name: "missing name",
+			tools: []*config.GemTool{
+				{Name: "", Version: "1.0.0"},
+			},
+			wantErr: errInvalidGem,
+		},
+		{
+			name: "missing version",
+			tools: []*config.GemTool{
+				{Name: "rubocop", Version: ""},
+			},
+			wantErr: errInvalidGem,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			err := Install(t.Context(), test.tools)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Install() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/gem/gem_test.go
+++ b/internal/gem/gem_test.go
@@ -51,7 +51,7 @@ echo "gem $@" >> %q
 			tools: []*config.GemTool{
 				{Name: "rubocop", Version: "1.50.0"},
 			},
-			wantLog: "gem install rubocop -v 1.50.0",
+			wantLog: "gem install rubocop -v 1.50.0 --no-document",
 		},
 		{
 			name: "install multiple gems",
@@ -59,7 +59,7 @@ echo "gem $@" >> %q
 				{Name: "rubocop", Version: "1.50.0"},
 				{Name: "rake", Version: "13.0.6"},
 			},
-			wantLog: "gem install rubocop -v 1.50.0\ngem install rake -v 13.0.6",
+			wantLog: "gem install rubocop -v 1.50.0 --no-document\ngem install rake -v 13.0.6 --no-document",
 		},
 		{
 			name:    "empty or nil tools",


### PR DESCRIPTION
Add the internal/gem package and GemTool configuration to support installing Ruby gem dependencies via the gem CLI.

This includes updating internal/config to support gem tool definitions in librarian.yaml, adding doc/config-schema.md documentation, and adding unit tests for gem installation.

Tesed via gem v3.6.7.

For https://github.com/googleapis/librarian/issues/6634