### PR TITLE
feat(tool/cmd/migrate): add support to php

### DIFF
--- a/tool/cmd/migrate/main.go
+++ b/tool/cmd/migrate/main.go
@@ -62,6 +62,8 @@ func run(ctx context.Context, args []string) error {
 	switch base {
 	case "google-cloud-dotnet":
 		return runDotnetMigration(ctx, abs)
+	case "google-cloud-php":
+		return runPHPMigration(ctx, abs)
 	default:
 		return fmt.Errorf("invalid path: %q", repoPath)
 	}

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+)
+
+func runPHPMigration(ctx context.Context, repoPath string) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6628): implement php migration
+	return nil
+}

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -16,9 +16,30 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"log"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/librarian"
 )
 
 func runPHPMigration(ctx context.Context, repoPath string) error {
-	// TODO(https://github.com/googleapis/librarian/issues/6628): implement php migration
+	src, err := fetchSource(ctx)
+	if err != nil {
+		return errFetchSource
+	}
+	cfg := &config.Config{
+		Language: config.LanguagePhp,
+		Sources: &config.Sources{
+			Googleapis: src,
+		},
+	}
+	// The directory name in Googleapis is present for migration code to look
+	// up API details. It shouldn't be persisted.
+	cfg.Sources.Googleapis.Dir = ""
+	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
+		return fmt.Errorf("%w: %w", errTidyFailed, err)
+	}
+	log.Println("Successfully migrated PHP libraries configuration skeleton")
 	return nil
 }

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/yaml"
+)
+
+func TestRunPHPMigration(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Override fetchSource.
+	fetchSource = func(ctx context.Context) (*config.Source, error) {
+		return &config.Source{
+			Commit: "abcd123",
+			SHA256: "sha123",
+			Dir:    filepath.Join(wd, "../../internal/testdata/googleapis"),
+		}, nil
+	}
+	dir := t.TempDir()
+	err = runPHPMigration(t.Context(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify librarian.yaml is written and contains the expected content.
+	cfgPath := filepath.Join(dir, config.LibrarianYAML)
+	got, err := yaml.Read[config.Config](cfgPath)
+	if err != nil {
+		t.Fatalf("reading generated librarian.yaml: %v", err)
+	}
+	want := &config.Config{
+		Language: config.LanguagePhp,
+		Sources: &config.Sources{
+			Googleapis: &config.Source{
+				Commit: "abcd123",
+				SHA256: "sha123",
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,7 +25,11 @@ import (
 )
 
 func TestRunPHPMigration(t *testing.T) {
-	wd, err := os.Getwd()
+	oldFetchSource := fetchSource
+	t.Cleanup(func() {
+		fetchSource = oldFetchSource
+	})
+	absGoogleapis, err := filepath.Abs("../../internal/testdata/googleapis")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,17 +38,17 @@ func TestRunPHPMigration(t *testing.T) {
 		return &config.Source{
 			Commit: "abcd123",
 			SHA256: "sha123",
-			Dir:    filepath.Join(wd, "../../internal/testdata/googleapis"),
+			Dir:    absGoogleapis,
 		}, nil
 	}
 	dir := t.TempDir()
-	err = runPHPMigration(t.Context(), dir)
+	t.Chdir(dir)
+	err = runPHPMigration(t.Context(), ".")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Verify librarian.yaml is written and contains the expected content.
-	cfgPath := filepath.Join(dir, config.LibrarianYAML)
-	got, err := yaml.Read[config.Config](cfgPath)
+	got, err := yaml.Read[config.Config](config.LibrarianYAML)
 	if err != nil {
 		t.Fatalf("reading generated librarian.yaml: %v", err)
 	}


### PR DESCRIPTION
Add initial support for php, populate language and sources in the produced librarian.yaml file.

For #6723