### PR TITLE
feat(migrate): discover and list PHP libraries during migration

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
@@ -28,11 +31,16 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 	if err != nil {
 		return errFetchSource
 	}
+	libs, err := findPHPLibraries(repoPath)
+	if err != nil {
+		return err
+	}
 	cfg := &config.Config{
 		Language: config.LanguagePhp,
 		Sources: &config.Sources{
 			Googleapis: src,
 		},
+		Libraries: libs,
 	}
 	// The directory name in Googleapis is present for migration code to look
 	// up API details. It shouldn't be persisted.
@@ -40,6 +48,45 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
 		return fmt.Errorf("%w: %w", errTidyFailed, err)
 	}
-	log.Println("Successfully migrated PHP libraries configuration skeleton")
+	log.Printf("Successfully migrated %d PHP libraries configuration skeleton", len(cfg.Libraries))
 	return nil
+}
+
+// findPHPLibraries scans the repository root directory for subdirectories containing
+// both a VERSION file and a composer.json file. It assumes each matching subdirectory
+// represents a PHP library, where the library name is the subdirectory's name and
+// the version is extracted from the VERSION file.
+func findPHPLibraries(repoPath string) ([]*config.Library, error) {
+	entries, err := os.ReadDir(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	var libs []*config.Library
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		versionPath := filepath.Join(repoPath, name, "VERSION")
+		composerPath := filepath.Join(repoPath, name, "composer.json")
+		// Check if both VERSION and composer.json exist
+		if !fileExists(versionPath) || !fileExists(composerPath) {
+			continue
+		}
+		versionBytes, err := os.ReadFile(versionPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading version for %s: %w", name, err)
+		}
+		version := strings.TrimSpace(string(versionBytes))
+		libs = append(libs, &config.Library{
+			Name:    name,
+			Version: version,
+		})
+	}
+	return libs, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -88,6 +88,6 @@ func TestRunPHPMigration(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in generated librarian.yaml (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,6 +43,25 @@ func TestRunPHPMigration(t *testing.T) {
 		}, nil
 	}
 	dir := t.TempDir()
+	// Create a fake library SecretManager.
+	libDir := filepath.Join(dir, "SecretManager")
+	if err := os.Mkdir(libDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("2.3.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Create a fake non-library directory to ensure it is ignored.
+	ignoredDir := filepath.Join(dir, "dev")
+	if err := os.Mkdir(ignoredDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ignoredDir, "composer.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	t.Chdir(dir)
 	err = runPHPMigration(t.Context(), ".")
 	if err != nil {
@@ -60,8 +80,14 @@ func TestRunPHPMigration(t *testing.T) {
 				SHA256: "sha123",
 			},
 		},
+		Libraries: []*config.Library{
+			{
+				Name:    "SecretManager",
+				Version: "2.3.0",
+			},
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch in generated librarian.yaml (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Scans the repository root for directories containing both `VERSION` and `composer.json` to populate the `libraries` list in the generated configuration.

For context, composer.json  is the standard configuration file used by PHP's package manager, VERSION is used by release-please. We use these two to verify directory is a PHP Package.

Fixes https://github.com/googleapis/librarian/issues/6723