### PR TITLE
feat(internal/librarian/java): add ToKeepSet helper and unit tests

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -535,3 +535,13 @@ func createOrVerifyOwlbotPy(outDir string) (err error) {
 	}
 	return nil
 }
+
+// ToKeepSet normalizes a list of keep paths into a lookup map.
+func ToKeepSet(keep []string) map[string]bool {
+	keepSet := make(map[string]bool, len(keep))
+	for _, k := range keep {
+		normalized := strings.TrimSuffix(filepath.ToSlash(k), "/")
+		keepSet[normalized] = true
+	}
+	return keepSet
+}

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -1139,3 +1139,18 @@ func TestCreateOrVerifyOwlbotPy_Error(t *testing.T) {
 		t.Errorf("error = %v, wantErr %v", err, fs.ErrPermission)
 	}
 }
+
+func TestToKeepSet(t *testing.T) {
+	t.Parallel()
+	input := []string{"foo/", "bar/baz", "qux/", ""}
+	got := ToKeepSet(input)
+	want := map[string]bool{
+		"foo":     true,
+		"bar/baz": true,
+		"qux":     true,
+		"":        true,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Add ToKeepSet helper function to normalize a list of keep paths into a lookup map for file preservation during post-processing.

For #6516