### PR TITLE
feat(nodejs): support both PNPM v7 and v11 global bin layout

### DIFF
--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cache"
@@ -56,7 +57,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		}
 	}
 
-	env, err := getPNPMEnv()
+	env, err := getPNPMEnv(ctx)
 	if err != nil {
 		return err
 	}
@@ -114,7 +115,7 @@ func getToolsEnv() (map[string]string, error) {
 // This enables complete environment caching and restore on CI runners,
 // while permanently avoiding persistent side-effects on the host machine
 // (it does not modify the user's personal ~/.config/pnpm/rc files).
-func getPNPMEnv() ([]string, error) {
+func getPNPMEnv(ctx context.Context) ([]string, error) {
 	cacheDir, err := cache.Directory()
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve librarian cache directory: %w", err)
@@ -128,14 +129,44 @@ func getPNPMEnv() ([]string, error) {
 		return nil, fmt.Errorf("failed to resolve librarian bin directory: %w", err)
 	}
 
+	major, err := pnpmMajorVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// In pnpm v11+, globally installed binaries are stored in PNPM_HOME/bin.
+	// In pnpm v7, globally installed binaries are stored directly in PNPM_HOME.
+	// We want global binaries to be installed in binDir.
+	pnpmHome := binDir
+	if major >= 11 {
+		pnpmHome = installDir
+	}
+
 	env := os.Environ()
-	env = append(env, "PNPM_HOME="+installDir)
+	env = append(env, "PNPM_HOME="+pnpmHome)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil
+}
+
+func pnpmMajorVersion(ctx context.Context) (int, error) {
+	out, err := exec.CommandContext(ctx, "pnpm", "--version").Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get pnpm version: %w", err)
+	}
+	vStr := strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
+	if vStr == "" {
+		return 0, fmt.Errorf("empty pnpm version output")
+	}
+	parts := strings.Split(vStr, ".")
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse pnpm major version from %q: %w", vStr, err)
+	}
+	return major, nil
 }
 
 func runPNPM(ctx context.Context, dir string, env []string, args ...string) error {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -16,8 +16,10 @@ package nodejs
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -25,8 +27,20 @@ import (
 
 func stubExecutables(t *testing.T) {
 	t.Helper()
+	stubExecutablesWithPNPMVersion(t, "7.33.7")
+}
+
+func stubExecutablesWithPNPMVersion(t *testing.T, pnpmVersion string) {
+	t.Helper()
 	bin := t.TempDir()
-	pnpmStub := `#!/bin/sh
+	pnpmStub := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+    *--version*|-v)
+        echo "%s"
+        exit 0
+        ;;
+esac
+
 # Assert that transient environmental variables are set dynamically for process lifetime
 if [ -n "$PNPM_HOME" ] && [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] && [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] && [ -n "$PNPM_CONFIG_STORE_DIR" ] && \
    [ -n "$PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS" ]; then
@@ -46,7 +60,7 @@ case "$*" in
         ;;
 esac
 exit 0
-`
+`, pnpmVersion)
 	nodeStub := `#!/bin/sh
 exit 0
 `
@@ -280,4 +294,111 @@ func TestGetToolsEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetPNPMEnv_PNPMVersion(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		pnpmVersion string
+		wantSubdir  string
+	}{
+		{
+			name:        "pnpm v7",
+			pnpmVersion: "7.33.7",
+			wantSubdir:  "bin",
+		},
+		{
+			name:        "pnpm v11",
+			pnpmVersion: "11.7.0",
+			wantSubdir:  "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			t.Setenv("LIBRARIAN_BIN", binDir)
+			stubExecutablesWithPNPMVersion(t, test.pnpmVersion)
+
+			env, err := getPNPMEnv(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			installDir, err := InstallDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantPNPMHome := filepath.Join(installDir, test.wantSubdir)
+
+			var gotPNPMHome string
+			for _, e := range env {
+				if strings.HasPrefix(e, "PNPM_HOME=") {
+					gotPNPMHome = strings.TrimPrefix(e, "PNPM_HOME=")
+					break
+				}
+			}
+
+			if gotPNPMHome != wantPNPMHome {
+				t.Errorf("PNPM_HOME = %q, want %q", gotPNPMHome, wantPNPMHome)
+			}
+		})
+	}
+}
+
+func TestGetPNPMEnv_PNPMVersion_Error(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		pnpmVersion string
+		exitCode    int
+	}{
+		{
+			name:        "pnpm --version command fails",
+			pnpmVersion: "",
+			exitCode:    1,
+		},
+		{
+			name:        "empty pnpm version output",
+			pnpmVersion: "",
+			exitCode:    0,
+		},
+		{
+			name:        "invalid pnpm version output",
+			pnpmVersion: "invalid",
+			exitCode:    0,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			t.Setenv("LIBRARIAN_BIN", binDir)
+			stubFailingPNPMVersion(t, test.pnpmVersion, test.exitCode)
+
+			_, err := getPNPMEnv(t.Context())
+			if err == nil {
+				t.Fatalf("getPNPMEnv() succeeded, want error")
+			}
+		})
+	}
+}
+
+func stubFailingPNPMVersion(t *testing.T, versionOutput string, exitCode int) {
+	t.Helper()
+	bin := t.TempDir()
+	pnpmStub := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+    *--version*|-v)
+        echo "%s"
+        exit %d
+        ;;
+esac
+exit 0
+`, versionOutput, exitCode)
+	nodeStub := `#!/bin/sh
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }


### PR DESCRIPTION
This PR adds support for both PNPM v7 and v11 global bin layout.
It dynamically detects the PNPM version and sets `PNPM_HOME` accordingly.
PNPM v11+ uses isolated global installs (PNPM_HOME/bin), while PNPM v7 installs directly to PNPM_HOME.

See https://github.com/pnpm/pnpm/releases/tag/v11.0.0 for more details on PNPM v11 changes.