### PR TITLE
chore(tool/cmd/migrate): add a ruby migration tool

### DIFF
--- a/tool/cmd/migrate/main.go
+++ b/tool/cmd/migrate/main.go
@@ -64,6 +64,8 @@ func run(ctx context.Context, args []string) error {
 		return runDotnetMigration(ctx, abs)
 	case "google-cloud-php":
 		return runPHPMigration(ctx, abs)
+	case "google-cloud-ruby":
+		return runRubyMigration(ctx, abs)
 	default:
 		return fmt.Errorf("invalid path: %q", repoPath)
 	}

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/librarian"
+)
+
+func runRubyMigration(ctx context.Context, repoPath string) error {
+	src, err := fetchSource(ctx)
+	if err != nil {
+		return errFetchSource
+	}
+	cfg := &config.Config{
+		Language: config.LanguageRuby,
+		Sources: &config.Sources{
+			Googleapis: src,
+		},
+	}
+	// The directory name in Googleapis is present for migration code to look
+	// up API details. It shouldn't be persisted.
+	cfg.Sources.Googleapis.Dir = ""
+	if err := librarian.RunTidyOnConfig(ctx, repoPath, cfg); err != nil {
+		return fmt.Errorf("%w: %w", errTidyFailed, err)
+	}
+	log.Printf("Successfully migrated Ruby libraries configuration skeleton")
+	return nil
+}

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/yaml"
+)
+
+func TestRunRubyMigration(t *testing.T) {
+	oldFetchSource := fetchSource
+	t.Cleanup(func() {
+		fetchSource = oldFetchSource
+	})
+	absGoogleapis, err := filepath.Abs("../../internal/testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Override fetchSource.
+	fetchSource = func(ctx context.Context) (*config.Source, error) {
+		return &config.Source{
+			Commit: "abcd123",
+			SHA256: "sha123",
+			Dir:    absGoogleapis,
+		}, nil
+	}
+	dir := t.TempDir()
+	t.Chdir(dir)
+	err = runRubyMigration(t.Context(), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify librarian.yaml is written and contains the expected content.
+	got, err := yaml.Read[config.Config](config.LibrarianYAML)
+	if err != nil {
+		t.Fatalf("reading generated librarian.yaml: %v", err)
+	}
+	want := &config.Config{
+		Language: config.LanguageRuby,
+		Sources: &config.Sources{
+			Googleapis: &config.Source{
+				Commit: "abcd123",
+				SHA256: "sha123",
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Add skeleton of ruby migration tool.

For https://github.com/googleapis/librarian/issues/6632