### PR TITLE
fix(internal/librarian/php): enforce explicit API paths and add default output path

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -355,6 +355,8 @@ func defaultOutput(language string, name, api, defaultOut string) string {
 		return golang.DefaultOutput(name, defaultOut)
 	case config.LanguageNodejs:
 		return nodejs.DefaultOutput(name, defaultOut)
+	case config.LanguagePhp:
+		return php.DefaultOutput(name, defaultOut)
 	case config.LanguagePython:
 		return python.DefaultOutput(name, defaultOut)
 	case config.LanguageRust:

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -338,7 +338,7 @@ func applyDefaults(language string, lib *config.Library, defaults *config.Defaul
 // derive the API path.
 func canDeriveAPIPath(language string) bool {
 	switch language {
-	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs, config.LanguageJava:
+	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs, config.LanguageJava, config.LanguagePhp:
 		return false
 	default:
 		return true

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -217,3 +217,9 @@ func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigPath s
 	}
 	return opts
 }
+
+// DefaultOutput derives an output path from a library name and a default
+// output directory.
+func DefaultOutput(name, defaultOutput string) string {
+	return filepath.Join(defaultOutput, name)
+}

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -269,3 +269,32 @@ func TestBuildProtocArgs(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestDefaultOutput(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		libName       string
+		defaultOutput string
+		want          string
+	}{
+		{
+			name:          "standard",
+			libName:       "Ces",
+			defaultOutput: "packages",
+			want:          "packages/Ces",
+		},
+		{
+			name:          "empty default",
+			libName:       "Ces",
+			defaultOutput: "",
+			want:          "Ces",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultOutput(test.libName, test.defaultOutput)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Disable API path derivation for PHP to force explicit configuration in librarian.yaml and implement PHP DefaultOutput to default the output directory to the library name.

For https://github.com/googleapis/librarian/issues/6629