### PR TITLE
refactor(internal/librarian/java): align default output logic with other languages

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -353,6 +353,8 @@ func defaultOutput(language string, name, api, defaultOut string) string {
 		return dart.DefaultOutput(name, defaultOut)
 	case config.LanguageGo:
 		return golang.DefaultOutput(name, defaultOut)
+	case config.LanguageJava:
+		return java.DefaultOutput(name, defaultOut)
 	case config.LanguageNodejs:
 		return nodejs.DefaultOutput(name, defaultOut)
 	case config.LanguagePython:

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -17,6 +17,7 @@ package java
 import (
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -38,7 +39,7 @@ func deriveArtifactID(name string) string {
 
 // DefaultOutput derives the default output directory name for a Java library.
 func DefaultOutput(name, defaultOutput string) string {
-	return filepath.Join(defaultOutput, javaPrefix+name)
+	return path.Join(defaultOutput, javaPrefix+name)
 }
 
 // Fill populates Java-specific default values for the library.

--- a/internal/librarian/java/defaults.go
+++ b/internal/librarian/java/defaults.go
@@ -36,16 +36,13 @@ func deriveArtifactID(name string) string {
 	return defaultArtifactIDPrefix + name
 }
 
-// deriveOutput computes the default output directory name for a given library name.
-func deriveOutput(name string) string {
-	return javaPrefix + name
+// DefaultOutput derives the default output directory name for a Java library.
+func DefaultOutput(name, defaultOutput string) string {
+	return filepath.Join(defaultOutput, javaPrefix+name)
 }
 
 // Fill populates Java-specific default values for the library.
 func Fill(library *config.Library) (*config.Library, error) {
-	if library.Output == "" {
-		library.Output = deriveOutput(library.Name)
-	}
 	if library.Java == nil {
 		library.Java = &config.JavaModule{}
 	}
@@ -90,9 +87,6 @@ func Fill(library *config.Library) (*config.Library, error) {
 // values.
 func Tidy(library *config.Library) (*config.Library, error) {
 	library.Keep = tidyKeep(library.Keep)
-	if library.Output == deriveOutput(library.Name) {
-		library.Output = ""
-	}
 	if library.Java != nil {
 		if library.Java.ArtifactID == deriveArtifactID(library.Name) {
 			library.Java.ArtifactID = ""

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -53,7 +53,7 @@ func TestFill(t *testing.T) {
 				},
 			},
 			want: &config.Library{
-				Name:   "secretmanager",
+				Name: "secretmanager",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -86,7 +86,7 @@ func TestFill(t *testing.T) {
 				},
 			},
 			want: &config.Library{
-				Name:   "secretmanager",
+				Name: "secretmanager",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -114,7 +114,7 @@ func TestFill(t *testing.T) {
 				},
 			},
 			want: &config.Library{
-				Name:   "secretmanager",
+				Name: "secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "google-cloud-secretmanager",
 					GroupID:    "com.google.custom",
@@ -127,7 +127,7 @@ func TestFill(t *testing.T) {
 				Name: "secretmanager",
 			},
 			want: &config.Library{
-				Name:   "secretmanager",
+				Name: "secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "google-cloud-secretmanager",
 					GroupID:    "com.google.cloud",
@@ -143,7 +143,7 @@ func TestFill(t *testing.T) {
 				},
 			},
 			want: &config.Library{
-				Name:   "secretmanager",
+				Name: "secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "custom-secretmanager",
 					GroupID:    "com.google.cloud",

--- a/internal/librarian/java/defaults_test.go
+++ b/internal/librarian/java/defaults_test.go
@@ -30,20 +30,6 @@ func TestFill(t *testing.T) {
 		want *config.Library
 	}{
 		{
-			name: "fill output from name",
-			lib: &config.Library{
-				Name: "secretmanager",
-			},
-			want: &config.Library{
-				Name:   "secretmanager",
-				Output: "java-secretmanager",
-				Java: &config.JavaModule{
-					ArtifactID: "google-cloud-secretmanager",
-					GroupID:    "com.google.cloud",
-				},
-			},
-		},
-		{
 			name: "do not overwrite output",
 			lib: &config.Library{
 				Name:   "secretmanager",
@@ -68,7 +54,6 @@ func TestFill(t *testing.T) {
 			},
 			want: &config.Library{
 				Name:   "secretmanager",
-				Output: "java-secretmanager",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -102,7 +87,6 @@ func TestFill(t *testing.T) {
 			},
 			want: &config.Library{
 				Name:   "secretmanager",
-				Output: "java-secretmanager",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -131,7 +115,6 @@ func TestFill(t *testing.T) {
 			},
 			want: &config.Library{
 				Name:   "secretmanager",
-				Output: "java-secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "google-cloud-secretmanager",
 					GroupID:    "com.google.custom",
@@ -145,7 +128,6 @@ func TestFill(t *testing.T) {
 			},
 			want: &config.Library{
 				Name:   "secretmanager",
-				Output: "java-secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "google-cloud-secretmanager",
 					GroupID:    "com.google.cloud",
@@ -162,7 +144,6 @@ func TestFill(t *testing.T) {
 			},
 			want: &config.Library{
 				Name:   "secretmanager",
-				Output: "java-secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "custom-secretmanager",
 					GroupID:    "com.google.cloud",
@@ -178,7 +159,6 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:    "secretmanager",
 				Version: "1.2.0-SNAPSHOT",
-				Output:  "java-secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID:      "google-cloud-secretmanager",
 					GroupID:         "com.google.cloud",
@@ -197,7 +177,6 @@ func TestFill(t *testing.T) {
 				Name:         "secretmanager",
 				Version:      "1.2.0-SNAPSHOT",
 				SkipGenerate: true,
-				Output:       "java-secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID: "google-cloud-secretmanager",
 					GroupID:    "com.google.cloud",
@@ -216,7 +195,6 @@ func TestFill(t *testing.T) {
 			want: &config.Library{
 				Name:    "secretmanager",
 				Version: "1.2.0-SNAPSHOT",
-				Output:  "java-secretmanager",
 				Java: &config.JavaModule{
 					ArtifactID:      "google-cloud-secretmanager",
 					GroupID:         "com.google.cloud",
@@ -243,17 +221,6 @@ func TestTidy(t *testing.T) {
 		lib  *config.Library
 		want *config.Library
 	}{
-		{
-			name: "tidy default output",
-			lib: &config.Library{
-				Name:   "secretmanager",
-				Output: "java-secretmanager",
-			},
-			want: &config.Library{
-				Name:   "secretmanager",
-				Output: "",
-			},
-		},
 		{
 			name: "do not tidy custom output",
 			lib: &config.Library{
@@ -710,6 +677,35 @@ func TestDeriveLastReleasedVersion_Error(t *testing.T) {
 			_, err := deriveLastReleasedVersion(test.input)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultOutput(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		libName       string
+		defaultOutput string
+		want          string
+	}{
+		{
+			name:          "standard",
+			libName:       "secretmanager",
+			defaultOutput: "packages",
+			want:          "packages/java-secretmanager",
+		},
+		{
+			name:          "empty default",
+			libName:       "secretmanager",
+			defaultOutput: "",
+			want:          "java-secretmanager",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultOutput(test.libName, test.defaultOutput)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -908,6 +908,17 @@ func TestApplyDefaults(t *testing.T) {
 			nilDefaults: true,
 			wantOutput:  "google-cloud-secretmanager-v1",
 		},
+		{
+			name:       "java empty output derives path",
+			language:   config.LanguageJava,
+			wantOutput: "src/generated/java-google-cloud-secretmanager-v1",
+		},
+		{
+			name:        "java nil defaults is handled safely",
+			language:    config.LanguageJava,
+			nilDefaults: true,
+			wantOutput:  "java-google-cloud-secretmanager-v1",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			lib := &config.Library{

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -598,7 +598,7 @@ func TestTidy_DerivableOutput(t *testing.T) {
 			name:     "java derivable output",
 			language: config.LanguageJava,
 			libName:  "secretmanager",
-			output:   "java-secretmanager",
+			output:   "generated/java-secretmanager",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Align Java's default output resolution with the common librarian flow, to rely on the common default-application and tidy logic, deduplicating code and removing Java-specific logic from the tidy and fill steps. Also if a global `default: output` is ever configured, Java libraries will correctly inherit it as a prefix.

Specifically, define and register `java.DefaultOutput`, remove `java.Fill` and  `java.Tidy` logic for output and delegate them to the common flows.

This is a pure refactoring and does not introduce any behavior changes or differences in `google-cloud-java` configurations or generation.