### PR TITLE
feat(internal/librarian/ruby): support installing Ruby gem dependencies

### DIFF
--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -30,6 +30,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
 	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
+	"github.com/googleapis/librarian/internal/librarian/ruby"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/tool/protoc"
 	"github.com/googleapis/librarian/internal/yaml"
@@ -123,6 +124,8 @@ Examples:
 				return php.Install(ctx, tools)
 			case config.LanguagePython:
 				return python.Install(ctx)
+			case config.LanguageRuby:
+				return ruby.Install(ctx, tools)
 			case config.LanguageRust:
 				return rust.Install(ctx, tools)
 			default:

--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -34,6 +34,7 @@ var (
 	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Ruby tool installation")
 )
 
+// Install installs Ruby gem dependencies.
 func Install(ctx context.Context, tools *config.Tools) error {
 	if err := verify(tools); err != nil {
 		return err

--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -15,13 +15,34 @@
 package ruby
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 
+	"context"
+
 	"github.com/googleapis/librarian/internal/cache"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/tool/gem"
 )
 
 const toolsDir = "ruby_tools"
+
+var (
+	errNoGems            = errors.New("no gem tools specified")
+	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Ruby tool installation")
+)
+
+func Install(ctx context.Context, tools *config.Tools) error {
+	if err := verify(tools); err != nil {
+		return err
+	}
+	if err := gem.Install(ctx, tools.Gem); err != nil {
+		return err
+	}
+	return nil
+}
 
 // InstallDir gets the directory where tools should be installed.
 func InstallDir() (string, error) {
@@ -43,4 +64,17 @@ func binDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(installDir, "bin"), nil
+}
+
+func verify(tools *config.Tools) error {
+	if tools == nil || len(tools.Gem) == 0 {
+		return errNoGems
+	}
+
+	for _, cmd := range []string{"gem"} {
+		if _, err := exec.LookPath(cmd); err != nil {
+			return fmt.Errorf("%s %w: %w", cmd, errMissingExecutable, err)
+		}
+	}
+	return nil
 }

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -15,8 +15,11 @@
 package ruby
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestInstallDir(t *testing.T) {
@@ -42,5 +45,28 @@ func TestBinDir(t *testing.T) {
 	want := filepath.Join(dir, "ruby_tools", "bin")
 	if got != want {
 		t.Errorf("binDir() = %q, want %q", got, want)
+	}
+}
+
+func TestVerify(t *testing.T) {
+	stubDir := t.TempDir()
+	gemStubPath := filepath.Join(stubDir, "gem")
+	// Create a simple shell script stub for "gem".
+	stubContent := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(gemStubPath, []byte(stubContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	tools := &config.Tools{
+		Gem: []*config.GemTool{
+			{
+				Name:    "a-gem-tool",
+				Version: "1.0",
+			},
+		},
+	}
+
+	if err := verify(tools); err != nil {
+		t.Errorf("verify() returned unexpected error: %v", err)
 	}
 }

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -23,6 +23,37 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+func TestInstall(t *testing.T) {
+	stubDir := t.TempDir()
+	gemStubPath := filepath.Join(stubDir, "gem")
+	recordFile := filepath.Join(t.TempDir(), "calls.txt")
+	stubContent := "#!/bin/sh\necho \"$*\" >> \"" + recordFile + "\"\nexit 0\n"
+	if err := os.WriteFile(gemStubPath, []byte(stubContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	tools := &config.Tools{
+		Gem: []*config.GemTool{
+			{
+				Name:    "gapic-generator",
+				Version: "1.2.3",
+			},
+		},
+	}
+	if err := Install(t.Context(), tools); err != nil {
+		t.Fatalf("Install() returned unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(recordFile)
+	if err != nil {
+		t.Fatalf("failed to read call records: %v", err)
+	}
+	got := string(data)
+	want := "install gapic-generator -v 1.2.3 --no-document\n"
+	if got != want {
+		t.Errorf("gem called with = %q, want %q", got, want)
+	}
+}
+
 func TestInstallDir(t *testing.T) {
 	binDir := t.TempDir()
 	t.Setenv("LIBRARIAN_BIN", binDir)

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -15,6 +15,7 @@
 package ruby
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,5 +69,50 @@ func TestVerify(t *testing.T) {
 
 	if err := verify(tools); err != nil {
 		t.Errorf("verify() returned unexpected error: %v", err)
+	}
+}
+
+func TestVerify_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tools   *config.Tools
+		setup   func(t *testing.T)
+		wantErr error
+	}{
+		{
+			name:    "nil tools",
+			tools:   nil,
+			wantErr: errNoGems,
+		},
+		{
+			name:    "empty tools",
+			tools:   &config.Tools{},
+			wantErr: errNoGems,
+		},
+		{
+			name: "missing gem in path",
+			tools: &config.Tools{
+				Gem: []*config.GemTool{
+					{
+						Name:    "a-gem-tool",
+						Version: "1.0",
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("PATH", t.TempDir())
+			},
+			wantErr: errMissingExecutable,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			err := verify(test.tools)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("verify() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
 	}
 }

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -15,6 +15,7 @@
 package ruby
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -47,10 +48,9 @@ func TestInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read call records: %v", err)
 	}
-	got := string(data)
-	want := "install gapic-generator -v 1.2.3 --no-document\n"
-	if got != want {
-		t.Errorf("gem called with = %q, want %q", got, want)
+	want := []byte("install gapic-generator -v 1.2.3 --no-document\n")
+	if !bytes.Equal(data, want) {
+		t.Errorf("gem called with = %q, want %q", data, want)
 	}
 }
 


### PR DESCRIPTION
Introduce support for installing Ruby gem dependencies via the gem CLI.

An Install function is added to `internal/librarian/ruby` which validates the environment and calls the underlying gem installer tool for each configured gem.

The gems are not installed to bin directory yet, this will be implemented in follow ups.

For #6634
