### PR TITLE
feat(internal/librarian/java): add RestructureToLibrary helper and unit tests

### DIFF
--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -569,3 +569,83 @@ func ToKeepSet(keep []string) map[string]bool {
 	}
 	return keepSet
 }
+
+// RestructureToLibrary moves all generated source code to the library root directories.
+// It also removes conflicting files, and copies public proto files to the library.
+func RestructureToLibrary(params postProcessParams, destRoot string, keepSet map[string]bool) error {
+	tempProtoSrcDir := params.protoDir()
+	isCommonProtos := params.library != nil && params.library.Name == commonProtosLibrary
+	if !isCommonProtos {
+		if err := removeConflictingFiles(tempProtoSrcDir); err != nil {
+			return err
+		}
+	}
+	if err := moveSourcesToLibrary(params, destRoot, keepSet); err != nil {
+		return err
+	}
+	if err := copyProtoFilesToLibrary(params, destRoot); err != nil {
+		return err
+	}
+	return nil
+}
+
+// moveSourcesToLibrary relocates the generated Java source files (GAPIC, proto,
+// gRPC, resource names, and samples) to their repository destinations.
+func moveSourcesToLibrary(params postProcessParams, destRoot string, keepSet map[string]bool) error {
+	coords := params.coords()
+	isMonolithic := params.javaAPI.Monolithic
+	var protoDest, grpcDest, gapicMainDest, gapicTestDest string
+	// Determine target repository subdirectories based on library structure.
+	if isMonolithic {
+		protoDest = filepath.Join(destRoot, "src", "main", "java")
+		grpcDest = filepath.Join(destRoot, "src", "main", "java")
+		gapicMainDest = filepath.Join(destRoot, "src", "main")
+		gapicTestDest = filepath.Join(destRoot, "src", "test")
+	} else {
+		protoDest = filepath.Join(destRoot, coords.Proto.ArtifactID, "src", "main", "java")
+		grpcDest = filepath.Join(destRoot, coords.GRPC.ArtifactID, "src", "main", "java")
+		gapicMainDest = filepath.Join(destRoot, coords.GAPIC.ArtifactID, "src", "main")
+		gapicTestDest = filepath.Join(destRoot, coords.GAPIC.ArtifactID, "src", "test")
+	}
+	var actions []moveAction
+	// Collect generated source directories to relocate.
+	if shouldGenerateProto(params.javaAPI) {
+		actions = append(actions, moveAction{src: params.protoDir(), dest: protoDest, description: "proto main source files"})
+	}
+	if shouldGenerateGRPC(params.javaAPI) {
+		actions = append(actions, moveAction{src: params.gRPCDir(), dest: grpcDest, description: "gRPC main source files"})
+	}
+	if shouldGenerateGAPIC(params.javaAPI) {
+		actions = append(actions,
+			moveAction{src: filepath.Join(params.gapicDir(), "src", "main"), dest: gapicMainDest, description: "GAPIC main source files"},
+			moveAction{src: filepath.Join(params.gapicDir(), "src", "test"), dest: gapicTestDest, description: "GAPIC test source files"},
+		)
+	}
+	if shouldGenerateResourceNames(params.javaAPI) {
+		actions = append(actions, moveAction{src: filepath.Join(params.gapicDir(), "proto", "src", "main", "java"), dest: protoDest, description: "resource name source files"})
+	}
+	if params.includeSamples && shouldGenerateGAPIC(params.javaAPI) {
+		actions = append(actions, moveAction{src: filepath.Join(params.gapicDir(), "samples", "snippets", "generated", "src", "main", "java"), dest: filepath.Join(destRoot, "samples", "snippets", "generated"), description: "samples"})
+	}
+	// Relocate all collected source files to their destinations.
+	return ApplyMoveActionsToLibrary(actions, destRoot, keepSet)
+}
+
+// copyProtoFilesToLibrary copies public proto definition (.proto) files from the
+// generator inputs to their target directory structure.
+func copyProtoFilesToLibrary(params postProcessParams, destRoot string) error {
+	if !shouldGenerateProto(params.javaAPI) {
+		return nil
+	}
+	coords := params.coords()
+	var destProtoDir string
+	if params.javaAPI.Monolithic {
+		destProtoDir = filepath.Join(destRoot, "src", "main", "proto")
+	} else {
+		destProtoDir = filepath.Join(destRoot, coords.Proto.ArtifactID, "src", "main", "proto")
+	}
+	if err := copyProtos(params.protosToCopy, destProtoDir); err != nil {
+		return fmt.Errorf("failed to copy proto files: %w", err)
+	}
+	return nil
+}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -574,7 +574,7 @@ func ToKeepSet(keep []string) map[string]bool {
 // It also removes conflicting files, and copies public proto files to the library.
 func RestructureToLibrary(params postProcessParams, destRoot string, keepSet map[string]bool) error {
 	tempProtoSrcDir := params.protoDir()
-	isCommonProtos := params.library != nil && params.library.Name == commonProtosLibrary
+	isCommonProtos := params.library.Name == commonProtosLibrary
 	if !isCommonProtos {
 		if err := removeConflictingFiles(tempProtoSrcDir); err != nil {
 			return err

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -1260,6 +1260,162 @@ func TestApplyMoveActionsToLibrary_NonExistentSource(t *testing.T) {
 	}
 }
 
+func TestRestructureToLibrary(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name           string
+		monolithic     bool
+		includeSamples bool
+		filesToWrite   map[string]string
+		wantFiles      map[string]string
+	}{
+		{
+			name:           "standard multi-module",
+			monolithic:     false,
+			includeSamples: true,
+			filesToWrite: map[string]string{
+				"v1/gapic/src/main/java/Foo.java":                               "class Foo {}",
+				"v1/gapic/src/test/FooTest.java":                                "class FooTest {}",
+				"v1/proto/com/google/cloud/test/v1/BarProto.java":               "class BarProto {}",
+				"v1/grpc/com/google/cloud/test/v1/BarGrpc.java":                 "class BarGrpc {}",
+				"v1/gapic/proto/src/main/java/Resource.java":                    "class Resource {}",
+				"v1/gapic/samples/snippets/generated/src/main/java/Sample.java": "class Sample {}",
+			},
+			wantFiles: map[string]string{
+				"proto-google-cloud-test-v1/src/main/java/com/google/cloud/test/v1/BarProto.java": "class BarProto {}",
+				"grpc-google-cloud-test-v1/src/main/java/com/google/cloud/test/v1/BarGrpc.java":   "class BarGrpc {}",
+				"proto-google-cloud-test-v1/src/main/java/Resource.java":                          "class Resource {}",
+				"google-cloud-test/src/main/java/Foo.java":                                        "class Foo {}",
+				"google-cloud-test/src/test/FooTest.java":                                         "class FooTest {}",
+				"samples/snippets/generated/Sample.java":                                          "class Sample {}",
+			},
+		},
+		{
+			name:           "monolithic library",
+			monolithic:     true,
+			includeSamples: false,
+			filesToWrite: map[string]string{
+				"v1/gapic/src/main/java/Gapic.java": "class Gapic {}",
+				"v1/grpc/Grpc.java":                 "class Grpc {}",
+				"v1/proto/Proto.java":               "class Proto {}",
+			},
+			wantFiles: map[string]string{
+				"src/main/java/Gapic.java": "class Gapic {}",
+				"src/main/java/Grpc.java":  "class Grpc {}",
+				"src/main/java/Proto.java": "class Proto {}",
+			},
+		},
+		{
+			name:           "samples disabled",
+			monolithic:     false,
+			includeSamples: false,
+			filesToWrite: map[string]string{
+				"v1/gapic/src/main/java/Foo.java":                               "class Foo {}",
+				"v1/gapic/samples/snippets/generated/src/main/java/Sample.java": "class Sample {}",
+			},
+			wantFiles: map[string]string{
+				"google-cloud-test/src/main/java/Foo.java": "class Foo {}",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srcDir := t.TempDir()
+			destDir := t.TempDir()
+			writeFiles(t, srcDir, tc.filesToWrite)
+			library := &config.Library{
+				Name: "test-lib",
+				APIs: []*config.API{{Path: "google/cloud/test/v1", Java: &config.JavaAPI{Monolithic: tc.monolithic}}},
+				Java: &config.JavaModule{GroupID: "com.google.cloud", ArtifactID: "google-cloud-test"},
+			}
+			params := postProcessParams{
+				cfg:            &config.Config{},
+				library:        library,
+				javaAPI:        library.APIs[0].Java,
+				outDir:         srcDir,
+				includeSamples: tc.includeSamples,
+				apiBase:        "v1",
+			}
+			if err := RestructureToLibrary(params, destDir, nil); err != nil {
+				t.Fatal(err)
+			}
+			gotFiles := readDirFiles(t, destDir)
+			if diff := cmp.Diff(tc.wantFiles, gotFiles); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestRestructureToLibrary_OverwritesExistingFiles verifies that existing files in the destination are overwritten.
+func TestRestructureToLibrary_OverwritesExistingFiles(t *testing.T) {
+	t.Parallel()
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
+	writeFiles(t, srcDir, map[string]string{
+		"v1/gapic/src/main/java/Foo.java": "class Foo { /* new content */ }",
+	})
+	writeFiles(t, destDir, map[string]string{
+		"google-cloud-test/src/main/java/Foo.java": "class Foo { /* old content */ }",
+	})
+	library := &config.Library{
+		Name: "test-lib",
+		APIs: []*config.API{{Path: "google/cloud/test/v1", Java: &config.JavaAPI{}}},
+		Java: &config.JavaModule{GroupID: "com.google.cloud", ArtifactID: "google-cloud-test"},
+	}
+	params := postProcessParams{
+		cfg:            &config.Config{},
+		library:        library,
+		javaAPI:        library.APIs[0].Java,
+		outDir:         srcDir,
+		includeSamples: false,
+		apiBase:        "v1",
+	}
+	// Pass nil keepSet to expect default overwriting of conflicting files.
+	if err := RestructureToLibrary(params, destDir, nil); err != nil {
+		t.Fatal(err)
+	}
+	gotFiles := readDirFiles(t, destDir)
+	wantFiles := map[string]string{
+		"google-cloud-test/src/main/java/Foo.java": "class Foo { /* new content */ }",
+	}
+	if diff := cmp.Diff(wantFiles, gotFiles); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRestructureToLibrary_CommonProtos(t *testing.T) {
+	t.Parallel()
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
+	writeFiles(t, srcDir, map[string]string{
+		"v1/proto/com/google/cloud/location/LocationsProto.java": "class LocationsProto {}",
+	})
+	library := &config.Library{
+		Name: commonProtosLibrary,
+		APIs: []*config.API{{Path: "google/cloud/test/v1", Java: &config.JavaAPI{ProtoArtifactIDOverride: "proto-google-common-protos"}}},
+		Java: &config.JavaModule{GroupID: "com.google.cloud", ArtifactID: "google-cloud-" + commonProtosLibrary},
+	}
+	params := postProcessParams{
+		cfg:            &config.Config{},
+		library:        library,
+		javaAPI:        library.APIs[0].Java,
+		outDir:         srcDir,
+		includeSamples: false,
+		apiBase:        "v1",
+	}
+	if err := RestructureToLibrary(params, destDir, nil); err != nil {
+		t.Fatal(err)
+	}
+	gotFiles := readDirFiles(t, destDir)
+	wantFiles := map[string]string{
+		"proto-google-common-protos/src/main/java/com/google/cloud/location/LocationsProto.java": "class LocationsProto {}",
+	}
+	if diff := cmp.Diff(wantFiles, gotFiles); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func writeFiles(t *testing.T, dir string, files map[string]string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0755); err != nil {


### PR DESCRIPTION
Add RestructureToLibrary helper function to reorganize and relocate generated Java source files (GAPIC, proto, gRPC, and samples) from intermediate directories into target library directories. It also handles conflicting file cleanup and copying of public proto files.

For #6516