### PR TITLE
ci(.github): add ci for ruby package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests and check coverage
         run: |
           go run ./tool/cmd/coverage -target=80 \
-            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|php|python|rust|swift)|internal/sidekick|internal/sample|internal/testhelper')
+            $(go list ./... | grep -v -E 'github.com/googleapis/librarian$|internal/librarian/(dart|golang|java|nodejs|php|python|ruby|rust|swift)|internal/sidekick|internal/sample|internal/testhelper')
   create-issue-on-failure:
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -26,4 +26,4 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
       - name: Run tests
-        run: go run ./tool/cmd/coverage ./internal/librarian/ruby
+        run: go run ./tool/cmd/coverage -target=60 ./internal/librarian/ruby

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -26,4 +26,4 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
       - name: Run tests
-        run: go run ./tool/cmd/coverage -target=60 ./internal/librarian/ruby
+        run: go run ./tool/cmd/coverage ./internal/librarian/ruby

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Ruby
+on: [push, pull_request, merge_group]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-librarian
+      - name: Run tests
+        run: go run ./tool/cmd/coverage ./internal/librarian/ruby

--- a/tool/cmd/coverage/main.go
+++ b/tool/cmd/coverage/main.go
@@ -50,7 +50,7 @@ var targets = map[string]float64{
 	// TODO(https://github.com/googleapis/librarian/issues/6705: raise to 80.
 	"internal/librarian/php": 60,
 	// TODO(https://github.com/googleapis/librarian/issues/6759): raise to 80.
-	"internal/librarian/ruby": 60,
+	"internal/librarian/ruby": 65,
 }
 
 func main() {

--- a/tool/cmd/coverage/main.go
+++ b/tool/cmd/coverage/main.go
@@ -49,6 +49,8 @@ var targets = map[string]float64{
 	"internal/librarian/nodejs": 73,
 	// TODO(https://github.com/googleapis/librarian/issues/6705: raise to 80.
 	"internal/librarian/php": 60,
+	// TODO(https://github.com/googleapis/librarian/issues/6759): raise to 80.
+	"internal/librarian/ruby": 60,
 }
 
 func main() {


### PR DESCRIPTION
Add CI for ruby package. Set the coverage target to 65% since we are in active development phase.

Fixes https://github.com/googleapis/librarian/issues/6760