### PR TITLE
refactor(internal/tool/gem): specify bindir and install-dir for gem installation

### DIFF
--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -39,7 +39,15 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err := verify(tools); err != nil {
 		return err
 	}
-	if err := gem.Install(ctx, tools.Gem); err != nil {
+	binDir, err := binDir()
+	if err != nil {
+		return err
+	}
+	libDir, err := libDir()
+	if err != nil {
+		return err
+	}
+	if err := gem.Install(ctx, tools.Gem, binDir, libDir); err != nil {
 		return err
 	}
 	return nil
@@ -65,6 +73,15 @@ func binDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(installDir, "bin"), nil
+}
+
+// libDir returns the directory where gem assets are stored.
+func libDir() (string, error) {
+	installDir, err := InstallDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(installDir, "lib"), nil
 }
 
 func verify(tools *config.Tools) error {

--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -39,18 +39,11 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err := verify(tools); err != nil {
 		return err
 	}
-	binDir, err := binDir()
+	binDir, libDir, err := binAndLibDir()
 	if err != nil {
 		return err
 	}
-	libDir, err := libDir()
-	if err != nil {
-		return err
-	}
-	if err := gem.Install(ctx, tools.Gem, binDir, libDir); err != nil {
-		return err
-	}
-	return nil
+	return gem.Install(ctx, tools.Gem, binDir, libDir)
 }
 
 // InstallDir gets the directory where tools should be installed.
@@ -66,22 +59,13 @@ func InstallDir() (string, error) {
 	return absDir, nil
 }
 
-// binDir returns the directory where Ruby tool executables are stored.
-func binDir() (string, error) {
+// binAndLibDir returns the directory where Gem wrapper and asset are stored.
+func binAndLibDir() (string, string, error) {
 	installDir, err := InstallDir()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return filepath.Join(installDir, "bin"), nil
-}
-
-// libDir returns the directory where gem assets are stored.
-func libDir() (string, error) {
-	installDir, err := InstallDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(installDir, "lib"), nil
+	return filepath.Join(installDir, "bin"), filepath.Join(installDir, "lib"), nil
 }
 
 func verify(tools *config.Tools) error {

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -15,8 +15,8 @@
 package ruby
 
 import (
-	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,6 +25,8 @@ import (
 )
 
 func TestInstall(t *testing.T) {
+	libBinDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", libBinDir)
 	stubDir := t.TempDir()
 	gemStubPath := filepath.Join(stubDir, "gem")
 	recordFile := filepath.Join(t.TempDir(), "calls.txt")
@@ -48,9 +50,11 @@ func TestInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read call records: %v", err)
 	}
-	want := []byte("install gapic-generator -v 1.2.3 --no-document\n")
-	if !bytes.Equal(data, want) {
-		t.Errorf("gem called with = %q, want %q", data, want)
+	expectedBinDir := filepath.Join(libBinDir, "ruby_tools", "bin")
+	expectedLibDir := filepath.Join(libBinDir, "ruby_tools", "lib")
+	want := fmt.Sprintf("install gapic-generator -v 1.2.3 --bindir %s --install-dir %s --no-document\n", expectedBinDir, expectedLibDir)
+	if got := string(data); got != want {
+		t.Errorf("gem called with = %q, want %q", got, want)
 	}
 }
 

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -71,16 +71,20 @@ func TestInstallDir(t *testing.T) {
 	}
 }
 
-func TestBinDir(t *testing.T) {
+func TestBinAndLibDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("LIBRARIAN_BIN", dir)
-	got, err := binDir()
+	gotBin, gotLib, err := binAndLibDir()
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join(dir, "ruby_tools", "bin")
-	if got != want {
-		t.Errorf("binDir() = %q, want %q", got, want)
+	wantBin := filepath.Join(dir, "ruby_tools", "bin")
+	if gotBin != wantBin {
+		t.Errorf("binAndLibDir() bin = %q, want %q", gotBin, wantBin)
+	}
+	wantLib := filepath.Join(dir, "ruby_tools", "lib")
+	if gotLib != wantLib {
+		t.Errorf("binAndLibDir() lib = %q, want %q", gotLib, wantLib)
 	}
 }
 

--- a/internal/tool/gem/gem.go
+++ b/internal/tool/gem/gem.go
@@ -32,6 +32,8 @@ var (
 )
 
 // Install installs a list of gem tools into the environment.
+// TODO(https://github.com/googleapis/librarian/issues/6762): Verify gem, bin, and lib
+// are valid before installation.
 func Install(ctx context.Context, tools []*config.GemTool, binDir, libDir string) error {
 	for _, tool := range tools {
 		if tool.Name == "" || tool.Version == "" {

--- a/internal/tool/gem/gem.go
+++ b/internal/tool/gem/gem.go
@@ -32,14 +32,21 @@ var (
 )
 
 // Install installs a list of gem tools into the environment.
-func Install(ctx context.Context, tools []*config.GemTool) error {
+func Install(ctx context.Context, tools []*config.GemTool, binDir, libDir string) error {
 	for _, tool := range tools {
 		if tool.Name == "" || tool.Version == "" {
 			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidGem, tool)
 		}
 		// Skip the generation of the local documentation to make installation faster
 		// and use less disk space.
-		args := []string{"install", tool.Name, "-v", tool.Version, "--no-document"}
+		args := []string{
+			"install",
+			tool.Name,
+			"-v", tool.Version,
+			"--bindir", binDir,
+			"--install-dir", libDir,
+			"--no-document",
+		}
 		if err := command.RunStreaming(ctx, "gem", args...); err != nil {
 			return fmt.Errorf("%w: %w", errInstall, err)
 		}

--- a/internal/tool/gem/gem.go
+++ b/internal/tool/gem/gem.go
@@ -39,14 +39,14 @@ func Install(ctx context.Context, tools []*config.GemTool, binDir, libDir string
 		if tool.Name == "" || tool.Version == "" {
 			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidGem, tool)
 		}
-		// Skip the generation of the local documentation to make installation faster
-		// and use less disk space.
 		args := []string{
 			"install",
 			tool.Name,
 			"-v", tool.Version,
 			"--bindir", binDir,
 			"--install-dir", libDir,
+			// Skip the generation of the local documentation to make installation faster
+			// and use less disk space.
 			"--no-document",
 		}
 		if err := command.RunStreaming(ctx, "gem", args...); err != nil {

--- a/internal/tool/gem/gem_test.go
+++ b/internal/tool/gem/gem_test.go
@@ -41,6 +41,8 @@ echo "gem $@" >> %q
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)
+	binDir := "/tmp/bin"
+	libDir := "/tmp/lib"
 	for _, test := range []struct {
 		name    string
 		tools   []*config.GemTool
@@ -51,7 +53,7 @@ echo "gem $@" >> %q
 			tools: []*config.GemTool{
 				{Name: "rubocop", Version: "1.50.0"},
 			},
-			wantLog: "gem install rubocop -v 1.50.0 --no-document",
+			wantLog: "gem install rubocop -v 1.50.0 --bindir /tmp/bin --install-dir /tmp/lib --no-document",
 		},
 		{
 			name: "install multiple gems",
@@ -59,7 +61,8 @@ echo "gem $@" >> %q
 				{Name: "rubocop", Version: "1.50.0"},
 				{Name: "rake", Version: "13.0.6"},
 			},
-			wantLog: "gem install rubocop -v 1.50.0 --no-document\ngem install rake -v 13.0.6 --no-document",
+			wantLog: `gem install rubocop -v 1.50.0 --bindir /tmp/bin --install-dir /tmp/lib --no-document
+gem install rake -v 13.0.6 --bindir /tmp/bin --install-dir /tmp/lib --no-document`,
 		},
 		{
 			name:    "empty or nil tools",
@@ -69,7 +72,7 @@ echo "gem $@" >> %q
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_ = os.Remove(stubLogPath)
-			if err := Install(t.Context(), test.tools); err != nil {
+			if err := Install(t.Context(), test.tools, binDir, libDir); err != nil {
 				t.Fatal(err)
 			}
 			data, _ := os.ReadFile(stubLogPath)
@@ -127,7 +130,7 @@ func TestInstall_Error(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t)
 			}
-			err := Install(t.Context(), test.tools)
+			err := Install(t.Context(), test.tools, "", "")
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("Install() error = %v, wantErr = %v", err, test.wantErr)
 			}


### PR DESCRIPTION
The gem installation utility in `internal/tool/gem` is updated to accept explicit binDir and libDir target paths, passing `--bindir` and `--install-dir` flags to the gem CLI. This ensures executable wrapper scripts and gem assets are stored in isolated, predictable subdirectories.

In `internal/librarian/ruby`, helper logic is updated to compute dedicated bin and lib directories under librarian-managed bin directory.

For https://github.com/googleapis/librarian/issues/6634