### PR TITLE
refactor(internal): simplify code using modern Go idioms

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,6 +26,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - modernize
     - staticcheck
     - unparam
     - unused

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -533,7 +533,7 @@ func makeTestContents(t *testing.T) *contents {
 	hasher := sha256.New()
 	var data []byte
 	for i := range 10 {
-		line := []byte(fmt.Sprintf("%08d the quick brown fox jumps over the lazy dog\n", i))
+		line := fmt.Appendf(nil, "%08d the quick brown fox jumps over the lazy dog\n", i)
 		data = append(data, line...)
 		hasher.Write(line)
 	}

--- a/internal/librarian/dart/codec.go
+++ b/internal/librarian/dart/codec.go
@@ -17,6 +17,7 @@ package dart
 import (
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
@@ -120,14 +121,8 @@ func buildCodec(library *config.Library) map[string]string {
 	if dart.SupportsSSE {
 		codec["supports-sse"] = "true"
 	}
-	for key, value := range dart.Packages {
-		codec[key] = value
-	}
-	for key, value := range dart.Prefixes {
-		codec[key] = value
-	}
-	for key, value := range dart.Protos {
-		codec[key] = value
-	}
+	maps.Copy(codec, dart.Packages)
+	maps.Copy(codec, dart.Prefixes)
+	maps.Copy(codec, dart.Protos)
 	return codec
 }

--- a/internal/librarian/golang/clean.go
+++ b/internal/librarian/golang/clean.go
@@ -20,6 +20,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -171,10 +172,8 @@ func cleanGeneratedClientFiles(clientPath, libraryDir string, keepSet map[string
 		if keepSet[relPath] {
 			return nil
 		}
-		for _, file := range generatedClientFiles {
-			if d.Name() == file {
-				return os.Remove(path)
-			}
+		if slices.Contains(generatedClientFiles, d.Name()) {
+			return os.Remove(path)
 		}
 		for _, file := range generatedClientFileSuffixes {
 			if strings.HasSuffix(filepath.Base(path), file) {

--- a/internal/librarian/golang/module.go
+++ b/internal/librarian/golang/module.go
@@ -146,11 +146,11 @@ func DefaultLibraryName(api string) string {
 	api = strings.TrimPrefix(api, apiPrefix)
 	api = strings.TrimPrefix(api, devtoolsAPIPrefix)
 	api = strings.TrimPrefix(api, "google/")
-	idx := strings.Index(api, "/")
-	if idx == -1 {
+	before, _, ok := strings.Cut(api, "/")
+	if !ok {
 		return api
 	}
-	return api[:idx]
+	return before
 }
 
 // DefaultOutput returns the default output directory for a Go library.

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -197,8 +197,8 @@ func readExistingModules(path string) (map[string]bool, error) {
 		return nil, err
 	}
 	modules := make(map[string]bool)
-	lines := bytes.Split(content, []byte("\n"))
-	for _, line := range lines {
+	lines := bytes.SplitSeq(content, []byte("\n"))
+	for line := range lines {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 || bytes.HasPrefix(line, []byte("#")) {
 			continue

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -249,7 +249,7 @@ func TestAdd_VersionsTxt(t *testing.T) {
 				t.Fatal(err)
 			}
 			var gotVersions []string
-			for _, line := range strings.Split(string(content), "\n") {
+			for line := range strings.SplitSeq(string(content), "\n") {
 				line = strings.TrimSpace(line)
 				if line != "" {
 					gotVersions = append(gotVersions, line)
@@ -300,7 +300,7 @@ func TestAdd_ExistingLibrary(t *testing.T) {
 		t.Fatal(err)
 	}
 	var gotVersions []string
-	for _, line := range strings.Split(string(content), "\n") {
+	for line := range strings.SplitSeq(string(content), "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			gotVersions = append(gotVersions, line)

--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -143,9 +143,9 @@ func cleanPath(targetPath, root string, keepSet map[string]bool, useMarker bool)
 		return err
 	}
 	// Remove empty directories in reverse order (bottom-up).
-	for i := len(dirs) - 1; i >= 0; i-- {
-		d := dirs[i]
-		rel, err := filepath.Rel(root, d)
+	for _, v := range slices.Backward(dirs) {
+		d := v
+		rel, err := filepath.Rel(root, v)
 		if err != nil {
 			return err
 		}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -477,12 +477,12 @@ func removeKeptFilesFromStaging(library *config.Library, outDir string) error {
 			return err
 		}
 		relSlash := filepath.ToSlash(relToStaging)
-		i := strings.Index(relSlash, "/")
-		if i == -1 {
+		_, after, ok := strings.Cut(relSlash, "/")
+		if !ok {
 			// Skip the staging root "." and API base directories (e.g., "v1").
 			return nil
 		}
-		keepPath := relSlash[i+1:]
+		keepPath := after
 		if d.IsDir() {
 			if keepSet[keepPath] {
 				destPath := filepath.Join(outDir, keepPath)

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -90,7 +90,7 @@ type readmeData struct {
 	Repo              *repoMetadata
 	Samples           []codeSample
 	MinJavaVersion    int
-	Partials          map[string]interface{}
+	Partials          map[string]any
 	Snippets          map[string]string
 	GroupID           string
 	ArtifactID        string
@@ -334,7 +334,7 @@ func parseRepoShortName(repo string) string {
 }
 
 // loadReadmePartials loads and camel-cases README partials from .readme-partials.yaml.
-func loadReadmePartials(dir string) (map[string]interface{}, error) {
+func loadReadmePartials(dir string) (map[string]any, error) {
 	if dir == "" {
 		return nil, errEmptyDir
 	}
@@ -348,14 +348,14 @@ func loadReadmePartials(dir string) (map[string]interface{}, error) {
 	if len(partialsBytes) == 0 {
 		return nil, nil
 	}
-	rawPartials, err := yaml.Unmarshal[map[string]interface{}](partialsBytes)
+	rawPartials, err := yaml.Unmarshal[map[string]any](partialsBytes)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to unmarshal partials: %w", errInvalidYAML, err)
 	}
 	if rawPartials == nil || len(*rawPartials) == 0 {
 		return nil, nil
 	}
-	result := make(map[string]interface{}, len(*rawPartials))
+	result := make(map[string]any, len(*rawPartials))
 	for k, v := range *rawPartials {
 		result[toCamelCase(k)] = v
 	}

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -593,7 +593,7 @@ func TestLoadReadmePartials(t *testing.T) {
 	for _, test := range []struct {
 		name       string
 		setupFiles func(t *testing.T, dir string)
-		want       map[string]interface{}
+		want       map[string]any
 	}{
 		{
 			name: "loads yaml partials with camel case conversion",
@@ -604,7 +604,7 @@ func TestLoadReadmePartials(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			want: map[string]interface{}{"AboutText": "Custom about"},
+			want: map[string]any{"AboutText": "Custom about"},
 		},
 		{
 			name: "missing partials file returns nil",

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -203,7 +203,7 @@ func mergeSwiftDependencies(defaults, lib []config.SwiftDependency) []config.Swi
 func mergeDartDependencies(libDeps, defaultDeps string) string {
 	seen := make(map[string]bool)
 	var deps []string
-	for _, dep := range strings.Split(libDeps, ",") {
+	for dep := range strings.SplitSeq(libDeps, ",") {
 		dep = strings.TrimSpace(dep)
 		if dep == "" {
 			continue
@@ -211,7 +211,7 @@ func mergeDartDependencies(libDeps, defaultDeps string) string {
 		seen[dep] = true
 		deps = append(deps, dep)
 	}
-	for _, dep := range strings.Split(defaultDeps, ",") {
+	for dep := range strings.SplitSeq(defaultDeps, ",") {
 		dep = strings.TrimSpace(dep)
 		if dep == "" || seen[dep] {
 			continue

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -426,7 +426,7 @@ func restoreCopyrightYear(outDir, year string) error {
 		return nil
 	}
 	re := regexp.MustCompile(`Copyright \d{4} Google`)
-	replacement := []byte(fmt.Sprintf("Copyright %s Google", year))
+	replacement := fmt.Appendf(nil, "Copyright %s Google", year)
 	for _, dir := range []string{"src", "test"} {
 		d := filepath.Join(outDir, dir)
 		if _, err := os.Stat(d); err != nil {

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -559,8 +559,8 @@ func deriveGAPICName(path string) string {
 func findOption(options []string, name string) (string, bool) {
 	prefix := name + "="
 	for _, candidate := range options {
-		if strings.HasPrefix(candidate, prefix) {
-			return strings.TrimPrefix(candidate, prefix), true
+		if after, ok := strings.CutPrefix(candidate, prefix); ok {
+			return after, true
 		}
 	}
 	return "", false

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -44,13 +44,6 @@ func absPath(t *testing.T, p string) string {
 	return abs
 }
 
-// ptr() makes it easier to define test data where the values are literals but the required type is a pointer.
-//
-//go:fix inline
-func ptr[T any](v T) *T {
-	return new(v)
-}
-
 func TestLibraryToModelConfig(t *testing.T) {
 	for _, test := range []struct {
 		name             string

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -45,8 +45,10 @@ func absPath(t *testing.T, p string) string {
 }
 
 // ptr() makes it easier to define test data where the values are literals but the required type is a pointer.
+//
+//go:fix inline
 func ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 func TestLibraryToModelConfig(t *testing.T) {
@@ -85,7 +87,7 @@ func TestLibraryToModelConfig(t *testing.T) {
 				Name: "google-cloud-secretmanager",
 				Rust: &config.RustCrate{
 					RustDefault: config.RustDefault{
-						ResourceNameHeuristic: ptr(true),
+						ResourceNameHeuristic: new(true),
 					},
 				},
 			},
@@ -166,8 +168,8 @@ func TestLibraryToModelConfig(t *testing.T) {
 						DisabledRustdocWarnings:   []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:     "true",
 						GenerateRpcSamples:        "true",
-						DetailedTracingAttributes: ptr(true),
-						ResourceNameHeuristic:     ptr(true),
+						DetailedTracingAttributes: new(true),
+						ResourceNameHeuristic:     new(true),
 					},
 					ModulePath:              "gcs",
 					PerServiceFeatures:      true,
@@ -619,7 +621,7 @@ func TestModuleToModelConfig(t *testing.T) {
 				Name: "google-cloud-secretmanager",
 				Rust: &config.RustCrate{
 					RustDefault: config.RustDefault{
-						ResourceNameHeuristic: ptr(false),
+						ResourceNameHeuristic: new(false),
 					},
 				},
 			},
@@ -638,7 +640,7 @@ func TestModuleToModelConfig(t *testing.T) {
 				Name: "google-cloud-secretmanager",
 				Rust: &config.RustCrate{
 					RustDefault: config.RustDefault{
-						ResourceNameHeuristic: ptr(true),
+						ResourceNameHeuristic: new(true),
 					},
 				},
 			},
@@ -1097,7 +1099,7 @@ func TestBuildModuleCodec(t *testing.T) {
 			name:    "with DetailedTracingAttributes set at module level",
 			library: &config.Library{},
 			module: &config.RustModule{
-				DetailedTracingAttributes: ptr(true),
+				DetailedTracingAttributes: new(true),
 			},
 			want: map[string]string{
 				"detailed-tracing-attributes": "true",
@@ -1108,7 +1110,7 @@ func TestBuildModuleCodec(t *testing.T) {
 			library: &config.Library{
 				Rust: &config.RustCrate{
 					RustDefault: config.RustDefault{
-						DetailedTracingAttributes: ptr(true),
+						DetailedTracingAttributes: new(true),
 					},
 				},
 			},
@@ -1122,12 +1124,12 @@ func TestBuildModuleCodec(t *testing.T) {
 			library: &config.Library{
 				Rust: &config.RustCrate{
 					RustDefault: config.RustDefault{
-						DetailedTracingAttributes: ptr(true),
+						DetailedTracingAttributes: new(true),
 					},
 				},
 			},
 			module: &config.RustModule{
-				DetailedTracingAttributes: ptr(false),
+				DetailedTracingAttributes: new(false),
 			},
 			want: map[string]string{},
 		},
@@ -1242,7 +1244,7 @@ func TestBuildModuleCodec(t *testing.T) {
 								Package: "pkg1",
 							},
 						},
-						DetailedTracingAttributes: ptr(false),
+						DetailedTracingAttributes: new(false),
 					},
 				},
 			},
@@ -1252,7 +1254,7 @@ func TestBuildModuleCodec(t *testing.T) {
 				HasVeneer:                 true,
 				IncludeGrpcOnlyMethods:    true,
 				IncludeStreamingMethods:   true,
-				DetailedTracingAttributes: ptr(true),
+				DetailedTracingAttributes: new(true),
 				ModulePath:                "crate::model",
 				NameOverrides:             "a=b",
 				PostProcessProtos:         "post",
@@ -1351,8 +1353,8 @@ func TestBuildCodec(t *testing.T) {
 					RustDefault: config.RustDefault{
 						GenerateSetterSamples:     "true",
 						GenerateRpcSamples:        "true",
-						DetailedTracingAttributes: ptr(true),
-						ResourceNameHeuristic:     ptr(true),
+						DetailedTracingAttributes: new(true),
+						ResourceNameHeuristic:     new(true),
 						DisabledRustdocWarnings:   []string{"warning1", "warning2"},
 						PackageDependencies: []*config.RustPackageDependency{
 							{

--- a/internal/postprocessing/delete.go
+++ b/internal/postprocessing/delete.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -64,8 +65,8 @@ func DeleteMethod(path, funcName, language string) error {
 	if err != nil {
 		return fmt.Errorf("deleting method %s in %s: %w", funcName, path, err)
 	}
-	for i := len(boundsList) - 1; i >= 0; i-- {
-		b := boundsList[i]
+	for _, v := range slices.Backward(boundsList) {
+		b := v
 		data = append(data[:b.start], data[b.end:]...)
 	}
 	return os.WriteFile(path, data, 0644)

--- a/internal/postprocessing/deprecate.go
+++ b/internal/postprocessing/deprecate.go
@@ -130,8 +130,8 @@ func addJavadocTag(lines [][]byte, indentation []byte, header methodHeader, tagN
 		return slices.Insert(lines, header.firstAnnotationIdx, newJavadoc...)
 	}
 	line := bytes.TrimSpace(lines[header.javadocEndIdx])
-	if bytes.HasPrefix(line, []byte("/**")) {
-		inner := bytes.TrimSpace(bytes.TrimSuffix(bytes.TrimPrefix(line, []byte("/**")), []byte("*/")))
+	if after, ok := bytes.CutPrefix(line, []byte("/**")); ok {
+		inner := bytes.TrimSpace(bytes.TrimSuffix(after, []byte("*/")))
 		newJavadoc := makeNewJavadoc(indentation, tagName, tagMessage, inner)
 		return slices.Replace(lines, header.javadocEndIdx, header.javadocEndIdx+1, newJavadoc...)
 	}

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -201,7 +201,7 @@ func Read(libraryOutputDir string) (*RepoMetadata, error) {
 
 // WriteJSON marshals the given data to JSON with indentation and writes it to
 // the specified file in the output directory.
-func WriteJSON(data interface{}, indent, libraryOutputDir, filename string) error {
+func WriteJSON(data any, indent, libraryOutputDir, filename string) error {
 	content, err := json.MarshalIndent(data, "", indent)
 	if err != nil {
 		return fmt.Errorf("failed to marshal metadata to JSON: %w", err)

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -21,11 +21,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-//go:fix inline
-func ptr(i int) *int {
-	return new(i)
-}
-
 func TestParse(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -21,8 +21,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+//go:fix inline
 func ptr(i int) *int {
-	return &i
+	return new(i)
 }
 
 func TestParse(t *testing.T) {
@@ -50,7 +51,7 @@ func TestParse(t *testing.T) {
 				Patch:               3,
 				Prerelease:          "alpha",
 				PrereleaseSeparator: ".",
-				PrereleaseNumber:    ptr(1),
+				PrereleaseNumber:    new(1),
 				SpecVersion:         SpecV2,
 			},
 		},
@@ -62,7 +63,7 @@ func TestParse(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "beta",
-				PrereleaseNumber: ptr(21),
+				PrereleaseNumber: new(21),
 				SpecVersion:      SpecV1,
 			},
 		},
@@ -95,7 +96,7 @@ func TestParse(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "alpha",
-				PrereleaseNumber: ptr(1),
+				PrereleaseNumber: new(1),
 				SpecVersion:      SpecV1,
 			},
 		},
@@ -107,7 +108,7 @@ func TestParse(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "beta",
-				PrereleaseNumber: ptr(2),
+				PrereleaseNumber: new(2),
 				SpecVersion:      SpecV1,
 			},
 		},
@@ -119,7 +120,7 @@ func TestParse(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "rc",
-				PrereleaseNumber: ptr(3),
+				PrereleaseNumber: new(3),
 				SpecVersion:      SpecV1,
 			},
 		},
@@ -131,7 +132,7 @@ func TestParse(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "preview",
-				PrereleaseNumber: ptr(4),
+				PrereleaseNumber: new(4),
 				SpecVersion:      SpecV1,
 			},
 		},
@@ -143,7 +144,7 @@ func TestParse(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "a",
-				PrereleaseNumber: ptr(5),
+				PrereleaseNumber: new(5),
 				SpecVersion:      SpecV1,
 			},
 		},
@@ -155,7 +156,7 @@ func TestParse(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "b",
-				PrereleaseNumber: ptr(6),
+				PrereleaseNumber: new(6),
 				SpecVersion:      SpecV1,
 			},
 		},
@@ -286,7 +287,7 @@ func TestVersion_String(t *testing.T) {
 				Patch:               3,
 				Prerelease:          "alpha",
 				PrereleaseSeparator: ".",
-				PrereleaseNumber:    ptr(1),
+				PrereleaseNumber:    new(1),
 			},
 			expected: "1.2.3-alpha.1",
 		},
@@ -297,7 +298,7 @@ func TestVersion_String(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "beta",
-				PrereleaseNumber: ptr(21),
+				PrereleaseNumber: new(21),
 				SpecVersion:      SpecV1,
 			},
 			expected: "1.2.3-beta21",
@@ -309,7 +310,7 @@ func TestVersion_String(t *testing.T) {
 				Minor:            2,
 				Patch:            3,
 				Prerelease:       "beta",
-				PrereleaseNumber: ptr(2),
+				PrereleaseNumber: new(2),
 				SpecVersion:      SpecV1,
 			},
 			expected: "1.2.3-beta02",

--- a/internal/sidekick/api/discovery.go
+++ b/internal/sidekick/api/discovery.go
@@ -70,7 +70,7 @@ func (d *Discovery) LroServices() map[string]bool {
 // poll the operation. This method returns that subset.
 func (p *Poller) PathParameters() []string {
 	var parameters []string
-	for _, segment := range strings.Split(p.Prefix, "/") {
+	for segment := range strings.SplitSeq(p.Prefix, "/") {
 		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
 			parameters = append(parameters, segment[1:len(segment)-1])
 		}

--- a/internal/sidekick/api/resource_identification.go
+++ b/internal/sidekick/api/resource_identification.go
@@ -83,8 +83,8 @@ func identifyHeuristicTarget(method *Method, binding *PathBinding, vocabulary ma
 	}
 
 	// Iterate backwards over segments
-	for i := len(tmpl.Segments) - 1; i >= 0; i-- {
-		seg := tmpl.Segments[i]
+	for i, v := range slices.Backward(tmpl.Segments) {
+		seg := v
 		if seg.Variable == nil || i == 0 || tmpl.Segments[i-1].Literal == "" {
 			continue
 		}

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -14,6 +14,8 @@
 
 package api
 
+import "slices"
+
 import "strings"
 
 // BuildHeuristicVocabulary builds the vocabulary of valid resource tokens
@@ -85,8 +87,8 @@ func BuildHeuristicVocabulary(model *API) map[string]bool {
 			}
 
 			// Iterate backwards.
-			for i := len(tmpl.Segments) - 1; i >= 0; i-- {
-				seg := tmpl.Segments[i]
+			for i, v := range slices.Backward(tmpl.Segments) {
+				seg := v
 				if seg.Variable != nil {
 					if i > 0 && tmpl.Segments[i-1].Literal != "" {
 						token := tmpl.Segments[i-1].Literal

--- a/internal/sidekick/api/resource_name_heuristic.go
+++ b/internal/sidekick/api/resource_name_heuristic.go
@@ -14,9 +14,10 @@
 
 package api
 
-import "slices"
-
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // BuildHeuristicVocabulary builds the vocabulary of valid resource tokens
 // based on the last literal before a variable in Get/List methods.

--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -567,8 +567,8 @@ func calculateImports(imports map[string]bool, curPkgName string, curMainFileNam
 			dartImports = append(dartImports, formatImport(imp))
 			continue
 		} else if scheme == "package" {
-			if strings.HasPrefix(body, curPkgName+"/") {
-				pathAndAlias := strings.TrimPrefix(body, curPkgName+"/")
+			if after, ok := strings.CutPrefix(body, curPkgName+"/"); ok {
+				pathAndAlias := after
 
 				pathOnly := strings.Split(pathAndAlias, " ")[0]
 				if pathOnly == curMainFileName {

--- a/internal/sidekick/parser/openapi.go
+++ b/internal/sidekick/parser/openapi.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/serviceconfig"
@@ -384,13 +385,7 @@ func makeMessageFields(model *api.API, packageName, messageName string, message 
 		if err != nil {
 			return nil, err
 		}
-		optional := true
-		for _, r := range message.Required {
-			if name == r {
-				optional = false
-				break
-			}
-		}
+		optional := !slices.Contains(message.Required, name)
 		field, err := makeField(model, packageName, messageName, name, optional, schema)
 		if err != nil {
 			return nil, err

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -129,7 +129,7 @@ func loadDescriptorSet(descriptorFiles string) ([]*descriptorpb.FileDescriptorPr
 
 func parseCommaSeparatedList(s string) []string {
 	var list []string
-	for _, f := range strings.Split(s, ",") {
+	for f := range strings.SplitSeq(s, ",") {
 		if f = strings.TrimSpace(f); f != "" {
 			list = append(list, f)
 		}

--- a/internal/sidekick/parser/protobuf_annotations.go
+++ b/internal/sidekick/parser/protobuf_annotations.go
@@ -17,6 +17,7 @@ package parser
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
@@ -192,11 +193,5 @@ func protobufIsAutoPopulated(field *descriptorpb.FieldDescriptorProto) bool {
 		return true
 	}
 	fieldBehavior := proto.GetExtension(field.GetOptions(), extensionId).([]fieldBehavior)
-	for _, b := range fieldBehavior {
-		if b == fieldBehaviorRequired {
-			return false
-		}
-	}
-
-	return true
+	return !slices.Contains(fieldBehavior, fieldBehaviorRequired)
 }

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -456,16 +456,17 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method) (*bindingSubsti
 	if err != nil {
 		return nil, err
 	}
-	fieldAccessor := "Some(&req)"
+	var fieldAccessor strings.Builder
+	fieldAccessor.WriteString("Some(&req)")
 	for _, a := range accessors {
-		fieldAccessor += a
+		fieldAccessor.WriteString(a)
 	}
 	var rustNames []string
 	for _, n := range v.FieldPath {
 		rustNames = append(rustNames, toSnakeNoMangling(n))
 	}
 	binding := &bindingSubstitution{
-		FieldAccessor: fieldAccessor,
+		FieldAccessor: fieldAccessor.String(),
 		FieldName:     strings.Join(rustNames, "."),
 		Template:      v.Segments,
 	}
@@ -571,11 +572,12 @@ func (c *codec) annotateResourceNameGeneration(m *api.Method, annotation *method
 				if err != nil {
 					return err
 				}
-				fieldAccessor := "Some(&req)"
+				var fieldAccessor strings.Builder
+				fieldAccessor.WriteString("Some(&req)")
 				for _, a := range accessors {
-					fieldAccessor += a
+					fieldAccessor.WriteString(a)
 				}
-				grpcArgs = append(grpcArgs, fieldAccessor)
+				grpcArgs = append(grpcArgs, fieldAccessor.String())
 			}
 			annotation.GrpcResourceNameArgs = grpcArgs
 

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -205,11 +205,11 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		return ""
 	}()
 	defaultHostShort := func() string {
-		idx := strings.Index(defaultHost, ".")
-		if idx == -1 {
+		before, _, ok := strings.Cut(defaultHost, ".")
+		if !ok {
 			return defaultHost
 		}
-		return defaultHost[:idx]
+		return before
 	}()
 
 	var quickstartService *api.Service

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -84,7 +84,7 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 			codec.packageNameOverride = definition
 		case key == "name-overrides":
 			codec.nameOverrides = make(map[string]string)
-			for _, override := range strings.Split(definition, ",") {
+			for override := range strings.SplitSeq(definition, ",") {
 				tokens := strings.Split(override, "=")
 				if len(tokens) != 2 {
 					return nil, fmt.Errorf("cannot parse `name-overrides`. Expected input in the form of: 'n1=r1,n2=r2': %q", definition)
@@ -218,7 +218,7 @@ func parsePackageOption(key, definition string) (*packageOption, error) {
 	pkg := &packagez{
 		name: strings.TrimPrefix(key, "package:"),
 	}
-	for _, element := range strings.Split(definition, ",") {
+	for element := range strings.SplitSeq(definition, ",") {
 		s := strings.SplitN(element, "=", 2)
 		if len(s) != 2 {
 			return nil, fmt.Errorf("the definition for package %q should be a comma-separated list of key=value pairs, got=%q", key, definition)
@@ -1062,8 +1062,8 @@ func escapeUrls(line string) string {
 			lastIndex = match[1]
 		} else {
 			escapedLine.WriteString(line[lastIndex:match[0]])
-			if strings.HasSuffix(url, ".") {
-				fmt.Fprintf(&escapedLine, "<%s>.", strings.TrimSuffix(url, "."))
+			if before, ok := strings.CutSuffix(url, "."); ok {
+				fmt.Fprintf(&escapedLine, "<%s>.", before)
 			} else {
 				fmt.Fprintf(&escapedLine, "<%s>", url)
 			}

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -125,7 +125,7 @@ func addGeneratedCrate(t *testing.T, location, name string) {
 func AddCrate(t *testing.T, location, name string) {
 	t.Helper()
 	_ = os.MkdirAll(path.Join(location, "src"), 0755)
-	contents := []byte(fmt.Sprintf(InitialCargoContents, name))
+	contents := fmt.Appendf(nil, InitialCargoContents, name)
 	if err := os.WriteFile(path.Join(location, "Cargo.toml"), contents, 0644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Refactor code across internal packages to adopt standard library helper functions and modern Go features.

The change is generated by:
1. enable `modernize` in `.golangci.yaml`.
2. run `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --fix`

Fixes https://github.com/googleapis/librarian/issues/6764