### PR TITLE
fix(librarian/rust): detect inconsistent repos

### DIFF
--- a/internal/librarian/rust/crate_exists.go
+++ b/internal/librarian/rust/crate_exists.go
@@ -48,6 +48,8 @@ func crateExists(output string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// The production version of `Cargo.toml` is always formatted with `taplo
+	// fmt`. That guarantees the entries will follow this strict format.
 	hasCargoEntry := bytes.Contains(contents, fmt.Appendf(nil, "\n  \"%s\",\n", output))
 	if !hasCargoEntry && hasDirectory {
 		return false, fmt.Errorf("inconsistent repository state, crate missing in Cargo.toml, but the directory exists: %s", output)

--- a/internal/librarian/rust/crate_exists.go
+++ b/internal/librarian/rust/crate_exists.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// crateExists determines if a crate (the Rust mapping for "library") exists.
+//
+// Once a crate is generated the following things are true:
+// - The output directory exists
+// - The output directory is listed in the top-level Cargo.toml file
+//
+// If none of those things are true, it is safe to assume the crate is a new
+// crate and to execute the commands to add the crate to the repository. If
+// both are true, then we can skip the commands to add the crate.
+//
+// If one of them is true, but not the other, then there is an error in the
+// repository configuration that requires human intervention.
+func crateExists(output string) (bool, error) {
+	hasDirectory := true
+	if _, err := os.Stat(output); err != nil {
+		hasDirectory = false
+		if !errors.Is(err, fs.ErrNotExist) {
+			return false, fmt.Errorf("cannot access output directory %q: %w", output, err)
+		}
+	}
+	// The librarian commands are always executed at the top-level directory of
+	// the monorepo.
+	contents, err := os.ReadFile("Cargo.toml")
+	if err != nil {
+		return false, err
+	}
+	hasCargoEntry := bytes.Contains(contents, fmt.Appendf(nil, "\n  \"%s\",\n", output))
+	if !hasCargoEntry && hasDirectory {
+		return false, fmt.Errorf("inconsistent repository state, crate missing in Cargo.toml, but the directory exists: %s", output)
+	}
+	if hasCargoEntry && !hasDirectory {
+		return false, fmt.Errorf("inconsistent repository state, crate listed in Cargo.toml, but the directory is missing: %s", output)
+	}
+	return hasDirectory && hasCargoEntry, nil
+}

--- a/internal/librarian/rust/crate_exists_test.go
+++ b/internal/librarian/rust/crate_exists_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+const formatTestCargoToml = `
+[workspace]
+resolver = "3"
+
+members = [
+ "src/auth",
+%s
+]
+`
+
+func TestCrateExists(t *testing.T) {
+	const testDir = "src/generated/test/service/v1"
+	for _, test := range []struct {
+		name       string
+		cargoText  string
+		makeDir    string
+		wantErr    bool
+		wantResult bool
+	}{
+		{
+			name:       "exists",
+			cargoText:  fmt.Sprintf(`  "%s",`, testDir),
+			makeDir:    testDir,
+			wantErr:    false,
+			wantResult: true,
+		},
+		{
+			name:       "not exists",
+			cargoText:  `  "src/generated/test/service/v2",`,
+			makeDir:    "src/generated/test/service/v2",
+			wantErr:    false,
+			wantResult: false,
+		},
+		{
+			name:       "only directory",
+			cargoText:  `  "bad-bad-bad",`,
+			makeDir:    testDir,
+			wantErr:    true,
+			wantResult: false,
+		},
+		{
+			name:       "only entry",
+			cargoText:  fmt.Sprintf(`  "%s",`, testDir),
+			makeDir:    "src/generated",
+			wantErr:    true,
+			wantResult: false,
+		},
+		{
+			name:       "entry is substring",
+			cargoText:  `  "src/generated/test/service/v1/weird/but/should/test",`,
+			makeDir:    testDir,
+			wantErr:    true,
+			wantResult: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			d := t.TempDir()
+			t.Chdir(d)
+			if err := os.MkdirAll(test.makeDir, 0775); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile("Cargo.toml", fmt.Appendf(nil, formatTestCargoToml, test.cargoText), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := crateExists(testDir)
+			if test.wantErr && err == nil {
+				t.Fatalf("crateExists() succeed when an error was expected: %v", got)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("crateExists() failed unexpectedly: %v", err)
+			}
+			if test.wantResult != got {
+				t.Errorf("crateExists() mismatch, want=%v, got=%v", test.wantResult, got)
+			}
+		})
+	}
+}
+
+func TestCrateExistsDirectoryError(t *testing.T) {
+	d := t.TempDir()
+	t.Chdir(d)
+	// Create part of the path, but make it unreadable.
+	if err := os.MkdirAll("src", 0000); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("Cargo.toml", []byte("# test only"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := crateExists("src/generated/unreachable"); err == nil {
+		t.Errorf("expected an error from crateExists(), got=%v", got)
+	}
+}
+
+func TestCrateExistsCargoTomlError(t *testing.T) {
+	d := t.TempDir()
+	t.Chdir(d)
+	// Create part of the path, but make it unreadable.
+	if err := os.MkdirAll("src/generated/test", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := crateExists("src/generated/test"); err == nil {
+		t.Errorf("expected an error from crateExists(), got=%v", got)
+	}
+}

--- a/internal/librarian/rust/crate_exists_test.go
+++ b/internal/librarian/rust/crate_exists_test.go
@@ -36,42 +36,18 @@ func TestCrateExists(t *testing.T) {
 		name       string
 		cargoText  string
 		makeDir    string
-		wantErr    bool
 		wantResult bool
 	}{
 		{
 			name:       "exists",
 			cargoText:  fmt.Sprintf(`  "%s",`, testDir),
 			makeDir:    testDir,
-			wantErr:    false,
 			wantResult: true,
 		},
 		{
 			name:       "not exists",
 			cargoText:  `  "src/generated/test/service/v2",`,
 			makeDir:    "src/generated/test/service/v2",
-			wantErr:    false,
-			wantResult: false,
-		},
-		{
-			name:       "only directory",
-			cargoText:  `  "bad-bad-bad",`,
-			makeDir:    testDir,
-			wantErr:    true,
-			wantResult: false,
-		},
-		{
-			name:       "only entry",
-			cargoText:  fmt.Sprintf(`  "%s",`, testDir),
-			makeDir:    "src/generated",
-			wantErr:    true,
-			wantResult: false,
-		},
-		{
-			name:       "entry is substring",
-			cargoText:  `  "src/generated/test/service/v1/weird/but/should/test",`,
-			makeDir:    testDir,
-			wantErr:    true,
 			wantResult: false,
 		},
 	} {
@@ -85,14 +61,51 @@ func TestCrateExists(t *testing.T) {
 				t.Fatal(err)
 			}
 			got, err := crateExists(testDir)
-			if test.wantErr && err == nil {
-				t.Fatalf("crateExists() succeed when an error was expected: %v", got)
-			}
-			if !test.wantErr && err != nil {
-				t.Fatalf("crateExists() failed unexpectedly: %v", err)
+			if err != nil {
+				t.Fatal(err)
 			}
 			if test.wantResult != got {
 				t.Errorf("crateExists() mismatch, want=%v, got=%v", test.wantResult, got)
+			}
+		})
+	}
+}
+
+func TestCrateExists_Errors(t *testing.T) {
+	const testDir = "src/generated/test/service/v1"
+	for _, test := range []struct {
+		name      string
+		cargoText string
+		makeDir   string
+	}{
+		{
+			name:      "only directory",
+			cargoText: `  "bad-bad-bad",`,
+			makeDir:   testDir,
+		},
+		{
+			name:      "only entry",
+			cargoText: fmt.Sprintf(`  "%s",`, testDir),
+			makeDir:   "src/generated",
+		},
+		{
+			name:      "entry is substring",
+			cargoText: `  "src/generated/test/service/v1/weird/but/should/test",`,
+			makeDir:   testDir,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			d := t.TempDir()
+			t.Chdir(d)
+			if err := os.MkdirAll(test.makeDir, 0775); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile("Cargo.toml", fmt.Appendf(nil, formatTestCargoToml, test.cargoText), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := crateExists(testDir)
+			if err == nil {
+				t.Fatalf("crateExists() succeed when an error was expected: %v", got)
 			}
 		})
 	}

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -16,10 +16,8 @@ package rust
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -73,12 +71,9 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return err
 	}
-	exists := true
-	if _, err := os.Stat(library.Output); err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("cannot access output directory %q: %w", library.Output, err)
-		}
-		exists = false
+	exists, err := crateExists(library.Output)
+	if err != nil {
+		return err
 	}
 	if !exists {
 		if err := create(ctx, library.Output); err != nil {

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -17,6 +17,7 @@ package rust
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -418,15 +419,6 @@ func TestGenerateLibrary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	workspaceDir, err := filepath.Abs("testdata")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		os.RemoveAll(filepath.Join(workspaceDir, "target"))
-		os.Remove(filepath.Join(workspaceDir, "Cargo.lock"))
-	})
 
 	// Mock validate to speed up the test.
 	oldValidate := validate
@@ -447,17 +439,24 @@ func TestGenerateLibrary(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			// Change to testdata directory so cargo fmt can find Cargo.toml
-			t.Chdir(workspaceDir)
+			// Do all the work in a temporary directory, to keep the source
+			// directory unchanged.
+			temp := t.TempDir()
+			t.Chdir(temp)
 
 			libName := "google-cloud-secretmanager-v1"
-			outDir := filepath.Join(workspaceDir, libName)
-
-			if err := os.RemoveAll(outDir); err != nil {
-				t.Fatal(err)
-			}
+			outDir := "src/generated/cloud/secretmanager/v1"
 			if test.preExists {
 				if err := os.MkdirAll(outDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				contents := fmt.Appendf(nil, formatTestCargoToml, fmt.Sprintf(`  "%s",`, outDir))
+				if err := os.WriteFile("Cargo.toml", contents, 0644); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				contents := fmt.Appendf(nil, formatTestCargoToml, "")
+				if err := os.WriteFile("Cargo.toml", contents, 0644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/librarian/rust/testdata/Cargo.toml
+++ b/internal/librarian/rust/testdata/Cargo.toml
@@ -1,5 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 [workspace]
-resolver = "3"
+members = ["google-cloud-secretmanager-v1"]
+resolver = "2"
 
-members = ["google-cloud-secretmanager-v1", "src/auth"]
+[workspace.package]
+edition = "2024"
+authors = ["Google LLC"]
+license = "Apache-2.0"
+repository = "https://github.com/googleapis/google-cloud-rust/tree/main"
+keywords = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
+categories = ["network-programming"]
+rust-version = "1.85.0"
+
+[workspace.dependencies]
+async-trait = "0.1"
+bytes = "1"
+gax = { version = "1", package = "google-cloud-gax" }
+iam_v1 = { version = "1", package = "google-cloud-iam-v1" }
+location = { version = "1", package = "google-cloud-location" }
+reqwest = "0.12"
+serde = "1"
+serde_json = "1"
+serde_with = "3"
+time = "0.3"
+wkt = { version = "1", package = "google-cloud-wkt" }

--- a/internal/librarian/rust/testdata/Cargo.toml
+++ b/internal/librarian/rust/testdata/Cargo.toml
@@ -1,39 +1,5 @@
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 [workspace]
-members = ["google-cloud-secretmanager-v1"]
-resolver = "2"
+resolver = "3"
 
-[workspace.package]
-edition = "2024"
-authors = ["Google LLC"]
-license = "Apache-2.0"
-repository = "https://github.com/googleapis/google-cloud-rust/tree/main"
-keywords = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
-categories = ["network-programming"]
-rust-version = "1.85.0"
-
-[workspace.dependencies]
-async-trait = "0.1"
-bytes = "1"
-gax = { version = "1", package = "google-cloud-gax" }
-iam_v1 = { version = "1", package = "google-cloud-iam-v1" }
-location = { version = "1", package = "google-cloud-location" }
-reqwest = "0.12"
-serde = "1"
-serde_json = "1"
-serde_with = "3"
-time = "0.3"
-wkt = { version = "1", package = "google-cloud-wkt" }
+members = ["google-cloud-secretmanager-v1", "src/auth"]


### PR DESCRIPTION
In Rust, to generate a new library the library needs to be inserted into the top-level `Cargo.toml` file *and* the new directory must be created. If only the directory exists, or only the entry in `Cargo.toml` exist, then the commands to update the state will fail with strange errors.

With this change, the user gets an explicit error and they can take action. I believe it would be unsafe to automatically repair the problem, but maybe with more experience we can figure out some default action to take.