### PR TITLE
feat(internal/librarian/golang): support protoc tool configuration

### DIFF
--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -29,16 +29,12 @@ const envPath = "PATH"
 
 // runProtoc runs the protoc command with the given environment variable and arguments.
 func runProtoc(ctx context.Context, pc *config.Protoc, env map[string]string, args ...string) error {
-	if pc == nil {
-		// Fallback to global protoc if no tool configured.
-		return runWithEnv(ctx, env, "protoc", args...)
-	}
 	// Ensure that the toolchain environment variables are set before calling protoc.
 	env, err := mergeEnv(env)
 	if err != nil {
 		return err
 	}
-	return protoc.Run(ctx, env, pc, args...)
+	return protoc.RunOrSystem(ctx, env, pc, args...)
 }
 
 // runWithEnv runs a command with the given environment.

--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -27,6 +27,7 @@ import (
 
 const envPath = "PATH"
 
+// runProtoc runs the protoc command with the given environment variable and arguments.
 func runProtoc(ctx context.Context, pc *config.Protoc, env map[string]string, args ...string) error {
 	if pc == nil {
 		// Fallback to global protoc if no tool configured.

--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -27,11 +27,13 @@ import (
 
 const envPath = "PATH"
 
-func runProtoc(ctx context.Context, pc *config.Protoc, args ...string) error {
+func runProtoc(ctx context.Context, pc *config.Protoc, env map[string]string, args ...string) error {
 	if pc == nil {
-		return runWithEnv(ctx, nil, "protoc", args...)
+		// Fallback to global protoc if no tool configured.
+		return runWithEnv(ctx, env, "protoc", args...)
 	}
-	env, err := mergeEnv(nil)
+	// Ensure that the toolchain environment variables are set before calling protoc.
+	env, err := mergeEnv(env)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -21,9 +21,22 @@ import (
 	"os"
 
 	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/tool/protoc"
 )
 
 const envPath = "PATH"
+
+func runProtoc(ctx context.Context, pc *config.Protoc, args ...string) error {
+	if pc == nil {
+		return runWithEnv(ctx, nil, "protoc", args...)
+	}
+	env, err := mergeEnv(nil)
+	if err != nil {
+		return err
+	}
+	return protoc.Run(ctx, env, pc, args...)
+}
 
 // runWithEnv runs a command with the given environment.
 func runWithEnv(ctx context.Context, env map[string]string, cmd string, args ...string) error {

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -15,11 +15,14 @@
 package golang
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/cache"
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestMergeEnv(t *testing.T) {
@@ -82,5 +85,58 @@ func TestMergeEnv(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestRunProtoc(t *testing.T) {
+	stubName := "protoc"
+	if runtime.GOOS == "windows" {
+		stubName += ".exe"
+	}
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T) *config.Protoc
+	}{
+		{
+			name: "nil config uses system protoc in PATH",
+			setup: func(t *testing.T) *config.Protoc {
+				stubDir := t.TempDir()
+				createStubExecutable(t, filepath.Join(stubDir, stubName))
+				t.Setenv(envPath, stubDir+string(filepath.ListSeparator)+os.Getenv(envPath))
+				return nil
+			},
+		},
+		{
+			name: "configured protoc uses installed tool",
+			setup: func(t *testing.T) *config.Protoc {
+				binDir := t.TempDir()
+				t.Setenv(cache.EnvLibrarianBin, binDir)
+				version := "25.1"
+				protocPath := filepath.Join(binDir, "protoc", "v"+version, "bin", stubName)
+				createStubExecutable(t, protocPath)
+				return &config.Protoc{Version: version}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pc := test.setup(t)
+			if err := runProtoc(t.Context(), pc, "--version"); err != nil {
+				t.Fatalf("runProtoc() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func createStubExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		content = "@echo off\r\nexit /b 0\r\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -15,9 +15,11 @@
 package golang
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -95,46 +97,56 @@ func TestRunProtoc(t *testing.T) {
 	}
 	for _, test := range []struct {
 		name  string
-		setup func(t *testing.T) *config.Protoc
+		setup func(t *testing.T, recordFile string) (*config.Protoc, string)
 	}{
 		{
 			name: "nil config uses system protoc in PATH",
-			setup: func(t *testing.T) *config.Protoc {
+			setup: func(t *testing.T, recordFile string) (*config.Protoc, string) {
 				stubDir := t.TempDir()
-				createStubExecutable(t, filepath.Join(stubDir, stubName))
+				path := filepath.Join(stubDir, stubName)
+				createStubExecutable(t, path, recordFile)
 				t.Setenv(envPath, stubDir+string(filepath.ListSeparator)+os.Getenv(envPath))
-				return nil
+				return nil, path
 			},
 		},
 		{
 			name: "configured protoc uses installed tool",
-			setup: func(t *testing.T) *config.Protoc {
+			setup: func(t *testing.T, recordFile string) (*config.Protoc, string) {
 				binDir := t.TempDir()
 				t.Setenv(cache.EnvLibrarianBin, binDir)
 				version := "25.1"
 				protocPath := filepath.Join(binDir, "protoc", "v"+version, "bin", stubName)
-				createStubExecutable(t, protocPath)
-				return &config.Protoc{Version: version}
+				createStubExecutable(t, protocPath, recordFile)
+				return &config.Protoc{Version: version}, protocPath
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			pc := test.setup(t)
+			recordFile := filepath.Join(t.TempDir(), "calls.txt")
+			pc, want := test.setup(t, recordFile)
 			if err := runProtoc(t.Context(), pc, "--version"); err != nil {
-				t.Fatalf("runProtoc() error = %v, want nil", err)
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(recordFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := strings.TrimSpace(string(data))
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func createStubExecutable(t *testing.T, path string) {
+func createStubExecutable(t *testing.T, path, recordFile string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)
 	}
-	content := "#!/bin/sh\nexit 0\n"
+	content := fmt.Sprintf("#!/bin/sh\necho \"$0\" >> %q\nexit 0\n", recordFile)
 	if runtime.GOOS == "windows" {
-		content = "@echo off\r\nexit /b 0\r\n"
+		content = fmt.Sprintf("@echo off\r\necho %%0 >> %q\r\nexit /b 0\r\n", recordFile)
 	}
 	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
 		t.Fatal(err)

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -124,7 +124,7 @@ func TestRunProtoc(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			recordFile := filepath.Join(t.TempDir(), "calls.txt")
 			pc, want := test.setup(t, recordFile)
-			if err := runProtoc(t.Context(), pc, "--version"); err != nil {
+			if err := runProtoc(t.Context(), pc, nil, "--version"); err != nil {
 				t.Fatal(err)
 			}
 			data, err := os.ReadFile(recordFile)

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -76,7 +76,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		googleapisDir = filepath.Join(googleapisDir, "preview")
 	}
 	var pc *config.Protoc
-	if cfg.Tools != nil {
+	if cfg != nil && cfg.Tools != nil {
 		pc = cfg.Tools.Protoc
 	}
 	var fallbackTitle string

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -33,7 +33,6 @@ import (
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
-	"github.com/googleapis/librarian/internal/tool/protoc"
 )
 
 const defaultSampleURI = "https://cloud.google.com/docs/samples?l=go"
@@ -168,10 +167,7 @@ func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, pc *c
 		return err
 	}
 	args = append(args, protoFiles...)
-	if pc == nil {
-		return runWithEnv(ctx, nil, "protoc", args...)
-	}
-	return protoc.Run(ctx, nil, pc, args...)
+	return runProtoc(ctx, pc, args...)
 }
 
 func buildGAPICOpts(apiPath string, goAPI *config.GoAPI, version, googleapisDir string) ([]string, error) {

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -30,10 +30,10 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
-	"github.com/googleapis/librarian/internal/tool/protoc"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
+	"github.com/googleapis/librarian/internal/tool/protoc"
 )
 
 const defaultSampleURI = "https://cloud.google.com/docs/samples?l=go"

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -30,6 +30,7 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
+	"github.com/googleapis/librarian/internal/tool/protoc"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
@@ -74,7 +75,10 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if isPreview(outDir) {
 		googleapisDir = filepath.Join(googleapisDir, "preview")
 	}
-
+	var pc *config.Protoc
+	if cfg.Tools != nil {
+		pc = cfg.Tools.Protoc
+	}
 	var fallbackTitle string
 	var customSampleURI string
 	for i, api := range library.APIs {
@@ -83,7 +87,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("error finding goAPI associated with API %s: %w", api.Path, errGoAPINotFound)
 		}
 
-		if err := generateAPI(ctx, api.Path, goAPI, googleapisDir, library.Version, tempDir); err != nil {
+		if err := generateAPI(ctx, api.Path, goAPI, pc, googleapisDir, library.Version, tempDir); err != nil {
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 		if err := moveGeneratedFiles(library, goAPI, tempDir, outDir); err != nil {
@@ -139,10 +143,9 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return runInDirWithEnv(ctx, outDir, env, command.Go, "mod", "tidy")
 }
 
-func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, googleapisDir, version, outDir string) error {
+func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, pc *config.Protoc, googleapisDir, version, outDir string) error {
 	nestedProtos := goAPI.NestedProtos
 	args := []string{
-		"protoc",
 		"--experimental_allow_proto3_optional",
 		"--go_out=" + outDir,
 		"-I=" + googleapisDir,
@@ -165,7 +168,10 @@ func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, googl
 		return err
 	}
 	args = append(args, protoFiles...)
-	return runWithEnv(ctx, nil, args[0], args[1:]...)
+	if pc == nil {
+		return runWithEnv(ctx, nil, "protoc", args...)
+	}
+	return protoc.Run(ctx, nil, pc, args...)
 }
 
 func buildGAPICOpts(apiPath string, goAPI *config.GoAPI, version, googleapisDir string) ([]string, error) {

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -167,7 +167,7 @@ func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, pc *c
 		return err
 	}
 	args = append(args, protoFiles...)
-	return runProtoc(ctx, pc, args...)
+	return runProtoc(ctx, pc, nil, args...)
 }
 
 func buildGAPICOpts(apiPath string, goAPI *config.GoAPI, version, googleapisDir string) ([]string, error) {

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -167,6 +167,8 @@ func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, pc *c
 		return err
 	}
 	args = append(args, protoFiles...)
+	// We don't have other environment variables to set here; the toolchain is set
+	// in the call to runProtoc.
 	return runProtoc(ctx, pc, nil, args...)
 }
 


### PR DESCRIPTION
Update `internal/librarian/golang` to support executing a managed protoc installation during Go client generation.

A runProtoc helper function is introduced to execute the configured protoc tool binary if `tools.protoc` is defined in configuration, or fall back to system protoc from PATH when unconfigured.

Fixes https://github.com/googleapis/librarian/issues/6769
