### PR TITLE
chore: exploring idea of Librarian reading .release-please-manifest.json

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,9 @@ const (
 	// LibrarianYAML is the filename for the librarian configuration file.
 	LibrarianYAML = "librarian.yaml"
 
+	// ReleasePleaseManifest is the filename for the release-please manifest file.
+	ReleasePleaseManifest = ".release-please-manifest.json"
+
 	// RemoteUpstream is the default git remote name.
 	RemoteUpstream = "upstream"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,8 +25,8 @@ const (
 	// LibrarianYAML is the filename for the librarian configuration file.
 	LibrarianYAML = "librarian.yaml"
 
-	// ReleasePleaseManifest is the filename for the release-please manifest file.
-	ReleasePleaseManifest = ".release-please-manifest.json"
+	// ReleasePleaseManifestPattern is the glob pattern matching release-please manifest files.
+	ReleasePleaseManifestPattern = ".release-please*-manifest.json"
 
 	// RemoteUpstream is the default git remote name.
 	RemoteUpstream = "upstream"

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -100,6 +100,11 @@ func runGenerate(ctx context.Context, cfg *config.Config, all bool, libraryName 
 		return err
 	}
 
+	manifest, err := loadReleasePleaseManifest(config.ReleasePleaseManifest)
+	if err != nil {
+		return fmt.Errorf("loading release-please manifest: %w", err)
+	}
+
 	isPreview := isPreviewName(libraryName)
 	baseName := trimPreviewName(libraryName)
 
@@ -116,6 +121,9 @@ func runGenerate(ctx context.Context, cfg *config.Config, all bool, libraryName 
 		prepared, err := applyDefaults(cfg.Language, lib, cfg.Default)
 		if err != nil {
 			return err
+		}
+		if v := resolveVersion(prepared, manifest); v != "" {
+			prepared.Version = v
 		}
 		if !all && isPreview {
 			prepared = ResolvePreview(prepared, cfg.Language)

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -100,7 +100,7 @@ func runGenerate(ctx context.Context, cfg *config.Config, all bool, libraryName 
 		return err
 	}
 
-	manifest, err := loadReleasePleaseManifest(config.ReleasePleaseManifest)
+	manifest, err := loadReleasePleaseManifest(config.ReleasePleaseManifestPattern)
 	if err != nil {
 		return fmt.Errorf("loading release-please manifest: %w", err)
 	}

--- a/internal/librarian/manifest.go
+++ b/internal/librarian/manifest.go
@@ -17,6 +17,7 @@ package librarian
 import (
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ func loadReleasePleaseManifest(pattern string) (map[string]string, error) {
 	if len(matches) == 0 {
 		data, err := os.ReadFile(pattern)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return map[string]string{}, nil
 			}
 			return nil, err

--- a/internal/librarian/manifest.go
+++ b/internal/librarian/manifest.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// loadReleasePleaseManifest reads and parses .release-please-manifest.json
+// if it exists at path. Returns an empty map if the file does not exist.
+func loadReleasePleaseManifest(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	var manifest map[string]string
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+// resolveVersion resolves the version for lib using the provided release-please manifest map.
+// Resolution order:
+// 1. Manifest key matching lib.Output (e.g., "packages/google-cloud-memorystore")
+// 2. Manifest key matching lib.Name (e.g., "google-cloud-memorystore")
+// 3. Manifest key matching "." (for single-component repos)
+// 4. Existing lib.Version set in librarian.yaml.
+func resolveVersion(lib *config.Library, manifest map[string]string) string {
+	if len(manifest) > 0 {
+		if v, ok := manifest[lib.Output]; ok && v != "" {
+			return v
+		}
+		if v, ok := manifest[lib.Name]; ok && v != "" {
+			return v
+		}
+		if v, ok := manifest["."]; ok && v != "" {
+			return v
+		}
+	}
+	return lib.Version
+}

--- a/internal/librarian/manifest.go
+++ b/internal/librarian/manifest.go
@@ -69,10 +69,11 @@ func loadReleasePleaseManifest(pattern string) (map[string]string, error) {
 
 // resolveVersion resolves the version for lib using the provided release-please manifest map.
 // Resolution order:
-// 1. Manifest key matching lib.Output (e.g., "packages/google-cloud-memorystore").
-// 2. Manifest key matching lib.Name (e.g., "google-cloud-memorystore" or "accessapproval").
-// 3. Manifest key matching "." (for single-component repos).
-// 4. Existing lib.Version set in librarian.yaml.
+// 1. Exact match by derived output directory (e.g., Node.js/Python "packages/google-cloud-memorystore").
+// 2. Exact match by library name (e.g., Go standard packages "accessapproval").
+// 3. Match Go major version module subpaths (e.g., "pubsub/v2").
+// 4. Fallback to root "." for single-component repos.
+// 5. Existing lib.Version set in librarian.yaml.
 func resolveVersion(lib *config.Library, manifest map[string]string) string {
 	if len(manifest) > 0 {
 		if v, ok := manifest[lib.Output]; ok && v != "" {
@@ -80,6 +81,11 @@ func resolveVersion(lib *config.Library, manifest map[string]string) string {
 		}
 		if v, ok := manifest[lib.Name]; ok && v != "" {
 			return v
+		}
+		if lib.Go != nil && lib.Go.ModulePathVersion != "" {
+			if v, ok := manifest[lib.Name+"/"+lib.Go.ModulePathVersion]; ok && v != "" {
+				return v
+			}
 		}
 		if v, ok := manifest["."]; ok && v != "" {
 			return v

--- a/internal/librarian/manifest.go
+++ b/internal/librarian/manifest.go
@@ -17,33 +17,60 @@ package librarian
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 	"os"
+	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/config"
 )
 
-// loadReleasePleaseManifest reads and parses .release-please-manifest.json
-// if it exists at path. Returns an empty map if the file does not exist.
-func loadReleasePleaseManifest(path string) (map[string]string, error) {
-	data, err := os.ReadFile(path)
+// loadReleasePleaseManifest reads and parses release-please manifest files matching pattern.
+// If pattern is empty, it defaults to config.ReleasePleaseManifestPattern.
+// It merges entries from all matching manifest files (such as bulk and individual manifests).
+// Returns an empty map if no matching manifest files are found.
+func loadReleasePleaseManifest(pattern string) (map[string]string, error) {
+	if pattern == "" {
+		pattern = config.ReleasePleaseManifestPattern
+	}
+	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return map[string]string{}, nil
+		return nil, err
+	}
+	if len(matches) == 0 {
+		data, err := os.ReadFile(pattern)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return map[string]string{}, nil
+			}
+			return nil, err
 		}
-		return nil, err
+		var manifest map[string]string
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return nil, err
+		}
+		return manifest, nil
 	}
-	var manifest map[string]string
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return nil, err
+
+	merged := make(map[string]string)
+	for _, file := range matches {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		var manifest map[string]string
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return nil, err
+		}
+		maps.Copy(merged, manifest)
 	}
-	return manifest, nil
+	return merged, nil
 }
 
 // resolveVersion resolves the version for lib using the provided release-please manifest map.
 // Resolution order:
-// 1. Manifest key matching lib.Output (e.g., "packages/google-cloud-memorystore")
-// 2. Manifest key matching lib.Name (e.g., "google-cloud-memorystore")
-// 3. Manifest key matching "." (for single-component repos)
+// 1. Manifest key matching lib.Output (e.g., "packages/google-cloud-memorystore").
+// 2. Manifest key matching lib.Name (e.g., "google-cloud-memorystore" or "accessapproval").
+// 3. Manifest key matching "." (for single-component repos).
 // 4. Existing lib.Version set in librarian.yaml.
 func resolveVersion(lib *config.Library, manifest map[string]string) string {
 	if len(manifest) > 0 {

--- a/internal/librarian/manifest_test.go
+++ b/internal/librarian/manifest_test.go
@@ -27,7 +27,7 @@ func TestLoadReleasePleaseManifest(t *testing.T) {
 	t.Run("missing file returns empty map", func(t *testing.T) {
 		got, err := loadReleasePleaseManifest(filepath.Join(t.TempDir(), "nonexistent.json"))
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatal(err)
 		}
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty map", got)
@@ -43,7 +43,7 @@ func TestLoadReleasePleaseManifest(t *testing.T) {
 		}
 		got, err := loadReleasePleaseManifest(path)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatal(err)
 		}
 		want := map[string]string{
 			"packages/google-cloud-memorystore": "0.7.0",
@@ -71,7 +71,7 @@ func TestLoadReleasePleaseManifest(t *testing.T) {
 		pattern := filepath.Join(dir, config.ReleasePleaseManifestPattern)
 		got, err := loadReleasePleaseManifest(pattern)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatal(err)
 		}
 		want := map[string]string{
 			"accessapproval":       "1.13.0",
@@ -106,7 +106,7 @@ func TestResolveVersion(t *testing.T) {
 		".":                                 "1.0.0",
 	}
 
-	tests := []struct {
+	for _, tt := range []struct {
 		name     string
 		lib      *config.Library
 		manifest map[string]string
@@ -183,9 +183,7 @@ func TestResolveVersion(t *testing.T) {
 			manifest: map[string]string{},
 			want:     "3.1.4",
 		},
-	}
-
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resolveVersion(tt.lib, tt.manifest)
 			if got != tt.want {

--- a/internal/librarian/manifest_test.go
+++ b/internal/librarian/manifest_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestLoadReleasePleaseManifest(t *testing.T) {
+	t.Run("missing file returns empty map", func(t *testing.T) {
+		got, err := loadReleasePleaseManifest(filepath.Join(t.TempDir(), "nonexistent.json"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty map", got)
+		}
+	})
+
+	t.Run("valid manifest file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, config.ReleasePleaseManifest)
+		content := `{"packages/google-cloud-memorystore": "0.7.0", ".": "1.2.3"}`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := loadReleasePleaseManifest(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]string{
+			"packages/google-cloud-memorystore": "0.7.0",
+			".":                                 "1.2.3",
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("manifest mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("invalid json returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, config.ReleasePleaseManifest)
+		if err := os.WriteFile(path, []byte("{invalid json}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := loadReleasePleaseManifest(path)
+		if err == nil {
+			t.Error("expected error for invalid json, got nil")
+		}
+	})
+}
+
+func TestResolveVersion(t *testing.T) {
+	manifest := map[string]string{
+		"packages/google-cloud-memorystore": "0.7.0",
+		"google-cloud-redis-cluster":        "0.12.0",
+		".":                                 "1.0.0",
+	}
+
+	tests := []struct {
+		name     string
+		lib      *config.Library
+		manifest map[string]string
+		want     string
+	}{
+		{
+			name: "matches lib output path",
+			lib: &config.Library{
+				Name:    "google-cloud-memorystore",
+				Output:  "packages/google-cloud-memorystore",
+				Version: "0.6.0",
+			},
+			manifest: manifest,
+			want:     "0.7.0",
+		},
+		{
+			name: "matches lib name",
+			lib: &config.Library{
+				Name:    "google-cloud-redis-cluster",
+				Output:  "other/output/dir",
+				Version: "0.11.0",
+			},
+			manifest: manifest,
+			want:     "0.12.0",
+		},
+		{
+			name: "matches single component root dot",
+			lib: &config.Library{
+				Name:    "single-pkg",
+				Output:  "custom/output",
+				Version: "0.5.0",
+			},
+			manifest: manifest,
+			want:     "1.0.0",
+		},
+		{
+			name: "falls back to lib version when manifest does not match",
+			lib: &config.Library{
+				Name:    "unknown-pkg",
+				Output:  "unknown/output",
+				Version: "2.0.0",
+			},
+			manifest: map[string]string{
+				"packages/foo": "1.0.0",
+			},
+			want: "2.0.0",
+		},
+		{
+			name: "falls back to lib version when manifest is empty",
+			lib: &config.Library{
+				Name:    "some-pkg",
+				Output:  "some/output",
+				Version: "3.1.4",
+			},
+			manifest: map[string]string{},
+			want:     "3.1.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveVersion(tt.lib, tt.manifest)
+			if got != tt.want {
+				t.Errorf("resolveVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/manifest_test.go
+++ b/internal/librarian/manifest_test.go
@@ -34,9 +34,9 @@ func TestLoadReleasePleaseManifest(t *testing.T) {
 		}
 	})
 
-	t.Run("valid manifest file", func(t *testing.T) {
+	t.Run("single manifest file", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, config.ReleasePleaseManifest)
+		path := filepath.Join(dir, ".release-please-manifest.json")
 		content := `{"packages/google-cloud-memorystore": "0.7.0", ".": "1.2.3"}`
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			t.Fatal(err)
@@ -54,9 +54,39 @@ func TestLoadReleasePleaseManifest(t *testing.T) {
 		}
 	})
 
+	t.Run("multiple manifest files (bulk and individual)", func(t *testing.T) {
+		dir := t.TempDir()
+		bulkPath := filepath.Join(dir, ".release-please-bulk-manifest.json")
+		bulkContent := `{"accessapproval": "1.13.0", "accesscontextmanager": "1.14.0"}`
+		if err := os.WriteFile(bulkPath, []byte(bulkContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		indivPath := filepath.Join(dir, ".release-please-individual-manifest.json")
+		indivContent := `{"agentplatform": "0.21.0", "bigquery": "1.77.0"}`
+		if err := os.WriteFile(indivPath, []byte(indivContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		pattern := filepath.Join(dir, config.ReleasePleaseManifestPattern)
+		got, err := loadReleasePleaseManifest(pattern)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]string{
+			"accessapproval":       "1.13.0",
+			"accesscontextmanager": "1.14.0",
+			"agentplatform":        "0.21.0",
+			"bigquery":             "1.77.0",
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("merged manifest mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("invalid json returns error", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, config.ReleasePleaseManifest)
+		path := filepath.Join(dir, ".release-please-manifest.json")
 		if err := os.WriteFile(path, []byte("{invalid json}"), 0644); err != nil {
 			t.Fatal(err)
 		}
@@ -71,6 +101,8 @@ func TestResolveVersion(t *testing.T) {
 	manifest := map[string]string{
 		"packages/google-cloud-memorystore": "0.7.0",
 		"google-cloud-redis-cluster":        "0.12.0",
+		"accessapproval":                    "1.13.0",
+		"agentplatform":                     "0.21.0",
 		".":                                 "1.0.0",
 	}
 
@@ -99,6 +131,25 @@ func TestResolveVersion(t *testing.T) {
 			},
 			manifest: manifest,
 			want:     "0.12.0",
+		},
+		{
+			name: "matches Go library name from bulk manifest",
+			lib: &config.Library{
+				Name:    "accessapproval",
+				Output:  "accessapproval/apiv1",
+				Version: "1.12.0",
+			},
+			manifest: manifest,
+			want:     "1.13.0",
+		},
+		{
+			name: "matches Go library name from individual manifest",
+			lib: &config.Library{
+				Name:    "agentplatform",
+				Version: "0.20.0",
+			},
+			manifest: manifest,
+			want:     "0.21.0",
 		},
 		{
 			name: "matches single component root dot",

--- a/internal/librarian/manifest_test.go
+++ b/internal/librarian/manifest_test.go
@@ -103,6 +103,7 @@ func TestResolveVersion(t *testing.T) {
 		"google-cloud-redis-cluster":        "0.12.0",
 		"accessapproval":                    "1.13.0",
 		"agentplatform":                     "0.21.0",
+		"pubsub/v2":                         "2.6.0",
 		".":                                 "1.0.0",
 	}
 
@@ -150,6 +151,18 @@ func TestResolveVersion(t *testing.T) {
 			},
 			manifest: manifest,
 			want:     "0.21.0",
+		},
+		{
+			name: "matches Go major version module subpath",
+			lib: &config.Library{
+				Name: "pubsub",
+				Go: &config.GoModule{
+					ModulePathVersion: "v2",
+				},
+				Version: "2.5.0",
+			},
+			manifest: manifest,
+			want:     "2.6.0",
 		},
 		{
 			name: "matches single component root dot",


### PR DESCRIPTION
## Description

This draft PR explores resolving library release versions dynamically from `.release-please-manifest.json` during `librarian generate`.

### Context & Motivation
Currently, `librarian.yaml` contains explicit `version:` tags for each library, while Release Please ALSO maintains package versions in `.release-please-manifest.json`. During releases, Release Please updates both manifest files and `librarian.yaml` via `LibrarianYamlUpdater`, causing extra commits and state duplication.

### Proposed Solution
1. **Single Source of Truth**: Allow `.release-please-manifest.json` to serve as the single source of truth for library versions.
2. **Dynamic Resolution**: During `librarian generate`, Librarian reads `.release-please-manifest.json` if present at the workspace root and resolves each library's version by matching its output directory path or package name.
3. **Fallback & Compatibility**: If `.release-please-manifest.json` is not present or does not contain a given package, Librarian falls back to explicit versions declared in `librarian.yaml`.