### PR TITLE
refactor(internal/librarian/ruby): update gem install directory

### DIFF
--- a/internal/librarian/ruby/install.go
+++ b/internal/librarian/ruby/install.go
@@ -39,11 +39,12 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err := verify(tools); err != nil {
 		return err
 	}
-	binDir, libDir, err := binAndLibDir()
+	installDir, err := InstallDir()
 	if err != nil {
 		return err
 	}
-	return gem.Install(ctx, tools.Gem, binDir, libDir)
+	binDir := filepath.Join(installDir, "bin")
+	return gem.Install(ctx, tools.Gem, binDir, installDir)
 }
 
 // InstallDir gets the directory where tools should be installed.
@@ -57,15 +58,6 @@ func InstallDir() (string, error) {
 		return "", fmt.Errorf("failed to get install directory: %w", err)
 	}
 	return absDir, nil
-}
-
-// binAndLibDir returns the directory where Gem wrapper and asset are stored.
-func binAndLibDir() (string, string, error) {
-	installDir, err := InstallDir()
-	if err != nil {
-		return "", "", err
-	}
-	return filepath.Join(installDir, "bin"), filepath.Join(installDir, "lib"), nil
 }
 
 func verify(tools *config.Tools) error {

--- a/internal/librarian/ruby/install_test.go
+++ b/internal/librarian/ruby/install_test.go
@@ -51,8 +51,8 @@ func TestInstall(t *testing.T) {
 		t.Fatalf("failed to read call records: %v", err)
 	}
 	expectedBinDir := filepath.Join(libBinDir, "ruby_tools", "bin")
-	expectedLibDir := filepath.Join(libBinDir, "ruby_tools", "lib")
-	want := fmt.Sprintf("install gapic-generator -v 1.2.3 --bindir %s --install-dir %s --no-document\n", expectedBinDir, expectedLibDir)
+	expectedInstallDir := filepath.Join(libBinDir, "ruby_tools")
+	want := fmt.Sprintf("install gapic-generator -v 1.2.3 --bindir %s --install-dir %s --no-document\n", expectedBinDir, expectedInstallDir)
 	if got := string(data); got != want {
 		t.Errorf("gem called with = %q, want %q", got, want)
 	}
@@ -68,23 +68,6 @@ func TestInstallDir(t *testing.T) {
 	want := filepath.Join(binDir, "ruby_tools")
 	if got != want {
 		t.Errorf("InstallDir() = %q, want %q", got, want)
-	}
-}
-
-func TestBinAndLibDir(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("LIBRARIAN_BIN", dir)
-	gotBin, gotLib, err := binAndLibDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	wantBin := filepath.Join(dir, "ruby_tools", "bin")
-	if gotBin != wantBin {
-		t.Errorf("binAndLibDir() bin = %q, want %q", gotBin, wantBin)
-	}
-	wantLib := filepath.Join(dir, "ruby_tools", "lib")
-	if gotLib != wantLib {
-		t.Errorf("binAndLibDir() lib = %q, want %q", gotLib, wantLib)
 	}
 }
 

--- a/internal/tool/gem/gem.go
+++ b/internal/tool/gem/gem.go
@@ -32,9 +32,9 @@ var (
 )
 
 // Install installs a list of gem tools into the environment.
-// TODO(https://github.com/googleapis/librarian/issues/6762): Verify gem, bin, and lib
+// TODO(https://github.com/googleapis/librarian/issues/6762): Verify gem, bin, and installDir
 // are valid before installation.
-func Install(ctx context.Context, tools []*config.GemTool, binDir, libDir string) error {
+func Install(ctx context.Context, tools []*config.GemTool, binDir, installDir string) error {
 	for _, tool := range tools {
 		if tool.Name == "" || tool.Version == "" {
 			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidGem, tool)
@@ -44,7 +44,7 @@ func Install(ctx context.Context, tools []*config.GemTool, binDir, libDir string
 			tool.Name,
 			"-v", tool.Version,
 			"--bindir", binDir,
-			"--install-dir", libDir,
+			"--install-dir", installDir,
 			// Skip the generation of the local documentation to make installation faster
 			// and use less disk space.
 			"--no-document",

--- a/internal/tool/gem/gem_test.go
+++ b/internal/tool/gem/gem_test.go
@@ -41,8 +41,8 @@ echo "gem $@" >> %q
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)
-	binDir := "/tmp/bin"
-	libDir := "/tmp/lib"
+	binDir := "/tmp/ruby_tools/bin"
+	installDir := "/tmp/ruby_tools"
 	for _, test := range []struct {
 		name    string
 		tools   []*config.GemTool
@@ -53,7 +53,7 @@ echo "gem $@" >> %q
 			tools: []*config.GemTool{
 				{Name: "rubocop", Version: "1.50.0"},
 			},
-			wantLog: "gem install rubocop -v 1.50.0 --bindir /tmp/bin --install-dir /tmp/lib --no-document",
+			wantLog: "gem install rubocop -v 1.50.0 --bindir /tmp/ruby_tools/bin --install-dir /tmp/ruby_tools --no-document",
 		},
 		{
 			name: "install multiple gems",
@@ -61,8 +61,8 @@ echo "gem $@" >> %q
 				{Name: "rubocop", Version: "1.50.0"},
 				{Name: "rake", Version: "13.0.6"},
 			},
-			wantLog: `gem install rubocop -v 1.50.0 --bindir /tmp/bin --install-dir /tmp/lib --no-document
-gem install rake -v 13.0.6 --bindir /tmp/bin --install-dir /tmp/lib --no-document`,
+			wantLog: `gem install rubocop -v 1.50.0 --bindir /tmp/ruby_tools/bin --install-dir /tmp/ruby_tools --no-document
+gem install rake -v 13.0.6 --bindir /tmp/ruby_tools/bin --install-dir /tmp/ruby_tools --no-document`,
 		},
 		{
 			name:    "empty or nil tools",
@@ -72,7 +72,7 @@ gem install rake -v 13.0.6 --bindir /tmp/bin --install-dir /tmp/lib --no-documen
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_ = os.Remove(stubLogPath)
-			if err := Install(t.Context(), test.tools, binDir, libDir); err != nil {
+			if err := Install(t.Context(), test.tools, binDir, installDir); err != nil {
 				t.Fatal(err)
 			}
 			data, _ := os.ReadFile(stubLogPath)


### PR DESCRIPTION
The Ruby tool installation logic is updated to pass the ruby tool installation directory directly to gem.Install instead of creating a separate lib subdirectory.

When run `gem install --bindir {binDir} --install-dir {installDir} ...`, gem automatically creates a `gems` directory under {installDir}. Therefore, we don't need to create `lib` directory.

After the installation, the directory structure is:
```
.../ruby_tools/
      |_bin/      <- executable wrapper
      |_gems/     <- gem assets
         |_gapic-generator-0.49.0/
         |_grpc-1.82.0-x86_64-linux-gnu/
      |_...       <- other support files downloaded by gem
```

To execute the wrapper, run `GEM_PATH=.../ruby_tools .../ruby_tools/bin/gapic-generator ...`.

For https://github.com/googleapis/librarian/issues/6634