### PR TITLE
fix(internal/snippetmetadata): disable HTML escaping in JSON output

### DIFF
--- a/internal/snippetmetadata/snippetmetadata.go
+++ b/internal/snippetmetadata/snippetmetadata.go
@@ -58,6 +58,7 @@ func writeMetadata(path string, metadata map[string]any) error {
 		return fmt.Errorf("error encoding snippet metadata file %s: %w", path, err)
 	}
 	content := buf.Bytes()
+	// Trim the trailing newline added by Encode to match the generator's format.
 	if len(content) > 0 && content[len(content)-1] == '\n' {
 		content = content[:len(content)-1]
 	}

--- a/internal/snippetmetadata/snippetmetadata.go
+++ b/internal/snippetmetadata/snippetmetadata.go
@@ -17,6 +17,7 @@
 package snippetmetadata
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,9 +50,16 @@ func readMetadata(path string) (map[string]any, error) {
 // writeMetadata formats and writes the given metadata as a JSON file at the
 // given path.
 func writeMetadata(path string, metadata map[string]any) error {
-	content, err := json.MarshalIndent(metadata, "", "  ")
-	if err != nil {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(metadata); err != nil {
 		return fmt.Errorf("error encoding snippet metadata file %s: %w", path, err)
+	}
+	content := buf.Bytes()
+	if len(content) > 0 && content[len(content)-1] == '\n' {
+		content = content[:len(content)-1]
 	}
 	if err := os.WriteFile(path, content, 0644); err != nil {
 		return fmt.Errorf("error writing snippet metadata file %s: %w", path, err)

--- a/internal/snippetmetadata/snippetmetadata_test.go
+++ b/internal/snippetmetadata/snippetmetadata_test.go
@@ -412,7 +412,7 @@ func copyInputFileToTemp(t *testing.T, inputFile string) string {
 }
 
 func TestHTMLCharsNoEscape(t *testing.T) {
-	for _, tc := range []struct {
+	for _, test := range []struct {
 		name  string
 		input string
 		run   func(string) error

--- a/internal/snippetmetadata/snippetmetadata_test.go
+++ b/internal/snippetmetadata/snippetmetadata_test.go
@@ -449,21 +449,21 @@ func TestHTMLCharsNoEscape(t *testing.T) {
 }`,
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
 			path := filepath.Join(dir, "snippet_metadata.json")
-			if err := os.WriteFile(path, []byte(tc.input), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.input), 0644); err != nil {
 				t.Fatal(err)
 			}
-			if err := tc.run(path); err != nil {
+			if err := test.run(path); err != nil {
 				t.Fatal(err)
 			}
 			got, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+			if diff := cmp.Diff(test.want, string(got)); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/snippetmetadata/snippetmetadata_test.go
+++ b/internal/snippetmetadata/snippetmetadata_test.go
@@ -450,6 +450,7 @@ func TestHTMLCharsNoEscape(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			path := filepath.Join(dir, "snippet_metadata.json")
 			if err := os.WriteFile(path, []byte(tc.input), 0644); err != nil {

--- a/internal/snippetmetadata/snippetmetadata_test.go
+++ b/internal/snippetmetadata/snippetmetadata_test.go
@@ -410,3 +410,61 @@ func copyInputFileToTemp(t *testing.T, inputFile string) string {
 	}
 	return path
 }
+
+func TestHTMLCharsNoEscape(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		run   func(string) error
+		want  string
+	}{
+		{
+			name: "updateLibraryVersion",
+			input: `{
+  "clientLibrary": {
+    "someFieldWithHTML": "a > b & c < d",
+    "version": "1.0.0"
+  }
+}`,
+			run: func(path string) error {
+				return updateLibraryVersion(path, "1.2.0")
+			},
+			want: `{
+  "clientLibrary": {
+    "someFieldWithHTML": "a > b & c < d",
+    "version": "1.2.0"
+  }
+}`,
+		},
+		{
+			name: "reformat",
+			input: `{
+  "someFieldWithHTML": "a > b & c < d"
+}`,
+			run: func(path string) error {
+				return reformat(path)
+			},
+			want: `{
+  "someFieldWithHTML": "a > b & c < d"
+}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "snippet_metadata.json")
+			if err := os.WriteFile(path, []byte(tc.input), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := tc.run(path); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Snippet metadata files are written using Go's json encoder, which by defaultescapes HTML characters like >, <, and &. This causes these characters to be serialized as unicode sequences (e.g., \u003e), which is unnecessary for these metadata files and causes issues with other tools that expect raw characters.

We now use a custom json.Encoder with SetEscapeHTML(false) to prevent this escaping. We also continue to trim the trailing newline added by the encoder to maintain format consistency with the generator.

Fixes #6776