### PR TITLE
feat(internal/tool/gem): verify input directories and tools before installation

### DIFF
--- a/internal/tool/gem/gem.go
+++ b/internal/tool/gem/gem.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
@@ -29,16 +30,18 @@ var (
 	errInstall = errors.New("failed to install ruby gems")
 	// errInvalidGem indicates an invalid gem tool.
 	errInvalidGem = errors.New("invalid gem tool")
+	// errInvalidBinDir indicates an invalid bin directory.
+	errInvalidBinDir = errors.New("bin dir is not an absolute path")
+	// errInvalidInstallDir indicates an invalid install directory.
+	errInvalidInstallDir = errors.New("install dir is not an absolute path")
 )
 
 // Install installs a list of gem tools into the environment.
-// TODO(https://github.com/googleapis/librarian/issues/6762): Verify gem, bin, and installDir
-// are valid before installation.
 func Install(ctx context.Context, tools []*config.GemTool, binDir, installDir string) error {
+	if err := verify(tools, binDir, installDir); err != nil {
+		return err
+	}
 	for _, tool := range tools {
-		if tool.Name == "" || tool.Version == "" {
-			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidGem, tool)
-		}
 		args := []string{
 			"install",
 			tool.Name,
@@ -52,6 +55,22 @@ func Install(ctx context.Context, tools []*config.GemTool, binDir, installDir st
 		if err := command.RunStreaming(ctx, "gem", args...); err != nil {
 			return fmt.Errorf("%w: %w", errInstall, err)
 		}
+	}
+	return nil
+}
+
+func verify(tools []*config.GemTool, binDir, installDir string) error {
+	if !filepath.IsAbs(binDir) {
+		return fmt.Errorf("%w: Ruby bin directory %q is not an absolute path", errInvalidBinDir, binDir)
+	}
+	if !filepath.IsAbs(installDir) {
+		return fmt.Errorf("%w: Ruby install directory %q is not an absolute path", errInvalidInstallDir, installDir)
+	}
+	for _, tool := range tools {
+		if tool.Name == "" || tool.Version == "" {
+			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidGem, tool)
+		}
+
 	}
 	return nil
 }

--- a/internal/tool/gem/gem_test.go
+++ b/internal/tool/gem/gem_test.go
@@ -130,7 +130,7 @@ func TestInstall_Error(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t)
 			}
-			err := Install(t.Context(), test.tools, "", "")
+			err := Install(t.Context(), test.tools, "/tmp/tools/bin", "/tmp/tools")
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("Install() error = %v, wantErr = %v", err, test.wantErr)
 			}

--- a/internal/tool/gem/gem_test.go
+++ b/internal/tool/gem/gem_test.go
@@ -137,3 +137,57 @@ func TestInstall_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestVerify_Error(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		tools      []*config.GemTool
+		binDir     string
+		installDir string
+		wantErr    error
+	}{
+		{
+			name: "relative binDir",
+			tools: []*config.GemTool{
+				{Name: "rubocop", Version: "1.50.0"},
+			},
+			binDir:     "relative/bin",
+			installDir: "/tmp/ruby_tools",
+			wantErr:    errInvalidBinDir,
+		},
+		{
+			name: "relative installDir",
+			tools: []*config.GemTool{
+				{Name: "rubocop", Version: "1.50.0"},
+			},
+			binDir:     "/tmp/ruby_tools/bin",
+			installDir: "relative/install",
+			wantErr:    errInvalidInstallDir,
+		},
+		{
+			name: "missing name",
+			tools: []*config.GemTool{
+				{Name: "", Version: "1.50.0"},
+			},
+			binDir:     "/tmp/ruby_tools/bin",
+			installDir: "/tmp/ruby_tools",
+			wantErr:    errInvalidGem,
+		},
+		{
+			name: "missing version",
+			tools: []*config.GemTool{
+				{Name: "rubocop", Version: ""},
+			},
+			binDir:     "/tmp/ruby_tools/bin",
+			installDir: "/tmp/ruby_tools",
+			wantErr:    errInvalidGem,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := verify(test.tools, test.binDir, test.installDir)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("verify() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/tool/gem/gem_test.go
+++ b/internal/tool/gem/gem_test.go
@@ -138,6 +138,15 @@ func TestInstall_Error(t *testing.T) {
 	}
 }
 
+func TestVerify(t *testing.T) {
+	tools := []*config.GemTool{
+		{Name: "rubocop", Version: "1.50.0"},
+	}
+	if err := verify(tools, "/tmp/ruby_tools/bin", "/tmp/ruby_tools"); err != nil {
+		t.Errorf("verify() error = %v, want nil", err)
+	}
+}
+
 func TestVerify_Error(t *testing.T) {
 	for _, test := range []struct {
 		name       string


### PR DESCRIPTION
A verify function is added to internal/tool/gem to validate target installation paths and gem tool specifications before running the gem installation command.

Fixes https://github.com/googleapis/librarian/issues/6762
