### PR TITLE
feat(internal/librarian): add ruby tools directory to env output

### DIFF
--- a/internal/librarian/debug.go
+++ b/internal/librarian/debug.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/ruby"
 	"github.com/urfave/cli/v3"
 )
 
@@ -60,6 +61,7 @@ func runEnv(w io.Writer) error {
 	goToolsDir := dirOrErr(golang.InstallDir())
 	javaToolsDir := dirOrErr(java.InstallDir())
 	nodejsToolsDir := dirOrErr(nodejs.InstallDir())
+	rubyToolsDir := dirOrErr(ruby.InstallDir())
 	var b strings.Builder
 	fmt.Fprintf(&b, "LIBRARIAN_CACHE=%s\n", cacheDir)
 	fmt.Fprintf(&b, "LIBRARIAN_BIN=%s\n", buildDir)
@@ -68,6 +70,7 @@ func runEnv(w io.Writer) error {
 	fmt.Fprintf(&b, "  golang: %s\n", goToolsDir)
 	fmt.Fprintf(&b, "  java: %s\n", javaToolsDir)
 	fmt.Fprintf(&b, "  nodejs: %s\n", nodejsToolsDir)
+	fmt.Fprintf(&b, "  ruby: %s\n", rubyToolsDir)
 	_, err := io.WriteString(w, b.String())
 	return err
 }

--- a/internal/librarian/debug_test.go
+++ b/internal/librarian/debug_test.go
@@ -38,6 +38,7 @@ func TestRunEnv(t *testing.T) {
 		fmt.Sprintf("golang: %s", filepath.Join(binDir, "go_tools")),
 		fmt.Sprintf("java: %s", filepath.Join(binDir, "java_tools")),
 		fmt.Sprintf("nodejs: %s", filepath.Join(binDir, "nodejs_tools")),
+		fmt.Sprintf("ruby: %s", filepath.Join(binDir, "ruby_tools")),
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {
@@ -63,6 +64,7 @@ func TestRunEnv_Error(t *testing.T) {
 		"golang: <error:",
 		"java: <error:",
 		"nodejs: <error:",
+		"ruby: <error:",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {


### PR DESCRIPTION
The Ruby tools installation directory is added to the output of the `librarian env debug` command so users and developers can verify the resolved path for installed Ruby tools.

Fixes https://github.com/googleapis/librarian/issues/6780
