### PR TITLE
feat(tool/cmd/migrate): support union versions in PHP OwlBot configs

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -80,8 +80,14 @@ type deepCopyRegexSpec struct {
 	Dest   string `yaml:"dest"`
 }
 
+// extractAPIPaths extracts target API paths from an OwlBot source matcher pattern.
+// It supports both unversioned paths and versioned paths, including union matchers
+// (e.g. "(v1|v1beta2)") which are expanded into separate versioned paths.
+// Returns nil if the pattern is invalid.
 func extractAPIPaths(source string) []string {
 	if matches := owlbotSourceWithVersionRegexp.FindStringSubmatch(source); len(matches) == 3 {
+		// matches[1] is the base path (e.g. "google/cloud/secretmanager")
+		// matches[2] is the version or version union (e.g. "v1" or "v1|v1beta2")
 		base := matches[1]
 		versions := strings.Split(matches[2], "|")
 		var paths []string
@@ -91,6 +97,7 @@ func extractAPIPaths(source string) []string {
 		return paths
 	}
 	if matches := owlbotSourceWithoutVersionRegexp.FindStringSubmatch(source); len(matches) == 2 {
+		// matches[1] is the full path without a version suffix (e.g. "google/identity/accesscontextmanager/type")
 		return []string{matches[1]}
 	}
 	return nil

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -66,7 +66,7 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 }
 
 var (
-	owlbotSourceWithVersionRegexp    = regexp.MustCompile(`^/([a-zA-Z0-9_/]+)/\((v[0-9a-zA-Z]+)\)/.*-php/.*$`)
+	owlbotSourceWithVersionRegexp    = regexp.MustCompile(`^/([a-zA-Z0-9_/]+)/\((v[0-9a-zA-Z|]+)\)/.*-php/.*$`)
 	owlbotSourceWithoutVersionRegexp = regexp.MustCompile(`^/([a-zA-Z0-9_/]+)/.*-php/.*$`)
 )
 
@@ -80,14 +80,20 @@ type deepCopyRegexSpec struct {
 	Dest   string `yaml:"dest"`
 }
 
-func extractAPIPath(source string) (string, bool) {
+func extractAPIPaths(source string) []string {
 	if matches := owlbotSourceWithVersionRegexp.FindStringSubmatch(source); len(matches) == 3 {
-		return matches[1] + "/" + matches[2], true
+		base := matches[1]
+		versions := strings.Split(matches[2], "|")
+		var paths []string
+		for _, v := range versions {
+			paths = append(paths, base+"/"+v)
+		}
+		return paths
 	}
 	if matches := owlbotSourceWithoutVersionRegexp.FindStringSubmatch(source); len(matches) == 2 {
-		return matches[1], true
+		return []string{matches[1]}
 	}
-	return "", false
+	return nil
 }
 
 func extractAPIsFromOwlBot(owlbotPath string) ([]*config.API, error) {
@@ -101,7 +107,7 @@ func extractAPIsFromOwlBot(owlbotPath string) ([]*config.API, error) {
 	var apis []*config.API
 	seenAPIs := make(map[string]bool)
 	for _, spec := range owlbot.DeepCopyRegex {
-		if path, ok := extractAPIPath(spec.Source); ok {
+		for _, path := range extractAPIPaths(spec.Source) {
 			if !seenAPIs[path] {
 				seenAPIs[path] = true
 				apis = append(apis, &config.API{Path: path})

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -103,45 +103,42 @@ func TestRunPHPMigration(t *testing.T) {
 	}
 }
 
-func TestExtractAPIPath(t *testing.T) {
+func TestExtractAPIPaths(t *testing.T) {
 	for _, test := range []struct {
-		name     string
-		source   string
-		wantPath string
-		wantOk   bool
+		name      string
+		source    string
+		wantPaths []string
 	}{
 		{
-			name:     "versioned api",
-			source:   "/google/cloud/ces/(v1)/.*-php/(.*)",
-			wantPath: "google/cloud/ces/v1",
-			wantOk:   true,
+			name:      "versioned api",
+			source:    "/google/cloud/ces/(v1)/.*-php/(.*)",
+			wantPaths: []string{"google/cloud/ces/v1"},
 		},
 		{
-			name:     "unversioned api",
-			source:   "/google/identity/accesscontextmanager/type/.*-php/(.*)",
-			wantPath: "google/identity/accesscontextmanager/type",
-			wantOk:   true,
+			name:      "unversioned api",
+			source:    "/google/identity/accesscontextmanager/type/.*-php/(.*)",
+			wantPaths: []string{"google/identity/accesscontextmanager/type"},
 		},
 		{
-			name:     "non-matching path",
-			source:   "/some/other/path",
-			wantPath: "",
-			wantOk:   false,
+			name:      "non-matching path",
+			source:    "/some/other/path",
+			wantPaths: nil,
 		},
 		{
-			name:     "grafeas versioned",
-			source:   "/grafeas/(v1)/.*-php/(.*)",
-			wantPath: "grafeas/v1",
-			wantOk:   true,
+			name:      "grafeas versioned",
+			source:    "/grafeas/(v1)/.*-php/(.*)",
+			wantPaths: []string{"grafeas/v1"},
+		},
+		{
+			name:      "union versioned api",
+			source:    "/google/cloud/secretmanager/(v1|v1beta2)/.*-php/(.*)",
+			wantPaths: []string{"google/cloud/secretmanager/v1", "google/cloud/secretmanager/v1beta2"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			gotPath, gotOk := extractAPIPath(test.source)
-			if gotOk != test.wantOk {
-				t.Fatal("extractAPIPath ok =", gotOk, ", want", test.wantOk)
-			}
-			if gotPath != test.wantPath {
-				t.Error("extractAPIPath path =", gotPath, ", want", test.wantPath)
+			gotPaths := extractAPIPaths(test.source)
+			if diff := cmp.Diff(test.wantPaths, gotPaths); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Updates the PHP migration tool to support version union groups in `.OwlBot.yaml` (e.g. `(v1|v1beta2)`). Ensures individual versioned API paths are included in config for compound libraries.

Fixes #6779