### PR TITLE
chore(tool/cmd/migrate): add tool section to generated `librarian.yaml` for ruby migration

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -33,6 +33,18 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 		Sources: &config.Sources{
 			Googleapis: src,
 		},
+		Tools: &config.Tools{
+			Gem: []*config.GemTool{
+				{
+					Name:    "gapic-generator",
+					Version: "0.49.0",
+				},
+				{
+					Name:    "grpc",
+					Version: "1.78.1",
+				},
+			},
+		},
 	}
 	// The directory name in Googleapis is present for migration code to look
 	// up API details. It shouldn't be persisted.

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -46,7 +46,7 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 			},
 			Protoc: &config.Protoc{
 				Version: "33.2",
-				SHA256: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf",
+				SHA256:  "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf",
 			},
 		},
 	}

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -44,6 +44,10 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 					Version: "1.78.1",
 				},
 			},
+			Protoc: &config.Protoc{
+				Version: "33.2",
+				SHA256: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf",
+			},
 		},
 	}
 	// The directory name in Googleapis is present for migration code to look

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -73,7 +73,7 @@ func TestRunRubyMigration(t *testing.T) {
 			},
 			Protoc: &config.Protoc{
 				Version: "33.2",
-				SHA256: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf",
+				SHA256:  "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf",
 			},
 		},
 	}

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -60,6 +60,18 @@ func TestRunRubyMigration(t *testing.T) {
 				SHA256: "sha123",
 			},
 		},
+		Tools: &config.Tools{
+			Gem: []*config.GemTool{
+				{
+					Name:    "gapic-generator",
+					Version: "0.49.0",
+				},
+				{
+					Name:    "grpc",
+					Version: "1.78.1",
+				},
+			},
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -71,6 +71,10 @@ func TestRunRubyMigration(t *testing.T) {
 					Version: "1.78.1",
 				},
 			},
+			Protoc: &config.Protoc{
+				Version: "33.2",
+				SHA256: "b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf",
+			},
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
Add tool section in the generated `librarian.yaml` in google-cloud-ruby.

For #6632