### PR TITLE
feat(too/cmd/migrate): specify protoc version in tools section

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -53,6 +53,9 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 					Build:   []string{"composer install"},
 				},
 			},
+			Protoc: &config.Protoc{
+				Version: "31.0",
+			},
 		},
 	}
 	// The directory name in Googleapis is present for migration code to look

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -96,6 +96,9 @@ func TestRunPHPMigration(t *testing.T) {
 					Build:   []string{"composer install"},
 				},
 			},
+			Protoc: &config.Protoc{
+				Version: "31.0",
+			},
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
Add protoc version to tool section in librarian.yaml produced. Version 31.0 comes from googleapis WORKSPACE [here](https://github.com/googleapis/googleapis/blob/2c4dd791cc44104f1fdc49b4cbdadb160772b11e/WORKSPACE#L181).

For #6791
