### PR TITLE
fix(tool/cmd/migrate): add SHA256 for protoc version in php migrate

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -55,6 +55,7 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 			},
 			Protoc: &config.Protoc{
 				Version: "31.0",
+				SHA256:  "24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42",
 			},
 		},
 	}

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -98,6 +98,7 @@ func TestRunPHPMigration(t *testing.T) {
 			},
 			Protoc: &config.Protoc{
 				Version: "31.0",
+				SHA256:  "24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42",
 			},
 		},
 	}


### PR DESCRIPTION
Add SHA256 for protoc version config. This was missed in #6793.


For https://github.com/googleapis/librarian/issues/6791