### PR TITLE
feat(internal/config): add additional_protos configuration support for php

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -443,12 +443,14 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `migration_mode` | string | Controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY"). |
 
 ## PHPPackage Configuration
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `additional_protos` | list of string | Is a list of additional proto files to include in generation. This can be overridden at the API level. |
 
 ## PythonDefault Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -807,10 +807,16 @@ type NodejsAPI struct {
 
 // PHPPackage contains PHP-specific library configuration.
 type PHPPackage struct {
+	// AdditionalProtos is a list of additional proto files to include in generation.
+	// This can be overridden at the API level.
+	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 }
 
 // PHPAPI represents configuration for a single API within a PHP package.
 type PHPAPI struct {
+	// AdditionalProtos is a list of additional proto files to include in generation.
+	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
+
 	// MigrationMode controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY").
 	MigrationMode string `yaml:"migration_mode,omitempty"`
 }

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -412,6 +412,8 @@ func ResolvePreview(lib *config.Library, language string) *config.Library {
 		res.Python = mergePython(res.Python, p.Python)
 	case config.LanguageRust:
 		res.Rust = mergeRust(res.Rust, p.Rust)
+	case config.LanguagePhp:
+		res.PHP = mergePHP(res.PHP, p.PHP)
 	}
 	res.Preview = nil
 	return &res
@@ -818,6 +820,20 @@ func mergeRustDiscovery(dst, src *config.RustDiscovery) *config.RustDiscovery {
 	}
 	if src.Pollers != nil {
 		res.Pollers = src.Pollers
+	}
+	return &res
+}
+
+func mergePHP(dst, src *config.PHPPackage) *config.PHPPackage {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		return src
+	}
+	res := *dst
+	if src.AdditionalProtos != nil {
+		res.AdditionalProtos = src.AdditionalProtos
 	}
 	return &res
 }

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -1566,3 +1566,39 @@ func TestMergeRust(t *testing.T) {
 		})
 	}
 }
+
+func TestMergePHP(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		dst  *config.PHPPackage
+		src  *config.PHPPackage
+		want *config.PHPPackage
+	}{
+		{
+			name: "nil src returns dst",
+			dst:  &config.PHPPackage{AdditionalProtos: []string{"a.proto"}},
+			src:  nil,
+			want: &config.PHPPackage{AdditionalProtos: []string{"a.proto"}},
+		},
+		{
+			name: "nil dst returns src",
+			dst:  nil,
+			src:  &config.PHPPackage{AdditionalProtos: []string{"b.proto"}},
+			want: &config.PHPPackage{AdditionalProtos: []string{"b.proto"}},
+		},
+		{
+			name: "merges all fields",
+			dst:  &config.PHPPackage{AdditionalProtos: []string{"a.proto"}},
+			src:  &config.PHPPackage{AdditionalProtos: []string{"b.proto"}},
+			want: &config.PHPPackage{AdditionalProtos: []string{"b.proto"}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := mergePHP(test.dst, test.src)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -1601,4 +1601,3 @@ func TestMergePHP(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Add support for `additional_protos` in PHP package and API-level configuration structures. This enables specifying mixin proto dependencies (e.g., location.proto, iam_policy.proto) to compile them directly as target protos for client code generation.

For #6743