### PR TITLE
ci(.github/workflows): if the config is changed, rerun tests that depend on a cache

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -48,7 +48,7 @@ jobs:
           path: |
             ~/.cache/librarian
             venv
-          key: librarian-java-tools-v1-${{ runner.os }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
+          key: librarian-java-tools-v2-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
       - name: Create Python virtual environment
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: python3 -m venv venv

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -53,7 +53,7 @@ jobs:
           path: |
             ${{ steps.tool-paths.outputs.npm }}
             ~/.cache/librarian
-          key: nodejs-tools-v3-${{ hashFiles('google-cloud-node/librarian.yaml') }}
+          key: nodejs-tools-v4-${{ hashFiles('internal/config/config.go') }}-${{ hashFiles('google-cloud-node/librarian.yaml') }}
       - name: "Install Node.js dependencies (run librarian install)"
         if: steps.tools-cache.outputs.cache-hit != 'true'
         run: librarian -v install nodejs

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -53,7 +53,7 @@ jobs:
           path: |
             ${{ steps.tool-paths.outputs.npm }}
             ~/.cache/librarian
-          key: nodejs-tools-v4-${{ hashFiles('internal/config/config.go') }}-${{ hashFiles('google-cloud-node/librarian.yaml') }}
+          key: nodejs-tools-v4-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-node/librarian.yaml') }}
       - name: "Install Node.js dependencies (run librarian install)"
         if: steps.tools-cache.outputs.cache-hit != 'true'
         run: librarian -v install nodejs


### PR DESCRIPTION
This PR ensures tests rerun without a cache if a change to the config is ever made, which can affect all languages. However, only Node and Java currently use caching.

Fixes https://github.com/googleapis/librarian/issues/6803