### PR TITLE
refactor(internal/librarian/golang): replace mergeEnv with toolsEnv

### DIFF
--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -28,7 +28,7 @@ const envPath = "PATH"
 // runProtoc runs the protoc command with the given environment variable and arguments.
 func runProtoc(ctx context.Context, pc *config.Protoc, args ...string) error {
 	// Ensure that the toolchain environment variables are set before calling protoc.
-	env, err := installEnv()
+	env, err := toolsEnv()
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func runWithEnv(ctx context.Context, env map[string]string, cmd string, args ...
 
 // runInDirWithEnv runs a command in the given directory with the given environment.
 func runInDirWithEnv(ctx context.Context, dir string, env map[string]string, cmd string, args ...string) error {
-	additionalEnv, err := installEnv()
+	additionalEnv, err := toolsEnv()
 	if err != nil {
 		return err
 	}
@@ -50,8 +50,8 @@ func runInDirWithEnv(ctx context.Context, dir string, env map[string]string, cmd
 	return command.RunInDirWithEnv(ctx, dir, env, cmd, args...)
 }
 
-// installEnv returns the environment variables required to run the Go tools.
-func installEnv() (map[string]string, error) {
+// toolsEnv returns the environment variables required to run the Go tools.
+func toolsEnv() (map[string]string, error) {
 	toolsBinDir, err := InstallDir()
 	if err != nil {
 		return nil, err

--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -16,9 +16,7 @@ package golang
 
 import (
 	"context"
-	"fmt"
 	"maps"
-	"os"
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
@@ -28,9 +26,9 @@ import (
 const envPath = "PATH"
 
 // runProtoc runs the protoc command with the given environment variable and arguments.
-func runProtoc(ctx context.Context, pc *config.Protoc, env map[string]string, args ...string) error {
+func runProtoc(ctx context.Context, pc *config.Protoc, args ...string) error {
 	// Ensure that the toolchain environment variables are set before calling protoc.
-	env, err := mergeEnv(env)
+	env, err := installEnv()
 	if err != nil {
 		return err
 	}
@@ -44,20 +42,19 @@ func runWithEnv(ctx context.Context, env map[string]string, cmd string, args ...
 
 // runInDirWithEnv runs a command in the given directory with the given environment.
 func runInDirWithEnv(ctx context.Context, dir string, env map[string]string, cmd string, args ...string) error {
-	env, err := mergeEnv(env)
+	additionalEnv, err := installEnv()
 	if err != nil {
 		return err
 	}
+	maps.Copy(env, additionalEnv)
 	return command.RunInDirWithEnv(ctx, dir, env, cmd, args...)
 }
 
-// mergeEnv merges the given environment with the installation directory.
-func mergeEnv(env map[string]string) (map[string]string, error) {
+// installEnv returns the environment variables required to run the Go tools.
+func installEnv() (map[string]string, error) {
 	toolsBinDir, err := InstallDir()
 	if err != nil {
 		return nil, err
 	}
-	res := map[string]string{envPath: fmt.Sprintf("%s:%s", toolsBinDir, os.Getenv(envPath))}
-	maps.Copy(res, env)
-	return res, nil
+	return map[string]string{envPath: toolsBinDir}, nil
 }

--- a/internal/librarian/golang/command.go
+++ b/internal/librarian/golang/command.go
@@ -46,8 +46,10 @@ func runInDirWithEnv(ctx context.Context, dir string, env map[string]string, cmd
 	if err != nil {
 		return err
 	}
-	maps.Copy(env, additionalEnv)
-	return command.RunInDirWithEnv(ctx, dir, env, cmd, args...)
+	mergedEnv := make(map[string]string)
+	maps.Copy(mergedEnv, additionalEnv)
+	maps.Copy(mergedEnv, env)
+	return command.RunInDirWithEnv(ctx, dir, mergedEnv, cmd, args...)
 }
 
 // toolsEnv returns the environment variables required to run the Go tools.

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -76,7 +76,7 @@ func TestRunProtoc(t *testing.T) {
 	}
 }
 
-func TestInstallEnv(t *testing.T) {
+func TestToolsEnv(t *testing.T) {
 	for _, test := range []struct {
 		name   string
 		binDir func(t *testing.T) string
@@ -108,7 +108,7 @@ func TestInstallEnv(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			binDir := test.binDir(t)
 			t.Setenv(cache.EnvLibrarianBin, binDir)
-			got, err := installEnv()
+			got, err := toolsEnv()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -124,15 +124,15 @@ func TestInstallEnv(t *testing.T) {
 	}
 }
 
-func TestInstallEnv_Error(t *testing.T) {
+func TestToolsEnv_Error(t *testing.T) {
 	t.Setenv(cache.EnvLibrarianBin, "")
 	t.Setenv(cache.EnvLibrarianCache, "")
 	t.Setenv("HOME", "")
 	t.Setenv("XDG_CACHE_HOME", "")
 	// This error is not easy to check, we only make sure
 	// it doesn't return nil.
-	if _, err := installEnv(); err == nil {
-		t.Error("installEnv() error = nil, want error")
+	if _, err := toolsEnv(); err == nil {
+		t.Error("toolsEnv() error = nil, want error")
 	}
 }
 

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -76,6 +76,64 @@ func TestRunProtoc(t *testing.T) {
 	}
 }
 
+func TestInstallEnv(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		binDir func(t *testing.T) string
+		want   func(absBin string) map[string]string
+	}{
+		{
+			name: "returns PATH pointing to go_tools directory",
+			binDir: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			want: func(absBin string) map[string]string {
+				return map[string]string{
+					envPath: filepath.Join(absBin, toolsDir),
+				}
+			},
+		},
+		{
+			name: "handles nested bin directory path",
+			binDir: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "nested", "bin")
+			},
+			want: func(absBin string) map[string]string {
+				return map[string]string{
+					envPath: filepath.Join(absBin, toolsDir),
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binDir := test.binDir(t)
+			t.Setenv(cache.EnvLibrarianBin, binDir)
+			got, err := installEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantAbsBin, err := filepath.Abs(binDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantMap := test.want(wantAbsBin)
+			if diff := cmp.Diff(wantMap, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestInstallEnv_Error(t *testing.T) {
+	t.Setenv(cache.EnvLibrarianBin, "")
+	t.Setenv(cache.EnvLibrarianCache, "")
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	if _, err := installEnv(); err == nil {
+		t.Error("installEnv() error = nil, want error")
+	}
+}
+
 func createStubExecutable(t *testing.T, path, recordFile string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -27,69 +27,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func TestMergeEnv(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		env  map[string]string
-		path string
-		want func(base string) map[string]string
-	}{
-		{
-			name: "nil env",
-			env:  nil,
-			path: "/original/path",
-			want: func(base string) map[string]string {
-				return map[string]string{
-					envPath: filepath.Join(base, toolsDir) + ":/original/path",
-				}
-			},
-		},
-		{
-			name: "custom env keys merged",
-			env: map[string]string{
-				"FOO": "bar",
-			},
-			path: "/original/path",
-			want: func(base string) map[string]string {
-				return map[string]string{
-					envPath: filepath.Join(base, toolsDir) + ":/original/path",
-					"FOO":   "bar",
-				}
-			},
-		},
-		{
-			name: "env overrides PATH",
-			env: map[string]string{
-				envPath: "/env/custom/path",
-			},
-			path: "/original/path",
-			want: func(base string) map[string]string {
-				return map[string]string{
-					envPath: "/env/custom/path",
-				}
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			baseDir := t.TempDir()
-			t.Setenv(cache.EnvLibrarianBin, baseDir)
-			t.Setenv(envPath, test.path)
-			got, err := mergeEnv(test.env)
-			if err != nil {
-				t.Fatal(err)
-			}
-			wantAbsBase, err := filepath.Abs(baseDir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			wantMap := test.want(wantAbsBase)
-			if diff := cmp.Diff(wantMap, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestRunProtoc(t *testing.T) {
 	stubName := "protoc"
 	if runtime.GOOS == "windows" {
@@ -124,7 +61,7 @@ func TestRunProtoc(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			recordFile := filepath.Join(t.TempDir(), "calls.txt")
 			pc, want := test.setup(t, recordFile)
-			if err := runProtoc(t.Context(), pc, nil, "--version"); err != nil {
+			if err := runProtoc(t.Context(), pc, "--version"); err != nil {
 				t.Fatal(err)
 			}
 			data, err := os.ReadFile(recordFile)

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -129,6 +129,8 @@ func TestInstallEnv_Error(t *testing.T) {
 	t.Setenv(cache.EnvLibrarianCache, "")
 	t.Setenv("HOME", "")
 	t.Setenv("XDG_CACHE_HOME", "")
+	// This error is not easy to check, we only make sure
+	// it doesn't return nil.
 	if _, err := installEnv(); err == nil {
 		t.Error("installEnv() error = nil, want error")
 	}

--- a/internal/librarian/golang/format.go
+++ b/internal/librarian/golang/format.go
@@ -32,7 +32,7 @@ func Format(ctx context.Context, library *config.Library) error {
 	if err != nil {
 		return err
 	}
-	return runWithEnv(ctx, nil, "goimports", args...)
+	return runWithEnv(ctx, map[string]string{}, "goimports", args...)
 }
 
 func buildFormatArgs(library *config.Library) ([]string, error) {

--- a/internal/librarian/golang/format.go
+++ b/internal/librarian/golang/format.go
@@ -32,7 +32,7 @@ func Format(ctx context.Context, library *config.Library) error {
 	if err != nil {
 		return err
 	}
-	return runWithEnv(ctx, map[string]string{}, "goimports", args...)
+	return runWithEnv(ctx, nil, "goimports", args...)
 }
 
 func buildFormatArgs(library *config.Library) ([]string, error) {

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -169,7 +169,7 @@ func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, pc *c
 	args = append(args, protoFiles...)
 	// We don't have other environment variables to set here; the toolchain is set
 	// in the call to runProtoc.
-	return runProtoc(ctx, pc, nil, args...)
+	return runProtoc(ctx, pc, args...)
 }
 
 func buildGAPICOpts(apiPath string, goAPI *config.GoAPI, version, googleapisDir string) ([]string, error) {


### PR DESCRIPTION
The environment resolution helper in `internal/librarian/golang` is refactored from `mergeEnv` to `toolsEnv`, returning a map containing PATH set to the Go tools bin directory.

We don't need to merge system PATH env because the underlying `command.RunInDirWithEnv` will do the merging.

Fixes https://github.com/googleapis/librarian/issues/6785