### PR TITLE
feat(internal/librarian/php): integrate additional_protos into client generation

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -108,7 +109,9 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 		return err
 	}
 	opts := gapicOpts(params.api, apiMetadata, grpcConfigPath)
-	targetProtos, err := gatherTargetProtos(googleapisDir, params.api.Path)
+	additionalProtos := resolveAdditionalProtos(params.library, params.api)
+
+	targetProtos, err := gatherTargetProtos(googleapisDir, params.api.Path, additionalProtos)
 	if err != nil {
 		return err
 	}
@@ -124,9 +127,9 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 	return extractOutput(ctx, params.outputZipPath, params.library.Output)
 }
 
-// gatherTargetProtos collects all proto files inside the target API directory
-// and appends common resources.
-func gatherTargetProtos(googleapisDir, apiPath string) ([]string, error) {
+// gatherTargetProtos collects all proto files inside the target API directory,
+// appends common resources, and appends any configured additional protos.
+func gatherTargetProtos(googleapisDir, apiPath string, additionalProtos []string) ([]string, error) {
 	var targetProtos []string
 	apiDir := filepath.Join(googleapisDir, apiPath)
 	protos, err := gatherProtos(apiDir)
@@ -138,6 +141,9 @@ func gatherTargetProtos(googleapisDir, apiPath string) ([]string, error) {
 	commonResources := filepath.Join(googleapisDir, "google/cloud/common_resources.proto")
 	if _, err := os.Stat(commonResources); err == nil {
 		targetProtos = append(targetProtos, commonResources)
+	}
+	for _, p := range additionalProtos {
+		targetProtos = append(targetProtos, filepath.Join(googleapisDir, filepath.FromSlash(p)))
 	}
 	if len(targetProtos) == 0 {
 		return nil, fmt.Errorf("no target protos found for API %s", apiPath)
@@ -222,4 +228,16 @@ func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigPath s
 // output directory.
 func DefaultOutput(name, defaultOutput string) string {
 	return filepath.Join(defaultOutput, name)
+}
+
+func resolveAdditionalProtos(library *config.Library, api *config.API) []string {
+	var additionalProtos []string
+	if library.PHP != nil {
+		additionalProtos = append(additionalProtos, library.PHP.AdditionalProtos...)
+	}
+	if api.PHP != nil {
+		additionalProtos = append(additionalProtos, api.PHP.AdditionalProtos...)
+	}
+	slices.Sort(additionalProtos)
+	return slices.Compact(additionalProtos)
 }

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -110,7 +110,6 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 	}
 	opts := gapicOpts(params.api, apiMetadata, grpcConfigPath)
 	additionalProtos := resolveAdditionalProtos(params.library, params.api)
-
 	targetProtos, err := gatherTargetProtos(googleapisDir, params.api.Path, additionalProtos)
 	if err != nil {
 		return err

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -373,4 +373,3 @@ func TestResolveAdditionalProtos(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -181,11 +181,12 @@ func TestGapicOpts(t *testing.T) {
 
 func TestGatherTargetProtos(t *testing.T) {
 	for _, test := range []struct {
-		name       string
-		setupFiles []string
-		apiPath    string
-		wantProtos []string
-		wantErr    bool
+		name             string
+		setupFiles       []string
+		apiPath          string
+		additionalProtos []string
+		wantProtos       []string
+		wantErr          bool
 	}{
 		{
 			name:       "no protos found",
@@ -213,6 +214,23 @@ func TestGatherTargetProtos(t *testing.T) {
 				"google/cloud/common_resources.proto",
 			},
 		},
+		{
+			name: "protos found, common resources and additional protos present",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+				"google/cloud/common_resources.proto",
+				"google/cloud/location/location.proto",
+			},
+			apiPath: "google/cloud/secretmanager/v1",
+			additionalProtos: []string{
+				"google/cloud/location/location.proto",
+			},
+			wantProtos: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+				"google/cloud/common_resources.proto",
+				"google/cloud/location/location.proto",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -225,7 +243,7 @@ func TestGatherTargetProtos(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			got, err := gatherTargetProtos(tempDir, test.apiPath)
+			got, err := gatherTargetProtos(tempDir, test.apiPath, test.additionalProtos)
 			if (err != nil) != test.wantErr {
 				t.Fatalf("gatherTargetProtos() error = %v, wantErr = %v", err, test.wantErr)
 			}
@@ -298,3 +316,61 @@ func TestDefaultOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveAdditionalProtos(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		api     *config.API
+		want    []string
+	}{
+		{
+			name:    "empty configs returns nil",
+			library: &config.Library{},
+			api:     &config.API{},
+			want:    nil,
+		},
+		{
+			name: "only library additional protos",
+			library: &config.Library{
+				PHP: &config.PHPPackage{
+					AdditionalProtos: []string{"a.proto", "b.proto"},
+				},
+			},
+			api:  &config.API{},
+			want: []string{"a.proto", "b.proto"},
+		},
+		{
+			name:    "only api additional protos",
+			library: &config.Library{},
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					AdditionalProtos: []string{"c.proto", "d.proto"},
+				},
+			},
+			want: []string{"c.proto", "d.proto"},
+		},
+		{
+			name: "merges and deduplicates with sorted output",
+			library: &config.Library{
+				PHP: &config.PHPPackage{
+					AdditionalProtos: []string{"b.proto", "a.proto"},
+				},
+			},
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					AdditionalProtos: []string{"c.proto", "b.proto", "d.proto"},
+				},
+			},
+			want: []string{"a.proto", "b.proto", "c.proto", "d.proto"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := resolveAdditionalProtos(test.library, test.api)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -186,14 +186,7 @@ func TestGatherTargetProtos(t *testing.T) {
 		apiPath          string
 		additionalProtos []string
 		wantProtos       []string
-		wantErr          bool
 	}{
-		{
-			name:       "no protos found",
-			setupFiles: nil,
-			apiPath:    "google/cloud/secretmanager/v1",
-			wantErr:    true,
-		},
 		{
 			name: "protos found, no common resources",
 			setupFiles: []string{
@@ -244,11 +237,8 @@ func TestGatherTargetProtos(t *testing.T) {
 				}
 			}
 			got, err := gatherTargetProtos(tempDir, test.apiPath, test.additionalProtos)
-			if (err != nil) != test.wantErr {
-				t.Fatalf("gatherTargetProtos() error = %v, wantErr = %v", err, test.wantErr)
-			}
-			if test.wantErr {
-				return
+			if err != nil {
+				t.Fatal(err)
 			}
 			var want []string
 			for _, file := range test.wantProtos {
@@ -256,6 +246,37 @@ func TestGatherTargetProtos(t *testing.T) {
 			}
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGatherTargetProtos_Error(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		setupFiles []string
+		apiPath    string
+	}{
+		{
+			name:       "no protos found",
+			setupFiles: nil,
+			apiPath:    "google/cloud/secretmanager/v1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			for _, file := range test.setupFiles {
+				p := filepath.Join(tempDir, file)
+				if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(p, []byte(""), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := gatherTargetProtos(tempDir, test.apiPath, nil)
+			if err == nil {
+				t.Fatal("gatherTargetProtos() expected error, got nil")
 			}
 		})
 	}


### PR DESCRIPTION
Gather additional protos from package-level and API-level configurations, deduplicate them, and append them as target compile files to the protoc command.
This allows generator plugins to resolve and generate code for mixed-in APIs.

Tested locally with `librarian generate Ces`, looks like mixin (location) is generated as expected.

For #6743