### PR TITLE
feat(sidekick/swift): use internal import over @_implementationOnly

### DIFF
--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -106,7 +106,7 @@ type codec struct {
 	GeneratedFiles map[string]int
 
 	// The name of the private module containing raw stubs (e.g. "StorageControlProtos").
-	// Used by convert-swift to generate @_implementationOnly imports and prefix raw types.
+	// Used by convert-swift to generate internal imports and prefix raw types.
 	ModulePath string
 }
 

--- a/internal/sidekick/swift/templates/convert/convert_enum_file.swift.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_enum_file.swift.mustache
@@ -25,8 +25,8 @@ limitations under the License.
 {{/Codec.IsGated}}
 import Foundation
 import GoogleCloudGax
-@_implementationOnly import SwiftProtobuf
-@_implementationOnly import {{Codec.ModulePath}}
+internal import SwiftProtobuf
+internal import {{Codec.ModulePath}}
 
 {{> /templates/convert/convert_enum}}
 {{#Codec.IsGated}}


### PR DESCRIPTION
`@_implementationOnly` is deprecated https://docs.swift.org/compiler/documentation/diagnostics/implementation-only-deprecated/.

Moving to `internal import`