### PR TITLE
feat(internal/librarian/php): add tidying logic for additional_protos

### DIFF
--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"slices"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/yaml"
+)
+
+// Tidy tidies configuration for a library.
+func Tidy(lib *config.Library) (*config.Library, error) {
+	for _, api := range lib.APIs {
+		if api.PHP == nil {
+			continue
+		}
+		if len(api.PHP.AdditionalProtos) > 0 {
+			slices.Sort(api.PHP.AdditionalProtos)
+			api.PHP.AdditionalProtos = slices.Compact(api.PHP.AdditionalProtos)
+		}
+	}
+	if lib.PHP != nil {
+		empty, err := yaml.Empty(lib.PHP)
+		if err != nil {
+			return nil, err
+		}
+		if empty {
+			lib.PHP = nil
+		}
+	}
+	return lib, nil
+}

--- a/internal/librarian/php/tidy_test.go
+++ b/internal/librarian/php/tidy_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestTidy(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   *config.Library
+		want *config.Library
+	}{
+		{
+			name: "nil configurations",
+			in:   &config.Library{},
+			want: &config.Library{},
+		},
+		{
+			name: "nilifies empty package config",
+			in: &config.Library{
+				PHP: &config.PHPPackage{},
+			},
+			want: &config.Library{
+				PHP: nil,
+			},
+		},
+		{
+			name: "sorts and deduplicates API additional protos",
+			in: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/ces/v1",
+						PHP: &config.PHPAPI{
+							AdditionalProtos: []string{"d.proto", "b.proto", "d.proto", "a.proto", "b.proto"},
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/ces/v1",
+						PHP: &config.PHPAPI{
+							AdditionalProtos: []string{"a.proto", "b.proto", "d.proto"},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Tidy(test.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/serviceconfig"
@@ -204,6 +205,7 @@ func validateLanguageConfig(cfg *config.Config) error {
 var languageTidiers = map[string]func(*config.Library) (*config.Library, error){
 	config.LanguageJava:   java.Tidy,
 	config.LanguageNodejs: nodejs.Tidy,
+	config.LanguagePhp:    php.Tidy,
 	config.LanguagePython: python.Tidy,
 	config.LanguageRust:   rust.Tidy,
 }


### PR DESCRIPTION
Add a PHP config tidier to deduplicate AdditionalProtos and cleans up empty package-level PHP configurations.

Fixes #6811 
For #6743
