### PR TITLE
cleanup(sidekick/swift): rename version file

### DIFF
--- a/internal/sidekick/swift/generate_version.go
+++ b/internal/sidekick/swift/generate_version.go
@@ -54,7 +54,7 @@ func GenerateVersion(ctx context.Context, outDir string, library *config.Library
 	if err != nil {
 		return err
 	}
-	destination := filepath.Join(outDir, "Package+Version.swift")
+	destination := filepath.Join(outDir, "PackageVersion.swift")
 	if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
 		return err
 	}

--- a/internal/sidekick/swift/generate_version_test.go
+++ b/internal/sidekick/swift/generate_version_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestGenerateVersion(t *testing.T) {
-	const expectedFile = "Package+Version.swift"
+	const expectedFile = "PackageVersion.swift"
 	library := &config.Library{
 		CopyrightYear: "2038",
 		Version:       "1.2.3-test",


### PR DESCRIPTION
Use `PackageVersion.swift` instead of `Package+Version.swift`. The naming conventions in Swift recommand using `+` only for extension files.