### PR TITLE
feat(internal/librarian/php): make CommonResources configurable for php

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -446,6 +446,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `migration_mode` | string | Controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY"). |
+| `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Defaults to true if nil. |
 
 ## PHPPackage Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -129,6 +129,7 @@ This document describes the schema for the librarian.yaml.
 | `go` | [GoDefault](#godefault-configuration) (optional) | Contains Go-specific default configuration. |
 | `java` | [JavaDefault](#javadefault-configuration) (optional) | Contains Java-specific default configuration. |
 | `nodejs` | [NodejsPackage](#nodejspackage-configuration) (optional) | Contains Node.js-specific default configuration. |
+| `php` | [PHPDefault](#phpdefault-configuration) (optional) | Contains PHP-specific default configuration. |
 | `rust` | [RustDefault](#rustdefault-configuration) (optional) | Contains Rust-specific default configuration. |
 | `python` | [PythonDefault](#pythondefault-configuration) (optional) | Contains Python-specific default configuration. |
 | `swift` | [SwiftDefault](#swiftdefault-configuration) (optional) | Contains Swift-specific default configuration. |
@@ -446,6 +447,12 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `migration_mode` | string | Controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY"). |
+| `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Defaults to true if nil. |
+
+## PHPDefault Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Defaults to true if nil. |
 
 ## PHPPackage Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -447,13 +447,13 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `migration_mode` | string | Controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY"). |
-| `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Defaults to true if nil. |
+| `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
 
 ## PHPDefault Configuration
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Defaults to true if nil. |
+| `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
 
 ## PHPPackage Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,6 +271,9 @@ type Default struct {
 	// Nodejs contains Node.js-specific default configuration.
 	Nodejs *NodejsPackage `yaml:"nodejs,omitempty"`
 
+	// PHP contains PHP-specific default configuration.
+	PHP *PHPDefault `yaml:"php,omitempty"`
+
 	// Rust contains Rust-specific default configuration.
 	Rust *RustDefault `yaml:"rust,omitempty"`
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -817,4 +817,8 @@ type PHPAPI struct {
 
 	// MigrationMode controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY").
 	MigrationMode string `yaml:"migration_mode,omitempty"`
+
+	// CommonResources indicates whether to include common resources in generation.
+	// Defaults to true if nil.
+	CommonResources *bool `yaml:"common_resources,omitempty"`
 }

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -809,7 +809,7 @@ type NodejsAPI struct {
 // PHPDefault contains PHP-specific global default configuration.
 type PHPDefault struct {
 	// CommonResources indicates whether to include common resources in generation.
-	// Defaults to true if nil.
+	// Must be configured either globally or per-API.
 	CommonResources *bool `yaml:"common_resources,omitempty"`
 }
 
@@ -826,6 +826,6 @@ type PHPAPI struct {
 	MigrationMode string `yaml:"migration_mode,omitempty"`
 
 	// CommonResources indicates whether to include common resources in generation.
-	// Defaults to true if nil.
+	// Must be configured either globally or per-API.
 	CommonResources *bool `yaml:"common_resources,omitempty"`
 }

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -806,6 +806,13 @@ type NodejsAPI struct {
 	Path string `yaml:"path,omitempty"`
 }
 
+// PHPDefault contains PHP-specific global default configuration.
+type PHPDefault struct {
+	// CommonResources indicates whether to include common resources in generation.
+	// Defaults to true if nil.
+	CommonResources *bool `yaml:"common_resources,omitempty"`
+}
+
 // PHPPackage contains PHP-specific library configuration.
 type PHPPackage struct {
 }

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -24,7 +24,6 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
-	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
@@ -58,9 +57,27 @@ func fillDefaults(lib *config.Library, d *config.Default) *config.Library {
 		return fillPython(lib, d)
 	case d.Swift != nil:
 		return fillSwift(lib, d)
+	case d.PHP != nil:
+		return fillPHP(lib, d)
 	default:
 		return lib
 	}
+}
+
+// fillPHP populates empty PHP-specific fields in lib from the provided default.
+func fillPHP(lib *config.Library, d *config.Default) *config.Library {
+	if d == nil || d.PHP == nil {
+		return lib
+	}
+	for _, api := range lib.APIs {
+		if api.PHP == nil {
+			api.PHP = &config.PHPAPI{}
+		}
+		if api.PHP.CommonResources == nil && d.PHP.CommonResources != nil {
+			api.PHP.CommonResources = d.PHP.CommonResources
+		}
+	}
+	return lib
 }
 
 // fillGo populates empty Go-specific fields in lib from the provided default.
@@ -341,8 +358,6 @@ func fillLibraryDefaults(language string, lib *config.Library) (*config.Library,
 		return java.Fill(lib)
 	case config.LanguagePython:
 		return python.Fill(lib)
-	case config.LanguagePhp:
-		return php.Fill(lib)
 	default:
 		return lib, nil
 	}

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
@@ -340,6 +341,8 @@ func fillLibraryDefaults(language string, lib *config.Library) (*config.Library,
 		return java.Fill(lib)
 	case config.LanguagePython:
 		return python.Fill(lib)
+	case config.LanguagePhp:
+		return php.Fill(lib)
 	default:
 		return lib, nil
 	}

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -627,6 +627,75 @@ func TestFillDefaults_Go(t *testing.T) {
 	}
 }
 
+func TestFillDefaults_PHP(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		lib      *config.Library
+		defaults *config.PHPDefault
+		want     *config.Library
+	}{
+		{
+			name: "fills common_resources default when nil",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+					},
+				},
+			},
+			defaults: &config.PHPDefault{
+				CommonResources: new(true),
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: new(true),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "does not override API level common_resources",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: new(false),
+						},
+					},
+				},
+			},
+			defaults: &config.PHPDefault{
+				CommonResources: new(true),
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: new(false),
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			defaults := &config.Default{
+				PHP: test.defaults,
+			}
+			got := fillDefaults(test.lib, defaults)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestApplyDefaults(t *testing.T) {
 	for _, test := range []struct {
 		name        string

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -32,6 +32,10 @@ import (
 	"github.com/googleapis/librarian/internal/tool/protoc"
 )
 
+var (
+	errCommonResourcesUnconfigured = errors.New("common_resources must be set (either per-API or globally under default.php)")
+)
+
 // Generate generates a PHP client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) (err error) {
 	if len(library.APIs) == 0 {
@@ -97,6 +101,9 @@ type generateAPIParams struct {
 // all target proto files, and executing the PHP generator plugin via protoc.
 // It extracts the resulting ZIP archive directly to the library output directory.
 func generateAPI(ctx context.Context, params *generateAPIParams) error {
+	if params.api.PHP == nil || params.api.PHP.CommonResources == nil {
+		return errCommonResourcesUnconfigured
+	}
 	googleapisDir := params.srcCfg.Root("googleapis")
 	// Resolve service config files
 	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, params.api.Path)

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -112,7 +112,8 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 	if params.api.PHP != nil {
 		additionalProtos = params.api.PHP.AdditionalProtos
 	}
-	targetProtos, err := gatherTargetProtos(googleapisDir, params.api.Path, additionalProtos)
+	includeCommonResources := *params.api.PHP.CommonResources
+	targetProtos, err := gatherTargetProtos(googleapisDir, params.api.Path, additionalProtos, includeCommonResources)
 	if err != nil {
 		return err
 	}
@@ -130,25 +131,22 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 
 // gatherTargetProtos collects all proto files inside the target API directory,
 // appends common resources, and appends any configured additional protos.
-func gatherTargetProtos(googleapisDir, apiPath string, additionalProtos []string) ([]string, error) {
-	var targetProtos []string
-	apiDir := filepath.Join(googleapisDir, apiPath)
-	protos, err := gatherProtos(apiDir)
+func gatherTargetProtos(googleapisDir, apiPath string, additionalProtos []string, includeCommonResources bool) ([]string, error) {
+	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
+	targetProtos, err := gatherProtos(apiDir)
 	if err != nil {
 		return nil, err
 	}
-	targetProtos = append(targetProtos, protos...)
-	// Always include common resources if present
-	// TODO(https://github.com/googleapis/librarian/issues/6813): make this configurable
-	commonResources := filepath.Join(googleapisDir, "google/cloud/common_resources.proto")
-	if _, err := os.Stat(commonResources); err == nil {
+	if len(targetProtos) == 0 {
+		return nil, fmt.Errorf("no target protos found for API %s", apiPath)
+	}
+
+	if includeCommonResources {
+		commonResources := filepath.Join(googleapisDir, "google/cloud/common_resources.proto")
 		targetProtos = append(targetProtos, commonResources)
 	}
 	for _, p := range additionalProtos {
 		targetProtos = append(targetProtos, filepath.Join(googleapisDir, filepath.FromSlash(p)))
-	}
-	if len(targetProtos) == 0 {
-		return nil, fmt.Errorf("no target protos found for API %s", apiPath)
 	}
 	return targetProtos, nil
 }

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -32,6 +32,10 @@ import (
 	"github.com/googleapis/librarian/internal/tool/protoc"
 )
 
+const (
+	commonResourcesProto = "google/cloud/common_resources.proto"
+)
+
 var (
 	errCommonResourcesUnconfigured = errors.New("common_resources must be set (either per-API or globally under default.php)")
 )
@@ -149,7 +153,7 @@ func gatherTargetProtos(googleapisDir, apiPath string, additionalProtos []string
 	}
 
 	if includeCommonResources {
-		commonResources := filepath.Join(googleapisDir, "google/cloud/common_resources.proto")
+		commonResources := filepath.Join(googleapisDir, commonResourcesProto)
 		targetProtos = append(targetProtos, commonResources)
 	}
 	for _, p := range additionalProtos {

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -181,43 +181,47 @@ func TestGapicOpts(t *testing.T) {
 
 func TestGatherTargetProtos(t *testing.T) {
 	for _, test := range []struct {
-		name             string
-		setupFiles       []string
-		apiPath          string
-		additionalProtos []string
-		wantProtos       []string
+		name                   string
+		setupFiles             []string
+		apiPath                string
+		additionalProtos       []string
+		includeCommonResources bool
+		wantProtos             []string
 	}{
 		{
-			name: "protos found, no common resources",
+			name: "protos found, common resources enabled",
 			setupFiles: []string{
 				"google/cloud/secretmanager/v1/service.proto",
 			},
-			apiPath:    "google/cloud/secretmanager/v1",
-			wantProtos: []string{"google/cloud/secretmanager/v1/service.proto"},
-		},
-		{
-			name: "protos found, common resources present",
-			setupFiles: []string{
-				"google/cloud/secretmanager/v1/service.proto",
-				"google/cloud/common_resources.proto",
-			},
-			apiPath: "google/cloud/secretmanager/v1",
+			apiPath:                "google/cloud/secretmanager/v1",
+			includeCommonResources: true,
 			wantProtos: []string{
 				"google/cloud/secretmanager/v1/service.proto",
 				"google/cloud/common_resources.proto",
 			},
 		},
 		{
+			name: "protos found, common resources disabled",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+			apiPath:                "google/cloud/secretmanager/v1",
+			includeCommonResources: false,
+			wantProtos: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+		{
 			name: "protos found, common resources and additional protos present",
 			setupFiles: []string{
 				"google/cloud/secretmanager/v1/service.proto",
-				"google/cloud/common_resources.proto",
 				"google/cloud/location/location.proto",
 			},
 			apiPath: "google/cloud/secretmanager/v1",
 			additionalProtos: []string{
 				"google/cloud/location/location.proto",
 			},
+			includeCommonResources: true,
 			wantProtos: []string{
 				"google/cloud/secretmanager/v1/service.proto",
 				"google/cloud/common_resources.proto",
@@ -236,7 +240,7 @@ func TestGatherTargetProtos(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			got, err := gatherTargetProtos(tempDir, test.apiPath, test.additionalProtos)
+			got, err := gatherTargetProtos(tempDir, test.apiPath, test.additionalProtos, test.includeCommonResources)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -274,7 +278,7 @@ func TestGatherTargetProtos_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			_, err := gatherTargetProtos(tempDir, test.apiPath, nil)
+			_, err := gatherTargetProtos(tempDir, test.apiPath, nil, true)
 			if err == nil {
 				t.Fatal("gatherTargetProtos() expected error, got nil")
 			}

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -15,6 +15,7 @@
 package php
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,6 +47,9 @@ func TestGenerate(t *testing.T) {
 		APIs: []*config.API{
 			{
 				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					CommonResources: new(true),
+				},
 			},
 		},
 	}
@@ -76,6 +80,50 @@ func requirePHPGenerator(t *testing.T) {
 	wrapperPath := filepath.Join(genDir, "wrapper.sh")
 	if _, err := os.Stat(wrapperPath); err != nil {
 		t.Skip("skipping test: PHP generator is not installed (run 'librarian install php' first)")
+	}
+}
+
+func TestGenerate_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		lib     *config.Library
+		wantErr error
+	}{
+		{
+			name: "missing PHP config",
+			lib: &config.Library{
+				Name: "SecretManager",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+					},
+				},
+			},
+			wantErr: errCommonResourcesUnconfigured,
+		},
+		{
+			name: "missing common_resources config",
+			lib: &config.Library{
+				Name: "SecretManager",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP:  &config.PHPAPI{},
+					},
+				},
+			},
+			wantErr: errCommonResourcesUnconfigured,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Language: config.LanguagePhp,
+			}
+			err := Generate(t.Context(), cfg, test.lib, &sources.Sources{Googleapis: t.TempDir()})
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Generate() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -28,8 +28,7 @@ func Fill(lib *config.Library) (*config.Library, error) {
 			api.PHP = &config.PHPAPI{}
 		}
 		if api.PHP.CommonResources == nil {
-			trueVal := true
-			api.PHP.CommonResources = &trueVal
+			api.PHP.CommonResources = new(true)
 		}
 	}
 	return lib, nil

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -41,7 +41,6 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			api.PHP = nil
 		}
 	}
-
 	if lib.PHP != nil {
 		empty, err := yaml.Empty(lib.PHP)
 		if err != nil {
@@ -51,7 +50,6 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			lib.PHP = nil
 		}
 	}
-
 	return lib, nil
 }
 

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -21,7 +21,21 @@ import (
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
-// Tidy tidies configuration for a library.
+// Fill populates PHP-specific default values for a library.
+func Fill(lib *config.Library) (*config.Library, error) {
+	for _, api := range lib.APIs {
+		if api.PHP == nil {
+			api.PHP = &config.PHPAPI{}
+		}
+		if api.PHP.CommonResources == nil {
+			trueVal := true
+			api.PHP.CommonResources = &trueVal
+		}
+	}
+	return lib, nil
+}
+
+// Tidy tidies PHP-specific configuration for a library.
 func Tidy(lib *config.Library) (*config.Library, error) {
 	for _, api := range lib.APIs {
 		if api.PHP == nil {
@@ -31,7 +45,18 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			slices.Sort(api.PHP.AdditionalProtos)
 			api.PHP.AdditionalProtos = slices.Compact(api.PHP.AdditionalProtos)
 		}
+		if api.PHP.CommonResources != nil && *api.PHP.CommonResources {
+			api.PHP.CommonResources = nil
+		}
+		empty, err := yaml.Empty(api.PHP)
+		if err != nil {
+			return nil, err
+		}
+		if empty {
+			api.PHP = nil
+		}
 	}
+
 	if lib.PHP != nil {
 		empty, err := yaml.Empty(lib.PHP)
 		if err != nil {
@@ -41,5 +66,6 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			lib.PHP = nil
 		}
 	}
+
 	return lib, nil
 }

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -15,24 +15,13 @@
 package php
 
 import (
+	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/yaml"
 )
-
-// Fill populates PHP-specific default values for a library.
-func Fill(lib *config.Library) (*config.Library, error) {
-	for _, api := range lib.APIs {
-		if api.PHP == nil {
-			api.PHP = &config.PHPAPI{}
-		}
-		if api.PHP.CommonResources == nil {
-			api.PHP.CommonResources = new(true)
-		}
-	}
-	return lib, nil
-}
 
 // Tidy tidies PHP-specific configuration for a library.
 func Tidy(lib *config.Library) (*config.Library, error) {
@@ -67,4 +56,29 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 	}
 
 	return lib, nil
+}
+
+// Validate checks that the PHP-specific configuration is complete and valid.
+func Validate(cfg *config.Config) error {
+	if cfg.Language != config.LanguagePhp {
+		return nil
+	}
+	var errs []error
+	// Check if a global default is set.
+	var hasGlobalDefault bool
+	if cfg.Default != nil && cfg.Default.PHP != nil && cfg.Default.PHP.CommonResources != nil {
+		hasGlobalDefault = true
+	}
+	for _, library := range cfg.Libraries {
+		for _, api := range library.APIs {
+			// If neither API override nor global default is configured, return an error.
+			if !hasGlobalDefault && (api.PHP == nil || api.PHP.CommonResources == nil) {
+				errs = append(errs, fmt.Errorf("library %q, API %q: common_resources is required for PHP configurations but was not configured (either set it on the API level or globally under default.php.common_resources)", library.Name, api.Path))
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
 }

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -53,6 +53,9 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 	return lib, nil
 }
 
+// ErrMissingCommonResources is returned when common_resources is not configured.
+var ErrMissingCommonResources = errors.New("common_resources is required for PHP configurations but was not configured (either set it on the API level or globally under default.php.common_resources)")
+
 // Validate checks that the PHP-specific configuration is complete and valid.
 func Validate(cfg *config.Config) error {
 	if cfg.Language != config.LanguagePhp {
@@ -68,7 +71,7 @@ func Validate(cfg *config.Config) error {
 		for _, api := range library.APIs {
 			// If neither API override nor global default is configured, return an error.
 			if !hasGlobalDefault && (api.PHP == nil || api.PHP.CommonResources == nil) {
-				errs = append(errs, fmt.Errorf("library %q, API %q: common_resources is required for PHP configurations but was not configured (either set it on the API level or globally under default.php.common_resources)", library.Name, api.Path))
+				errs = append(errs, fmt.Errorf("library %q, API %q: %w", library.Name, api.Path, ErrMissingCommonResources))
 			}
 		}
 	}

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -33,9 +33,6 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			slices.Sort(api.PHP.AdditionalProtos)
 			api.PHP.AdditionalProtos = slices.Compact(api.PHP.AdditionalProtos)
 		}
-		if api.PHP.CommonResources != nil && *api.PHP.CommonResources {
-			api.PHP.CommonResources = nil
-		}
 		empty, err := yaml.Empty(api.PHP)
 		if err != nil {
 			return nil, err

--- a/internal/librarian/php/tidy_test.go
+++ b/internal/librarian/php/tidy_test.go
@@ -15,6 +15,7 @@
 package php
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -137,9 +138,8 @@ func TestTidy(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		cfg     *config.Config
-		wantErr bool
+		name string
+		cfg  *config.Config
 	}{
 		{
 			name: "valid when configured per-API",
@@ -159,7 +159,6 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "valid when configured globally",
@@ -181,24 +180,6 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
-		},
-		{
-			name: "invalid when not configured anywhere",
-			cfg: &config.Config{
-				Language: config.LanguagePhp,
-				Libraries: []*config.Library{
-					{
-						Name: "secretmanager",
-						APIs: []*config.API{
-							{
-								Path: "google/cloud/secretmanager/v1",
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
 		},
 		{
 			name: "skips other languages",
@@ -215,13 +196,44 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Validate(test.cfg); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidate_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		cfg     *config.Config
+		wantErr error
+	}{
+		{
+			name: "invalid when not configured anywhere",
+			cfg: &config.Config{
+				Language: config.LanguagePhp,
+				Libraries: []*config.Library{
+					{
+						Name: "secretmanager",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/secretmanager/v1",
+							},
+						},
+					},
+				},
+			},
+			wantErr: ErrMissingCommonResources,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := Validate(test.cfg)
-			if (err != nil) != test.wantErr {
-				t.Errorf("Validate() error = %v, wantErr = %v", err, test.wantErr)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Validate() error = %v, wantErr %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/php/tidy_test.go
+++ b/internal/librarian/php/tidy_test.go
@@ -22,97 +22,104 @@ import (
 )
 
 func TestTidy(t *testing.T) {
-	trueVal := true
-	falseVal := false
-
 	for _, test := range []struct {
 		name string
 		in   *config.Library
 		want *config.Library
 	}{
 		{
-			name: "nil configurations",
-			in:   &config.Library{},
-			want: &config.Library{},
-		},
-		{
-			name: "nilifies empty package config",
-			in: &config.Library{
-				PHP: &config.PHPPackage{},
-			},
-			want: &config.Library{
-				PHP: nil,
-			},
-		},
-		{
-			name: "sorts and deduplicates API additional protos",
+			name: "nil_configurations",
 			in: &config.Library{
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/ces/v1",
-						PHP: &config.PHPAPI{
-							AdditionalProtos: []string{"d.proto", "b.proto", "d.proto", "a.proto", "b.proto"},
-						},
+						Path: "google/cloud/secretmanager/v1",
 					},
 				},
 			},
 			want: &config.Library{
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/ces/v1",
+						Path: "google/cloud/secretmanager/v1",
+					},
+				},
+			},
+		},
+		{
+			name: "nilifies_empty_package_config",
+			in: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{},
+				},
+			},
+		},
+		{
+			name: "sorts_and_deduplicates_API_additional_protos",
+			in: &config.Library{
+				APIs: []*config.API{
+					{
 						PHP: &config.PHPAPI{
-							AdditionalProtos: []string{"a.proto", "b.proto", "d.proto"},
+							AdditionalProtos: []string{"b.proto", "a.proto", "a.proto"},
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{
+							AdditionalProtos: []string{"a.proto", "b.proto"},
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "removes default true CommonResources and empty PHP structs",
+			name: "keeps_true_CommonResources",
 			in: &config.Library{
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
-							CommonResources: &trueVal,
+							CommonResources: new(true),
 						},
 					},
 				},
-				PHP: &config.PHPPackage{},
 			},
 			want: &config.Library{
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/secretmanager/v1",
-						PHP:  nil,
+						PHP: &config.PHPAPI{
+							CommonResources: new(true),
+						},
 					},
 				},
-				PHP: nil,
 			},
 		},
 		{
-			name: "keeps false CommonResources",
+			name: "keeps_false_CommonResources",
 			in: &config.Library{
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
-							CommonResources: &falseVal,
+							CommonResources: new(false),
 						},
 					},
 				},
-				PHP: &config.PHPPackage{},
 			},
 			want: &config.Library{
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
-							CommonResources: &falseVal,
+							CommonResources: new(false),
 						},
 					},
 				},
-				PHP: nil,
 			},
 		},
 	} {

--- a/internal/librarian/php/tidy_test.go
+++ b/internal/librarian/php/tidy_test.go
@@ -21,91 +21,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func TestFill(t *testing.T) {
-	trueVal := true
-
-	for _, test := range []struct {
-		name string
-		lib  *config.Library
-		want *config.Library
-	}{
-		{
-			name: "fills empty PHP config with defaults",
-			lib: &config.Library{
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			want: &config.Library{
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-						PHP: &config.PHPAPI{
-							CommonResources: &trueVal,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "preserves existing PHP config",
-			lib: &config.Library{
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-						PHP: &config.PHPAPI{
-							CommonResources: &trueVal,
-						},
-					},
-				},
-			},
-			want: &config.Library{
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-						PHP: &config.PHPAPI{
-							CommonResources: &trueVal,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "preserves explicitly disabled CommonResources",
-			lib: &config.Library{
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-						PHP: &config.PHPAPI{
-							CommonResources: func() *bool { b := false; return &b }(),
-						},
-					},
-				},
-			},
-			want: &config.Library{
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-						PHP: &config.PHPAPI{
-							CommonResources: func() *bool { b := false; return &b }(),
-						},
-					},
-				},
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := Fill(test.lib)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestTidy(t *testing.T) {
 	trueVal := true
 	falseVal := false
@@ -208,6 +123,98 @@ func TestTidy(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		cfg     *config.Config
+		wantErr bool
+	}{
+		{
+			name: "valid when configured per-API",
+			cfg: &config.Config{
+				Language: config.LanguagePhp,
+				Libraries: []*config.Library{
+					{
+						Name: "secretmanager",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/secretmanager/v1",
+								PHP: &config.PHPAPI{
+									CommonResources: new(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid when configured globally",
+			cfg: &config.Config{
+				Language: config.LanguagePhp,
+				Default: &config.Default{
+					PHP: &config.PHPDefault{
+						CommonResources: new(true),
+					},
+				},
+				Libraries: []*config.Library{
+					{
+						Name: "secretmanager",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/secretmanager/v1",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid when not configured anywhere",
+			cfg: &config.Config{
+				Language: config.LanguagePhp,
+				Libraries: []*config.Library{
+					{
+						Name: "secretmanager",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/secretmanager/v1",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "skips other languages",
+			cfg: &config.Config{
+				Language: config.LanguageGo,
+				Libraries: []*config.Library{
+					{
+						Name: "secretmanager",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/secretmanager/v1",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := Validate(test.cfg)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Validate() error = %v, wantErr = %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/php/tidy_test.go
+++ b/internal/librarian/php/tidy_test.go
@@ -21,7 +21,95 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+func TestFill(t *testing.T) {
+	trueVal := true
+
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want *config.Library
+	}{
+		{
+			name: "fills empty PHP config with defaults",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: &trueVal,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "preserves existing PHP config",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: &trueVal,
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: &trueVal,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "preserves explicitly disabled CommonResources",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: func() *bool { b := false; return &b }(),
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: func() *bool { b := false; return &b }(),
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Fill(test.lib)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestTidy(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
 	for _, test := range []struct {
 		name string
 		in   *config.Library
@@ -62,6 +150,54 @@ func TestTidy(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			name: "removes default true CommonResources and empty PHP structs",
+			in: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: &trueVal,
+						},
+					},
+				},
+				PHP: &config.PHPPackage{},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP:  nil,
+					},
+				},
+				PHP: nil,
+			},
+		},
+		{
+			name: "keeps false CommonResources",
+			in: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: &falseVal,
+						},
+					},
+				},
+				PHP: &config.PHPPackage{},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							CommonResources: &falseVal,
+						},
+					},
+				},
+				PHP: nil,
 			},
 		},
 	} {

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -190,6 +190,7 @@ func validateLibraries(cfg *config.Config) error {
 // configuration.
 var languageValidators = map[string]func(*config.Config) error{
 	config.LanguageJava: java.Validate,
+	config.LanguagePhp:  php.Validate,
 }
 
 // validateLanguageConfig finds and executes the language-specific validator for a library.
@@ -251,7 +252,8 @@ func isDefaultEmpty(defaults *config.Default) bool {
 		defaults.Nodejs == nil &&
 		defaults.Rust == nil &&
 		defaults.Python == nil &&
-		defaults.Swift == nil
+		defaults.Swift == nil &&
+		defaults.PHP == nil
 }
 
 // tidyConfig removes unused sections from the configuration.


### PR DESCRIPTION
Makes `common_resources` configurable via a per API config instead of hardcoded in generation. A new configuration option is added under default: php: in the global configuration block, making `common_resources` a repository-wide configurable parameter for generation.

A validation check is added in `tidy`. Users are now required to specify common_resources either globally or per-API. If it is not configured, validation will fail.

For #6813

