### PR TITLE
chore: update go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24.3 AS build
+FROM golang:1.26.5 AS build
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/librarian
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/secretmanager v1.20.0


### PR DESCRIPTION
Update version in Dockerfile to match the version as specified in `go.mod` otherwise docker build will fail with a version mismatch error:
<img width="1484" height="230" alt="image" src="https://github.com/user-attachments/assets/ea399123-98fb-4169-8684-2c5d0385dca6" />

NOTE: I had to also bump the version of go to the next patch because of a security vulnerability.