### PR TITLE
refactor(tool/cmd/migrate): move hardcoded PHP starter configuration to yaml

### DIFF
--- a/tool/cmd/migrate/librarian_php.yaml
+++ b/tool/cmd/migrate/librarian_php.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#
 # This file serves as the starter configuration template for PHP library migrations.
 # It defines the default tools and versions (like composer packages and protoc)
 # that will be populated in the generated librarian.yaml during migration.

--- a/tool/cmd/migrate/librarian_php.yaml
+++ b/tool/cmd/migrate/librarian_php.yaml
@@ -30,6 +30,10 @@ tools:
       sha256: 29635b02c6e505fe31cba2f88ae999f00d2710fe1d65cb7cad521a82e7c5a518
       build:
         - composer install
+  pip:
+    - name: synthtool
+      version: "e643ce8e20f8fe237a31a1754524ba987de72875"
+      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875"
   protoc:
     version: "31.0"
     sha256: 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42

--- a/tool/cmd/migrate/librarian_php.yaml
+++ b/tool/cmd/migrate/librarian_php.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file serves as the starter configuration template for PHP library migrations.
+# It defines the default tools and versions (like composer packages and protoc)
+# that will be populated in the generated librarian.yaml during migration.
+#
+# This file is embedded in tool/cmd/migrate/php.go.
+# If you need to update the default tool versions for future migrations, update them here.
+language: php
+tools:
+  composer:
+    - name: google/gapic-generator-php
+      version: v1.21.2
+      package: https://github.com/googleapis/gapic-generator-php/archive/refs/tags/v1.21.2.tar.gz
+      sha256: 29635b02c6e505fe31cba2f88ae999f00d2710fe1d65cb7cad521a82e7c5a518
+      build:
+        - composer install
+  protoc:
+    version: "31.0"
+    sha256: 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42

--- a/tool/cmd/migrate/librarian_php.yaml
+++ b/tool/cmd/migrate/librarian_php.yaml
@@ -16,6 +16,9 @@
 # It defines the default tools and versions (like composer packages and protoc)
 # that will be populated in the generated librarian.yaml during migration.
 #
+# Note: Any "sources" or "libraries" defined in this template will be overwritten
+# entirely by the migration tool at runtime.
+#
 # This file is embedded in tool/cmd/migrate/php.go.
 # If you need to update the default tool versions for future migrations, update them here.
 language: php

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -31,6 +32,9 @@ import (
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
+//go:embed librarian_php.yaml
+var librarianPHPYAML []byte
+
 var protoMappings = map[string]string{
 	"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
 	"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
@@ -45,28 +49,15 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 	if err != nil {
 		return err
 	}
-	cfg := &config.Config{
-		Language: config.LanguagePhp,
-		Sources: &config.Sources{
-			Googleapis: src,
-		},
-		Libraries: libs,
-		Tools: &config.Tools{
-			Composer: []*config.ComposerTool{
-				{
-					Name:    "google/gapic-generator-php",
-					Version: "v1.21.2",
-					Package: "https://github.com/googleapis/gapic-generator-php/archive/refs/tags/v1.21.2.tar.gz",
-					SHA256:  "29635b02c6e505fe31cba2f88ae999f00d2710fe1d65cb7cad521a82e7c5a518",
-					Build:   []string{"composer install"},
-				},
-			},
-			Protoc: &config.Protoc{
-				Version: "31.0",
-				SHA256:  "24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42",
-			},
-		},
+	cfg, err := yaml.Unmarshal[config.Config](librarianPHPYAML)
+	if err != nil {
+		return fmt.Errorf("unmarshaling librarian_php.yaml: %w", err)
 	}
+	cfg.Sources = &config.Sources{
+		Googleapis: src,
+	}
+	cfg.Libraries = libs
+
 	// The directory name in Googleapis is present for migration code to look
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -96,6 +96,13 @@ func TestRunPHPMigration(t *testing.T) {
 					Build:   []string{"composer install"},
 				},
 			},
+			Pip: []*config.PipTool{
+				{
+					Name:    "synthtool",
+					Version: "e643ce8e20f8fe237a31a1754524ba987de72875",
+					Package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875",
+				},
+			},
 			Protoc: &config.Protoc{
 				Version: "31.0",
 				SHA256:  "24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42",


### PR DESCRIPTION
The hardcoded PHP starter configuration values in the migration tool are moved to an embedded `librarian_php.yaml` file for better readability. Making it easier to update default and tool section for future migrations.

The new librarian_php.yaml file is embedded into php.go and unmarshaled at runtime to initialize the configuration. Added the synthtool section to the new librarian_php.yaml  referencing  internal/librarian/python/librarian.yaml.
    
Explanatory comments have been added to the YAML file to document its purpose and usage.

For #6773 