### PR TITLE
fix(sidekick/swift): no escaping for `GateExpression`

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -59,7 +59,7 @@ func (ann *enumAnnotations) IsGated() bool {
 // In the generated code this is used as:
 //
 // ```
-// #if {{GateExpression}}
+// #if {{{GateExpression}}}
 // ... all the normal code ...
 // #endif
 // ```

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -91,7 +91,7 @@ func (ann *messageAnnotations) IsGated() bool {
 // In the generated code this is used as:
 //
 // ```
-// #if {{GateExpression}}
+// #if {{{GateExpression}}}
 // ... all the normal code ...
 // #endif
 // ```

--- a/internal/sidekick/swift/templates/common/enum_file.swift.mustache
+++ b/internal/sidekick/swift/templates/common/enum_file.swift.mustache
@@ -21,7 +21,7 @@ limitations under the License.
 {{/Codec.BoilerPlate}}
 
 {{#Codec.IsGated}}
-#if {{Codec.GateExpression}}
+#if {{{Codec.GateExpression}}}
 {{/Codec.IsGated}}
 import Foundation
 

--- a/internal/sidekick/swift/templates/common/message_file.swift.mustache
+++ b/internal/sidekick/swift/templates/common/message_file.swift.mustache
@@ -21,7 +21,7 @@ limitations under the License.
 {{/Codec.Model.BoilerPlate}}
 
 {{#Codec.IsGated}}
-#if {{Codec.GateExpression}}
+#if {{{Codec.GateExpression}}}
 {{/Codec.IsGated}}
 import Foundation
 {{#Codec.MessageImports}}

--- a/internal/sidekick/swift/templates/common/placeholder_file.swift.mustache
+++ b/internal/sidekick/swift/templates/common/placeholder_file.swift.mustache
@@ -21,7 +21,7 @@ limitations under the License.
 {{/Codec.Model.BoilerPlate}}
 
 {{#Codec.IsGated}}
-#if {{Codec.GateExpression}}
+#if {{{Codec.GateExpression}}}
 {{/Codec.IsGated}}
 import Foundation
 {{#Codec.MessageImports}}

--- a/internal/sidekick/swift/templates/convert/convert_enum_file.swift.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_enum_file.swift.mustache
@@ -21,7 +21,7 @@ limitations under the License.
 {{/Codec.BoilerPlate}}
 
 {{#Codec.IsGated}}
-#if {{Codec.GateExpression}}
+#if {{{Codec.GateExpression}}}
 {{/Codec.IsGated}}
 import Foundation
 import GoogleCloudGax


### PR DESCRIPTION
When `GateExpression` include an `&&` the generated code for `{{Codec.GateExpression}}` includes an `&amp;&amp;`. With this PR, we use triple braces to avoid the HTML escaping.

Fixes #6827 