### PR TITLE
feat(tool/cmd/migrate): add prettier formatting tools to PHP migration template

### DIFF
--- a/tool/cmd/migrate/librarian_php.yaml
+++ b/tool/cmd/migrate/librarian_php.yaml
@@ -34,6 +34,11 @@ tools:
     - name: synthtool
       version: "e643ce8e20f8fe237a31a1754524ba987de72875"
       package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875"
+  pnpm:
+    - name: prettier
+      version: 2.8.8
+    - name: "@prettier/plugin-php"
+      version: 0.19.2
   protoc:
     version: "31.0"
     sha256: 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42

--- a/tool/cmd/migrate/librarian_php.yaml
+++ b/tool/cmd/migrate/librarian_php.yaml
@@ -35,10 +35,10 @@ tools:
       version: "e643ce8e20f8fe237a31a1754524ba987de72875"
       package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875"
   pnpm:
-    - name: prettier
-      version: 2.8.8
     - name: "@prettier/plugin-php"
-      version: 0.19.2
+      version: "0.19.2"
+    - name: prettier
+      version: "2.8.8"
   protoc:
     version: "31.0"
     sha256: 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -103,6 +103,16 @@ func TestRunPHPMigration(t *testing.T) {
 					Package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875",
 				},
 			},
+			PNPM: []*config.PNPMTool{
+				{
+					Name:    "@prettier/plugin-php",
+					Version: "0.19.2",
+				},
+				{
+					Name:    "prettier",
+					Version: "2.8.8",
+				},
+			},
 			Protoc: &config.Protoc{
 				Version: "31.0",
 				SHA256:  "24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42",


### PR DESCRIPTION
Add `prettier` and `@prettier/plugin-php` to the `pnpm` tools section of `librarian_php.yaml` so that migrated librarian.yaml carry over the required tools for post-generation code formatting.

Version choices:
    - `@prettier/plugin-php` (0.19.2): Selected to match the `^0.19` constraint
      defined in the legacy `owlbot.py` post-processors (e.g., in
      `google-cloud-php/AccessApproval/owlbot.py`).
    - `prettier` (2.8.8): `@prettier/plugin-php` 0.19.x is incompatible with
      Prettier 3.x. Prettier 2.8.8 is the final stable release of Prettier 2.x,
      ensuring compatibility.

For https://github.com/googleapis/librarian/issues/6773
For https://github.com/googleapis/librarian/issues/6830
