### PR TITLE
feat(tool/cmd/migrate): set php default for common_resources

### DIFF
--- a/tool/cmd/migrate/librarian_php.yaml
+++ b/tool/cmd/migrate/librarian_php.yaml
@@ -22,6 +22,9 @@
 # This file is embedded in tool/cmd/migrate/php.go.
 # If you need to update the default tool versions for future migrations, update them here.
 language: php
+default:
+  php:
+    common_resources: true
 tools:
   composer:
     - name: google/gapic-generator-php

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -72,12 +72,18 @@ func TestRunPHPMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	commonResources := true
 	want := &config.Config{
 		Language: config.LanguagePhp,
 		Sources: &config.Sources{
 			Googleapis: &config.Source{
 				Commit: "abcd123",
 				SHA256: "sha123",
+			},
+		},
+		Default: &config.Default{
+			PHP: &config.PHPDefault{
+				CommonResources: &commonResources,
 			},
 		},
 		Libraries: []*config.Library{


### PR DESCRIPTION
Add a global default to `common_resources` to true. 
Will do followup to parse per API value from BUILD.bazel. This global default un-blocks testing with generate.

For #6813