### PR TITLE
feat(rust): run google_cloud_lro::Poller for BigQuery jobs

### DIFF
--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -46,6 +46,7 @@ type methodAnnotation struct {
 	GrpcResourceNameArgs      []string
 	IsLroPoller               bool
 	IsDiscoveryLro            bool
+	IsBigQueryInsertJob       bool
 }
 
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
@@ -316,6 +317,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		InternalBuilders:          c.internalBuilders,
 		IsLroPoller:               m.IsLroPoller,
 		IsDiscoveryLro:            isDiscoveryLro(m),
+		IsBigQueryInsertJob:       m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob",
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -158,7 +158,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	hasLROs := false
 	for _, s := range model.Services {
 		for _, m := range s.Methods {
-			if m.OperationInfo != nil || m.DiscoveryLro != nil {
+			if m.OperationInfo != nil || m.DiscoveryLro != nil || m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob" {
 				hasLROs = true
 			}
 			if !codec.generateMethod(m) {

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -385,7 +385,7 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
 		// not save us any computations.
 
 		for _, m := range s.Methods {
-			if m.OperationInfo != nil || m.IsLroPoller {
+			if m.OperationInfo != nil || m.IsLroPoller || m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob" {
 				hasLROs = true
 			}
 			if len(m.AutoPopulated) != 0 {

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -220,7 +220,7 @@ pub mod {{Codec.ModuleName}} {
             {{/Model.Codec.LroStubOptions}}
 
             let stub = self.0.stub.clone();
-            let mut options = self.0.options.clone();
+            let options = self.0.options.clone();
             options.set_retry_policy(google_cloud_gax::retry_policy::NeverRetry);
             {{#Codec.PollingPathParameters}}
             let {{Name}} = self.0.request.{{Name}}.clone();
@@ -267,6 +267,59 @@ pub mod {{Codec.ModuleName}} {
             {{/Model.Codec.LroStubOptions}}
         }
         {{/DiscoveryLro}}
+        {{#Codec.IsBigQueryInsertJob}}
+
+        /// Creates a [Poller][google_cloud_lro::Poller] to work with `InsertJob`.
+        pub fn poller(
+            self
+        ) -> impl google_cloud_lro::Poller<crate::model::Job, crate::model::Job>
+        {
+            let req = self.0.request.clone();
+            let stub = self.0.stub.clone();
+            let options = self.0.options.clone();
+
+            let polling_error_policy =
+                std::sync::Arc::new(google_cloud_gax::polling_error_policy::AlwaysContinue);
+            let polling_backoff_policy = std::sync::Arc::new(
+                google_cloud_gax::exponential_backoff::ExponentialBackoff::default(),
+            );
+
+            let query = move |name: String| {
+                let stub_clone = stub.clone();
+                let mut options_clone = options.clone();
+                let req_clone = req.clone();
+                options_clone.set_retry_policy(google_cloud_gax::retry_policy::NeverRetry);
+                async move {
+                    let get_req = crate::model::GetJobRequest {
+                        project_id: req_clone.project_id.clone(),
+                        job_id: name,
+                        location: req_clone
+                            .job
+                            .as_ref()
+                            .and_then(|j| j.job_reference.as_ref())
+                            .and_then(|jr| jr.location.clone())
+                            .unwrap_or_default(),
+                        _unknown_fields: std::default::Default::default(),
+                    };
+                    let job = stub_clone
+                        .get_job(get_req, options_clone.clone())
+                        .await
+                        .map(crate::Response::into_body)?;
+
+                    Ok(job)
+                }
+            };
+
+            let start = move || async move { self.send().await };
+
+            google_cloud_lro::internal::new_discovery_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
+        }
+        {{/Codec.IsBigQueryInsertJob}}
         {{#OperationInfo}}
 
         /// Creates a [Poller][google_cloud_lro::Poller] to work with `{{Method.Codec.Name}}`.
@@ -301,7 +354,7 @@ pub mod {{Codec.ModuleName}} {
             {{/Model.Codec.LroStubOptions}}
 
             let stub = self.0.stub.clone();
-            let mut options = self.0.options.clone();
+            let options = self.0.options.clone();
             options.set_retry_policy(google_cloud_gax::retry_policy::NeverRetry);
             let query = move |name| {
                 let stub = stub.clone();


### PR DESCRIPTION
This PR modifies the template to generate an exposed \`.poller()\` method for BigQuery jobs. It delegates backoff/polling strictly to the LRO state machine by forcing \`NeverRetry\` on the underlying RPC parameters.