### PR TITLE
feat(rust): add opt-in include_bidi_streaming_methods config option

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -501,6 +501,7 @@ This document describes the schema for the librarian.yaml.
 | `routing_required` | bool | Indicates whether routing is required. |
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
+| `include_bidi_streaming_methods` | bool | Indicates whether to include gRPC bi-directional streaming methods. |
 | `post_process_protos` | string | Indicates whether to post-process protos. |
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |
 | `pagination_overrides` | list of [RustPaginationOverride](#rustpaginationoverride-configuration) | Contains overrides for pagination configuration. |
@@ -544,6 +545,7 @@ This document describes the schema for the librarian.yaml.
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_list` | yaml.StringSlice | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
+| `include_bidi_streaming_methods` | bool | Indicates whether to include gRPC bi-directional streaming methods. |
 | `internal_builders` | bool | Indicates whether generated builders should be internal to the crate. |
 | `module_path` | string | Is the Rust module path for converters (e.g., "crate::generated::gapic::model"). |
 | `module_roots` | map[string]string |  |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -162,6 +162,10 @@ type RustModule struct {
 	// methods.
 	IncludeStreamingMethods bool `yaml:"include_streaming_methods,omitempty"`
 
+	// IncludeBidiStreamingMethods indicates whether to include gRPC bi-directional streaming
+	// methods.
+	IncludeBidiStreamingMethods bool `yaml:"include_bidi_streaming_methods,omitempty"`
+
 	// InternalBuilders indicates whether generated builders should be internal to the crate.
 	InternalBuilders bool `yaml:"internal_builders,omitempty"`
 
@@ -260,6 +264,10 @@ type RustCrate struct {
 	// IncludeStreamingMethods indicates whether to include gRPC streaming
 	// methods.
 	IncludeStreamingMethods bool `yaml:"include_streaming_methods,omitempty"`
+
+	// IncludeBidiStreamingMethods indicates whether to include gRPC bi-directional streaming
+	// methods.
+	IncludeBidiStreamingMethods bool `yaml:"include_bidi_streaming_methods,omitempty"`
 
 	// PostProcessProtos indicates whether to post-process protos.
 	PostProcessProtos string `yaml:"post_process_protos,omitempty"`

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -133,6 +133,9 @@ func buildCodec(library *config.Library, releaseLevel string) map[string]string 
 	if rust.IncludeStreamingMethods {
 		codec["include-streaming-methods"] = "true"
 	}
+	if rust.IncludeBidiStreamingMethods {
+		codec["include-bidi-streaming-methods"] = "true"
+	}
 	if rust.PerServiceFeatures {
 		codec["per-service-features"] = "true"
 	}
@@ -306,6 +309,9 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	}
 	if module.IncludeStreamingMethods {
 		codec["include-streaming-methods"] = "true"
+	}
+	if module.IncludeBidiStreamingMethods {
+		codec["include-bidi-streaming-methods"] = "true"
 	}
 	detailedTracingAttributes := library.Rust != nil && library.Rust.DetailedTracingAttributes != nil && *library.Rust.DetailedTracingAttributes
 	if module.DetailedTracingAttributes != nil {

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -132,6 +132,12 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `include-streaming-methods` value %q to boolean: %w", definition, err)
 			}
 			codec.includeStreamingMethods = value
+		case key == "include-bidi-streaming-methods":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `include-bidi-streaming-methods` value %q to boolean: %w", definition, err)
+			}
+			codec.includeBidiStreamingMethods = value
 		case key == "per-service-features":
 			value, err := strconv.ParseBool(definition)
 			if err != nil {
@@ -306,6 +312,8 @@ type codec struct {
 	includeGrpcOnlyMethods bool
 	// If true, this includes gRPC streaming methods.
 	includeStreamingMethods bool
+	// If true, this includes gRPC bi-directional streaming methods.
+	includeBidiStreamingMethods bool
 	// If true, the generator will produce per-client features.
 	perServiceFeatures bool
 	// If not empty, and if `perServiceFeatures` is true, the default features

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -228,6 +228,15 @@ func TestParseOptions(t *testing.T) {
 		{
 			Format: libconfig.SpecProtobuf,
 			Options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			Update: func(c *codec) {
+				c.includeBidiStreamingMethods = true
+			},
+		},
+		{
+			Format: libconfig.SpecProtobuf,
+			Options: map[string]string{
 				"per-service-features": "true",
 			},
 			Update: func(c *codec) {
@@ -384,6 +393,7 @@ func TestParseOptionsErrors(t *testing.T) {
 		{Options: map[string]string{"package:": ""}},
 		{Options: map[string]string{"include-grpc-only-methods": ""}},
 		{Options: map[string]string{"include-streaming-methods": ""}},
+		{Options: map[string]string{"include-bidi-streaming-methods": ""}},
 		{Options: map[string]string{"per-service-features": ""}},
 		{Options: map[string]string{"detailed-tracing-attributes": ""}},
 		{Options: map[string]string{"lro-stub-options": ""}},


### PR DESCRIPTION
This change adds the include-bidi-streaming-methods configuration option in sidekick and librarian for Rust GAPIC generation. This allows target crates to opt in to experimental bidirectional streaming code generation while keeping it off by default. This is completely unused for now and is just set up for the implementation to follow. We create a separate config from include_streaming_methods, since this will involve additional changes and we don't want to break the existing workflows that rely on include_streaming_methods.

For #6835