### PR TITLE
feat(swift): format all module output directories

### DIFF
--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -53,14 +53,14 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 func Format(ctx context.Context, library *config.Library) error {
 	// Collect unique output directories to format to avoid running the formatter
 	// multiple times on the same directory (e.g. library.Output and module.Output mapping to same path).
-	dirs := map[string]bool{}
+	dirs := map[string]struct{}{}
 	if library.Output != "" {
-		dirs[library.Output] = true
+		dirs[library.Output] = struct{}{}
 	}
 	if library.Swift != nil {
 		for _, module := range library.Swift.Modules {
 			if module.Output != "" {
-				dirs[module.Output] = true
+				dirs[module.Output] = struct{}{}
 			}
 		}
 	}

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -51,7 +51,29 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 
 // Format formats a generated Swift library.
 func Format(ctx context.Context, library *config.Library) error {
-	return command.Run(ctx, "swift-format", "format", "--in-place", "--recursive", library.Output)
+	// Collect unique output directories to format to avoid running the formatter
+	// multiple times on the same directory (e.g. library.Output and module.Output mapping to same path).
+	dirs := map[string]bool{}
+	if library.Output != "" {
+		dirs[library.Output] = true
+	}
+	if library.Swift != nil {
+		for _, module := range library.Swift.Modules {
+			if module.Output != "" {
+				dirs[module.Output] = true
+			}
+		}
+	}
+
+	if len(dirs) == 0 {
+		return nil
+	}
+
+	args := []string{"format", "--in-place", "--recursive"}
+	for dir := range dirs {
+		args = append(args, dir)
+	}
+	return command.Run(ctx, "swift-format", args...)
 }
 
 // DefaultLibraryName derives a library name from an API path.

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -15,6 +15,7 @@
 package swift
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -147,15 +148,15 @@ func TestFormat(t *testing.T) {
 	}
 
 	// Verify that files in both directories were actually formatted.
-	wantContent := "func foo() {\n  print(\"hello\")\n}\n"
+	wantContent := []byte("func foo() {\n  print(\"hello\")\n}\n")
 	for _, dir := range []string{libraryDir, moduleDir} {
 		filePath := filepath.Join(dir, "Sources", "test.swift")
 		gotContent, err := os.ReadFile(filePath)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if string(gotContent) != wantContent {
-			t.Errorf("ReadFile(%s) = %q, want %q", filePath, string(gotContent), wantContent)
+		if !bytes.Equal(gotContent, wantContent) {
+			t.Errorf("ReadFile(%s) = %q, want %q", filePath, gotContent, wantContent)
 		}
 	}
 }

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -116,22 +116,47 @@ func TestFormat(t *testing.T) {
 	testhelper.RequireCommand(t, "swift-format")
 
 	outDir := t.TempDir()
-	sourcesDir := filepath.Join(outDir, "Sources")
-	if err := os.MkdirAll(sourcesDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	filePath := filepath.Join(sourcesDir, "test.swift")
-	// Write a file that needs formatting.
-	if err := os.WriteFile(filePath, []byte("func foo(){\n  print(\"hello\")\n}\n"), 0644); err != nil {
-		t.Fatal(err)
+	libraryDir := filepath.Join(outDir, "LibraryOutput")
+	moduleDir := filepath.Join(outDir, "ModuleOutput")
+
+	for _, dir := range []string{libraryDir, moduleDir} {
+		sourcesDir := filepath.Join(dir, "Sources")
+		if err := os.MkdirAll(sourcesDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		filePath := filepath.Join(sourcesDir, "test.swift")
+		// Write a file that needs formatting.
+		if err := os.WriteFile(filePath, []byte("func foo(){\n  print(\"hello\")\n}\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	library := &config.Library{
-		Output: outDir,
+		Output: libraryDir,
+		Swift: &config.SwiftPackage{
+			Modules: []*config.SwiftModule{
+				{
+					Output: moduleDir,
+				},
+			},
+		},
 	}
 
 	if err := Format(t.Context(), library); err != nil {
 		t.Fatal(err)
+	}
+
+	// Verify that files in both directories were actually formatted.
+	wantContent := "func foo() {\n  print(\"hello\")\n}\n"
+	for _, dir := range []string{libraryDir, moduleDir} {
+		filePath := filepath.Join(dir, "Sources", "test.swift")
+		gotContent, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(gotContent) != wantContent {
+			t.Errorf("ReadFile(%s) = %q, want %q", filePath, string(gotContent), wantContent)
+		}
 	}
 }
 


### PR DESCRIPTION
Previously, the format runner was hardcoded to only run `swift-format` on `library.Output`, leaving secondary modules (like conversions generated under unformatted.

for https://github.com/googleapis/google-cloud-swift/issues/452