### PR TITLE
feat(nodejs): install pnpm during librarian install

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,9 @@ type Tools struct {
 	// PNPM defines tools to install via pnpm.
 	PNPM []*PNPMTool `yaml:"pnpm,omitempty"`
 
+	// PNPMVersion specifies the version of pnpm to bootstrap.
+	PNPMVersion string `yaml:"pnpm_version,omitempty"`
+
 	// Protoc defines the protoc installation.
 	Protoc *Protoc `yaml:"protoc,omitempty"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,14 +112,20 @@ type Tools struct {
 	// Pip defines tools to install via pip.
 	Pip []*PipTool `yaml:"pip,omitempty"`
 
-	// PNPM defines tools to install via pnpm.
-	PNPM []*PNPMTool `yaml:"pnpm,omitempty"`
-
-	// PNPMVersion specifies the version of pnpm to bootstrap.
-	PNPMVersion string `yaml:"pnpm_version,omitempty"`
+	// PNPM defines the pnpm configuration.
+	PNPM *PNPMConfig `yaml:"pnpm,omitempty"`
 
 	// Protoc defines the protoc installation.
 	Protoc *Protoc `yaml:"protoc,omitempty"`
+}
+
+// PNPMConfig defines the configuration for pnpm tool installation.
+type PNPMConfig struct {
+	// Version specifies the version of pnpm to bootstrap.
+	Version string `yaml:"version,omitempty"`
+
+	// Tools defines tools to install via pnpm.
+	Tools []*PNPMTool `yaml:"tools,omitempty"`
 }
 
 // CargoTool defines a tool to install via cargo.

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -67,13 +67,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err != nil {
 		return err
 	}
-	var pnpmVersion string
-	for _, tool := range tools.PNPM {
-		if tool.Name == "pnpm" {
-			pnpmVersion = tool.Version
-			break
-		}
-	}
+	pnpmVersion := tools.PNPMVersion
 	if pnpmVersion == "" {
 		return errMissingPNPMVersion
 	}
@@ -88,9 +82,6 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 
 	for _, tool := range tools.PNPM {
-		if tool.Name == "pnpm" {
-			continue
-		}
 		if len(tool.Build) > 0 {
 			if err := installToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -62,6 +62,12 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return err
 	}
 	pnpmVersion := "7.32.2"
+	for _, tool := range tools.PNPM {
+		if tool.Name == "pnpm" {
+			pnpmVersion = tool.Version
+			break
+		}
+	}
 	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "-g", "pnpm@"+pnpmVersion); err != nil {
 		return fmt.Errorf("failed to bootstrap pnpm: %w", err)
 	}
@@ -72,6 +78,9 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 
 	for _, tool := range tools.PNPM {
+		if tool.Name == "pnpm" {
+			continue
+		}
 		if len(tool.Build) > 0 {
 			if err := installPNPMToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -43,6 +43,7 @@ var (
 	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
 	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
 	errMissingPackageURL = errors.New("has build steps but no package URL")
+	errMissingPNPMVersion = errors.New("pnpm version must be specified in tools.pnpm")
 )
 
 // Install installs Node.js tool dependencies.
@@ -57,18 +58,27 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		}
 	}
 
+	cacheDir, err := cache.Directory()
+	if err != nil {
+		return err
+	}
+
 	installDir, err := InstallDir()
 	if err != nil {
 		return err
 	}
-	pnpmVersion := "7.32.2"
+	var pnpmVersion string
 	for _, tool := range tools.PNPM {
 		if tool.Name == "pnpm" {
 			pnpmVersion = tool.Version
 			break
 		}
 	}
-	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "-g", "pnpm@"+pnpmVersion); err != nil {
+	if pnpmVersion == "" {
+		return errMissingPNPMVersion
+	}
+	npmCacheDir := filepath.Join(cacheDir, "npm-cache")
+	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "--cache", npmCacheDir, "-g", "pnpm@"+pnpmVersion); err != nil {
 		return fmt.Errorf("failed to bootstrap pnpm: %w", err)
 	}
 
@@ -155,6 +165,7 @@ func getPNPMEnv() ([]string, error) {
 	env = append(env, "NPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "NPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
+	env = append(env, "NPM_CONFIG_CACHE="+filepath.Join(cacheDir, "npm-cache"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -92,7 +92,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 			continue
 		}
 		if len(tool.Build) > 0 {
-			if err := installPNPMToolFromSource(ctx, env, tool); err != nil {
+			if err := installToolFromSource(ctx, env, tool); err != nil {
 				return err
 			}
 			continue
@@ -189,7 +189,7 @@ func runPNPMBuildCmd(ctx context.Context, dir string, env []string, cmdStr strin
 	return cmd.Run()
 }
 
-func installPNPMToolFromSource(ctx context.Context, env []string, tool *config.PNPMTool) error {
+func installToolFromSource(ctx context.Context, env []string, tool *config.PNPMTool) error {
 	if tool.Package == "" {
 		return fmt.Errorf("pnpm tool %s %w", tool.Name, errMissingPackageURL)
 	}

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cache"
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/fetch"
 )
@@ -50,10 +51,19 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return errNoToolsSpecified
 	}
 
-	for _, cmd := range []string{"node", "pnpm"} {
+	for _, cmd := range []string{"node", "npm"} {
 		if _, err := exec.LookPath(cmd); err != nil {
 			return fmt.Errorf("%s %w: %w", cmd, errMissingExecutable, err)
 		}
+	}
+
+	installDir, err := InstallDir()
+	if err != nil {
+		return err
+	}
+	pnpmVersion := "7.32.2"
+	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "-g", "pnpm@"+pnpmVersion); err != nil {
+		return fmt.Errorf("failed to bootstrap pnpm: %w", err)
 	}
 
 	env, err := getPNPMEnv()
@@ -131,8 +141,11 @@ func getPNPMEnv() ([]string, error) {
 	env := os.Environ()
 	env = append(env, "PNPM_HOME="+installDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
+	env = append(env, "NPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
+	env = append(env, "NPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
+	env = append(env, "NPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -48,7 +48,7 @@ var (
 
 // Install installs Node.js tool dependencies.
 func Install(ctx context.Context, tools *config.Tools) error {
-	if tools == nil || len(tools.PNPM) == 0 {
+	if tools == nil || tools.PNPM == nil || len(tools.PNPM.Tools) == 0 {
 		return errNoToolsSpecified
 	}
 
@@ -67,7 +67,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err != nil {
 		return err
 	}
-	pnpmVersion := tools.PNPMVersion
+	pnpmVersion := tools.PNPM.Version
 	if pnpmVersion == "" {
 		return errMissingPNPMVersion
 	}
@@ -81,7 +81,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return err
 	}
 
-	for _, tool := range tools.PNPM {
+	for _, tool := range tools.PNPM.Tools {
 		if len(tool.Build) > 0 {
 			if err := installToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -39,10 +39,10 @@ const (
 )
 
 var (
-	errNoToolsSpecified  = errors.New("no tools.pnpm field specified in configuration")
-	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
-	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
-	errMissingPackageURL = errors.New("has build steps but no package URL")
+	errNoToolsSpecified   = errors.New("no tools.pnpm field specified in configuration")
+	errCannotExtractRepo  = errors.New("cannot extract repo from package URL")
+	errMissingExecutable  = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
+	errMissingPackageURL  = errors.New("has build steps but no package URL")
 	errMissingPNPMVersion = errors.New("pnpm version must be specified in tools.pnpm")
 )
 

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -78,11 +78,8 @@ func TestInstall(t *testing.T) {
 		{
 			name: "source build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{
-						Name:    "pnpm",
-						Version: "7.32.2",
-					},
 					{
 						Name:    "gapic-generator-typescript",
 						Version: "4.12.1",
@@ -114,11 +111,8 @@ func TestInstall(t *testing.T) {
 		{
 			name: "non-build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{
-						Name:    "pnpm",
-						Version: "7.32.2",
-					},
 					{
 						Name:    "gapic-node-processing",
 						Version: "0.1.8",
@@ -136,13 +130,10 @@ func TestInstall(t *testing.T) {
 			},
 		},
 		{
-			name: "tool configuration contains pnpm version",
+			name: "tool configuration contains pnpm_version",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{
-						Name:    "pnpm",
-						Version: "7.32.2",
-					},
 					{
 						Name:    "gapic-node-processing",
 						Version: "0.1.8",
@@ -186,7 +177,7 @@ func TestInstall_Error(t *testing.T) {
 		},
 		{
 			name:  "missing node or npm in path",
-			tools: &config.Tools{PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
+			tools: &config.Tools{PNPMVersion: "7.32.2", PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
 			setup: func(t *testing.T) {
 				t.Setenv("PATH", t.TempDir())
 			},
@@ -195,8 +186,8 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "missing package url for build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Build: []string{"echo 1"}},
 				},
 			},
@@ -208,8 +199,8 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "invalid package url for build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
 				},
 			},
@@ -219,7 +210,7 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errCannotExtractRepo,
 		},
 		{
-			name: "missing pnpm in tools configuration",
+			name: "missing pnpm_version in tools configuration",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
 					{Name: "tool", Version: "1.0"},
@@ -228,10 +219,11 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errMissingPNPMVersion,
 		},
 		{
-			name: "empty pnpm version in tools configuration",
+			name: "empty pnpm_version in tools configuration",
 			tools: &config.Tools{
+				PNPMVersion: "",
 				PNPM: []*config.PNPMTool{
-					{Name: "pnpm", Version: ""},
+					{Name: "tool", Version: "1.0"},
 				},
 			},
 			wantErr: errMissingPNPMVersion,

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -28,11 +28,14 @@ func stubExecutables(t *testing.T) {
 	bin := t.TempDir()
 	pnpmStub := `#!/bin/sh
 # Assert that transient environmental variables are set dynamically for process lifetime
-if [ -n "$PNPM_HOME" ] && [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] && [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] && [ -n "$PNPM_CONFIG_STORE_DIR" ] && \
+if [ -n "$PNPM_HOME" ] && \
+   { [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_BIN_DIR" ]; } && \
+   { [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_DIR" ]; } && \
+   { [ -n "$PNPM_CONFIG_STORE_DIR" ] || [ -n "$NPM_CONFIG_STORE_DIR" ]; } && \
    [ -n "$PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS" ]; then
     :
 else
-    echo "Error: Required transient PNPM environment variables are missing!" >&2
+    echo "Error: Required transient PNPM/NPM environment variables are missing!" >&2
     exit 1
 fi
 
@@ -50,10 +53,16 @@ exit 0
 	nodeStub := `#!/bin/sh
 exit 0
 `
+	npmStub := `#!/bin/sh
+exit 0
+`
 	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "npm"), []byte(npmStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -147,7 +156,7 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errNoToolsSpecified,
 		},
 		{
-			name:  "missing node or pnpm in path",
+			name:  "missing node or npm in path",
 			tools: &config.Tools{PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
 			setup: func(t *testing.T) {
 				t.Setenv("PATH", t.TempDir())

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -78,16 +78,18 @@ func TestInstall(t *testing.T) {
 		{
 			name: "source build tool",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
-				PNPM: []*config.PNPMTool{
-					{
-						Name:    "gapic-generator-typescript",
-						Version: "4.12.1",
-						Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
-						Build: []string{
-							"pnpm install",
-							"./node_modules/.bin/tsc",
-							"cp -a templates protos build/",
+				PNPM: &config.PNPMConfig{
+					Version: "7.32.2",
+					Tools: []*config.PNPMTool{
+						{
+							Name:    "gapic-generator-typescript",
+							Version: "4.12.1",
+							Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
+							Build: []string{
+								"pnpm install",
+								"./node_modules/.bin/tsc",
+								"cp -a templates protos build/",
+							},
 						},
 					},
 				},
@@ -111,15 +113,17 @@ func TestInstall(t *testing.T) {
 		{
 			name: "non-build tool",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
-				PNPM: []*config.PNPMTool{
-					{
-						Name:    "gapic-node-processing",
-						Version: "0.1.8",
-					},
-					{
-						Name:    "custom-pkg",
-						Package: "custom-pkg@1.0.0",
+				PNPM: &config.PNPMConfig{
+					Version: "7.32.2",
+					Tools: []*config.PNPMTool{
+						{
+							Name:    "gapic-node-processing",
+							Version: "0.1.8",
+						},
+						{
+							Name:    "custom-pkg",
+							Package: "custom-pkg@1.0.0",
+						},
 					},
 				},
 			},
@@ -132,11 +136,13 @@ func TestInstall(t *testing.T) {
 		{
 			name: "tool configuration contains pnpm_version",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
-				PNPM: []*config.PNPMTool{
-					{
-						Name:    "gapic-node-processing",
-						Version: "0.1.8",
+				PNPM: &config.PNPMConfig{
+					Version: "7.32.2",
+					Tools: []*config.PNPMTool{
+						{
+							Name:    "gapic-node-processing",
+							Version: "0.1.8",
+						},
 					},
 				},
 			},
@@ -177,7 +183,7 @@ func TestInstall_Error(t *testing.T) {
 		},
 		{
 			name:  "missing node or npm in path",
-			tools: &config.Tools{PNPMVersion: "7.32.2", PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
+			tools: &config.Tools{PNPM: &config.PNPMConfig{Version: "7.32.2", Tools: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}}},
 			setup: func(t *testing.T) {
 				t.Setenv("PATH", t.TempDir())
 			},
@@ -186,9 +192,11 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "missing package url for build tool",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
-				PNPM: []*config.PNPMTool{
-					{Name: "tool", Build: []string{"echo 1"}},
+				PNPM: &config.PNPMConfig{
+					Version: "7.32.2",
+					Tools: []*config.PNPMTool{
+						{Name: "tool", Build: []string{"echo 1"}},
+					},
 				},
 			},
 			setup: func(t *testing.T) {
@@ -199,9 +207,11 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "invalid package url for build tool",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
-				PNPM: []*config.PNPMTool{
-					{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
+				PNPM: &config.PNPMConfig{
+					Version: "7.32.2",
+					Tools: []*config.PNPMTool{
+						{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
+					},
 				},
 			},
 			setup: func(t *testing.T) {
@@ -212,8 +222,10 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "missing pnpm_version in tools configuration",
 			tools: &config.Tools{
-				PNPM: []*config.PNPMTool{
-					{Name: "tool", Version: "1.0"},
+				PNPM: &config.PNPMConfig{
+					Tools: []*config.PNPMTool{
+						{Name: "tool", Version: "1.0"},
+					},
 				},
 			},
 			wantErr: errMissingPNPMVersion,
@@ -221,9 +233,11 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "empty pnpm_version in tools configuration",
 			tools: &config.Tools{
-				PNPMVersion: "",
-				PNPM: []*config.PNPMTool{
-					{Name: "tool", Version: "1.0"},
+				PNPM: &config.PNPMConfig{
+					Version: "",
+					Tools: []*config.PNPMTool{
+						{Name: "tool", Version: "1.0"},
+					},
 				},
 			},
 			wantErr: errMissingPNPMVersion,

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -126,6 +126,26 @@ func TestInstall(t *testing.T) {
 				stubExecutables(t)
 			},
 		},
+		{
+			name: "tool configuration contains pnpm version",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "pnpm",
+						Version: "7.32.2",
+					},
+					{
+						Name:    "gapic-node-processing",
+						Version: "0.1.8",
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				stubExecutables(t)
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if test.setup != nil {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -32,6 +32,7 @@ if [ -n "$PNPM_HOME" ] && \
    { [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_BIN_DIR" ]; } && \
    { [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_DIR" ]; } && \
    { [ -n "$PNPM_CONFIG_STORE_DIR" ] || [ -n "$NPM_CONFIG_STORE_DIR" ]; } && \
+   [ -n "$NPM_CONFIG_CACHE" ] && \
    [ -n "$PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS" ]; then
     :
 else
@@ -79,6 +80,10 @@ func TestInstall(t *testing.T) {
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
 					{
+						Name:    "pnpm",
+						Version: "7.32.2",
+					},
+					{
 						Name:    "gapic-generator-typescript",
 						Version: "4.12.1",
 						Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
@@ -110,6 +115,10 @@ func TestInstall(t *testing.T) {
 			name: "non-build tool",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
+					{
+						Name:    "pnpm",
+						Version: "7.32.2",
+					},
 					{
 						Name:    "gapic-node-processing",
 						Version: "0.1.8",
@@ -187,6 +196,7 @@ func TestInstall_Error(t *testing.T) {
 			name: "missing package url for build tool",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
+					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Build: []string{"echo 1"}},
 				},
 			},
@@ -199,6 +209,7 @@ func TestInstall_Error(t *testing.T) {
 			name: "invalid package url for build tool",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
+					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
 				},
 			},
@@ -206,6 +217,24 @@ func TestInstall_Error(t *testing.T) {
 				stubExecutables(t)
 			},
 			wantErr: errCannotExtractRepo,
+		},
+		{
+			name: "missing pnpm in tools configuration",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{Name: "tool", Version: "1.0"},
+				},
+			},
+			wantErr: errMissingPNPMVersion,
+		},
+		{
+			name: "empty pnpm version in tools configuration",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{Name: "pnpm", Version: ""},
+				},
+			},
+			wantErr: errMissingPNPMVersion,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -81,7 +81,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		}
 	}
 	// Install PNPM tools
-	if len(tools.PNPM) > 0 {
+	if tools.PNPM != nil && len(tools.PNPM.Tools) > 0 {
 		if err := nodejs.Install(ctx, tools); err != nil {
 			return fmt.Errorf("failed to install pnpm tools: %w", err)
 		}

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -109,7 +109,6 @@ func TestInstall(t *testing.T) {
 		{
 			name: "with composer, pip, and pnpm tools",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
 				Composer: []*config.ComposerTool{
 					{
 						Name:    "fake-composer-tool",
@@ -124,10 +123,13 @@ func TestInstall(t *testing.T) {
 						Version: "2.0.0",
 					},
 				},
-				PNPM: []*config.PNPMTool{
-					{
-						Name:    "fake-pnpm-tool",
-						Version: "3.0.0",
+				PNPM: &config.PNPMConfig{
+					Version: "7.32.2",
+					Tools: []*config.PNPMTool{
+						{
+							Name:    "fake-pnpm-tool",
+							Version: "3.0.0",
+						},
 					},
 				},
 			},

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -109,6 +109,7 @@ func TestInstall(t *testing.T) {
 		{
 			name: "with composer, pip, and pnpm tools",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				Composer: []*config.ComposerTool{
 					{
 						Name:    "fake-composer-tool",

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -234,7 +234,7 @@ func isToolsEmpty(tools *config.Tools) bool {
 		len(tools.Go) == 0 &&
 		len(tools.Maven) == 0 &&
 		len(tools.Pip) == 0 &&
-		len(tools.PNPM) == 0 &&
+		(tools.PNPM == nil || (tools.PNPM.Version == "" && len(tools.PNPM.Tools) == 0)) &&
 		len(tools.Gem) == 0 &&
 		tools.Protoc == nil
 }
@@ -275,9 +275,11 @@ func formatConfig(cfg *config.Config) *config.Config {
 		slices.SortFunc(cfg.Tools.Composer, func(a, b *config.ComposerTool) int {
 			return strings.Compare(a.Name, b.Name)
 		})
-		slices.SortFunc(cfg.Tools.PNPM, func(a, b *config.PNPMTool) int {
-			return strings.Compare(a.Name, b.Name)
-		})
+		if cfg.Tools.PNPM != nil {
+			slices.SortFunc(cfg.Tools.PNPM.Tools, func(a, b *config.PNPMTool) int {
+				return strings.Compare(a.Name, b.Name)
+			})
+		}
 		slices.SortFunc(cfg.Tools.Pip, func(a, b *config.PipTool) int {
 			return strings.Compare(a.Name, b.Name)
 		})


### PR DESCRIPTION
Install a pinned version of `pnpm` inside Librarian's local tools directory during `install nodejs` instead of relying on the host's global `pnpm` binary to ensure environment uniformity.
 
For #6638