### PR TITLE
fix(internal/librarian/nodejs): update pnpm PATH check for v11.7.0

### DIFF
--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -91,11 +91,7 @@ func InstallDir() (string, error) {
 
 // getBinDir returns the directory where Node.js tool executables are stored.
 func getBinDir() (string, error) {
-	installDir, err := InstallDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(installDir, "bin"), nil
+	return InstallDir()
 }
 
 // getToolsEnv returns an environment map with the Node.js tools bin directory prepended to PATH.

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -274,7 +274,7 @@ func TestGetToolsEnv(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := filepath.Join(binDir, "nodejs_tools", "bin")
+			want := filepath.Join(binDir, "nodejs_tools")
 			if got := env["PATH"]; got != want {
 				t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, want)
 			}


### PR DESCRIPTION
This fixes a compatibility issue with pnpm v11.7.0, which strictly enforces that the PNPM_HOME directory is exactly present in the PATH.

The bug in the main branch went undetected for a month due to the following sequence of events:
1. June 15: GitHub Actions updated their runners to use pnpm v11.7.0.
2. The librarian CI aggressively caches the nodejs_tools installation, so the CI runners kept restoring the old cache (which used an older pnpm) and skipped the installation step entirely.
3. July 14: PR #6805 changed the cache key calculation, effectively invalidating the cache for everyone.
4. July 15: The next PR opened experienced a cache miss and was forced to run 'librarian install nodejs' from scratch. The newly downloaded pnpm v11.7.0 was finally executed, surfacing this strict PATH validation error.

To fix this, the getBinDir function is updated to return the root tools directory (InstallDir) instead of appending a 'bin/' subdirectory, aligning with modern pnpm installation layouts.
