### PR TITLE
fix(internal/librarian/nodejs): update pnpm PATH check for v11.7.0

### DIFF
--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -131,6 +131,7 @@ func getPNPMEnv() ([]string, error) {
 	env := os.Environ()
 	env = append(env, "PNPM_HOME="+installDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
+	env = append(env, "npm_config_global_bin_dir="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")


### PR DESCRIPTION
This fixes a compatibility issue with pnpm v11.7.0, which strictly enforces that the PNPM_HOME directory is exactly present in the PATH.

The bug in the main branch went undetected for a month due to the following sequence of events:
1. June 15: GitHub Actions updated their runners to use pnpm v11.7.0.
2. The librarian CI aggressively caches the nodejs_tools installation, so the CI runners kept restoring the old cache (which used an older pnpm) and skipped the installation step entirely.
3. July 14: PR #6805 changed the cache key calculation, effectively invalidating the cache for everyone.
4. July 15: The next PR opened experienced a cache miss and was forced to run 'librarian install nodejs' from scratch. The newly downloaded pnpm v11.7.0 was finally executed, surfacing this strict PATH validation error.

To fix this without breaking compatibility with older pnpm versions (like v7.32.2) which install directly to PNPM_HOME instead of PNPM_HOME/bin, we explicitly configure both 'PNPM_CONFIG_GLOBAL_BIN_DIR' (for modern pnpm) and 'npm_config_global_bin_dir' (for legacy pnpm) to target the 'bin/' subdirectory.

Fixes https://github.com/googleapis/librarian/issues/6846
Unblocks #6843 