### PR TITLE
feat(internal/librarian/nodejs): install pnpm during librarian install

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -44,6 +44,7 @@ This document describes the schema for the librarian.yaml.
 | `maven` | list of [MavenTool](#maventool-configuration) (optional) | Defines tools to install via Maven. |
 | `pip` | list of [PipTool](#piptool-configuration) (optional) | Defines tools to install via pip. |
 | `pnpm` | list of [PNPMTool](#pnpmtool-configuration) (optional) | Defines tools to install via pnpm. |
+| `pnpm_version` | string | Specifies the version of pnpm to bootstrap. |
 | `protoc` | [Protoc](#protoc-configuration) (optional) | Defines the protoc installation. |
 
 ## CargoTool Configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,9 @@ type Tools struct {
 	// PNPM defines tools to install via pnpm.
 	PNPM []*PNPMTool `yaml:"pnpm,omitempty"`
 
+	// PNPMVersion specifies the version of pnpm to bootstrap.
+	PNPMVersion string `yaml:"pnpm_version,omitempty"`
+
 	// Protoc defines the protoc installation.
 	Protoc *Protoc `yaml:"protoc,omitempty"`
 }

--- a/internal/librarian/nodejs/clean_test.go
+++ b/internal/librarian/nodejs/clean_test.go
@@ -93,6 +93,9 @@ func TestClean(t *testing.T) {
 				"protos/protos.js",
 				"samples/package.json",
 			}},
+		{
+			name: "non-existent library output directory returns nil",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			repoRoot := t.TempDir()

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cache"
-	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/fetch"
 )
@@ -51,16 +50,17 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return errNoToolsSpecified
 	}
 
-	for _, cmd := range []string{"node", "npm"} {
+	for _, cmd := range []string{"node", "corepack"} {
 		if _, err := exec.LookPath(cmd); err != nil {
 			return fmt.Errorf("%s %w: %w", cmd, errMissingExecutable, err)
 		}
 	}
 
-	cacheDir, err := cache.Directory()
+	env, err := getPNPMEnv()
 	if err != nil {
 		return err
 	}
+
 	pnpmVersion := tools.PNPMVersion
 	if pnpmVersion == "" {
 		for _, tool := range tools.PNPM {
@@ -70,24 +70,23 @@ func Install(ctx context.Context, tools *config.Tools) error {
 			}
 		}
 	}
-	if pnpmVersion == "" {
-		if _, err := exec.LookPath("pnpm"); err != nil {
-			return fmt.Errorf("pnpm %w: %w", errMissingExecutable, err)
-		}
-	} else {
-		installDir, err := InstallDir()
+
+	if !isPNPMInstalled(ctx, env, pnpmVersion) {
+		binDir, err := getBinDir()
 		if err != nil {
 			return err
 		}
-		npmCacheDir := filepath.Join(cacheDir, "npm-cache")
-		if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "--cache", npmCacheDir, "-g", "pnpm@"+pnpmVersion); err != nil {
-			return fmt.Errorf("failed to bootstrap pnpm: %w", err)
+		if err := os.MkdirAll(binDir, 0o755); err != nil {
+			return err
 		}
-	}
-
-	env, err := getPNPMEnv()
-	if err != nil {
-		return err
+		if err := runCorepack(ctx, env, "enable", "--install-directory", binDir, "pnpm"); err != nil {
+			return fmt.Errorf("failed to enable pnpm via corepack: %w", err)
+		}
+		if pnpmVersion != "" {
+			if err := runCorepack(ctx, env, "install", "-g", "pnpm@"+pnpmVersion); err != nil {
+				return fmt.Errorf("failed to install pnpm via corepack: %w", err)
+			}
+		}
 	}
 
 	for _, tool := range tools.PNPM {
@@ -161,6 +160,8 @@ func getPNPMEnv() ([]string, error) {
 	}
 
 	env := os.Environ()
+	env = append(env, "COREPACK_HOME="+filepath.Join(cacheDir, "corepack"))
+	env = append(env, "COREPACK_ENABLE_DOWNLOAD_PROMPT=0")
 	env = append(env, "PNPM_HOME="+installDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "NPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
@@ -172,6 +173,27 @@ func getPNPMEnv() ([]string, error) {
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil
+}
+
+func isPNPMInstalled(ctx context.Context, env []string, pnpmVersion string) bool {
+	cmd := exec.CommandContext(ctx, "pnpm", "--version")
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	if pnpmVersion == "" {
+		return true
+	}
+	return strings.TrimSpace(string(out)) == pnpmVersion
+}
+
+func runCorepack(ctx context.Context, env []string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "corepack", args...)
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func runPNPM(ctx context.Context, dir string, env []string, args ...string) error {

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -62,15 +62,6 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 
 	pnpmVersion := tools.PNPMVersion
-	if pnpmVersion == "" {
-		for _, tool := range tools.PNPM {
-			if tool.Name == "pnpm" {
-				pnpmVersion = tool.Version
-				break
-			}
-		}
-	}
-
 	if !isPNPMInstalled(ctx, env, pnpmVersion) {
 		binDir, err := getBinDir()
 		if err != nil {
@@ -90,9 +81,6 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 
 	for _, tool := range tools.PNPM {
-		if tool.Name == "pnpm" {
-			continue
-		}
 		if len(tool.Build) > 0 {
 			if err := installToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -39,11 +39,10 @@ const (
 )
 
 var (
-	errNoToolsSpecified   = errors.New("no tools.pnpm field specified in configuration")
-	errCannotExtractRepo  = errors.New("cannot extract repo from package URL")
-	errMissingExecutable  = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
-	errMissingPackageURL  = errors.New("has build steps but no package URL")
-	errMissingPNPMVersion = errors.New("pnpm version must be specified in tools.pnpm")
+	errNoToolsSpecified  = errors.New("no tools.pnpm field specified in configuration")
+	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
+	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
+	errMissingPackageURL = errors.New("has build steps but no package URL")
 )
 
 // Install installs Node.js tool dependencies.

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -164,7 +164,14 @@ func getPNPMEnv() ([]string, error) {
 }
 
 func isPNPMInstalled(ctx context.Context, env []string, pnpmVersion string) bool {
-	cmd := exec.CommandContext(ctx, "pnpm", "--version")
+	pnpmPath := "pnpm"
+	if binDir, err := getBinDir(); err == nil {
+		candidate := filepath.Join(binDir, "pnpm")
+		if _, err := os.Stat(candidate); err == nil {
+			pnpmPath = candidate
+		}
+	}
+	cmd := exec.CommandContext(ctx, pnpmPath, "--version")
 	cmd.Env = env
 	out, err := cmd.Output()
 	if err != nil {
@@ -185,7 +192,14 @@ func runCorepack(ctx context.Context, env []string, args ...string) error {
 }
 
 func runPNPM(ctx context.Context, dir string, env []string, args ...string) error {
-	cmd := exec.CommandContext(ctx, "pnpm", args...)
+	pnpmPath := "pnpm"
+	if binDir, err := getBinDir(); err == nil {
+		candidate := filepath.Join(binDir, "pnpm")
+		if _, err := os.Stat(candidate); err == nil {
+			pnpmPath = candidate
+		}
+	}
+	cmd := exec.CommandContext(ctx, pnpmPath, args...)
 	cmd.Dir = dir
 	cmd.Env = env
 	cmd.Stdout = os.Stdout

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -67,13 +67,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err != nil {
 		return err
 	}
-	var pnpmVersion string
-	for _, tool := range tools.PNPM {
-		if tool.Name == "pnpm" {
-			pnpmVersion = tool.Version
-			break
-		}
-	}
+	pnpmVersion := tools.PNPMVersion
 	if pnpmVersion == "" {
 		return errMissingPNPMVersion
 	}
@@ -88,9 +82,6 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 
 	for _, tool := range tools.PNPM {
-		if tool.Name == "pnpm" {
-			continue
-		}
 		if len(tool.Build) > 0 {
 			if err := installToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -62,11 +62,6 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err != nil {
 		return err
 	}
-
-	installDir, err := InstallDir()
-	if err != nil {
-		return err
-	}
 	pnpmVersion := tools.PNPMVersion
 	if pnpmVersion == "" {
 		for _, tool := range tools.PNPM {
@@ -77,11 +72,18 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		}
 	}
 	if pnpmVersion == "" {
-		return errMissingPNPMVersion
-	}
-	npmCacheDir := filepath.Join(cacheDir, "npm-cache")
-	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "--cache", npmCacheDir, "-g", "pnpm@"+pnpmVersion); err != nil {
-		return fmt.Errorf("failed to bootstrap pnpm: %w", err)
+		if _, err := exec.LookPath("pnpm"); err != nil {
+			return fmt.Errorf("pnpm %w: %w", errMissingExecutable, err)
+		}
+	} else {
+		installDir, err := InstallDir()
+		if err != nil {
+			return err
+		}
+		npmCacheDir := filepath.Join(cacheDir, "npm-cache")
+		if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "--cache", npmCacheDir, "-g", "pnpm@"+pnpmVersion); err != nil {
+			return fmt.Errorf("failed to bootstrap pnpm: %w", err)
+		}
 	}
 
 	env, err := getPNPMEnv()

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -62,6 +62,12 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return err
 	}
 	pnpmVersion := "7.32.2"
+	for _, tool := range tools.PNPM {
+		if tool.Name == "pnpm" {
+			pnpmVersion = tool.Version
+			break
+		}
+	}
 	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "-g", "pnpm@"+pnpmVersion); err != nil {
 		return fmt.Errorf("failed to bootstrap pnpm: %w", err)
 	}
@@ -72,6 +78,9 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 
 	for _, tool := range tools.PNPM {
+		if tool.Name == "pnpm" {
+			continue
+		}
 		if len(tool.Build) > 0 {
 			if err := installPNPMToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -43,6 +43,7 @@ var (
 	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
 	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
 	errMissingPackageURL = errors.New("has build steps but no package URL")
+	errMissingPNPMVersion = errors.New("pnpm version must be specified in tools.pnpm")
 )
 
 // Install installs Node.js tool dependencies.
@@ -57,18 +58,27 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		}
 	}
 
+	cacheDir, err := cache.Directory()
+	if err != nil {
+		return err
+	}
+
 	installDir, err := InstallDir()
 	if err != nil {
 		return err
 	}
-	pnpmVersion := "7.32.2"
+	var pnpmVersion string
 	for _, tool := range tools.PNPM {
 		if tool.Name == "pnpm" {
 			pnpmVersion = tool.Version
 			break
 		}
 	}
-	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "-g", "pnpm@"+pnpmVersion); err != nil {
+	if pnpmVersion == "" {
+		return errMissingPNPMVersion
+	}
+	npmCacheDir := filepath.Join(cacheDir, "npm-cache")
+	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "--cache", npmCacheDir, "-g", "pnpm@"+pnpmVersion); err != nil {
 		return fmt.Errorf("failed to bootstrap pnpm: %w", err)
 	}
 
@@ -155,6 +165,7 @@ func getPNPMEnv() ([]string, error) {
 	env = append(env, "NPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "NPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
+	env = append(env, "NPM_CONFIG_CACHE="+filepath.Join(cacheDir, "npm-cache"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -69,6 +69,14 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 	pnpmVersion := tools.PNPMVersion
 	if pnpmVersion == "" {
+		for _, tool := range tools.PNPM {
+			if tool.Name == "pnpm" {
+				pnpmVersion = tool.Version
+				break
+			}
+		}
+	}
+	if pnpmVersion == "" {
 		return errMissingPNPMVersion
 	}
 	npmCacheDir := filepath.Join(cacheDir, "npm-cache")
@@ -82,6 +90,9 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 
 	for _, tool := range tools.PNPM {
+		if tool.Name == "pnpm" {
+			continue
+		}
 		if len(tool.Build) > 0 {
 			if err := installToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -92,7 +92,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 			continue
 		}
 		if len(tool.Build) > 0 {
-			if err := installPNPMToolFromSource(ctx, env, tool); err != nil {
+			if err := installToolFromSource(ctx, env, tool); err != nil {
 				return err
 			}
 			continue
@@ -189,7 +189,7 @@ func runPNPMBuildCmd(ctx context.Context, dir string, env []string, cmdStr strin
 	return cmd.Run()
 }
 
-func installPNPMToolFromSource(ctx context.Context, env []string, tool *config.PNPMTool) error {
+func installToolFromSource(ctx context.Context, env []string, tool *config.PNPMTool) error {
 	if tool.Package == "" {
 		return fmt.Errorf("pnpm tool %s %w", tool.Name, errMissingPackageURL)
 	}

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/cache"
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/fetch"
 )
@@ -50,10 +51,19 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return errNoToolsSpecified
 	}
 
-	for _, cmd := range []string{"node", "pnpm"} {
+	for _, cmd := range []string{"node", "npm"} {
 		if _, err := exec.LookPath(cmd); err != nil {
 			return fmt.Errorf("%s %w: %w", cmd, errMissingExecutable, err)
 		}
+	}
+
+	installDir, err := InstallDir()
+	if err != nil {
+		return err
+	}
+	pnpmVersion := "7.32.2"
+	if err := command.RunStreaming(ctx, "npm", "install", "--prefix", installDir, "-g", "pnpm@"+pnpmVersion); err != nil {
+		return fmt.Errorf("failed to bootstrap pnpm: %w", err)
 	}
 
 	env, err := getPNPMEnv()
@@ -131,8 +141,11 @@ func getPNPMEnv() ([]string, error) {
 	env := os.Environ()
 	env = append(env, "PNPM_HOME="+installDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
+	env = append(env, "NPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
+	env = append(env, "NPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
+	env = append(env, "NPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
 	env = append(env, "PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true")
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -39,10 +39,10 @@ const (
 )
 
 var (
-	errNoToolsSpecified  = errors.New("no tools.pnpm field specified in configuration")
-	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
-	errMissingExecutable = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
-	errMissingPackageURL = errors.New("has build steps but no package URL")
+	errNoToolsSpecified   = errors.New("no tools.pnpm field specified in configuration")
+	errCannotExtractRepo  = errors.New("cannot extract repo from package URL")
+	errMissingExecutable  = errors.New("is not installed or not in PATH, which is required for Node.js tool installation")
+	errMissingPackageURL  = errors.New("has build steps but no package URL")
 	errMissingPNPMVersion = errors.New("pnpm version must be specified in tools.pnpm")
 )
 

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -78,11 +78,8 @@ func TestInstall(t *testing.T) {
 		{
 			name: "source build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{
-						Name:    "pnpm",
-						Version: "7.32.2",
-					},
 					{
 						Name:    "gapic-generator-typescript",
 						Version: "4.12.1",
@@ -114,11 +111,8 @@ func TestInstall(t *testing.T) {
 		{
 			name: "non-build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{
-						Name:    "pnpm",
-						Version: "7.32.2",
-					},
 					{
 						Name:    "gapic-node-processing",
 						Version: "0.1.8",
@@ -136,13 +130,10 @@ func TestInstall(t *testing.T) {
 			},
 		},
 		{
-			name: "tool configuration contains pnpm version",
+			name: "tool configuration contains pnpm_version",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{
-						Name:    "pnpm",
-						Version: "7.32.2",
-					},
 					{
 						Name:    "gapic-node-processing",
 						Version: "0.1.8",
@@ -186,7 +177,7 @@ func TestInstall_Error(t *testing.T) {
 		},
 		{
 			name:  "missing node or npm in path",
-			tools: &config.Tools{PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
+			tools: &config.Tools{PNPMVersion: "7.32.2", PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
 			setup: func(t *testing.T) {
 				t.Setenv("PATH", t.TempDir())
 			},
@@ -195,8 +186,8 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "missing package url for build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Build: []string{"echo 1"}},
 				},
 			},
@@ -208,8 +199,8 @@ func TestInstall_Error(t *testing.T) {
 		{
 			name: "invalid package url for build tool",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				PNPM: []*config.PNPMTool{
-					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
 				},
 			},
@@ -219,7 +210,7 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errCannotExtractRepo,
 		},
 		{
-			name: "missing pnpm in tools configuration",
+			name: "missing pnpm_version in tools configuration",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
 					{Name: "tool", Version: "1.0"},
@@ -228,10 +219,11 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errMissingPNPMVersion,
 		},
 		{
-			name: "empty pnpm version in tools configuration",
+			name: "empty pnpm_version in tools configuration",
 			tools: &config.Tools{
+				PNPMVersion: "",
 				PNPM: []*config.PNPMTool{
-					{Name: "pnpm", Version: ""},
+					{Name: "tool", Version: "1.0"},
 				},
 			},
 			wantErr: errMissingPNPMVersion,

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -230,23 +230,29 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errCannotExtractRepo,
 		},
 		{
-			name: "missing pnpm_version in tools configuration",
+			name: "missing pnpm version and missing pnpm in PATH",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
 					{Name: "tool", Version: "1.0"},
 				},
 			},
-			wantErr: errMissingPNPMVersion,
+			setup: func(t *testing.T) {
+				t.Setenv("PATH", t.TempDir())
+			},
+			wantErr: errMissingExecutable,
 		},
 		{
-			name: "empty pnpm_version in tools configuration",
+			name: "empty pnpm version and missing pnpm in PATH",
 			tools: &config.Tools{
 				PNPMVersion: "",
 				PNPM: []*config.PNPMTool{
 					{Name: "tool", Version: "1.0"},
 				},
 			},
-			wantErr: errMissingPNPMVersion,
+			setup: func(t *testing.T) {
+				t.Setenv("PATH", t.TempDir())
+			},
+			wantErr: errMissingExecutable,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -25,6 +25,12 @@ import (
 
 func stubExecutables(t *testing.T) {
 	t.Helper()
+	if os.Getenv("LIBRARIAN_CACHE") == "" {
+		t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+	}
+	if os.Getenv("LIBRARIAN_BIN") == "" {
+		t.Setenv("LIBRARIAN_BIN", t.TempDir())
+	}
 	bin := t.TempDir()
 	pnpmStub := `#!/bin/sh
 if [ "$1" = "--version" ]; then
@@ -111,6 +117,12 @@ exit 0
 
 func stubExecutablesWithoutPNPM(t *testing.T) {
 	t.Helper()
+	if os.Getenv("LIBRARIAN_CACHE") == "" {
+		t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+	}
+	if os.Getenv("LIBRARIAN_BIN") == "" {
+		t.Setenv("LIBRARIAN_BIN", t.TempDir())
+	}
 	bin := t.TempDir()
 	nodeStub := `#!/bin/sh
 exit 0

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -28,11 +28,14 @@ func stubExecutables(t *testing.T) {
 	bin := t.TempDir()
 	pnpmStub := `#!/bin/sh
 # Assert that transient environmental variables are set dynamically for process lifetime
-if [ -n "$PNPM_HOME" ] && [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] && [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] && [ -n "$PNPM_CONFIG_STORE_DIR" ] && \
+if [ -n "$PNPM_HOME" ] && \
+   { [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_BIN_DIR" ]; } && \
+   { [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_DIR" ]; } && \
+   { [ -n "$PNPM_CONFIG_STORE_DIR" ] || [ -n "$NPM_CONFIG_STORE_DIR" ]; } && \
    [ -n "$PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS" ]; then
     :
 else
-    echo "Error: Required transient PNPM environment variables are missing!" >&2
+    echo "Error: Required transient PNPM/NPM environment variables are missing!" >&2
     exit 1
 fi
 
@@ -50,10 +53,16 @@ exit 0
 	nodeStub := `#!/bin/sh
 exit 0
 `
+	npmStub := `#!/bin/sh
+exit 0
+`
 	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "npm"), []byte(npmStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -147,7 +156,7 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errNoToolsSpecified,
 		},
 		{
-			name:  "missing node or pnpm in path",
+			name:  "missing node or npm in path",
 			tools: &config.Tools{PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
 			setup: func(t *testing.T) {
 				t.Setenv("PATH", t.TempDir())

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -173,26 +173,6 @@ func TestInstall(t *testing.T) {
 				stubExecutables(t)
 			},
 		},
-		{
-			name: "legacy tool configuration style fallback",
-			tools: &config.Tools{
-				PNPM: []*config.PNPMTool{
-					{
-						Name:    "pnpm",
-						Version: "7.32.2",
-					},
-					{
-						Name:    "gapic-node-processing",
-						Version: "0.1.8",
-					},
-				},
-			},
-			setup: func(t *testing.T) {
-				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
-				t.Setenv("LIBRARIAN_BIN", t.TempDir())
-				stubExecutables(t)
-			},
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if test.setup != nil {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -45,6 +45,11 @@ else
     exit 1
 fi
 
+if [ "$PNPM_ADD_FAIL" = "1" ]; then
+    echo "pnpm add error" >&2
+    exit 1
+fi
+
 case "$*" in
     *install*)
         mkdir -p node_modules/.bin
@@ -56,6 +61,57 @@ case "$*" in
 esac
 exit 0
 `
+	nodeStub := `#!/bin/sh
+exit 0
+`
+	corepackStub := `#!/bin/sh
+if [ -z "$COREPACK_HOME" ] || [ -z "$COREPACK_ENABLE_DOWNLOAD_PROMPT" ]; then
+    echo "Error: Required Corepack environment variables missing!" >&2
+    exit 1
+fi
+if [ "$COREPACK_STUB_FAIL" = "1" ]; then
+    echo "Corepack stub error triggered" >&2
+    exit 1
+fi
+case "$*" in
+    *install*pnpm@fail*)
+        echo "Corepack install failure triggered" >&2
+        exit 1
+        ;;
+    *enable*--install-directory*)
+        dir=""
+        prev=""
+        for arg in "$@"; do
+            if [ "$prev" = "--install-directory" ]; then
+                dir="$arg"
+                break
+            fi
+            prev="$arg"
+        done
+        if [ -n "$dir" ]; then
+            mkdir -p "$dir"
+            printf '#!/bin/sh\nif [ "$1" = "--version" ]; then\n  echo "8.0.0"\n  exit 0\nfi\ncase "$*" in\n  *install*)\n    mkdir -p node_modules/.bin\n    printf "#!/bin/sh\\nmkdir -p build\\n" > node_modules/.bin/tsc\n    chmod +x node_modules/.bin/tsc\n    ;;\nesac\nexit 0\n' > "$dir/pnpm"
+            chmod +x "$dir/pnpm"
+        fi
+        ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "corepack"), []byte(corepackStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func stubExecutablesWithoutPNPM(t *testing.T) {
+	t.Helper()
+	bin := t.TempDir()
 	nodeStub := `#!/bin/sh
 exit 0
 `
@@ -84,9 +140,6 @@ case "$*" in
 esac
 exit 0
 `
-	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -157,9 +210,9 @@ func TestInstall(t *testing.T) {
 			},
 		},
 		{
-			name: "tool configuration contains pnpm_version",
+			name: "tool configuration triggers corepack bootstrap on version mismatch",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
+				PNPMVersion: "8.0.0",
 				PNPM: []*config.PNPMTool{
 					{
 						Name:    "gapic-node-processing",
@@ -171,6 +224,22 @@ func TestInstall(t *testing.T) {
 				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
 				t.Setenv("LIBRARIAN_BIN", t.TempDir())
 				stubExecutables(t)
+			},
+		},
+		{
+			name: "tool configuration triggers corepack bootstrap on missing pnpm",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "gapic-node-processing",
+						Version: "0.1.8",
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				stubExecutablesWithoutPNPM(t)
 			},
 		},
 	} {
@@ -261,14 +330,94 @@ func TestInstall_Error(t *testing.T) {
 			},
 			wantErr: errMissingExecutable,
 		},
+		{
+			name: "corepack enable failure",
+			tools: &config.Tools{
+				PNPMVersion: "8.0.0",
+				PNPM: []*config.PNPMTool{
+					{Name: "tool", Version: "1.0"},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				t.Setenv("COREPACK_STUB_FAIL", "1")
+				stubExecutables(t)
+			},
+			wantErr: nil, // checked via non-nil error
+		},
+		{
+			name: "corepack install failure",
+			tools: &config.Tools{
+				PNPMVersion: "fail",
+				PNPM: []*config.PNPMTool{
+					{Name: "tool", Version: "1.0"},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				stubExecutables(t)
+			},
+			wantErr: nil,
+		},
+		{
+			name: "pnpm add global failure",
+			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
+				PNPM: []*config.PNPMTool{
+					{Name: "tool", Version: "1.0"},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				t.Setenv("PNPM_ADD_FAIL", "1")
+				stubExecutables(t)
+			},
+			wantErr: nil,
+		},
+		{
+			name: "source build command failure",
+			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "gapic-generator-typescript",
+						Version: "4.12.1",
+						Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
+						Build: []string{
+							"exit 1",
+						},
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				cache := t.TempDir()
+				t.Setenv("LIBRARIAN_CACHE", cache)
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				genDir := filepath.Join(cache,
+					"github.com/googleapis/google-cloud-node@4.12.1",
+					gapicGeneratorSubdir)
+				if err := os.MkdirAll(genDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				stubExecutables(t)
+			},
+			wantErr: nil,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t)
 			}
 			err := Install(t.Context(), test.tools)
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
+				}
+			} else if err == nil {
+				t.Fatalf("Install() expected error, got nil")
 			}
 		})
 	}
@@ -360,6 +509,78 @@ func TestGetToolsEnv(t *testing.T) {
 			want := filepath.Join(binDir, "nodejs_tools", "bin")
 			if got := env["PATH"]; got != want {
 				t.Errorf("getToolsEnv()[PATH] = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestIsPNPMInstalled(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		version string
+		setup   func(t *testing.T)
+		want    bool
+	}{
+		{
+			name:    "version matches stub",
+			version: "7.32.2",
+			setup:   stubExecutables,
+			want:    true,
+		},
+		{
+			name:    "empty version requested and pnpm present",
+			version: "",
+			setup:   stubExecutables,
+			want:    true,
+		},
+		{
+			name:    "version mismatch",
+			version: "9.9.9",
+			setup:   stubExecutables,
+			want:    false,
+		},
+		{
+			name:    "pnpm missing in PATH",
+			version: "7.32.2",
+			setup: func(t *testing.T) {
+				t.Setenv("PATH", t.TempDir())
+			},
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			env, err := getPNPMEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := isPNPMInstalled(t.Context(), env, test.version)
+			if got != test.want {
+				t.Errorf("isPNPMInstalled(version=%q) = %t, want %t", test.version, got, test.want)
+			}
+		})
+	}
+}
+
+func TestGetPNPMEnv(t *testing.T) {
+	for _, test := range []struct {
+		name string
+	}{
+		{
+			name: "returns valid environment slice",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+			t.Setenv("LIBRARIAN_BIN", t.TempDir())
+			env, err := getPNPMEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(env) == 0 {
+				t.Errorf("getPNPMEnv() returned empty slice")
 			}
 		})
 	}

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -27,6 +27,11 @@ func stubExecutables(t *testing.T) {
 	t.Helper()
 	bin := t.TempDir()
 	pnpmStub := `#!/bin/sh
+if [ "$1" = "--version" ]; then
+    echo "7.32.2"
+    exit 0
+fi
+
 # Assert that transient environmental variables are set dynamically for process lifetime
 if [ -n "$PNPM_HOME" ] && \
    { [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_BIN_DIR" ]; } && \
@@ -54,7 +59,29 @@ exit 0
 	nodeStub := `#!/bin/sh
 exit 0
 `
-	npmStub := `#!/bin/sh
+	corepackStub := `#!/bin/sh
+if [ -z "$COREPACK_HOME" ] || [ -z "$COREPACK_ENABLE_DOWNLOAD_PROMPT" ]; then
+    echo "Error: Required Corepack environment variables missing!" >&2
+    exit 1
+fi
+case "$*" in
+    *enable*--install-directory*)
+        dir=""
+        prev=""
+        for arg in "$@"; do
+            if [ "$prev" = "--install-directory" ]; then
+                dir="$arg"
+                break
+            fi
+            prev="$arg"
+        done
+        if [ -n "$dir" ]; then
+            mkdir -p "$dir"
+            printf '#!/bin/sh\nif [ "$1" = "--version" ]; then\n  echo "7.32.2"\n  exit 0\nfi\ncase "$*" in\n  *install*)\n    mkdir -p node_modules/.bin\n    printf "#!/bin/sh\\nmkdir -p build\\n" > node_modules/.bin/tsc\n    chmod +x node_modules/.bin/tsc\n    ;;\nesac\nexit 0\n' > "$dir/pnpm"
+            chmod +x "$dir/pnpm"
+        fi
+        ;;
+esac
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
@@ -63,7 +90,7 @@ exit 0
 	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(bin, "npm"), []byte(npmStub), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(bin, "corepack"), []byte(corepackStub), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -196,7 +223,7 @@ func TestInstall_Error(t *testing.T) {
 			wantErr: errNoToolsSpecified,
 		},
 		{
-			name:  "missing node or npm in path",
+			name:  "missing node or corepack in path",
 			tools: &config.Tools{PNPMVersion: "7.32.2", PNPM: []*config.PNPMTool{{Name: "foo", Version: "1.0"}}},
 			setup: func(t *testing.T) {
 				t.Setenv("PATH", t.TempDir())

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -126,6 +126,26 @@ func TestInstall(t *testing.T) {
 				stubExecutables(t)
 			},
 		},
+		{
+			name: "tool configuration contains pnpm version",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "pnpm",
+						Version: "7.32.2",
+					},
+					{
+						Name:    "gapic-node-processing",
+						Version: "0.1.8",
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				stubExecutables(t)
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if test.setup != nil {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -32,6 +32,7 @@ if [ -n "$PNPM_HOME" ] && \
    { [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_BIN_DIR" ]; } && \
    { [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] || [ -n "$NPM_CONFIG_GLOBAL_DIR" ]; } && \
    { [ -n "$PNPM_CONFIG_STORE_DIR" ] || [ -n "$NPM_CONFIG_STORE_DIR" ]; } && \
+   [ -n "$NPM_CONFIG_CACHE" ] && \
    [ -n "$PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS" ]; then
     :
 else
@@ -79,6 +80,10 @@ func TestInstall(t *testing.T) {
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
 					{
+						Name:    "pnpm",
+						Version: "7.32.2",
+					},
+					{
 						Name:    "gapic-generator-typescript",
 						Version: "4.12.1",
 						Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
@@ -110,6 +115,10 @@ func TestInstall(t *testing.T) {
 			name: "non-build tool",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
+					{
+						Name:    "pnpm",
+						Version: "7.32.2",
+					},
 					{
 						Name:    "gapic-node-processing",
 						Version: "0.1.8",
@@ -187,6 +196,7 @@ func TestInstall_Error(t *testing.T) {
 			name: "missing package url for build tool",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
+					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Build: []string{"echo 1"}},
 				},
 			},
@@ -199,6 +209,7 @@ func TestInstall_Error(t *testing.T) {
 			name: "invalid package url for build tool",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{
+					{Name: "pnpm", Version: "7.32.2"},
 					{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
 				},
 			},
@@ -206,6 +217,24 @@ func TestInstall_Error(t *testing.T) {
 				stubExecutables(t)
 			},
 			wantErr: errCannotExtractRepo,
+		},
+		{
+			name: "missing pnpm in tools configuration",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{Name: "tool", Version: "1.0"},
+				},
+			},
+			wantErr: errMissingPNPMVersion,
+		},
+		{
+			name: "empty pnpm version in tools configuration",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{Name: "pnpm", Version: ""},
+				},
+			},
+			wantErr: errMissingPNPMVersion,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -146,6 +146,26 @@ func TestInstall(t *testing.T) {
 				stubExecutables(t)
 			},
 		},
+		{
+			name: "legacy tool configuration style fallback",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "pnpm",
+						Version: "7.32.2",
+					},
+					{
+						Name:    "gapic-node-processing",
+						Version: "0.1.8",
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				stubExecutables(t)
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if test.setup != nil {

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -109,6 +109,7 @@ func TestInstall(t *testing.T) {
 		{
 			name: "with composer, pip, and pnpm tools",
 			tools: &config.Tools{
+				PNPMVersion: "7.32.2",
 				Composer: []*config.ComposerTool{
 					{
 						Name:    "fake-composer-tool",

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -109,7 +109,6 @@ func TestInstall(t *testing.T) {
 		{
 			name: "with composer, pip, and pnpm tools",
 			tools: &config.Tools{
-				PNPMVersion: "7.32.2",
 				Composer: []*config.ComposerTool{
 					{
 						Name:    "fake-composer-tool",


### PR DESCRIPTION
Install a pinned version of `pnpm` inside Librarian's local tools directory during `install nodejs` instead of relying on the host's global `pnpm` binary to ensure environment uniformity.
 
For #6638
Fixes #6846