### PR TITLE
fix(sidekick/swift): skip external package traits

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -199,6 +199,17 @@ func (m *Method) WithPathTemplate(pt *PathTemplate) *Method {
 	return m
 }
 
+// WithSourceMethod defines mixin methods.
+func (m *Method) WithSourceMethod(source *Method) *Method {
+	m.WithOutput(source.OutputType).WithInput(source.InputType)
+	m.SourceService = source.Service
+	if m.SourceService != nil {
+		m.SourceServiceID = m.SourceService.ID
+	}
+	m.PathInfo = source.PathInfo
+	return m
+}
+
 // NewTestField creates a field with defaults for testing.
 // JSONName is automatically camelCased.
 func NewTestField(name string) *Field {

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -552,6 +553,9 @@ func TestAnnotateMessage_Gating(t *testing.T) {
 func TestAnnotateMessage_PlaceholderGating(t *testing.T) {
 	model := makeRequiredServicesTestModel()
 	codec := newTestCodec(t, model, nil)
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{ApiPackage: "external", Name: "GoogleCloudExternal"},
+	})
 	codec.PerServiceTraits = true
 
 	if err := codec.annotateModel(); err != nil {

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -275,6 +275,9 @@ func TestModelAnnotations_Pagination(t *testing.T) {
 func TestModelAnnotations_Gating(t *testing.T) {
 	model := makeRequiredServicesTestModel()
 	codec := newTestCodec(t, model, nil)
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{ApiPackage: "external", Name: "GoogleCloudExternal"},
+	})
 	codec.PerServiceTraits = true
 	codec.DefaultTraits = []string{"TestService"}
 

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -85,7 +85,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (
 				return nil, err
 			}
 			restMethods = append(restMethods, method)
-			if method.IsLroPoller && method.SourceService != nil {
+			if method.IsLroPoller && method.SourceService != nil && method.SourceService.Package == service.Package {
 				requiredServices[method.SourceService.ID] = method.SourceService
 			}
 		}

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -250,6 +250,9 @@ func TestAnnotateService_Gating(t *testing.T) {
 func TestAnnotateService_RequiredServices(t *testing.T) {
 	model := makeRequiredServicesTestModel()
 	codec := newTestCodec(t, model, nil)
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{ApiPackage: "external", Name: "GoogleCloudExternal"},
+	})
 	codec.PerServiceTraits = true
 
 	if err := codec.annotateModel(); err != nil {

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -208,6 +208,17 @@ func makeGatedTestModel() *api.API {
 }
 
 func makeRequiredServicesTestModel() *api.API {
+	externalRequest := api.NewTestMessage("Request").WithPackage("external")
+	externalResponse := api.NewTestMessage("Response").WithPackage("external")
+	externalMethod := api.NewTestMethod("GetThing").
+		WithVerb("GET").
+		WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("things")).
+		WithInput(externalRequest).
+		WithOutput(externalResponse)
+	externalService := api.NewTestService("ExternalService").
+		WithPackage("external").
+		WithMethods(externalMethod)
+
 	placeholder := &api.Message{
 		Name:               "zoneOperations",
 		ID:                 ".test.zoneOperations",
@@ -225,46 +236,29 @@ func makeRequiredServicesTestModel() *api.API {
 		ID:      ".test.Operation",
 		Package: "test",
 	}
-	sourceMethod := &api.Method{
-		Name:         "GetOperation",
-		ID:           ".test.zoneOperations.GetOperation",
-		IsLroPoller:  false,
-		InputTypeID:  inputType.ID,
-		InputType:    inputType,
-		OutputTypeID: outputType.ID,
-		OutputType:   outputType,
-		PathInfo: &api.PathInfo{
-			Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
-		},
-	}
-	sourceService := &api.Service{
-		Name:    "zoneOperations",
-		ID:      ".test.zoneOperations",
-		Package: "test",
-		Methods: []*api.Method{sourceMethod},
-	}
+	sourceMethod := api.NewTestMethod("GetOperation").
+		WithInput(inputType).
+		WithOutput(outputType).
+		WithVerb("GET").
+		WithPathTemplate(&api.PathTemplate{})
+	sourceService := api.NewTestService("zoneOperations").
+		WithPackage("test").
+		WithMethods(sourceMethod)
 	sourceMethod.Service = sourceService
-	method := &api.Method{
-		Name:            sourceMethod.Name,
-		ID:              ".test.TestService.GetOperation",
-		IsLroPoller:     true,
-		SourceService:   sourceService,
-		SourceServiceID: sourceService.ID,
-		PathInfo:        sourceMethod.PathInfo,
-		InputTypeID:     sourceMethod.InputTypeID,
-		InputType:       sourceMethod.InputType,
-		OutputTypeID:    sourceMethod.OutputTypeID,
-		OutputType:      sourceMethod.OutputType,
-	}
-	targetService := &api.Service{
-		Name:    "TestService",
-		ID:      ".test.TestService",
-		Package: "test",
-		Methods: []*api.Method{method},
-	}
-	method.Service = targetService
+	internalMixin := api.NewTestMethod(sourceMethod.Name).
+		WithSourceMethod(sourceMethod)
+	internalMixin.IsLroPoller = true
+	externalMixin := api.NewTestMethod(externalMethod.Name).
+		WithSourceMethod(externalMethod)
+	externalMixin.IsLroPoller = true
+	targetService := api.NewTestService("TestService").
+		WithPackage("test").
+		WithMethods(internalMixin, externalMixin)
 
 	model := api.NewTestAPI([]*api.Message{placeholder, inputType, outputType}, nil, []*api.Service{sourceService, targetService})
+	model.AddMessage(externalRequest)
+	model.AddMessage(externalResponse)
+	model.AddService(externalService)
 	api.CrossReference(model)
 	return model
 }


### PR DESCRIPTION
When using per-service traits we automatically enable trait B if trait A depends on B. That does not apply to external packages.

Fixes #6828 