### PR TITLE
chore(tool/cmd/migrate): update ruby tools

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -36,7 +36,7 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 		Tools: &config.Tools{
 			Gem: []*config.GemTool{
 				{
-					Name:    "gapic-generator",
+					Name:    "gapic-generator-cloud",
 					Version: "0.49.0",
 				},
 				{

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -63,7 +63,7 @@ func TestRunRubyMigration(t *testing.T) {
 		Tools: &config.Tools{
 			Gem: []*config.GemTool{
 				{
-					Name:    "gapic-generator",
+					Name:    "gapic-generator-cloud",
 					Version: "0.49.0",
 				},
 				{


### PR DESCRIPTION
Update ruby generator to `gapic-generator-cloud`. See https://github.com/googleapis/librarian/issues/6634#issuecomment-4984151756 for more info.

For #6632
Fixes #6634
