### PR TITLE
refactor(internal/librarian/java): simplify README template by removing monorepo check

### DIFF
--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -98,7 +98,6 @@ type readmeData struct {
 	Version           string
 	RepoShort         string
 	MigratedSplitRepo bool
-	Monorepo          bool
 	BOMVersion        string
 	RequiresBilling   bool
 }
@@ -153,7 +152,6 @@ func renderREADME(params libraryPostProcessParams, keepSet map[string]bool) erro
 		Version:           libraryVersion,
 		RepoShort:         repoShort,
 		MigratedSplitRepo: false,
-		Monorepo:          true,
 		BOMVersion:        bomVersion,
 		RequiresBilling:   apiRequiresBilling,
 	}

--- a/internal/librarian/java/template/README.md.go.tmpl
+++ b/internal/librarian/java/template/README.md.go.tmpl
@@ -65,7 +65,9 @@ implementation platform('com.google.cloud:libraries-bom:{{ .BOMVersion }}')
 
 implementation '{{ .GroupID }}:{{ .ArtifactID }}'
 ```
-{{ end }}If you are using Gradle without BOM, add this to your dependencies:
+
+{{ end -}}
+If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
 implementation '{{ .GroupID }}:{{ .ArtifactID }}:{{ .Version }}'

--- a/internal/librarian/java/template/README.md.go.tmpl
+++ b/internal/librarian/java/template/README.md.go.tmpl
@@ -21,15 +21,7 @@ The Maven artifact coordinates (`{{ .GroupID }}:{{ .ArtifactID }}`) remain the s
 {{ end }}
 ## Quickstart
 
-{{ if and .Snippets (index .Snippets (print .Repo.APIShortname "_install_with_bom")) -}}
-If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
-
-```xml
-{{ index .Snippets (print .Repo.APIShortname "_install_with_bom") }}
-```
-
-If you are using Maven without the BOM, add this to your dependencies:
-{{ else if and .Monorepo (or (eq .GroupID "com.google.cloud") (eq .GroupID "com.google.analytics") (eq .GroupID "com.google.area120")) }}
+{{ if or (eq .GroupID "com.google.cloud") (eq .GroupID "com.google.analytics") (eq .GroupID "com.google.area120") -}}
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 
 ```xml
@@ -58,18 +50,14 @@ If you are using Maven without the BOM, add this to your dependencies:
 {{ end }}
 
 ```xml
-{{ if and .Snippets (index .Snippets (print .Repo.APIShortname "_install_without_bom")) -}}
-{{ index .Snippets (print .Repo.APIShortname "_install_without_bom") }}
-{{- else -}}
 <dependency>
   <groupId>{{ .GroupID }}</groupId>
   <artifactId>{{ .ArtifactID }}</artifactId>
   <version>{{ .Version }}</version>
 </dependency>
-{{- end }}
 ```
 
-{{ if and .Snippets (index .Snippets (print .Repo.APIShortname "_install_with_bom")) -}}
+{{ if or (eq .GroupID "com.google.cloud") (eq .GroupID "com.google.analytics") (eq .GroupID "com.google.area120") -}}
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy

--- a/internal/librarian/java/testdata/readme/partials.golden
+++ b/internal/librarian/java/testdata/readme/partials.golden
@@ -52,6 +52,7 @@ implementation platform('com.google.cloud:libraries-bom:1.0.0-BOM')
 
 implementation 'com.google.cloud:google-cloud-myapi'
 ```
+
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy

--- a/internal/librarian/java/testdata/readme/partials.golden
+++ b/internal/librarian/java/testdata/readme/partials.golden
@@ -11,7 +11,6 @@ Java idiomatic client for [My API][product-docs].
 
 ## Quickstart
 
-
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 
 ```xml
@@ -46,6 +45,13 @@ If you are using Maven without the BOM, add this to your dependencies:
 </dependency>
 ```
 
+If you are using Gradle 5.x or later, add this to your dependencies:
+
+```Groovy
+implementation platform('com.google.cloud:libraries-bom:1.0.0-BOM')
+
+implementation 'com.google.cloud:google-cloud-myapi'
+```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy

--- a/internal/librarian/java/testdata/readme/standard.golden
+++ b/internal/librarian/java/testdata/readme/standard.golden
@@ -52,6 +52,7 @@ implementation platform('com.google.cloud:libraries-bom:1.0.0-BOM')
 
 implementation 'com.google.cloud:google-cloud-myapi'
 ```
+
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy

--- a/internal/librarian/java/testdata/readme/standard.golden
+++ b/internal/librarian/java/testdata/readme/standard.golden
@@ -11,7 +11,6 @@ Java idiomatic client for [My API][product-docs].
 
 ## Quickstart
 
-
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 
 ```xml
@@ -46,6 +45,13 @@ If you are using Maven without the BOM, add this to your dependencies:
 </dependency>
 ```
 
+If you are using Gradle 5.x or later, add this to your dependencies:
+
+```Groovy
+implementation platform('com.google.cloud:libraries-bom:1.0.0-BOM')
+
+implementation 'com.google.cloud:google-cloud-myapi'
+```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy


### PR DESCRIPTION
Remove the redundant `.Monorepo` boolean check from the README template and the corresponding Go generation code. The template now only relies on `GroupID` to decide whether to render BOM installation instructions, which is equivalent because `.Monorepo` was previously hardcoded to true. 


For #6515