### PR TITLE
feat(tool/cmd/migrate): discover ruby libraries during migration

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
@@ -50,6 +52,11 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 			},
 		},
 	}
+	libs, err := findRubyLibraryDirs(repoPath)
+	if err != nil {
+		return err
+	}
+	cfg.Libraries = libs
 	// The directory name in Googleapis is present for migration code to look
 	// up API details. It shouldn't be persisted.
 	cfg.Sources.Googleapis.Dir = ""
@@ -59,3 +66,26 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 	log.Printf("Successfully migrated Ruby libraries configuration skeleton")
 	return nil
 }
+
+func findRubyLibraryDirs(repoPath string) ([]*config.Library, error) {
+	entries, err := os.ReadDir(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	var libraries []*config.Library
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		owlBotPath := filepath.Join(repoPath, name, ".OwlBot.yaml")
+		if _, err := os.Stat(owlBotPath); err != nil {
+			continue
+		}
+		libraries = append(libraries, &config.Library{
+			Name: name,
+		})
+	}
+	return libraries, nil
+}
+	

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -52,7 +52,7 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 			},
 		},
 	}
-	libs, err := findRubyLibraryDirs(repoPath)
+	libs, err := findRubyLibraries(repoPath)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 	return nil
 }
 
-func findRubyLibraryDirs(repoPath string) ([]*config.Library, error) {
+func findRubyLibraries(repoPath string) ([]*config.Library, error) {
 	entries, err := os.ReadDir(repoPath)
 	if err != nil {
 		return nil, err
@@ -88,4 +88,3 @@ func findRubyLibraryDirs(repoPath string) ([]*config.Library, error) {
 	}
 	return libraries, nil
 }
-	

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -80,7 +82,10 @@ func findRubyLibraries(repoPath string) ([]*config.Library, error) {
 		name := entry.Name()
 		owlBotPath := filepath.Join(repoPath, name, ".OwlBot.yaml")
 		if _, err := os.Stat(owlBotPath); err != nil {
-			continue
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("checking OwlBot config: %w", err)
 		}
 		libraries = append(libraries, &config.Library{
 			Name: name,

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -72,7 +72,7 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 func findRubyLibraries(repoPath string) ([]*config.Library, error) {
 	entries, err := os.ReadDir(repoPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading repository directory: %w", err)
 	}
 	var libraries []*config.Library
 	for _, entry := range entries {

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -79,5 +80,62 @@ func TestRunRubyMigration(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFindRubyLibraries(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		files []string
+		want  []*config.Library
+	}{
+		{
+			name: "single library with .OwlBot.yaml",
+			files: []string{
+				"google-cloud-secret_manager/.OwlBot.yaml",
+			},
+			want: []*config.Library{
+				{Name: "google-cloud-secret_manager"},
+			},
+		},
+		{
+			name: "multiple libraries with non-library files and directories",
+			files: []string{
+				"google-cloud-secret_manager/.OwlBot.yaml",
+				"google-cloud-storage/.OwlBot.yaml",
+				"README.md",
+				".OwlBot.yaml",
+				"script/helper.rb",
+			},
+			want: []*config.Library{
+				{Name: "google-cloud-secret_manager"},
+				{Name: "google-cloud-storage"},
+			},
+		},
+		{
+			name:  "no libraries found",
+			files: []string{"README.md", "script/helper.rb"},
+			want:  nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range test.files {
+				path := filepath.Join(dir, f)
+				if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := findRubyLibraries(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add helper logic to inspect a Ruby repository and automatically populate the libraries list during migration.

A directory is recognized as a Ruby library if it contains a .OwlBot.yaml configuration file.

For #6632
