### PR TITLE
refactor(internal/librarian/nodejs): expose InstallPNPM for reuse in php

### DIFF
--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -46,7 +46,15 @@ var (
 
 // Install installs Node.js tool dependencies.
 func Install(ctx context.Context, tools *config.Tools) error {
-	if tools == nil || len(tools.PNPM) == 0 {
+	if tools == nil {
+		return errNoToolsSpecified
+	}
+	return InstallPNPM(ctx, tools.PNPM)
+}
+
+// InstallPNPM installs PNPM tools.
+func InstallPNPM(ctx context.Context, pnpmTools []*config.PNPMTool) error {
+	if len(pnpmTools) == 0 {
 		return errNoToolsSpecified
 	}
 
@@ -61,7 +69,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return err
 	}
 
-	for _, tool := range tools.PNPM {
+	for _, tool := range pnpmTools {
 		if len(tool.Build) > 0 {
 			if err := installPNPMToolFromSource(ctx, env, tool); err != nil {
 				return err

--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -82,7 +82,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 	// Install PNPM tools
 	if len(tools.PNPM) > 0 {
-		if err := nodejs.Install(ctx, tools); err != nil {
+		if err := nodejs.InstallPNPM(ctx, tools.PNPM); err != nil {
 			return fmt.Errorf("failed to install pnpm tools: %w", err)
 		}
 	}


### PR DESCRIPTION
 Expose InstallPNPM in the nodejs package to allow installing PNPM tools directly by passing a slice of PNPMTool config.  This is a minimum fix to allow php.Install to reuse and install `tools.PNPM` properly.

For https://github.com/googleapis/librarian/issues/6857