### PR TITLE
refactor(internal/tool/pnpm): extract pnpm tool installation logic

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -108,6 +108,7 @@ This document describes the schema for the librarian.yaml.
 | `sha256` | string | Is the SHA256 checksum of the package. |
 | `checksum` | string | Is a deprecated alias for SHA256. |
 | `build` | list of string | Defines the commands to run to build the tool after installation. |
+| `src_dir` | string | Is the path to the directory inside the fetched archive that should be treated as the root for operations. |
 
 ## Protoc Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,6 +225,10 @@ type PNPMTool struct {
 
 	// Build defines the commands to run to build the tool after installation.
 	Build []string `yaml:"build,omitempty"`
+
+	// SrcDir is the path to the directory inside the fetched archive that should
+	// be treated as the root for operations.
+	SrcDir string `yaml:"src_dir,omitempty"`
 }
 
 // Protoc defines the configuration for installing the protoc compiler.

--- a/internal/tool/pnpm/pnpm.go
+++ b/internal/tool/pnpm/pnpm.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pnpm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/cache"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/fetch"
+)
+
+var (
+	errCannotExtractRepo = errors.New("cannot extract repo from package URL")
+	errMissingPackageURL = errors.New("has build steps but no package URL")
+)
+
+// InstallPNPM installs PNPM tools.
+func Install(ctx context.Context, pnpmTools []*config.PNPMTool, binDir string) error {
+	env, err := envs(binDir)
+	if err != nil {
+		return err
+	}
+
+	for _, tool := range pnpmTools {
+		if len(tool.Build) > 0 {
+			if err := installFromSource(ctx, env, tool, tool.SrcDir); err != nil {
+				return err
+			}
+			continue
+		}
+
+		pkg := tool.Package
+		if pkg == "" {
+			pkg = fmt.Sprintf("%s@%s", tool.Name, tool.Version)
+		}
+		if err := run(ctx, "", env, "add", "-g", pkg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getPNPMEnv constructs a transient environment variable block to configure pnpm.
+//
+// This redirects all globally-installed pnpm binaries to LIBRARIAN_BIN, and
+// virtual stores / content-addressable storage caches to LIBRARIAN_CACHE.
+// This enables complete environment caching and restore on CI runners,
+// while permanently avoiding persistent side-effects on the host machine
+// (it does not modify the user's personal ~/.config/pnpm/rc files).
+func envs(binDir string) ([]string, error) {
+	cacheDir, err := cache.Directory()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve librarian cache directory: %w", err)
+	}
+	env := os.Environ()
+	env = append(env, "PNPM_HOME="+binDir)
+	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
+	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
+	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
+	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return env, nil
+}
+
+func run(ctx context.Context, dir string, env []string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "pnpm", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func build(ctx context.Context, dir string, env []string, cmdStr string) error {
+	cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func installFromSource(ctx context.Context, env []string, tool *config.PNPMTool, srcDir string) error {
+	if tool.Package == "" {
+		return fmt.Errorf("pnpm tool %s %w", tool.Name, errMissingPackageURL)
+	}
+	repo, err := repoFromPackageURL(tool.Package)
+	if err != nil {
+		return err
+	}
+	sha := tool.SHA256
+	if sha == "" {
+		sha = tool.Checksum
+	}
+	dir, err := fetch.Repo(ctx, repo, tool.Version, sha)
+	if err != nil {
+		return fmt.Errorf("fetching %s: %w", tool.Name, err)
+	}
+
+	// Run build steps.
+	buildDir := filepath.Join(dir, srcDir)
+	for _, cmd := range tool.Build {
+		if err := build(ctx, buildDir, env, cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// repoFromPackageURL extracts the repository path (e.g.,
+// "github.com/googleapis/google-cloud-node") from a GitHub archive URL
+// like "https://github.com/googleapis/google-cloud-node/archive/<sha>.tar.gz".
+func repoFromPackageURL(packageURL string) (string, error) {
+	parts := strings.SplitN(packageURL, "/archive/", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("%w %q", errCannotExtractRepo, packageURL)
+	}
+	return strings.TrimPrefix(parts[0], "https://"), nil
+}

--- a/internal/tool/pnpm/pnpm.go
+++ b/internal/tool/pnpm/pnpm.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package pnpm provides utilities to install pnpm packages.
 package pnpm
 
 import (
@@ -33,7 +34,7 @@ var (
 	errMissingPackageURL = errors.New("has build steps but no package URL")
 )
 
-// InstallPNPM installs PNPM tools.
+// Install installs PNPM tools.
 func Install(ctx context.Context, pnpmTools []*config.PNPMTool, binDir string) error {
 	env, err := envs(binDir)
 	if err != nil {

--- a/internal/tool/pnpm/pnpm_test.go
+++ b/internal/tool/pnpm/pnpm_test.go
@@ -129,16 +129,12 @@ func TestInstall_Error(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		pnpmTools []*config.PNPMTool
-		setup     func(t *testing.T)
 		wantErr   error
 	}{
 		{
 			name: "missing package url for build tool",
 			pnpmTools: []*config.PNPMTool{
 				{Name: "tool", Build: []string{"echo 1"}},
-			},
-			setup: func(t *testing.T) {
-				stubExecutables(t)
 			},
 			wantErr: errMissingPackageURL,
 		},
@@ -147,16 +143,10 @@ func TestInstall_Error(t *testing.T) {
 			pnpmTools: []*config.PNPMTool{
 				{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
 			},
-			setup: func(t *testing.T) {
-				stubExecutables(t)
-			},
 			wantErr: errCannotExtractRepo,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if test.setup != nil {
-				test.setup(t)
-			}
 			err := Install(t.Context(), test.pnpmTools, t.TempDir())
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)

--- a/internal/tool/pnpm/pnpm_test.go
+++ b/internal/tool/pnpm/pnpm_test.go
@@ -23,41 +23,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func stubExecutables(t *testing.T) {
-	t.Helper()
-	bin := t.TempDir()
-	pnpmStub := `#!/bin/sh
-# Assert that transient environmental variables are set dynamically for process lifetime
-if [ -n "$PNPM_HOME" ] && [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] && [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] && [ -n "$PNPM_CONFIG_STORE_DIR" ]; then
-    :
-else
-    echo "Error: Required transient PNPM environment variables are missing!" >&2
-    exit 1
-fi
-
-case "$*" in
-    *install*)
-        mkdir -p node_modules/.bin
-        printf '#!/bin/sh\nmkdir -p build\n' > node_modules/.bin/tsc
-        chmod +x node_modules/.bin/tsc
-        ;;
-    *add\ -g*)
-        ;;
-esac
-exit 0
-`
-	nodeStub := `#!/bin/sh
-exit 0
-`
-	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-}
-
 func TestInstall(t *testing.T) {
 	for _, test := range []struct {
 		name      string
@@ -198,4 +163,39 @@ func TestRepoFromPackageURL_Error(t *testing.T) {
 			}
 		})
 	}
+}
+
+func stubExecutables(t *testing.T) {
+	t.Helper()
+	bin := t.TempDir()
+	pnpmStub := `#!/bin/sh
+# Assert that transient environmental variables are set dynamically for process lifetime
+if [ -n "$PNPM_HOME" ] && [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] && [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] && [ -n "$PNPM_CONFIG_STORE_DIR" ]; then
+    :
+else
+    echo "Error: Required transient PNPM environment variables are missing!" >&2
+    exit 1
+fi
+
+case "$*" in
+    *install*)
+        mkdir -p node_modules/.bin
+        printf '#!/bin/sh\nmkdir -p build\n' > node_modules/.bin/tsc
+        chmod +x node_modules/.bin/tsc
+        ;;
+    *add\ -g*)
+        ;;
+esac
+exit 0
+`
+	nodeStub := `#!/bin/sh
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/tool/pnpm/pnpm_test.go
+++ b/internal/tool/pnpm/pnpm_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pnpm
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func stubExecutables(t *testing.T) {
+	t.Helper()
+	bin := t.TempDir()
+	pnpmStub := `#!/bin/sh
+# Assert that transient environmental variables are set dynamically for process lifetime
+if [ -n "$PNPM_HOME" ] && [ -n "$PNPM_CONFIG_GLOBAL_BIN_DIR" ] && [ -n "$PNPM_CONFIG_GLOBAL_DIR" ] && [ -n "$PNPM_CONFIG_STORE_DIR" ]; then
+    :
+else
+    echo "Error: Required transient PNPM environment variables are missing!" >&2
+    exit 1
+fi
+
+case "$*" in
+    *install*)
+        mkdir -p node_modules/.bin
+        printf '#!/bin/sh\nmkdir -p build\n' > node_modules/.bin/tsc
+        chmod +x node_modules/.bin/tsc
+        ;;
+    *add\ -g*)
+        ;;
+esac
+exit 0
+`
+	nodeStub := `#!/bin/sh
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(bin, "pnpm"), []byte(pnpmStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "node"), []byte(nodeStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestInstall(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		pnpmTools []*config.PNPMTool
+		setup     func(t *testing.T)
+	}{
+		{
+			name: "source build tool",
+			pnpmTools: []*config.PNPMTool{
+				{
+					Name:    "gapic-generator-typescript",
+					Version: "4.12.1",
+					Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
+					SrcDir:  "gapic-generator-v4.12.1",
+					Build: []string{
+						"pnpm install",
+						"./node_modules/.bin/tsc",
+						"cp -a templates protos build/",
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				cache := t.TempDir()
+				t.Setenv("LIBRARIAN_CACHE", cache)
+				binDir := t.TempDir()
+				t.Setenv("LIBRARIAN_BIN", binDir)
+				genDir := filepath.Join(cache,
+					"github.com/googleapis/google-cloud-node@4.12.1",
+					"gapic-generator-v4.12.1")
+				for _, sub := range []string{"templates", "protos"} {
+					if err := os.MkdirAll(filepath.Join(genDir, sub), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				stubExecutables(t)
+			},
+		},
+		{
+			name: "non-build tool",
+			pnpmTools: []*config.PNPMTool{
+				{
+					Name:    "gapic-node-processing",
+					Version: "0.1.8",
+				},
+				{
+					Name:    "custom-pkg",
+					Package: "custom-pkg@1.0.0",
+				},
+			},
+			setup: func(t *testing.T) {
+				t.Setenv("LIBRARIAN_CACHE", t.TempDir())
+				t.Setenv("LIBRARIAN_BIN", t.TempDir())
+				stubExecutables(t)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			if err := Install(t.Context(), test.pnpmTools, t.TempDir()); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestInstall_Error(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		pnpmTools []*config.PNPMTool
+		setup     func(t *testing.T)
+		wantErr   error
+	}{
+		{
+			name: "missing package url for build tool",
+			pnpmTools: []*config.PNPMTool{
+				{Name: "tool", Build: []string{"echo 1"}},
+			},
+			setup: func(t *testing.T) {
+				stubExecutables(t)
+			},
+			wantErr: errMissingPackageURL,
+		},
+		{
+			name: "invalid package url for build tool",
+			pnpmTools: []*config.PNPMTool{
+				{Name: "tool", Package: "invalid-url", Build: []string{"echo 1"}},
+			},
+			setup: func(t *testing.T) {
+				stubExecutables(t)
+			},
+			wantErr: errCannotExtractRepo,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			err := Install(t.Context(), test.pnpmTools, t.TempDir())
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestRepoFromPackageURL(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		packageURL string
+		want       string
+	}{
+		{
+			name:       "valid archive url",
+			packageURL: "https://github.com/googleapis/google-cloud-node/archive/gapic-generator-v4.12.1.tar.gz",
+			want:       "github.com/googleapis/google-cloud-node",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := repoFromPackageURL(test.packageURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("repoFromPackageURL(%q) = %q, want %q", test.packageURL, got, test.want)
+			}
+		})
+	}
+}
+
+func TestRepoFromPackageURL_Error(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		packageURL string
+		wantErr    error
+	}{
+		{
+			name:       "invalid archive url",
+			packageURL: "https://github.com/googleapis/google-cloud-node/invalid",
+			wantErr:    errCannotExtractRepo,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := repoFromPackageURL(test.packageURL)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("repoFromPackageURL(%q) error = %v, wantErr = %v", test.packageURL, err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Extract the pnpm tool installation functionality out of the Node.js language package into a dedicated internal tool package.

A new SrcDir field is added to PNPMTool in configuration to specify the sub-directory inside source archives used during builds.

Functions and tests are copied from nodejs package. This change can unblock us from further refactors.

For #6857
