### PR TITLE
test(librarian/php): check for generator before running

### DIFF
--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -84,6 +84,7 @@ func requirePHPGenerator(t *testing.T) {
 }
 
 func TestGenerate_Error(t *testing.T) {
+	requirePHPGenerator(t)
 	for _, test := range []struct {
 		name    string
 		lib     *config.Library

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -31,7 +31,6 @@ func TestGenerate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow integration test")
 	}
-	testhelper.RequireCommand(t, "protoc")
 	requirePHPGenerator(t)
 
 	// Use mock googleapis checked in as test data
@@ -72,6 +71,7 @@ func TestGenerate(t *testing.T) {
 
 func requirePHPGenerator(t *testing.T) {
 	t.Helper()
+	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "php")
 	genDir, err := generatorDir(t.Context())
 	if err != nil {


### PR DESCRIPTION
The `TestGenerate_Error()` function requires the PHP generator to be installed. Check that the generator is present before running the test.