### PR TITLE
chore(ci): use sparse-checkout for Java presubmit test

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -31,6 +31,10 @@ jobs:
           repository: googleapis/google-cloud-java
           path: google-cloud-java
           persist-credentials: false
+          sparse-checkout: |
+            librarian.yaml
+            pom.xml
+            sdk-platform-java
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4


### PR DESCRIPTION
The Java presubmit test job was timing out often, checking out the full google-cloud-java monorepo took too long (over 1min in recent [runs](https://screenshot.googleplex.com/rvhLUBEzwDpPNdf)).

Configure actions/checkout to use sparse-checkout to only download librarian.yaml, pom.xml, and the sdk-platform-java directory. This provides the necessary files to build and install local tools while avoiding downloading the rest of the monorepo.