### PR TITLE
feat(sidekick/swift): `oneof` in method signatures

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -129,6 +129,21 @@ func (m *Message) WithOneOfs(oneofs ...*OneOf) *Message {
 	return m
 }
 
+// WithPagination items and page token fields for a pagination response.
+func (m *Message) WithPagination(nextPageToken *Field, items *Field) *Message {
+	if nextPageToken.Parent != m {
+		m.WithFields(nextPageToken)
+	}
+	if items.Parent != m {
+		m.WithFields(items)
+	}
+	m.Pagination = &PaginationInfo{
+		NextPageToken: nextPageToken,
+		PageableItem:  items,
+	}
+	return m
+}
+
 // WithResource sets the resource definition on the message.
 func (m *Message) WithResource(resource *Resource) *Message {
 	m.Resource = resource
@@ -220,6 +235,13 @@ func (m *Method) WithSourceMethod(source *Method) *Method {
 		m.SourceServiceID = m.SourceService.ID
 	}
 	m.PathInfo = source.PathInfo
+	return m
+}
+
+// WithPagination sets the page token field for the request.
+func (m *Method) WithPagination(pageToken *Field) *Method {
+	m.IsList = true
+	m.Pagination = pageToken
 	return m
 }
 

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -116,6 +116,19 @@ func (m *Message) WithFields(fields ...*Field) *Message {
 	return m
 }
 
+// WithOneOfs adds oneofs to the message and updates their parent/ID.
+func (m *Message) WithOneOfs(oneofs ...*OneOf) *Message {
+	for _, o := range oneofs {
+		// If oneof ID is generic/default, re-scope it to the message.
+		if strings.HasPrefix(o.ID, ".test.") || o.ID == "" {
+			o.ID = fmt.Sprintf("%s.%s", m.ID, o.Name)
+		}
+		m.OneOfs = append(m.OneOfs, o)
+		m.WithFields(o.Fields...)
+	}
+	return m
+}
+
 // WithResource sets the resource definition on the message.
 func (m *Message) WithResource(resource *Resource) *Message {
 	m.Resource = resource
@@ -210,6 +223,57 @@ func (m *Method) WithSourceMethod(source *Method) *Method {
 	return m
 }
 
+// WithOperationInfo sets the LRO information and flag.
+func (m *Method) WithOperationInfo(info *OperationInfo) *Method {
+	m.IsLRO = true
+	m.OperationInfo = info
+	return m
+}
+
+// WithDiscoveryLro sets the discovery LRO information.
+func (m *Method) WithDiscoveryLro(info *DiscoveryLro) *Method {
+	m.DiscoveryLro = info
+	return m
+}
+
+// WithSignature adds method signatures.
+func (m *Method) WithSignatures(signatures ...*MethodSignature) *Method {
+	if m.InputType == nil {
+		panic(fmt.Sprintf("missing InputType for method: %s", m.Name))
+	}
+	for _, s := range signatures {
+		s.Method = m
+		for _, name := range s.Names {
+			for _, f := range m.InputType.Fields {
+				if name != f.Name {
+					continue
+				}
+				s.Fields = append(s.Fields, f)
+				break
+			}
+		}
+		m.Signatures = append(m.Signatures, s)
+	}
+	return m
+}
+
+// NewTestOneOf creates a OneOf with defaults for testing.
+func NewTestOneOf(name string) *OneOf {
+	return &OneOf{
+		Name: name,
+		ID:   fmt.Sprintf(".test.%s", name),
+	}
+}
+
+func (o *OneOf) WithFields(fields ...*Field) *OneOf {
+	for _, f := range fields {
+		f.IsOneOf = true
+		f.Group = o
+		o.Fields = append(o.Fields, f)
+	}
+	return o
+}
+
 // NewTestField creates a field with defaults for testing.
 // JSONName is automatically camelCased.
 func NewTestField(name string) *Field {
@@ -229,12 +293,24 @@ func (f *Field) WithType(t Typez) *Field {
 // WithRepeated marks the field as repeated.
 func (f *Field) WithRepeated() *Field {
 	f.Repeated = true
+	f.Optional = false
+	f.Map = false
+	return f
+}
+
+// WithOptional marks the field as optional.
+func (f *Field) WithOptional() *Field {
+	f.Optional = true
+	f.Repeated = false
+	f.Map = false
 	return f
 }
 
 // WithMap marks the field as a map.
 func (f *Field) WithMap() *Field {
 	f.Map = true
+	f.Repeated = false
+	f.Optional = false
 	return f
 }
 

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -258,7 +258,10 @@ func (m *Method) WithDiscoveryLro(info *DiscoveryLro) *Method {
 	return m
 }
 
-// WithSignature adds method signatures.
+// WithSignatures adds method signatures.
+//
+// A method signature typically maps to an overloads with a subset of
+// the request fields.
 func (m *Method) WithSignatures(signatures ...*MethodSignature) *Method {
 	if m.InputType == nil {
 		panic(fmt.Sprintf("missing InputType for method: %s", m.Name))
@@ -287,6 +290,10 @@ func NewTestOneOf(name string) *OneOf {
 	}
 }
 
+// WithFields adds fields to a oneof group.
+//
+// When the group is included in a message, all its fields are included into the
+// message too.
 func (o *OneOf) WithFields(fields ...*Field) *OneOf {
 	for _, f := range fields {
 		f.IsOneOf = true

--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -94,7 +94,7 @@ func (ann *methodAnnotations) HasQueryParams() bool {
 
 // PlainRPC returns true if the method is not a pagination or LRO.
 func (ann *methodAnnotations) PlainRPC() bool {
-	return ann.LRO == nil && ann.Pagination == nil
+	return ann.LRO == nil && ann.Pagination == nil && ann.DiscoveryLRO == nil
 }
 
 func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) error {

--- a/internal/sidekick/swift/generate_method_signatures_test.go
+++ b/internal/sidekick/swift/generate_method_signatures_test.go
@@ -130,6 +130,39 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Discovery LROs",
+			want: []expectedBlock{
+				{
+					start: "public func lroDiscoveryMethod(\n  name: Swift.String,\n  optionalField: Swift.String?,",
+					end:   "    }\n",
+					want: `public func lroDiscoveryMethod(
+  name: Swift.String,
+  optionalField: Swift.String?,
+) async throws -> any GoogleCloudGax.PollableOperation<GoogleCloudLongrunningV1.GetOperationRequest>
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = optionalField.map { .optionalField($0) }
+    }
+`,
+				},
+				{
+					start: "public func lroDiscoveryMethod(\n  name: Swift.String,\n  normalField: Swift.String,",
+					end:   "    }\n",
+					want: `public func lroDiscoveryMethod(
+  name: Swift.String,
+  normalField: Swift.String,
+) async throws -> any GoogleCloudGax.PollableOperation<GoogleCloudLongrunningV1.GetOperationRequest>
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = .normalField(normalField)
+    }
+`,
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()

--- a/internal/sidekick/swift/generate_method_signatures_test.go
+++ b/internal/sidekick/swift/generate_method_signatures_test.go
@@ -97,6 +97,39 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "LROs",
+			want: []expectedBlock{
+				{
+					start: "public func lroMethod(\n  name: Swift.String,\n  optionalField: Swift.String?,",
+					end:   "    }\n",
+					want: `public func lroMethod(
+  name: Swift.String,
+  optionalField: Swift.String?,
+) async throws -> any GoogleCloudGax.PollableOperation<LROResult>
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = optionalField.map { .optionalField($0) }
+    }
+`,
+				},
+				{
+					start: "public func lroMethod(\n  name: Swift.String,\n  normalField: Swift.String,",
+					end:   "    }\n",
+					want: `public func lroMethod(
+  name: Swift.String,
+  normalField: Swift.String,
+) async throws -> any GoogleCloudGax.PollableOperation<LROResult>
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = .normalField(normalField)
+    }
+`,
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()

--- a/internal/sidekick/swift/generate_method_signatures_test.go
+++ b/internal/sidekick/swift/generate_method_signatures_test.go
@@ -64,6 +64,39 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Pagination",
+			want: []expectedBlock{
+				{
+					start: "public func paginationMethod(\n  name: Swift.String,\n  optionalField: Swift.String?,",
+					end:   "    }\n",
+					want: `public func paginationMethod(
+  name: Swift.String,
+  optionalField: Swift.String?,
+) throws -> any AsyncSequence<Item, Swift.Error>
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = optionalField.map { .optionalField($0) }
+    }
+`,
+				},
+				{
+					start: "public func paginationMethod(\n  name: Swift.String,\n  normalField: Swift.String,",
+					end:   "    }\n",
+					want: `public func paginationMethod(
+  name: Swift.String,
+  normalField: Swift.String,
+) throws -> any AsyncSequence<Item, Swift.Error>
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = .normalField(normalField)
+    }
+`,
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
@@ -108,8 +141,10 @@ func newModelWithSignatures(t *testing.T) *api.API {
 		api.NewTestField("optional_field").WithType(api.TypezString).WithOptional(),
 		api.NewTestField("normal_field").WithType(api.TypezString),
 	)
+	pageToken := api.NewTestField("page_token").WithType(api.TypezString)
 	requestType := api.NewTestMessage("Request").WithPackage("test").
 		WithFields(api.NewTestField("name").WithType(api.TypezString)).
+		WithFields(pageToken).
 		WithOneOfs(oneof)
 	responseType := api.NewTestMessage("Response")
 
@@ -125,17 +160,14 @@ func newModelWithSignatures(t *testing.T) *api.API {
 
 	itemType := api.NewTestMessage("Item")
 	paginationResponseType := api.NewTestMessage("PaginationResponse").
-		WithFields(
-			api.NewTestField("items").WithMessageType(itemType).WithRepeated(),
+		WithPagination(
 			api.NewTestField("next_page_token").WithType(api.TypezString),
+			api.NewTestField("items").WithMessageType(itemType).WithRepeated(),
 		)
-	paginationResponseType.Pagination = &api.PaginationInfo{
-		PageableItem:  paginationResponseType.Fields[0],
-		NextPageToken: paginationResponseType.Fields[1],
-	}
 	paginationMethod := api.NewTestMethod("PaginationMethod").
 		WithInput(requestType).
 		WithOutput(paginationResponseType).
+		WithPagination(pageToken).
 		WithVerb("GET").
 		WithSignatures(
 			&api.MethodSignature{Names: []string{"name", "optional_field"}},

--- a/internal/sidekick/swift/generate_method_signatures_test.go
+++ b/internal/sidekick/swift/generate_method_signatures_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerateService_MethodSignatures(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want []expectedBlock
+	}{
+		{
+			name: "Simple",
+			want: []expectedBlock{
+				{
+					start: "public func simpleMethod(\n  name: Swift.String,\n  optionalField: Swift.String?,",
+					end:   "    }\n",
+					want: `public func simpleMethod(
+  name: Swift.String,
+  optionalField: Swift.String?,
+) async throws -> GoogleTest.Response
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = optionalField.map { .optionalField($0) }
+    }
+`,
+				},
+				{
+					start: "public func simpleMethod(\n  name: Swift.String,\n  normalField: Swift.String,",
+					end:   "    }\n",
+					want: `public func simpleMethod(
+  name: Swift.String,
+  normalField: Swift.String,
+) async throws -> GoogleTest.Response
+ {
+    let request = Request().with {
+      $0.name = name
+      $0.group = .normalField(normalField)
+    }
+`,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			model := newModelWithSignatures(t)
+			cfg := &parser.ModelConfig{}
+			swiftCfg := swiftConfig(t, []config.SwiftDependency{
+				{Name: "GoogleCloudGax", RequiredByServices: true},
+				{Name: "GoogleCloudAuth", RequiredByServices: true},
+				{ApiPackage: "google.longrunning", Name: "GoogleCloudLongrunningV1"},
+				{ApiPackage: "google.rpc", Name: "GoogleRpc"},
+			})
+
+			if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+				t.Fatal(err)
+			}
+
+			filename := filepath.Join(outDir, "Sources", "GoogleTest", "TestService.swift")
+			content, err := os.ReadFile(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// We only want to search within the default implementations.
+			contentStr := extractBlock(t, string(content), "// Default implementations\nextension Clients.TestServiceProtocol {", "\n}")
+			for i, want := range test.want {
+				t.Run(fmt.Sprintf("block %d", i), func(t *testing.T) {
+					got := extractBlock(t, contentStr, want.start, want.end)
+					if diff := cmp.Diff(want.want, got); diff != "" {
+						t.Errorf("mismatch (-want +got):\n%s", diff)
+					}
+				})
+			}
+		})
+	}
+}
+
+// Creates a model with a normal method, a paginated method, and a LRO method.
+//
+// All of them have a method signatures with a normal field, a oneof field, and an optional oneof field.
+func newModelWithSignatures(t *testing.T) *api.API {
+	t.Helper()
+	oneof := api.NewTestOneOf("group").WithFields(
+		api.NewTestField("optional_field").WithType(api.TypezString).WithOptional(),
+		api.NewTestField("normal_field").WithType(api.TypezString),
+	)
+	requestType := api.NewTestMessage("Request").WithPackage("test").
+		WithFields(api.NewTestField("name").WithType(api.TypezString)).
+		WithOneOfs(oneof)
+	responseType := api.NewTestMessage("Response")
+
+	simpleMethod := api.NewTestMethod("SimpleMethod").
+		WithInput(requestType).
+		WithOutput(responseType).
+		WithVerb("POST").
+		WithSignatures(
+			&api.MethodSignature{Names: []string{"name", "optional_field"}},
+			&api.MethodSignature{Names: []string{"name", "normal_field"}},
+		).
+		WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("simple"))
+
+	itemType := api.NewTestMessage("Item")
+	paginationResponseType := api.NewTestMessage("PaginationResponse").
+		WithFields(
+			api.NewTestField("items").WithMessageType(itemType).WithRepeated(),
+			api.NewTestField("next_page_token").WithType(api.TypezString),
+		)
+	paginationResponseType.Pagination = &api.PaginationInfo{
+		PageableItem:  paginationResponseType.Fields[0],
+		NextPageToken: paginationResponseType.Fields[1],
+	}
+	paginationMethod := api.NewTestMethod("PaginationMethod").
+		WithInput(requestType).
+		WithOutput(paginationResponseType).
+		WithVerb("GET").
+		WithSignatures(
+			&api.MethodSignature{Names: []string{"name", "optional_field"}},
+			&api.MethodSignature{Names: []string{"name", "normal_field"}},
+		).
+		WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("page"))
+
+	operationType := api.NewTestMessage("Operation").WithPackage("google.longrunning")
+	getOperationInputType := api.NewTestMessage("GetOperationRequest").WithPackage("google.longrunning")
+
+	lroResultType := api.NewTestMessage("LROResult")
+	lroMetadataType := api.NewTestMessage("LROMetadata")
+	lroMethod := api.NewTestMethod("LroMethod").
+		WithInput(requestType).
+		WithOutput(getOperationInputType).
+		WithVerb("POST").
+		WithSignatures(
+			&api.MethodSignature{Names: []string{"name", "optional_field"}},
+			&api.MethodSignature{Names: []string{"name", "normal_field"}},
+		).
+		WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("lro"))
+	lroMethod.IsLRO = true
+	lroMethod.OperationInfo = &api.OperationInfo{
+		ResponseTypeID: lroResultType.ID,
+		MetadataTypeID: lroMetadataType.ID,
+	}
+
+	discoveryLroMethod := api.NewTestMethod("LroDiscoveryMethod").
+		WithInput(requestType).
+		WithOutput(getOperationInputType).
+		WithVerb("POST").
+		WithSignatures(
+			&api.MethodSignature{Names: []string{"name", "optional_field"}},
+			&api.MethodSignature{Names: []string{"name", "normal_field"}},
+		).
+		WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("discoveryLro"))
+	discoveryLroMethod.DiscoveryLro = &api.DiscoveryLro{
+		PollingPathParameters: []string{"test_only"},
+	}
+
+	service := api.NewTestService("TestService").
+		WithPackage("test").
+		WithMethods(simpleMethod, paginationMethod, lroMethod, discoveryLroMethod)
+	model := api.NewTestAPI([]*api.Message{
+		requestType, responseType, itemType, paginationResponseType,
+		operationType, lroResultType, lroMetadataType,
+	}, nil, []*api.Service{service})
+	model.PackageName = "test"
+	model.AddMessage(getOperationInputType)
+	model.AddMessage(operationType)
+	return model
+}

--- a/internal/sidekick/swift/templates/common/client_protocol.mustache
+++ b/internal/sidekick/swift/templates/common/client_protocol.mustache
@@ -112,9 +112,7 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
 
   public func {{> /templates/common/method_signature/overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
-      {{#Fields}}
-      $0.{{Codec.Name}} = {{Codec.Name}}
-      {{/Fields}}
+      {{> /templates/common/method_body/overload_fields}}
     }
     {{#Method.ReturnsEmpty}}
     try await self.{{Method.Codec.Name}}(request: request)
@@ -141,9 +139,7 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
 
   public func {{> /templates/common/method_signature/pagination_overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
-      {{#Fields}}
-      $0.{{Codec.Name}} = {{Codec.Name}}
-      {{/Fields}}
+      {{> /templates/common/method_body/overload_fields}}
     }
     return try self.{{Codec.Name}}(byItem: request)
   }
@@ -165,9 +161,7 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
 
   public func {{> /templates/common/method_signature/lro_overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
-      {{#Fields}}
-      $0.{{Codec.Name}} = {{Codec.Name}}
-      {{/Fields}}
+      {{> /templates/common/method_body/overload_fields}}
     }
     return try await self.{{Method.Codec.Name}}(withPolling: request)
   }
@@ -189,9 +183,7 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
 
   public func {{> /templates/common/method_signature/discovery_lro_overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
-      {{#Fields}}
-      $0.{{Codec.Name}} = {{Codec.Name}}
-      {{/Fields}}
+      {{> /templates/common/method_body/overload_fields}}
     }
     return try await self.{{Method.Codec.Name}}(withPolling: request)
   }

--- a/internal/sidekick/swift/templates/common/method_body/overload_fields.mustache
+++ b/internal/sidekick/swift/templates/common/method_body/overload_fields.mustache
@@ -19,7 +19,7 @@ $0.{{Codec.Name}} = {{Codec.Name}}
 {{/IsOneOf}}
 {{#IsOneOf}}
 {{^Optional}}
-$0.{{Group.Codec.PropertyName}} = .{{Codec.Name}}($0)
+$0.{{Group.Codec.PropertyName}} = .{{Codec.Name}}({{Codec.Name}})
 {{/Optional}}
 {{#Optional}}
 $0.{{Group.Codec.PropertyName}} = {{Codec.Name}}.map { .{{Codec.Name}}($0) }

--- a/internal/sidekick/swift/templates/common/method_body/overload_fields.mustache
+++ b/internal/sidekick/swift/templates/common/method_body/overload_fields.mustache
@@ -1,0 +1,28 @@
+{{!
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{#Fields}}
+{{^IsOneOf}}
+$0.{{Codec.Name}} = {{Codec.Name}}
+{{/IsOneOf}}
+{{#IsOneOf}}
+{{^Optional}}
+$0.{{Group.Codec.PropertyName}} = .{{Codec.Name}}($0)
+{{/Optional}}
+{{#Optional}}
+$0.{{Group.Codec.PropertyName}} = {{Codec.Name}}.map { .{{Codec.Name}}($0) }
+{{/Optional}}
+{{/IsOneOf}}
+{{/Fields}}


### PR DESCRIPTION
A method signature may reference a `oneof` field. In this case we need different syntax to initialize the request fields.

Refactored the mustache template to use the same code for all method types (unary, pagination, LROs, and discovery LROs).

Fixes https://github.com/googleapis/librarian/issues/6854
