### PR TITLE
fix(sidekick/swift): dependencies on `Clients.swift`

### DIFF
--- a/internal/sidekick/swift/templates/common/clients.swift.mustache
+++ b/internal/sidekick/swift/templates/common/clients.swift.mustache
@@ -25,9 +25,7 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
-{{#Codec.ServiceImports}}
-import {{.}}
-{{/Codec.ServiceImports}}
+import GoogleCloudGax
 
 // Defines concrete implementations of the client protocols.
 public enum Clients {


### PR DESCRIPTION
The previous definition was wrong, it assumed the context was a `api.Service` but it is a full `api.API`.

We only need `GoogleCloudGax`. It is simpler to hard-code both the import and the usage in the code.