### PR TITLE
fix(internal/librarian/nodejs): pass --no-comments to compileProtos

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -292,7 +292,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 	compileArgs := []string{"--no-comments"}
 	if library.Nodejs != nil && library.Nodejs.ESM {
 		protoDir = "esm/src"
-		compileArgs = append([]string{"--esm"}, compileArgs...)
+		compileArgs = append(compileArgs, "--esm")
 	}
 	runArgs := append([]string{protoDir}, compileArgs...)
 

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -289,10 +289,10 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		return fmt.Errorf("failed to copy missing protos: %w", err)
 	}
 	protoDir := "src"
-	var compileArgs []string
+	compileArgs := []string{"--no-comments"}
 	if library.Nodejs != nil && library.Nodejs.ESM {
 		protoDir = "esm/src"
-		compileArgs = []string{"--esm"}
+		compileArgs = append([]string{"--esm"}, compileArgs...)
 	}
 	runArgs := append([]string{protoDir}, compileArgs...)
 


### PR DESCRIPTION
Updates the Node.js generator post-processor in Librarian to pass `--no-comments` to `compileProtos` for both CommonJS and ESM libraries. This resolves issue where generated `protos.js` files for large API surfaces (such as `google-cloud-compute`) exceeded GitHub's 100MB file size limit.


For #6638 
    
    