### PR TITLE
feat(sidekick/rust): implement `DiscoveryOperation` for bigquery Job

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -608,3 +608,33 @@ pub mod {{Codec.ModuleName}} {
     {{/Codec.Methods}}
 }
 {{/Codec.Services}}
+
+{{#Codec.Services}}
+{{#Codec.Methods}}
+{{#Codec.IsBigQueryInsertJob}}
+impl google_cloud_lro::internal::DiscoveryOperation for crate::model::Job {
+    fn done(&self) -> bool {
+        self.status
+            .as_ref()
+            .map(|s| s.state == "DONE")
+            .unwrap_or(false)
+    }
+
+    fn name(&self) -> Option<&String> {
+        self.job_reference.as_ref().map(|r| &r.job_id)
+    }
+
+    fn error(&self) -> Option<google_cloud_gax::error::rpc::Status> {
+        self.status.as_ref().and_then(|s| {
+            s.error_result.as_ref().map(|e| {
+                let mut status = google_cloud_gax::error::rpc::Status::default();
+                status = status.set_code(google_cloud_gax::error::rpc::Code::Unknown);
+                status = status.set_message(e.message.clone());
+                status
+            })
+        })
+    }
+}
+{{/Codec.IsBigQueryInsertJob}}
+{{/Codec.Methods}}
+{{/Codec.Services}}


### PR DESCRIPTION
Update the template to automatically generate the `DiscoveryOperation` implementation for Job.

Staged @ https://github.com/googleapis/google-cloud-rust/pull/6067