### PR TITLE
feat(internal/librarian/php): run owlbot.py in generate phase

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -448,6 +448,7 @@ This document describes the schema for the librarian.yaml.
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `migration_mode` | string | Controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY"). |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
+| `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -828,4 +828,7 @@ type PHPAPI struct {
 	// CommonResources indicates whether to include common resources in generation.
 	// Must be configured either globally or per-API.
 	CommonResources *bool `yaml:"common_resources,omitempty"`
+
+	// StagingSubdir is the subdirectory in staging where the generated files should be placed.
+	StagingSubdir string `yaml:"staging_subdir,omitempty"`
 }

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -34,10 +34,12 @@ import (
 
 const (
 	commonResourcesProto = "google/cloud/common_resources.proto"
+	owlBotStagingDir     = "owl-bot-staging"
 )
 
 var (
 	errCommonResourcesUnconfigured = errors.New("common_resources must be set (either per-API or globally under default.php)")
+	errMissingStagingSubdir        = errors.New("staging_subdir is required for PHP configurations")
 )
 
 // Generate generates a PHP client library.
@@ -86,9 +88,24 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		}
 	}()
 
+	stagingDir := filepath.Join(owlBotStagingDir, library.Name)
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		return err
+	}
 	outputZipPath := filepath.Join(tempDir, "output.zip")
 	srcCfg := sources.NewSourceConfig(src, library.Roots)
 	for _, api := range library.APIs {
+		if api.PHP == nil || api.PHP.StagingSubdir == "" {
+			return fmt.Errorf("API %q: %w", api.Path, errMissingStagingSubdir)
+		}
+		destDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return err
+		}
+
 		params := &generateAPIParams{
 			cfg:           cfg,
 			api:           api,
@@ -96,12 +113,16 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			srcCfg:        srcCfg,
 			wrapperPath:   wrapperPath,
 			outputZipPath: outputZipPath,
+			destDir:       destDir,
 		}
 		if err := generateAPI(ctx, params); err != nil {
 			return err
 		}
 		// Cleanup output zip for subsequent APIs in the same library package
 		_ = os.Remove(outputZipPath)
+	}
+	if err := postProcessLibrary(ctx, library); err != nil {
+		return fmt.Errorf("failed to postprocess: %w", err)
 	}
 	return nil
 }
@@ -113,6 +134,7 @@ type generateAPIParams struct {
 	srcCfg        *sources.SourceConfig
 	wrapperPath   string
 	outputZipPath string
+	destDir       string
 }
 
 // generateAPI generates a single target API by resolving its service config, gathering
@@ -151,7 +173,7 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protocArgs...); err != nil {
 		return fmt.Errorf("failed to generate PHP API %s: %w", params.api.Path, err)
 	}
-	return extractOutput(ctx, params.outputZipPath, params.library.Output)
+	return extractOutput(ctx, params.outputZipPath, params.destDir)
 }
 
 // gatherTargetProtos collects all proto files inside the target API directory,

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -40,34 +40,19 @@ func TestGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	absOwlbotCopy, err := filepath.Abs(filepath.Join("testdata", "owlbot_copy.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	repoRoot := t.TempDir()
 	t.Chdir(repoRoot)
-
 	destDir := filepath.Join(repoRoot, "output")
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	// Create a mock owlbot.py. In production, owlbot.py also runs prettier formatting
-	// (which requires Node.js/pnpm). In this integration test, we use a simplified stub
-	// that only handles file copying to keep the test hermetic and avoid Node.js dependencies.
-	owlbotContent := `import os
-import shutil
-import sys
-
-staging = "../owl-bot-staging/secretmanager/v1"
-if not os.path.exists(staging):
-    sys.exit(0)
-for item in os.listdir(staging):
-    s = os.path.join(staging, item)
-    d = os.path.join(".", item)
-    if os.path.isdir(s):
-        if os.path.exists(d):
-            shutil.rmtree(d)
-        shutil.copytree(s, d)
-    else:
-        shutil.copy2(s, d)
-`
-	if err := os.WriteFile(filepath.Join(destDir, "owlbot.py"), []byte(owlbotContent), 0755); err != nil {
+	// Symlink mock owlbot.py. Tests use a simplified copy-only stub to
+	// avoid Node.js/prettier dependencies.
+	if err := os.Symlink(absOwlbotCopy, filepath.Join(destDir, "owlbot.py")); err != nil {
 		t.Fatal(err)
 	}
 	library := &config.Library{

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -31,8 +31,9 @@ func TestGenerate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow integration test")
 	}
+	testhelper.RequireCommand(t, "protoc")
+	testhelper.RequireCommand(t, "python3")
 	requirePHPGenerator(t)
-
 	// Use mock googleapis checked in as test data
 	googleapisDir := "../../testdata/googleapis"
 	absGoogleapis, err := filepath.Abs(googleapisDir)
@@ -40,14 +41,44 @@ func TestGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+
+	destDir := filepath.Join(repoRoot, "output")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create a mock owlbot.py. In production, owlbot.py also runs prettier formatting
+	// (which requires Node.js/pnpm). In this integration test, we use a simplified stub
+	// that only handles file copying to keep the test hermetic and avoid Node.js dependencies.
+	owlbotContent := `import os
+import shutil
+import sys
+
+staging = "../owl-bot-staging/secretmanager/v1"
+if not os.path.exists(staging):
+    sys.exit(0)
+for item in os.listdir(staging):
+    s = os.path.join(staging, item)
+    d = os.path.join(".", item)
+    if os.path.isdir(s):
+        if os.path.exists(d):
+            shutil.rmtree(d)
+        shutil.copytree(s, d)
+    else:
+        shutil.copy2(s, d)
+`
+	if err := os.WriteFile(filepath.Join(destDir, "owlbot.py"), []byte(owlbotContent), 0755); err != nil {
+		t.Fatal(err)
+	}
 	library := &config.Library{
 		Name:   "secretmanager",
-		Output: filepath.Join(repoRoot, "output"),
+		Output: destDir,
 		APIs: []*config.API{
 			{
 				Path: "google/cloud/secretmanager/v1",
 				PHP: &config.PHPAPI{
 					CommonResources: new(true),
+					StagingSubdir:   "v1",
 				},
 			},
 		},
@@ -71,7 +102,6 @@ func TestGenerate(t *testing.T) {
 
 func requirePHPGenerator(t *testing.T) {
 	t.Helper()
-	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "php")
 	genDir, err := generatorDir(t.Context())
 	if err != nil {
@@ -84,14 +114,13 @@ func requirePHPGenerator(t *testing.T) {
 }
 
 func TestGenerate_Error(t *testing.T) {
-	requirePHPGenerator(t)
 	for _, test := range []struct {
 		name    string
 		lib     *config.Library
 		wantErr error
 	}{
 		{
-			name: "missing PHP config",
+			name: "missing PHP config (requires staging_subdir)",
 			lib: &config.Library{
 				Name: "SecretManager",
 				APIs: []*config.API{
@@ -100,7 +129,7 @@ func TestGenerate_Error(t *testing.T) {
 					},
 				},
 			},
-			wantErr: errCommonResourcesUnconfigured,
+			wantErr: errMissingStagingSubdir,
 		},
 		{
 			name: "missing common_resources config",
@@ -109,7 +138,9 @@ func TestGenerate_Error(t *testing.T) {
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
-						PHP:  &config.PHPAPI{},
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
 					},
 				},
 			},

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -31,12 +31,6 @@ var (
 )
 
 func postProcessLibrary(ctx context.Context, library *config.Library) (err error) {
-	if library.Name == "" {
-		return fmt.Errorf("library name is empty")
-	}
-	if library.Output == "" {
-		return fmt.Errorf("library output directory is empty")
-	}
 	stagingDir := filepath.Join(owlBotStagingDir, library.Name)
 	defer func() {
 		if cleanupErr := os.RemoveAll(stagingDir); cleanupErr != nil {

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+var (
+	errOwlBotNotFound = errors.New("owlbot.py not found")
+)
+
+func postProcessLibrary(ctx context.Context, library *config.Library) (err error) {
+	if library.Name == "" {
+		return fmt.Errorf("library name is empty")
+	}
+	if library.Output == "" {
+		return fmt.Errorf("library output directory is empty")
+	}
+	stagingDir := filepath.Join(owlBotStagingDir, library.Name)
+	defer func() {
+		if cleanupErr := os.RemoveAll(stagingDir); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+	}()
+
+	owlbotPy := filepath.Join(library.Output, "owlbot.py")
+	if _, err := os.Stat(owlbotPy); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("library %q: %w", library.Name, errOwlBotNotFound)
+		}
+		return err
+	}
+
+	if err := command.RunInDir(ctx, library.Output, "python3", "owlbot.py"); err != nil {
+		return fmt.Errorf("failed to run owlbot.py: %w", err)
+	}
+	return nil
+}

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+func TestPostProcess_ValidationErrors(t *testing.T) {
+	ctx := t.Context()
+	tests := []struct {
+		name    string
+		library *config.Library
+	}{
+		{
+			name:    "empty library",
+			library: &config.Library{},
+		},
+		{
+			name: "empty output",
+			library: &config.Library{
+				Name: "SecretManager",
+			},
+		},
+		{
+			name: "empty name",
+			library: &config.Library{
+				Output: "some/path",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := postProcessLibrary(ctx, tc.library); err == nil {
+				t.Error("postProcessLibrary() expected error for invalid library, got nil")
+			}
+		})
+	}
+}
+
+func TestPostProcess_MissingOwlBot(t *testing.T) {
+	ctx := t.Context()
+	destDir := t.TempDir()
+	lib := &config.Library{
+		Name:   "SecretManager",
+		Output: destDir,
+	}
+	err := postProcessLibrary(ctx, lib)
+	if !errors.Is(err, errOwlBotNotFound) {
+		t.Errorf("postProcessLibrary() error = %v, want = %v", err, errOwlBotNotFound)
+	}
+}
+
+func TestPostProcess_OwlBot(t *testing.T) {
+	testhelper.RequireCommand(t, "python3")
+	ctx := t.Context()
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+
+	destDir := filepath.Join(repoRoot, "SecretManager")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create a mock owlbot.py that writes a file "owlbot_ran.txt" when executed.
+	owlbotContent := `
+import os
+with open("owlbot_ran.txt", "w") as f:
+    f.write("yes")
+`
+	owlbotPy := filepath.Join(destDir, "owlbot.py")
+	if err := os.WriteFile(owlbotPy, []byte(owlbotContent), 0755); err != nil {
+		t.Fatal(err)
+	}
+	lib := &config.Library{
+		Name:   "SecretManager",
+		Output: destDir,
+	}
+	if err := postProcessLibrary(ctx, lib); err != nil {
+		t.Fatalf("postProcessLibrary() failed: %v", err)
+	}
+	// Verify owlbot.py ran
+	expectedFile := filepath.Join(destDir, "owlbot_ran.txt")
+	if _, err := os.Stat(expectedFile); err != nil {
+		t.Errorf("expected file %s to exist (indicating owlbot.py ran)", expectedFile)
+	}
+}

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestPostProcess_ValidationErrors(t *testing.T) {
 	ctx := t.Context()
-	tests := []struct {
+	for _, test := range []struct {
 		name    string
 		library *config.Library
 	}{
@@ -46,10 +46,9 @@ func TestPostProcess_ValidationErrors(t *testing.T) {
 				Output: "some/path",
 			},
 		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := postProcessLibrary(ctx, tc.library); err == nil {
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := postProcessLibrary(ctx, test.library); err == nil {
 				t.Error("postProcessLibrary() expected error for invalid library, got nil")
 			}
 		})

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -72,21 +72,18 @@ func TestPostProcess_MissingOwlBot(t *testing.T) {
 func TestPostProcess_OwlBot(t *testing.T) {
 	testhelper.RequireCommand(t, "python3")
 	ctx := t.Context()
+	absOwlbotRan, err := filepath.Abs(filepath.Join("testdata", "owlbot_ran.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	repoRoot := t.TempDir()
 	t.Chdir(repoRoot)
-
 	destDir := filepath.Join(repoRoot, "SecretManager")
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	// Create a mock owlbot.py that writes a file "owlbot_ran.txt" when executed.
-	owlbotContent := `
-import os
-with open("owlbot_ran.txt", "w") as f:
-    f.write("yes")
-`
-	owlbotPy := filepath.Join(destDir, "owlbot.py")
-	if err := os.WriteFile(owlbotPy, []byte(owlbotContent), 0755); err != nil {
+	// Symlink mock owlbot.py from testdata that writes "owlbot_ran.txt" when executed.
+	if err := os.Symlink(absOwlbotRan, filepath.Join(destDir, "owlbot.py")); err != nil {
 		t.Fatal(err)
 	}
 	lib := &config.Library{
@@ -94,7 +91,7 @@ with open("owlbot_ran.txt", "w") as f:
 		Output: destDir,
 	}
 	if err := postProcessLibrary(ctx, lib); err != nil {
-		t.Fatalf("postProcessLibrary() failed: %v", err)
+		t.Fatal(err)
 	}
 	// Verify owlbot.py ran
 	expectedFile := filepath.Join(destDir, "owlbot_ran.txt")

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
-
-
 func TestPostProcess_MissingOwlBot(t *testing.T) {
 	ctx := t.Context()
 	destDir := t.TempDir()

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -24,36 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/testhelper"
 )
 
-func TestPostProcess_ValidationErrors(t *testing.T) {
-	ctx := t.Context()
-	for _, test := range []struct {
-		name    string
-		library *config.Library
-	}{
-		{
-			name:    "empty library",
-			library: &config.Library{},
-		},
-		{
-			name: "empty output",
-			library: &config.Library{
-				Name: "SecretManager",
-			},
-		},
-		{
-			name: "empty name",
-			library: &config.Library{
-				Output: "some/path",
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if err := postProcessLibrary(ctx, test.library); err == nil {
-				t.Error("postProcessLibrary() expected error for invalid library, got nil")
-			}
-		})
-	}
-}
+
 
 func TestPostProcess_MissingOwlBot(t *testing.T) {
 	ctx := t.Context()

--- a/internal/librarian/php/testdata/owlbot_copy.py
+++ b/internal/librarian/php/testdata/owlbot_copy.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import sys
+
+staging = "../owl-bot-staging/secretmanager/v1"
+if not os.path.exists(staging):
+    sys.exit(0)
+for item in os.listdir(staging):
+    s = os.path.join(staging, item)
+    d = os.path.join(".", item)
+    if os.path.isdir(s):
+        if os.path.exists(d):
+            shutil.rmtree(d)
+        shutil.copytree(s, d)
+    else:
+        shutil.copy2(s, d)

--- a/internal/librarian/php/testdata/owlbot_ran.py
+++ b/internal/librarian/php/testdata/owlbot_ran.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+with open("owlbot_ran.txt", "w") as f:
+    f.write("yes")


### PR DESCRIPTION
Move generated code in the expected staging dir and invoke owlbot.py from generate as postprocessing step per library.
Introduced a `StagingSubdir` and make it explicit for now.  Follow up PR will populate `staging_subdir` in migrating librarian.yaml.

For #6773