### PR TITLE
Revert "chore(ci): use sparse-checkout for Java presubmit test"

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -31,10 +31,6 @@ jobs:
           repository: googleapis/google-cloud-java
           path: google-cloud-java
           persist-credentials: false
-          sparse-checkout: |
-            librarian.yaml
-            pom.xml
-            sdk-platform-java
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4


### PR DESCRIPTION
Reverts googleapis/librarian#6862

It seems to be failing: https://github.com/googleapis/librarian/actions/runs/29531033304/job/87731114107?pr=6869.
The presubmit may be cached?