### PR TITLE
fix(nodejs): unify pnpm v7 and v8+ global bin environment configuration

### DIFF
--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -132,11 +132,16 @@ func getPNPMEnv() ([]string, error) {
 		return nil, fmt.Errorf("failed to resolve librarian bin directory: %w", err)
 	}
 
+	globalDir := filepath.Join(cacheDir, "pnpm-global")
+	storeDir := filepath.Join(cacheDir, "pnpm-store")
+
 	env := os.Environ()
 	env = append(env, "PNPM_HOME="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
-	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+filepath.Join(cacheDir, "pnpm-global"))
-	env = append(env, "PNPM_CONFIG_STORE_DIR="+filepath.Join(cacheDir, "pnpm-store"))
+	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+globalDir)
+	env = append(env, "PNPM_CONFIG_STORE_DIR="+storeDir)
+	env = append(env, "NPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
+	env = append(env, "npm_config_global_bin_dir="+binDir)
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return env, nil
 }

--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -140,6 +140,8 @@ func getPNPMEnv() ([]string, error) {
 	env = append(env, "PNPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "PNPM_CONFIG_GLOBAL_DIR="+globalDir)
 	env = append(env, "PNPM_CONFIG_STORE_DIR="+storeDir)
+	// TODO(https://github.com/googleapis/librarian/issues/6889): Remove legacy NPM_CONFIG_*
+	// environment variables once pnpm is upgraded to version 8+.
 	env = append(env, "NPM_CONFIG_GLOBAL_BIN_DIR="+binDir)
 	env = append(env, "npm_config_global_bin_dir="+binDir)
 	env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -283,55 +283,45 @@ func TestGetToolsEnv(t *testing.T) {
 }
 
 func TestGetPNPMEnv(t *testing.T) {
-	for _, test := range []struct {
-		name string
-	}{
-		{
-			name: "configures unified pnpm and npm global bin environment variables",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			cacheDir := t.TempDir()
-			binDir := t.TempDir()
-			t.Setenv("LIBRARIAN_CACHE", cacheDir)
-			t.Setenv("LIBRARIAN_BIN", binDir)
+	cacheDir := t.TempDir()
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_CACHE", cacheDir)
+	t.Setenv("LIBRARIAN_BIN", binDir)
 
-			envList, err := getPNPMEnv()
-			if err != nil {
-				t.Fatal(err)
-			}
+	envList, err := getPNPMEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-			wantBinDir := filepath.Join(binDir, "nodejs_tools", "bin")
-			wantGlobalDir := filepath.Join(cacheDir, "pnpm-global")
-			wantStoreDir := filepath.Join(cacheDir, "pnpm-store")
+	wantBinDir := filepath.Join(binDir, "nodejs_tools", "bin")
+	wantGlobalDir := filepath.Join(cacheDir, "pnpm-global")
+	wantStoreDir := filepath.Join(cacheDir, "pnpm-store")
 
-			envMap := make(map[string]string)
-			for _, entry := range envList {
-				parts := strings.SplitN(entry, "=", 2)
-				if len(parts) == 2 {
-					envMap[parts[0]] = parts[1]
-				}
-			}
+	envMap := make(map[string]string)
+	for _, entry := range envList {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
 
-			if got := envMap["PNPM_HOME"]; got != wantBinDir {
-				t.Errorf("PNPM_HOME = %q, want %q", got, wantBinDir)
-			}
-			if got := envMap["PNPM_CONFIG_GLOBAL_BIN_DIR"]; got != wantBinDir {
-				t.Errorf("PNPM_CONFIG_GLOBAL_BIN_DIR = %q, want %q", got, wantBinDir)
-			}
-			if got := envMap["NPM_CONFIG_GLOBAL_BIN_DIR"]; got != wantBinDir {
-				t.Errorf("NPM_CONFIG_GLOBAL_BIN_DIR = %q, want %q", got, wantBinDir)
-			}
-			if got := envMap["npm_config_global_bin_dir"]; got != wantBinDir {
-				t.Errorf("npm_config_global_bin_dir = %q, want %q", got, wantBinDir)
-			}
-			if got := envMap["PNPM_CONFIG_GLOBAL_DIR"]; got != wantGlobalDir {
-				t.Errorf("PNPM_CONFIG_GLOBAL_DIR = %q, want %q", got, wantGlobalDir)
-			}
-			if got := envMap["PNPM_CONFIG_STORE_DIR"]; got != wantStoreDir {
-				t.Errorf("PNPM_CONFIG_STORE_DIR = %q, want %q", got, wantStoreDir)
-			}
-		})
+	if got := envMap["PNPM_HOME"]; got != wantBinDir {
+		t.Errorf("PNPM_HOME = %q, want %q", got, wantBinDir)
+	}
+	if got := envMap["PNPM_CONFIG_GLOBAL_BIN_DIR"]; got != wantBinDir {
+		t.Errorf("PNPM_CONFIG_GLOBAL_BIN_DIR = %q, want %q", got, wantBinDir)
+	}
+	if got := envMap["NPM_CONFIG_GLOBAL_BIN_DIR"]; got != wantBinDir {
+		t.Errorf("NPM_CONFIG_GLOBAL_BIN_DIR = %q, want %q", got, wantBinDir)
+	}
+	if got := envMap["npm_config_global_bin_dir"]; got != wantBinDir {
+		t.Errorf("npm_config_global_bin_dir = %q, want %q", got, wantBinDir)
+	}
+	if got := envMap["PNPM_CONFIG_GLOBAL_DIR"]; got != wantGlobalDir {
+		t.Errorf("PNPM_CONFIG_GLOBAL_DIR = %q, want %q", got, wantGlobalDir)
+	}
+	if got := envMap["PNPM_CONFIG_STORE_DIR"]; got != wantStoreDir {
+		t.Errorf("PNPM_CONFIG_STORE_DIR = %q, want %q", got, wantStoreDir)
 	}
 }
 

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -280,3 +281,57 @@ func TestGetToolsEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPNPMEnv(t *testing.T) {
+	for _, test := range []struct {
+		name string
+	}{
+		{
+			name: "configures unified pnpm and npm global bin environment variables",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cacheDir := t.TempDir()
+			binDir := t.TempDir()
+			t.Setenv("LIBRARIAN_CACHE", cacheDir)
+			t.Setenv("LIBRARIAN_BIN", binDir)
+
+			envList, err := getPNPMEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wantBinDir := filepath.Join(binDir, "nodejs_tools", "bin")
+			wantGlobalDir := filepath.Join(cacheDir, "pnpm-global")
+			wantStoreDir := filepath.Join(cacheDir, "pnpm-store")
+
+			envMap := make(map[string]string)
+			for _, entry := range envList {
+				parts := strings.SplitN(entry, "=", 2)
+				if len(parts) == 2 {
+					envMap[parts[0]] = parts[1]
+				}
+			}
+
+			if got := envMap["PNPM_HOME"]; got != wantBinDir {
+				t.Errorf("PNPM_HOME = %q, want %q", got, wantBinDir)
+			}
+			if got := envMap["PNPM_CONFIG_GLOBAL_BIN_DIR"]; got != wantBinDir {
+				t.Errorf("PNPM_CONFIG_GLOBAL_BIN_DIR = %q, want %q", got, wantBinDir)
+			}
+			if got := envMap["NPM_CONFIG_GLOBAL_BIN_DIR"]; got != wantBinDir {
+				t.Errorf("NPM_CONFIG_GLOBAL_BIN_DIR = %q, want %q", got, wantBinDir)
+			}
+			if got := envMap["npm_config_global_bin_dir"]; got != wantBinDir {
+				t.Errorf("npm_config_global_bin_dir = %q, want %q", got, wantBinDir)
+			}
+			if got := envMap["PNPM_CONFIG_GLOBAL_DIR"]; got != wantGlobalDir {
+				t.Errorf("PNPM_CONFIG_GLOBAL_DIR = %q, want %q", got, wantGlobalDir)
+			}
+			if got := envMap["PNPM_CONFIG_STORE_DIR"]; got != wantStoreDir {
+				t.Errorf("PNPM_CONFIG_STORE_DIR = %q, want %q", got, wantStoreDir)
+			}
+		})
+	}
+}
+

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -324,4 +324,3 @@ func TestGetPNPMEnv(t *testing.T) {
 		t.Errorf("PNPM_CONFIG_STORE_DIR = %q, want %q", got, wantStoreDir)
 	}
 }
-


### PR DESCRIPTION
set global binary directory environment variables for both PNPM v7 ( NPM_CONFIG_GLOBAL_BIN_DIR ,  npm_config_global_bin_dir ) and PNPM v8+ ( PNPM_HOME ,  PNPM_CONFIG_GLOBAL_BIN_DIR ). Adds a unit test in  install_test.go  to verify environment configuration. PNPM v7 and PNPM v8+ use different configuration variable names for global binary directories. Setting both ensures that installed tool symlinks are placed directly in Librarian's isolated cache  binDir  across all supported PNPM versions.

For https://github.com/googleapis/librarian/issues/6638