### PR TITLE
fix(nodejs): require cached tools and prevent host binary fallback

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -82,7 +82,36 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
+var (
+	errToolNotInstalled = errors.New("tool not installed in librarian cache")
+)
+
+func requireCachedTool(toolName string) error {
+	binDir, err := getBinDir()
+	if err != nil {
+		return fmt.Errorf("failed to get bin directory: %w", err)
+	}
+	toolPath := filepath.Join(binDir, toolName)
+	info, err := os.Stat(toolPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("tool %s %w", toolName, errToolNotInstalled)
+		}
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("tool path %s is a directory: %w", toolPath, errToolNotInstalled)
+	}
+	return nil
+}
+
 func generateAPI(ctx context.Context, api *config.API, library *config.Library, googleapisDir, repoRoot string) error {
+	for _, requiredTool := range []string{"gapic-generator-typescript", "compileProtos", "gapic-node-processing"} {
+		if err := requireCachedTool(requiredTool); err != nil {
+			return err
+		}
+	}
+
 	version := filepath.Base(api.Path)
 	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, version)
 	if err := os.MkdirAll(stagingDir, 0755); err != nil {

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -86,30 +86,35 @@ var (
 	errToolNotInstalled = errors.New("tool not installed in librarian cache")
 )
 
-func requireCachedTool(toolName string) error {
+func requireCachedTool(toolName string) (string, error) {
 	binDir, err := getBinDir()
 	if err != nil {
-		return fmt.Errorf("failed to get bin directory: %w", err)
+		return "", fmt.Errorf("failed to get bin directory: %w", err)
 	}
 	toolPath := filepath.Join(binDir, toolName)
 	info, err := os.Stat(toolPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("tool %s %w", toolName, errToolNotInstalled)
+			return "", fmt.Errorf("tool %s %w", toolName, errToolNotInstalled)
 		}
-		return err
+		return "", err
 	}
 	if info.IsDir() {
-		return fmt.Errorf("tool path %s is a directory: %w", toolPath, errToolNotInstalled)
+		return "", fmt.Errorf("tool path %s is a directory: %w", toolPath, errToolNotInstalled)
 	}
-	return nil
+	return toolPath, nil
 }
 
 func generateAPI(ctx context.Context, api *config.API, library *config.Library, googleapisDir, repoRoot string) error {
-	for _, requiredTool := range []string{"gapic-generator-typescript", "compileProtos", "gapic-node-processing"} {
-		if err := requireCachedTool(requiredTool); err != nil {
-			return err
-		}
+	generatorPath, err := requireCachedTool("gapic-generator-typescript")
+	if err != nil {
+		return err
+	}
+	if _, err := requireCachedTool("compileProtos"); err != nil {
+		return err
+	}
+	if _, err := requireCachedTool("gapic-node-processing"); err != nil {
+		return err
 	}
 
 	version := filepath.Base(api.Path)
@@ -120,7 +125,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 
 	nodejsAPI := resolveNodejsAPI(library, api)
 
-	googleapisDir, err := filepath.Abs(googleapisDir)
+	googleapisDir, err = filepath.Abs(googleapisDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve googleapis directory path: %w", err)
 	}
@@ -144,7 +149,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	// Add additional protos from configuration.
 	protos = append(protos, nodejsAPI.AdditionalProtos...)
 
-	args, err := buildGeneratorArgs(api, library, googleapisDir, stagingDir, nodejsAPI)
+	args, err := buildGeneratorArgs(generatorPath, api, library, googleapisDir, stagingDir, nodejsAPI)
 	if err != nil {
 		return err
 	}
@@ -221,14 +226,14 @@ func unique(ss []string) []string {
 
 // buildGeneratorArgs constructs the gapic-generator-typescript arguments,
 // excluding proto files.
-func buildGeneratorArgs(api *config.API, library *config.Library, googleapisDir, stagingDir string, nodejsAPI *config.NodejsAPI) ([]string, error) {
+func buildGeneratorArgs(generatorPath string, api *config.API, library *config.Library, googleapisDir, stagingDir string, nodejsAPI *config.NodejsAPI) ([]string, error) {
 	protocPath, err := exec.LookPath("protoc")
 	if err != nil {
 		return nil, fmt.Errorf("failed to find protoc: %w", err)
 	}
 
 	args := []string{
-		"gapic-generator-typescript",
+		generatorPath,
 		"--protoc=" + protocPath,
 		"--common-proto-path=.",
 		"-I", ".",
@@ -330,7 +335,12 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		return err
 	}
 
-	if err := command.RunInDirWithEnv(ctx, outDir, toolsEnv, "compileProtos", runArgs...); err != nil {
+	compileProtosPath, err := requireCachedTool("compileProtos")
+	if err != nil {
+		return err
+	}
+
+	if err := command.RunInDirWithEnv(ctx, outDir, toolsEnv, compileProtosPath, runArgs...); err != nil {
 		return fmt.Errorf("failed to compile protos: %w", err)
 	}
 
@@ -396,7 +406,11 @@ func movePackageFromStaging(ctx context.Context, library *config.Library, repoRo
 	if err != nil {
 		return err
 	}
-	if err := command.RunWithEnv(ctx, toolsEnv, "gapic-node-processing", combineArgs...); err != nil {
+	combineToolPath, err := requireCachedTool("gapic-node-processing")
+	if err != nil {
+		return err
+	}
+	if err := command.RunWithEnv(ctx, toolsEnv, combineToolPath, combineArgs...); err != nil {
 		return fmt.Errorf("combine-library: %w", err)
 	}
 	// Restore keep files.

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -95,7 +95,7 @@ func requireCachedTool(toolName string) (string, error) {
 	info, err := os.Stat(toolPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("tool %s %w", toolName, errToolNotInstalled)
+			return "", fmt.Errorf("tool %s %w at %s (did you run 'librarian install nodejs'?): %w", toolName, errToolNotInstalled, toolPath, err)
 		}
 		return "", err
 	}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -94,10 +94,7 @@ func requireCachedTool(toolName string) (string, error) {
 	toolPath := filepath.Join(binDir, toolName)
 	info, err := os.Stat(toolPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("tool %s %w at %s (did you run 'librarian install nodejs'?): %w", toolName, errToolNotInstalled, toolPath, err)
-		}
-		return "", err
+		return "", fmt.Errorf("tool %s %w at %s (did you run 'librarian install nodejs'?): %w", toolName, errToolNotInstalled, toolPath, err)
 	}
 	if info.IsDir() {
 		return "", fmt.Errorf("tool path %s is a directory: %w", toolPath, errToolNotInstalled)

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1763,4 +1763,3 @@ func TestRequireCachedTool_Error(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1727,7 +1727,7 @@ func TestRequireCachedTool_Error(t *testing.T) {
 		name      string
 		setup     func(t *testing.T, binDir string)
 		toolName  string
-		wantErrIs error
+		wantErr error
 	}{
 		{
 			name: "returns errToolNotInstalled when tool is missing from cache",

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1724,17 +1724,17 @@ func TestRequireCachedTool(t *testing.T) {
 
 func TestRequireCachedTool_Error(t *testing.T) {
 	for _, test := range []struct {
-		name      string
-		setup     func(t *testing.T, binDir string)
-		toolName  string
-		wantErr error
+		name     string
+		setup    func(t *testing.T, binDir string)
+		toolName string
+		wantErr  error
 	}{
 		{
 			name: "returns errToolNotInstalled when tool is missing from cache",
 			setup: func(t *testing.T, binDir string) {
 			},
-			toolName:  "missingTool",
-			wantErrIs: errToolNotInstalled,
+			toolName: "missingTool",
+			wantErr:  errToolNotInstalled,
 		},
 		{
 			name: "returns errToolNotInstalled when tool path is a directory",
@@ -1744,8 +1744,8 @@ func TestRequireCachedTool_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			toolName:  "dirTool",
-			wantErrIs: errToolNotInstalled,
+			toolName: "dirTool",
+			wantErr:  errToolNotInstalled,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -1757,8 +1757,8 @@ func TestRequireCachedTool_Error(t *testing.T) {
 			}
 			test.setup(t, nodeBinDir)
 			_, err := requireCachedTool(test.toolName)
-			if !errors.Is(err, test.wantErrIs) {
-				t.Errorf("requireCachedTool(%q) error = %v, wantErrIs %v", test.toolName, err, test.wantErrIs)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("requireCachedTool(%q) error = %v, wantErr %v", test.toolName, err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -410,7 +410,7 @@ func TestBuildGeneratorArgs(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			nodejsAPI := resolveNodejsAPI(test.library, test.api)
-			got, err := buildGeneratorArgs(test.api, test.library, absGoogleapisDir, "staging", nodejsAPI)
+			got, err := buildGeneratorArgs("gapic-generator-typescript", test.api, test.library, absGoogleapisDir, "staging", nodejsAPI)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1713,8 +1713,12 @@ func TestRequireCachedTool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := requireCachedTool("compileProtos"); err != nil {
+	gotPath, err := requireCachedTool("compileProtos")
+	if err != nil {
 		t.Errorf("requireCachedTool(%q) unexpected error = %v", "compileProtos", err)
+	}
+	if gotPath != toolPath {
+		t.Errorf("requireCachedTool(%q) = %q, want %q", "compileProtos", gotPath, toolPath)
 	}
 }
 
@@ -1752,7 +1756,7 @@ func TestRequireCachedTool_Error(t *testing.T) {
 				t.Fatal(err)
 			}
 			test.setup(t, nodeBinDir)
-			err := requireCachedTool(test.toolName)
+			_, err := requireCachedTool(test.toolName)
 			if !errors.Is(err, test.wantErrIs) {
 				t.Errorf("requireCachedTool(%q) error = %v, wantErrIs %v", test.toolName, err, test.wantErrIs)
 			}

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1700,3 +1700,63 @@ func TestMoveKeep_Errors(t *testing.T) {
 		})
 	}
 }
+
+func TestRequireCachedTool(t *testing.T) {
+	tempBin := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", tempBin)
+	nodeBinDir := filepath.Join(tempBin, "nodejs_tools", "bin")
+	if err := os.MkdirAll(nodeBinDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	toolPath := filepath.Join(nodeBinDir, "compileProtos")
+	if err := os.WriteFile(toolPath, []byte("#!/bin/sh"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := requireCachedTool("compileProtos"); err != nil {
+		t.Errorf("requireCachedTool(%q) unexpected error = %v", "compileProtos", err)
+	}
+}
+
+func TestRequireCachedTool_Error(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		setup     func(t *testing.T, binDir string)
+		toolName  string
+		wantErrIs error
+	}{
+		{
+			name: "returns errToolNotInstalled when tool is missing from cache",
+			setup: func(t *testing.T, binDir string) {
+			},
+			toolName:  "missingTool",
+			wantErrIs: errToolNotInstalled,
+		},
+		{
+			name: "returns errToolNotInstalled when tool path is a directory",
+			setup: func(t *testing.T, binDir string) {
+				dirPath := filepath.Join(binDir, "dirTool")
+				if err := os.MkdirAll(dirPath, 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			toolName:  "dirTool",
+			wantErrIs: errToolNotInstalled,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempBin := t.TempDir()
+			t.Setenv("LIBRARIAN_BIN", tempBin)
+			nodeBinDir := filepath.Join(tempBin, "nodejs_tools", "bin")
+			if err := os.MkdirAll(nodeBinDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			test.setup(t, nodeBinDir)
+			err := requireCachedTool(test.toolName)
+			if !errors.Is(err, test.wantErrIs) {
+				t.Errorf("requireCachedTool(%q) error = %v, wantErrIs %v", test.toolName, err, test.wantErrIs)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
Adds cache verification for Node.js generator tools ( gapic-generator-typescript ,  compileProtos , and  gapic-node-processing ) before execution during client library generation. Currently, when a required tool was missing from Librarian's isolated cache ( ~/.cache/librarian/bin/nodejs_tools/bin ), execution silently fell back to searching the host machine's system  PATH . This caused non-deterministic behavior and silent drift across developer machines and CI runners executing unmanaged ambient binaries. With this change, Librarian verifies that the required tools exist in its cache and returns an explicit, actionable error instructing the user to run  librarian install nodejs  if they are missing.

For https://github.com/googleapis/librarian/issues/6638