### PR TITLE
chore(ci): use sparse-checkout for Java presubmit test

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -44,7 +44,6 @@ jobs:
             google-cloud-pom-parent/pom.xml
             grpc-gcp-java/pom.xml
             java-*/pom.xml
-
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -31,6 +31,10 @@ jobs:
           repository: googleapis/google-cloud-java
           path: google-cloud-java
           persist-credentials: false
+          sparse-checkout: |
+            librarian.yaml
+            pom.xml
+            sdk-platform-java
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -61,7 +61,7 @@ jobs:
           path: |
             ~/.cache/librarian
             venv
-          key: librarian-java-tools-v2-invalidate-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
+          key: librarian-java-tools-v2-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
       - name: Create Python virtual environment
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: python3 -m venv venv

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -31,10 +31,20 @@ jobs:
           repository: googleapis/google-cloud-java
           path: google-cloud-java
           persist-credentials: false
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             librarian.yaml
             pom.xml
-            sdk-platform-java
+            sdk-platform-java/
+            java-shared-config/
+            google-auth-library-java/
+            java-common-protos/
+            gapic-libraries-bom/pom.xml
+            google-cloud-jar-parent/pom.xml
+            google-cloud-pom-parent/pom.xml
+            grpc-gcp-java/pom.xml
+            java-*/pom.xml
+
       - name: Display Go version
         run: go version
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -62,7 +62,7 @@ jobs:
           path: |
             ~/.cache/librarian
             venv
-          key: librarian-java-tools-v2-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
+          key: librarian-java-tools-v2-invalidate-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
       - name: Create Python virtual environment
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: python3 -m venv venv


### PR DESCRIPTION
The Java presubmit test job was timing out often, checking out the full google-cloud-java monorepo took too long (over 1min in recent [runs](https://screenshot.googleplex.com/rvhLUBEzwDpPNdf)).

Configure actions/checkout to use sparse-checkout to only download librarian.yaml, all pom.xml files needed to build, and the sdk-platform-java directory. This provides the necessary files to build and install local tools while avoiding downloading the rest of the monorepo.

This is a second attempt to #6862.

For #6871