### PR TITLE
feat(internal/librarian/nodejs): support src_dir for pnpm tool sourcebuilds

### DIFF
--- a/internal/librarian/nodejs/install.go
+++ b/internal/librarian/nodejs/install.go
@@ -177,7 +177,11 @@ func installPNPMToolFromSource(ctx context.Context, env []string, tool *config.P
 	}
 
 	// Run build steps.
-	genDir := filepath.Join(dir, gapicGeneratorSubdir)
+	subdir := tool.SrcDir
+	if subdir == "" {
+		subdir = gapicGeneratorSubdir
+	}
+	genDir := filepath.Join(dir, subdir)
 	for _, cmd := range tool.Build {
 		if err := runPNPMBuildCmd(ctx, genDir, env, cmd); err != nil {
 			return err

--- a/internal/librarian/nodejs/install_test.go
+++ b/internal/librarian/nodejs/install_test.go
@@ -97,6 +97,31 @@ func TestInstall(t *testing.T) {
 			},
 		},
 		{
+			name: "build tool with custom src_dir",
+			tools: &config.Tools{
+				PNPM: []*config.PNPMTool{
+					{
+						Name:    "gapic-tools",
+						Version: "1.1.0",
+						Package: "https://github.com/googleapis/google-cloud-node/archive/gapic-tools-v1.1.0.tar.gz",
+						SrcDir:  "core/packages/tools",
+						Build:   []string{"true"},
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				cache := t.TempDir()
+				t.Setenv("LIBRARIAN_CACHE", cache)
+				binDir := t.TempDir()
+				t.Setenv("LIBRARIAN_BIN", binDir)
+				toolsDir := filepath.Join(cache, "github.com/googleapis/google-cloud-node@1.1.0", "core/packages/tools")
+				if err := os.MkdirAll(toolsDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				stubExecutables(t)
+			},
+		},
+		{
 			name: "non-build tool",
 			tools: &config.Tools{
 				PNPM: []*config.PNPMTool{


### PR DESCRIPTION
When installing Node.js generator tools from source archives or monorepos, `installPNPMToolFromSource` hardcodes the build working directory to `core/generator/gapic-generator-typescript`. This prevents other monorepo tools (such as gapic-tools in core/packages/tools and gapic-node-processing in core/packages/gapic-node-processing) from being built from source with frozen lockfiles.

This change modifies `installPNPMToolFromSource` to respect tool.SrcDir from configuration before falling back to the default generator subdirectory. When src_dir is specified in librarian.yaml, Librarian runs the tool's build steps inside that specific subdirectory of the fetched archive.

For https://github.com/googleapis/librarian/issues/6638