### PR TITLE
fix(sidekick/swift): clashes for `Logging`

### DIFF
--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -46,6 +46,12 @@ type serviceAnnotations struct {
 func (ann *serviceAnnotations) ServiceImports() []string {
 	result := make([]string, 0, len(ann.DependsOn))
 	for _, dep := range ann.DependsOn {
+		if dep.RequiredByServices {
+			// Skip dependencies configured in the librarian.yaml file.
+			// These are needed in some files, but not others, and sometimes we
+			// need to import just an specific type to minimize clashes.
+			continue
+		}
 		result = append(result, dep.Name)
 	}
 	slices.Sort(result)

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -352,7 +352,7 @@ func TestAnnotateService_LRO(t *testing.T) {
 	}
 
 	annotations := service.Codec.(*serviceAnnotations)
-	wantImports := []string{"GoogleCloudExternal", "GoogleCloudGax", "GoogleCloudWkt", "GoogleLongrunning", "GoogleRpc"}
+	wantImports := []string{"GoogleCloudExternal", "GoogleCloudWkt", "GoogleLongrunning", "GoogleRpc"}
 	if diff := cmp.Diff(wantImports, annotations.ServiceImports()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -313,8 +313,8 @@ func TestGenerateService_WithImports(t *testing.T) {
 	}
 	contentStr := string(content)
 
-	expectedImports := `import GoogleCloudAuth
-import GoogleCloudExternalV1
+	expectedImports := `import GoogleCloudExternalV1
+import GoogleCloudWkt
 import GoogleCloudGax`
 
 	if !strings.Contains(contentStr, expectedImports) {

--- a/internal/sidekick/swift/templates/common/logging.swift.mustache
+++ b/internal/sidekick/swift/templates/common/logging.swift.mustache
@@ -28,17 +28,18 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
-
 {{#Codec.ServiceImports}}
 import {{.}}
 {{/Codec.ServiceImports}}
+import GoogleCloudGax
+import struct Logging.Logger
 
 extension Clients {
   final class {{Codec.StubPrefix}}Logging: {{Codec.StubPrefix}}Stub {
     let inner: any {{Codec.StubPrefix}}Stub
-    let logger: Logging.Logger
+    let logger: Logger
 
-    public init(_ inner: any {{Codec.StubPrefix}}Stub, logger: Logging.Logger) {
+    public init(_ inner: any {{Codec.StubPrefix}}Stub, logger: Logger) {
       var logger = logger
       logger[metadataKey: "gcp.artifact.id"] = "{{Codec.Model.PackageName}}"
       logger[metadataKey: "gcp.client.service"] = "{{Codec.HostnameShort}}"

--- a/internal/sidekick/swift/templates/common/retry.swift.mustache
+++ b/internal/sidekick/swift/templates/common/retry.swift.mustache
@@ -28,10 +28,10 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
-
 {{#Codec.ServiceImports}}
 import {{.}}
 {{/Codec.ServiceImports}}
+import GoogleCloudGax
 
 extension Clients {
   final class {{Codec.StubPrefix}}Retry: {{Codec.StubPrefix}}Stub {

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -28,10 +28,10 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
-
 {{#Codec.ServiceImports}}
 import {{.}}
 {{/Codec.ServiceImports}}
+import GoogleCloudGax
 
 {{#Codec.DocLines}}
 /// {{{.}}}

--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -28,10 +28,10 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
-
 {{#Codec.ServiceImports}}
 import {{.}}
 {{/Codec.ServiceImports}}
+import GoogleCloudGax
 
 extension Clients {
   protocol {{Codec.StubPrefix}}Stub {


### PR DESCRIPTION
On APIs that use types from `GoogleApi` we get a conflict in the `*+Logging.swift` file because `Logging.Logger` is ambiguous. It could mean:

- A type in the `GoogleApi.Logging` struct
- A type in the `Logging` module

We want the latter, but the compiler cannot tell. With this change we import modules like `Logging` or `GoogleCloudGax` manually in the mustache template. That gives us finer control over how to import these well-known modules when needed.

Fixes #6849 