### PR TITLE
fix(tool/cmd/migrate): resolve staging subdir for library-root destinations

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -41,6 +41,10 @@ var protoMappings = map[string]string{
 	"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
 }
 
+var (
+	errUnableToResolveStagingSubdir = errors.New("unable to resolve staging subdir")
+)
+
 func runPHPMigration(ctx context.Context, repoPath string) error {
 	src, err := fetchSource(ctx)
 	if err != nil {
@@ -135,7 +139,7 @@ func createAPIConfig(path string, dest string) (*config.API, error) {
 
 	stagingSubdir := resolveStagingSubdir(dest, ver)
 	if stagingSubdir == "" {
-		return nil, fmt.Errorf("unable to resolve staging subdir for %s from destination %q", path, dest)
+		return nil, fmt.Errorf("%w: path %s from destination %q", errUnableToResolveStagingSubdir, path, dest)
 	}
 	return &config.API{
 		Path: path,

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -113,7 +113,7 @@ func extractAPIPaths(source string) []string {
 
 // resolveStagingSubdir extracts the target staging subdirectory path relative to the staging root
 // from the OwlBot destination path. If the path contains "$1" it is replaced with the provided version.
-// e.g. "owl-bot-staging/google-cloud-pubsub/src/$1" with version "v1" returns "src/v1".
+// e.g. "/owl-bot-staging/PubSub/$1/$2" with version "v1" returns "v1".
 // If "owl-bot-staging" is not found in dest, or if the path is invalid, returns empty string.
 //
 // For paths that target the library root directly (meaning there are no subdirectory segments

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
@@ -106,6 +107,44 @@ func extractAPIPaths(source string) []string {
 	return nil
 }
 
+// resolveStagingSubdir extracts the target staging subdirectory path relative to the staging root
+// from the OwlBot destination path. If the path contains "$1" it is replaced with the provided version.
+// e.g. "owl-bot-staging/google-cloud-pubsub/src/$1" with version "v1" returns "src/v1".
+// If "owl-bot-staging" is not found in dest, or if the path is invalid, returns empty string.
+//
+// For paths that target the library root directly (meaning there are no subdirectory segments
+// between the library name and the file wildcard), it returns "." to represent the root.
+// This is for GeoCommonProtos and ShoppingCommonProtos (dest="/owl-bot-staging/ShoppingCommonProtos/$1").
+func resolveStagingSubdir(dest string, version string) string {
+	parts := strings.Split(dest, "/")
+	idx := slices.Index(parts, "owl-bot-staging")
+	if idx == -1 || idx+2 >= len(parts) {
+		return ""
+	}
+	subdirParts := parts[idx+2 : len(parts)-1]
+	subdir := strings.ReplaceAll(strings.Join(subdirParts, "/"), "$1", version)
+	if subdir == "" {
+		return "."
+	}
+	return subdir
+}
+
+func createAPIConfig(path string, dest string) (*config.API, error) {
+	parts := strings.Split(path, "/")
+	ver := parts[len(parts)-1]
+
+	stagingSubdir := resolveStagingSubdir(dest, ver)
+	if stagingSubdir == "" {
+		return nil, fmt.Errorf("unable to resolve staging subdir for %s from destination %q", path, dest)
+	}
+	return &config.API{
+		Path: path,
+		PHP: &config.PHPAPI{
+			StagingSubdir: stagingSubdir,
+		},
+	}, nil
+}
+
 func extractAPIsFromOwlBot(owlbotPath string) ([]*config.API, error) {
 	if !fileExists(owlbotPath) {
 		return nil, nil
@@ -120,7 +159,11 @@ func extractAPIsFromOwlBot(owlbotPath string) ([]*config.API, error) {
 		for _, path := range extractAPIPaths(spec.Source) {
 			if !seenAPIs[path] {
 				seenAPIs[path] = true
-				apis = append(apis, &config.API{Path: path})
+				api, err := createAPIConfig(path, spec.Dest)
+				if err != nil {
+					return nil, err
+				}
+				apis = append(apis, api)
 			}
 		}
 	}
@@ -167,9 +210,10 @@ func findPHPLibraries(repoPath string, googleapisDir string) ([]*config.Library,
 				continue
 			}
 			if len(additionalProtos) > 0 {
-				api.PHP = &config.PHPAPI{
-					AdditionalProtos: additionalProtos,
+				if api.PHP == nil {
+					api.PHP = &config.PHPAPI{}
 				}
+				api.PHP.AdditionalProtos = additionalProtos
 			}
 		}
 

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -266,6 +267,7 @@ func TestExtractAPIsFromOwlBot_Error(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		setupFile func(dir string) string
+		wantErr   error
 	}{
 		{
 			name: "invalid file",
@@ -277,6 +279,8 @@ func TestExtractAPIsFromOwlBot_Error(t *testing.T) {
 				}
 				return path
 			},
+			// wantErr is nil as we only assert that a YAML parsing error is returned.
+			wantErr: nil,
 		},
 		{
 			name: "missing staging marker",
@@ -293,6 +297,7 @@ api-name: Ces
 				}
 				return path
 			},
+			wantErr: errUnableToResolveStagingSubdir,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -301,6 +306,9 @@ api-name: Ces
 			_, err := extractAPIsFromOwlBot(path)
 			if err == nil {
 				t.Fatal("expected error, got nil")
+			}
+			if test.wantErr != nil && !errors.Is(err, test.wantErr) {
+				t.Errorf("expected error %v, got %v", test.wantErr, err)
 			}
 		})
 	}

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -192,8 +192,8 @@ deep-copy-regex:
     dest: /owl-bot-staging/Ces/$1/$2
   - source: /google/identity/accesscontextmanager/type/.*-php/(.*)
     dest: /owl-bot-staging/AccessContextManager/type-protos/$1
-  - source: /google/cloud/ces/(v1)/.*-php/(.*)
-    dest: /owl-bot-staging/Ces/$1/$2
+  - source: /google/apps/card/(v1)/.*-php/(.*)
+    dest: /owl-bot-staging/AppsChat/card-protos/$1/$2
 api-name: Ces
 `
 				path := filepath.Join(dir, ".OwlBot.yaml")
@@ -203,8 +203,48 @@ api-name: Ces
 				return path
 			},
 			want: []*config.API{
-				{Path: "google/cloud/ces/v1"},
-				{Path: "google/identity/accesscontextmanager/type"},
+				{
+					Path: "google/cloud/ces/v1",
+					PHP: &config.PHPAPI{
+						StagingSubdir: "v1",
+					},
+				},
+				{
+					Path: "google/identity/accesscontextmanager/type",
+					PHP: &config.PHPAPI{
+						StagingSubdir: "type-protos",
+					},
+				},
+				{
+					Path: "google/apps/card/v1",
+					PHP: &config.PHPAPI{
+						StagingSubdir: "card-protos/v1",
+					},
+				},
+			},
+		},
+		{
+			name: "destination with library root (dot)",
+			setupFile: func(dir string) string {
+				content := `
+deep-copy-regex:
+  - source: /google/geo/type/.*-php/(.*)
+    dest: /owl-bot-staging/GeoCommonProtos/$1
+api-name: GeoCommonProtos
+`
+				path := filepath.Join(dir, ".OwlBot.yaml")
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			want: []*config.API{
+				{
+					Path: "google/geo/type",
+					PHP: &config.PHPAPI{
+						StagingSubdir: ".",
+					},
+				},
 			},
 		},
 	} {
@@ -231,6 +271,22 @@ func TestExtractAPIsFromOwlBot_Error(t *testing.T) {
 			name: "invalid file",
 			setupFile: func(dir string) string {
 				content := `{invalid`
+				path := filepath.Join(dir, ".OwlBot.yaml")
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+		},
+		{
+			name: "missing staging marker",
+			setupFile: func(dir string) string {
+				content := `
+deep-copy-regex:
+  - source: /google/cloud/ces/(v1)/.*-php/(.*)
+    dest: /no-staging/Ces/$1/$2
+api-name: Ces
+`
 				path := filepath.Join(dir, ".OwlBot.yaml")
 				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
The migration tool now extracts the staging subdirectory configuration for PHP APIs from the repository's OwlBot configuration. This ensures that the generated librarian.yaml correctly preserves the staging directories previously used by OwlBot.
Note: current generate implementation expect staging subdir be explicit set. We may change that in the future, but for now we populate this for all libraries.

For #6773