### PR TITLE
feat(sidekick/swift): default version on `add`

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -583,6 +583,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `dependencies` | list of [SwiftDependency](#swiftdependency-configuration) | Is a list of package dependencies. |
+| `default_version` | string | The default version for new libraries. |
 
 ## SwiftDependency Configuration
 

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -18,6 +18,9 @@ package config
 type SwiftDefault struct {
 	// Dependencies is a list of package dependencies.
 	Dependencies []SwiftDependency `yaml:"dependencies,omitempty"`
+
+	// The default version for new libraries.
+	DefaultVersion string `yaml:"default_version,omitempty"`
 }
 
 // SwiftPackage contains Swift-specific configuration for a Swift library.

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -256,6 +256,8 @@ func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config,
 		}
 	case config.LanguageRust:
 		lib = rust.Add(lib)
+	case config.LanguageSwift:
+		lib = swift.Add(lib, cfg)
 	case config.LanguageFake:
 		lib = fakeAdd(lib, defaultVersion)
 	}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sample"
 	"github.com/googleapis/librarian/internal/yaml"
@@ -649,5 +650,77 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 	}
 	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAddLibrary_Swift(t *testing.T) {
+	copyrightYear := strconv.Itoa(time.Now().Year())
+	for _, test := range []struct {
+		name               string
+		swiftDefault       *config.SwiftDefault
+		wantFinalLibraries []*config.Library
+	}{
+		{
+			name:         "new library stable",
+			swiftDefault: &config.SwiftDefault{DefaultVersion: "1.0.0"},
+			wantFinalLibraries: []*config.Library{
+				{
+					Name:          "GoogleCloudSecretmanagerV1",
+					CopyrightYear: copyrightYear,
+					Version:       "1.0.0",
+				},
+			},
+		},
+		{
+			name:         "new library preview",
+			swiftDefault: &config.SwiftDefault{DefaultVersion: "0.1.2-preview"},
+			wantFinalLibraries: []*config.Library{
+				{
+					Name:          "GoogleCloudSecretmanagerV1",
+					CopyrightYear: copyrightYear,
+					Version:       "0.1.2-preview",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			googleapisDir, err := filepath.Abs("../testdata/googleapis")
+			if err != nil {
+				t.Fatal(err)
+			}
+			tmpDir := t.TempDir()
+			t.Chdir(tmpDir)
+
+			cfg := &config.Config{
+				Language: config.LanguageSwift,
+				Default: &config.Default{
+					Swift:  test.swiftDefault,
+					Output: "output",
+				},
+				Libraries: []*config.Library{},
+				Sources: &config.Sources{
+					Googleapis: &config.Source{
+						Dir: googleapisDir,
+					},
+				},
+			}
+			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+				t.Fatal(err)
+			}
+			err = runAdd(t.Context(), cfg, "google/cloud/secretmanager/v1")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			less := func(a, b *config.Library) bool { return a.Name < b.Name }
+			if diff := cmp.Diff(test.wantFinalLibraries, gotCfg.Libraries, cmpopts.SortSlices(less), cmpopts.IgnoreFields(config.Library{}, "APIs")); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/librarian/swift/add.go
+++ b/internal/librarian/swift/add.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import "github.com/googleapis/librarian/internal/config"
+
+// defaultVersion provides a default value in case `librarian.yaml` is missing it.
+const defaultVersion = "0.0.0-preview"
+
+// Add executes Swift-specific mutations of the given [config.Library]
+// entry to be added to the librarian.yaml via `librarian add`.
+func Add(lib *config.Library, cfg *config.Config) *config.Library {
+	lib.Version = defaultVersion
+	if cfg.Default != nil && cfg.Default.Swift != nil && cfg.Default.Swift.DefaultVersion != "" {
+		lib.Version = cfg.Default.Swift.DefaultVersion
+	}
+	return lib
+}

--- a/internal/librarian/swift/add_test.go
+++ b/internal/librarian/swift/add_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestAdd(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cfg  *config.Config
+		want string
+	}{
+		{
+			name: "no config",
+			cfg:  &config.Config{},
+			want: defaultVersion},
+		{
+			name: "no swift default",
+			cfg:  &config.Config{Default: &config.Default{}},
+			want: defaultVersion,
+		},
+		{
+			name: "no swift default version",
+			cfg:  &config.Config{Default: &config.Default{Swift: &config.SwiftDefault{}}},
+			want: defaultVersion,
+		},
+		{
+			name: "with version",
+			cfg:  &config.Config{Default: &config.Default{Swift: &config.SwiftDefault{DefaultVersion: "0.1.0-preview"}}},
+			want: "0.1.0-preview",
+		},
+		{
+			name: "with stable version",
+			cfg:  &config.Config{Default: &config.Default{Swift: &config.SwiftDefault{DefaultVersion: "1.0.0"}}},
+			want: "1.0.0",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lib := &config.Library{}
+			got := Add(lib, test.cfg)
+			if diff := cmp.Diff(test.want, got.Version); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Read the default version from the `librarian.yaml` file. That makes it easier to use `librarian add`.