### PR TITLE
chore(tool/cmd/migrate): pin baseline versions for consistency testing

### DIFF
--- a/internal/librarian/php/DEVELOPMENT.md
+++ b/internal/librarian/php/DEVELOPMENT.md
@@ -35,6 +35,16 @@ sibling repositories (typically under a common parent directory, e.g.,
 When modifying the PHP generator or adding PHP support, use the following
 workflow to test and verify your changes:
 
+### Step 0: Checkout a specific commit (Optional, for consistency testing)
+
+If you want to verify the generator output against a known baseline, checkout a specific commit of `google-cloud-php` before running migration:
+
+```bash
+cd ../google-cloud-php
+git checkout 1831905d
+cd ../librarian
+```
+
 ### Step 1: Run the Migration Tool
 Before running generation, you must first generate the `librarian.yaml`
 configuration file for the `google-cloud-php` repository. This tool will

--- a/internal/librarian/php/DEVELOPMENT.md
+++ b/internal/librarian/php/DEVELOPMENT.md
@@ -35,9 +35,9 @@ sibling repositories (typically under a common parent directory, e.g.,
 When modifying the PHP generator or adding PHP support, use the following
 workflow to test and verify your changes:
 
-### Step 0: Checkout a specific commit (Optional, for consistency testing)
+### Step 0: Check out a specific commit (Optional, for consistency testing)
 
-If you want to verify the generator output against a known baseline, checkout a specific commit of `google-cloud-php` before running migration:
+If you want to verify the generator output against a known baseline, check out a specific commit of `google-cloud-php` before running `migrate`:
 
 ```bash
 cd ../google-cloud-php

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -47,7 +47,7 @@ var (
 
 var phpFetchSource = func(ctx context.Context) (*config.Source, error) {
 	// Temp codepath to pin googleapis commit for consistency testing.
-	// TODO(https://github.com/googleapis/librarian/issues/6898): remove before merging.
+	// TODO(https://github.com/googleapis/librarian/issues/6898): remove before migration
 	return fetchGoogleapisWithCommit(ctx, githubEndpoints, "6145fa8cc2b137bf4c0ed114e2e39c1157ea9722")
 }
 

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -45,8 +45,14 @@ var (
 	errUnableToResolveStagingSubdir = errors.New("unable to resolve staging subdir")
 )
 
+var phpFetchSource = func(ctx context.Context) (*config.Source, error) {
+	// Temp codepath to pin googleapis commit for consistency testing.
+	// TODO(https://github.com/googleapis/librarian/issues/6898): remove before merging.
+	return fetchGoogleapisWithCommit(ctx, githubEndpoints, "6145fa8cc2b137bf4c0ed114e2e39c1157ea9722")
+}
+
 func runPHPMigration(ctx context.Context, repoPath string) error {
-	src, err := fetchSource(ctx)
+	src, err := phpFetchSource(ctx)
 	if err != nil {
 		return errFetchSource
 	}

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -27,16 +27,16 @@ import (
 )
 
 func TestRunPHPMigration(t *testing.T) {
-	oldFetchSource := fetchSource
+	oldFetchSource := phpFetchSource
 	t.Cleanup(func() {
-		fetchSource = oldFetchSource
+		phpFetchSource = oldFetchSource
 	})
 	absGoogleapis, err := filepath.Abs("../../internal/testdata/googleapis")
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Override fetchSource.
-	fetchSource = func(ctx context.Context) (*config.Source, error) {
+	// Override phpFetchSource.
+	phpFetchSource = func(ctx context.Context) (*config.Source, error) {
 		return &config.Source{
 			Commit: "abcd123",
 			SHA256: "sha123",


### PR DESCRIPTION
This change pins the baseline versions of `googleapis` and `google-cloud-php` (in dev guide) to allow consistent verification of the PHP client library generator.

The googleapis repository is pinned to commit 6145fa8cc2b137bf4c0ed114e2e39c1157ea9722 (Fri Jul 17 07:10:04 2026 -0700) and the google-cloud-php repository is pinned to commit 1831905d9cc (Fri Jul 17 19:39:21 2026 +0000).

Fixes https://github.com/googleapis/librarian/issues/6897