### PR TITLE
fix(librarian): enable `google/cloud/batch/v1` for all

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -536,11 +536,7 @@
 - path: google/cloud/batch/v1
   documentation_uri: https://cloud.google.com/batch/docs
   languages:
-    - go
-    - java
-    - nodejs
-    - php
-    - python
+    - all
 - path: google/cloud/batch/v1alpha
   documentation_uri: https://cloud.google.com/batch/docs
   languages:


### PR DESCRIPTION
It seems odd that this API is only enabled for a subset of the languages. I thought the intent was to enable all google/cloud APIs for everybody.