### PR TITLE
feat(tool/cmd/migrate): parse common resources for php libraries

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -50,13 +50,17 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 	if err != nil {
 		return errFetchSource
 	}
-	libs, err := findPHPLibraries(repoPath, src.Dir)
-	if err != nil {
-		return err
-	}
 	cfg, err := yaml.Unmarshal[config.Config](librarianPHPYAML)
 	if err != nil {
 		return fmt.Errorf("unmarshaling librarian_php.yaml: %w", err)
+	}
+	globalDefaultCommonResources := true
+	if cfg.Default != nil && cfg.Default.PHP != nil && cfg.Default.PHP.CommonResources != nil {
+		globalDefaultCommonResources = *cfg.Default.PHP.CommonResources
+	}
+	libs, err := findPHPLibraries(repoPath, src.Dir, globalDefaultCommonResources)
+	if err != nil {
+		return err
 	}
 	cfg.Sources = &config.Sources{
 		Googleapis: src,
@@ -179,7 +183,7 @@ func extractAPIsFromOwlBot(owlbotPath string) ([]*config.API, error) {
 // represents a PHP library, where the library name is the subdirectory's name and
 // the version is extracted from the VERSION file.
 // It also attempts to parse .OwlBot.yaml to extract API paths.
-func findPHPLibraries(repoPath string, googleapisDir string) ([]*config.Library, error) {
+func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommonResources bool) ([]*config.Library, error) {
 	entries, err := os.ReadDir(repoPath)
 	if err != nil {
 		return nil, err
@@ -208,16 +212,21 @@ func findPHPLibraries(repoPath string, googleapisDir string) ([]*config.Library,
 		}
 
 		for _, api := range apis {
-			additionalProtos, err := parsePHPBazel(googleapisDir, api.Path)
+			additionalProtos, hasCommonResources, err := parsePHPBazel(googleapisDir, api.Path)
 			if err != nil {
 				log.Printf("Warning: failed to parse BUILD.bazel for %s: %v", api.Path, err)
 				continue
 			}
-			if len(additionalProtos) > 0 {
+			if len(additionalProtos) > 0 || hasCommonResources != globalDefaultCommonResources {
 				if api.PHP == nil {
 					api.PHP = &config.PHPAPI{}
 				}
+			}
+			if len(additionalProtos) > 0 {
 				api.PHP.AdditionalProtos = additionalProtos
+			}
+			if hasCommonResources != globalDefaultCommonResources {
+				api.PHP.CommonResources = &hasCommonResources
 			}
 		}
 
@@ -230,15 +239,16 @@ func findPHPLibraries(repoPath string, googleapisDir string) ([]*config.Library,
 	return libs, nil
 }
 
-func parsePHPBazel(googleapisDir, apiPath string) ([]string, error) {
+func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, error) {
 	file, err := parseBazel(googleapisDir, apiPath)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if file == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 	var additionalProtos []string
+	var hasCommonResources bool
 	if rules := file.Rules("proto_library_with_info"); len(rules) > 0 {
 		rule := rules[0]
 		if attr := rule.Attr("deps"); attr != nil {
@@ -247,10 +257,9 @@ func parsePHPBazel(googleapisDir, apiPath string) ([]string, error) {
 				if strings.HasPrefix(dep, ":") {
 					continue
 				}
-				// Ignore common resources which are handled natively.
-				// TODO(https://github.com/googleapis/librarian/issues/6813):
-				// load this to dedicated config
+				// Identify common resources usage.
 				if strings.Contains(dep, "common_resources_proto") {
+					hasCommonResources = true
 					continue
 				}
 				// Ignore LROs since PHP does not compile LRO methods as mixins.
@@ -269,7 +278,7 @@ func parsePHPBazel(googleapisDir, apiPath string) ([]string, error) {
 			}
 		}
 	}
-	return additionalProtos, nil
+	return additionalProtos, hasCommonResources, nil
 }
 
 func parseBazel(googleapisDir, dir string) (*build.File, error) {

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -316,14 +316,16 @@ api-name: Ces
 
 func TestParsePHPBazel(t *testing.T) {
 	for _, test := range []struct {
-		name       string
-		bazelRules string
-		want       []string
+		name                string
+		bazelRules          string
+		want                []string
+		wantCommonResources bool
 	}{
 		{
-			name:       "no BUILD.bazel",
-			bazelRules: "",
-			want:       nil,
+			name:                "no BUILD.bazel",
+			bazelRules:          "",
+			want:                nil,
+			wantCommonResources: false,
 		},
 		{
 			name: "valid BUILD.bazel with location and iam mixins",
@@ -343,6 +345,7 @@ proto_library_with_info(
 				"google/cloud/location/locations.proto",
 				"google/iam/v1/iam_policy.proto",
 			},
+			wantCommonResources: true,
 		},
 		{
 			name: "valid BUILD.bazel with no mixins",
@@ -355,7 +358,21 @@ proto_library_with_info(
     ],
 )
 `,
-			want: nil,
+			want:                nil,
+			wantCommonResources: true,
+		},
+		{
+			name: "valid BUILD.bazel with no common resources",
+			bazelRules: `
+proto_library_with_info(
+    name = "ces_proto_with_info",
+    deps = [
+        ":ces_proto",
+    ],
+)
+`,
+			want:                nil,
+			wantCommonResources: false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -369,7 +386,81 @@ proto_library_with_info(
 					t.Fatal(err)
 				}
 			}
-			got, err := parsePHPBazel(tempDir, "google/cloud/ces/v1")
+			got, gotCommonResources, err := parsePHPBazel(tempDir, "google/cloud/ces/v1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch additional protos (-want +got):\n%s", diff)
+			}
+			if gotCommonResources != test.wantCommonResources {
+				t.Errorf("mismatch common resources flag: want %t, got %t", test.wantCommonResources, gotCommonResources)
+			}
+		})
+	}
+}
+
+func TestFindPHPLibraries(t *testing.T) {
+	googleapisDir := "testdata/googleapis"
+
+	for _, test := range []struct {
+		name                         string
+		setupLib                     func(t *testing.T, dir string)
+		globalDefaultCommonResources bool
+		want                         []*config.Library
+	}{
+		{
+			name: "common resources configuration",
+			setupLib: func(t *testing.T, dir string) {
+				libDir := filepath.Join(dir, "SecretManager")
+				if err := os.Mkdir(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("2.3.0\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				owlbotContent := `
+deep-copy-regex:
+  - source: /google/cloud/secretmanager/(v1)/.*-php/(.*)
+    dest: /owl-bot-staging/SecretManager/$1/$2
+  - source: /google/cloud/multipygapic/.*-php/(.*)
+    dest: /owl-bot-staging/SecretManager/multipygapic/$1
+`
+				if err := os.WriteFile(filepath.Join(libDir, ".OwlBot.yaml"), []byte(owlbotContent), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			globalDefaultCommonResources: true,
+			want: []*config.Library{
+				{
+					Name:    "SecretManager",
+					Version: "2.3.0",
+					APIs: []*config.API{
+						{
+							Path: "google/cloud/secretmanager/v1",
+							PHP: &config.PHPAPI{
+								StagingSubdir: "v1",
+							},
+						},
+						{
+							Path: "google/cloud/multipygapic",
+							PHP: &config.PHPAPI{
+								StagingSubdir:   "multipygapic",
+								CommonResources: new(false),
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			test.setupLib(t, dir)
+			got, err := findPHPLibraries(dir, googleapisDir, test.globalDefaultCommonResources)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -391,7 +391,7 @@ proto_library_with_info(
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch additional protos (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if gotCommonResources != test.wantCommonResources {
 				t.Errorf("mismatch common resources flag: want %t, got %t", test.wantCommonResources, gotCommonResources)


### PR DESCRIPTION
The PHP migration tool now parses common_resources_proto usage from BUILD.bazel dependencies. The parsed setting is compared against the default template in librarian_php.yaml, and written to librarian.yaml only if it differs.

Fixes #6813