### PR TITLE
chore(internal/librarian): do not derive api path for ruby

### DIFF
--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -330,7 +330,12 @@ func applyDefaults(language string, lib *config.Library, defaults *config.Defaul
 // derive the API path.
 func canDeriveAPIPath(language string) bool {
 	switch language {
-	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs, config.LanguageJava, config.LanguagePhp:
+	case config.LanguageGo,
+		config.LanguagePython,
+		config.LanguageNodejs,
+		config.LanguageJava,
+		config.LanguagePhp,
+		config.LanguageRuby:
 		return false
 	default:
 		return true

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -867,6 +867,10 @@ func TestCanDeriveAPIPath(t *testing.T) {
 			language: config.LanguageNodejs,
 		},
 		{
+			name:     "ruby",
+			language: config.LanguageRuby,
+		},
+		{
 			name:     "rust",
 			language: config.LanguageRust,
 			want:     true,


### PR DESCRIPTION
Do not derive api path for ruby.