### PR TITLE
fix(sidekick/swift): warnings in enums with dups

### DIFF
--- a/internal/sidekick/swift/generate_enum_swift_test.go
+++ b/internal/sidekick/swift/generate_enum_swift_test.go
@@ -44,13 +44,7 @@ func TestGenerateEnum_Files(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{color, kind, clash0, clash1}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
-
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
+	cfg := &parser.ModelConfig{}
 	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -67,6 +61,44 @@ func TestGenerateEnum_Files(t *testing.T) {
 		if _, err := os.Stat(filename); err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func TestGenerateEnum_UniqueNumbers(t *testing.T) {
+	outDir := t.TempDir()
+
+	kind := &api.Enum{Name: "Kind", Package: "google.cloud.test.v1", ID: ".google.cloud.test.v1.Kind"}
+	kind.Values = []*api.EnumValue{
+		{Name: "KIND_UNSPECIFIED", Number: 0, Parent: kind},
+		{Name: "KIND_TEST", Number: 0, Parent: kind},
+		{Name: "KIND_OTHER_TEST", Number: 1, Parent: kind},
+	}
+	kind.UniqueNumberValues = []*api.EnumValue{kind.Values[1], kind.Values[2]}
+
+	model := api.NewTestAPI(nil, []*api.Enum{kind}, nil)
+	model.PackageName = "google.cloud.test.v1"
+	cfg := &parser.ModelConfig{}
+	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	contentsB, err := os.ReadFile(filepath.Join(outDir, "Sources", "GoogleCloudTestV1", "Kind.swift"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := extractBlock(t, string(contentsB), "/// Initialize from an integer value.", "\n  }")
+	want := `/// Initialize from an integer value.
+  ///
+  /// If the value is unknown, this initializes to ` + "``.unknownIntValue(_:)``." + `
+  public init(intValue: Int) {
+    switch intValue {
+    case 0: self = .test
+    case 1: self = .otherTest
+    default: self = .unknownIntValue(intValue)
+    }
+  }`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -89,9 +89,9 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
   /// If the value is unknown, this initializes to ``.{{Codec.UnknownIntName}}(_:)``.
   public init(intValue: Int) {
     switch intValue {
-    {{#Values}}
+    {{#UniqueNumberValues}}
     case {{Number}}: self = .{{Codec.CaseName}}
-    {{/Values}}
+    {{/UniqueNumberValues}}
     default: self = .{{Codec.UnknownIntName}}(intValue)
     }
   }


### PR DESCRIPTION
The generated code for enums with duplicate numeric values had warnings about duplicate cases. This fixes the problem.

Fixes #6910 