### PR TITLE
fix(sidekick/swift): pagination dependencies

### DIFF
--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -188,7 +188,7 @@ func (c *codec) addPaginationDependencies(annotations *serviceAnnotations, metho
 	if itemsField == nil {
 		return fmt.Errorf("inconsistent pagination info for method: %s", method.ID)
 	}
-	if itemsField.Repeated && itemsField.Typez == api.TypezMessage {
+	if itemsField.Repeated {
 		return c.addFieldDependencies(annotations, itemsField)
 	}
 	if itemsField.Map {

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -164,51 +164,14 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (
 				}
 			}
 		}
+		if method.Pagination != nil && method.OutputType != nil && method.OutputType.Pagination != nil {
+			if err := c.addPaginationDependencies(annotations, method); err != nil {
+				return nil, err
+			}
+		}
 		if method.IsLRO && method.OperationInfo != nil {
-			// LROs depend on PollableOperation package
-			lroDep, err := c.addPackageDependency(lroSwiftPackage)
-			if err != nil {
+			if err := c.addLroDependencies(annotations, method); err != nil {
 				return nil, err
-			}
-			if lroDep != nil {
-				annotations.DependsOn[lroDep.Name] = lroDep
-			}
-
-			// LRO error mapping relies on GoogleRpc.Code, so we depend on GoogleRpc package
-			rpcDep, err := c.addApiPackageDependency("google.rpc")
-			if err != nil {
-				return nil, err
-			}
-			if rpcDep != nil {
-				annotations.DependsOn[rpcDep.Name] = rpcDep
-			}
-
-			// Ensure we have the necessary dependencies for the LRO response and metadata types.
-			respMsg, err := lookupMessage(c.Model, method.OperationInfo.ResponseTypeID)
-			if err != nil {
-				return nil, err
-			}
-			if respMsg.Package != c.Model.PackageName {
-				dep, err := c.addApiPackageDependency(respMsg.Package)
-				if err != nil {
-					return nil, err
-				}
-				if dep != nil {
-					annotations.DependsOn[dep.Name] = dep
-				}
-			}
-			metaMsg, err := lookupMessage(c.Model, method.OperationInfo.MetadataTypeID)
-			if err != nil {
-				return nil, err
-			}
-			if metaMsg.Package != c.Model.PackageName {
-				dep, err := c.addApiPackageDependency(metaMsg.Package)
-				if err != nil {
-					return nil, err
-				}
-				if dep != nil {
-					annotations.DependsOn[dep.Name] = dep
-				}
 			}
 		}
 	}
@@ -218,6 +181,113 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (
 		return nil, err
 	}
 	return annotations, nil
+}
+
+func (c *codec) addPaginationDependencies(annotations *serviceAnnotations, method *api.Method) error {
+	itemsField := method.OutputType.Pagination.PageableItem
+	if itemsField == nil {
+		return fmt.Errorf("inconsistent pagination info for method: %s", method.ID)
+	}
+	if itemsField.Repeated && itemsField.Typez == api.TypezMessage {
+		return c.addFieldDependencies(annotations, itemsField)
+	}
+	if itemsField.Map {
+		mapType, err := lookupMessage(c.Model, itemsField.TypezID)
+		if err != nil {
+			return err
+		}
+		if len(mapType.Fields) != 2 {
+			return fmt.Errorf("missing key/value fields for map type: %s", itemsField.TypezID)
+		}
+		return c.addFieldDependencies(annotations, mapType.Fields[1])
+	}
+	return nil
+}
+
+func (c *codec) addFieldDependencies(annotations *serviceAnnotations, field *api.Field) error {
+	switch field.Typez {
+	case api.TypezMessage:
+		item, err := lookupMessage(c.Model, field.TypezID)
+		if err != nil {
+			return err
+		}
+		if item.Package != c.Model.PackageName {
+			dep, err := c.addApiPackageDependency(item.Package)
+			if err != nil {
+				return err
+			}
+			if dep != nil {
+				annotations.DependsOn[dep.Name] = dep
+			}
+		}
+		return nil
+	case api.TypezEnum:
+		item, err := lookupEnum(c.Model, field.TypezID)
+		if err != nil {
+			return err
+		}
+		if item.Package != c.Model.PackageName {
+			dep, err := c.addApiPackageDependency(item.Package)
+			if err != nil {
+				return err
+			}
+			if dep != nil {
+				annotations.DependsOn[dep.Name] = dep
+			}
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (c *codec) addLroDependencies(annotations *serviceAnnotations, method *api.Method) error {
+	// LROs depend on PollableOperation package
+	lroDep, err := c.addPackageDependency(lroSwiftPackage)
+	if err != nil {
+		return err
+	}
+	if lroDep != nil {
+		annotations.DependsOn[lroDep.Name] = lroDep
+	}
+
+	// LRO error mapping relies on GoogleRpc.Code, so we depend on GoogleRpc package
+	rpcDep, err := c.addApiPackageDependency("google.rpc")
+	if err != nil {
+		return err
+	}
+	if rpcDep != nil {
+		annotations.DependsOn[rpcDep.Name] = rpcDep
+	}
+
+	// Ensure we have the necessary dependencies for the LRO response and metadata types.
+	respMsg, err := lookupMessage(c.Model, method.OperationInfo.ResponseTypeID)
+	if err != nil {
+		return err
+	}
+	if respMsg.Package != c.Model.PackageName {
+		dep, err := c.addApiPackageDependency(respMsg.Package)
+		if err != nil {
+			return err
+		}
+		if dep != nil {
+			annotations.DependsOn[dep.Name] = dep
+		}
+	}
+	metaMsg, err := lookupMessage(c.Model, method.OperationInfo.MetadataTypeID)
+	if err != nil {
+		return err
+	}
+	if metaMsg.Package != c.Model.PackageName {
+		dep, err := c.addApiPackageDependency(metaMsg.Package)
+		if err != nil {
+			return err
+		}
+		if dep != nil {
+			annotations.DependsOn[dep.Name] = dep
+		}
+	}
+	return nil
 }
 
 func isGeneratedMethod(method *api.Method) bool {

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -357,3 +357,105 @@ func TestAnnotateService_LRO(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestAnnotateService_Pagination(t *testing.T) {
+	itemType := api.NewTestMessage("Item").WithPackage("external")
+
+	pageToken := api.NewTestField("page_token").WithType(api.TypezString)
+	inputType := api.NewTestMessage("ListItemsRequest").
+		WithFields(api.NewTestField("name").WithType(api.TypezString)).
+		WithFields(pageToken)
+	outputType := api.NewTestMessage("ListItemsResponse").
+		WithPagination(
+			api.NewTestField("next_page_token").WithType(api.TypezString),
+			api.NewTestField("items").WithMessageType(itemType).WithRepeated(),
+		)
+	list := api.NewTestMethod("ListItems").
+		WithInput(inputType).
+		WithOutput(outputType).
+		WithPagination(pageToken).
+		WithVerb("GET").
+		WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("items"))
+
+	service := api.NewTestService("TestService").WithMethods(list)
+
+	model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})
+	model.PackageName = "test"
+	model.AddMessage(itemType)
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+
+	codec := newTestCodec(t, model, nil)
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{
+			ApiPackage: "external",
+			Name:       "GoogleCloudExternal",
+		},
+	})
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	annotations := service.Codec.(*serviceAnnotations)
+	wantImports := []string{"GoogleCloudExternal", "GoogleCloudWkt"}
+	if diff := cmp.Diff(wantImports, annotations.ServiceImports()); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAnnotateService_MapPagination(t *testing.T) {
+	itemType := api.NewTestMessage("Item").WithPackage("external")
+	mapType := api.NewTestMessage("$map<string, Item>").
+		WithPackage("test").
+		WithFields(
+			api.NewTestField("key").WithType(api.TypezString),
+			api.NewTestField("value").WithMessageType(itemType),
+		)
+	mapType.IsMap = true
+
+	pageToken := api.NewTestField("page_token").WithType(api.TypezString)
+	inputType := api.NewTestMessage("ListItemsRequest").
+		WithFields(api.NewTestField("name").WithType(api.TypezString)).
+		WithFields(pageToken)
+	outputType := api.NewTestMessage("ListItemsResponse").
+		WithPagination(
+			api.NewTestField("next_page_token").WithType(api.TypezString),
+			api.NewTestField("items").WithMessageType(mapType).WithMap(),
+		)
+	list := api.NewTestMethod("ListItems").
+		WithInput(inputType).
+		WithOutput(outputType).
+		WithPagination(pageToken).
+		WithVerb("GET").
+		WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("items"))
+
+	service := api.NewTestService("TestService").WithMethods(list)
+
+	model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})
+	model.PackageName = "test"
+	model.AddMessage(itemType)
+	model.AddMessage(mapType)
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+
+	codec := newTestCodec(t, model, nil)
+	codec.withExtraDependencies(t, []config.SwiftDependency{
+		{
+			ApiPackage: "external",
+			Name:       "GoogleCloudExternal",
+		},
+	})
+
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	annotations := service.Codec.(*serviceAnnotations)
+	wantImports := []string{"GoogleCloudExternal", "GoogleCloudWkt"}
+	if diff := cmp.Diff(wantImports, annotations.ServiceImports()); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
When a pagination method returns external items the service needs to import the external package.

Fixes #6915 