### PR TITLE
fix(sidekick/swift): unqualified String type

### DIFF
--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -139,7 +139,7 @@ func TestGenerateOneOf(t *testing.T) {
     return copy
   }
 
-  private enum CodingKeys: String, CodingKey {
+  private enum CodingKeys: Swift.String, CodingKey {
     case stringField = "stringField"
     case messageField = "messageField"
     case regularInt32 = "regularInt32"
@@ -191,7 +191,9 @@ func TestGenerateOneOf(t *testing.T) {
     indirect case messageField(Inner)
   }
 
-  public static var _anyTypeUrl: String { return "type.googleapis.com/google.cloud.test.v1.Outer" }
+  public static var _anyTypeUrl: Swift.String {
+    return "type.googleapis.com/google.cloud.test.v1.Outer"
+  }
   public init(fromAny any: GoogleCloudWkt.` + "`Any`" + `) throws {
     self = try GoogleCloudWkt._slowAnyDeserialize(Self.self, from: any)
   }
@@ -291,7 +293,7 @@ func TestGenerateOneOfWithKeyword(t *testing.T) {
     return copy
   }
 
-  private enum CodingKeys: String, CodingKey {
+  private enum CodingKeys: Swift.String, CodingKey {
     case header = "header"
     case query = "query"
     case cookie = "cookie"

--- a/internal/sidekick/swift/generate_pagination_swift_test.go
+++ b/internal/sidekick/swift/generate_pagination_swift_test.go
@@ -160,7 +160,7 @@ func verifyGeneratedMapService(t *testing.T, outDir string) {
     byItem: ListSecretsRequest, options: GoogleCloudGax.RequestOptions
 ) throws -> any AsyncSequence<(Swift.String, Secret), Swift.Error>
  {
-    let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
+    let listRpc = { (token: Swift.String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
       var request = byItem
       request.pageToken = token
       return try await self.listSecrets(request: request, options: options)

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -583,7 +583,7 @@ func verifyGeneratedService(t *testing.T, outDir string) {
     byItem: ListSecretsRequest, options: GoogleCloudGax.RequestOptions
 ) throws -> any AsyncSequence<Secret, Swift.Error>
  {
-    let listRpc = { (token: String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
+    let listRpc = { (token: Swift.String) async throws -> GoogleCloudSecretmanagerV1.ListSecretsResponse in
       var request = byItem
       request.pageToken = token
       return try await self.listSecrets(request: request, options: options)

--- a/internal/sidekick/swift/generate_version_test.go
+++ b/internal/sidekick/swift/generate_version_test.go
@@ -52,7 +52,7 @@ func TestGenerateVersion(t *testing.T) {
 		want  string
 	}{
 		{"// Copyright ", "// Copyright 2038 Google LLC\n"},
-		{"static let version:", "static let version: String = \"1.2.3-test\"\n"},
+		{"static let version:", "static let version: Swift.String = \"1.2.3-test\"\n"},
 	} {
 		t.Run(test.start, func(t *testing.T) {
 			got := extractBlock(t, contentStr, test.start, "\n")

--- a/internal/sidekick/swift/templates/common/client_protocol.mustache
+++ b/internal/sidekick/swift/templates/common/client_protocol.mustache
@@ -130,7 +130,7 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
   }
 
   public func {{> /templates/common/method_signature/pagination_options}} {
-    let listRpc = { (token: String) async throws -> {{Codec.ReturnType}} in
+    let listRpc = { (token: Swift.String) async throws -> {{Codec.ReturnType}} in
       throw GoogleCloudGax.RequestError.unimplemented
     }
     return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)

--- a/internal/sidekick/swift/templates/common/clients.swift.mustache
+++ b/internal/sidekick/swift/templates/common/clients.swift.mustache
@@ -29,6 +29,6 @@ import GoogleCloudGax
 
 // Defines concrete implementations of the client protocols.
 public enum Clients {
-  static let clientHeader: String =
+  static let clientHeader: Swift.String =
     GoogleCloudGax._gapicApiClientHeader(packageVersion: "{{Codec.PackageVersion}}")
 }

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -62,7 +62,7 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
   /// Returns the string value (or name) associated with the enumeration.
   ///
   /// If the enumeration was initialized with an unknown integer value, this returns `nil`.
-  public var stringValue: String? {
+  public var stringValue: Swift.String? {
     switch self {
     {{#UniqueNumberValues}}
     case .{{Codec.CaseName}}: return "{{Name}}"
@@ -75,7 +75,7 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
   /// Initialize from a string value.
   ///
   /// If the value is unknown, this initializes to ``.{{Codec.UnknownStringName}}(_:)``.
-  public init(stringValue: String) {
+  public init(stringValue: Swift.String) {
     switch stringValue {
     {{#Values}}
     case "{{Name}}": self = .{{Codec.CaseName}}

--- a/internal/sidekick/swift/templates/common/logging.swift.mustache
+++ b/internal/sidekick/swift/templates/common/logging.swift.mustache
@@ -51,7 +51,7 @@ extension Clients {
     func _intercept<Input, Output>(
         request: Input,
         options: GoogleCloudGax.RequestOptions,
-        name: String,
+        name: Swift.String,
         action: (Input, GoogleCloudGax.RequestOptions) async throws -> Output,
     ) async throws -> Output {
       var logger = logger

--- a/internal/sidekick/swift/templates/common/message.mustache
+++ b/internal/sidekick/swift/templates/common/message.mustache
@@ -80,7 +80,7 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
   }
 
   {{#Codec.CustomSerialization}}
-  private enum CodingKeys: String, CodingKey {
+  private enum CodingKeys: Swift.String, CodingKey {
     {{#Fields}}
     case {{Codec.Name}} = "{{JSONName}}"
     {{/Fields}}
@@ -155,7 +155,9 @@ public struct {{Codec.Name}}: Codable, Equatable, {{Codec.Model.WktPackage}}._An
   {{> /templates/common/oneof}}
   {{/OneOfs}}
 
-  public static var _anyTypeUrl: String { return "{{Codec.TypeURL}}" }
+  public static var _anyTypeUrl: Swift.String {
+    return "{{Codec.TypeURL}}"
+  }
   public init(fromAny any: {{Codec.Model.WktPackage}}.`Any`) throws {
     self = try {{Codec.Model.WktPackage}}._slowAnyDeserialize(Self.self, from: any)
   }

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -77,7 +77,7 @@ public class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol {
   @available(*, deprecated)
   {{/Deprecated}}
   public func {{> /templates/common/method_signature/pagination_options}} {
-    let listRpc = { (token: String) async throws -> {{Codec.ReturnType}} in
+    let listRpc = { (token: Swift.String) async throws -> {{Codec.ReturnType}} in
       var request = byItem
       request.pageToken = token
       return try await self.{{Codec.Name}}(request: request, options: options)

--- a/internal/sidekick/swift/templates/version/version.swift.mustache
+++ b/internal/sidekick/swift/templates/version/version.swift.mustache
@@ -21,5 +21,5 @@ limitations under the License.
 {{/BoilerPlate}}
 
 enum PackageVersion {
-  static let version: String = "{{Version}}"
+  static let version: Swift.String = "{{Version}}"
 }


### PR DESCRIPTION
In a few places we used unqualified `String` as a type, as opposed to `Swift.String`. The unqualified type introduced ambiguity and errors if the generated code also defined a type called `String`.

Fixes #6923 