### PR TITLE
fix(tool/cmd/migrate): validate version suffix for ruby wrapper libraries

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -192,7 +192,7 @@ func parseWrapperOf(libraries []*config.Library) {
 			suffix := strings.TrimPrefix(other.Name, prefix)
 			// Verify that the suffix after the prefix represents a valid version,
 			// e.g., starting with v followed by a digit.
-			// We use simple, string comparsion because the migration tool will
+			// We use simple, string comparison because the migration tool will
 			// be removed after language onboarding.
 			if len(suffix) > 1 && suffix[0] == 'v' && suffix[1] >= '0' && suffix[1] <= '9' {
 				wrapperOf = append(wrapperOf, other.Name)

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -184,12 +184,18 @@ func parseWrapperOf(libraries []*config.Library) {
 		// are guaranteed to appear after the wrapper library.
 		for j := i + 1; j < len(libraries); j++ {
 			other := libraries[j]
-			if strings.HasPrefix(other.Name, prefix) {
-				wrapperOf = append(wrapperOf, other.Name)
-			} else {
+			if !strings.HasPrefix(other.Name, prefix) {
 				// Since libraries are sorted by name, the wrapped libraries
 				// must be consecutive.
 				break
+			}
+			suffix := strings.TrimPrefix(other.Name, prefix)
+			// Verify that the suffix after the prefix represents a valid version,
+			// e.g., starting with v followed by a digit.
+			// We use simple, string comparsion because the migration tool will
+			// be removed after language onboarding.
+			if len(suffix) > 1 && suffix[0] == 'v' && suffix[1] >= '0' && suffix[1] <= '9' {
+				wrapperOf = append(wrapperOf, other.Name)
 			}
 		}
 		if len(wrapperOf) > 0 {

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -214,7 +214,7 @@ func TestParseWrapperOf(t *testing.T) {
 			},
 		},
 		{
-			name: "do not wrap a library if the version suffix does not match",
+			name: "ignore libraries with non-version suffix",
 			libraries: []*config.Library{
 				{Name: "google-cloud-storage"},
 				{Name: "google-cloud-storage-transfer-v1", APIs: []*config.API{{Path: "google/cloud/storage/transfer/v1"}}},

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -213,6 +213,17 @@ func TestParseWrapperOf(t *testing.T) {
 				{Name: "google-cloud-storage"},
 			},
 		},
+		{
+			name: "do not wrap a library if the version suffix does not match",
+			libraries: []*config.Library{
+				{Name: "google-cloud-storage"},
+				{Name: "google-cloud-storage-transfer-v1", APIs: []*config.API{{Path: "google/cloud/storage/transfer/v1"}}},
+			},
+			want: []*config.Library{
+				{Name: "google-cloud-storage"},
+				{Name: "google-cloud-storage-transfer-v1", APIs: []*config.API{{Path: "google/cloud/storage/transfer/v1"}}},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			parseWrapperOf(test.libraries)


### PR DESCRIPTION
Ensure that `parseWrapperOf` validates that the suffix following the library prefix begins with a version string starting with 'v' followed by a digit.

This prevents distinct gems sharing a common prefix, such as `google-cloud-storage-transfer-v1`, from being incorrectly attached as wrapped libraries of `google-cloud-storage`. 

Fixes https://github.com/googleapis/librarian/issues/6918
