### PR TITLE
fix(internal/librarian/php): split protoc compilation for gapic and proto

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -120,8 +120,12 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return err
 		}
 		// Cleanup output zips for subsequent APIs in the same library package
-		_ = os.Remove(gapicZipPath)
-		_ = os.Remove(protoZipPath)
+		if err := os.Remove(gapicZipPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to remove gapic zip: %w", err)
+		}
+		if err := os.Remove(protoZipPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to remove proto zip: %w", err)
+		}
 	}
 	if err := postProcessLibrary(ctx, library); err != nil {
 		return fmt.Errorf("failed to postprocess: %w", err)

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -95,31 +95,39 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := os.MkdirAll(stagingDir, 0755); err != nil {
 		return err
 	}
-	outputZipPath := filepath.Join(tempDir, "output.zip")
+	gapicZipPath := filepath.Join(tempDir, "output.zip")
+	protoZipPath := filepath.Join(tempDir, "proto.zip")
 	srcCfg := sources.NewSourceConfig(src, library.Roots)
 	for _, api := range library.APIs {
 		if api.PHP == nil || api.PHP.StagingSubdir == "" {
 			return fmt.Errorf("API %q: %w", api.Path, errMissingStagingSubdir)
 		}
-		destDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
-		if err := os.MkdirAll(destDir, 0755); err != nil {
+		gapicDestDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
+		if err := os.MkdirAll(gapicDestDir, 0755); err != nil {
+			return err
+		}
+		protoDestDir := filepath.Join(gapicDestDir, "proto/src")
+		if err := os.MkdirAll(protoDestDir, 0755); err != nil {
 			return err
 		}
 
 		params := &generateAPIParams{
-			cfg:           cfg,
-			api:           api,
-			library:       library,
-			srcCfg:        srcCfg,
-			wrapperPath:   wrapperPath,
-			outputZipPath: outputZipPath,
-			destDir:       destDir,
+			cfg:          cfg,
+			api:          api,
+			library:      library,
+			srcCfg:       srcCfg,
+			wrapperPath:  wrapperPath,
+			gapicZipPath: gapicZipPath,
+			protoZipPath: protoZipPath,
+			gapicDestDir: gapicDestDir,
+			protoDestDir: protoDestDir,
 		}
 		if err := generateAPI(ctx, params); err != nil {
 			return err
 		}
-		// Cleanup output zip for subsequent APIs in the same library package
-		_ = os.Remove(outputZipPath)
+		// Cleanup output zips for subsequent APIs in the same library package
+		_ = os.Remove(gapicZipPath)
+		_ = os.Remove(protoZipPath)
 	}
 	if err := postProcessLibrary(ctx, library); err != nil {
 		return fmt.Errorf("failed to postprocess: %w", err)
@@ -128,13 +136,15 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 }
 
 type generateAPIParams struct {
-	cfg           *config.Config
-	api           *config.API
-	library       *config.Library
-	srcCfg        *sources.SourceConfig
-	wrapperPath   string
-	outputZipPath string
-	destDir       string
+	cfg          *config.Config
+	api          *config.API
+	library      *config.Library
+	srcCfg       *sources.SourceConfig
+	wrapperPath  string
+	gapicZipPath string
+	protoZipPath string
+	gapicDestDir string
+	protoDestDir string
 }
 
 // generateAPI generates a single target API by resolving its service config, gathering
@@ -155,37 +165,43 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 		return err
 	}
 	opts := gapicOpts(params.api, apiMetadata, grpcConfigPath)
-	var additionalProtos []string
-	if params.api.PHP != nil {
-		additionalProtos = params.api.PHP.AdditionalProtos
-	}
+	additionalProtos := params.api.PHP.AdditionalProtos
 	includeCommonResources := *params.api.PHP.CommonResources
-	targetProtos, err := gatherTargetProtos(googleapisDir, params.api.Path, additionalProtos, includeCommonResources)
+	gapicProtos, err := gatherGAPICProtos(googleapisDir, params.api.Path, additionalProtos, includeCommonResources)
 	if err != nil {
 		return err
 	}
-	protocArgs := buildProtocArgs(params, opts, targetProtos)
-	// Run compilation
+	mainProtos, err := gatherMainProtos(googleapisDir, params.api.Path)
+	if err != nil {
+		return err
+	}
+
 	var pc *config.Protoc
 	if params.cfg.Tools != nil && params.cfg.Tools.Protoc != nil {
 		pc = params.cfg.Tools.Protoc
 	}
-	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protocArgs...); err != nil {
-		return fmt.Errorf("failed to generate PHP API %s: %w", params.api.Path, err)
+	// Run 1: GAPIC Client Generation
+	gapicArgs := buildGapicProtocArgs(params, opts, gapicProtos)
+	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, gapicArgs...); err != nil {
+		return fmt.Errorf("failed to generate PHP GAPIC API %s: %w", params.api.Path, err)
 	}
-	return extractOutput(ctx, params.outputZipPath, params.destDir)
+	if err := extractOutput(ctx, params.gapicZipPath, params.gapicDestDir); err != nil {
+		return err
+	}
+	// Run 2: Proto Message Generation
+	protoArgs := buildProtoProtocArgs(params, mainProtos)
+	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protoArgs...); err != nil {
+		return fmt.Errorf("failed to generate PHP Proto API %s: %w", params.api.Path, err)
+	}
+	return extractOutput(ctx, params.protoZipPath, params.protoDestDir)
 }
 
-// gatherTargetProtos collects all proto files inside the target API directory,
+// gatherGAPICProtos collects all proto files inside the target API directory,
 // appends common resources, and appends any configured additional protos.
-func gatherTargetProtos(googleapisDir, apiPath string, additionalProtos []string, includeCommonResources bool) ([]string, error) {
-	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
-	targetProtos, err := gatherProtos(apiDir)
+func gatherGAPICProtos(googleapisDir, apiPath string, additionalProtos []string, includeCommonResources bool) ([]string, error) {
+	targetProtos, err := gatherMainProtos(googleapisDir, apiPath)
 	if err != nil {
 		return nil, err
-	}
-	if len(targetProtos) == 0 {
-		return nil, fmt.Errorf("no target protos found for API %s", apiPath)
 	}
 
 	if includeCommonResources {
@@ -198,20 +214,32 @@ func gatherTargetProtos(googleapisDir, apiPath string, additionalProtos []string
 	return targetProtos, nil
 }
 
-func buildProtocArgs(params *generateAPIParams, opts []string, targetProtos []string) []string {
-	gapicOutArg := fmt.Sprintf("--gapic_out=%s:%s", strings.Join(opts, ","), params.outputZipPath)
-	protocArgs := []string{
-		"--experimental_allow_proto3_optional",
+func buildGapicProtocArgs(params *generateAPIParams, opts []string, targetProtos []string) []string {
+	gapicOutArg := fmt.Sprintf("--gapic_out=%s:%s", strings.Join(opts, ","), params.gapicZipPath)
+	outputArgs := []string{
 		"--plugin=protoc-gen-gapic=" + params.wrapperPath,
 		gapicOutArg,
 	}
+	return buildBaseProtocArgs(params.srcCfg, outputArgs, targetProtos)
+}
+
+func buildProtoProtocArgs(params *generateAPIParams, targetProtos []string) []string {
+	phpOutArg := fmt.Sprintf("--php_out=%s", params.protoZipPath)
+	return buildBaseProtocArgs(params.srcCfg, []string{phpOutArg}, targetProtos)
+}
+
+func buildBaseProtocArgs(srcCfg *sources.SourceConfig, outputArgs []string, targetProtos []string) []string {
+	args := []string{
+		"--experimental_allow_proto3_optional",
+	}
+	args = append(args, outputArgs...)
 	// Append active root directories as include paths (-I) to resolve proto imports.
-	for _, root := range params.srcCfg.ActiveRoots {
-		if r := params.srcCfg.Root(root); r != "" {
-			protocArgs = append(protocArgs, "-I", r)
+	for _, root := range srcCfg.ActiveRoots {
+		if r := srcCfg.Root(root); r != "" {
+			args = append(args, "-I", r)
 		}
 	}
-	return append(protocArgs, targetProtos...)
+	return append(args, targetProtos...)
 }
 
 func extractOutput(ctx context.Context, zipPath, outDir string) error {
@@ -222,6 +250,18 @@ func extractOutput(ctx context.Context, zipPath, outDir string) error {
 		return fmt.Errorf("failed to extract generated output to %s: %w", outDir, err)
 	}
 	return nil
+}
+
+func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
+	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
+	protos, err := gatherProtos(apiDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(protos) == 0 {
+		return nil, fmt.Errorf("no target protos found for API %s", apiPath)
+	}
+	return protos, nil
 }
 
 // gatherProtos walks the directory tree recursively from root and returns

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -103,13 +103,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("API %q: %w", api.Path, errMissingStagingSubdir)
 		}
 		gapicDestDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
-		if err := os.MkdirAll(gapicDestDir, 0755); err != nil {
-			return err
-		}
 		protoDestDir := filepath.Join(gapicDestDir, "proto/src")
-		if err := os.MkdirAll(protoDestDir, 0755); err != nil {
-			return err
-		}
 
 		params := &generateAPIParams{
 			cfg:          cfg,

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -95,8 +95,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := os.MkdirAll(stagingDir, 0755); err != nil {
 		return err
 	}
-	gapicZipPath := filepath.Join(tempDir, "output.zip")
-	protoZipPath := filepath.Join(tempDir, "proto.zip")
 	srcCfg := sources.NewSourceConfig(src, library.Roots)
 	for _, api := range library.APIs {
 		if api.PHP == nil || api.PHP.StagingSubdir == "" {
@@ -111,20 +109,12 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			library:      library,
 			srcCfg:       srcCfg,
 			wrapperPath:  wrapperPath,
-			gapicZipPath: gapicZipPath,
-			protoZipPath: protoZipPath,
+			tempDir:      tempDir,
 			gapicDestDir: gapicDestDir,
 			protoDestDir: protoDestDir,
 		}
 		if err := generateAPI(ctx, params); err != nil {
 			return err
-		}
-		// Cleanup output zips for subsequent APIs in the same library package
-		if err := os.Remove(gapicZipPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("failed to remove gapic zip: %w", err)
-		}
-		if err := os.Remove(protoZipPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("failed to remove proto zip: %w", err)
 		}
 	}
 	if err := postProcessLibrary(ctx, library); err != nil {
@@ -139,8 +129,7 @@ type generateAPIParams struct {
 	library      *config.Library
 	srcCfg       *sources.SourceConfig
 	wrapperPath  string
-	gapicZipPath string
-	protoZipPath string
+	tempDir      string
 	gapicDestDir string
 	protoDestDir string
 }
@@ -148,10 +137,22 @@ type generateAPIParams struct {
 // generateAPI generates a single target API by resolving its service config, gathering
 // all target proto files, and executing the PHP generator plugin via protoc.
 // It extracts the resulting ZIP archive directly to the library output directory.
-func generateAPI(ctx context.Context, params *generateAPIParams) error {
+func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) {
 	if params.api.PHP == nil || params.api.PHP.CommonResources == nil {
 		return errCommonResourcesUnconfigured
 	}
+	sanitizedPath := strings.ReplaceAll(params.api.Path, "/", "_")
+	gapicZipPath := filepath.Join(params.tempDir, sanitizedPath+"-gapic.zip")
+	protoZipPath := filepath.Join(params.tempDir, sanitizedPath+"-proto.zip")
+
+	defer func() {
+		if cleanupErr := os.Remove(gapicZipPath); cleanupErr != nil && !errors.Is(cleanupErr, os.ErrNotExist) {
+			retErr = errors.Join(retErr, fmt.Errorf("failed to remove gapic zip: %w", cleanupErr))
+		}
+		if cleanupErr := os.Remove(protoZipPath); cleanupErr != nil && !errors.Is(cleanupErr, os.ErrNotExist) {
+			retErr = errors.Join(retErr, fmt.Errorf("failed to remove proto zip: %w", cleanupErr))
+		}
+	}()
 	googleapisDir := params.srcCfg.Root("googleapis")
 	// Resolve service config files
 	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, params.api.Path)
@@ -179,19 +180,19 @@ func generateAPI(ctx context.Context, params *generateAPIParams) error {
 		pc = params.cfg.Tools.Protoc
 	}
 	// Run 1: GAPIC Client Generation
-	gapicArgs := buildGapicProtocArgs(params, opts, gapicProtos)
+	gapicArgs := buildGapicProtocArgs(params, gapicZipPath, opts, gapicProtos)
 	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, gapicArgs...); err != nil {
 		return fmt.Errorf("failed to generate PHP GAPIC API %s: %w", params.api.Path, err)
 	}
-	if err := extractOutput(ctx, params.gapicZipPath, params.gapicDestDir); err != nil {
+	if err := extractOutput(ctx, gapicZipPath, params.gapicDestDir); err != nil {
 		return err
 	}
 	// Run 2: Proto Message Generation
-	protoArgs := buildProtoProtocArgs(params, mainProtos)
+	protoArgs := buildProtoProtocArgs(params, protoZipPath, mainProtos)
 	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protoArgs...); err != nil {
 		return fmt.Errorf("failed to generate PHP Proto API %s: %w", params.api.Path, err)
 	}
-	return extractOutput(ctx, params.protoZipPath, params.protoDestDir)
+	return extractOutput(ctx, protoZipPath, params.protoDestDir)
 }
 
 // gatherGAPICProtos collects all proto files inside the target API directory,
@@ -212,8 +213,8 @@ func gatherGAPICProtos(googleapisDir, apiPath string, additionalProtos []string,
 	return targetProtos, nil
 }
 
-func buildGapicProtocArgs(params *generateAPIParams, opts []string, targetProtos []string) []string {
-	gapicOutArg := fmt.Sprintf("--gapic_out=%s:%s", strings.Join(opts, ","), params.gapicZipPath)
+func buildGapicProtocArgs(params *generateAPIParams, gapicZipPath string, opts []string, targetProtos []string) []string {
+	gapicOutArg := fmt.Sprintf("--gapic_out=%s:%s", strings.Join(opts, ","), gapicZipPath)
 	outputArgs := []string{
 		"--plugin=protoc-gen-gapic=" + params.wrapperPath,
 		gapicOutArg,
@@ -221,8 +222,8 @@ func buildGapicProtocArgs(params *generateAPIParams, opts []string, targetProtos
 	return buildBaseProtocArgs(params.srcCfg, outputArgs, targetProtos)
 }
 
-func buildProtoProtocArgs(params *generateAPIParams, targetProtos []string) []string {
-	phpOutArg := fmt.Sprintf("--php_out=%s", params.protoZipPath)
+func buildProtoProtocArgs(params *generateAPIParams, protoZipPath string, targetProtos []string) []string {
+	phpOutArg := fmt.Sprintf("--php_out=%s", protoZipPath)
 	return buildBaseProtocArgs(params.srcCfg, []string{phpOutArg}, targetProtos)
 }
 

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -365,13 +365,12 @@ func TestBuildGapicProtocArgs(t *testing.T) {
 	}
 	srcCfg := sources.NewSourceConfig(src, []string{"googleapis"})
 	params := &generateAPIParams{
-		srcCfg:       srcCfg,
-		wrapperPath:  "/path/to/wrapper.sh",
-		gapicZipPath: "/path/to/output.zip",
+		srcCfg:      srcCfg,
+		wrapperPath: "/path/to/wrapper.sh",
 	}
 	opts := []string{"metadata", "generate-snippets"}
 	targetProtos := []string{"/path/to/proto1.proto", "/path/to/proto2.proto"}
-	got := buildGapicProtocArgs(params, opts, targetProtos)
+	got := buildGapicProtocArgs(params, "/path/to/output.zip", opts, targetProtos)
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"--plugin=protoc-gen-gapic=/path/to/wrapper.sh",
@@ -392,11 +391,10 @@ func TestBuildProtoProtocArgs(t *testing.T) {
 	}
 	srcCfg := sources.NewSourceConfig(src, []string{"googleapis"})
 	params := &generateAPIParams{
-		srcCfg:       srcCfg,
-		protoZipPath: "/path/to/proto.zip",
+		srcCfg: srcCfg,
 	}
 	targetProtos := []string{"/path/to/proto1.proto", "/path/to/proto2.proto"}
-	got := buildProtoProtocArgs(params, targetProtos)
+	got := buildProtoProtocArgs(params, "/path/to/proto.zip", targetProtos)
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"--php_out=/path/to/proto.zip",

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -245,7 +245,7 @@ func TestGapicOpts(t *testing.T) {
 	}
 }
 
-func TestGatherTargetProtos(t *testing.T) {
+func TestGatherGAPICProtos(t *testing.T) {
 	for _, test := range []struct {
 		name                   string
 		setupFiles             []string
@@ -258,40 +258,46 @@ func TestGatherTargetProtos(t *testing.T) {
 			name: "protos found, common resources enabled",
 			setupFiles: []string{
 				"google/cloud/secretmanager/v1/service.proto",
+				"google/cloud/secretmanager/v1/resources.proto",
+				commonResourcesProto,
 			},
 			apiPath:                "google/cloud/secretmanager/v1",
 			includeCommonResources: true,
 			wantProtos: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
 				"google/cloud/secretmanager/v1/service.proto",
-				"google/cloud/common_resources.proto",
+				commonResourcesProto,
 			},
 		},
 		{
 			name: "protos found, common resources disabled",
 			setupFiles: []string{
 				"google/cloud/secretmanager/v1/service.proto",
+				"google/cloud/secretmanager/v1/resources.proto",
+				commonResourcesProto,
 			},
 			apiPath:                "google/cloud/secretmanager/v1",
 			includeCommonResources: false,
 			wantProtos: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
 				"google/cloud/secretmanager/v1/service.proto",
 			},
 		},
 		{
-			name: "protos found, common resources and additional protos present",
+			name: "additional protos added",
 			setupFiles: []string{
 				"google/cloud/secretmanager/v1/service.proto",
-				"google/cloud/location/location.proto",
+				"google/cloud/secretmanager/v1/resources.proto",
+				"google/cloud/location/locations.proto",
 			},
 			apiPath: "google/cloud/secretmanager/v1",
 			additionalProtos: []string{
-				"google/cloud/location/location.proto",
+				"google/cloud/location/locations.proto",
 			},
-			includeCommonResources: true,
 			wantProtos: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
 				"google/cloud/secretmanager/v1/service.proto",
-				"google/cloud/common_resources.proto",
-				"google/cloud/location/location.proto",
+				"google/cloud/location/locations.proto",
 			},
 		},
 	} {
@@ -306,7 +312,7 @@ func TestGatherTargetProtos(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			got, err := gatherTargetProtos(tempDir, test.apiPath, test.additionalProtos, test.includeCommonResources)
+			got, err := gatherGAPICProtos(tempDir, test.apiPath, test.additionalProtos, test.includeCommonResources)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -321,7 +327,7 @@ func TestGatherTargetProtos(t *testing.T) {
 	}
 }
 
-func TestGatherTargetProtos_Error(t *testing.T) {
+func TestGatherGAPICProtos_Error(t *testing.T) {
 	for _, test := range []struct {
 		name       string
 		setupFiles []string
@@ -344,32 +350,56 @@ func TestGatherTargetProtos_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			_, err := gatherTargetProtos(tempDir, test.apiPath, nil, true)
+			_, err := gatherGAPICProtos(tempDir, test.apiPath, nil, true)
 			if err == nil {
-				t.Fatal("gatherTargetProtos() expected error, got nil")
+				t.Fatal("gatherGAPICProtos() expected error, got nil")
 			}
 		})
 	}
 }
 
-func TestBuildProtocArgs(t *testing.T) {
+func TestBuildGapicProtocArgs(t *testing.T) {
 	tempDir := t.TempDir()
 	src := &sources.Sources{
 		Googleapis: tempDir,
 	}
 	srcCfg := sources.NewSourceConfig(src, []string{"googleapis"})
 	params := &generateAPIParams{
-		srcCfg:        srcCfg,
-		wrapperPath:   "/path/to/wrapper.sh",
-		outputZipPath: "/path/to/output.zip",
+		srcCfg:       srcCfg,
+		wrapperPath:  "/path/to/wrapper.sh",
+		gapicZipPath: "/path/to/output.zip",
 	}
 	opts := []string{"metadata", "generate-snippets"}
 	targetProtos := []string{"/path/to/proto1.proto", "/path/to/proto2.proto"}
-	got := buildProtocArgs(params, opts, targetProtos)
+	got := buildGapicProtocArgs(params, opts, targetProtos)
 	want := []string{
 		"--experimental_allow_proto3_optional",
 		"--plugin=protoc-gen-gapic=/path/to/wrapper.sh",
 		"--gapic_out=metadata,generate-snippets:/path/to/output.zip",
+		"-I", tempDir,
+		"/path/to/proto1.proto",
+		"/path/to/proto2.proto",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBuildProtoProtocArgs(t *testing.T) {
+	tempDir := t.TempDir()
+	src := &sources.Sources{
+		Googleapis: tempDir,
+	}
+	srcCfg := sources.NewSourceConfig(src, []string{"googleapis"})
+	params := &generateAPIParams{
+		srcCfg:       srcCfg,
+		protoZipPath: "/path/to/proto.zip",
+	}
+	targetProtos := []string{"/path/to/proto1.proto", "/path/to/proto2.proto"}
+	got := buildProtoProtocArgs(params, targetProtos)
+	want := []string{
+		"--experimental_allow_proto3_optional",
+		"--php_out=/path/to/proto.zip",
 		"-I", tempDir,
 		"/path/to/proto1.proto",
 		"/path/to/proto2.proto",


### PR DESCRIPTION
This change splits the protoc execution into two separate runs: one for the GAPIC client generation (running on main, additional, and common resources protos) and one for the Proto message generation (running on main protos only).

By running them separately and only passing main protos to --php_out, we prevent the over-generation of dependency protobuf classes (like Location) inside the library package. 

Fixes #6924 
Fixes #6927