### PR TITLE
fix(internal/librarian/php): check error and add test case for TestGatherGAPICProtos_Error

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -40,6 +40,7 @@ const (
 var (
 	errCommonResourcesUnconfigured = errors.New("common_resources must be set (either per-API or globally under default.php)")
 	errMissingStagingSubdir        = errors.New("staging_subdir is required for PHP configurations")
+	errNoProtos                    = errors.New("no target protos found")
 )
 
 // Generate generates a PHP client library.
@@ -255,10 +256,13 @@ func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
 	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
 	protos, err := gatherProtos(apiDir)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w for API %s: %w", errNoProtos, apiPath, err)
+		}
 		return nil, err
 	}
 	if len(protos) == 0 {
-		return nil, fmt.Errorf("no target protos found for API %s", apiPath)
+		return nil, fmt.Errorf("%w for API %s", errNoProtos, apiPath)
 	}
 	return protos, nil
 }

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -147,10 +148,10 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 	protoZipPath := filepath.Join(params.tempDir, sanitizedPath+"-proto.zip")
 
 	defer func() {
-		if cleanupErr := os.Remove(gapicZipPath); cleanupErr != nil && !errors.Is(cleanupErr, os.ErrNotExist) {
+		if cleanupErr := os.Remove(gapicZipPath); cleanupErr != nil && !errors.Is(cleanupErr, fs.ErrNotExist) {
 			retErr = errors.Join(retErr, fmt.Errorf("failed to remove gapic zip: %w", cleanupErr))
 		}
-		if cleanupErr := os.Remove(protoZipPath); cleanupErr != nil && !errors.Is(cleanupErr, os.ErrNotExist) {
+		if cleanupErr := os.Remove(protoZipPath); cleanupErr != nil && !errors.Is(cleanupErr, fs.ErrNotExist) {
 			retErr = errors.Join(retErr, fmt.Errorf("failed to remove proto zip: %w", cleanupErr))
 		}
 	}()
@@ -256,7 +257,7 @@ func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
 	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
 	protos, err := gatherProtos(apiDir)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("%w for API %s: %w", errNoProtos, apiPath, err)
 		}
 		return nil, err

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -332,11 +332,19 @@ func TestGatherGAPICProtos_Error(t *testing.T) {
 		name       string
 		setupFiles []string
 		apiPath    string
+		wantErr    error
 	}{
 		{
-			name:       "no protos found",
+			name:       "directory not found",
 			setupFiles: nil,
 			apiPath:    "google/cloud/secretmanager/v1",
+			wantErr:    errNoProtos,
+		},
+		{
+			name:       "empty directory",
+			setupFiles: []string{"google/cloud/secretmanager/v1/not-a-proto.txt"},
+			apiPath:    "google/cloud/secretmanager/v1",
+			wantErr:    errNoProtos,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -353,6 +361,9 @@ func TestGatherGAPICProtos_Error(t *testing.T) {
 			_, err := gatherGAPICProtos(tempDir, test.apiPath, nil, true)
 			if err == nil {
 				t.Fatal("gatherGAPICProtos() expected error, got nil")
+			}
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("gatherGAPICProtos() error = %v, wantErr = %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -359,9 +359,6 @@ func TestGatherGAPICProtos_Error(t *testing.T) {
 				}
 			}
 			_, err := gatherGAPICProtos(tempDir, test.apiPath, nil, true)
-			if err == nil {
-				t.Fatal("gatherGAPICProtos() expected error, got nil")
-			}
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("gatherGAPICProtos() error = %v, wantErr = %v", err, test.wantErr)
 			}


### PR DESCRIPTION
Introduces a new sentinel error `errNoProtos` to handle missing target proto files or directories, and updates the corresponding tests to verify this error. 

Followup to https://github.com/googleapis/librarian/pull/6929#discussion_r3616006700

For #6629