### PR TITLE
fix(sidekick/rust): no repo metadata for showcase

### DIFF
--- a/internal/librarian/rust/create_repo_metadata.go
+++ b/internal/librarian/rust/create_repo_metadata.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"fmt"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/repometadata"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+func createRepoMetadata(cfg *config.Config, library *config.Library, sources *sources.Sources) (*repometadata.RepoMetadata, error) {
+	googleapisDir := sources.Googleapis
+	if len(library.APIs) > 0 && library.APIs[0].Path == "schema/google/showcase/v1beta1" {
+		googleapisDir = sources.Showcase
+	}
+	metadata, err := repometadata.FromLibrary(cfg, library, googleapisDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set fields not set by FromLibrary.
+	metadata.ClientDocumentation = fmt.Sprintf("https://docs.rs/%s/latest", library.Name)
+	metadata.LibraryType = repometadata.GAPICAutoLibraryType
+
+	return metadata, nil
+}
+
+func needsRepoMetadata(model *api.API, library *config.Library) bool {
+	if len(model.Services) == 0 {
+		return false
+	}
+	if len(library.APIs) == 0 {
+		return false
+	}
+	if library.APIs[0].Path == repometadata.ShowcasePath {
+		return false
+	}
+	return true
+}

--- a/internal/librarian/rust/create_repo_metadata.go
+++ b/internal/librarian/rust/create_repo_metadata.go
@@ -24,11 +24,7 @@ import (
 )
 
 func createRepoMetadata(cfg *config.Config, library *config.Library, sources *sources.Sources) (*repometadata.RepoMetadata, error) {
-	googleapisDir := sources.Googleapis
-	if len(library.APIs) > 0 && library.APIs[0].Path == "schema/google/showcase/v1beta1" {
-		googleapisDir = sources.Showcase
-	}
-	metadata, err := repometadata.FromLibrary(cfg, library, googleapisDir)
+	metadata, err := repometadata.FromLibrary(cfg, library, sources.Googleapis)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/repometadata"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	sidekickrust "github.com/googleapis/librarian/internal/sidekick/rust"
@@ -83,7 +82,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := sidekickrust.Generate(ctx, model, library.Output, modelConfig); err != nil {
 		return err
 	}
-	if len(model.Services) > 0 {
+	if needsRepoMetadata(model, library) {
 		repoMetadata, err := createRepoMetadata(cfg, library, sources)
 		if err != nil {
 			return err
@@ -96,23 +95,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		validate(ctx, library.Output)
 	}
 	return nil
-}
-
-func createRepoMetadata(cfg *config.Config, library *config.Library, sources *sources.Sources) (*repometadata.RepoMetadata, error) {
-	googleapisDir := sources.Googleapis
-	if len(library.APIs) > 0 && library.APIs[0].Path == "schema/google/showcase/v1beta1" {
-		googleapisDir = sources.Showcase
-	}
-	metadata, err := repometadata.FromLibrary(cfg, library, googleapisDir)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set fields not set by FromLibrary.
-	metadata.ClientDocumentation = fmt.Sprintf("https://docs.rs/%s/latest", library.Name)
-	metadata.LibraryType = repometadata.GAPICAutoLibraryType
-
-	return metadata, nil
 }
 
 // UpdateWorkspace updates dependencies for the entire Rust workspace.

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -663,20 +663,17 @@ func TestFindModuleByOutput(t *testing.T) {
 		})
 	}
 }
+
 func TestCreateRepoMetadata(t *testing.T) {
 	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
 	if err != nil {
 		t.Fatal(err)
 	}
-	showcaseDir, err := filepath.Abs("../../testdata/gapic-showcase")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	for _, test := range []struct {
 		name    string
 		library *config.Library
 		sources *sources.Sources
+		needed  bool
 		want    *repometadata.RepoMetadata
 	}{
 		{
@@ -693,6 +690,7 @@ func TestCreateRepoMetadata(t *testing.T) {
 			sources: &sources.Sources{
 				Googleapis: googleapisDir,
 			},
+			needed: true,
 			want: &repometadata.RepoMetadata{
 				Name:                 "secretmanager",
 				NamePretty:           "Secret Manager",
@@ -707,33 +705,6 @@ func TestCreateRepoMetadata(t *testing.T) {
 				APIDescription:       "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
 				ReleaseLevel:         "preview",
 				LibraryType:          "GAPIC_AUTO",
-			},
-		},
-		{
-			name: "showcase",
-			library: &config.Library{
-				Name:    "google-cloud-showcase-v1beta1",
-				Version: "0.1.0",
-				APIs: []*config.API{
-					{
-						Path: "schema/google/showcase/v1beta1",
-					},
-				},
-			},
-			sources: &sources.Sources{
-				Showcase: showcaseDir,
-			},
-			want: &repometadata.RepoMetadata{
-				Name:                "showcase",
-				NamePretty:          "Client Libraries Showcase",
-				ClientDocumentation: "https://docs.rs/google-cloud-showcase-v1beta1/latest",
-				Language:            config.LanguageRust,
-				Repo:                "googleapis/google-cloud-rust",
-				DistributionName:    "google-cloud-showcase-v1beta1",
-				APIID:               "showcase.googleapis.com",
-				APIShortname:        "showcase",
-				ReleaseLevel:        "preview",
-				LibraryType:         "GAPIC_AUTO",
 			},
 		},
 	} {

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -34,10 +34,11 @@ const (
 	// GAPICAutoLibraryType is the library_type to use for GAPIC libraries.
 	GAPICAutoLibraryType = "GAPIC_AUTO"
 
-	// Never generate a .repo-metadata.json file for showcase.
+	// ShowcasePath defines the API path for the showcase API.
 	//
-	// It serves no purpose, and the result has problems. For example, the short
-	// name is invalid.
+	// We never generate a .repo-metadata.json file for showcase. It serves no
+	// purpose, and the result has problems. For example, the short name is
+	// invalid.
 	ShowcasePath = "schema/google/showcase/v1beta1"
 )
 

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -33,6 +33,12 @@ const (
 
 	// GAPICAutoLibraryType is the library_type to use for GAPIC libraries.
 	GAPICAutoLibraryType = "GAPIC_AUTO"
+
+	// Never generate a .repo-metadata.json file for showcase.
+	//
+	// It serves no purpose, and the result has problems. For example, the short
+	// name is invalid.
+	ShowcasePath = "schema/google/showcase/v1beta1"
 )
 
 var (


### PR DESCRIPTION
The showcase client does not need a `.repo-metadata.json` file. The file is not used, and generates spurious warnings.

Towards https://github.com/googleapis/google-cloud-rust/issues/1859 and #6935 