### PR TITLE
fix(librarian): another API that is not allow listed

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -771,11 +771,7 @@
 - path: google/cloud/billing/budgets/v1
   documentation_uri: https://cloud.google.com/billing/docs/how-to/budget-api-overview
   languages:
-    - go
-    - java
-    - nodejs
-    - php
-    - python
+    - all
   new_issue_uri: https://issuetracker.google.com/savedsearches/559770
 - path: google/cloud/billing/budgets/v1beta1
   documentation_uri: https://cloud.google.com/billing/docs/how-to/budget-api-overview


### PR DESCRIPTION
I want to generate `google/cloud/billins/budgets/v1` for Swift. I don't see why it wouldn't be allowed for all languages.