### PR TITLE
fix(sidekick/swift): snippets and repeated fields

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -391,6 +391,12 @@ func (r *Resource) WithSingular(singular string) *Resource {
 	return r
 }
 
+// WithPlural sets the plural name of the resource.
+func (r *Resource) WithPlural(name string) *Resource {
+	r.Plural = name
+	return r
+}
+
 // ParseTemplateForTest converts a string literal into a []PathSegment slice for testing purposes.
 func ParseTemplateForTest(template string) []PathSegment {
 	var segments []PathSegment

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -386,8 +386,8 @@ func (r *Resource) WithPatterns(patterns ...ResourcePattern) *Resource {
 }
 
 // WithSingular sets the singular name of the resource.
-func (r *Resource) WithSingular(singular string) *Resource {
-	r.Singular = singular
+func (r *Resource) WithSingular(name string) *Resource {
+	r.Singular = name
 	return r
 }
 

--- a/internal/sidekick/swift/generate_snippets_test.go
+++ b/internal/sidekick/swift/generate_snippets_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerateSnippets(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		repeated bool
+		file     string
+		want     string
+	}{
+		{
+			name:     "quickstart singular",
+			repeated: false,
+			file:     "TestServiceQuickstart.swift",
+			want: `func sample(name: String, ) async throws {
+  let client = try GoogleTest.TestServiceClient()
+  let response = try await client.getThing(
+    request: GetThingRequest()
+  .with {
+    $0.name = "\(name)"
+  }
+)
+  print("Success: \(response)")
+}`,
+		},
+		{
+			name:     "quickstart repeated",
+			repeated: true,
+			file:     "TestServiceQuickstart.swift",
+			want: `func sample(name: String, ) async throws {
+  let client = try GoogleTest.TestServiceClient()
+  let response = try await client.getThing(
+    request: GetThingRequest()
+  .with {
+    $0.name = ["\(name)"]
+  }
+)
+  print("Success: \(response)")
+}`,
+		},
+		{
+			name:     "method snippet singular",
+			repeated: false,
+			file:     "TestService_GetThing.swift",
+			want: `func sample(client: TestServiceClient, name: String) async throws {
+  let response = try await client.getThing(
+    request: GetThingRequest()
+  .with {
+    $0.name = "\(name)"
+  }
+)
+  print("Success: \(response)")
+}`,
+		},
+		{
+			name:     "method snippet repeated",
+			repeated: true,
+			file:     "TestService_GetThing.swift",
+			want: `func sample(client: TestServiceClient, name: String) async throws {
+  let response = try await client.getThing(
+    request: GetThingRequest()
+  .with {
+    $0.name = ["\(name)"]
+  }
+)
+  print("Success: \(response)")
+}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			thingResource := api.NewTestResource("test.googleapis.com/Thing").
+				WithSingular("thing").
+				WithPlural("things")
+			thing := api.NewTestMessage("Thing").WithResource(thingResource).WithFields(
+				api.NewTestField("name").WithType(api.TypezString).WithResourceReference(
+					thingResource.Type,
+				),
+				api.NewTestField("cool_attribute").WithType(api.TypezBytes),
+			)
+			name := api.NewTestField("name").
+				WithType(api.TypezString).
+				WithResourceReference(thingResource.Type)
+			if test.repeated {
+				name = name.WithRepeated()
+			}
+			getThingRequest := api.NewTestMessage("GetThingRequest").
+				WithFields(name)
+			getThing := api.NewTestMethod("GetThing").
+				WithInput(getThingRequest).
+				WithOutput(thing).
+				WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("one"))
+			testService := api.NewTestService("TestService").WithMethods(getThing)
+			model := api.NewTestAPI([]*api.Message{thing, getThingRequest}, nil, []*api.Service{testService})
+			model.PackageName = "test"
+			model.AddResource(thingResource)
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
+			cfg := &parser.ModelConfig{}
+			if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+				t.Fatal(err)
+			}
+			contentsBytes, err := os.ReadFile(filepath.Join(outDir, "Snippets", test.file))
+			if err != nil {
+				t.Fatal(err)
+			}
+			contents := string(contentsBytes)
+			got := extractBlock(t, contents, "func sample(", "\n}")
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/templates/snippet/method_request_body.mustache
+++ b/internal/sidekick/swift/templates/snippet/method_request_body.mustache
@@ -25,25 +25,30 @@ limitations under the License.
 {{InputType.Codec.ParameterTypeName}}()
   {{#SampleInfo}}
   .with {
-  {{#IsRequestResourceName}}
+    {{#IsRequestResourceName}}
+    {{#ResourceNameField.Singular}}
     $0.{{Codec.Name}} = "{{Codec.FormatString}}"
-  {{/IsRequestResourceName}}
-  {{#ResourceIDField}}
+    {{/ResourceNameField.Singular}}
+    {{#ResourceNameField.Repeated}}
+    $0.{{Codec.Name}} = ["{{Codec.FormatString}}"]
+    {{/ResourceNameField.Repeated}}
+    {{/IsRequestResourceName}}
+    {{#ResourceIDField}}
     $0.{{Codec.Name}} = "[replace with a valid ID]"
-  {{/ResourceIDField}}
-  {{#IsMessageResourceName}}
+    {{/ResourceIDField}}
+    {{#IsMessageResourceName}}
     $0.{{MessageField.Codec.Name}} = {{MessageField.Codec.BaseFieldType}}().with {
       $0.{{Codec.Name}} = "{{Codec.FormatString}}"
     }
-  {{/IsMessageResourceName}}
-  {{^IsMessageResourceName}}
-  {{#MessageField}}
+    {{/IsMessageResourceName}}
+    {{^IsMessageResourceName}}
+    {{#MessageField}}
     $0.{{Codec.Name}} = {{Codec.BaseFieldType}}() /* .with { ... } */
-  {{/MessageField}}
-  {{/IsMessageResourceName}}
-  {{#UpdateMaskField}}
+    {{/MessageField}}
+    {{/IsMessageResourceName}}
+    {{#UpdateMaskField}}
     $0.{{Codec.Name}} = {{Service.Codec.Model.WktPackage}}.FieldMask(paths: ["field.path1", "field.path2"])
-  {{/UpdateMaskField}}
+    {{/UpdateMaskField}}
   }
   {{/SampleInfo}}
   {{^SampleInfo}}


### PR DESCRIPTION
A few methods use repeated fields to specify multiple resource names. The generator produced incorrect snippets for these methods.

Fixes #6932 