### PR TITLE
fix(sidekick/swift): deps added via method signatures

### DIFF
--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -174,6 +174,11 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (
 				return nil, err
 			}
 		}
+		for _, signature := range method.Signatures {
+			if err := c.addSignatureDependencies(annotations, signature); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	service.Codec = annotations
@@ -285,6 +290,15 @@ func (c *codec) addLroDependencies(annotations *serviceAnnotations, method *api.
 		}
 		if dep != nil {
 			annotations.DependsOn[dep.Name] = dep
+		}
+	}
+	return nil
+}
+
+func (c *codec) addSignatureDependencies(annotations *serviceAnnotations, signature *api.MethodSignature) error {
+	for _, field := range signature.Fields {
+		if err := c.addFieldDependencies(annotations, field); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -477,7 +477,7 @@ func TestAnnotateService_MethodSignatures(t *testing.T) {
 			wantImports: []string{"GoogleCloudWkt"},
 		},
 		{
-			name:        "unrealistic, but good for testing",
+			name:        "with external field",
 			signatures:  []*api.MethodSignature{{Names: []string{"parent", "thing_id", "thing"}}},
 			wantImports: []string{"GoogleCloudExternal", "GoogleCloudWkt"},
 		},

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -459,3 +459,68 @@ func TestAnnotateService_MapPagination(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestAnnotateService_MethodSignatures(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		signatures  []*api.MethodSignature
+		wantImports []string
+	}{
+		{
+			name:        "no signature",
+			signatures:  nil,
+			wantImports: []string{"GoogleCloudWkt"},
+		},
+		{
+			name:        "unrealistic, but good for testing",
+			signatures:  []*api.MethodSignature{{Names: []string{"parent", "thing_id"}}},
+			wantImports: []string{"GoogleCloudWkt"},
+		},
+		{
+			name:        "unrealistic, but good for testing",
+			signatures:  []*api.MethodSignature{{Names: []string{"parent", "thing_id", "thing"}}},
+			wantImports: []string{"GoogleCloudExternal", "GoogleCloudWkt"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			thing := api.NewTestMessage("Thing").WithPackage("external")
+			inputType := api.NewTestMessage("Request").
+				WithFields(
+					api.NewTestField("parent").WithType(api.TypezString),
+					api.NewTestField("thing_id").WithType(api.TypezString),
+					api.NewTestField("thing").WithMessageType(thing),
+				)
+			outputType := api.NewTestMessage("Response")
+			create := api.NewTestMethod("CreateThing").
+				WithInput(inputType).
+				WithOutput(outputType).
+				WithSignatures(test.signatures...).
+				WithVerb("POST").
+				WithPathTemplate((&api.PathTemplate{}).WithLiteral("v1").WithLiteral("things"))
+			service := api.NewTestService("TestService").WithMethods(create)
+			model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})
+			model.PackageName = "test"
+			model.AddMessage(thing)
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
+			codec := newTestCodec(t, model, nil)
+			codec.withExtraDependencies(t, []config.SwiftDependency{
+				{
+					ApiPackage: "external",
+					Name:       "GoogleCloudExternal",
+				},
+			})
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			annotations := service.Codec.(*serviceAnnotations)
+			if annotations == nil {
+				t.Fatalf("service should have a `serviceAnnotations`, got=%+v", service.Codec)
+			}
+			if diff := cmp.Diff(test.wantImports, annotations.ServiceImports()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -478,7 +478,7 @@ func TestAnnotateService_MethodSignatures(t *testing.T) {
 		},
 		{
 			name:        "with external field",
-			signatures:  []*api.MethodSignature{{Names: []string{"parent", "thing_id", "thing"}}},
+			signatures:  []*api.MethodSignature{{Names: []string{"parent", "thing_id", "external_thing"}}},
 			wantImports: []string{"GoogleCloudExternal", "GoogleCloudWkt"},
 		},
 	} {
@@ -488,7 +488,7 @@ func TestAnnotateService_MethodSignatures(t *testing.T) {
 				WithFields(
 					api.NewTestField("parent").WithType(api.TypezString),
 					api.NewTestField("thing_id").WithType(api.TypezString),
-					api.NewTestField("thing").WithMessageType(thing),
+					api.NewTestField("external_thing").WithMessageType(thing),
 				)
 			outputType := api.NewTestMessage("Response")
 			create := api.NewTestMethod("CreateThing").


### PR DESCRIPTION
If a method signature references a field with an external type then the service needs to import the external field: the field type name will appear in the overloads emitted to match the method signature.

Fixes #6944 