### PR TITLE
feat(internal/librarian/php): remove empty directories during cleanup

### DIFF
--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -151,16 +151,17 @@ func RemoveEmptyDirs(targetPath, root string, keepFunc func(string) bool) error 
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
-			rel, err := filepath.Rel(root, path)
-			if err != nil {
-				return err
-			}
-			if keepFunc != nil && keepFunc(filepath.ToSlash(rel)) {
-				return filepath.SkipDir
-			}
-			dirs = append(dirs, path)
+		if !d.IsDir() {
+			return nil
 		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if keepFunc != nil && keepFunc(filepath.ToSlash(rel)) {
+			return filepath.SkipDir
+		}
+		dirs = append(dirs, path)
 		return nil
 	})
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -23,6 +23,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
+	"syscall"
 
 	"github.com/googleapis/librarian/internal/command"
 )
@@ -138,4 +140,41 @@ func CopyFile(src, dest string) error {
 // Unzip unzips the src archive into dest directory using the system unzip command.
 func Unzip(ctx context.Context, src, dest string) error {
 	return command.Run(ctx, "unzip", "-q", "-o", src, "-d", dest)
+}
+
+// RemoveEmptyDirs walks the targetPath and removes empty subdirectories bottom-up.
+// It preserves directories if keepFunc returns true.
+// root is used to calculate relative paths passed to keepFunc.
+func RemoveEmptyDirs(targetPath, root string, keepFunc func(string) bool) error {
+	var dirs []string
+	err := filepath.WalkDir(targetPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			if keepFunc != nil && keepFunc(filepath.ToSlash(rel)) {
+				return filepath.SkipDir
+			}
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	for _, dir := range slices.Backward(dirs) {
+		if err := os.Remove(dir); err != nil && !errors.Is(err, fs.ErrNotExist) && !isDirNotEmpty(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func isDirNotEmpty(err error) bool {
+	return errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST)
 }

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -166,7 +166,6 @@ func RemoveEmptyDirs(targetPath, root string, keepFunc func(string) bool) error 
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
-
 	for _, dir := range slices.Backward(dirs) {
 		if err := os.Remove(dir); err != nil && !errors.Is(err, fs.ErrNotExist) && !isDirNotEmpty(err) {
 			return err
@@ -175,6 +174,7 @@ func RemoveEmptyDirs(targetPath, root string, keepFunc func(string) bool) error 
 	return nil
 }
 
+// isDirNotEmpty returns true if err indicates the directory is not empty.
 func isDirNotEmpty(err error) bool {
 	return errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST)
 }

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -418,3 +418,101 @@ func checkDir(t *testing.T, dir string, want map[string]string) {
 		t.Errorf("mismatch in %s (-want +got):\n%s", dir, diff)
 	}
 }
+
+func TestRemoveEmptyDirs(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name       string
+		setupDirs  []string
+		setupFiles map[string]string
+		keepFunc   func(string) bool
+		wantExist  []string
+		wantAbsent []string
+	}{
+		{
+			name:      "empty dirs are removed",
+			setupDirs: []string{"dir1/dir2/dir3"},
+			wantAbsent: []string{
+				"dir1/dir2/dir3",
+				"dir1/dir2",
+				"dir1",
+			},
+		},
+		{
+			name:      "non-empty dirs are preserved",
+			setupDirs: []string{"dir1/dir2"},
+			setupFiles: map[string]string{
+				"dir1/dir2/file.txt": "content",
+			},
+			wantExist: []string{
+				"dir1/dir2/file.txt",
+				"dir1/dir2",
+				"dir1",
+			},
+		},
+		{
+			name:      "partially empty dirs are cleaned",
+			setupDirs: []string{"dir1/dir2", "dir1/dir3"},
+			setupFiles: map[string]string{
+				"dir1/dir3/file.txt": "content",
+			},
+			wantExist: []string{
+				"dir1/dir3/file.txt",
+				"dir1/dir3",
+				"dir1",
+			},
+			wantAbsent: []string{
+				"dir1/dir2",
+			},
+		},
+		{
+			name:      "kept dirs are preserved",
+			setupDirs: []string{"dir1/dir2/dir3"},
+			keepFunc: func(rel string) bool {
+				return rel == "dir1/dir2"
+			},
+			wantExist: []string{
+				"dir1/dir2/dir3",
+				"dir1/dir2",
+				"dir1",
+			},
+			wantAbsent: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			for _, d := range test.setupDirs {
+				if err := os.MkdirAll(filepath.Join(root, d), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for f, content := range test.setupFiles {
+				p := filepath.Join(root, f)
+				if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := RemoveEmptyDirs(root, root, test.keepFunc); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, path := range test.wantExist {
+				p := filepath.Join(root, path)
+				if _, err := os.Stat(p); err != nil {
+					t.Errorf("expected %s to exist, but got error: %v", path, err)
+				}
+			}
+			for _, path := range test.wantAbsent {
+				p := filepath.Join(root, path)
+				if _, err := os.Stat(p); !errors.Is(err, fs.ErrNotExist) {
+					t.Errorf("expected %s to be absent, but stat got: %v", path, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"syscall"
 	"testing"
 
@@ -428,17 +429,12 @@ func TestRemoveEmptyDirs(t *testing.T) {
 		setupDirs  []string
 		setupFiles map[string]string
 		keepFunc   func(string) bool
-		wantExist  []string
-		wantAbsent []string
+		want       []string
 	}{
 		{
 			name:      "empty dirs are removed",
 			setupDirs: []string{"dir1/dir2/dir3"},
-			wantAbsent: []string{
-				"dir1/dir2/dir3",
-				"dir1/dir2",
-				"dir1",
-			},
+			want:      nil,
 		},
 		{
 			name:      "non-empty dirs are preserved",
@@ -446,10 +442,10 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			setupFiles: map[string]string{
 				"dir1/dir2/file.txt": "content",
 			},
-			wantExist: []string{
-				"dir1/dir2/file.txt",
-				"dir1/dir2",
+			want: []string{
 				"dir1",
+				"dir1/dir2",
+				"dir1/dir2/file.txt",
 			},
 		},
 		{
@@ -458,13 +454,10 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			setupFiles: map[string]string{
 				"dir1/dir3/file.txt": "content",
 			},
-			wantExist: []string{
-				"dir1/dir3/file.txt",
-				"dir1/dir3",
+			want: []string{
 				"dir1",
-			},
-			wantAbsent: []string{
-				"dir1/dir2",
+				"dir1/dir3",
+				"dir1/dir3/file.txt",
 			},
 		},
 		{
@@ -473,12 +466,11 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			keepFunc: func(rel string) bool {
 				return rel == "dir1/dir2"
 			},
-			wantExist: []string{
-				"dir1/dir2/dir3",
-				"dir1/dir2",
+			want: []string{
 				"dir1",
+				"dir1/dir2",
+				"dir1/dir2/dir3",
 			},
-			wantAbsent: nil,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -501,17 +493,30 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			if err := RemoveEmptyDirs(root, root, test.keepFunc); err != nil {
 				t.Fatal(err)
 			}
-			for _, path := range test.wantExist {
-				p := filepath.Join(root, path)
-				if _, err := os.Stat(p); err != nil {
-					t.Errorf("expected %s to exist, but got error: %v", path, err)
+			var got []string
+			if _, err := os.Stat(root); err == nil {
+				err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+					if path == root {
+						return nil
+					}
+					rel, err := filepath.Rel(root, path)
+					if err != nil {
+						return err
+					}
+					got = append(got, filepath.ToSlash(rel))
+					return nil
+				})
+				if err != nil {
+					t.Fatal(err)
 				}
 			}
-			for _, path := range test.wantAbsent {
-				p := filepath.Join(root, path)
-				if _, err := os.Stat(p); !errors.Is(err, fs.ErrNotExist) {
-					t.Errorf("expected %s to be absent, but stat got: %v", path, err)
-				}
+			slices.Sort(got)
+			slices.Sort(test.want)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -498,11 +498,9 @@ func TestRemoveEmptyDirs(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-
 			if err := RemoveEmptyDirs(root, root, test.keepFunc); err != nil {
 				t.Fatal(err)
 			}
-
 			for _, path := range test.wantExist {
 				p := filepath.Join(root, path)
 				if _, err := os.Stat(p); err != nil {

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -476,20 +476,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			root := t.TempDir()
-			for _, d := range test.setupDirs {
-				if err := os.MkdirAll(filepath.Join(root, d), 0755); err != nil {
-					t.Fatal(err)
-				}
-			}
-			for f, content := range test.setupFiles {
-				p := filepath.Join(root, f)
-				if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.WriteFile(p, []byte(content), 0644); err != nil {
-					t.Fatal(err)
-				}
-			}
+			setupDirStructure(t, root, test.setupDirs, test.setupFiles)
 			if err := RemoveEmptyDirs(root, root, test.keepFunc); err != nil {
 				t.Fatal(err)
 			}
@@ -566,4 +553,14 @@ func TestIsDirNotEmpty(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupDirStructure(t *testing.T, root string, dirs []string, files map[string]string) {
+	t.Helper()
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, d), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeTestFiles(t, root, files)
 }

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -17,9 +17,11 @@ package filesystem
 import (
 	"archive/zip"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -512,6 +514,52 @@ func TestRemoveEmptyDirs(t *testing.T) {
 				if _, err := os.Stat(p); !errors.Is(err, fs.ErrNotExist) {
 					t.Errorf("expected %s to be absent, but stat got: %v", path, err)
 				}
+			}
+		})
+	}
+}
+
+func TestIsDirNotEmpty(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("generic error"),
+			want: false,
+		},
+		{
+			name: "ENOTEMPTY",
+			err:  &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.ENOTEMPTY},
+			want: true,
+		},
+		{
+			name: "EEXIST",
+			err:  &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.EEXIST},
+			want: true,
+		},
+		{
+			name: "EACCES",
+			err:  &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.EACCES},
+			want: false,
+		},
+		{
+			name: "wrapped ENOTEMPTY",
+			err:  fmt.Errorf("failed: %w", &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.ENOTEMPTY}),
+			want: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := isDirNotEmpty(test.err)
+			if got != test.want {
+				t.Errorf("isDirNotEmpty(%v) = %v, want %v", test.err, got, test.want)
 			}
 		})
 	}

--- a/internal/librarian/java/clean.go
+++ b/internal/librarian/java/clean.go
@@ -24,9 +24,9 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"syscall"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/filesystem"
 )
 
 const (
@@ -101,7 +101,6 @@ func cleanPatterns(library *config.Library) map[string]bool {
 }
 
 func cleanPath(targetPath, root string, keepSet map[string]bool, useMarker bool) error {
-	var dirs []string
 	err := filepath.WalkDir(targetPath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -114,7 +113,6 @@ func cleanPath(targetPath, root string, keepSet map[string]bool, useMarker bool)
 			if keepSet[filepath.ToSlash(rel)] {
 				return filepath.SkipDir
 			}
-			dirs = append(dirs, path)
 			return nil
 		}
 		rel, err := filepath.Rel(root, path)
@@ -142,24 +140,10 @@ func cleanPath(targetPath, root string, keepSet map[string]bool, useMarker bool)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
-	// Remove empty directories in reverse order (bottom-up).
-	for _, dir := range slices.Backward(dirs) {
-		rel, err := filepath.Rel(root, dir)
-		if err != nil {
-			return err
-		}
-		if !keepSet[filepath.ToSlash(rel)] {
-			if err := os.Remove(dir); err != nil && !errors.Is(err, fs.ErrNotExist) && !isDirNotEmpty(err) {
-				return err
-			}
-		}
+	keepFunc := func(rel string) bool {
+		return keepSet[rel]
 	}
-	return nil
-}
-
-// isDirNotEmpty returns true if err indicates the directory is not empty.
-func isDirNotEmpty(err error) bool {
-	return errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST)
+	return filesystem.RemoveEmptyDirs(targetPath, root, keepFunc)
 }
 
 // shouldPreserve returns true if the given slash-separated path should be preserved

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -20,7 +20,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -189,52 +188,6 @@ func TestShouldCleanMarkerPath(t *testing.T) {
 		})
 	}
 }
-func TestIsDirNotEmpty(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{
-			name: "nil error",
-			err:  nil,
-			want: false,
-		},
-		{
-			name: "generic error",
-			err:  errors.New("generic error"),
-			want: false,
-		},
-		{
-			name: "ENOTEMPTY",
-			err:  &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.ENOTEMPTY},
-			want: true,
-		},
-		{
-			name: "EEXIST",
-			err:  &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.EEXIST},
-			want: true,
-		},
-		{
-			name: "EACCES",
-			err:  &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.EACCES},
-			want: false,
-		},
-		{
-			name: "wrapped ENOTEMPTY",
-			err:  fmt.Errorf("failed: %w", &os.PathError{Op: "remove", Path: "/tmp", Err: syscall.ENOTEMPTY}),
-			want: true,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := isDirNotEmpty(test.err)
-			if got != test.want {
-				t.Errorf("isDirNotEmpty(%v) = %v, want %v", test.err, got, test.want)
-			}
-		})
-	}
-}
-
 func TestCleanPatterns(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/librarian/php/clean.go
+++ b/internal/librarian/php/clean.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/filesystem"
 )
 
 const (
@@ -51,6 +52,13 @@ func Clean(library *config.Library) error {
 	}
 	for _, dir := range directoriesToClean {
 		if err := cleanFiles(library, keepSet, dir); err != nil {
+			return err
+		}
+		targetDir := filepath.Join(library.Output, dir)
+		keepFunc := func(rel string) bool {
+			return keepSet[rel]
+		}
+		if err := filesystem.RemoveEmptyDirs(targetDir, library.Output, keepFunc); err != nil {
 			return err
 		}
 	}

--- a/internal/librarian/php/clean_test.go
+++ b/internal/librarian/php/clean_test.go
@@ -274,11 +274,9 @@ func TestClean_RemovesEmptyDirectories(t *testing.T) {
 		t.Fatal(err)
 	}
 	lib.Keep = []string{"src/V1/Kept/Handwritten.php"}
-
 	if err := Clean(lib); err != nil {
 		t.Fatal(err)
 	}
-
 	dirsAbsent := []string{
 		emptyDir,
 		dirWithDeletedFile,

--- a/internal/librarian/php/clean_test.go
+++ b/internal/librarian/php/clean_test.go
@@ -250,13 +250,11 @@ func TestClean_RemovesEmptyDirectories(t *testing.T) {
 		Name:   "test",
 		Output: filepath.Join(repoRoot, "test"),
 	}
-
 	// Setup: empty directory under src
 	emptyDir := filepath.Join(lib.Output, "src", "V1", "Empty")
 	if err := os.MkdirAll(emptyDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-
 	// Setup: directory with a file that will be deleted
 	dirWithDeletedFile := filepath.Join(lib.Output, "src", "V1", "Deleted")
 	fileToDelete := filepath.Join(dirWithDeletedFile, "gapic_metadata.json")
@@ -266,7 +264,6 @@ func TestClean_RemovesEmptyDirectories(t *testing.T) {
 	if err := os.WriteFile(fileToDelete, []byte("{}"), 0644); err != nil {
 		t.Fatal(err)
 	}
-
 	// Setup: directory with a kept file
 	dirWithKeptFile := filepath.Join(lib.Output, "src", "V1", "Kept")
 	fileToKeep := filepath.Join(dirWithKeptFile, "Handwritten.php")
@@ -291,7 +288,6 @@ func TestClean_RemovesEmptyDirectories(t *testing.T) {
 			t.Errorf("expected directory %s to be deleted, but stat got: %v", d, err)
 		}
 	}
-
 	dirsExist := []string{
 		dirWithKeptFile,
 		filepath.Join(lib.Output, "src", "V1"),

--- a/internal/librarian/php/clean_test.go
+++ b/internal/librarian/php/clean_test.go
@@ -242,3 +242,64 @@ func TestClean_WalkDirError(t *testing.T) {
 		t.Errorf("Clean() error = %v, want os.ErrPermission", err)
 	}
 }
+
+func TestClean_RemovesEmptyDirectories(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	lib := &config.Library{
+		Name:   "test",
+		Output: filepath.Join(repoRoot, "test"),
+	}
+
+	// Setup: empty directory under src
+	emptyDir := filepath.Join(lib.Output, "src", "V1", "Empty")
+	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup: directory with a file that will be deleted
+	dirWithDeletedFile := filepath.Join(lib.Output, "src", "V1", "Deleted")
+	fileToDelete := filepath.Join(dirWithDeletedFile, "gapic_metadata.json")
+	if err := os.MkdirAll(dirWithDeletedFile, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileToDelete, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup: directory with a kept file
+	dirWithKeptFile := filepath.Join(lib.Output, "src", "V1", "Kept")
+	fileToKeep := filepath.Join(dirWithKeptFile, "Handwritten.php")
+	if err := os.MkdirAll(dirWithKeptFile, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileToKeep, []byte("<?php class Handwritten {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	lib.Keep = []string{"src/V1/Kept/Handwritten.php"}
+
+	if err := Clean(lib); err != nil {
+		t.Fatal(err)
+	}
+
+	dirsAbsent := []string{
+		emptyDir,
+		dirWithDeletedFile,
+	}
+	for _, d := range dirsAbsent {
+		if _, err := os.Stat(d); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("expected directory %s to be deleted, but stat got: %v", d, err)
+		}
+	}
+
+	dirsExist := []string{
+		dirWithKeptFile,
+		filepath.Join(lib.Output, "src", "V1"),
+		filepath.Join(lib.Output, "src"),
+	}
+	for _, d := range dirsExist {
+		if _, err := os.Stat(d); err != nil {
+			t.Errorf("expected directory %s to exist, but got error: %v", d, err)
+		}
+	}
+}


### PR DESCRIPTION
Empty directory cleanup is implemented for PHP client libraries. During the clean phase, after generated files are deleted, any resulting empty subdirectories within the source, tests, metadata, and samples directories are now removed.

To support this, a shared RemoveEmptyDirs helper is extracted into the internal/filesystem package. This helper is also used to refactor the Java cleanup logic.

For https://github.com/googleapis/librarian/issues/6659