### PR TITLE
feat(sidekick/rust): make request builder fields `pub(crate)` for gapic extensions

### DIFF
--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -49,6 +49,7 @@ type methodAnnotation struct {
 	IsBigQueryInsertJob       bool
 	ClientSideStreaming       bool
 	ServerSideStreaming       bool
+	IsBigQueryV2              bool
 }
 
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
@@ -322,6 +323,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		IsBigQueryInsertJob:       m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob",
 		ClientSideStreaming:       m.ClientSideStreaming,
 		ServerSideStreaming:       m.ServerSideStreaming,
+		IsBigQueryV2:              m.Service != nil && m.Service.Package == "google.cloud.bigquery.v2",
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {

--- a/internal/sidekick/rust/annotate_service.go
+++ b/internal/sidekick/rust/annotate_service.go
@@ -58,6 +58,8 @@ type serviceAnnotations struct {
 	InternalBuilders bool
 	// If true, the service has at least one bidirectional streaming RPC in the API definition.
 	HasBidiStreaming bool
+	// If true, this is the BigQuery v2 service.
+	IsBigQueryV2 bool
 }
 
 // BuilderVisibility returns the visibility for client and request builders.
@@ -142,6 +144,7 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
 		HasBidiStreaming:          hasBidiStreaming,
+		IsBigQueryV2:              s.Package == "google.cloud.bigquery.v2",
 	}
 	s.Codec = ann
 	return ann, nil

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -62,9 +62,9 @@ pub mod {{Codec.ModuleName}} {
     /// Common implementation for [crate::client::{{Codec.Name}}] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
-        stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
-        request: R,
-        options: crate::RequestOptions,
+        pub(crate) stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
+        pub(crate) request: R,
+        pub(crate) options: crate::RequestOptions,
     }
 
     impl<R> RequestBuilder<R>
@@ -117,7 +117,7 @@ pub mod {{Codec.ModuleName}} {
     /// ```
     {{/Codec.InternalBuilders}}
     #[derive(Clone, Debug)]
-    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
+    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(pub(crate) RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -62,9 +62,9 @@ pub mod {{Codec.ModuleName}} {
     /// Common implementation for [crate::client::{{Codec.Name}}] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
-        pub(crate) stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
-        pub(crate) request: R,
-        pub(crate) options: crate::RequestOptions,
+        {{#Codec.IsBigQueryV2}}pub(crate) {{/Codec.IsBigQueryV2}}stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
+        {{#Codec.IsBigQueryV2}}pub(crate) {{/Codec.IsBigQueryV2}}request: R,
+        {{#Codec.IsBigQueryV2}}pub(crate) {{/Codec.IsBigQueryV2}}options: crate::RequestOptions,
     }
 
     impl<R> RequestBuilder<R>
@@ -117,7 +117,7 @@ pub mod {{Codec.ModuleName}} {
     /// ```
     {{/Codec.InternalBuilders}}
     #[derive(Clone, Debug)]
-    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(pub(crate) RequestBuilder<{{InputType.Codec.QualifiedName}}>);
+    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}({{#Service.Codec.IsBigQueryV2}}pub(crate) {{/Service.Codec.IsBigQueryV2}}RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {


### PR DESCRIPTION
Expose the internal `RequestBuilder` on generated builders like `InsertJob`. 

By exposing these fields to the rest of the crate, handwritten extensions `src/operation.rs` can directly inspect requests.

Staged @ https://github.com/googleapis/google-cloud-rust/pull/6120