### PR TITLE
fix(internal/librarian/java): customize README template for storage library dual dependencies

### DIFF
--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -913,6 +913,17 @@ func TestRenderREADME(t *testing.T) {
 			},
 			goldenFile: filepath.Join("testdata", "readme", "partials.golden"),
 		},
+		{
+			name: "renders storage README with dual dependencies",
+			setupParams: func(p *libraryPostProcessParams) {
+				meta := *p.metadata
+				meta.DistributionName = "com.google.cloud:google-cloud-storage"
+				meta.NamePretty = "Storage"
+				meta.APIShortname = "storage"
+				p.metadata = &meta
+			},
+			goldenFile: filepath.Join("testdata", "readme", "storage.golden"),
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()

--- a/internal/librarian/java/template/README.md.go.tmpl
+++ b/internal/librarian/java/template/README.md.go.tmpl
@@ -42,6 +42,13 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <groupId>{{ .GroupID }}</groupId>
     <artifactId>{{ .ArtifactID }}</artifactId>
   </dependency>
+  {{- if eq .ArtifactID "google-cloud-storage" }}
+  {{- /* java-storage contains both storage and storage-control, which must both be listed in the README. */}}
+  <dependency>
+    <groupId>{{ .GroupID }}</groupId>
+    <artifactId>google-cloud-storage-control</artifactId>
+  </dependency>
+  {{- end }}
 </dependencies>
 ```
 
@@ -55,6 +62,13 @@ If you are using Maven without the BOM, add this to your dependencies:
   <artifactId>{{ .ArtifactID }}</artifactId>
   <version>{{ .Version }}</version>
 </dependency>
+{{- if eq .ArtifactID "google-cloud-storage" }}
+<dependency>
+  <groupId>{{ .GroupID }}</groupId>
+  <artifactId>google-cloud-storage-control</artifactId>
+  <version>{{ .Version }}</version>
+</dependency>
+{{- end }}
 ```
 
 {{ if or (eq .GroupID "com.google.cloud") (eq .GroupID "com.google.analytics") (eq .GroupID "com.google.area120") -}}

--- a/internal/librarian/java/testdata/readme/storage.golden
+++ b/internal/librarian/java/testdata/readme/storage.golden
@@ -1,0 +1,209 @@
+# Google Storage Client for Java
+
+Java idiomatic client for [Storage][product-docs].
+
+[![Maven][maven-version-image]][maven-version-link]
+![Stability][stability-image]
+
+- [Product Documentation][product-docs]
+- [Client Library Documentation][javadocs]
+
+
+## Quickstart
+
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>1.0.0-BOM</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-storage</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-storage-control</artifactId>
+  </dependency>
+</dependencies>
+```
+
+If you are using Maven without the BOM, add this to your dependencies:
+
+
+```xml
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-storage</artifactId>
+  <version>1.2.3-LIB</version>
+</dependency>
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-storage-control</artifactId>
+  <version>1.2.3-LIB</version>
+</dependency>
+```
+
+If you are using Gradle 5.x or later, add this to your dependencies:
+
+```Groovy
+implementation platform('com.google.cloud:libraries-bom:1.0.0-BOM')
+
+implementation 'com.google.cloud:google-cloud-storage'
+```
+
+If you are using Gradle without BOM, add this to your dependencies:
+
+```Groovy
+implementation 'com.google.cloud:google-cloud-storage:1.2.3-LIB'
+```
+
+If you are using SBT, add this to your dependencies:
+
+```Scala
+libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "1.2.3-LIB"
+```
+
+## Authentication
+
+See the [Authentication][authentication] section in the base directory's README.
+
+## Authorization
+
+The client application making API calls must be granted [authorization scopes][auth-scopes] required for the desired Storage APIs, and the authenticated principal must have the [IAM role(s)][predefined-iam-roles] required to access GCP resources using the Storage API calls.
+
+## Getting Started
+
+### Prerequisites
+
+You will need a [Google Cloud Platform Console][developer-console] project with the Storage [API enabled][enable-api].
+
+[Follow these instructions][create-project] to get your project set up. You will also need to set up the local development environment by
+[installing the Google Cloud Command Line Interface][cloud-cli] and running the following commands in command line:
+`gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
+
+### Installation and setup
+
+You'll need to obtain the `google-cloud-storage` library.  See the [Quickstart](#quickstart) section
+to add `google-cloud-storage` as a dependency in your code.
+
+## About Storage
+
+
+[Storage][product-docs] 
+
+See the [Storage client library docs][javadocs] to learn how to
+use this Storage Client Library.
+
+
+
+
+
+
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document][troubleshooting].
+
+## Supported Java Versions
+
+Java 8 or above is required for using this client.
+
+Google's Java client libraries,
+[Google Cloud Client Libraries][cloudlibs]
+and
+[Google Cloud API Libraries][apilibs],
+follow the
+[Oracle Java SE support roadmap][oracle]
+(see the Oracle Java SE Product Releases section).
+
+### For new development
+
+In general, new feature development occurs with support for the lowest Java
+LTS version covered by  Oracle's Premier Support (which typically lasts 5 years
+from initial General Availability). If the minimum required JVM for a given
+library is changed, it is accompanied by a [semver][semver] major release.
+
+Java 11 and (in September 2021) Java 17 are the best choices for new
+development.
+
+### Keeping production systems current
+
+Google tests its client libraries with all current LTS versions covered by
+Oracle's Extended Support (which typically lasts 8 years from initial
+General Availability).
+
+#### Legacy support
+
+Google's client libraries support legacy versions of Java runtimes with long
+term stable libraries that don't receive feature updates on a best efforts basis
+as it may not be possible to backport all patches.
+
+Google provides updates on a best efforts basis to apps that continue to use
+Java 7, though apps might need to upgrade to current versions of the library
+that supports their JVM.
+
+#### Where to find specific information
+
+The latest versions and the supported Java versions are identified on
+the individual GitHub repository `github.com/GoogleAPIs/java-SERVICENAME`
+and on [google-cloud-java][g-c-j].
+
+## Versioning
+This library follows [Semantic Versioning](http://semver.org/).
+
+
+
+## Contributing
+
+
+Contributions to this library are always welcome and highly encouraged.
+
+See [CONTRIBUTING][contributing] for more information how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in
+this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more
+information.
+
+
+## License
+
+Apache 2.0 - See [LICENSE][license] for more information.
+
+Java is a registered trademark of Oracle and/or its affiliates.
+
+[product-docs]: 
+[javadocs]: 
+[stability-image]: https://img.shields.io/badge/stability-unknown-red
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/1.2.3-LIB
+[authentication]: https://github.com/googleapis/google-cloud-java#authentication
+[auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
+[predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles
+[iam-policy]: https://cloud.google.com/iam/docs/overview#cloud-iam-policy
+[developer-console]: https://console.developers.google.com/
+[create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+[cloud-cli]: https://cloud.google.com/cli
+[troubleshooting]: https://github.com/googleapis/google-cloud-java/blob/main/TROUBLESHOOTING.md
+[contributing]: https://github.com/googleapis/google-cloud-java/blob/main/CONTRIBUTING.md
+[code-of-conduct]: https://github.com/googleapis/google-cloud-java/blob/main/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[license]: https://github.com/googleapis/google-cloud-java/blob/main/LICENSE
+
+
+[libraries-bom]: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+
+[semver]: https://semver.org/
+[cloudlibs]: https://cloud.google.com/apis/docs/client-libraries-explained
+[apilibs]: https://cloud.google.com/apis/docs/client-libraries-explained#google_api_client_libraries
+[oracle]: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
+[g-c-j]: http://github.com/googleapis/google-cloud-java


### PR DESCRIPTION
The  java-storage library contains both storage and storage-control. modify README template to list both in the dependencies section. Add unit test for it.

For https://github.com/googleapis/librarian/issues/6931