### PR TITLE
ci(go): add presubmit smoke test for go, and refactor go.yaml

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,7 +40,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
-
       - name: Checkout google-cloud-go
         if: matrix.task != 'unit-test'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -48,26 +47,21 @@ jobs:
           repository: googleapis/google-cloud-go
           path: google-cloud-go
           persist-credentials: false
-
       - name: Run librarian install
         if: matrix.task != 'unit-test'
         working-directory: google-cloud-go
         run: librarian install
-
       - name: Run Unit Tests
         if: matrix.task == 'unit-test'
         run: go run ./tool/cmd/coverage ./internal/librarian/golang
-
       - name: Generate a single library (smoke test)
         if: matrix.task == 'smoke-test'
         working-directory: google-cloud-go
         run: librarian generate secretmanager
-
       - name: Run librarian generate all (integration test)
         if: matrix.task == 'integration' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: google-cloud-go
         run: librarian generate --all
-
   create-issue-on-failure:
     needs: [build-and-test]
     permissions:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,7 +22,6 @@ jobs:
     # Presubmit jobs must complete within 5 minutes. Integration might take longer.
     timeout-minutes: ${{ matrix.timeout }}
     # Skip integration test unless it's a push to main
-    if: matrix.task != 'integration' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +64,7 @@ jobs:
         run: librarian generate secretmanager
 
       - name: Run librarian generate all (integration test)
-        if: matrix.task == 'integration'
+        if: matrix.task == 'integration' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: google-cloud-go
         run: librarian generate --all
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,39 +16,61 @@ on: [push, pull_request, merge_group]
 permissions:
   contents: read
 jobs:
-  test:
+  build-and-test:
+    name: ${{ matrix.job-name }}
     runs-on: ubuntu-24.04
-    # Presubmit jobs must complete within 5 minutes. See CONTRIBUTING.md.
-    timeout-minutes: 5
+    # Presubmit jobs must complete within 5 minutes. Integration might take longer.
+    timeout-minutes: ${{ matrix.timeout }}
+    # Skip integration test unless it's a push to main
+    if: matrix.task != 'integration' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - job-name: 'Unit Tests'
+            task: 'unit-test'
+            timeout: 5
+          - job-name: 'Smoke Test'
+            task: 'smoke-test'
+            timeout: 5
+          - job-name: 'Integration Test'
+            task: 'integration'
+            timeout: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
-      - name: Run tests
-        run: go run ./tool/cmd/coverage ./internal/librarian/golang
-  integration:
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-librarian
+
       - name: Checkout google-cloud-go
+        if: matrix.task != 'unit-test'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: googleapis/google-cloud-go
           path: google-cloud-go
           persist-credentials: false
+
       - name: Run librarian install
+        if: matrix.task != 'unit-test'
         working-directory: google-cloud-go
         run: librarian install
-      - name: Run librarian generate
+
+      - name: Run Unit Tests
+        if: matrix.task == 'unit-test'
+        run: go run ./tool/cmd/coverage ./internal/librarian/golang
+
+      - name: Generate a single library (smoke test)
+        if: matrix.task == 'smoke-test'
+        working-directory: google-cloud-go
+        run: librarian generate secretmanager
+
+      - name: Run librarian generate all (integration test)
+        if: matrix.task == 'integration'
         working-directory: google-cloud-go
         run: librarian generate --all
+
   create-issue-on-failure:
-    needs: [integration]
+    needs: [build-and-test]
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
This change modifies Librarian to use a matrix strategy for the Go tests in order to share setup instructions across unit, smoke, and integration tests. It also adds a smoke test for presubmits

For #6815 