### PR TITLE
chore(internal/config): introduce RubyCloudOpts struct for ruby_cloud_opts field

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -493,8 +493,8 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `env_prefix` | string | Is the environment variable prefix. |
-| `extra_dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
+| `ruby-cloud-env-prefix` | string | Is the environment variable prefix. |
+| `ruby-cloud-extra-dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
 
 ## RubyPackage Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -487,6 +487,12 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `ruby_cloud_opts` | [RubyCloudOpts](#rubycloudopts-configuration) (optional) | Contains options passed to the Ruby Cloud GAPIC generator. |
+
+## RubyCloudOpts Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
 | `env_prefix` | string | Is the environment variable prefix. |
 | `extra_dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -487,7 +487,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `ruby_cloud_opts` | [RubyCloudOpts](#rubycloudopts-configuration) (optional) | Contains options passed to the Ruby Cloud GAPIC generator. |
+| `ruby_cloud_opts` | [RubyCloudOpts](#rubycloudopts-configuration) (optional) | Contains options passed to the Ruby Cloud GAPIC generator as the `--ruby_cloud_opt` option. |
 
 ## RubyCloudOpts Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -850,10 +850,10 @@ type RubyPackage struct {
 // RubyCloudOpts contains options passed to the Ruby Cloud GAPIC generator.
 type RubyCloudOpts struct {
 	// EnvPrefix is the environment variable prefix.
-	EnvPrefix string `yaml:"env_prefix,omitempty"`
+	EnvPrefix string `yaml:"ruby-cloud-env-prefix,omitempty"`
 
 	// ExtraDependencies contains extra runtime dependencies to the .gemspec file.
-	ExtraDependencies string `yaml:"extra_dependencies,omitempty"`
+	ExtraDependencies string `yaml:"ruby-cloud-extra-dependencies,omitempty"`
 }
 
 // RubyAPI represents configuration for a single API within a Ruby package.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -847,8 +847,8 @@ type RubyPackage struct {
 	WrapperOf []string `yaml:"wrapper_of,omitempty"`
 }
 
-// RubyCloudOpts contains options passed to the Ruby Cloud GAPIC generator.
-// The library entries in the librarian.yaml holds the exact parameter names passed to GAPIC Generator Ruby.
+// RubyCloudOpts contains the options passed to the `--ruby_cloud_opt` argument of GAPIC generator Ruby.
+// The library entries in the librarian.yaml holds the exact parameter names appearing in the option value.
 type RubyCloudOpts struct {
 	// EnvPrefix is the environment variable prefix.
 	EnvPrefix string `yaml:"ruby-cloud-env-prefix,omitempty"`

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -847,11 +847,17 @@ type RubyPackage struct {
 	WrapperOf []string `yaml:"wrapper_of,omitempty"`
 }
 
-// RubyAPI represents configuration for a single API within a Ruby package.
-type RubyAPI struct {
+// RubyCloudOpts contains options passed to the Ruby Cloud GAPIC generator.
+type RubyCloudOpts struct {
 	// EnvPrefix is the environment variable prefix.
 	EnvPrefix string `yaml:"env_prefix,omitempty"`
 
 	// ExtraDependencies contains extra runtime dependencies to the .gemspec file.
 	ExtraDependencies string `yaml:"extra_dependencies,omitempty"`
+}
+
+// RubyAPI represents configuration for a single API within a Ruby package.
+type RubyAPI struct {
+	// RubyCloudOpts contains options passed to the Ruby Cloud GAPIC generator.
+	RubyCloudOpts *RubyCloudOpts `yaml:"ruby_cloud_opts,omitempty"`
 }

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -848,7 +848,7 @@ type RubyPackage struct {
 }
 
 // RubyCloudOpts contains the options passed to the `--ruby_cloud_opt` argument of GAPIC generator Ruby.
-// The library entries in the librarian.yaml holds the exact parameter names appearing in the option value.
+// The library entries in the librarian.yaml hold the exact parameter names appearing in the option value.
 type RubyCloudOpts struct {
 	// EnvPrefix is the environment variable prefix.
 	EnvPrefix string `yaml:"ruby-cloud-env-prefix,omitempty"`

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -859,6 +859,6 @@ type RubyCloudOpts struct {
 
 // RubyAPI represents configuration for a single API within a Ruby package.
 type RubyAPI struct {
-	// RubyCloudOpts contains options passed to the Ruby Cloud GAPIC generator.
+	// RubyCloudOpts contains options passed to the Ruby Cloud GAPIC generator as the `--ruby_cloud_opt` option.
 	RubyCloudOpts *RubyCloudOpts `yaml:"ruby_cloud_opts,omitempty"`
 }

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -848,6 +848,7 @@ type RubyPackage struct {
 }
 
 // RubyCloudOpts contains options passed to the Ruby Cloud GAPIC generator.
+// The library entries in the librarian.yaml holds the exact parameter names passed to GAPIC Generator Ruby.
 type RubyCloudOpts struct {
 	// EnvPrefix is the environment variable prefix.
 	EnvPrefix string `yaml:"ruby-cloud-env-prefix,omitempty"`

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -63,7 +63,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	// TODO(https://github.com/googleapis/librarian/issues/6885): Implement main client gem wrapper generation
 	// for libraries configured with `ruby.wrapper_of`.
 	for _, api := range library.APIs {
-		if err := generateAPI(ctx, api.Path, library.Name, pc, googleapisDir, tempDir); err != nil {
+		if err := generateAPI(ctx, api, library.Name, pc, googleapisDir, tempDir); err != nil {
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
@@ -73,12 +73,12 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
-func generateAPI(ctx context.Context, apiPath, gemName string, pc *config.Protoc, googleapisDir, stagingDir string) error {
-	protoFiles, err := collectProtoFiles(googleapisDir, apiPath)
+func generateAPI(ctx context.Context, api *config.API, gemName string, pc *config.Protoc, googleapisDir, stagingDir string) error {
+	protoFiles, err := collectProtoFiles(googleapisDir, api.Path)
 	if err != nil {
 		return err
 	}
-	gapicOpts, err := buildGAPICOpts(apiPath, gemName, googleapisDir)
+	gapicOpts, err := buildGAPICOpts(api, gemName, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -106,12 +106,15 @@ func generateAPI(ctx context.Context, apiPath, gemName string, pc *config.Protoc
 	return protoc.RunOrSystem(ctx, env, pc, args...)
 }
 
-func buildGAPICOpts(apiPath, gemName, googleapisDir string) ([]string, error) {
-	sc, err := serviceconfig.Find(googleapisDir, apiPath, config.LanguageRuby)
+func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, error) {
+	if api == nil {
+		return nil, errors.New("api is nil")
+	}
+	sc, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
 	if err != nil {
 		return nil, err
 	}
-	gc, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, apiPath)
+	gc, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -130,6 +133,14 @@ func buildGAPICOpts(apiPath, gemName, googleapisDir string) ([]string, error) {
 	}
 	if sc != nil && sc.HasRESTNumericEnums(config.LanguageRuby) {
 		opts = append(opts, "ruby-cloud-rest-numeric-enums=true")
+	}
+	if api.Ruby != nil && api.Ruby.RubyCloudOpts != nil {
+		if api.Ruby.RubyCloudOpts.EnvPrefix != "" {
+			opts = append(opts, "ruby-cloud-env-prefix="+api.Ruby.RubyCloudOpts.EnvPrefix)
+		}
+		if api.Ruby.RubyCloudOpts.ExtraDependencies != "" {
+			opts = append(opts, "ruby-cloud-extra-dependencies="+api.Ruby.RubyCloudOpts.ExtraDependencies)
+		}
 	}
 	return opts, nil
 }

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -107,9 +107,6 @@ func generateAPI(ctx context.Context, api *config.API, gemName string, pc *confi
 }
 
 func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, error) {
-	if api == nil {
-		return nil, errors.New("api is nil")
-	}
 	sc, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
 	if err != nil {
 		return nil, err

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -39,13 +39,15 @@ func TestBuildGAPICOpts(t *testing.T) {
 
 	for _, test := range []struct {
 		name    string
-		apiPath string
+		api     *config.API
 		gemName string
 		want    []string
 	}{
 		{
-			name:    "basic case with service and grpc configs",
-			apiPath: "google/cloud/secretmanager/v1",
+			name: "basic case with service and grpc configs",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+			},
 			gemName: "google-cloud-secret_manager-v1",
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
@@ -56,8 +58,10 @@ func TestBuildGAPICOpts(t *testing.T) {
 			},
 		},
 		{
-			name:    "rest transport from sdk.yaml",
-			apiPath: "google/cloud/compute/v1",
+			name: "rest transport from sdk.yaml",
+			api: &config.API{
+				Path: "google/cloud/compute/v1",
+			},
 			gemName: "google-cloud-compute-v1",
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-compute-v1",
@@ -66,9 +70,31 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"ruby-cloud-rest-numeric-enums=true",
 			},
 		},
+		{
+			name: "ruby_cloud_opts with env_prefix and extra_dependencies",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Ruby: &config.RubyAPI{
+					RubyCloudOpts: &config.RubyCloudOpts{
+						EnvPrefix:         "MY_PREFIX",
+						ExtraDependencies: "foo=1.0",
+					},
+				},
+			},
+			gemName: "google-cloud-secret_manager-v1",
+			want: []string{
+				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
+				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
+				"transport=grpc+rest",
+				"ruby-cloud-rest-numeric-enums=true",
+				"ruby-cloud-env-prefix=MY_PREFIX",
+				"ruby-cloud-extra-dependencies=foo=1.0",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := buildGAPICOpts(test.apiPath, test.gemName, googleapisDir)
+			got, err := buildGAPICOpts(test.api, test.gemName, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -347,10 +373,10 @@ func TestGenerateAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 	stagingDir := t.TempDir()
-	apiPath := "google/cloud/secretmanager/v1"
+	api := &config.API{Path: "google/cloud/secretmanager/v1"}
 	gemName := "google-cloud-secret_manager-v1"
 
-	err = generateAPI(t.Context(), apiPath, gemName, nil, googleapisDir, stagingDir)
+	err = generateAPI(t.Context(), api, gemName, nil, googleapisDir, stagingDir)
 	if err != nil {
 		t.Fatalf("generateAPI() error = %v", err)
 	}
@@ -365,7 +391,8 @@ func TestGenerateAPI_Error(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = generateAPI(t.Context(), "non/existent/path", "gem-name", nil, googleapisDir, t.TempDir())
+	api := &config.API{Path: "non/existent/path"}
+	err = generateAPI(t.Context(), api, "gem-name", nil, googleapisDir, t.TempDir())
 	if err == nil {
 		t.Error("generateAPI() error = nil, want error")
 	}

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -70,28 +70,6 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"ruby-cloud-rest-numeric-enums=true",
 			},
 		},
-		{
-			name: "ruby_cloud_opts with env_prefix and extra_dependencies",
-			api: &config.API{
-				Path: "google/cloud/secretmanager/v1",
-				Ruby: &config.RubyAPI{
-					RubyCloudOpts: &config.RubyCloudOpts{
-						EnvPrefix:         "MY_PREFIX",
-						ExtraDependencies: "foo=1.0",
-					},
-				},
-			},
-			gemName: "google-cloud-secret_manager-v1",
-			want: []string{
-				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
-				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
-				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
-				"transport=grpc+rest",
-				"ruby-cloud-rest-numeric-enums=true",
-				"ruby-cloud-env-prefix=MY_PREFIX",
-				"ruby-cloud-extra-dependencies=foo=1.0",
-			},
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := buildGAPICOpts(test.api, test.gemName, googleapisDir)

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -131,10 +131,12 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 			if err != nil {
 				return nil, err
 			}
-			if vb != nil {
+			if vb != nil && (vb.EnvPrefix != "" || vb.ExtraDeps != "") {
 				lib.APIs[0].Ruby = &config.RubyAPI{
-					EnvPrefix:         vb.EnvPrefix,
-					ExtraDependencies: vb.ExtraDeps,
+					RubyCloudOpts: &config.RubyCloudOpts{
+						EnvPrefix:         vb.EnvPrefix,
+						ExtraDependencies: vb.ExtraDeps,
+					},
 				}
 			}
 		}

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -96,8 +96,10 @@ func TestFindRubyLibraries(t *testing.T) {
 				{
 					Path: "google/cloud/compute/v1",
 					Ruby: &config.RubyAPI{
-						EnvPrefix:         "COMPUTE",
-						ExtraDependencies: "google-cloud-common=~> 1.0",
+						RubyCloudOpts: &config.RubyCloudOpts{
+							EnvPrefix:         "COMPUTE",
+							ExtraDependencies: "google-cloud-common=~> 1.0",
+						},
 					},
 				},
 			},
@@ -116,7 +118,9 @@ func TestFindRubyLibraries(t *testing.T) {
 				{
 					Path: "google/cloud/secretmanager/v1",
 					Ruby: &config.RubyAPI{
-						EnvPrefix: "SECRET_MANAGER",
+						RubyCloudOpts: &config.RubyCloudOpts{
+							EnvPrefix: "SECRET_MANAGER",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Introduce `RubyCloudOpts` struct under `RubyAPI` to support the `apis[].ruby_cloud_opts` field in librarian configuration, moving `env_prefix` and `extra_dependencies` fields into `RubyCloudOpts`.

For #6632