### PR TITLE
fix(internal/librarian/python): gapic-generator 1.37.1

### DIFF
--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -19,7 +19,7 @@ language: python
 tools:
   pip:
     - name: gapic-generator
-      version: "1.36.0"
+      version: "1.37.1"
     - name: nox
       version: "2025.11.12"
     - name: ruff


### PR DESCRIPTION
For https://github.com/googleapis/librarian/issues/6967.