### PR TITLE
feat(internal/librarian/php): implement add command support

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
@@ -161,6 +162,8 @@ func deriveLibraryName(language string, api string) string {
 		return rust.DefaultLibraryName(api)
 	case config.LanguageSwift:
 		return swift.DefaultLibraryName(api)
+	case config.LanguagePhp:
+		return php.DefaultLibraryName(api)
 	default:
 		return strings.ReplaceAll(api, "/", "-")
 	}
@@ -258,6 +261,8 @@ func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config,
 		lib = rust.Add(lib)
 	case config.LanguageSwift:
 		lib = swift.Add(lib, cfg)
+	case config.LanguagePhp:
+		lib = php.Add(lib)
 	case config.LanguageFake:
 		lib = fakeAdd(lib, defaultVersion)
 	}
@@ -290,6 +295,9 @@ func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api 
 		if err != nil {
 			return "", nil, err
 		}
+	case config.LanguagePhp:
+		existingLib.APIs = append(existingLib.APIs, api)
+		existingLib = php.Add(existingLib)
 	default:
 		return "", nil, fmt.Errorf("%w: %s", errLibraryAlreadyExists, existingLib.Name)
 	}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -591,6 +591,9 @@ func TestDeriveLibraryName(t *testing.T) {
 		{config.LanguageNodejs, "google/cloud/secretmanager/v1beta2", "google-cloud-secretmanager"},
 		{config.LanguageNodejs, "google/cloud/storage/v2alpha", "google-cloud-storage"},
 		{config.LanguageNodejs, "google/maps/addressvalidation/v1", "google-maps-addressvalidation"},
+		{config.LanguagePhp, "google/cloud/secretmanager/v1", "Secretmanager"},
+		{config.LanguagePhp, "google/cloud/security/privateca/v1", "SecurityPrivateca"},
+		{config.LanguagePhp, "google/pubsub/v1", "Pubsub"},
 	} {
 		t.Run(test.language+"/"+test.apiPath, func(t *testing.T) {
 			got := deriveLibraryName(test.language, test.apiPath)

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"path"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+	"github.com/iancoleman/strcase"
+)
+
+// DefaultLibraryName derives the library name (component name) for PHP purely from the API path.
+// E.g., "google/cloud/speech/v2" -> "Speech"
+// E.g., "google/cloud/security/privateca/v1" -> "SecurityPrivateca".
+func DefaultLibraryName(apiPath string) string {
+	apiPath = strings.TrimPrefix(apiPath, "google/cloud/")
+	apiPath = strings.TrimPrefix(apiPath, "google/")
+	if serviceconfig.ExtractVersion(apiPath) != "" {
+		apiPath = path.Dir(apiPath)
+	}
+	// Replace slash with underscore for strcase.ToCamel to handle nested paths
+	apiPath = strings.ReplaceAll(apiPath, "/", "_")
+	return strcase.ToCamel(apiPath)
+}
+
+// Add populates PHP-specific default configuration for all APIs in the library.
+func Add(lib *config.Library) *config.Library {
+	for _, api := range lib.APIs {
+		if api.PHP == nil {
+			api.PHP = &config.PHPAPI{}
+		}
+		if api.PHP.StagingSubdir == "" {
+			api.PHP.StagingSubdir = serviceconfig.ExtractVersion(api.Path)
+		}
+		if api.PHP.MigrationMode == "" {
+			api.PHP.MigrationMode = "NEW_SURFACE_ONLY"
+		}
+	}
+	return lib
+}

--- a/internal/librarian/php/add_test.go
+++ b/internal/librarian/php/add_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestDefaultLibraryName(t *testing.T) {
+	for _, test := range []struct {
+		apiPath string
+		want    string
+	}{
+		{
+			apiPath: "google/cloud/speech/v2",
+			want:    "Speech",
+		},
+		{
+			apiPath: "google/cloud/security/privateca/v1",
+			want:    "SecurityPrivateca",
+		},
+		{
+			apiPath: "google/cloud/bigquery/datatransfer/v1",
+			want:    "BigqueryDatatransfer",
+		},
+		{
+			apiPath: "google/pubsub/v1",
+			want:    "Pubsub",
+		},
+		{
+			apiPath: "google/cloud/vision",
+			want:    "Vision",
+		},
+		{
+			apiPath: "google/cloud/vision/v1",
+			want:    "Vision",
+		},
+		{
+			apiPath: "google/cloud/vision/v1p1beta1",
+			want:    "Vision",
+		},
+	} {
+		t.Run(test.apiPath, func(t *testing.T) {
+			got := DefaultLibraryName(test.apiPath)
+			if got != test.want {
+				t.Errorf("DefaultLibraryName(%q) = %q, want %q", test.apiPath, got, test.want)
+			}
+		})
+	}
+}
+
+func TestAdd(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want *config.Library
+	}{
+		{
+			name: "empty php config",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/speech/v2"},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/speech/v2",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v2",
+							MigrationMode: "NEW_SURFACE_ONLY",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "existing php config preserved",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/speech/v2",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "custom_subdir",
+							MigrationMode: "MIGRATED",
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/speech/v2",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "custom_subdir",
+							MigrationMode: "MIGRATED",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple APIs",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/speech/v2"},
+					{Path: "google/cloud/speech/v2beta1"},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/speech/v2",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v2",
+							MigrationMode: "NEW_SURFACE_ONLY",
+						},
+					},
+					{
+						Path: "google/cloud/speech/v2beta1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v2beta1",
+							MigrationMode: "NEW_SURFACE_ONLY",
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Add(test.lib)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Add() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Initial support PHP for librarian add command. The default library name (component name) is derived from the API path by stripping known prefixes and version suffixes, and converting the remaining path to CamelCase (e.g., google/cloud/security/privateca/v1 becomes SecurityPrivateca). 
PHP-specific default configurations like staging_subdir and migration_mode are automatically populated.

We are aware that this naive deriving logic is problematic for PHP. This provides a base skeleton to evolve on according to decision in https://github.com/googleapis/librarian/issues/6972#issuecomment-5050268191.

For #6972