### PR TITLE
refactor(global): convert legacy octal literals to modern style

### DIFF
--- a/cmd/config_doc_generate_test.go
+++ b/cmd/config_doc_generate_test.go
@@ -290,13 +290,13 @@ type Alpha struct {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(dir, "config.go"), []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "config.go"), []byte(configContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "other.go"), []byte(otherContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "other.go"), []byte(otherContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module config\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module config\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -165,7 +165,7 @@ func lookPath(cmdName string, pathEnv string) (string, error) {
 		}
 		commandPath := filepath.Join(dir, cmdName)
 		if fileInfo, err := os.Stat(commandPath); err == nil && !fileInfo.IsDir() {
-			if filepath.Separator != '\\' && fileInfo.Mode().Perm()&0111 == 0 {
+			if filepath.Separator != '\\' && fileInfo.Mode().Perm()&0o111 == 0 {
 				continue
 			}
 			return filepath.Abs(commandPath)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -258,7 +258,7 @@ func TestLookPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	exeName := "test-exe"
 	exePath := filepath.Join(tmpDir, exeName)
-	if err := os.WriteFile(exePath, []byte("dummy binary content"), 0755); err != nil {
+	if err := os.WriteFile(exePath, []byte("dummy binary content"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, test := range []struct {
@@ -307,7 +307,7 @@ func TestLookPath(t *testing.T) {
 func TestLookPath_Error(t *testing.T) {
 	tmpDir := t.TempDir()
 	dirName := "test-dir"
-	if err := os.WriteFile(filepath.Join(tmpDir, dirName), []byte("non-executable file"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, dirName), []byte("non-executable file"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/docuploader/archive_test.go
+++ b/internal/docuploader/archive_test.go
@@ -48,10 +48,10 @@ func TestCreateArchive(t *testing.T) {
 	}
 	for _, path := range paths {
 		fullPath := filepath.Join(dir, path)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(fullPath, []byte{}, 0644); err != nil {
+		if err := os.WriteFile(fullPath, []byte{}, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -125,7 +125,7 @@ func Repo(ctx context.Context, repo, commit, expectedSHA256 string) (string, err
 		sha, err := computeSHA256(tgz)
 		if err == nil {
 			if sha == expectedSHA256 {
-				if err := os.MkdirAll(outDir, 0755); err != nil {
+				if err := os.MkdirAll(outDir, 0o755); err != nil {
 					return "", fmt.Errorf("failed creating %q: %w", outDir, err)
 				}
 				if err := extractTarball(tgz, outDir); err == nil {
@@ -140,10 +140,10 @@ func Repo(ctx context.Context, repo, commit, expectedSHA256 string) (string, err
 
 	// Step 3: Download tarball, compute SHA256, verify against expected, extract.
 	sourceURL := fmt.Sprintf("https://%s/archive/%s.tar.gz", repo, commit)
-	if err := os.MkdirAll(filepath.Dir(tgz), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(tgz), 0o755); err != nil {
 		return "", fmt.Errorf("failed creating %q: %w", filepath.Dir(tgz), err)
 	}
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return "", fmt.Errorf("failed creating %q: %w", outDir, err)
 	}
 	if err := Download(ctx, tgz, sourceURL, expectedSHA256); err != nil {
@@ -296,7 +296,7 @@ func Download(ctx context.Context, target, url, expectedSHA256 string) error {
 	if expectedSHA256 == "" {
 		return errMissingSHA256
 	}
-	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return err
 	}
 	tempFile, err := os.CreateTemp(filepath.Dir(target), "temp-")
@@ -431,11 +431,11 @@ func extractTarball(tarballPath, destDir string) error {
 		target := filepath.Join(destDir, name)
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
+			if err := os.MkdirAll(target, 0o755); err != nil {
 				return err
 			}
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
 
@@ -460,7 +460,7 @@ func extractTarball(tarballPath, destDir string) error {
 			if err != nil || strings.Contains(relLink, "..") {
 				return fmt.Errorf("%w: symlink target %q escapes destination directory %q", errSymlinkEscape, linkTarget, destDir)
 			}
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
 			if err := os.Symlink(linkTarget, target); err != nil {

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -65,10 +65,10 @@ func TestTarballPath(t *testing.T) {
 func TestExtractedDir(t *testing.T) {
 	cachedir := t.TempDir()
 	want := filepath.Join(cachedir, testExtractedDir)
-	if err := os.MkdirAll(want, 0755); err != nil {
+	if err := os.MkdirAll(want, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(want, "test.txt"), []byte("content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(want, "test.txt"), []byte("content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -93,10 +93,10 @@ func TestRepo_ExtractedDirExists(t *testing.T) {
 	t.Setenv(cache.EnvLibrarianCache, cachedir)
 
 	extractedDir := filepath.Join(cachedir, testExtractedDir)
-	if err := os.MkdirAll(extractedDir, 0755); err != nil {
+	if err := os.MkdirAll(extractedDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(extractedDir, "test.txt"), []byte("content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(extractedDir, "test.txt"), []byte("content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,7 +115,7 @@ func TestRepo_TarballExists(t *testing.T) {
 	t.Setenv(cache.EnvLibrarianCache, cachedir)
 
 	tarballPath := filepath.Join(cachedir, testTarball)
-	if err := os.MkdirAll(filepath.Dir(tarballPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(tarballPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,7 +123,7 @@ func TestRepo_TarballExists(t *testing.T) {
 		"README.md": "# Test Repo",
 		"main.go":   "package main",
 	})
-	if err := os.WriteFile(tarballPath, tarballData, 0644); err != nil {
+	if err := os.WriteFile(tarballPath, tarballData, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -170,7 +170,7 @@ func TestRepo_MismatchTarball(t *testing.T) {
 	// Create an empty tarball file in the cache directory.
 	repo := strings.TrimPrefix(server.URL, "https://")
 	downloadDir := filepath.Join(cacheDir, "download")
-	if err := os.MkdirAll(downloadDir, 0755); err != nil {
+	if err := os.MkdirAll(downloadDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	tarballName := fmt.Sprintf("%s@%s.tar.gz", repo, testCommit)
@@ -443,7 +443,7 @@ func TestDownload_TgzExists(t *testing.T) {
 	testDir := t.TempDir()
 	tarball := makeTestContents(t)
 	target := path.Join(testDir, "existing-file")
-	if err := os.WriteFile(target, tarball.Contents, 0644); err != nil {
+	if err := os.WriteFile(target, tarball.Contents, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := Download(t.Context(), target, "https://unused/placeholder.tar.gz", tarball.Sha256); err != nil {
@@ -552,7 +552,7 @@ func TestExtractTarball(t *testing.T) {
 	})
 
 	tarballPath := path.Join(t.TempDir(), "test.tar.gz")
-	if err := os.WriteFile(tarballPath, tarballData, 0644); err != nil {
+	if err := os.WriteFile(tarballPath, tarballData, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -598,7 +598,7 @@ func createTestTarball(t *testing.T, topLevelDir string, files map[string]string
 		fullPath := topLevelDir + "/" + filePath
 		hdr := &tar.Header{
 			Name: fullPath,
-			Mode: 0644,
+			Mode: 0o644,
 			Size: int64(len(content)),
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
@@ -629,7 +629,7 @@ func TestExtractTarball_Error(t *testing.T) {
 			name: "not a gzip file",
 			tarballPath: func(t *testing.T) string {
 				p := path.Join(t.TempDir(), "file.txt")
-				if err := os.WriteFile(p, []byte("not a tarball"), 0644); err != nil {
+				if err := os.WriteFile(p, []byte("not a tarball"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return p
@@ -651,7 +651,7 @@ func TestExtractTarball_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 				p := path.Join(t.TempDir(), "file.gz")
-				if err := os.WriteFile(p, buf.Bytes(), 0644); err != nil {
+				if err := os.WriteFile(p, buf.Bytes(), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return p
@@ -670,7 +670,7 @@ func TestExtractTarball_Error(t *testing.T) {
 				hdr := &tar.Header{
 					Typeflag: tar.TypeBlock,
 					Name:     "repo-abc123/src/block.dev",
-					Mode:     0644,
+					Mode:     0o644,
 				}
 				if err := tw.WriteHeader(hdr); err != nil {
 					t.Fatal(err)
@@ -682,7 +682,7 @@ func TestExtractTarball_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 				p := path.Join(t.TempDir(), "unsupported.tar.gz")
-				if err := os.WriteFile(p, buf.Bytes(), 0644); err != nil {
+				if err := os.WriteFile(p, buf.Bytes(), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return p
@@ -703,7 +703,7 @@ func TestExtractTarball_Error(t *testing.T) {
 					Typeflag: tar.TypeSymlink,
 					Name:     "repo-abc123/src/link.txt",
 					Linkname: "/etc/passwd",
-					Mode:     0777,
+					Mode:     0o777,
 				}
 				if err := tw.WriteHeader(hdr); err != nil {
 					t.Fatal(err)
@@ -715,7 +715,7 @@ func TestExtractTarball_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 				p := path.Join(t.TempDir(), "abs-symlink.tar.gz")
-				if err := os.WriteFile(p, buf.Bytes(), 0644); err != nil {
+				if err := os.WriteFile(p, buf.Bytes(), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return p
@@ -736,7 +736,7 @@ func TestExtractTarball_Error(t *testing.T) {
 					Typeflag: tar.TypeSymlink,
 					Name:     "repo-abc123/src/link.txt",
 					Linkname: "../../../escape.txt",
-					Mode:     0777,
+					Mode:     0o777,
 				}
 				if err := tw.WriteHeader(hdr); err != nil {
 					t.Fatal(err)
@@ -748,7 +748,7 @@ func TestExtractTarball_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 				p := path.Join(t.TempDir(), "escaping-symlink.tar.gz")
-				if err := os.WriteFile(p, buf.Bytes(), 0644); err != nil {
+				if err := os.WriteFile(p, buf.Bytes(), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return p
@@ -788,14 +788,14 @@ func TestExtractTarball_PathError(t *testing.T) {
 			tarballPath: func(t *testing.T) string {
 				tarballData := createTestTarball(t, "repo-abc123", map[string]string{"file.txt": "content"})
 				p := path.Join(t.TempDir(), "test.tar.gz")
-				if err := os.WriteFile(p, tarballData, 0644); err != nil {
+				if err := os.WriteFile(p, tarballData, 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return p
 			},
 			dest: func(t *testing.T) string {
 				p := path.Join(t.TempDir(), "destfile")
-				if err := os.WriteFile(p, []byte("i am a file"), 0644); err != nil {
+				if err := os.WriteFile(p, []byte("i am a file"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return p
@@ -840,12 +840,12 @@ func TestDownload_Error(t *testing.T) {
 			target: func(t *testing.T) string {
 				// Create a read-only directory to trigger a permission error.
 				readOnlyDir := path.Join(t.TempDir(), "read-only")
-				if err := os.Mkdir(readOnlyDir, 0555); err != nil { // Read and execute only
+				if err := os.Mkdir(readOnlyDir, 0o555); err != nil { // Read and execute only
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
 					// Restore permissions so the temp dir can be cleaned up.
-					os.Chmod(readOnlyDir, 0755)
+					os.Chmod(readOnlyDir, 0o755)
 				})
 				return path.Join(readOnlyDir, "subdir", "target")
 			},
@@ -1082,7 +1082,7 @@ func TestExtractTarball_Symlink(t *testing.T) {
 	fileHdr := &tar.Header{
 		Typeflag: tar.TypeReg,
 		Name:     "repo-abc123/src/file.txt",
-		Mode:     0644,
+		Mode:     0o644,
 		Size:     4,
 	}
 	if err := tw.WriteHeader(fileHdr); err != nil {
@@ -1096,7 +1096,7 @@ func TestExtractTarball_Symlink(t *testing.T) {
 		Typeflag: tar.TypeSymlink,
 		Name:     "repo-abc123/src/link.txt",
 		Linkname: "file.txt",
-		Mode:     0777,
+		Mode:     0o777,
 	}
 	if err := tw.WriteHeader(linkHdr); err != nil {
 		t.Fatal(err)
@@ -1110,7 +1110,7 @@ func TestExtractTarball_Symlink(t *testing.T) {
 	}
 
 	tarballPath := filepath.Join(t.TempDir(), "test-symlink.tar.gz")
-	if err := os.WriteFile(tarballPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(tarballPath, buf.Bytes(), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -35,10 +35,10 @@ func TestMoveAndMerge_Success(t *testing.T) {
 	// Setup: src contains files and dirs, dst has no collisions.
 	writeFile := func(dir, path, content string) {
 		p := filepath.Join(dir, path)
-		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -97,10 +97,10 @@ func TestMoveAndMerge_Success(t *testing.T) {
 func TestMoveAndMerge_FileCollisionError(t *testing.T) {
 	t.Parallel()
 	src, dst := t.TempDir(), t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("src"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("src"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dst, "file.txt"), []byte("dst"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dst, "file.txt"), []byte("dst"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := MoveAndMerge(src, dst); err == nil {
@@ -119,11 +119,11 @@ func TestMoveAndMerge_RenameError(t *testing.T) {
 	t.Parallel()
 	src := t.TempDir()
 	dst := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "file"), []byte("data"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "file"), []byte("data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Create a directory with the same name as src file in destination
-	if err := os.Mkdir(filepath.Join(dst, "file"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dst, "file"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := MoveAndMerge(src, dst); err == nil {
@@ -136,21 +136,21 @@ func TestMoveAndMerge_RecursiveError(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 	// Create src/dir/file
-	if err := os.MkdirAll(filepath.Join(src, "dir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(src, "dir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(src, "dir", "file"), []byte("data"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "dir", "file"), []byte("data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Create dst/dir
-	if err := os.MkdirAll(filepath.Join(dst, "dir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dst, "dir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Make src/dir unreadable to cause ReadDir failure inside MoveAndMerge
-	if err := os.Chmod(filepath.Join(src, "dir"), 0000); err != nil {
+	if err := os.Chmod(filepath.Join(src, "dir"), 0o000); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(filepath.Join(src, "dir"), 0755) // cleanup for TempDir
+	defer os.Chmod(filepath.Join(src, "dir"), 0o755) // cleanup for TempDir
 	if err := MoveAndMerge(src, dst); err == nil {
 		t.Error("MoveAndMerge() expected error for recursive failure, got nil")
 	}
@@ -160,10 +160,10 @@ func TestMoveAndMerge_SameSourceAndTarget(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	subdir := filepath.Join(dir, "sub")
-	if err := os.Mkdir(subdir, 0755); err != nil {
+	if err := os.Mkdir(subdir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(subdir, "file.txt"), []byte("data"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(subdir, "file.txt"), []byte("data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := MoveAndMerge(dir, dir); err == nil {
@@ -237,7 +237,7 @@ func TestMoveAndMergeWithKeep_Error(t *testing.T) {
 			setupFunc: func(t *testing.T, root string) (string, string) {
 				src, dst := filepath.Join(root, "src"), filepath.Join(root, "dst")
 				writeTestFiles(t, src, map[string]string{"file.txt": "content"})
-				if err := os.MkdirAll(dst, 0444); err != nil {
+				if err := os.MkdirAll(dst, 0o444); err != nil {
 					t.Fatal(err)
 				}
 				return src, dst
@@ -262,7 +262,7 @@ func TestCopyFile_Success(t *testing.T) {
 	src := filepath.Join(tmp, "src.txt")
 	dst := filepath.Join(tmp, "dst.txt")
 	content := "hello world"
-	if err := os.WriteFile(src, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(src, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := CopyFile(src, dst); err != nil {
@@ -284,7 +284,7 @@ func TestCopyFile_Error(t *testing.T) {
 		t.Error("CopyFile() expected error for non-existent source, got nil")
 	}
 	src := filepath.Join(tmp, "src")
-	if err := os.WriteFile(src, []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(src, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Try to create file in a non-existent directory
@@ -330,8 +330,8 @@ func TestUnzip_Permissions(t *testing.T) {
 		"exec.sh": "#!/bin/sh\necho hi",
 	}
 	modes := map[string]os.FileMode{
-		"dir/":    0755,
-		"exec.sh": 0755,
+		"dir/":    0o755,
+		"exec.sh": 0o755,
 	}
 	createZip(t, zipPath, files, modes)
 
@@ -343,7 +343,7 @@ func TestUnzip_Permissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm()&0111 == 0 {
+	if info.Mode().Perm()&0o111 == 0 {
 		t.Errorf("expected directory to be traversable, got %v", info.Mode().Perm())
 	}
 	info, err = os.Stat(filepath.Join(destDir, "exec.sh"))
@@ -351,7 +351,7 @@ func TestUnzip_Permissions(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check if the executable bit is set (0111)
-	if info.Mode()&0111 == 0 {
+	if info.Mode()&0o111 == 0 {
 		t.Errorf("expected file to be executable, got mode %v", info.Mode())
 	}
 }
@@ -386,10 +386,10 @@ func writeTestFiles(t *testing.T, dir string, files map[string]string) {
 	t.Helper()
 	for path, content := range files {
 		full := filepath.Join(dir, path)
-		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -558,7 +558,7 @@ func TestIsDirNotEmpty(t *testing.T) {
 func setupDirStructure(t *testing.T, root string, dirs []string, files map[string]string) {
 	t.Helper()
 	for _, d := range dirs {
-		if err := os.MkdirAll(filepath.Join(root, d), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -66,16 +66,16 @@ func TestIsNewFileSuccess(t *testing.T) {
 	}
 	headCommit := strings.TrimSpace(string(out))
 	existingName := path.Join("src", "storage", "src", "lib.rs")
-	if err := os.WriteFile(existingName, []byte(newLibRsContents), 0644); err != nil {
+	if err := os.WriteFile(existingName, []byte(newLibRsContents), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	gitExe := command.Git
 
 	newName := path.Join("src", "storage", "src", "new.rs")
-	if err := os.MkdirAll(path.Dir(newName), 0755); err != nil {
+	if err := os.MkdirAll(path.Dir(newName), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(newName, []byte(newLibRsContents), 0644); err != nil {
+	if err := os.WriteFile(newName, []byte(newLibRsContents), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	testhelper.RunGit(t, "add", ".")
@@ -204,7 +204,7 @@ func TestAssertGitStatusClean(t *testing.T) {
 			setup: func(t *testing.T) {
 				remoteDir := testhelper.SetupRepoWithChange(t, "release-1.2.3")
 				testhelper.CloneRepository(t, remoteDir)
-				if err := os.WriteFile("dirty.txt", []byte("uncommitted"), 0644); err != nil {
+				if err := os.WriteFile("dirty.txt", []byte("uncommitted"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -167,7 +167,7 @@ func TestAddCommand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -225,7 +225,7 @@ func TestAddLibrary(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -412,7 +412,7 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
@@ -461,7 +461,7 @@ func TestAddLibrary_ExistingLibrary_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
@@ -611,7 +611,7 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 	}
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -588,7 +588,7 @@ func TestPostBump(t *testing.T) {
 			name: "rust language runs cargo update",
 			setup: func() {
 				script := "#!/bin/sh\nexit 0"
-				if err := os.WriteFile(fakeCargo, []byte(script), 0755); err != nil {
+				if err := os.WriteFile(fakeCargo, []byte(script), 0o755); err != nil {
 					t.Fatal(err)
 				}
 				t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -601,7 +601,7 @@ func TestPostBump(t *testing.T) {
 			name: "rust language runs cargo update fails",
 			setup: func() {
 				script := "#!/bin/sh\nexit 1"
-				if err := os.WriteFile(fakeCargo, []byte(script), 0755); err != nil {
+				if err := os.WriteFile(fakeCargo, []byte(script), 0o755); err != nil {
 					t.Fatal(err)
 				}
 				t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -1286,7 +1286,7 @@ func writeConfigAndCommitWithMessage(t *testing.T, cfg *config.Config, message s
 }
 
 func writeFileAndCommit(t *testing.T, path string, content []byte, message string) {
-	if err := os.WriteFile(path, content, 0644); err != nil {
+	if err := os.WriteFile(path, content, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	testhelper.RunGit(t, "add", ".")

--- a/internal/librarian/clean_test.go
+++ b/internal/librarian/clean_test.go
@@ -86,10 +86,10 @@ func TestCleanOutput(t *testing.T) {
 			dir := t.TempDir()
 			for _, f := range test.files {
 				path := filepath.Join(dir, f)
-				if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+				if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/librarian/config_test.go
+++ b/internal/librarian/config_test.go
@@ -117,7 +117,7 @@ func TestRunConfigGet_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			t.Chdir(tempDir)
-			if err := os.WriteFile("librarian.yaml", []byte(test.configYAML), 0644); err != nil {
+			if err := os.WriteFile("librarian.yaml", []byte(test.configYAML), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			var buf bytes.Buffer
@@ -152,7 +152,7 @@ func TestRunConfigSet(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			t.Chdir(tempDir)
-			if err := os.WriteFile("librarian.yaml", []byte(test.configYAML), 0644); err != nil {
+			if err := os.WriteFile("librarian.yaml", []byte(test.configYAML), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			err := runConfigSet(test.path, test.value)
@@ -204,7 +204,7 @@ func TestRunConfigSet_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			t.Chdir(tempDir)
-			if err := os.WriteFile("librarian.yaml", []byte(test.configYAML), 0644); err != nil {
+			if err := os.WriteFile("librarian.yaml", []byte(test.configYAML), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			err := runConfigSet(test.path, test.value)

--- a/internal/librarian/dart/generate_test.go
+++ b/internal/librarian/dart/generate_test.go
@@ -187,7 +187,7 @@ func TestFormat(t *testing.T) {
 	testhelper.RequireCommand(t, "dart")
 	outDir := t.TempDir()
 	dartFile := filepath.Join(outDir, "test.dart")
-	if err := os.WriteFile(dartFile, []byte("void main() { print('hello'); }"), 0644); err != nil {
+	if err := os.WriteFile(dartFile, []byte("void main() { print('hello'); }"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/dart/publish_test.go
+++ b/internal/librarian/dart/publish_test.go
@@ -339,26 +339,26 @@ func setupTestRepo(t *testing.T, repoVersions map[string]string) {
 	}
 	testhelper.CloneRepository(t, remoteDir)
 
-	if err := os.MkdirAll("generated/a", 0755); err != nil {
+	if err := os.MkdirAll("generated/a", 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll("generated/b", 0755); err != nil {
+	if err := os.MkdirAll("generated/b", 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	pubspecA := "name: a\nversion: " + repoVersions["a"] + "\ndependencies:\n  sdk: \">=3.0.0 <4.0.0\"\n"
 	pubspecB := "name: b\nversion: " + repoVersions["b"] + "\ndependencies:\n  sdk: \">=3.0.0 <4.0.0\"\n  a: ^1.0.0\n"
 
-	if err := os.WriteFile("generated/a/pubspec.yaml", []byte(pubspecA), 0644); err != nil {
+	if err := os.WriteFile("generated/a/pubspec.yaml", []byte(pubspecA), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile("generated/b/pubspec.yaml", []byte(pubspecB), 0644); err != nil {
+	if err := os.WriteFile("generated/b/pubspec.yaml", []byte(pubspecB), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile("generated/a/lib.dart", []byte("// library a"), 0644); err != nil {
+	if err := os.WriteFile("generated/a/lib.dart", []byte("// library a"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile("generated/b/lib.dart", []byte("// library b"), 0644); err != nil {
+	if err := os.WriteFile("generated/b/lib.dart", []byte("// library b"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -417,7 +417,7 @@ func setupFakeScript(t *testing.T, name, script string) {
 	}
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, name)
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/librarian/fake.go
+++ b/internal/librarian/fake.go
@@ -29,7 +29,7 @@ const fakeVersionFile = "VERSION"
 
 func fakeBumpLibrary(output, version string) error {
 	content := fmt.Sprintf("version=%s", version)
-	return os.WriteFile(filepath.Join(output, fakeVersionFile), []byte(content), 0644)
+	return os.WriteFile(filepath.Join(output, fakeVersionFile), []byte(content), 0o644)
 }
 
 func fakeGenerate(library *config.Library) error {
@@ -43,12 +43,12 @@ func fakeGenerate(library *config.Library) error {
 	}
 	content := fmt.Sprintf("# %s\n\nGenerated library\n", library.Name)
 	readmePath := filepath.Join(library.Output, "README.md")
-	if err := os.WriteFile(readmePath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(readmePath, []byte(content), 0o644); err != nil {
 		return err
 	}
 	versionPath := filepath.Join(library.Output, "VERSION")
 	if _, err := os.Stat(versionPath); errors.Is(err, fs.ErrNotExist) {
-		return os.WriteFile(versionPath, []byte("0.0.0"), 0644)
+		return os.WriteFile(versionPath, []byte("0.0.0"), 0o644)
 	}
 	return nil
 }
@@ -60,20 +60,20 @@ func fakeFormat(library *config.Library) error {
 		return err
 	}
 	formatted := string(content) + "\n---\nFormatted\n"
-	return os.WriteFile(readmePath, []byte(formatted), 0644)
+	return os.WriteFile(readmePath, []byte(formatted), 0o644)
 }
 
 func fakePostGenerate() error {
-	return os.WriteFile("POST_GENERATE_README.md", []byte("PostGenerated\n"), 0644)
+	return os.WriteFile("POST_GENERATE_README.md", []byte("PostGenerated\n"), 0o644)
 }
 
 func fakeCreateSkeleton(library *config.Library) error {
-	if err := os.MkdirAll(library.Output, 0755); err != nil {
+	if err := os.MkdirAll(library.Output, 0o755); err != nil {
 		return err
 	}
 	content := fmt.Sprintf("# %s\n\nThis is a starter file.\n", library.Name)
 	starterPath := filepath.Join(library.Output, "STARTER.md")
-	return os.WriteFile(starterPath, []byte(content), 0644)
+	return os.WriteFile(starterPath, []byte(content), 0o644)
 }
 
 // fakeDefaultLibraryName derives a library name from an API path by

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -271,7 +271,7 @@ libraries:
     apis:
       - path: google/cloud/texttospeech/v1
 `, googleapisDir, lib1, lib1Output, lib2, lib2Output)
-			if err := os.WriteFile(filepath.Join(tempDir, config.LibrarianYAML), []byte(configContent), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tempDir, config.LibrarianYAML), []byte(configContent), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			err := Run(t.Context(), test.args...)
@@ -313,11 +313,11 @@ func TestGenerate_Java(t *testing.T) {
 
 	// Create a fake protoc that just exits successfully.
 	protocDir := filepath.Join(tempDir, "bin")
-	if err := os.MkdirAll(protocDir, 0755); err != nil {
+	if err := os.MkdirAll(protocDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	protocPath := filepath.Join(protocDir, "protoc")
-	if err := os.WriteFile(protocPath, []byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
+	if err := os.WriteFile(protocPath, []byte("#!/bin/bash\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", protocDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -337,7 +337,7 @@ libraries:
       - path: google/cloud/secretmanager/v1
 `, googleapisDir)
 
-	if err := os.WriteFile(filepath.Join(tempDir, config.LibrarianYAML), []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, config.LibrarianYAML), []byte(configContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -365,10 +365,10 @@ func createGoogleapisServiceConfigs(t *testing.T, tempDir string, configs map[st
 
 	for apiPath, filename := range configs {
 		dir := filepath.Join(googleapisDir, apiPath)
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(dir, filename), []byte(""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, filename), []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/librarian/golang/bump.go
+++ b/internal/librarian/golang/bump.go
@@ -72,5 +72,5 @@ func findAndReplace(path string, version string) error {
 		return err
 	}
 	result := versionRegex.ReplaceAllString(string(content), `${1}`+version+`${3}`)
-	return os.WriteFile(path, []byte(result), 0644)
+	return os.WriteFile(path, []byte(result), 0o644)
 }

--- a/internal/librarian/golang/bump_test.go
+++ b/internal/librarian/golang/bump_test.go
@@ -198,15 +198,15 @@ func TestBump(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			output := t.TempDir()
 			libraryDir := filepath.Join(output, test.library.Name)
-			if err := os.MkdirAll(libraryDir, 0755); err != nil {
+			if err := os.MkdirAll(libraryDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			for path, content := range test.initialFiles {
 				fullPath := filepath.Join(output, path)
-				if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -247,7 +247,7 @@ func TestBump_Error(t *testing.T) {
 			library: &config.Library{Name: "test-lib"},
 			version: "0.2.0",
 			setup: func(t *testing.T, dir string) {
-				if err := os.Chmod(filepath.Join(dir, "test-lib", "internal", "version.go"), 0444); err != nil {
+				if err := os.Chmod(filepath.Join(dir, "test-lib", "internal", "version.go"), 0o444); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -271,7 +271,7 @@ func TestBump_Error(t *testing.T) {
 			},
 			version: "0.2.0",
 			setup: func(t *testing.T, dir string) {
-				if err := os.Chmod(filepath.Join(dir, "test-lib", "examples", "apiv1", "snippet_metadata_foo.json"), 0444); err != nil {
+				if err := os.Chmod(filepath.Join(dir, "test-lib", "examples", "apiv1", "snippet_metadata_foo.json"), 0o444); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -294,20 +294,20 @@ func TestBump_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			output := t.TempDir()
 			libraryDir := filepath.Join(output, test.library.Name)
-			if err := os.MkdirAll(libraryDir, 0755); err != nil {
+			if err := os.MkdirAll(libraryDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			snippetsDir := filepath.Join(output, "internal", "generated", "snippets", test.library.Name)
-			if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+			if err := os.MkdirAll(snippetsDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 
 			for path, content := range test.initialFiles {
 				fullPath := filepath.Join(output, path)
-				if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/librarian/golang/clean_test.go
+++ b/internal/librarian/golang/clean_test.go
@@ -177,11 +177,11 @@ func TestClean_Error(t *testing.T) {
 			},
 			outputFiles: []string{"README.md"},
 			setup: func(t *testing.T, base string) {
-				if err := os.Chmod(base, 0555); err != nil {
+				if err := os.Chmod(base, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					if err := os.Chmod(base, 0755); err != nil {
+					if err := os.Chmod(base, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -204,11 +204,11 @@ func TestClean_Error(t *testing.T) {
 			outputFiles: []string{"apiv1/doc.go"},
 			setup: func(t *testing.T, base string) {
 				base = filepath.Join(base, "apiv1")
-				if err := os.Chmod(base, 0555); err != nil {
+				if err := os.Chmod(base, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					if err := os.Chmod(base, 0755); err != nil {
+					if err := os.Chmod(base, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -231,11 +231,11 @@ func TestClean_Error(t *testing.T) {
 			outputFiles: []string{"examples/apiv1/snippet1.go"},
 			setup: func(t *testing.T, base string) {
 				base = filepath.Join(base, "examples/apiv1")
-				if err := os.Chmod(base, 0555); err != nil {
+				if err := os.Chmod(base, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					if err := os.Chmod(base, 0755); err != nil {
+					if err := os.Chmod(base, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -267,15 +267,15 @@ func TestClean_Error(t *testing.T) {
 
 func createFiles(t *testing.T, base string, files []string) {
 	t.Helper()
-	if err := os.MkdirAll(base, 0755); err != nil {
+	if err := os.MkdirAll(base, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, file := range files {
 		filePath := filepath.Join(base, file)
-		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+		if err := os.WriteFile(filePath, []byte("test"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/librarian/golang/command_test.go
+++ b/internal/librarian/golang/command_test.go
@@ -138,14 +138,14 @@ func TestToolsEnv_Error(t *testing.T) {
 
 func createStubExecutable(t *testing.T, path, recordFile string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	content := fmt.Sprintf("#!/bin/sh\necho \"$0\" >> %q\nexit 0\n", recordFile)
 	if runtime.GOOS == "windows" {
 		content = fmt.Sprintf("@echo off\r\necho %%0 >> %q\r\nexit /b 0\r\n", recordFile)
 	}
-	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/librarian/golang/format_test.go
+++ b/internal/librarian/golang/format_test.go
@@ -96,10 +96,10 @@ func main() {
 `
 			for _, aPath := range test.goFilePath {
 				path := filepath.Join(repoRoot, aPath)
-				if err := os.MkdirAll(path, 0755); err != nil {
+				if err := os.MkdirAll(path, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(path, "example.go"), []byte(unformatted), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(path, "example.go"), []byte(unformatted), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -53,7 +53,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path of output directory: %w", err)
 	}
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
@@ -247,7 +247,7 @@ func moveAPIDirectory(library *config.Library, goAPI *config.GoAPI, srcDir, outD
 	libraryDirPrefix := filepath.Join(srcDir, "cloud.google.com", "go")
 	librarySrc := filepath.Join(libraryDirPrefix, goAPI.ImportPath)
 	libraryDest := filepath.Join(repoRootPath(outDir, library.Name), clientPathFromRepoRoot(library, goAPI))
-	if err := os.MkdirAll(libraryDest, 0755); err != nil {
+	if err := os.MkdirAll(libraryDest, 0o755); err != nil {
 		return err
 	}
 	return filesystem.MoveAndMerge(librarySrc, libraryDest)
@@ -260,7 +260,7 @@ func moveAndUpdateSnippets(library *config.Library, goAPI *config.GoAPI, srcDir,
 	if snippetDest == "" {
 		return nil
 	}
-	if err := os.MkdirAll(snippetDest, 0755); err != nil {
+	if err := os.MkdirAll(snippetDest, 0o755); err != nil {
 		return err
 	}
 	snippetDirPrefix := filepath.Join(srcDir, "cloud.google.com", "go", "internal", "generated", "snippets")

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -173,7 +173,7 @@ func TestGenerate_MkdirAllError(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "file_blocking_dir")
-	if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -399,14 +399,14 @@ func TestGenerateLibrary(t *testing.T) {
 			t.Parallel()
 			repoRoot := t.TempDir()
 			setupSnippets(t, repoRoot)
-			if err := os.MkdirAll(filepath.Join(repoRoot, "internal"), 0777); err != nil {
+			if err := os.MkdirAll(filepath.Join(repoRoot, "internal"), 0o777); err != nil {
 				t.Fatal(err)
 			}
 			test.library.Output = filepath.Join(repoRoot, test.library.Name)
 			for _, file := range test.library.Keep {
 				src := filepath.Join("..", "..", "testdata/golang-generate", file)
 				dst := filepath.Join(test.library.Output, file)
-				if err := os.MkdirAll(filepath.Dir(dst), 0777); err != nil {
+				if err := os.MkdirAll(filepath.Dir(dst), 0o777); err != nil {
 					t.Fatal(err)
 				}
 				if err := filesystem.CopyFile(src, dst); err != nil {
@@ -486,7 +486,7 @@ func TestGenerateREADME(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
 			moduleRoot := filepath.Join(dir, "secretmanager")
-			if err := os.MkdirAll(moduleRoot, 0755); err != nil {
+			if err := os.MkdirAll(moduleRoot, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			test.library.Output = dir
@@ -536,7 +536,7 @@ func TestGenerateREADME_Skipped(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 			moduleRoot := filepath.Join(dir, "secretmanager")
-			if err := os.MkdirAll(moduleRoot, 0755); err != nil {
+			if err := os.MkdirAll(moduleRoot, 0o755); err != nil {
 				t.Fatal(err)
 			}
 
@@ -842,18 +842,18 @@ func TestMoveGeneratedFiles(t *testing.T) {
 				repoRoot := filepath.Join(tmpDir, "repo")
 				outDir := filepath.Join(repoRoot, "lib")
 				srcDir := filepath.Join(outDir, "cloud.google.com", "go", "lib", "apiv1")
-				if err := os.MkdirAll(srcDir, 0755); err != nil {
+				if err := os.MkdirAll(srcDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				snippetDirSuffix := filepath.Join("internal", "generated", "snippets", "lib", "apiv1")
 				snippetDir := filepath.Join(outDir, "cloud.google.com", "go", snippetDirSuffix)
-				if err := os.MkdirAll(snippetDir, 0755); err != nil {
+				if err := os.MkdirAll(snippetDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(snippetDir, "snippet.go"), []byte("package internal"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(snippetDir, "snippet.go"), []byte("package internal"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				lib := &config.Library{
@@ -872,18 +872,18 @@ func TestMoveGeneratedFiles(t *testing.T) {
 				repoRoot := filepath.Join(tmpDir, "repo")
 				outDir := filepath.Join(repoRoot, "lib", "v2")
 				srcDir := filepath.Join(outDir, "cloud.google.com", "go", "lib", "v2", "apiv2")
-				if err := os.MkdirAll(srcDir, 0755); err != nil {
+				if err := os.MkdirAll(srcDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				snippetDirSuffix := filepath.Join("internal", "generated", "snippets", "lib", "v2", "apiv2")
 				snippetDir := filepath.Join(outDir, "cloud.google.com", "go", snippetDirSuffix)
-				if err := os.MkdirAll(snippetDir, 0755); err != nil {
+				if err := os.MkdirAll(snippetDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(snippetDir, "snippet.go"), []byte("package internal"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(snippetDir, "snippet.go"), []byte("package internal"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				lib := &config.Library{
@@ -902,18 +902,18 @@ func TestMoveGeneratedFiles(t *testing.T) {
 				repoRoot := filepath.Join(tmpDir, "repo")
 				outDir := filepath.Join(repoRoot, "lib")
 				srcDir := filepath.Join(outDir, "cloud.google.com", "go", "lib", "v2", "apiv1")
-				if err := os.MkdirAll(srcDir, 0755); err != nil {
+				if err := os.MkdirAll(srcDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				snippetDirSuffix := filepath.Join("internal", "generated", "snippets", "lib", "v2", "apiv1")
 				snippetDir := filepath.Join(outDir, "cloud.google.com", "go", snippetDirSuffix)
-				if err := os.MkdirAll(snippetDir, 0755); err != nil {
+				if err := os.MkdirAll(snippetDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(snippetDir, "snippet.go"), []byte("package internal"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(snippetDir, "snippet.go"), []byte("package internal"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				lib := &config.Library{
@@ -935,18 +935,18 @@ func TestMoveGeneratedFiles(t *testing.T) {
 				repoRoot := filepath.Join(tmpDir, "repo")
 				outDir := filepath.Join(repoRoot, "lib")
 				srcDir := filepath.Join(outDir, "cloud.google.com", "go", "lib", "apiv1")
-				if err := os.MkdirAll(srcDir, 0755); err != nil {
+				if err := os.MkdirAll(srcDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package foo"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				snippetDirSuffix := filepath.Join("internal", "generated", "snippets", "lib", "apiv1")
 				snippetSrcDir := filepath.Join(outDir, "cloud.google.com", "go", snippetDirSuffix)
-				if err := os.MkdirAll(snippetSrcDir, 0755); err != nil {
+				if err := os.MkdirAll(snippetSrcDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(snippetSrcDir, "snippet.go"), []byte("package internal"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(snippetSrcDir, "snippet.go"), []byte("package internal"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				lib := &config.Library{
@@ -986,11 +986,11 @@ func TestMoveGeneratedFiles(t *testing.T) {
 func setupSnippets(t *testing.T, repoRoot string) {
 	t.Helper()
 	snippetsDir := filepath.Join(repoRoot, "internal", "generated", "snippets")
-	if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+	if err := os.MkdirAll(snippetsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	snippetsGoMod := filepath.Join(snippetsDir, "go.mod")
-	if err := os.WriteFile(snippetsGoMod, []byte("module cloud.google.com/go/internal/generated/snippets\n\ngo 1.22\n"), 0644); err != nil {
+	if err := os.WriteFile(snippetsGoMod, []byte("module cloud.google.com/go/internal/generated/snippets\n\ngo 1.22\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/librarian/golang/module_test.go
+++ b/internal/librarian/golang/module_test.go
@@ -669,7 +669,7 @@ func TestInitModule(t *testing.T) {
 	outDir := t.TempDir()
 	// Write an import so go mod tidy can generate a go.sum file.
 	content := []byte("package main\nimport _ \"golang.org/x/text\"\n")
-	if err := os.WriteFile(filepath.Join(outDir, "main.go"), content, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(outDir, "main.go"), content, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := initModule(t.Context(), outDir, "example.com/testmod", ""); err != nil {

--- a/internal/librarian/golang/repometadata_test.go
+++ b/internal/librarian/golang/repometadata_test.go
@@ -103,7 +103,7 @@ func TestGenerateRepoMetadata(t *testing.T) {
 				Path:      test.path,
 			}
 			metadataDir := filepath.Join(tmpDir, "secretmanager", filepath.Base(test.importPath))
-			if err := os.MkdirAll(metadataDir, 0755); err != nil {
+			if err := os.MkdirAll(metadataDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			if err := generateRepoMetadata(api, library, library.APIs[0].Go); err != nil {
@@ -152,10 +152,10 @@ func TestGenerateRepoMetadata_Error(t *testing.T) {
 			setup: func(library *config.Library, api *serviceconfig.API, output string) {
 				library.Output = filepath.Join(output, "secretmanager")
 				dir := filepath.Join(output, "secretmanager", "apiv1")
-				if err := os.MkdirAll(filepath.Dir(dir), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(dir, []byte("not a directory"), 0644); err != nil {
+				if err := os.WriteFile(dir, []byte("not a directory"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 

--- a/internal/librarian/golang/version.go
+++ b/internal/librarian/golang/version.go
@@ -39,7 +39,7 @@ func generateInternalVersionFile(moduleDir, year, version string) (err error) {
 		version = "0.0.0"
 	}
 	internalDir := filepath.Join(moduleDir, "internal")
-	if err := os.MkdirAll(internalDir, 0755); err != nil {
+	if err := os.MkdirAll(internalDir, 0o755); err != nil {
 		return err
 	}
 	f, err := os.Create(filepath.Join(internalDir, "version.go"))
@@ -68,7 +68,7 @@ func generateClientVersionFile(library *config.Library, goAPI *config.GoAPI) (er
 		return nil
 	}
 	dir := filepath.Join(repoRootPath(library.Output, library.Name), clientPathFromRepoRoot(library, goAPI))
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 	f, err := os.Create(filepath.Join(dir, "version.go"))

--- a/internal/librarian/install_test.go
+++ b/internal/librarian/install_test.go
@@ -117,7 +117,7 @@ func TestFakeClean_Error(t *testing.T) {
 	}
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	if err := os.MkdirAll(library.Output, 0755); err != nil {
+	if err := os.MkdirAll(library.Output, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	err := fakeClean(library)

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -251,7 +251,7 @@ func appendLines(path string, lines []string) error {
 		buf.WriteString(line)
 		buf.WriteByte('\n')
 	}
-	return os.WriteFile(path, buf.Bytes(), 0644)
+	return os.WriteFile(path, buf.Bytes(), 0o644)
 }
 
 func setNonCloudMavenDefaults(lib *config.Library, groupID string) *config.Library {

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -134,7 +134,7 @@ func TestAdd(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-			if err := os.WriteFile(versionsFileName, nil, 0644); err != nil {
+			if err := os.WriteFile(versionsFileName, nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := Add(test.lib, nil)
@@ -237,7 +237,7 @@ func TestAdd_VersionsTxt(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-			if err := os.WriteFile(versionsFileName, nil, 0644); err != nil {
+			if err := os.WriteFile(versionsFileName, nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
 			_, err := Add(test.lib, nil)
@@ -273,7 +273,7 @@ func TestAdd_ExistingLibrary(t *testing.T) {
 		"grpc-google-cloud-secretmanager-v1:1.0.0:1.1.0-SNAPSHOT",
 		"google-cloud-secretmanager:1.0.0:1.1.0-SNAPSHOT",
 	}
-	if err := os.WriteFile(versionsFileName, []byte(strings.Join(initial, "\n")+"\n"), 0644); err != nil {
+	if err := os.WriteFile(versionsFileName, []byte(strings.Join(initial, "\n")+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -377,7 +377,7 @@ func TestAppendVersions(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-			if err := os.WriteFile(versionsFileName, []byte(test.initial), 0644); err != nil {
+			if err := os.WriteFile(versionsFileName, []byte(test.initial), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := appendVersions(test.lines); err != nil {
@@ -397,7 +397,7 @@ func TestAppendVersions(t *testing.T) {
 func TestAppendVersions_Error(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	if err := os.Mkdir(versionsFileName, 0755); err != nil {
+	if err := os.Mkdir(versionsFileName, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := appendVersions([]string{"line"}); err == nil {

--- a/internal/librarian/java/clean_test.go
+++ b/internal/librarian/java/clean_test.go
@@ -41,7 +41,7 @@ func TestClean(t *testing.T) {
 		filepath.Join(tmpDir, "kept-dir"),
 	}
 	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -57,7 +57,7 @@ func TestClean(t *testing.T) {
 		filepath.Join(tmpDir, "kept-dir", "file.txt"),
 	}
 	for _, file := range files {
-		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		content := []byte("content")
@@ -65,7 +65,7 @@ func TestClean(t *testing.T) {
 			// Add marker to files we expect to be removed
 			content = []byte("// AUTO-GENERATED DOCUMENTATION AND CLASS.\n" + string(content))
 		}
-		if err := os.WriteFile(file, content, 0644); err != nil {
+		if err := os.WriteFile(file, content, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -166,7 +166,7 @@ func TestShouldCleanMarkerPath(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			path := filepath.Join(tmpDir, test.fileName)
-			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/librarian/java/clirr_test.go
+++ b/internal/librarian/java/clirr_test.go
@@ -25,11 +25,11 @@ func TestGenerateClirrIgnore(t *testing.T) {
 	tmpDir := t.TempDir()
 	protoModulePath := filepath.Join(tmpDir, "proto-google-cloud-test-v1")
 	srcDir := filepath.Join(protoModulePath, "src", "main", "java", "com", "google", "cloud", "test", "v1")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	orBuilderFile := filepath.Join(srcDir, "TestOrBuilder.java")
-	if err := os.WriteFile(orBuilderFile, []byte("package com.google.cloud.test.v1; public interface TestOrBuilder {}"), 0644); err != nil {
+	if err := os.WriteFile(orBuilderFile, []byte("package com.google.cloud.test.v1; public interface TestOrBuilder {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,7 +76,7 @@ func TestClirrIgnoreShouldGenerate(t *testing.T) {
 			artifactID: "proto-google-cloud-test-v1",
 			setup: func(t *testing.T, dir string) {
 				path := filepath.Join(dir, clirrIgnoreFile)
-				if err := os.WriteFile(path, []byte("exists"), 0644); err != nil {
+				if err := os.WriteFile(path, []byte("exists"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/internal/librarian/java/format_test.go
+++ b/internal/librarian/java/format_test.go
@@ -34,7 +34,7 @@ func TestFormat(t *testing.T) {
 		{
 			name: "successful format",
 			setup: func(t *testing.T, root string) {
-				if err := os.WriteFile(filepath.Join(root, "SomeClass.java"), []byte("public class SomeClass {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(root, "SomeClass.java"), []byte("public class SomeClass {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -47,10 +47,10 @@ func TestFormat(t *testing.T) {
 			name: "nested files in subdirectories",
 			setup: func(t *testing.T, root string) {
 				dir := filepath.Join(root, "sub", "dir")
-				if err := os.MkdirAll(dir, 0755); err != nil {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(dir, "Nested.java"), []byte("public class Nested {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, "Nested.java"), []byte("public class Nested {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -59,11 +59,11 @@ func TestFormat(t *testing.T) {
 			name: "files in excluded samples path are ignored",
 			setup: func(t *testing.T, root string) {
 				dir := filepath.Join(root, "samples", "snippets", "generated")
-				if err := os.MkdirAll(dir, 0755); err != nil {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				// This file should NOT be passed to the formatter.
-				if err := os.WriteFile(filepath.Join(dir, "Ignored.java"), []byte("public class Ignored {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, "Ignored.java"), []byte("public class Ignored {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -82,7 +82,7 @@ func TestFormat(t *testing.T) {
 
 func TestFormat_LookPathError(t *testing.T) {
 	tmpDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmpDir, "SomeClass.java"), []byte("public class SomeClass {}"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "SomeClass.java"), []byte("public class SomeClass {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", "")
@@ -106,10 +106,10 @@ func TestCollectJavaFiles(t *testing.T) {
 	}
 	for _, f := range filesToCreate {
 		path := filepath.Join(tmpDir, f)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+		if err := os.WriteFile(path, []byte("content"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/librarian/java/generate.go
+++ b/internal/librarian/java/generate.go
@@ -75,7 +75,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
-	if err := os.MkdirAll(outdir, 0755); err != nil {
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory %q: %w", outdir, err)
 	}
 	srcCfg := sources.NewSourceConfig(srcs, library.Roots)
@@ -151,7 +151,7 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 	gRPCDir := postParams.gRPCDir()
 	protoDir := postParams.protoDir()
 	for _, dir := range []string{gapicDir, gRPCDir, protoDir} {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("failed to create directory %q: %w", dir, err)
 		}
 	}

--- a/internal/librarian/java/generate_test.go
+++ b/internal/librarian/java/generate_test.go
@@ -176,7 +176,7 @@ func TestResolveGAPICOptions_MultipleConfigsError(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			apiDir := filepath.Join(tmpDir, test.apiPath)
-			if err := os.MkdirAll(apiDir, 0755); err != nil {
+			if err := os.MkdirAll(apiDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			for _, file := range test.files {
@@ -184,7 +184,7 @@ func TestResolveGAPICOptions_MultipleConfigsError(t *testing.T) {
 				if strings.HasSuffix(file, ".json") {
 					content = []byte("{}")
 				}
-				if err := os.WriteFile(filepath.Join(apiDir, file), content, 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(apiDir, file), content, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -272,7 +272,7 @@ func TestGenerateAPI(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc-gen-java_grpc")
 	outdir := t.TempDir()
 	// Force routing to the legacy owlbot.py postprocessor.
-	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := &config.Config{
@@ -302,7 +302,7 @@ func TestGenerateAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
-		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -342,7 +342,7 @@ func TestGenerateAPI_ProtoOnly(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc-gen-java_grpc")
 	outdir := t.TempDir()
 	// Force routing to the legacy owlbot.py postprocessor.
-	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := &config.Config{
@@ -371,7 +371,7 @@ func TestGenerateAPI_ProtoOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, artifact := range []string{"proto-google-cloud-gkehub-v1beta", "google-cloud-gkehub-bom"} {
-		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -431,7 +431,7 @@ func TestGenerateAPI_NoTools(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
-		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -483,7 +483,7 @@ func TestGenerateAPI_WithAdditionalProtosToGenerateAndCopy(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc-gen-java_grpc")
 	outdir := t.TempDir()
 	// Force routing to the legacy owlbot.py postprocessor.
-	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := &config.Config{
@@ -519,7 +519,7 @@ func TestGenerateAPI_WithAdditionalProtosToGenerateAndCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
-		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -583,7 +583,7 @@ func TestGenerateLibrary_Error(t *testing.T) {
 			},
 			setup: func(t *testing.T, library *config.Library) {
 				// Create a regular file where a directory is expected to cause os.MkdirAll to fail.
-				if err := os.WriteFile(library.Output, []byte(""), 0644); err != nil {
+				if err := os.WriteFile(library.Output, []byte(""), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -602,15 +602,15 @@ func TestGenerateLibrary_Error(t *testing.T) {
 			setup: func(t *testing.T, library *config.Library) {
 				// Ensure output artifacts exist for postProcessAPI to succeed.
 				for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
-					if err := os.MkdirAll(filepath.Join(library.Output, artifact), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Join(library.Output, artifact), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
-				if err := os.WriteFile(filepath.Join(library.Output, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0755); err != nil {
+				if err := os.WriteFile(filepath.Join(library.Output, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 				templatesDir := filepath.Join(filepath.Dir(library.Output), owlbotTemplatesRelPath)
-				if err := os.MkdirAll(templatesDir, 0755); err != nil {
+				if err := os.MkdirAll(templatesDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -692,15 +692,15 @@ func TestGenerate_Logic(t *testing.T) {
 	}
 	// Setup mandatory files for postProcessAPI and syncPOMs
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
-		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	templatesDir := filepath.Join(filepath.Dir(outdir), owlbotTemplatesRelPath)
-	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -742,15 +742,15 @@ func TestGenerate_ProtoExclusion(t *testing.T) {
 	}
 	// Setup mandatory files for postProcessAPI and syncPOMs
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
-		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	templatesDir := filepath.Join(filepath.Dir(outdir), owlbotTemplatesRelPath)
-	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := &config.Config{
@@ -798,10 +798,10 @@ func TestGatherProtos(t *testing.T) {
 	}
 	for _, f := range files {
 		path := filepath.Join(tmpDir, f)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1057,7 +1057,7 @@ func TestGenerateAPI_Gating(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			outdir := t.TempDir()
 			// Force routing to the legacy owlbot.py postprocessor.
-			if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0755); err != nil {
+			if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("#!/usr/bin/env python3\npass"), 0o755); err != nil {
 				t.Fatal(err)
 			}
 			api := &config.API{Path: "google/cloud/secretmanager/v1"}

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -60,14 +60,14 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(binDir, 0755); err != nil {
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create bin directory %q: %w", binDir, err)
 	}
 	libDir, err := getLibDir()
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(libDir, 0755); err != nil {
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create lib directory %q: %w", libDir, err)
 	}
 	for _, mvnTool := range tools.Maven {
@@ -199,7 +199,7 @@ func copyArtifactToLib(srcPath, libDir string, makeExecutable bool) (string, err
 		return "", fmt.Errorf("failed to copy artifact to lib folder: %w", err)
 	}
 	if makeExecutable {
-		if err := os.Chmod(destPath, 0755); err != nil {
+		if err := os.Chmod(destPath, 0o755); err != nil {
 			return "", fmt.Errorf("failed to make copied exe executable: %w", err)
 		}
 	}
@@ -218,7 +218,7 @@ func createBinWrapper(wrapperName, destPath, binDir string, isExecutable bool, m
 	default:
 		content = fmt.Sprintf("#!/bin/sh\nexec java -jar %q \"$@\"\n", destPath)
 	}
-	return os.WriteFile(wrapperPath, []byte(content), 0755)
+	return os.WriteFile(wrapperPath, []byte(content), 0o755)
 }
 
 // buildLocalMavenProject builds the local Maven project at the target relative path under the monorepo root.

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -31,11 +31,11 @@ func TestInstall(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
 	localPkgDir := filepath.Join(tmpDir, "sdk-platform-java", "hermetic_build", "library_generation")
-	if err := os.MkdirAll(localPkgDir, 0755); err != nil {
+	if err := os.MkdirAll(localPkgDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	localMvnDir := filepath.Join(tmpDir, "sdk-platform-java", "gapic-generator-java")
-	if err := os.MkdirAll(filepath.Join(localMvnDir, "target"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(localMvnDir, "target"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	mockPOM := `<project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -45,28 +45,28 @@ func TestInstall(t *testing.T) {
   </parent>
   <artifactId>gapic-generator-java</artifactId>
 </project>`
-	if err := os.WriteFile(filepath.Join(localMvnDir, "pom.xml"), []byte(mockPOM), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(localMvnDir, "pom.xml"), []byte(mockPOM), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	mockJarPath := filepath.Join(localMvnDir, "target", "gapic-generator-java-2.28.0-SNAPSHOT.jar")
-	if err := os.WriteFile(mockJarPath, []byte("local gapic jar content"), 0644); err != nil {
+	if err := os.WriteFile(mockJarPath, []byte("local gapic jar content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	m2Repo := filepath.Join(tempHome, ".m2", "repository")
 	gjfDir := filepath.Join(m2Repo, "com", "google", "googlejavaformat", "google-java-format", "1.25.2")
-	if err := os.MkdirAll(gjfDir, 0755); err != nil {
+	if err := os.MkdirAll(gjfDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	gjfJarPath := filepath.Join(gjfDir, "google-java-format-1.25.2-all-deps.jar")
-	if err := os.WriteFile(gjfJarPath, []byte("gjf jar content"), 0644); err != nil {
+	if err := os.WriteFile(gjfJarPath, []byte("gjf jar content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	grpcDir := filepath.Join(m2Repo, "io", "grpc", "protoc-gen-grpc-java", "1.81.0")
-	if err := os.MkdirAll(grpcDir, 0755); err != nil {
+	if err := os.MkdirAll(grpcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	grpcExePath := filepath.Join(grpcDir, "protoc-gen-grpc-java-1.81.0-linux-x86_64.exe")
-	if err := os.WriteFile(grpcExePath, []byte("grpc exe content"), 0755); err != nil {
+	if err := os.WriteFile(grpcExePath, []byte("grpc exe content"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	stubs := []struct {
@@ -89,17 +89,17 @@ func TestInstall(t *testing.T) {
 		},
 	}
 	stubDir := filepath.Join(tmpDir, "bin")
-	if err := os.MkdirAll(stubDir, 0755); err != nil {
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, s := range stubs {
 		logPath := filepath.Join(tmpDir, s.logFilename)
 		content := fmt.Sprintf("#!/bin/sh\necho %q \"$@\" >> %q\n", s.name, logPath)
-		if err := os.WriteFile(filepath.Join(stubDir, s.name), []byte(content), 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(stubDir, s.name), []byte(content), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(stubDir, "java"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)

--- a/internal/librarian/java/maven_test.go
+++ b/internal/librarian/java/maven_test.go
@@ -33,7 +33,7 @@ func TestParsePOM(t *testing.T) {
   <artifactId>gapic-generator-java</artifactId>
 </project>`
 	pomPath := filepath.Join(tmpDir, "pom.xml")
-	if err := os.WriteFile(pomPath, []byte(mockPOM), 0644); err != nil {
+	if err := os.WriteFile(pomPath, []byte(mockPOM), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	got, err := parsePOM(pomPath)
@@ -69,7 +69,7 @@ func TestParsePOM_Error(t *testing.T) {
 			name:    "invalid XML syntax",
 			pomPath: filepath.Join(tmpDir, "invalid.xml"),
 			setup: func(t *testing.T) {
-				if err := os.WriteFile(filepath.Join(tmpDir, "invalid.xml"), []byte("<project><invalid"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmpDir, "invalid.xml"), []byte("<project><invalid"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -79,7 +79,7 @@ func TestParsePOM_Error(t *testing.T) {
 			name:    "missing artifactId or version",
 			pomPath: filepath.Join(tmpDir, "empty.xml"),
 			setup: func(t *testing.T) {
-				if err := os.WriteFile(filepath.Join(tmpDir, "empty.xml"), []byte("<project></project>"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmpDir, "empty.xml"), []byte("<project></project>"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/internal/librarian/java/pom.go
+++ b/internal/librarian/java/pom.go
@@ -302,7 +302,7 @@ func updateClientPOM(pomPath string, data clientPOMData) error {
 	}
 	// compare to avoid unnecessary I/O
 	if updated != string(content) {
-		return os.WriteFile(pomPath, []byte(updated), 0644)
+		return os.WriteFile(pomPath, []byte(updated), 0o644)
 	}
 	return nil
 }
@@ -321,7 +321,7 @@ func updateBOMPOM(pomPath string, data bomParentPOMData) error {
 	}
 	// compare to avoid unnecessary I/O
 	if updated != string(content) {
-		return os.WriteFile(pomPath, []byte(updated), 0644)
+		return os.WriteFile(pomPath, []byte(updated), 0o644)
 	}
 	return nil
 }
@@ -343,7 +343,7 @@ func updateParentPOM(pomPath string, data bomParentPOMData) error {
 	}
 	// compare to avoid unnecessary I/O
 	if updated != string(content) {
-		return os.WriteFile(pomPath, []byte(updated), 0644)
+		return os.WriteFile(pomPath, []byte(updated), 0o644)
 	}
 	return nil
 }
@@ -499,7 +499,7 @@ func isPOMMissing(dir string) (bool, error) {
 }
 
 func writePOM(pomPath, templateName string, data any) (err error) {
-	if err := os.MkdirAll(filepath.Dir(pomPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(pomPath), 0o755); err != nil {
 		return fmt.Errorf("failed to create directory for %s: %w", pomPath, err)
 	}
 	f, err := os.Create(pomPath)

--- a/internal/librarian/java/pom_test.go
+++ b/internal/librarian/java/pom_test.go
@@ -59,7 +59,7 @@ func TestSyncPOMs_Golden(t *testing.T) {
 	gapicArtifactID := "google-cloud-secretmanager"
 	bomArtifactID := "google-cloud-secretmanager-bom"
 	for _, artifact := range []string{protoArtifactID, gRPCArtifactID, gapicArtifactID, bomArtifactID} {
-		if err := os.MkdirAll(filepath.Join(tmpDir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmpDir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -107,10 +107,10 @@ func TestSyncPOMs_Golden(t *testing.T) {
 		}
 		goldenPath := filepath.Join(testdataDir, artifact, "pom.xml")
 		if *update {
-			if err := os.MkdirAll(filepath.Dir(goldenPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile(goldenPath, got, 0644); err != nil {
+			if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -134,7 +134,7 @@ func TestSyncPOMs_Update(t *testing.T) {
 	gapicArtifactID := "google-cloud-secretmanager"
 	bomArtifactID := "google-cloud-secretmanager-bom"
 	for _, artifact := range []string{protoArtifactID, gRPCArtifactID, gapicArtifactID, bomArtifactID} {
-		if err := os.MkdirAll(filepath.Join(tmpDir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmpDir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -185,7 +185,7 @@ func TestSyncPOMs_Update(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err := os.WriteFile(filepath.Join(tmpDir, target.relPath), []byte(mangled), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, target.relPath), []byte(mangled), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -254,11 +254,11 @@ func TestSyncPOMs_NoUpdate(t *testing.T) {
 	bomArtifactID := "google-cloud-secretmanager-bom"
 	for _, artifact := range []string{protoArtifactID, gRPCArtifactID, gapicArtifactID, bomArtifactID, ""} {
 		dir := filepath.Join(tmpDir, artifact)
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		// Write a dummy pom.xml to ensure isMissing is false for all modules.
-		if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<!-- {x-generated-dependencies-start} -->\n      <mangled>true</mangled>\n<!-- {x-generated-dependencies-end} -->"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<!-- {x-generated-dependencies-start} -->\n      <mangled>true</mangled>\n<!-- {x-generated-dependencies-end} -->"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -352,7 +352,7 @@ func TestCollectModules(t *testing.T) {
 					"", // parent
 				}
 				for _, d := range dirs {
-					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -396,7 +396,7 @@ func TestCollectModules(t *testing.T) {
 					"", // parent
 				}
 				for _, d := range dirs {
-					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -441,10 +441,10 @@ func TestCollectModules(t *testing.T) {
 				}
 				for _, d := range dirs {
 					dir := filepath.Join(libraryDir, d)
-					if err := os.MkdirAll(dir, 0755); err != nil {
+					if err := os.MkdirAll(dir, 0o755); err != nil {
 						t.Fatal(err)
 					}
-					if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
+					if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0o644); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -489,7 +489,7 @@ func TestCollectModules(t *testing.T) {
 					"", // parent
 				}
 				for _, d := range dirs {
-					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -534,7 +534,7 @@ func TestCollectModules(t *testing.T) {
 					"", // parent
 				}
 				for _, d := range dirs {
-					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -579,7 +579,7 @@ func TestCollectModules(t *testing.T) {
 					"", // parent
 				}
 				for _, d := range dirs {
-					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -629,7 +629,7 @@ func TestIsPOMMissing(t *testing.T) {
 			name: "pom exists",
 			setup: func(t *testing.T) string {
 				dir := t.TempDir()
-				if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("content"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("content"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return dir
@@ -698,7 +698,7 @@ func TestIdentifyMissingModules(t *testing.T) {
 					"", // parent
 				}
 				for _, d := range dirs {
-					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Join(libraryDir, d), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -723,10 +723,10 @@ func TestIdentifyMissingModules(t *testing.T) {
 				}
 				for _, d := range dirs {
 					dir := filepath.Join(libraryDir, d)
-					if err := os.MkdirAll(dir, 0755); err != nil {
+					if err := os.MkdirAll(dir, 0o755); err != nil {
 						t.Fatal(err)
 					}
-					if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
+					if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0o644); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -745,12 +745,12 @@ func TestIdentifyMissingModules(t *testing.T) {
 				}
 				for _, d := range dirs {
 					dir := filepath.Join(libraryDir, d)
-					if err := os.MkdirAll(dir, 0755); err != nil {
+					if err := os.MkdirAll(dir, 0o755); err != nil {
 						t.Fatal(err)
 					}
 					// Only write pom.xml for client and BOM and parent
 					if d == "google-cloud-secretmanager" || d == "google-cloud-secretmanager-bom" || d == "" {
-						if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
+						if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0o644); err != nil {
 							t.Fatal(err)
 						}
 					}
@@ -838,7 +838,7 @@ func TestIdentifyMissingModules_ExcludedPOMs(t *testing.T) {
 		"", // parent
 	}
 	for _, dir := range dirs {
-		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -884,7 +884,7 @@ func TestIdentifyMissingModules_GenerateProtoFalse(t *testing.T) {
 		"", // parent
 	}
 	for _, dir := range dirs {
-		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -930,7 +930,7 @@ func TestIdentifyMissingModules_GenerateGAPICFalse(t *testing.T) {
 		"", // parent
 	}
 	for _, dir := range dirs {
-		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/librarian/java/postgenerate.go
+++ b/internal/librarian/java/postgenerate.go
@@ -278,7 +278,7 @@ func generateRootPOM(repoPath string, modules []string) error {
 // versions for all individual library BOMs in the monorepo.
 func generateGAPICLibrariesBOM(repoPath, version, parentVersion string, bomConfigs []*bomConfig) error {
 	bomDir := filepath.Join(repoPath, gapicBOM)
-	if err := os.MkdirAll(bomDir, 0755); err != nil {
+	if err := os.MkdirAll(bomDir, 0o755); err != nil {
 		return err
 	}
 	data := struct {

--- a/internal/librarian/java/postgenerate_test.go
+++ b/internal/librarian/java/postgenerate_test.go
@@ -152,13 +152,13 @@ func TestSearchForJavaModules(t *testing.T) {
 		"google-cloud-shared-deps",
 	}
 	for _, dir := range dirs {
-		if err := os.Mkdir(filepath.Join(tmpDir, dir), 0755); err != nil {
+		if err := os.Mkdir(filepath.Join(tmpDir, dir), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// Add pom.xml to modules (including an excluded one to verify filtering)
 	for _, mod := range []string{"module-a", "module-b", gapicBOM} {
-		if err := os.WriteFile(filepath.Join(tmpDir, mod, "pom.xml"), []byte("<project/>"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, mod, "pom.xml"), []byte("<project/>"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -176,10 +176,10 @@ func TestSearchForJavaModules_Error(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	// Make directory unreadable to cause os.ReadDir failure
-	if err := os.Chmod(tmpDir, 0000); err != nil {
+	if err := os.Chmod(tmpDir, 0o000); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(tmpDir, 0755)
+	defer os.Chmod(tmpDir, 0o755)
 	_, err := searchForJavaModules(tmpDir)
 	if err == nil {
 		t.Error("searchForJavaModules expected error, got nil")
@@ -190,10 +190,10 @@ func TestPostGenerate_SearchError(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	// Make directory unreadable to cause searchForJavaModules failure
-	if err := os.Chmod(tmpDir, 0000); err != nil {
+	if err := os.Chmod(tmpDir, 0o000); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(tmpDir, 0755)
+	defer os.Chmod(tmpDir, 0o755)
 	cfg := &config.Config{
 		Libraries: []*config.Library{
 			{Name: rootLibrary, Version: "1.2.3"},
@@ -210,10 +210,10 @@ func TestPostGenerate_Error(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	// Make directory read-only to cause os.Create("pom.xml") failure
-	if err := os.Chmod(tmpDir, 0555); err != nil {
+	if err := os.Chmod(tmpDir, 0o555); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(tmpDir, 0755)
+	defer os.Chmod(tmpDir, 0o755)
 	cfg := &config.Config{
 		Libraries: []*config.Library{
 			{Name: rootLibrary, Version: "1.2.3"},
@@ -260,10 +260,10 @@ func TestExtractBOMConfig_Error(t *testing.T) {
 			tmpDir := t.TempDir()
 			if test.pom != "" {
 				dir := filepath.Join(tmpDir, test.library, test.bom)
-				if err := os.MkdirAll(dir, 0755); err != nil {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte(test.pom), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte(test.pom), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/librarian/java/postprocess.go
+++ b/internal/librarian/java/postprocess.go
@@ -255,7 +255,7 @@ func addMissingHeaders(params postProcessParams, dir string) error {
 		if license.HasHeader(content) {
 			return nil
 		}
-		return os.WriteFile(path, append(headerText, content...), 0644)
+		return os.WriteFile(path, append(headerText, content...), 0o644)
 	})
 }
 
@@ -290,7 +290,7 @@ func copyFiles(params postProcessParams) error {
 		if _, err := os.Stat(src); err != nil {
 			return fmt.Errorf("failed to stat copy source %s: %w", src, err)
 		}
-		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 			return fmt.Errorf("failed to create destination directory for %s: %w", dest, err)
 		}
 		if err := filesystem.CopyFile(src, dest); err != nil {
@@ -340,7 +340,7 @@ func restructureToStaging(params postProcessParams) error {
 	if params.javaAPI.Monolithic {
 		destRoot = filepath.Join(destRoot, "src")
 	}
-	if err := os.MkdirAll(destRoot, 0755); err != nil {
+	if err := os.MkdirAll(destRoot, 0o755); err != nil {
 		return fmt.Errorf("failed to create staging directory: %w", err)
 	}
 	return restructureModules(params, destRoot)
@@ -356,7 +356,7 @@ type moveAction struct {
 func restructure(actions []moveAction) error {
 	for _, action := range actions {
 		if _, err := os.Stat(action.src); err == nil {
-			if err := os.MkdirAll(action.dest, 0755); err != nil {
+			if err := os.MkdirAll(action.dest, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", action.dest, err)
 			}
 			if err := filesystem.MoveAndMerge(action.src, action.dest); err != nil {
@@ -495,7 +495,7 @@ func runOwlBot(ctx context.Context, library *config.Library, outDir, bomVersion 
 func copyProtos(protos []protoFileToCopy, destDir string) error {
 	for _, proto := range protos {
 		target := filepath.Join(destDir, proto.relativePath)
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(target), err)
 		}
 		if err := filesystem.CopyFile(proto.absolutePath, target); err != nil {
@@ -576,7 +576,7 @@ func createOrVerifyOwlbotPy(outDir string) (err error) {
 	owlbotPath := filepath.Join(outDir, "owlbot.py")
 	// Open with O_EXCL to atomically ensure we only create the script if it does not exist.
 	// Executable permissions (0755) are set because owlbot.py is executed during post-processing.
-	file, createErr := os.OpenFile(owlbotPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0755)
+	file, createErr := os.OpenFile(owlbotPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o755)
 	if errors.Is(createErr, fs.ErrExist) {
 		return nil
 	}
@@ -605,7 +605,7 @@ func ApplyMoveActionsToLibrary(actions []moveAction, destRoot string, keepSet ma
 			}
 			return fmt.Errorf("failed to check source directory %s: %w", action.src, err)
 		}
-		if err := os.MkdirAll(action.dest, 0755); err != nil {
+		if err := os.MkdirAll(action.dest, 0o755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", action.dest, err)
 		}
 		err := filesystem.MoveAndMergeWithKeep(action.src, action.dest, destRoot, func(rel string) bool {

--- a/internal/librarian/java/postprocess_test.go
+++ b/internal/librarian/java/postprocess_test.go
@@ -37,7 +37,7 @@ func TestPostProcessAPI(t *testing.T) {
 	t.Parallel()
 	outdir := t.TempDir()
 	// Force routing to the legacy owlbot.py postprocessor.
-	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("# dummy"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, "owlbot.py"), []byte("# dummy"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	libraryName := "secretmanager"
@@ -45,35 +45,35 @@ func TestPostProcessAPI(t *testing.T) {
 	gapicDir := filepath.Join(outdir, apiBase, "gapic")
 	gRPCDir := filepath.Join(outdir, apiBase, "grpc")
 	protoDir := filepath.Join(outdir, apiBase, "proto")
-	if err := os.MkdirAll(filepath.Join(gapicDir, "src", "main", "java"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(gapicDir, "src", "main", "java"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(gRPCDir, 0755); err != nil {
+	if err := os.MkdirAll(gRPCDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, artifact := range []string{"google-cloud-secretmanager", "proto-google-cloud-secretmanager-v1", "grpc-google-cloud-secretmanager-v1", "google-cloud-secretmanager-bom"} {
-		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(outdir, artifact), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 	content := "package com.google.cloud.secretmanager.v1;"
 	grpcFile := filepath.Join(gRPCDir, "GRPCFile.java")
-	if err := os.WriteFile(grpcFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(grpcFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(protoDir, 0755); err != nil {
+	if err := os.MkdirAll(protoDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	protoFile := filepath.Join(protoDir, "ProtoFile.java")
-	if err := os.WriteFile(protoFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(protoFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	orBuilderDir := filepath.Join(protoDir, "com", "google", "cloud", "secretmanager", "v1")
-	if err := os.MkdirAll(orBuilderDir, 0755); err != nil {
+	if err := os.MkdirAll(orBuilderDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	orBuilderFile := filepath.Join(orBuilderDir, "SomeOrBuilder.java")
-	if err := os.WriteFile(orBuilderFile, []byte("package com.google.cloud.secretmanager.v1; public interface SomeOrBuilder {}"), 0644); err != nil {
+	if err := os.WriteFile(orBuilderFile, []byte("package com.google.cloud.secretmanager.v1; public interface SomeOrBuilder {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -98,7 +98,7 @@ func TestPostProcessAPI(t *testing.T) {
 	if err := zw.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(srcjarPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(srcjarPath, buf.Bytes(), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	apiProtos := []string{filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/service.proto")}
@@ -187,18 +187,18 @@ func TestRestructureModules(t *testing.T) {
 		filepath.Join(tmpDir, apiBase, "proto"),
 	}
 	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// Create a dummy sample file
 	sampleFile := filepath.Join(tmpDir, apiBase, "gapic", "samples", "snippets", "generated", "src", "main", "java", "Sample.java")
-	if err := os.WriteFile(sampleFile, []byte("public class Sample {}"), 0644); err != nil {
+	if err := os.WriteFile(sampleFile, []byte("public class Sample {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Create a dummy reflect-config.json
 	reflectConfigPath := filepath.Join(tmpDir, apiBase, "gapic", "src", "main", "resources", "META-INF", "native-image", "reflect-config.json")
-	if err := os.WriteFile(reflectConfigPath, []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(reflectConfigPath, []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	protoPath := filepath.Join(googleapisDir, "google", "cloud", "secretmanager", "v1", "service.proto")
@@ -316,11 +316,11 @@ func setupLocationProtoFile(t *testing.T, tmpDir, apiBase string) {
 	t.Helper()
 	protoSrcDir := filepath.Join(tmpDir, apiBase, "proto")
 	locationDir := filepath.Join(protoSrcDir, "com", "google", "cloud", "location")
-	if err := os.MkdirAll(locationDir, 0755); err != nil {
+	if err := os.MkdirAll(locationDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	dummyFile := filepath.Join(locationDir, "LocationsProto.java")
-	if err := os.WriteFile(dummyFile, []byte("public class LocationsProto {}"), 0644); err != nil {
+	if err := os.WriteFile(dummyFile, []byte("public class LocationsProto {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -336,13 +336,13 @@ func TestRestructureModules_SamplesDisabled(t *testing.T) {
 		filepath.Join(tmpDir, apiBase, "gapic", "samples", "snippets", "generated", "src", "main", "java"),
 	}
 	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// Create a dummy sample file
 	sampleFile := filepath.Join(tmpDir, apiBase, "gapic", "samples", "snippets", "generated", "src", "main", "java", "Sample.java")
-	if err := os.WriteFile(sampleFile, []byte("public class Sample {}"), 0644); err != nil {
+	if err := os.WriteFile(sampleFile, []byte("public class Sample {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -383,21 +383,21 @@ func TestRestructureModules_Monolithic(t *testing.T) {
 		filepath.Join(tmpDir, apiBase, "proto"),
 	}
 	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// Create dummy files
 	gapicFile := filepath.Join(tmpDir, apiBase, "gapic", "src", "main", "java", "Gapic.java")
-	if err := os.WriteFile(gapicFile, []byte("public class Gapic {}"), 0644); err != nil {
+	if err := os.WriteFile(gapicFile, []byte("public class Gapic {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	grpcFile := filepath.Join(tmpDir, apiBase, "grpc", "Grpc.java")
-	if err := os.WriteFile(grpcFile, []byte("public class Grpc {}"), 0644); err != nil {
+	if err := os.WriteFile(grpcFile, []byte("public class Grpc {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	protoFile := filepath.Join(tmpDir, apiBase, "proto", "Proto.java")
-	if err := os.WriteFile(protoFile, []byte("public class Proto {}"), 0644); err != nil {
+	if err := os.WriteFile(protoFile, []byte("public class Proto {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	params := postProcessParams{
@@ -448,11 +448,11 @@ func TestPostProcessAPI_SkipHeaders(t *testing.T) {
 			outdir := t.TempDir()
 			apiBase := "v1"
 			gRPCDir := filepath.Join(outdir, apiBase, "grpc")
-			if err := os.MkdirAll(gRPCDir, 0755); err != nil {
+			if err := os.MkdirAll(gRPCDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			grpcFile := filepath.Join(gRPCDir, "GRPCFile.java")
-			if err := os.WriteFile(grpcFile, []byte("package com.test;"), 0644); err != nil {
+			if err := os.WriteFile(grpcFile, []byte("package com.test;"), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			params := postProcessParams{
@@ -480,11 +480,11 @@ func TestPostProcessAPI_AlternateHeaders(t *testing.T) {
 	outdir := t.TempDir()
 	apiBase := "v1"
 	gRPCDir := filepath.Join(outdir, apiBase, "grpc")
-	if err := os.MkdirAll(gRPCDir, 0755); err != nil {
+	if err := os.MkdirAll(gRPCDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	grpcFile := filepath.Join(gRPCDir, "GRPCFile.java")
-	if err := os.WriteFile(grpcFile, []byte("package com.test;"), 0644); err != nil {
+	if err := os.WriteFile(grpcFile, []byte("package com.test;"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	params := postProcessParams{
@@ -495,7 +495,7 @@ func TestPostProcessAPI_AlternateHeaders(t *testing.T) {
 	}
 	altHeader := "/* Alternate */\n"
 	headerFile := filepath.Join(outdir, "header.txt")
-	if err := os.WriteFile(headerFile, []byte(altHeader), 0644); err != nil {
+	if err := os.WriteFile(headerFile, []byte(altHeader), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	params.library.Java.AlternateHeaders = "header.txt"
@@ -510,7 +510,7 @@ func TestPostProcessAPI_AlternateHeaders(t *testing.T) {
 	if !bytes.HasPrefix(got, []byte(wantHeader)) {
 		t.Errorf("mismatch got = %q, want %q", got, wantHeader)
 	}
-	if err := os.WriteFile(grpcFile, []byte("package com.test;"), 0644); err != nil {
+	if err := os.WriteFile(grpcFile, []byte("package com.test;"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	params.javaAPI.Monolithic = true
@@ -604,7 +604,7 @@ func TestPostProcessLibrary(t *testing.T) {
 			},
 			setup: func(t *testing.T, outDir string) {
 				writeOwlBot(t, outDir, "sys.exit(0)")
-				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -614,7 +614,7 @@ func TestPostProcessLibrary(t *testing.T) {
 			cfg:  defaultCfg,
 			setup: func(t *testing.T, outDir string) {
 				writeOwlBot(t, outDir, "sys.exit(0)")
-				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
 				libCoords := deriveLibraryCoordinates(library)
@@ -626,7 +626,7 @@ func TestPostProcessLibrary(t *testing.T) {
 					filepath.Join(outDir, apiCoords.Parent.ArtifactID),
 					filepath.Join(outDir, apiCoords.BOM.ArtifactID),
 				} {
-					if err := os.MkdirAll(dir, 0755); err != nil {
+					if err := os.MkdirAll(dir, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -707,7 +707,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			},
 			setup: func(t *testing.T, outDir string) {
 				writeOwlBot(t, outDir, "sys.exit(0)")
-				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -718,7 +718,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 			cfg:  defaultCfg,
 			setup: func(t *testing.T, outDir string) {
 				writeOwlBot(t, outDir, "sys.exit(1)")
-				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(filepath.Dir(outDir), owlbotTemplatesRelPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -750,7 +750,7 @@ func TestPostProcessLibrary_ErrorCase(t *testing.T) {
 func writeOwlBot(t *testing.T, outDir, script string) {
 	t.Helper()
 	content := "import sys; " + script
-	if err := os.WriteFile(filepath.Join(outDir, "owlbot.py"), []byte(content), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outDir, "owlbot.py"), []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -760,11 +760,11 @@ func TestRunOwlBot(t *testing.T) {
 	testhelper.RequireCommand(t, "python3")
 	tmp := t.TempDir()
 	outDir := filepath.Join(tmp, "out")
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	templatesDir := filepath.Join(tmp, "sdk-platform-java", "hermetic_build", "library_generation", "owlbot", "templates")
-	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Create a dummy owlbot.py that checks environment variables.
@@ -789,7 +789,7 @@ if not templates or not templates.endswith("templates"):
 with open("owlbot-ran.txt", "w") as f:
     f.write("success")
 `
-	if err := os.WriteFile(filepath.Join(outDir, "owlbot.py"), []byte(owlbotContent), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(outDir, "owlbot.py"), []byte(owlbotContent), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -812,17 +812,17 @@ func TestRunOwlBot_Error(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	outDir := filepath.Join(tmp, "out")
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	sDir := stagingDir(outDir)
-	if err := os.MkdirAll(sDir, 0755); err != nil {
+	if err := os.MkdirAll(sDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Create a dummy file to ensure the staging directory is non-empty,
 	// verifying that the cleanup logic correctly removes everything.
 	dummyFile := filepath.Join(sDir, "dummy.txt")
-	if err := os.WriteFile(dummyFile, []byte("dummy"), 0644); err != nil {
+	if err := os.WriteFile(dummyFile, []byte("dummy"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	library := &config.Library{
@@ -875,7 +875,7 @@ func TestAddMissingHeaders(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			path := filepath.Join(tmpDir, test.filename)
-			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -883,10 +883,10 @@ func TestAddMissingHeaders(t *testing.T) {
 			params.outDir = tmpDir
 			if params.library != nil && params.library.Java != nil && params.library.Java.AlternateHeaders != "" {
 				headerPath := filepath.Join(tmpDir, params.library.Java.AlternateHeaders)
-				if err := os.MkdirAll(filepath.Dir(headerPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(headerPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(headerPath, []byte("/* Alternate Header */\n"), 0644); err != nil {
+				if err := os.WriteFile(headerPath, []byte("/* Alternate Header */\n"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -932,11 +932,11 @@ func TestCopyFiles(t *testing.T) {
 	destPath := "src/main/resources/com/google/storage/v2/gapic_metadata.json"
 
 	fullSrcPath := filepath.Join(gapicDir, srcPath)
-	if err := os.MkdirAll(filepath.Dir(fullSrcPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fullSrcPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	content := `{"schema": "1.0"}`
-	if err := os.WriteFile(fullSrcPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(fullSrcPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	params := postProcessParams{
@@ -1010,10 +1010,10 @@ func TestRemoveKeptFilesFromStaging(t *testing.T) {
 	nonExistentKeptFile := filepath.Join(stagingDir, "v1", "google-cloud-lib", "src", "main", "java", "com", "google", "kept", "NonExistent.java")
 
 	for _, file := range []string{keptFile, versionFile, regularFile, keptDirFile, nonExistentKeptFile} {
-		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(file, []byte("public class Dummy {}"), 0644); err != nil {
+		if err := os.WriteFile(file, []byte("public class Dummy {}"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1025,10 +1025,10 @@ func TestRemoveKeptFilesFromStaging(t *testing.T) {
 	destKeptDirFile := filepath.Join(outDir, "google-cloud-lib", "src", "main", "java", "com", "google", "keptdir", "SubDir", "File.java")
 
 	for _, file := range []string{destKeptFile, destVersionFile, destKeptDirFile} {
-		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(file, []byte("public class Dummy {}"), 0644); err != nil {
+		if err := os.WriteFile(file, []byte("public class Dummy {}"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1084,10 +1084,10 @@ func TestCreateOrVerifyOwlbotPy(t *testing.T) {
 	}
 	goldenPath := filepath.Join("testdata", "postprocess", "owlbot.py.golden")
 	if *update {
-		if err := os.MkdirAll(filepath.Dir(goldenPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(goldenPath, gotContent, 0644); err != nil {
+		if err := os.WriteFile(goldenPath, gotContent, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1107,7 +1107,7 @@ func TestCreateOrVerifyOwlbotPy_AlreadyExists(t *testing.T) {
 	outDir := t.TempDir()
 	owlbotPath := filepath.Join(outDir, "owlbot.py")
 	existingContent := "existing content"
-	if err := os.WriteFile(owlbotPath, []byte(existingContent), 0755); err != nil {
+	if err := os.WriteFile(owlbotPath, []byte(existingContent), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := createOrVerifyOwlbotPy(outDir); err != nil {
@@ -1127,10 +1127,10 @@ func TestCreateOrVerifyOwlbotPy_AlreadyExists(t *testing.T) {
 func TestCreateOrVerifyOwlbotPy_Error(t *testing.T) {
 	t.Parallel()
 	outDir := t.TempDir()
-	if err := os.Chmod(outDir, 0000); err != nil {
+	if err := os.Chmod(outDir, 0o000); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(outDir, 0755)
+	defer os.Chmod(outDir, 0o755)
 	err := createOrVerifyOwlbotPy(outDir)
 	if !errors.Is(err, fs.ErrPermission) {
 		t.Errorf("error = %v, wantErr %v", err, fs.ErrPermission)
@@ -1221,10 +1221,10 @@ func TestApplyMoveActionsToLibrary_Error(t *testing.T) {
 			}
 			writeFiles(t, destDir, test.destFiles)
 			if test.readOnlySrcParent {
-				if err := os.Chmod(srcParent, 0000); err != nil {
+				if err := os.Chmod(srcParent, 0o000); err != nil {
 					t.Fatal(err)
 				}
-				defer os.Chmod(srcParent, 0755)
+				defer os.Chmod(srcParent, 0o755)
 			}
 			actions := []moveAction{
 				{src: srcDir, dest: destDir, description: "test files"},
@@ -1497,15 +1497,15 @@ func TestPostProcessLibrary_Go(t *testing.T) {
 
 func writeFiles(t *testing.T, dir string, files map[string]string) {
 	t.Helper()
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for rel, content := range files {
 		p := filepath.Join(dir, rel)
-		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/librarian/java/readme.go
+++ b/internal/librarian/java/readme.go
@@ -160,7 +160,7 @@ func renderREADME(params libraryPostProcessParams, keepSet map[string]bool) erro
 		return fmt.Errorf("failed to execute template: %w", err)
 	}
 	outputPath := filepath.Join(params.outDir, readmeFile)
-	return os.WriteFile(outputPath, buf.Bytes(), 0644)
+	return os.WriteFile(outputPath, buf.Bytes(), 0o644)
 }
 
 // validateReadmeParams validates that required parameters are present before rendering README.md.

--- a/internal/librarian/java/readme_test.go
+++ b/internal/librarian/java/readme_test.go
@@ -42,19 +42,19 @@ func TestExtractSamples(t *testing.T) {
 			name: "extract successfully",
 			setupFiles: func(t *testing.T, dir string) {
 				samplesDir := filepath.Join(dir, "samples", "src", "main", "java")
-				if err := os.MkdirAll(samplesDir, 0755); err != nil {
+				if err := os.MkdirAll(samplesDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				file1 := filepath.Join(samplesDir, "RequesterPays.java")
 				content1 := `// sample-metadata:
 //   title: Custom Title Override
 public class RequesterPays {}`
-				if err := os.WriteFile(file1, []byte(content1), 0644); err != nil {
+				if err := os.WriteFile(file1, []byte(content1), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				file2 := filepath.Join(samplesDir, "DemoSample.java")
 				content2 := `public class DemoSample {}`
-				if err := os.WriteFile(file2, []byte(content2), 0644); err != nil {
+				if err := os.WriteFile(file2, []byte(content2), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -101,14 +101,14 @@ func TestExtractSamples_Error(t *testing.T) {
 			name: "error on empty title override",
 			setupFiles: func(t *testing.T, dir string) {
 				samplesDir := filepath.Join(dir, "samples", "src", "main", "java")
-				if err := os.MkdirAll(samplesDir, 0755); err != nil {
+				if err := os.MkdirAll(samplesDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				file := filepath.Join(samplesDir, "Sample.java")
 				content := `// sample-metadata:
 //   title: ""
 public class Invalid {}`
-				if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -118,14 +118,14 @@ public class Invalid {}`
 			name: "error on missing title line immediately following sample-metadata",
 			setupFiles: func(t *testing.T, dir string) {
 				samplesDir := filepath.Join(dir, "samples", "src", "main", "java")
-				if err := os.MkdirAll(samplesDir, 0755); err != nil {
+				if err := os.MkdirAll(samplesDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				file := filepath.Join(samplesDir, "Sample.java")
 				content := `// sample-metadata:
 //   description: missing title line
 public class Invalid {}`
-				if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -163,20 +163,20 @@ func TestCollectSampleFiles(t *testing.T) {
 			name: "collects production java files only",
 			setupFiles: func(t *testing.T, dir string) {
 				samplesDir := filepath.Join(dir, "samples", "src", "main", "java", "com", "example")
-				if err := os.MkdirAll(samplesDir, 0755); err != nil {
+				if err := os.MkdirAll(samplesDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				testDir := filepath.Join(dir, "samples", "src", "test", "java", "com", "example")
-				if err := os.MkdirAll(testDir, 0755); err != nil {
+				if err := os.MkdirAll(testDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(samplesDir, "SampleA.java"), []byte("public class SampleA {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(samplesDir, "SampleA.java"), []byte("public class SampleA {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(samplesDir, "README.md"), []byte("# Docs"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(samplesDir, "README.md"), []byte("# Docs"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(testDir, "SampleATest.java"), []byte("public class SampleATest {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(testDir, "SampleATest.java"), []byte("public class SampleATest {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -190,19 +190,19 @@ func TestCollectSampleFiles(t *testing.T) {
 				pkg1 := filepath.Join(dir, "samples", "src", "main", "java", "com", "example")
 				pkg2 := filepath.Join(dir, "samples", "src", "main", "java", "com", "example", "subpkg")
 				fakeJavaDir := filepath.Join(dir, "samples", "src", "main", "java", "com", "example", "FakeDir.java")
-				if err := os.MkdirAll(pkg1, 0755); err != nil {
+				if err := os.MkdirAll(pkg1, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.MkdirAll(pkg2, 0755); err != nil {
+				if err := os.MkdirAll(pkg2, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.MkdirAll(fakeJavaDir, 0755); err != nil {
+				if err := os.MkdirAll(fakeJavaDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(pkg1, "Alpha.java"), []byte("public class Alpha {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(pkg1, "Alpha.java"), []byte("public class Alpha {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(pkg2, "Beta.java"), []byte("package com.example.subpkg; public class Beta {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(pkg2, "Beta.java"), []byte("package com.example.subpkg; public class Beta {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -256,10 +256,10 @@ func TestParseCodeSample(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			absPath := filepath.Join(tempDir, test.relPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile(absPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(absPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -297,10 +297,10 @@ func TestParseCodeSample_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			absPath := filepath.Join(tempDir, test.relPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile(absPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(absPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -433,7 +433,7 @@ public class Normal {}`,
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpPath := filepath.Join(t.TempDir(), "Sample.java")
-			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := extractTitle(tmpPath)
@@ -468,7 +468,7 @@ func TestExtractTitle_Error(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpPath := filepath.Join(t.TempDir(), "Sample.java")
-			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			_, gotErr := extractTitle(tmpPath)
@@ -600,7 +600,7 @@ func TestLoadReadmePartials(t *testing.T) {
 			setupFiles: func(t *testing.T, dir string) {
 				path := filepath.Join(dir, readmePartialsFile)
 				content := `about_text: "Custom about"`
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -617,7 +617,7 @@ func TestLoadReadmePartials(t *testing.T) {
 			name: "empty partials file returns nil",
 			setupFiles: func(t *testing.T, dir string) {
 				path := filepath.Join(dir, readmePartialsFile)
-				if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -627,7 +627,7 @@ func TestLoadReadmePartials(t *testing.T) {
 			name: "partials file with only comments returns nil",
 			setupFiles: func(t *testing.T, dir string) {
 				path := filepath.Join(dir, readmePartialsFile)
-				if err := os.WriteFile(path, []byte("# only comments\n# no keys defined"), 0644); err != nil {
+				if err := os.WriteFile(path, []byte("# only comments\n# no keys defined"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -665,7 +665,7 @@ func TestLoadReadmePartials_Error(t *testing.T) {
 			setupFiles: func(t *testing.T, dir string) {
 				path := filepath.Join(dir, readmePartialsFile)
 				content := `key: [unclosed list`
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -707,23 +707,23 @@ func TestCollectSnippetFiles(t *testing.T) {
 				testDir := filepath.Join(dir, "samples", "src", "test", "java")
 				genDir := filepath.Join(dir, "samples", "snippets", "generated")
 				for _, d := range []string{validJavaDir, validXMLDir, testDir, genDir} {
-					if err := os.MkdirAll(d, 0755); err != nil {
+					if err := os.MkdirAll(d, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
-				if err := os.WriteFile(filepath.Join(validJavaDir, "Sample.java"), []byte("public class Sample {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(validJavaDir, "Sample.java"), []byte("public class Sample {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(validXMLDir, "pom.xml"), []byte("<project></project>"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(validXMLDir, "pom.xml"), []byte("<project></project>"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(validJavaDir, "README.md"), []byte("# Ignore"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(validJavaDir, "README.md"), []byte("# Ignore"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(testDir, "TestSample.java"), []byte("public class TestSample {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(testDir, "TestSample.java"), []byte("public class TestSample {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(genDir, "GenSnippet.java"), []byte("public class GenSnippet {}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(genDir, "GenSnippet.java"), []byte("public class GenSnippet {}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -839,7 +839,7 @@ func TestExtractSnippetsFromFile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			tmpPath := filepath.Join(t.TempDir(), "SampleSnippet.java")
-			if err := os.WriteFile(tmpPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(tmpPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := extractSnippetsFromFile(tmpPath)
@@ -907,7 +907,7 @@ func TestRenderREADME(t *testing.T) {
 			setupFiles: func(t *testing.T, dir string) {
 				path := filepath.Join(dir, readmePartialsFile)
 				content := `about: "This is a great API."`
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -957,10 +957,10 @@ func TestRenderREADME(t *testing.T) {
 				t.Fatal(err)
 			}
 			if *update {
-				if err := os.MkdirAll(filepath.Dir(test.goldenFile), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(test.goldenFile), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(test.goldenFile, outputBytes, 0644); err != nil {
+				if err := os.WriteFile(test.goldenFile, outputBytes, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -979,7 +979,7 @@ func TestRenderREADME_KeepSet(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "README.md")
 	wantContent := "Custom README content"
-	if err := os.WriteFile(path, []byte(wantContent), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(wantContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	params := libraryPostProcessParams{outDir: dir}

--- a/internal/librarian/nodejs/clean_test.go
+++ b/internal/librarian/nodejs/clean_test.go
@@ -130,10 +130,10 @@ func verifyFileDeletions(t *testing.T, dir string, setupFiles, wantDeleted []str
 
 func createFileAndDirectories(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -54,7 +54,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
-	if err := os.MkdirAll(outdir, 0755); err != nil {
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 	repoRoot := filepath.Dir(filepath.Dir(outdir))
@@ -116,7 +116,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 
 	version := filepath.Base(api.Path)
 	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, version)
-	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}
 
@@ -504,7 +504,7 @@ func replaceCopyrightInDir(dir string, re *regexp.Regexp, replacement []byte) er
 		if bytes.Equal(updated, content) {
 			return nil
 		}
-		return os.WriteFile(path, updated, 0644)
+		return os.WriteFile(path, updated, 0o644)
 	})
 }
 
@@ -531,7 +531,7 @@ func writeRepoMetadata(cfg *config.Config, library *config.Library, googleapisDi
 		return err
 	}
 	content = bytes.ReplaceAll(content, []byte(`\u0026`), []byte(`&`))
-	return os.WriteFile(path, content, 0644)
+	return os.WriteFile(path, content, 0o644)
 }
 
 // copyMissingProtos reads *_proto_list.json files under outDir/src/ and copies
@@ -567,7 +567,7 @@ func copyMissingProtos(googleapisDir, outDir string) error {
 			if !ok {
 				continue
 			}
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 				return fmt.Errorf("failed to create directory for %s: %w", absPath, err)
 			}
 			srcPath := filepath.Join(googleapisDir, relPath)
@@ -614,14 +614,14 @@ func copySamplesFromStaging(stagingDir, outDir string) error {
 				return err
 			}
 			dst := filepath.Join(outDir, "samples", rel)
-			if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 				return err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
-			return os.WriteFile(dst, content, 0644)
+			return os.WriteFile(dst, content, 0o644)
 		}); err != nil {
 			return err
 		}
@@ -706,7 +706,7 @@ func injectV1SmallExports(outDir string) error {
 	}
 	content = updated
 
-	return os.WriteFile(indexPath, []byte(content), 0644)
+	return os.WriteFile(indexPath, []byte(content), 0o644)
 }
 
 func moveKeep(files []string, srcDir, dstDir string) error {
@@ -716,7 +716,7 @@ func moveKeep(files []string, srcDir, dstDir string) error {
 			continue // file doesn't exist, nothing to save
 		}
 		dst := filepath.Join(dstDir, name)
-		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return fmt.Errorf("failed to create destination subdirectory for %s: %w", name, err)
 		}
 		if err := os.Rename(src, dst); err != nil {

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -435,7 +435,7 @@ func TestGenerateAPI(t *testing.T) {
 
 	repoRoot := t.TempDir()
 	outDir := filepath.Join(repoRoot, "packages", "google-cloud-secretmanager")
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -476,7 +476,7 @@ func TestGenerateAPI_MultipleVersions(t *testing.T) {
 		},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	library.Output = outDir
@@ -507,7 +507,7 @@ func TestRunPostProcessor(t *testing.T) {
 		APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -540,27 +540,27 @@ func TestRunPostProcessor_RemovesOwlBotYaml(t *testing.T) {
 		APIs: []*config.API{{Path: "google/cloud/test/v1"}},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create staging structure with a .OwlBot.yaml file.
 	stagingBase := filepath.Join(repoRoot, "owl-bot-staging", library.Name, "v1")
 	srcDir := filepath.Join(stagingBase, "src", "v1")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {};\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {};\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	protoDir := filepath.Join(stagingBase, "protos", "google", "cloud", "test", "v1")
-	if err := os.MkdirAll(protoDir, 0755); err != nil {
+	if err := os.MkdirAll(protoDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(protoDir, "test.proto"), []byte("syntax = \"proto3\";\npackage google.cloud.test.v1;\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(protoDir, "test.proto"), []byte("syntax = \"proto3\";\npackage google.cloud.test.v1;\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(stagingBase, ".OwlBot.yaml"), []byte("deep-copy-regex:\n  - source: /owl-bot-staging\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingBase, ".OwlBot.yaml"), []byte("deep-copy-regex:\n  - source: /owl-bot-staging\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -583,27 +583,27 @@ func TestRunPostProcessor_RemovesCloudCommonResourcesProto(t *testing.T) {
 		APIs: []*config.API{{Path: "google/cloud/test/v1"}},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create staging structure with a common_resources.proto file.
 	stagingBase := filepath.Join(repoRoot, "owl-bot-staging", library.Name, "v1")
 	srcDir := filepath.Join(stagingBase, "src", "v1")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {};\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {};\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	protoDir := filepath.Join(stagingBase, "protos", "google", "cloud", "test", "v1")
-	if err := os.MkdirAll(protoDir, 0755); err != nil {
+	if err := os.MkdirAll(protoDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(protoDir, "test.proto"), []byte("syntax = \"proto3\";\npackage google.cloud.test.v1;\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(protoDir, "test.proto"), []byte("syntax = \"proto3\";\npackage google.cloud.test.v1;\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(stagingBase, "protos", cloudCommonResourcesProto), []byte("syntax = \"proto3\";\npackage google.cloud;\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingBase, "protos", cloudCommonResourcesProto), []byte("syntax = \"proto3\";\npackage google.cloud;\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -629,36 +629,36 @@ func TestRunPostProcessor_CustomScripts(t *testing.T) {
 		Keep: []string{"librarian.js", ".readme-partials.yaml"},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	stagingBase := filepath.Join(repoRoot, "owl-bot-staging", library.Name, "v1")
 	srcDir := filepath.Join(stagingBase, "src", "v1")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(
 		filepath.Join(srcDir, "index.ts"),
 		[]byte("export {SecretManagerServiceClient} from './secret_manager_service_client';\n"),
-		0644,
+		0o644,
 	); err != nil {
 		t.Fatal(err)
 	}
 	protoDir := filepath.Join(stagingBase, "protos", "google", "cloud", "secretmanager", "v1")
-	if err := os.MkdirAll(protoDir, 0755); err != nil {
+	if err := os.MkdirAll(protoDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	protoContent := "syntax = \"proto3\";\npackage google.cloud.secretmanager.v1;\n"
-	if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(protoContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(protoContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	librarianJS := filepath.Join(outDir, "librarian.js")
-	if err := os.WriteFile(librarianJS, []byte("const fs = require('fs');\nfs.writeFileSync('librarian-ran.txt', 'yes');\n"), 0644); err != nil {
+	if err := os.WriteFile(librarianJS, []byte("const fs = require('fs');\nfs.writeFileSync('librarian-ran.txt', 'yes');\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	readmePartials := filepath.Join(outDir, ".readme-partials.yaml")
-	if err := os.WriteFile(readmePartials, []byte("introduction: 'intro text'\nbody: 'body text'"), 0644); err != nil {
+	if err := os.WriteFile(readmePartials, []byte("introduction: 'intro text'\nbody: 'body text'"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	cfg := &config.Config{
@@ -704,26 +704,26 @@ func TestRunPostProcessor_PreservesFiles(t *testing.T) {
 		Keep: []string{"README.md", ".readme-partials.yaml", "system-test/.eslintrc.yml"},
 	}
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	createStagingFixture(t, repoRoot, library.Name, []string{"v1"})
 
 	readmeContent := "# Test README"
-	if err := os.WriteFile(filepath.Join(outDir, "README.md"), []byte(readmeContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(outDir, "README.md"), []byte(readmeContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	partialsContent := "introduction: ''\nbody: ''"
-	if err := os.WriteFile(filepath.Join(outDir, ".readme-partials.yaml"), []byte(partialsContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(outDir, ".readme-partials.yaml"), []byte(partialsContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	eslintContent := "extends: eslint:recommended"
 	eslintDir := filepath.Join(outDir, "system-test")
-	if err := os.MkdirAll(eslintDir, 0755); err != nil {
+	if err := os.MkdirAll(eslintDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(eslintDir, ".eslintrc.yml"), []byte(eslintContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(eslintDir, ".eslintrc.yml"), []byte(eslintContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -794,11 +794,11 @@ func TestRestoreCopyrightYear(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
 			dir := filepath.Join(outDir, test.dir)
-			if err := os.MkdirAll(dir, 0755); err != nil {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			file := filepath.Join(dir, "index.ts")
-			if err := os.WriteFile(file, []byte(test.input), 0644); err != nil {
+			if err := os.WriteFile(file, []byte(test.input), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := restoreCopyrightYear(outDir, test.year); err != nil {
@@ -877,24 +877,24 @@ func TestCopyMissingProtos(t *testing.T) {
 	outDir := t.TempDir()
 
 	srcProto := filepath.Join(googleapisDir, "google", "logging", "type", "log_severity.proto")
-	if err := os.MkdirAll(filepath.Dir(srcProto), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(srcProto), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	srcContent := []byte("syntax = \"proto3\";\npackage google.logging.type;\n")
-	if err := os.WriteFile(srcProto, srcContent, 0644); err != nil {
+	if err := os.WriteFile(srcProto, srcContent, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	listDir := filepath.Join(outDir, "src", "v1")
-	if err := os.MkdirAll(listDir, 0755); err != nil {
+	if err := os.MkdirAll(listDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	existingProto := filepath.Join(outDir, "protos", "google", "cloud", "foo", "v1", "existing.proto")
-	if err := os.MkdirAll(filepath.Dir(existingProto), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(existingProto), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(existingProto, []byte("existing"), 0644); err != nil {
+	if err := os.WriteFile(existingProto, []byte("existing"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -911,7 +911,7 @@ func TestCopyMissingProtos(t *testing.T) {
 		t.Fatal(err)
 	}
 	listPath := filepath.Join(listDir, "foo_proto_list.json")
-	if err := os.WriteFile(listPath, listData, 0644); err != nil {
+	if err := os.WriteFile(listPath, listData, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -950,15 +950,15 @@ func TestCopySamplesFromStaging(t *testing.T) {
 		{version: "v1beta1", metadataContent: `{"snippets":["beta"]}`},
 	} {
 		samplesDir := filepath.Join(stagingDir, v.version, "samples", "generated", v.version)
-		if err := os.MkdirAll(samplesDir, 0755); err != nil {
+		if err := os.MkdirAll(samplesDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		if v.sampleContent != "" {
-			if err := os.WriteFile(filepath.Join(samplesDir, "sample.js"), []byte(v.sampleContent), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(samplesDir, "sample.js"), []byte(v.sampleContent), 0o644); err != nil {
 				t.Fatal(err)
 			}
 		}
-		if err := os.WriteFile(filepath.Join(samplesDir, "snippet_metadata_google.cloud.test."+v.version+".json"), []byte(v.metadataContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(samplesDir, "snippet_metadata_google.cloud.test."+v.version+".json"), []byte(v.metadataContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1013,11 +1013,11 @@ func TestGenerateAPI_NoProtos(t *testing.T) {
 	// Create an API directory with no .proto files.
 	apiPath := "google/cloud/emptyapi/v1"
 	apiDir := filepath.Join(googleapisDir, apiPath)
-	if err := os.MkdirAll(apiDir, 0755); err != nil {
+	if err := os.MkdirAll(apiDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Write a non-proto file so the directory is not empty.
-	if err := os.WriteFile(filepath.Join(apiDir, "BUILD.bazel"), []byte("# empty"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(apiDir, "BUILD.bazel"), []byte("# empty"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1035,18 +1035,18 @@ func createStagingFixture(t *testing.T, repoRoot, libName string, versions []str
 	for _, v := range versions {
 		stagingBase := filepath.Join(repoRoot, "owl-bot-staging", libName, v)
 		srcDir := filepath.Join(stagingBase, "src", v)
-		if err := os.MkdirAll(srcDir, 0755); err != nil {
+		if err := os.MkdirAll(srcDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {};\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {};\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		protoDir := filepath.Join(stagingBase, "protos", "google", "cloud", "test", v)
-		if err := os.MkdirAll(protoDir, 0755); err != nil {
+		if err := os.MkdirAll(protoDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		protoContent := fmt.Sprintf("syntax = \"proto3\";\npackage google.cloud.test.%s;\n", v)
-		if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(protoContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(protoContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1186,7 +1186,7 @@ func TestRunPostProcessor_CustomScripts_RootRelativePath(t *testing.T) {
 	}
 
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// This script uses a path relative to the repository root.
@@ -1195,7 +1195,7 @@ func TestRunPostProcessor_CustomScripts_RootRelativePath(t *testing.T) {
 	script := fmt.Sprintf("const fs = require('fs');\nfs.writeFileSync('%s', 'success');\n", relPath)
 
 	librarianJS := filepath.Join(outDir, "librarian.js")
-	if err := os.WriteFile(librarianJS, []byte(script), 0644); err != nil {
+	if err := os.WriteFile(librarianJS, []byte(script), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	createStagingFixture(t, repoRoot, library.Name, []string{"v1"})
@@ -1467,11 +1467,11 @@ func TestInjectV1SmallExports(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
 			srcDir := filepath.Join(outDir, "src")
-			if err := os.MkdirAll(srcDir, 0755); err != nil {
+			if err := os.MkdirAll(srcDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			indexPath := filepath.Join(srcDir, "index.ts")
-			if err := os.WriteFile(indexPath, []byte(test.input), 0644); err != nil {
+			if err := os.WriteFile(indexPath, []byte(test.input), 0o644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1525,7 +1525,7 @@ func TestRemoveRedundantLinterFiles(t *testing.T) {
 			outDir := t.TempDir()
 			for _, f := range test.files {
 				path := filepath.Join(outDir, f)
-				if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+				if err := os.WriteFile(path, []byte("content"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1612,11 +1612,11 @@ func TestMoveKeep(t *testing.T) {
 		{
 			name: "moves existing files successfully",
 			setup: func(t *testing.T, srcDir string) {
-				if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 				for _, file := range []string{"file1.txt", "subdir/file2.txt"} {
-					if err := os.WriteFile(filepath.Join(srcDir, file), []byte("content"), 0644); err != nil {
+					if err := os.WriteFile(filepath.Join(srcDir, file), []byte("content"), 0o644); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -1627,7 +1627,7 @@ func TestMoveKeep(t *testing.T) {
 		{
 			name: "skips missing files without error",
 			setup: func(t *testing.T, srcDir string) {
-				if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("content1"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("content1"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1662,13 +1662,13 @@ func TestMoveKeep_Errors(t *testing.T) {
 		{
 			name: "mkdir failure when target parent is a regular file",
 			setup: func(t *testing.T, srcDir, dstDir string) {
-				if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(srcDir, "subdir", "file.txt"), []byte("content"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(srcDir, "subdir", "file.txt"), []byte("content"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(dstDir, "subdir"), []byte("not-a-dir"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(dstDir, "subdir"), []byte("not-a-dir"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1678,10 +1678,10 @@ func TestMoveKeep_Errors(t *testing.T) {
 		{
 			name: "rename failure when target is an existing directory",
 			setup: func(t *testing.T, srcDir, dstDir string) {
-				if err := os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("content"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("content"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.MkdirAll(filepath.Join(dstDir, "file.txt"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(dstDir, "file.txt"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1705,11 +1705,11 @@ func TestRequireCachedTool(t *testing.T) {
 	tempBin := t.TempDir()
 	t.Setenv("LIBRARIAN_BIN", tempBin)
 	nodeBinDir := filepath.Join(tempBin, "nodejs_tools", "bin")
-	if err := os.MkdirAll(nodeBinDir, 0755); err != nil {
+	if err := os.MkdirAll(nodeBinDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	toolPath := filepath.Join(nodeBinDir, "compileProtos")
-	if err := os.WriteFile(toolPath, []byte("#!/bin/sh"), 0755); err != nil {
+	if err := os.WriteFile(toolPath, []byte("#!/bin/sh"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1740,7 +1740,7 @@ func TestRequireCachedTool_Error(t *testing.T) {
 			name: "returns errToolNotInstalled when tool path is a directory",
 			setup: func(t *testing.T, binDir string) {
 				dirPath := filepath.Join(binDir, "dirTool")
-				if err := os.MkdirAll(dirPath, 0755); err != nil {
+				if err := os.MkdirAll(dirPath, 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1752,7 +1752,7 @@ func TestRequireCachedTool_Error(t *testing.T) {
 			tempBin := t.TempDir()
 			t.Setenv("LIBRARIAN_BIN", tempBin)
 			nodeBinDir := filepath.Join(tempBin, "nodejs_tools", "bin")
-			if err := os.MkdirAll(nodeBinDir, 0755); err != nil {
+			if err := os.MkdirAll(nodeBinDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			test.setup(t, nodeBinDir)

--- a/internal/librarian/nodejs/readme_test.go
+++ b/internal/librarian/nodejs/readme_test.go
@@ -64,7 +64,7 @@ func TestGenerateReadme(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			output := filepath.Join(t.TempDir(), "packages", library.Name)
 			sampleDir := filepath.Join(output, "samples", "generated", "v1")
-			if err := os.MkdirAll(sampleDir, 0755); err != nil {
+			if err := os.MkdirAll(sampleDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			for _, sample := range []string{
@@ -73,7 +73,7 @@ func TestGenerateReadme(t *testing.T) {
 				"secret_manager_service.create_secret.js",
 				"secret_manager_service.delete_secret.js",
 			} {
-				if err := os.WriteFile(filepath.Join(sampleDir, sample), []byte("example"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(sampleDir, sample), []byte("example"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -131,7 +131,7 @@ func TestGenerateReadme_Error(t *testing.T) {
 			output: func(t *testing.T) string {
 				tempDir := t.TempDir()
 				filePath := filepath.Join(tempDir, "README.md")
-				if err := os.WriteFile(filePath, []byte("existing file"), 0644); err != nil {
+				if err := os.WriteFile(filePath, []byte("existing file"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return filePath
@@ -147,11 +147,11 @@ func TestGenerateReadme_Error(t *testing.T) {
 			googleapisDir: absGoogleapisDir,
 			output: func(t *testing.T) string {
 				tempDir := t.TempDir()
-				if err := os.Chmod(tempDir, 0555); err != nil {
+				if err := os.Chmod(tempDir, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					_ = os.Chmod(tempDir, 0755)
+					_ = os.Chmod(tempDir, 0o755)
 				})
 				return tempDir
 			},
@@ -214,10 +214,10 @@ func TestFindSampleMetadata(t *testing.T) {
 				}
 				for _, file := range files {
 					fullPath := filepath.Join(generatedDir, file.path)
-					if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 						t.Fatal(err)
 					}
-					if err := os.WriteFile(fullPath, []byte(file.content), 0644); err != nil {
+					if err := os.WriteFile(fullPath, []byte(file.content), 0o644); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -252,15 +252,15 @@ func TestFindSampleMetadata(t *testing.T) {
 func TestFindSampleMetadata_Error(t *testing.T) {
 	tmpDir := t.TempDir()
 	generatedDir := filepath.Join(tmpDir, "samples", "generated")
-	if err := os.MkdirAll(generatedDir, 0755); err != nil {
+	if err := os.MkdirAll(generatedDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	unreadableSubdir := filepath.Join(generatedDir, "unreadable")
-	if err := os.MkdirAll(unreadableSubdir, 0000); err != nil {
+	if err := os.MkdirAll(unreadableSubdir, 0o000); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = os.Chmod(unreadableSubdir, 0755)
+		_ = os.Chmod(unreadableSubdir, 0o755)
 	})
 	_, err := findSampleMetadata(tmpDir)
 	if !errors.Is(err, errFindSampleMetadata) {

--- a/internal/librarian/php/clean_test.go
+++ b/internal/librarian/php/clean_test.go
@@ -133,10 +133,10 @@ func verifyFileDeletions(t *testing.T, dir string, setupFiles, wantDeleted []str
 
 func createFileAndDirectories(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -149,14 +149,14 @@ func TestClean_StatError(t *testing.T) {
 		Output: filepath.Join(repoRoot, "test"),
 	}
 	dir := filepath.Join(lib.Output, "src")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(lib.Output, 0000); err != nil {
+	if err := os.Chmod(lib.Output, 0o000); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = os.Chmod(lib.Output, 0755)
+		_ = os.Chmod(lib.Output, 0o755)
 	})
 	err := Clean(lib)
 	if err == nil {
@@ -176,11 +176,11 @@ func TestClean_ReadFileError(t *testing.T) {
 	}
 	filePath := filepath.Join(lib.Output, "src/V1/Service.php")
 	createFileAndDirectories(t, filePath, "<?php // "+string(gapicMarker))
-	if err := os.Chmod(filePath, 0000); err != nil {
+	if err := os.Chmod(filePath, 0o000); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = os.Chmod(filePath, 0644)
+		_ = os.Chmod(filePath, 0o644)
 	})
 	err := Clean(lib)
 	if err == nil {
@@ -201,11 +201,11 @@ func TestClean_RemoveError(t *testing.T) {
 	dirPath := filepath.Join(lib.Output, "src/V1")
 	filePath := filepath.Join(dirPath, gapicMetadataFile)
 	createFileAndDirectories(t, filePath, "{}")
-	if err := os.Chmod(dirPath, 0500); err != nil {
+	if err := os.Chmod(dirPath, 0o500); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = os.Chmod(dirPath, 0755)
+		_ = os.Chmod(dirPath, 0o755)
 	})
 	err := Clean(lib)
 	if err == nil {
@@ -225,14 +225,14 @@ func TestClean_WalkDirError(t *testing.T) {
 	}
 	dir := filepath.Join(lib.Output, "src")
 	subdir := filepath.Join(dir, "V1")
-	if err := os.MkdirAll(subdir, 0755); err != nil {
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(subdir, 0000); err != nil {
+	if err := os.Chmod(subdir, 0o000); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = os.Chmod(subdir, 0755)
+		_ = os.Chmod(subdir, 0o755)
 	})
 	err := Clean(lib)
 	if err == nil {
@@ -252,25 +252,25 @@ func TestClean_RemovesEmptyDirectories(t *testing.T) {
 	}
 	// Setup: empty directory under src
 	emptyDir := filepath.Join(lib.Output, "src", "V1", "Empty")
-	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+	if err := os.MkdirAll(emptyDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Setup: directory with a file that will be deleted
 	dirWithDeletedFile := filepath.Join(lib.Output, "src", "V1", "Deleted")
 	fileToDelete := filepath.Join(dirWithDeletedFile, "gapic_metadata.json")
-	if err := os.MkdirAll(dirWithDeletedFile, 0755); err != nil {
+	if err := os.MkdirAll(dirWithDeletedFile, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(fileToDelete, []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(fileToDelete, []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Setup: directory with a kept file
 	dirWithKeptFile := filepath.Join(lib.Output, "src", "V1", "Kept")
 	fileToKeep := filepath.Join(dirWithKeptFile, "Handwritten.php")
-	if err := os.MkdirAll(dirWithKeptFile, 0755); err != nil {
+	if err := os.MkdirAll(dirWithKeptFile, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(fileToKeep, []byte("<?php class Handwritten {}"), 0644); err != nil {
+	if err := os.WriteFile(fileToKeep, []byte("<?php class Handwritten {}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	lib.Keep = []string{"src/V1/Kept/Handwritten.php"}

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -94,7 +94,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := os.RemoveAll(stagingDir); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}
 	srcCfg := sources.NewSourceConfig(src, library.Roots)
@@ -244,7 +244,7 @@ func buildBaseProtocArgs(srcCfg *sources.SourceConfig, outputArgs []string, targ
 }
 
 func extractOutput(ctx context.Context, zipPath, outDir string) error {
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory %s: %w", outDir, err)
 	}
 	if err := filesystem.Unzip(ctx, zipPath, outDir); err != nil {

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -45,7 +45,7 @@ func TestGenerate(t *testing.T) {
 	repoRoot := t.TempDir()
 	t.Chdir(repoRoot)
 	destDir := filepath.Join(repoRoot, "output")
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Symlink mock owlbot.py. Tests use a simplified copy-only stub to
@@ -158,10 +158,10 @@ func TestGatherProtos(t *testing.T) {
 	}
 	for _, f := range files {
 		p := filepath.Join(tmp, f.path)
-		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(p, []byte(""), 0644); err != nil {
+		if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -305,10 +305,10 @@ func TestGatherGAPICProtos(t *testing.T) {
 			tempDir := t.TempDir()
 			for _, file := range test.setupFiles {
 				p := filepath.Join(tempDir, file)
-				if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(p, []byte(""), 0644); err != nil {
+				if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -351,10 +351,10 @@ func TestGatherGAPICProtos_Error(t *testing.T) {
 			tempDir := t.TempDir()
 			for _, file := range test.setupFiles {
 				p := filepath.Join(tempDir, file)
-				if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(p, []byte(""), 0644); err != nil {
+				if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/librarian/php/install.go
+++ b/internal/librarian/php/install.go
@@ -51,7 +51,7 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(bin, 0755); err != nil {
+	if err := os.MkdirAll(bin, 0o755); err != nil {
 		return fmt.Errorf("failed to create bin directory: %w", err)
 	}
 
@@ -150,7 +150,7 @@ func installGenerator(ctx context.Context) (string, error) {
 exec %q -d display_errors=stderr -d memory_limit=1024M %q --side_loaded_root_dir "$GOOGLEAPIS_DIR" "$@"
 `, phpPath, filepath.Join(generatorDir, "src/Main.php"))
 
-	if err := os.WriteFile(wrapperPath, []byte(wrapperContent), 0755); err != nil {
+	if err := os.WriteFile(wrapperPath, []byte(wrapperContent), 0o755); err != nil {
 		return "", fmt.Errorf("failed to write wrapper script: %w", err)
 	}
 
@@ -165,11 +165,11 @@ func generatorDir(ctx context.Context) (string, error) {
 func createBinWrapper(wrapperName, destPath, binDir string) error {
 	wrapperPath := filepath.Join(binDir, wrapperName)
 	content := fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", destPath)
-	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0o755); err != nil {
 		return fmt.Errorf("failed to create directory for wrapper: %w", err)
 	}
 	_ = os.Remove(wrapperPath)
-	f, err := os.OpenFile(wrapperPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
+	f, err := os.OpenFile(wrapperPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -227,7 +227,7 @@ func TestCreateBinWrapper(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if info.Mode().Perm() != 0755 {
+			if info.Mode().Perm() != 0o755 {
 				t.Errorf("wrapper permissions = %04o, want 0755", info.Mode().Perm())
 			}
 		})
@@ -237,7 +237,7 @@ func TestCreateBinWrapper(t *testing.T) {
 //nolint:unparam // content is the same for all calls but keeping parameter for flexibility
 func writeExecutable(t *testing.T, path string, content string) {
 	t.Helper()
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -48,7 +48,7 @@ func TestPostProcess_OwlBot(t *testing.T) {
 	repoRoot := t.TempDir()
 	t.Chdir(repoRoot)
 	destDir := filepath.Join(repoRoot, "SecretManager")
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Symlink mock owlbot.py from testdata that writes "owlbot_ran.txt" when executed.
@@ -75,11 +75,11 @@ func TestPostProcess_OwlBotError(t *testing.T) {
 	repoRoot := t.TempDir()
 	t.Chdir(repoRoot)
 	destDir := filepath.Join(repoRoot, "SecretManager")
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	owlbotPy := filepath.Join(destDir, "owlbot.py")
-	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(1)"), 0755); err != nil {
+	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(1)"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	lib := &config.Library{
@@ -100,18 +100,18 @@ func TestPostProcess_StatError(t *testing.T) {
 	ctx := t.Context()
 	repoRoot := t.TempDir()
 	destDir := filepath.Join(repoRoot, "SecretManager")
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	inaccessibleDir := filepath.Join(destDir, "inaccessible")
-	if err := os.MkdirAll(inaccessibleDir, 0755); err != nil {
+	if err := os.MkdirAll(inaccessibleDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(inaccessibleDir, 0000); err != nil {
+	if err := os.Chmod(inaccessibleDir, 0o000); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = os.Chmod(inaccessibleDir, 0755)
+		_ = os.Chmod(inaccessibleDir, 0o755)
 	})
 
 	lib := &config.Library{
@@ -129,27 +129,27 @@ func TestPostProcess_CleanupError(t *testing.T) {
 	repoRoot := t.TempDir()
 	t.Chdir(repoRoot)
 	destDir := filepath.Join(repoRoot, "SecretManager")
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	owlbotPy := filepath.Join(destDir, "owlbot.py")
-	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(0)"), 0755); err != nil {
+	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(0)"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	stagingDir := filepath.Join(repoRoot, owlBotStagingDir, "SecretManager")
-	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	inaccessibleSubdir := filepath.Join(stagingDir, "inaccessible")
-	if err := os.MkdirAll(inaccessibleSubdir, 0755); err != nil {
+	if err := os.MkdirAll(inaccessibleSubdir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(stagingDir, 0555); err != nil {
+	if err := os.Chmod(stagingDir, 0o555); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = os.Chmod(stagingDir, 0755)
+		_ = os.Chmod(stagingDir, 0o755)
 	})
 
 	lib := &config.Library{

--- a/internal/librarian/python/bump.go
+++ b/internal/librarian/python/bump.go
@@ -84,7 +84,7 @@ func bumpSingleGapicVersionFile(path, version string) error {
 	if !foundLine {
 		return fmt.Errorf("failed to bump '%s': %w", path, errNoVersionFound)
 	}
-	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
 		return fmt.Errorf("failed to bump '%s': %w", path, err)
 	}
 	return nil

--- a/internal/librarian/python/bump_test.go
+++ b/internal/librarian/python/bump_test.go
@@ -55,10 +55,10 @@ func TestBump(t *testing.T) {
 	dir := t.TempDir()
 	for file, content := range initial {
 		path := filepath.Join(dir, file)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -98,7 +98,7 @@ func TestBump_Error(t *testing.T) {
 			setup: func(dir string) error {
 				textPath := filepath.Join(dir, "test.txt")
 				versionPath := filepath.Join(dir, gapicVersionFile)
-				if err := os.WriteFile(textPath, []byte("just a text file"), 0644); err != nil {
+				if err := os.WriteFile(textPath, []byte("just a text file"), 0o644); err != nil {
 					return err
 				}
 				return os.Symlink(textPath, versionPath)
@@ -109,7 +109,7 @@ func TestBump_Error(t *testing.T) {
 			name: "gapic_version.py has no version",
 			setup: func(dir string) error {
 				versionPath := filepath.Join(dir, gapicVersionFile)
-				return os.WriteFile(versionPath, []byte("no version here"), 0644)
+				return os.WriteFile(versionPath, []byte("no version here"), 0o644)
 			},
 			wantErr: errNoVersionFound,
 		},
@@ -117,10 +117,10 @@ func TestBump_Error(t *testing.T) {
 			name: "snippet metadata file is invalid",
 			setup: func(dir string) error {
 				snippetMetadataPath := filepath.Join(dir, "samples", "generated_samples", "snippet_metadata.json")
-				if err := os.MkdirAll(filepath.Dir(snippetMetadataPath), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(snippetMetadataPath), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				return os.WriteFile(snippetMetadataPath, []byte("{}"), 0644)
+				return os.WriteFile(snippetMetadataPath, []byte("{}"), 0o644)
 			},
 			wantErr: snippetmetadata.ErrNoClientLibraryField,
 		},
@@ -144,7 +144,7 @@ func TestBumpSingleGapicVersionFile(t *testing.T) {
 		`line1
 __version__ = "before" # irrelevant
 line3`
-	if err := os.WriteFile(path, []byte(initialText), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(initialText), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := bumpSingleGapicVersionFile(path, "1.2.3"); err != nil {
@@ -181,14 +181,14 @@ func TestBumpSingleGapicVersionFile_Error(t *testing.T) {
 			name: "multiple version lines",
 			setup: func(path string) error {
 				content := fmt.Sprintf("line1\n%s\"1.2.3\"\n%s\"4.5.6\"", gapicVersionLinePrefix, gapicVersionLinePrefix)
-				return os.WriteFile(path, []byte(content), 0644)
+				return os.WriteFile(path, []byte(content), 0o644)
 			},
 			wantErr: errMultipleVersions,
 		},
 		{
 			name: "no version line",
 			setup: func(path string) error {
-				return os.WriteFile(path, []byte("line1\nline2"), 0644)
+				return os.WriteFile(path, []byte("line1\nline2"), 0o644)
 			},
 			wantErr: errNoVersionFound,
 		},
@@ -197,7 +197,7 @@ func TestBumpSingleGapicVersionFile_Error(t *testing.T) {
 			setup: func(path string) error {
 				content := fmt.Sprintf("line1\n%s\"1.2.3\"\nline3", gapicVersionLinePrefix)
 				// 0444 is read-only, even for the owner
-				return os.WriteFile(path, []byte(content), 0444)
+				return os.WriteFile(path, []byte(content), 0o444)
 			},
 			wantErr: os.ErrPermission,
 		},

--- a/internal/librarian/python/clean_test.go
+++ b/internal/librarian/python/clean_test.go
@@ -175,7 +175,7 @@ func TestClean_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 			test.lib.Output = filepath.Join(dir, test.lib.Name)
-			if err := os.Mkdir(test.lib.Output, 0755); err != nil {
+			if err := os.Mkdir(test.lib.Output, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			if test.setup != nil {
@@ -384,12 +384,12 @@ func TestCleanGAPIC_Error(t *testing.T) {
 			setup: func(t *testing.T, dir string) {
 				sourceDirectory := filepath.Join(dir, "google", "cloud", "functions_v1")
 				createFileAndDirectories(t, filepath.Join(sourceDirectory, "gapic_version.py"))
-				if err := os.Chmod(sourceDirectory, 0555); err != nil {
+				if err := os.Chmod(sourceDirectory, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
 					// Fix the permission afterwards so that it can be deleted.
-					if err := os.Chmod(sourceDirectory, 0755); err != nil {
+					if err := os.Chmod(sourceDirectory, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -497,12 +497,12 @@ func TestCleanGAPICCommon_Error(t *testing.T) {
 			setup: func(t *testing.T, dir string) {
 				createFileAndDirectories(t, filepath.Join(dir, "subdir", "file.txt"))
 				subdir := filepath.Join(dir, "subdir")
-				if err := os.Chmod(subdir, 0555); err != nil {
+				if err := os.Chmod(subdir, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
 					// Fix the permission afterwards so that it can be deleted.
-					if err := os.Chmod(subdir, 0755); err != nil {
+					if err := os.Chmod(subdir, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -595,12 +595,12 @@ func TestDeleteUnlessKept_Error(t *testing.T) {
 			name:       "can't delete file from read-only directory",
 			setupFiles: []string{"readonly.txt"},
 			setup: func(t *testing.T, dir string) {
-				if err := os.Chmod(dir, 0555); err != nil {
+				if err := os.Chmod(dir, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
 					// Fix the permission afterwards so that it can be deleted.
-					if err := os.Chmod(dir, 0755); err != nil {
+					if err := os.Chmod(dir, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -613,12 +613,12 @@ func TestDeleteUnlessKept_Error(t *testing.T) {
 			setupFiles: []string{"subdir/readonly.txt"},
 			setup: func(t *testing.T, dir string) {
 				subdir := filepath.Join(dir, "subdir")
-				if err := os.Chmod(subdir, 0555); err != nil {
+				if err := os.Chmod(subdir, 0o555); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
 					// Fix the permission afterwards so that it can be deleted.
-					if err := os.Chmod(subdir, 0755); err != nil {
+					if err := os.Chmod(subdir, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -631,12 +631,12 @@ func TestDeleteUnlessKept_Error(t *testing.T) {
 			setupFiles: []string{"subdir/file.txt"},
 			setup: func(t *testing.T, dir string) {
 				subdir := filepath.Join(dir, "subdir")
-				if err := os.Chmod(subdir, 0444); err != nil {
+				if err := os.Chmod(subdir, 0o444); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
 					// Fix the permission afterwards so that it can be deleted.
-					if err := os.Chmod(subdir, 0755); err != nil {
+					if err := os.Chmod(subdir, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -654,7 +654,7 @@ func TestDeleteUnlessKept_Error(t *testing.T) {
 				}
 				t.Cleanup(func() {
 					// Fix the permission afterwards so that it can be deleted.
-					if err := os.Chmod(subdir, 0755); err != nil {
+					if err := os.Chmod(subdir, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -700,10 +700,10 @@ func verifyFileDeletions(t *testing.T, dir string, setupFiles, wantDeleted []str
 }
 
 func createFileAndDirectories(t *testing.T, path string) {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/librarian/python/generate.go
+++ b/internal/librarian/python/generate.go
@@ -77,7 +77,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 
 	// Create output directory in case it's a new library
 	// (or cleaning has removed everything).
-	if err := os.MkdirAll(outdir, 0755); err != nil {
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
@@ -154,7 +154,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 func prepareGenerationRoot(packageRoot string) (string, error) {
 	packageName := filepath.Base(packageRoot)
 	generationRoot := filepath.Join(packageRoot, "tmp")
-	if err := os.MkdirAll(filepath.Join(generationRoot, "packages"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(generationRoot, "packages"), 0o755); err != nil {
 		return "", err
 	}
 	if err := os.Symlink("../..", filepath.Join(generationRoot, "packages", packageName)); err != nil {
@@ -252,7 +252,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	protoOnly := isProtoOnly(api, library)
 	stagingChildDirectory := getStagingChildDirectory(api.Path, protoOnly)
 	stagingDir := filepath.Join(generationRoot, "owl-bot-staging", library.Name, stagingChildDirectory)
-	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}
 	protocOptions, err := createProtocOptions(api, library, googleapisDir, stagingDir)
@@ -298,7 +298,7 @@ func stageProtoFiles(googleapisDir, targetDir string, relativeProtoPaths []strin
 		sourceProtoFile := filepath.Join(googleapisDir, proto)
 		targetProtoFile := filepath.Join(targetDir, proto)
 		dir := filepath.Dir(targetProtoFile)
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("creating directory %s failed: %w", dir, err)
 		}
 		if err := filesystem.CopyFile(sourceProtoFile, targetProtoFile); err != nil {
@@ -456,7 +456,7 @@ func copyReadmeToDocsDir(lib *config.Library, outdir string) error {
 	}
 
 	// Create docs directory if it doesn't exist
-	if err := os.MkdirAll(docsPath, 0755); err != nil {
+	if err := os.MkdirAll(docsPath, 0o755); err != nil {
 		return err
 	}
 
@@ -470,7 +470,7 @@ func copyReadmeToDocsDir(lib *config.Library, outdir string) error {
 	}
 
 	// Write content to destination as a real file
-	return os.WriteFile(destPath, content, 0644)
+	return os.WriteFile(destPath, content, 0o644)
 }
 
 // cleanUpFilesAfterPostProcessing cleans up files after post processing.
@@ -582,11 +582,11 @@ func createChangelog(libName, output string) error {
 		return statErr
 	}
 	docs := filepath.Join(output, "docs")
-	if err := os.MkdirAll(docs, 0755); err != nil {
+	if err := os.MkdirAll(docs, 0o755); err != nil {
 		return err
 	}
 	content := fmt.Sprintf(changelogTemplate, libName)
-	if err := os.WriteFile(rootChangelog, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(rootChangelog, []byte(content), 0o644); err != nil {
 		return err
 	}
 	// Create a relative symlink in docs: CHANGELOG.md => ../CHANGELOG.md

--- a/internal/librarian/python/generate_test.go
+++ b/internal/librarian/python/generate_test.go
@@ -298,7 +298,7 @@ func TestStageProtoFiles_Error(t *testing.T) {
 			relativeProtoPaths: []string{"google/cloud/gkehub/v1/feature.proto"},
 			setup: func(t *testing.T, targetDir string) {
 				// Create a file with the name of the directory we'd create.
-				if err := os.WriteFile(filepath.Join(targetDir, "google"), []byte{}, 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(targetDir, "google"), []byte{}, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -309,7 +309,7 @@ func TestStageProtoFiles_Error(t *testing.T) {
 			relativeProtoPaths: []string{"google/cloud/gkehub/v1/feature.proto"},
 			setup: func(t *testing.T, targetDir string) {
 				// Create a directory with the name of the file we'd create.
-				if err := os.MkdirAll(filepath.Join(targetDir, "google", "cloud", "gkehub", "v1", "feature.proto"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(targetDir, "google", "cloud", "gkehub", "v1", "feature.proto"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -347,13 +347,13 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		{
 			name: "handwritten library, target already exists",
 			setup: func(t *testing.T, outdir string) {
-				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("after"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("after"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.MkdirAll(filepath.Join(outdir, "docs"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(outdir, "docs"), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(outdir, "docs", "README.rst"), []byte("before"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "docs", "README.rst"), []byte("before"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -363,7 +363,7 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		{
 			name: "handwritten library, target doesn't already exist",
 			setup: func(t *testing.T, outdir string) {
-				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("after"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("after"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -372,7 +372,7 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		{
 			name: "readme is a regular file",
 			setup: func(t *testing.T, outdir string) {
-				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -381,7 +381,7 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		{
 			name: "readme is a symlink",
 			setup: func(t *testing.T, outdir string) {
-				if err := os.WriteFile(filepath.Join(outdir, "REAL_README.rst"), []byte("hello"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "REAL_README.rst"), []byte("hello"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				if err := os.Symlink("REAL_README.rst", filepath.Join(outdir, "README.rst")); err != nil {
@@ -393,10 +393,10 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		{
 			name: "dest is a symlink",
 			setup: func(t *testing.T, outdir string) {
-				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.MkdirAll(filepath.Join(outdir, "docs"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(outdir, "docs"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 				if err := os.Symlink("../some/other/file", filepath.Join(outdir, "docs", "README.rst")); err != nil {
@@ -408,11 +408,11 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		{
 			name: "unreadable readme",
 			setup: func(t *testing.T, outdir string) {
-				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0000); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0o000); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					os.Chmod(filepath.Join(outdir, "README.rst"), 0644)
+					os.Chmod(filepath.Join(outdir, "README.rst"), 0o644)
 				})
 			},
 			expectedErr: true,
@@ -420,10 +420,10 @@ func TestCopyReadmeToDocsDir(t *testing.T) {
 		{
 			name: "cannot create docs dir",
 			setup: func(t *testing.T, outdir string) {
-				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "README.rst"), []byte("hello"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(outdir, "docs"), []byte(""), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outdir, "docs"), []byte(""), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -475,10 +475,10 @@ func TestCleanUpFilesAfterPostProcessing(t *testing.T) {
 			name: "staging dir exists",
 			setup: func(t *testing.T, generationRoot, outputDir string) {
 				stagingDir := filepath.Join(generationRoot, "owl-bot-staging")
-				if err := os.MkdirAll(stagingDir, 0755); err != nil {
+				if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(stagingDir, "test.txt"), []byte("test"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(stagingDir, "test.txt"), []byte("test"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -487,10 +487,10 @@ func TestCleanUpFilesAfterPostProcessing(t *testing.T) {
 			name: "scripts dir exists",
 			setup: func(t *testing.T, generationRoot, outputDir string) {
 				scriptsDir := filepath.Join(outputDir, "scripts")
-				if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+				if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(scriptsDir, "test.txt"), []byte("test"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(scriptsDir, "test.txt"), []byte("test"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -535,19 +535,19 @@ func TestCleanUpFilesAfterPostProcessing_Error(t *testing.T) {
 			name: "error removing owl-bot-staging",
 			setup: func(t *testing.T, repoRoot, outputDir string) {
 				stagingDir := filepath.Join(repoRoot, "owl-bot-staging")
-				if err := os.MkdirAll(stagingDir, 0755); err != nil {
+				if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				// Create a file in the directory
-				if err := os.WriteFile(filepath.Join(stagingDir, "file"), []byte(""), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(stagingDir, "file"), []byte(""), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				// Make the directory read-only to cause an error
-				if err := os.Chmod(stagingDir, 0400); err != nil {
+				if err := os.Chmod(stagingDir, 0o400); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					os.Chmod(stagingDir, 0755)
+					os.Chmod(stagingDir, 0o755)
 				})
 			},
 			wantErr: os.ErrPermission,
@@ -556,19 +556,19 @@ func TestCleanUpFilesAfterPostProcessing_Error(t *testing.T) {
 			name: "error removing scripts",
 			setup: func(t *testing.T, repoRoot, outputDir string) {
 				scriptsDir := filepath.Join(outputDir, "scripts")
-				if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+				if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				// Create a file in the directory
-				if err := os.WriteFile(filepath.Join(scriptsDir, "file"), []byte(""), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(scriptsDir, "file"), []byte(""), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				// Make the directory read-only to cause an error
-				if err := os.Chmod(scriptsDir, 0400); err != nil {
+				if err := os.Chmod(scriptsDir, 0o400); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					os.Chmod(scriptsDir, 0755)
+					os.Chmod(scriptsDir, 0o755)
 				})
 			},
 			wantErr: os.ErrPermission,
@@ -594,7 +594,7 @@ func TestRunPostProcessor(t *testing.T) {
 	repoRoot := t.TempDir()
 	createReplacementScripts(t, repoRoot)
 	outdir := filepath.Join(repoRoot, "packages", "sample-package")
-	if err := os.MkdirAll(outdir, 0755); err != nil {
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	generationRoot, err := prepareGenerationRoot(outdir)
@@ -602,7 +602,7 @@ func TestRunPostProcessor(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Create minimal .repo-metadata.json that synthtool expects
-	if err := os.WriteFile(filepath.Join(outdir, ".repo-metadata.json"), []byte(`{"default_version":"v1"}`), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, ".repo-metadata.json"), []byte(`{"default_version":"v1"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	createMinimalNoxFile(t, outdir)
@@ -627,7 +627,7 @@ func TestRunPostProcessor_Error(t *testing.T) {
 			setup: func(t *testing.T, repoRoot, outputDir string) {
 				// Can't copy scripts into a "scripts" directory if that's a
 				// file...
-				if err := os.WriteFile(filepath.Join(outputDir, "scripts"), []byte{}, 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(outputDir, "scripts"), []byte{}, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -655,7 +655,7 @@ func TestRunPostProcessor_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			repoRoot := t.TempDir()
 			outputDir := filepath.Join(repoRoot, "packages", "test")
-			if err := os.MkdirAll(outputDir, 0755); err != nil {
+			if err := os.MkdirAll(outputDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			generationRoot, err := prepareGenerationRoot(outputDir)
@@ -664,7 +664,7 @@ func TestRunPostProcessor_Error(t *testing.T) {
 			}
 			createReplacementScripts(t, repoRoot)
 			createMinimalNoxFile(t, outputDir)
-			if err := os.WriteFile(filepath.Join(outputDir, ".repo-metadata.json"), []byte(`{"default_version":"v1"}`), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(outputDir, ".repo-metadata.json"), []byte(`{"default_version":"v1"}`), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if test.setup != nil {
@@ -721,7 +721,7 @@ func TestGenerateAPI_Error(t *testing.T) {
 			name: "error creating owl-bot-staging",
 			setup: func(t *testing.T, repoRoot, outputDir string) {
 				stagingDir := filepath.Join(repoRoot, "owl-bot-staging")
-				if err := os.WriteFile(stagingDir, []byte{}, 0644); err != nil {
+				if err := os.WriteFile(stagingDir, []byte{}, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -761,7 +761,7 @@ func TestGenerateAPI_Error(t *testing.T) {
 			},
 			setup: func(t *testing.T, repoRoot, outputDir string) {
 				expectedProtoFile := filepath.Join(repoRoot, "owl-bot-staging", "pkg", "v1", "google", "cloud", "secretmanager", "v1", "resources.proto")
-				if err := os.MkdirAll(expectedProtoFile, 0755); err != nil {
+				if err := os.MkdirAll(expectedProtoFile, 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -887,7 +887,7 @@ func TestGenerate_Error(t *testing.T) {
 				Output: "exists-as-file",
 			},
 			setup: func(t *testing.T, lib *config.Library) {
-				if err := os.WriteFile(lib.Output, []byte{}, 0644); err != nil {
+				if err := os.WriteFile(lib.Output, []byte{}, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -915,11 +915,11 @@ func TestGenerate_Error(t *testing.T) {
 				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 			setup: func(t *testing.T, lib *config.Library) {
-				if err := os.MkdirAll(lib.Output, 0755); err != nil {
+				if err := os.MkdirAll(lib.Output, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				metadataFile := filepath.Join(lib.Output, ".repo-metadata.json")
-				if err := os.WriteFile(metadataFile, []byte{}, 0444); err != nil {
+				if err := os.WriteFile(metadataFile, []byte{}, 0o444); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -937,7 +937,7 @@ func TestGenerate_Error(t *testing.T) {
 			},
 			setup: func(t *testing.T, lib *config.Library) {
 				postProcessorScript := filepath.Join(".librarian", "generator-input", "client-post-processing", "bad.yaml")
-				if err := os.WriteFile(postProcessorScript, []byte("-"), 0644); err != nil {
+				if err := os.WriteFile(postProcessorScript, []byte("-"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -953,7 +953,7 @@ func TestGenerate_Error(t *testing.T) {
 				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 			setup: func(t *testing.T, lib *config.Library) {
-				if err := os.MkdirAll(filepath.Join(lib.Output, "docs", "README.rst"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(lib.Output, "docs", "README.rst"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -970,10 +970,10 @@ func TestGenerate_Error(t *testing.T) {
 				Python: &config.PythonPackage{DefaultVersion: "v1"},
 			},
 			setup: func(t *testing.T, lib *config.Library) {
-				if err := os.MkdirAll(filepath.Join(lib.Output, "docs"), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(lib.Output, "docs"), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(lib.Output, "docs", changelog), []byte{}, 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(lib.Output, "docs", changelog), []byte{}, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1549,7 +1549,7 @@ func TestCreateChangelog(t *testing.T) {
 func TestCreateChangelog_FileExists(t *testing.T) {
 	libName := "google-cloud-test"
 	output := t.TempDir()
-	if err := os.WriteFile(filepath.Join(output, changelog), []byte{}, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(output, changelog), []byte{}, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := createChangelog(libName, output); err != nil {
@@ -1575,7 +1575,7 @@ func TestCreateChangelog_Error(t *testing.T) {
 		{
 			name: "docs is an existing file",
 			setup: func(t *testing.T, output string) {
-				if err := os.WriteFile(filepath.Join(output, "docs"), []byte{}, 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(output, "docs"), []byte{}, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1584,11 +1584,11 @@ func TestCreateChangelog_Error(t *testing.T) {
 		{
 			name: "output directory is readonly",
 			setup: func(t *testing.T, output string) {
-				if err := os.Chmod(output, 0644); err != nil {
+				if err := os.Chmod(output, 0o644); err != nil {
 					t.Fatal(err)
 				}
 				t.Cleanup(func() {
-					if err := os.Chmod(output, 0755); err != nil {
+					if err := os.Chmod(output, 0o755); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -1598,7 +1598,7 @@ func TestCreateChangelog_Error(t *testing.T) {
 		{
 			name: "docs changelog is an existing directory",
 			setup: func(t *testing.T, output string) {
-				if err := os.MkdirAll(filepath.Join(output, "docs", changelog), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(output, "docs", changelog), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1628,7 +1628,7 @@ func TestPrepareGenerationRoot_Error(t *testing.T) {
 		{
 			name: "tmp is an existing file",
 			setup: func(t *testing.T, output string) {
-				if err := os.WriteFile(filepath.Join(output, "tmp"), []byte{}, 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(output, "tmp"), []byte{}, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1637,7 +1637,7 @@ func TestPrepareGenerationRoot_Error(t *testing.T) {
 		{
 			name: "symlink target already exists",
 			setup: func(t *testing.T, output string) {
-				if err := os.MkdirAll(filepath.Join(output, "tmp", "packages", filepath.Base(output)), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Join(output, "tmp", "packages", filepath.Base(output)), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -1668,7 +1668,7 @@ func requireSynthtool(t *testing.T) {
 // script in the .librarian/generator-input/client-post-processing directory.
 func createReplacementScripts(t *testing.T, repoRoot string) {
 	dir := filepath.Join(repoRoot, ".librarian", "generator-input", "client-post-processing")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	yaml := `description: Sample string replacement file
@@ -1680,7 +1680,7 @@ replacements:
     before: replace-me
     after: replaced
     count: 1`
-	if err := os.WriteFile(filepath.Join(dir, "sample.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "sample.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1694,7 +1694,7 @@ nox.options.sessions = ["format"]
 def format(session):
 	print("This would format")
 `
-	if err := os.WriteFile(filepath.Join(outDir, "noxfile.py"), []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(outDir, "noxfile.py"), []byte(content), 0o644); err != nil {
 		t.Fatalf("unable to create noxfile.py: %v", err)
 	}
 }

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -124,7 +124,7 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(manifestPath, manifestOut, 0644); err != nil {
+	if err := os.WriteFile(manifestPath, manifestOut, 0o644); err != nil {
 		return err
 	}
 
@@ -132,7 +132,7 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(configPath, configOut, 0644); err != nil {
+	if err := os.WriteFile(configPath, configOut, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -97,12 +97,12 @@ func TestHasBulkReleasePleaseConfigs(t *testing.T) {
 				},
 			)
 			if test.createConfig {
-				if err := os.WriteFile(filepath.Join(tmp, configFile), []byte("{}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmp, configFile), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
 			if test.createManifest {
-				if err := os.WriteFile(filepath.Join(tmp, manifestFile), []byte("{}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmp, manifestFile), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -338,10 +338,10 @@ func TestSyncToReleasePlease(t *testing.T) {
 			)
 			manifestPath := filepath.Join(tmp, manifestFile)
 			configPath := filepath.Join(tmp, configFile)
-			if err := os.WriteFile(manifestPath, []byte(test.initialManifest), 0644); err != nil {
+			if err := os.WriteFile(manifestPath, []byte(test.initialManifest), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile(configPath, []byte(test.initialConfig), 0644); err != nil {
+			if err := os.WriteFile(configPath, []byte(test.initialConfig), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			cfg := &config.Config{
@@ -471,10 +471,10 @@ func TestSyncToReleasePlease_Errors(t *testing.T) {
 			tmp := t.TempDir()
 			manifestPath := filepath.Join(tmp, ".release-please-bulk-manifest.json")
 			configPath := filepath.Join(tmp, "release-please-bulk-config.json")
-			if err := os.WriteFile(manifestPath, []byte("{}"), 0644); err != nil {
+			if err := os.WriteFile(manifestPath, []byte("{}"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile(configPath, []byte(test.initialConfig), 0644); err != nil {
+			if err := os.WriteFile(configPath, []byte(test.initialConfig), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			cfg := &config.Config{

--- a/internal/librarian/ruby/clean_test.go
+++ b/internal/librarian/ruby/clean_test.go
@@ -84,10 +84,10 @@ func TestClean(t *testing.T) {
 			if test.files != nil {
 				for _, file := range test.files {
 					path := filepath.Join(targetDir, file)
-					if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 						t.Fatal(err)
 					}
-					if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+					if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -143,7 +143,7 @@ func TestClean_Error(t *testing.T) {
 				Name: "test",
 			},
 			setup: func(t *testing.T, targetDir string) {
-				if err := os.WriteFile(targetDir, []byte("file"), 0644); err != nil {
+				if err := os.WriteFile(targetDir, []byte("file"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -204,10 +204,10 @@ func TestCleanSubdirectory(t *testing.T) {
 			if test.files != nil {
 				for _, file := range test.files {
 					path := filepath.Join(dir, file)
-					if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+					if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 						t.Fatal(err)
 					}
-					if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+					if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
 						t.Fatal(err)
 					}
 				}

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -42,7 +42,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path of output directory: %w", err)
 	}
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 	tempDir, err := os.MkdirTemp(outDir, "librarian-ruby-")

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -179,7 +179,7 @@ func TestGenerate_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 	fileAsDir := filepath.Join(t.TempDir(), "file.txt")
-	if err := os.WriteFile(fileAsDir, []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(fileAsDir, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -278,7 +278,7 @@ func setupDummyProtoc(t *testing.T) {
 	t.Setenv("LIBRARIAN_BIN", binDir)
 
 	installDir := filepath.Join(binDir, "ruby_tools", "bin")
-	if err := os.MkdirAll(installDir, 0755); err != nil {
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -297,7 +297,7 @@ if [ -n "$outDir" ]; then
 fi
 exit 0
 `
-	if err := os.WriteFile(protocPath, []byte(script), 0755); err != nil {
+	if err := os.WriteFile(protocPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -305,10 +305,10 @@ exit 0
 		pPathInBin := filepath.Join(binDir, plugin)
 		pPathInInstallDir := filepath.Join(installDir, plugin)
 		pScript := "#!/bin/sh\nexit 0\n"
-		if err := os.WriteFile(pPathInBin, []byte(pScript), 0755); err != nil {
+		if err := os.WriteFile(pPathInBin, []byte(pScript), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(pPathInInstallDir, []byte(pScript), 0755); err != nil {
+		if err := os.WriteFile(pPathInInstallDir, []byte(pScript), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/librarian/rust/bump.go
+++ b/internal/librarian/rust/bump.go
@@ -66,7 +66,7 @@ name                   = "%s"
 version                = "%s"
 edition                = "2021"
 `, library.Name, version.String())
-		if err := os.WriteFile(cargoFile, []byte(cargo), 0644); err != nil {
+		if err := os.WriteFile(cargoFile, []byte(cargo), 0o644); err != nil {
 			return err
 		}
 	default:
@@ -101,5 +101,5 @@ func updateREADME(readmeFile, libraryName, version string) error {
 		return err
 	}
 	result := re.ReplaceAllString(string(content), "${1}"+version)
-	return os.WriteFile(readmeFile, []byte(result), 0644)
+	return os.WriteFile(readmeFile, []byte(result), 0o644)
 }

--- a/internal/librarian/rust/bump_test.go
+++ b/internal/librarian/rust/bump_test.go
@@ -80,7 +80,7 @@ func setupRelease(t *testing.T) *config.Config {
 
 func createCrate(t *testing.T, dir, name, version string) {
 	t.Helper()
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -90,7 +90,7 @@ version                = "%s"
 edition                = "2021"
 `, name, version)
 
-	if err := os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte(cargo), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -159,7 +159,7 @@ func TestBumpLibraryNoVersion(t *testing.T) {
 			dir := t.TempDir()
 			t.Chdir(dir)
 
-			if err := os.MkdirAll(libDir, 0755); err != nil {
+			if err := os.MkdirAll(libDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			if test.createCargo {
@@ -238,7 +238,7 @@ google-cloud-storage = { version = "0.1.0", path = "storage" }
 			t.Chdir(tmpDir)
 
 			libDir := "storage"
-			if err := os.WriteFile("Cargo.toml", []byte(test.rootCargo), 0644); err != nil {
+			if err := os.WriteFile("Cargo.toml", []byte(test.rootCargo), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			createCrate(t, libDir, test.libName, test.oldVersion)
@@ -320,7 +320,7 @@ func TestUpdateREADME(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			readmePath := filepath.Join(tmpDir, "README.md")
-			if err := os.WriteFile(readmePath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(readmePath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/librarian/rust/crate_exists_test.go
+++ b/internal/librarian/rust/crate_exists_test.go
@@ -54,10 +54,10 @@ func TestCrateExists(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			d := t.TempDir()
 			t.Chdir(d)
-			if err := os.MkdirAll(test.makeDir, 0775); err != nil {
+			if err := os.MkdirAll(test.makeDir, 0o775); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile("Cargo.toml", fmt.Appendf(nil, formatTestCargoToml, test.cargoText), 0644); err != nil {
+			if err := os.WriteFile("Cargo.toml", fmt.Appendf(nil, formatTestCargoToml, test.cargoText), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := crateExists(testDir)
@@ -97,10 +97,10 @@ func TestCrateExists_Errors(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			d := t.TempDir()
 			t.Chdir(d)
-			if err := os.MkdirAll(test.makeDir, 0775); err != nil {
+			if err := os.MkdirAll(test.makeDir, 0o775); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile("Cargo.toml", fmt.Appendf(nil, formatTestCargoToml, test.cargoText), 0644); err != nil {
+			if err := os.WriteFile("Cargo.toml", fmt.Appendf(nil, formatTestCargoToml, test.cargoText), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := crateExists(testDir)
@@ -115,10 +115,10 @@ func TestCrateExistsDirectoryError(t *testing.T) {
 	d := t.TempDir()
 	t.Chdir(d)
 	// Create part of the path, but make it unreadable.
-	if err := os.MkdirAll("src", 0000); err != nil {
+	if err := os.MkdirAll("src", 0o000); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile("Cargo.toml", []byte("# test only"), 0644); err != nil {
+	if err := os.WriteFile("Cargo.toml", []byte("# test only"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if got, err := crateExists("src/generated/unreachable"); err == nil {
@@ -130,7 +130,7 @@ func TestCrateExistsCargoTomlError(t *testing.T) {
 	d := t.TempDir()
 	t.Chdir(d)
 	// Create part of the path, but make it unreadable.
-	if err := os.MkdirAll("src/generated/test", 0755); err != nil {
+	if err := os.MkdirAll("src/generated/test", 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if got, err := crateExists("src/generated/test"); err == nil {

--- a/internal/librarian/rust/create_test.go
+++ b/internal/librarian/rust/create_test.go
@@ -38,7 +38,7 @@ func TestCreate(t *testing.T) {
 [workspace]
 members = []
 `
-	if err := os.WriteFile("Cargo.toml", []byte(workspaceCargo), 0644); err != nil {
+	if err := os.WriteFile("Cargo.toml", []byte(workspaceCargo), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,7 +81,7 @@ func TestValidate(t *testing.T) {
 [workspace]
 members = []
 `
-	if err := os.WriteFile("Cargo.toml", []byte(workspaceCargo), 0644); err != nil {
+	if err := os.WriteFile("Cargo.toml", []byte(workspaceCargo), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/rust/format_test.go
+++ b/internal/librarian/rust/format_test.go
@@ -33,7 +33,7 @@ func TestFormat(t *testing.T) {
 	libName := "format-test-lib"
 	libDir := filepath.Join(workspaceDir, libName)
 	srcDir := filepath.Join(libDir, "src")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -45,7 +45,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 `
-	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), []byte(workspaceCargo), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), []byte(workspaceCargo), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -55,14 +55,14 @@ name    =   "` + libName + `"
 version =    "0.1.0"
 edition.workspace  =    true
 `
-	if err := os.WriteFile(filepath.Join(libDir, "Cargo.toml"), []byte(libCargo), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(libDir, "Cargo.toml"), []byte(libCargo), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Write unformatted Rust source.
 	unformatted := `fn   main(  )   {   println!(  "hello"  )  ;   }
 `
-	if err := os.WriteFile(filepath.Join(srcDir, "lib.rs"), []byte(unformatted), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "lib.rs"), []byte(unformatted), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/rust/generate_test.go
+++ b/internal/librarian/rust/generate_test.go
@@ -230,10 +230,10 @@ func TestKeepVeneer(t *testing.T) {
 		"src/generated/model.rs",
 	} {
 		path := filepath.Join(dir, f)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+		if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -277,7 +277,7 @@ func TestGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), cargoToml, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), cargoToml, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -370,7 +370,7 @@ func TestGenerate_Error(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), cargoToml, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), cargoToml, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -447,16 +447,16 @@ func TestGenerateLibrary(t *testing.T) {
 			libName := "google-cloud-secretmanager-v1"
 			outDir := "src/generated/cloud/secretmanager/v1"
 			if test.preExists {
-				if err := os.MkdirAll(outDir, 0755); err != nil {
+				if err := os.MkdirAll(outDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				contents := fmt.Appendf(nil, formatTestCargoToml, fmt.Sprintf(`  "%s",`, outDir))
-				if err := os.WriteFile("Cargo.toml", contents, 0644); err != nil {
+				if err := os.WriteFile("Cargo.toml", contents, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			} else {
 				contents := fmt.Appendf(nil, formatTestCargoToml, "")
-				if err := os.WriteFile("Cargo.toml", contents, 0644); err != nil {
+				if err := os.WriteFile("Cargo.toml", contents, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/librarian/rust/publish_test.go
+++ b/internal/librarian/rust/publish_test.go
@@ -110,11 +110,11 @@ exit 0
 `)
 	_ = testhelper.SetupRepoWithChange(t, "release-2001-02-03")
 	name := path.Join("src", "storage", "src", "lib.rs")
-	if err := os.WriteFile(name, []byte(testhelper.NewLibRsContents), 0644); err != nil {
+	if err := os.WriteFile(name, []byte(testhelper.NewLibRsContents), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	name = path.Join("src", "storage", "Cargo.toml")
-	if err := os.WriteFile(name, []byte("bad-toml = {\n"), 0644); err != nil {
+	if err := os.WriteFile(name, []byte("bad-toml = {\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	testhelper.RunGit(t, "commit", "-m", "feat: changed storage", ".")
@@ -507,7 +507,7 @@ func setupFakeCargoScript(t *testing.T, script string) {
 	}
 	tmpDir := t.TempDir()
 	cargoScript := filepath.Join(tmpDir, "cargo")
-	if err := os.WriteFile(cargoScript, []byte(script), 0755); err != nil {
+	if err := os.WriteFile(cargoScript, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/librarian/rust/published_crate_test.go
+++ b/internal/librarian/rust/published_crate_test.go
@@ -50,7 +50,7 @@ func TestPublishedCrateUnmarshalError(t *testing.T) {
 	tmpDir := t.TempDir()
 	testhelper.AddCrate(t, tmpDir, "google-cloud-storage")
 	manifest := path.Join(tmpDir, "Cargo.toml")
-	if err := os.WriteFile(manifest, []byte("invalid-toml={\n"), 0644); err != nil {
+	if err := os.WriteFile(manifest, []byte("invalid-toml={\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if got, err := publishedCrate(manifest); err == nil {
@@ -64,7 +64,7 @@ func TestPublishedCrateNotForPublication(t *testing.T) {
 	manifest := path.Join(tmpDir, "Cargo.toml")
 	contents := fmt.Sprintf(testhelper.InitialCargoContents, "google-cloud-storage")
 	contents = contents + "\npublish = false\n"
-	if err := os.WriteFile(manifest, []byte(contents), 0644); err != nil {
+	if err := os.WriteFile(manifest, []byte(contents), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	got, err := publishedCrate(manifest)

--- a/internal/librarian/rust/update_manifest.go
+++ b/internal/librarian/rust/update_manifest.go
@@ -60,7 +60,7 @@ func updateCargoVersion(path string, newVersion semver.Version) error {
 	// The number of spaces may seem weird. They match the number of spaces in
 	// the mustache template.
 	lines[idx] = fmt.Sprintf(`version                = "%s"`, newVersion.String())
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
 }
 
 var versionRegex = regexp.MustCompile(`version\s*=\s*"[^"]*"`)
@@ -85,7 +85,7 @@ func updateWorkspaceVersion(path, crateName string, newVersion semver.Version) e
 	if !updated {
 		return nil
 	}
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
 }
 
 // isDirectDependency checks if the line describes a dependency named directly as the crate.

--- a/internal/librarian/rust/update_manifest_test.go
+++ b/internal/librarian/rust/update_manifest_test.go
@@ -46,7 +46,7 @@ func TestShouldBumpManifestVersionSuccess(t *testing.T) {
 		t.Fatalf("expected a line starting with `version ` in %v", lines)
 	}
 	lines[idx] = `version = "2.3.4"`
-	if err := os.WriteFile(name, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+	if err := os.WriteFile(name, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	testhelper.RunGit(t, "commit", "-m", "updated version", ".")
@@ -227,7 +227,7 @@ func setupTestCargoFile(t *testing.T, content string) string {
 	}
 	dir := t.TempDir()
 	filePath := path.Join(dir, "Cargo.toml")
-	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	return filePath

--- a/internal/librarian/rust/update_workspace_test.go
+++ b/internal/librarian/rust/update_workspace_test.go
@@ -33,12 +33,12 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 `
-	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), []byte(workspaceCargo), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "Cargo.toml"), []byte(workspaceCargo), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	libDir := filepath.Join(workspaceDir, "test-lib")
 	srcDir := filepath.Join(libDir, "src")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	libCargo := `[package]
@@ -46,10 +46,10 @@ name = "test-lib"
 version = "0.1.0"
 edition.workspace = true
 `
-	if err := os.WriteFile(filepath.Join(libDir, "Cargo.toml"), []byte(libCargo), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(libDir, "Cargo.toml"), []byte(libCargo), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "lib.rs"), []byte(""), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "lib.rs"), []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	t.Chdir(workspaceDir)

--- a/internal/librarian/rust/verify_cargo_tools_test.go
+++ b/internal/librarian/rust/verify_cargo_tools_test.go
@@ -72,7 +72,7 @@ func TestPreFlightMissingCargo(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	tmpDir := t.TempDir()
 	gitScript := filepath.Join(tmpDir, "git")
-	os.WriteFile(gitScript, []byte("#!/bin/sh\nexit 0"), 0755)
+	os.WriteFile(gitScript, []byte("#!/bin/sh\nexit 0"), 0o755)
 	t.Setenv("PATH", tmpDir)
 	if err := preFlight(t.Context(), nil); err == nil {
 		t.Fatal("expected an error, got nil")

--- a/internal/librarian/swift/compile_protobufs.go
+++ b/internal/librarian/swift/compile_protobufs.go
@@ -27,7 +27,7 @@ import (
 )
 
 func compileProtobufs(ctx context.Context, library *config.Library, module *config.SwiftModule, src *sources.Sources) error {
-	if err := os.MkdirAll(module.Output, 0755); err != nil {
+	if err := os.MkdirAll(module.Output, 0o755); err != nil {
 		return err
 	}
 

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -264,7 +264,7 @@ func TestGenerateModule_NoProtos(t *testing.T) {
 	}
 	googleapisDir := t.TempDir()
 	emptyAPIPath := "google/empty"
-	if err := os.MkdirAll(filepath.Join(googleapisDir, emptyAPIPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(googleapisDir, emptyAPIPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -122,12 +122,12 @@ func TestFormat(t *testing.T) {
 
 	for _, dir := range []string{libraryDir, moduleDir} {
 		sourcesDir := filepath.Join(dir, "Sources")
-		if err := os.MkdirAll(sourcesDir, 0755); err != nil {
+		if err := os.MkdirAll(sourcesDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		filePath := filepath.Join(sourcesDir, "test.swift")
 		// Write a file that needs formatting.
-		if err := os.WriteFile(filePath, []byte("func foo(){\n  print(\"hello\")\n}\n"), 0644); err != nil {
+		if err := os.WriteFile(filePath, []byte("func foo(){\n  print(\"hello\")\n}\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -398,7 +398,7 @@ libraries:
   - name: google-cloud-bigquery-v1
     version: "2.0.0"
 `, sample.LibrarianVersion)
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := Run(t.Context(), "librarian", "tidy"); err != nil {

--- a/internal/librarian/update_test.go
+++ b/internal/librarian/update_test.go
@@ -333,7 +333,7 @@ func fakeGoList(target, want string) func(*testing.T) {
 		goDir := t.TempDir()
 		goPath := filepath.Join(goDir, "go")
 		script := fmt.Sprintf("#!/bin/bash\nif [[ \"$*\" == *\"list -m -f {{.Version}} github.com/googleapis/librarian@%s\"* ]]; then\n  echo %q\n  exit 0\nfi\nexit 1\n", target, want)
-		if err := os.WriteFile(goPath, []byte(script), 0755); err != nil {
+		if err := os.WriteFile(goPath, []byte(script), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		t.Setenv("PATH", goDir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/librarianops/upgrade_test.go
+++ b/internal/librarianops/upgrade_test.go
@@ -98,7 +98,7 @@ func TestRunUpgrade_Error(t *testing.T) {
 				// Make writing the config file fail by creating a directory at its path.
 				repoDir := t.TempDir()
 				configPath := generateLibrarianConfigPath(t, repoDir)
-				if err := os.Mkdir(configPath, 0755); err != nil {
+				if err := os.Mkdir(configPath, 0o755); err != nil {
 					t.Fatal(err)
 				}
 				return repoDir

--- a/internal/postprocessing/delete.go
+++ b/internal/postprocessing/delete.go
@@ -68,7 +68,7 @@ func DeleteMethod(path, funcName, language string) error {
 	for _, bound := range slices.Backward(boundsList) {
 		data = append(data[:bound.start], data[bound.end:]...)
 	}
-	return os.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0o644)
 }
 
 // findMethodBounds locates the physical byte boundaries of all valid matches for the signature.

--- a/internal/postprocessing/delete_test.go
+++ b/internal/postprocessing/delete_test.go
@@ -247,7 +247,7 @@ class B {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			tmpFile := filepath.Join(t.TempDir(), "test.java")
-			if err := os.WriteFile(tmpFile, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(tmpFile, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := DeleteMethod(tmpFile, test.funcName, "java"); err != nil {
@@ -312,7 +312,7 @@ func TestDeleteMethod_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			tmpFile := filepath.Join(t.TempDir(), "test.java")
-			if err := os.WriteFile(tmpFile, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(tmpFile, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			err := DeleteMethod(tmpFile, test.funcName, test.language)

--- a/internal/postprocessing/deprecate.go
+++ b/internal/postprocessing/deprecate.go
@@ -76,7 +76,7 @@ func DeprecateMethod(path, funcName, deprecationMessage, language string) error 
 	indentation := trimLineIndentation(lines[sigLineIdx])
 	lines = annotateMethod(lines, sigLineIdx, indentation, header)
 	lines = addJavadocTag(lines, indentation, header, "deprecated", deprecationMessage)
-	return os.WriteFile(path, bytes.Join(lines, []byte("\n")), 0644)
+	return os.WriteFile(path, bytes.Join(lines, []byte("\n")), 0o644)
 }
 
 // analyzeMethodHeader scans the lines above a method signature to identify existing Javadoc and annotations.

--- a/internal/postprocessing/deprecate_test.go
+++ b/internal/postprocessing/deprecate_test.go
@@ -185,7 +185,7 @@ public class TestClass {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			filePath := filepath.Join(tmpDir, "TestClass.java")
-			if err := os.WriteFile(filePath, []byte(test.inputContent), 0644); err != nil {
+			if err := os.WriteFile(filePath, []byte(test.inputContent), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := DeprecateMethod(filePath, test.funcName, test.deprecationMessage, config.LanguageJava); err != nil {
@@ -293,7 +293,7 @@ public class TestClass {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			filePath := filepath.Join(tmpDir, "TestClass.java")
-			if err := os.WriteFile(filePath, []byte(test.inputContent), 0644); err != nil {
+			if err := os.WriteFile(filePath, []byte(test.inputContent), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			err := DeprecateMethod(filePath, test.funcName, test.deprecationMessage, test.language)

--- a/internal/postprocessing/duplicate.go
+++ b/internal/postprocessing/duplicate.go
@@ -73,5 +73,5 @@ func DuplicateMethod(path, funcName, newName, language string) error {
 	newContent = append(newContent, '\n')
 	newContent = append(newContent, renamedBlock...)
 	newContent = append(newContent, content[b.end:]...)
-	return os.WriteFile(path, newContent, 0644)
+	return os.WriteFile(path, newContent, 0o644)
 }

--- a/internal/postprocessing/duplicate_test.go
+++ b/internal/postprocessing/duplicate_test.go
@@ -122,7 +122,7 @@ public class TestClass {
 			t.Parallel()
 			dir := t.TempDir()
 			path := filepath.Join(dir, "TestClass.java")
-			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := DuplicateMethod(path, test.funcName, test.newName, "java"); err != nil {
@@ -237,7 +237,7 @@ public class TestClass {
 			t.Parallel()
 			dir := t.TempDir()
 			path := filepath.Join(dir, "TestClass.java")
-			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			err := DuplicateMethod(path, test.funcName, test.newName, test.language)

--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -85,7 +85,7 @@ func Replace(path, original, replacement string) error {
 		return fmt.Errorf("%w: %q in file %s", errTextNotFound, original, path)
 	}
 	newContent := bytes.ReplaceAll(content, oldBytes, []byte(replacement))
-	return os.WriteFile(path, newContent, 0644)
+	return os.WriteFile(path, newContent, 0o644)
 }
 
 // ReplaceRegex finds and replaces text in a file using a regular expression.
@@ -110,7 +110,7 @@ func ReplaceRegex(path, pattern, replacement string) error {
 		return fmt.Errorf("%w: pattern %q in file %s", errTextNotFound, pattern, path)
 	}
 	newContent := re.ReplaceAll(content, []byte(replacement))
-	return os.WriteFile(path, newContent, 0644)
+	return os.WriteFile(path, newContent, 0o644)
 }
 
 // CopyFiles copies files specified by copyConfigs from src to dst inside outDir.
@@ -121,7 +121,7 @@ func CopyFiles(outDir string, copyConfigs []config.CopyConfig) error {
 		if srcAbs == dstAbs {
 			return fmt.Errorf("invalid copy config for %s: %w", c.Src, errSameSourceAndDestination)
 		}
-		if err := os.MkdirAll(filepath.Dir(dstAbs), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dstAbs), 0o755); err != nil {
 			return fmt.Errorf("failed to create directory for %s: %w", c.Dst, err)
 		}
 		if err := filesystem.CopyFile(srcAbs, dstAbs); err != nil {

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -158,7 +158,7 @@ func TestReplace(t *testing.T) {
 	original := "World"
 	replacement := "Go"
 	want := "Hello Go"
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := Replace(path, original, replacement); err != nil {
@@ -200,7 +200,7 @@ func TestReplaceRegex(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 			path := filepath.Join(dir, "test.txt")
-			if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := ReplaceRegex(path, test.pattern, test.replacement); err != nil {
@@ -252,7 +252,7 @@ func TestReplace_Error(t *testing.T) {
 			path := filepath.Join(dir, "nonexistent.txt")
 			if test.content != "" {
 				path = filepath.Join(dir, "test.txt")
-				if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -298,7 +298,7 @@ func TestReplaceRegex_Error(t *testing.T) {
 			path := filepath.Join(dir, "nonexistent.txt")
 			if test.content != "" {
 				path = filepath.Join(dir, "test.txt")
-				if err := os.WriteFile(path, []byte(test.content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -470,10 +470,10 @@ func createFiles(t *testing.T, dir string, files map[string]string) {
 	t.Helper()
 	for relPath, content := range files {
 		absPath := filepath.Join(dir, relPath)
-		if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(absPath, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -214,7 +214,7 @@ func WriteJSON(data any, indent, libraryOutputDir, filename string) error {
 		return fmt.Errorf("failed to marshal metadata to JSON: %w", err)
 	}
 	path := filepath.Join(libraryOutputDir, filename)
-	if err := os.WriteFile(path, content, 0644); err != nil {
+	if err := os.WriteFile(path, content, 0o644); err != nil {
 		return fmt.Errorf("failed to write metadata file: %w", err)
 	}
 	return nil

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -94,7 +94,7 @@ func TestFromLibrary(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			outDir := filepath.Join(tmpDir, "output")
-			if err := os.MkdirAll(outDir, 0755); err != nil {
+			if err := os.MkdirAll(outDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
 
@@ -242,7 +242,7 @@ func TestRead_Error(t *testing.T) {
 		{
 			name: "not JSON",
 			setup: func(t *testing.T, dir string) {
-				if err := os.WriteFile(filepath.Join(dir, repoMetadataFile), []byte("not json"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, repoMetadataFile), []byte("not json"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -220,11 +220,11 @@ func TestFindGRPCServiceConfigMultipleFiles(t *testing.T) {
 	dir := t.TempDir()
 	apiPath := "google/example/v1"
 	apiDir := filepath.Join(dir, apiPath)
-	if err := os.MkdirAll(apiDir, 0755); err != nil {
+	if err := os.MkdirAll(apiDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range []string{"foo_grpc_service_config.json", "bar_grpc_service_config.json"} {
-		if err := os.WriteFile(filepath.Join(apiDir, name), []byte("{}"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(apiDir, name), []byte("{}"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -273,11 +273,11 @@ func TestFindGAPICConfigMultipleFiles(t *testing.T) {
 	dir := t.TempDir()
 	apiPath := "google/example/v1"
 	apiDir := filepath.Join(dir, apiPath)
-	if err := os.MkdirAll(apiDir, 0755); err != nil {
+	if err := os.MkdirAll(apiDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range []string{"foo_gapic.yaml", "bar_gapic.yaml"} {
-		if err := os.WriteFile(filepath.Join(apiDir, name), []byte(""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(apiDir, name), []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/sidekick/codec_sample/generate_test.go
+++ b/internal/sidekick/codec_sample/generate_test.go
@@ -69,7 +69,7 @@ func TestFromProtobuf(t *testing.T) {
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("missing %s: %s", filename, err)
 	}
-	if stat.Mode().Perm()|0666 != 0666 {
+	if stat.Mode().Perm()|0o666 != 0o666 {
 		t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 	}
 }

--- a/internal/sidekick/dart/generate_test.go
+++ b/internal/sidekick/dart/generate_test.go
@@ -77,7 +77,7 @@ func TestFromProtobuf(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}

--- a/internal/sidekick/language/generate.go
+++ b/internal/sidekick/language/generate.go
@@ -78,7 +78,7 @@ func generateElement(outDir string, element any, provider TemplateProvider, gen 
 		return err
 	}
 	destination := filepath.Join(outDir, gen.OutputPath)
-	if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 		return err
 	}
 	nestedProvider := mustacheProvider{
@@ -89,5 +89,5 @@ func generateElement(outDir string, element any, provider TemplateProvider, gen 
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(destination, []byte(s), 0666)
+	return os.WriteFile(destination, []byte(s), 0o666)
 }

--- a/internal/sidekick/language/generate_test.go
+++ b/internal/sidekick/language/generate_test.go
@@ -44,7 +44,7 @@ func TestGenerate(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
@@ -109,7 +109,7 @@ func verifyElementOutput(t *testing.T, outDir string) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Fatal(err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}

--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -141,7 +141,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
@@ -173,7 +173,7 @@ func TestRustFromDiscovery(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
@@ -216,7 +216,7 @@ func TestRustFromProtobuf(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
@@ -261,7 +261,7 @@ func TestRustClient(t *testing.T) {
 			if errors.Is(err, fs.ErrNotExist) {
 				t.Errorf("missing %s: %s", filename, err)
 			}
-			if stat.Mode().Perm()|0666 != 0666 {
+			if stat.Mode().Perm()|0o666 != 0o666 {
 				t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 			}
 		}
@@ -312,7 +312,7 @@ func TestRustNosvc(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
@@ -353,7 +353,7 @@ func TestRustModuleRpc(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}
@@ -394,7 +394,7 @@ func TestRustBootstrapWkt(t *testing.T) {
 		if errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("missing %s: %s", filename, err)
 		}
-		if stat.Mode().Perm()|0666 != 0666 {
+		if stat.Mode().Perm()|0o666 != 0o666 {
 			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
 		}
 	}

--- a/internal/sidekick/swift/generate_package_swift_test.go
+++ b/internal/sidekick/swift/generate_package_swift_test.go
@@ -30,7 +30,7 @@ func TestGeneratePackageSwift_WithDependencies(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 	outDir := filepath.Join("generated", "google-cloud-workflows-v1")
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll("generated")

--- a/internal/sidekick/swift/generate_test.go
+++ b/internal/sidekick/swift/generate_test.go
@@ -66,7 +66,7 @@ func TestFromProtobuf(t *testing.T) {
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("missing %s: %s", filename, err)
 	}
-	if stat.Mode().Perm()|0666 != 0666 {
+	if stat.Mode().Perm()|0o666 != 0o666 {
 		t.Errorf("generated files should just be read-write %s: %o", filename, stat.Mode())
 	}
 }

--- a/internal/sidekick/swift/generate_version.go
+++ b/internal/sidekick/swift/generate_version.go
@@ -55,12 +55,12 @@ func GenerateVersion(ctx context.Context, outDir string, library *config.Library
 		return err
 	}
 	destination := filepath.Join(outDir, "PackageVersion.swift")
-	if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 		return err
 	}
 	s, err := mustache.Render(string(contents), &versionView{library: library})
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(destination, []byte(s), 0666)
+	return os.WriteFile(destination, []byte(s), 0o666)
 }

--- a/internal/sidekick/swift/generate_version_test.go
+++ b/internal/sidekick/swift/generate_version_test.go
@@ -42,7 +42,7 @@ func TestGenerateVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stat.Mode().Perm()|0666 != 0666 {
+	if stat.Mode().Perm()|0o666 != 0o666 {
 		t.Errorf("generated files should just be read-write %s: %o", filename, stat.Mode())
 	}
 

--- a/internal/snippetmetadata/snippetmetadata.go
+++ b/internal/snippetmetadata/snippetmetadata.go
@@ -62,7 +62,7 @@ func writeMetadata(path string, metadata map[string]any) error {
 	if len(content) > 0 && content[len(content)-1] == '\n' {
 		content = content[:len(content)-1]
 	}
-	if err := os.WriteFile(path, content, 0644); err != nil {
+	if err := os.WriteFile(path, content, 0o644); err != nil {
 		return fmt.Errorf("error writing snippet metadata file %s: %w", path, err)
 	}
 	return nil

--- a/internal/snippetmetadata/snippetmetadata_test.go
+++ b/internal/snippetmetadata/snippetmetadata_test.go
@@ -58,7 +58,7 @@ func TestUpdateLibraryVersion_Error(t *testing.T) {
 		{
 			name: "invalid json",
 			setup: func(t *testing.T, path string) {
-				if err := os.WriteFile(path, []byte("this isn't valid JSON"), 0644); err != nil {
+				if err := os.WriteFile(path, []byte("this isn't valid JSON"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -68,7 +68,7 @@ func TestUpdateLibraryVersion_Error(t *testing.T) {
 		{
 			name: "no clientLibrary field",
 			setup: func(t *testing.T, path string) {
-				if err := os.WriteFile(path, []byte("{}"), 0644); err != nil {
+				if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -77,7 +77,7 @@ func TestUpdateLibraryVersion_Error(t *testing.T) {
 		{
 			name: "readonly file",
 			setup: func(t *testing.T, path string) {
-				if err := os.WriteFile(path, []byte("{\"clientLibrary\":{}}"), 0444); err != nil {
+				if err := os.WriteFile(path, []byte("{\"clientLibrary\":{}}"), 0o444); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -105,7 +105,7 @@ func TestUpdateAllLibraryVersions(t *testing.T) {
 	dir := filepath.Dir(metadataPath)
 	readmePath := filepath.Join(dir, "README.txt")
 	readmeContent := "This is a README file"
-	if err := os.WriteFile(readmePath, []byte(readmeContent), 0644); err != nil {
+	if err := os.WriteFile(readmePath, []byte(readmeContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := UpdateAllLibraryVersions(dir, "1.20.0"); err != nil {
@@ -144,7 +144,7 @@ func TestUpdateAllLibraryVersions_Error(t *testing.T) {
 		{
 			name: "unexpected directory",
 			setup: func(t *testing.T, dir string) {
-				if err := os.Mkdir(filepath.Join(dir, "snippet_metadata.json"), 0755); err != nil {
+				if err := os.Mkdir(filepath.Join(dir, "snippet_metadata.json"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -154,7 +154,7 @@ func TestUpdateAllLibraryVersions_Error(t *testing.T) {
 			name: "readonly file",
 			setup: func(t *testing.T, dir string) {
 				content := "{\"clientLibrary\":{}}"
-				if err := os.WriteFile(filepath.Join(dir, "snippet_metadata.json"), []byte(content), 0444); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, "snippet_metadata.json"), []byte(content), 0o444); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -204,7 +204,7 @@ func TestReformat_Error(t *testing.T) {
 		{
 			name: "invalid json",
 			setup: func(t *testing.T, path string) {
-				if err := os.WriteFile(path, []byte("This isn't valid JSON"), 0644); err != nil {
+				if err := os.WriteFile(path, []byte("This isn't valid JSON"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -214,7 +214,7 @@ func TestReformat_Error(t *testing.T) {
 		{
 			name: "readonly file",
 			setup: func(t *testing.T, path string) {
-				if err := os.WriteFile(path, []byte("{}"), 0444); err != nil {
+				if err := os.WriteFile(path, []byte("{}"), 0o444); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -248,7 +248,7 @@ func TestReformatAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(unformattedPath, []byte(unformattedContent), 0644); err != nil {
+	if err := os.WriteFile(unformattedPath, []byte(unformattedContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := ReformatAll(dir); err != nil {
@@ -287,7 +287,7 @@ func TestReformatAll_Error(t *testing.T) {
 		{
 			name: "unexpected directory",
 			setup: func(t *testing.T, dir string) {
-				if err := os.Mkdir(filepath.Join(dir, "snippet_metadata.json"), 0755); err != nil {
+				if err := os.Mkdir(filepath.Join(dir, "snippet_metadata.json"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -296,7 +296,7 @@ func TestReformatAll_Error(t *testing.T) {
 		{
 			name: "readonly file",
 			setup: func(t *testing.T, dir string) {
-				if err := os.WriteFile(filepath.Join(dir, "snippet_metadata.json"), []byte("{}"), 0444); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, "snippet_metadata.json"), []byte("{}"), 0o444); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -330,11 +330,11 @@ func TestFindAll(t *testing.T) {
 	allFiles := append(snippetMetadataFiles, nonSnippetMetadataFiles...)
 	for _, file := range allFiles {
 		path := filepath.Join(dir, file)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		// The content doesn't matter for this test; empty files are fine.
-		if err := os.WriteFile(path, nil, 0644); err != nil {
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -362,7 +362,7 @@ func TestFindAll_Error(t *testing.T) {
 		{
 			name: "match is a directory",
 			setup: func(t *testing.T, dir string) {
-				if err := os.Mkdir(filepath.Join(dir, "snippet_metadata.json"), 0755); err != nil {
+				if err := os.Mkdir(filepath.Join(dir, "snippet_metadata.json"), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -373,7 +373,7 @@ func TestFindAll_Error(t *testing.T) {
 			setup: func(t *testing.T, dir string) {
 				normalPath := filepath.Join(dir, "test.txt")
 				matchPath := filepath.Join(dir, "snippet_metadata.json")
-				if err := os.WriteFile(normalPath, nil, 0644); err != nil {
+				if err := os.WriteFile(normalPath, nil, 0o644); err != nil {
 					t.Fatal(err)
 				}
 				if err := os.Symlink(normalPath, matchPath); err != nil {
@@ -404,7 +404,7 @@ func copyInputFileToTemp(t *testing.T, inputFile string) string {
 		t.Fatal(err)
 	}
 	path := filepath.Join(dir, "snippet_metadata.json")
-	err = os.WriteFile(path, content, 0644)
+	err = os.WriteFile(path, content, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestHTMLCharsNoEscape(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
 			path := filepath.Join(dir, "snippet_metadata.json")
-			if err := os.WriteFile(path, []byte(test.input), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(test.input), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if err := test.run(path); err != nil {

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -56,16 +56,16 @@ func TestRoot(t *testing.T) {
 func TestResolve(t *testing.T) {
 	tempDir := t.TempDir()
 	googleapis := filepath.Join(tempDir, "googleapis")
-	if err := os.Mkdir(googleapis, 0755); err != nil {
+	if err := os.Mkdir(googleapis, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	specPath := "google/cloud/secretmanager/v1/secretmanager.yaml"
 	fullPath := filepath.Join(googleapis, specPath)
-	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(fullPath, []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(fullPath, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,7 +123,7 @@ func TestResolveDir(t *testing.T) {
 	googleapis := filepath.Join(tempDir, "googleapis")
 	dirPath := "google/cloud/secretmanager/v1"
 	fullDir := filepath.Join(googleapis, dirPath)
-	if err := os.MkdirAll(fullDir, 0755); err != nil {
+	if err := os.MkdirAll(fullDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -102,7 +102,7 @@ func configNewGitRepository(t *testing.T) {
 func initRepositoryContents(t *testing.T) {
 	t.Helper()
 	RequireCommand(t, command.Git)
-	if err := os.WriteFile(ReadmeFile, []byte(ReadmeContents), 0644); err != nil {
+	if err := os.WriteFile(ReadmeFile, []byte(ReadmeContents), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	AddCrate(t, sample.Lib1Output, sample.Lib1Name)
@@ -116,7 +116,7 @@ func initRepositoryContents(t *testing.T) {
 func addGeneratedCrate(t *testing.T, location, name string) {
 	t.Helper()
 	AddCrate(t, location, name)
-	if err := os.WriteFile(path.Join(location, ".sidekick.toml"), []byte("# initial version"), 0644); err != nil {
+	if err := os.WriteFile(path.Join(location, ".sidekick.toml"), []byte("# initial version"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -124,15 +124,15 @@ func addGeneratedCrate(t *testing.T, location, name string) {
 // AddCrate creates a new Rust crate at the specified location with the given name.
 func AddCrate(t *testing.T, location, name string) {
 	t.Helper()
-	_ = os.MkdirAll(path.Join(location, "src"), 0755)
+	_ = os.MkdirAll(path.Join(location, "src"), 0o755)
 	contents := fmt.Appendf(nil, InitialCargoContents, name)
-	if err := os.WriteFile(path.Join(location, "Cargo.toml"), contents, 0644); err != nil {
+	if err := os.WriteFile(path.Join(location, "Cargo.toml"), contents, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path.Join(location, "src", "lib.rs"), []byte(initialLibRsContents), 0644); err != nil {
+	if err := os.WriteFile(path.Join(location, "src", "lib.rs"), []byte(initialLibRsContents), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path.Join(location, ".repo-metadata.json"), []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(path.Join(location, ".repo-metadata.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -203,7 +203,7 @@ func setup(t *testing.T, opts SetupOptions) {
 
 func touchFile(t *testing.T, path string) {
 	t.Helper()
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func SetupRepoWithChange(t *testing.T, wantTag string) string {
 	remoteDir := SetupRepo(t)
 	RunGit(t, "tag", wantTag)
 	name := path.Join(sample.Lib1Output, "src", "lib.rs")
-	if err := os.WriteFile(name, []byte(NewLibRsContents), 0644); err != nil {
+	if err := os.WriteFile(name, []byte(NewLibRsContents), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	RunGit(t, "commit", "-m", "feat: changed storage", ".")

--- a/internal/tool/gem/gem_test.go
+++ b/internal/tool/gem/gem_test.go
@@ -33,11 +33,11 @@ func TestInstall(t *testing.T) {
 echo "gem $@" >> %q
 `, stubLogPath)
 	stubDir := filepath.Join(tmpDir, "bin")
-	if err := os.MkdirAll(stubDir, 0755); err != nil {
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	stubPath := filepath.Join(stubDir, "gem")
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0755); err != nil {
+	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)
@@ -87,11 +87,11 @@ gem install rake -v 13.0.6 --bindir /tmp/ruby_tools/bin --install-dir /tmp/ruby_
 func TestInstall_Error(t *testing.T) {
 	tmpDir := t.TempDir()
 	stubDir := filepath.Join(tmpDir, "bin")
-	if err := os.MkdirAll(stubDir, 0755); err != nil {
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	stubPath := filepath.Join(stubDir, "gem")
-	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/tool/pip/pip_test.go
+++ b/internal/tool/pip/pip_test.go
@@ -33,16 +33,16 @@ func TestInstall(t *testing.T) {
 echo "pip $@" >> %q
 `, stubLogPath)
 	stubDir := filepath.Join(tmpDir, "bin")
-	if err := os.MkdirAll(stubDir, 0755); err != nil {
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	stubPath := filepath.Join(stubDir, "pip")
-	if err := os.WriteFile(stubPath, []byte(stubContent), 0755); err != nil {
+	if err := os.WriteFile(stubPath, []byte(stubContent), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", stubDir)
 	localPkgPath := filepath.Join(tmpDir, "mylocalpkg")
-	if err := os.MkdirAll(localPkgPath, 0755); err != nil {
+	if err := os.MkdirAll(localPkgPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, test := range []struct {
@@ -102,11 +102,11 @@ echo "pip $@" >> %q
 func TestInstall_Error(t *testing.T) {
 	tmpDir := t.TempDir()
 	stubDir := filepath.Join(tmpDir, "bin")
-	if err := os.MkdirAll(stubDir, 0755); err != nil {
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	stubPath := filepath.Join(stubDir, "pip")
-	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, test := range []struct {

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -95,7 +95,7 @@ func Write(path string, v any) error {
 	header := b.String()
 
 	data = append([]byte(header), data...)
-	return os.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0o644)
 }
 
 // Empty returns whether the given value serializes to an empty YAML object

--- a/tool/cmd/importconfigs/bazel/parser_test.go
+++ b/tool/cmd/importconfigs/bazel/parser_test.go
@@ -70,7 +70,7 @@ go_proto_library()
 `
 	tmpDir := t.TempDir()
 	buildPath := filepath.Join(tmpDir, "BUILD.bazel")
-	if err := os.WriteFile(buildPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(buildPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -159,7 +159,7 @@ func TestParse_Errors(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			buildPath := filepath.Join(tmpDir, "BUILD.bazel")
-			if err := os.WriteFile(buildPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(buildPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if _, err := Parse(buildPath); err != nil {
@@ -305,7 +305,7 @@ go_gapic_library(
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			buildPath := filepath.Join(tmpDir, "BUILD.bazel")
-			if err := os.WriteFile(buildPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(buildPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := ParseTransports(buildPath)
@@ -357,7 +357,7 @@ go_gapic_library(
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			buildPath := filepath.Join(tmpDir, "BUILD.bazel")
-			if err := os.WriteFile(buildPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(buildPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := ParseRESTNumericEnums(buildPath)
@@ -410,7 +410,7 @@ go_gapic_library(
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			buildPath := filepath.Join(tmpDir, "BUILD.bazel")
-			if err := os.WriteFile(buildPath, []byte(test.content), 0644); err != nil {
+			if err := os.WriteFile(buildPath, []byte(test.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			got, err := ParseReleaseLevel(buildPath)
@@ -428,7 +428,7 @@ func mustParse(t *testing.T, content string) *Config {
 	t.Helper()
 	tmpDir := t.TempDir()
 	buildPath := filepath.Join(tmpDir, "BUILD.bazel")
-	if err := os.WriteFile(buildPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(buildPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tool/cmd/importconfigs/update_release_level_test.go
+++ b/tool/cmd/importconfigs/update_release_level_test.go
@@ -161,7 +161,7 @@ func TestRunUpdateReleaseLevel_Error(t *testing.T) {
 			name:    "invalid googleapis dir",
 			sdkYaml: filepath.Join(t.TempDir(), "empty.yaml"),
 			setup: func(t *testing.T, path string) {
-				if err := os.WriteFile(path, []byte(""), 0755); err != nil {
+				if err := os.WriteFile(path, []byte(""), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/tool/cmd/importconfigs/update_rest_numeric_enums_test.go
+++ b/tool/cmd/importconfigs/update_rest_numeric_enums_test.go
@@ -194,7 +194,7 @@ func TestRunUpdateRestNumericEnums_Error(t *testing.T) {
 			name:    "invalid googleapis dir",
 			sdkYaml: filepath.Join(t.TempDir(), "empty.yaml"),
 			setup: func(t *testing.T, path string) {
-				if err := os.WriteFile(path, []byte(""), 0755); err != nil {
+				if err := os.WriteFile(path, []byte(""), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/tool/cmd/migrate/fetch_test.go
+++ b/tool/cmd/migrate/fetch_test.go
@@ -55,10 +55,10 @@ func TestFetchGoogleapisWithCommit(t *testing.T) {
 	t.Setenv("LIBRARIAN_CACHE", tmp)
 	// Pre-populate cache to avoid RepoDir downloading (which ignores our mock download URL)
 	cachePath := filepath.Join(tmp, fmt.Sprintf("%s@%s", googleapisRepo, wantCommit))
-	if err := os.MkdirAll(cachePath, 0755); err != nil {
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cachePath, "dummy"), []byte("dummy"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(cachePath, "dummy"), []byte("dummy"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -46,13 +46,13 @@ func TestRunPHPMigration(t *testing.T) {
 	dir := t.TempDir()
 	// Create a fake library SecretManager.
 	libDir := filepath.Join(dir, "SecretManager")
-	if err := os.Mkdir(libDir, 0755); err != nil {
+	if err := os.Mkdir(libDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("2.3.0\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("2.3.0\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	owlbotContent := `
@@ -60,26 +60,26 @@ deep-copy-regex:
   - source: /google/cloud/secretmanager/(v1)/.*-php/(.*)
     dest: /owl-bot-staging/SecretManager/$1/$2
 `
-	if err := os.WriteFile(filepath.Join(libDir, ".OwlBot.yaml"), []byte(owlbotContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(libDir, ".OwlBot.yaml"), []byte(owlbotContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Create a fake non-library directory to ensure it is ignored.
 	ignoredDir := filepath.Join(dir, "dev")
-	if err := os.Mkdir(ignoredDir, 0755); err != nil {
+	if err := os.Mkdir(ignoredDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(ignoredDir, "composer.json"), []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(ignoredDir, "composer.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Create a fake library HandwrittenLib (no .OwlBot.yaml) to ensure it is skipped.
 	handwrittenLibDir := filepath.Join(dir, "HandwrittenLib")
-	if err := os.Mkdir(handwrittenLibDir, 0755); err != nil {
+	if err := os.Mkdir(handwrittenLibDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(handwrittenLibDir, "VERSION"), []byte("1.0.0\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(handwrittenLibDir, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(handwrittenLibDir, "composer.json"), []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(handwrittenLibDir, "composer.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	t.Chdir(dir)
@@ -225,7 +225,7 @@ deep-copy-regex:
 api-name: Ces
 `
 				path := filepath.Join(dir, ".OwlBot.yaml")
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return path
@@ -261,7 +261,7 @@ deep-copy-regex:
 api-name: GeoCommonProtos
 `
 				path := filepath.Join(dir, ".OwlBot.yaml")
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return path
@@ -301,7 +301,7 @@ func TestExtractAPIsFromOwlBot_Error(t *testing.T) {
 			setupFile: func(dir string) string {
 				content := `{invalid`
 				path := filepath.Join(dir, ".OwlBot.yaml")
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return path
@@ -319,7 +319,7 @@ deep-copy-regex:
 api-name: Ces
 `
 				path := filepath.Join(dir, ".OwlBot.yaml")
-				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				return path
@@ -406,10 +406,10 @@ proto_library_with_info(
 			tempDir := t.TempDir()
 			if test.bazelRules != "" {
 				apiDir := filepath.Join(tempDir, "google/cloud/ces/v1")
-				if err := os.MkdirAll(apiDir, 0755); err != nil {
+				if err := os.MkdirAll(apiDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(apiDir, "BUILD.bazel"), []byte(test.bazelRules), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(apiDir, "BUILD.bazel"), []byte(test.bazelRules), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -440,13 +440,13 @@ func TestFindPHPLibraries(t *testing.T) {
 			name: "common resources configuration",
 			setupLib: func(t *testing.T, dir string) {
 				libDir := filepath.Join(dir, "SecretManager")
-				if err := os.Mkdir(libDir, 0755); err != nil {
+				if err := os.Mkdir(libDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("2.3.0\n"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("2.3.0\n"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 				owlbotContent := `
@@ -456,7 +456,7 @@ deep-copy-regex:
   - source: /google/cloud/multipygapic/.*-php/(.*)
     dest: /owl-bot-staging/SecretManager/multipygapic/$1
 `
-				if err := os.WriteFile(filepath.Join(libDir, ".OwlBot.yaml"), []byte(owlbotContent), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(libDir, ".OwlBot.yaml"), []byte(owlbotContent), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},


### PR DESCRIPTION
Legacy octal literals (such as 0755 and 0644) are converted to the modern explicit octal format (0o755 and 0o644) in Go files across the codebase. This aligns with Go 1.13+ conventions.

ref: https://go.dev/doc/go1.13#language
 https://go.dev/ref/spec#Integer_literals