### PR TITLE
refactor(internal/librarian/php): remove unused config migration_mode

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -448,7 +448,6 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
-| `migration_mode` | string | Controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY"). |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -830,9 +830,6 @@ type PHPAPI struct {
 	// AdditionalProtos is a list of additional proto files to include in generation.
 	AdditionalProtos []string `yaml:"additional_protos,omitempty"`
 
-	// MigrationMode controls migration mode setting for the PHP generator (e.g. "NEW_SURFACE_ONLY").
-	MigrationMode string `yaml:"migration_mode,omitempty"`
-
 	// CommonResources indicates whether to include common resources in generation.
 	// Must be configured either globally or per-API.
 	CommonResources *bool `yaml:"common_resources,omitempty"`

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -46,9 +46,6 @@ func Add(lib *config.Library) *config.Library {
 		if api.PHP.StagingSubdir == "" {
 			api.PHP.StagingSubdir = serviceconfig.ExtractVersion(api.Path)
 		}
-		if api.PHP.MigrationMode == "" {
-			api.PHP.MigrationMode = "NEW_SURFACE_ONLY"
-		}
 	}
 	return lib
 }

--- a/internal/librarian/php/add_test.go
+++ b/internal/librarian/php/add_test.go
@@ -83,7 +83,6 @@ func TestAdd(t *testing.T) {
 						Path: "google/cloud/speech/v2",
 						PHP: &config.PHPAPI{
 							StagingSubdir: "v2",
-							MigrationMode: "NEW_SURFACE_ONLY",
 						},
 					},
 				},
@@ -97,7 +96,6 @@ func TestAdd(t *testing.T) {
 						Path: "google/cloud/speech/v2",
 						PHP: &config.PHPAPI{
 							StagingSubdir: "custom_subdir",
-							MigrationMode: "MIGRATED",
 						},
 					},
 				},
@@ -108,7 +106,6 @@ func TestAdd(t *testing.T) {
 						Path: "google/cloud/speech/v2",
 						PHP: &config.PHPAPI{
 							StagingSubdir: "custom_subdir",
-							MigrationMode: "MIGRATED",
 						},
 					},
 				},
@@ -128,14 +125,12 @@ func TestAdd(t *testing.T) {
 						Path: "google/cloud/speech/v2",
 						PHP: &config.PHPAPI{
 							StagingSubdir: "v2",
-							MigrationMode: "NEW_SURFACE_ONLY",
 						},
 					},
 					{
 						Path: "google/cloud/speech/v2beta1",
 						PHP: &config.PHPAPI{
 							StagingSubdir: "v2beta1",
-							MigrationMode: "NEW_SURFACE_ONLY",
 						},
 					},
 				},

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -165,7 +165,7 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 	if err != nil {
 		return err
 	}
-	opts := gapicOpts(params.api, apiMetadata, grpcConfigPath)
+	opts := gapicOpts(apiMetadata, grpcConfigPath)
 	additionalProtos := params.api.PHP.AdditionalProtos
 	includeCommonResources := *params.api.PHP.CommonResources
 	gapicProtos, err := gatherGAPICProtos(googleapisDir, params.api.Path, additionalProtos, includeCommonResources)
@@ -291,17 +291,13 @@ func gatherProtos(root string) ([]string, error) {
 	return protos, nil
 }
 
-func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigPath string) []string {
+func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigPath string) []string {
 	transport := serviceconfig.GRPCRest
 	if apiMetadata != nil {
 		transport = apiMetadata.Transport(config.LanguagePhp)
 	}
 	opts := []string{"metadata", "transport=" + string(transport)}
-	migrationMode := "NEW_SURFACE_ONLY"
-	if api.PHP != nil && api.PHP.MigrationMode != "" {
-		migrationMode = api.PHP.MigrationMode
-	}
-	opts = append(opts, "migration-mode="+migrationMode)
+	opts = append(opts, "migration-mode=NEW_SURFACE_ONLY")
 	if apiMetadata != nil && apiMetadata.HasRESTNumericEnums(config.LanguagePhp) {
 		opts = append(opts, "rest-numeric-enums")
 	}

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -297,6 +297,8 @@ func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigPath string) []string {
 		transport = apiMetadata.Transport(config.LanguagePhp)
 	}
 	opts := []string{"metadata", "transport=" + string(transport)}
+	// TODO(https://github.com/googleapis/gapic-generator-php/pull/834):
+	// remove when generator change is done
 	opts = append(opts, "migration-mode=NEW_SURFACE_ONLY")
 	if apiMetadata != nil && apiMetadata.HasRESTNumericEnums(config.LanguagePhp) {
 		opts = append(opts, "rest-numeric-enums")

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -182,28 +182,16 @@ func TestGatherProtos(t *testing.T) {
 func TestGapicOpts(t *testing.T) {
 	for _, test := range []struct {
 		name           string
-		api            *config.API
 		apiMetadata    *serviceconfig.API
 		grpcConfigPath string
 		want           []string
 	}{
 		{
 			name: "defaults",
-			api:  &config.API{},
 			want: []string{"metadata", "transport=grpc+rest", "migration-mode=NEW_SURFACE_ONLY", "generate-snippets"},
 		},
 		{
-			name: "custom migration mode",
-			api: &config.API{
-				PHP: &config.PHPAPI{
-					MigrationMode: "MIGRATING",
-				},
-			},
-			want: []string{"metadata", "transport=grpc+rest", "migration-mode=MIGRATING", "generate-snippets"},
-		},
-		{
 			name: "with grpc config and service yaml",
-			api:  &config.API{},
 			apiMetadata: &serviceconfig.API{
 				ServiceConfig: "service.yaml",
 			},
@@ -217,7 +205,6 @@ func TestGapicOpts(t *testing.T) {
 		},
 		{
 			name: "skip rest numeric enums",
-			api:  &config.API{},
 			apiMetadata: &serviceconfig.API{
 				SkipRESTNumericEnums: []string{"php"},
 			},
@@ -226,7 +213,6 @@ func TestGapicOpts(t *testing.T) {
 		},
 		{
 			name: "custom transport",
-			api:  &config.API{},
 			apiMetadata: &serviceconfig.API{
 				Transports: map[string]serviceconfig.Transport{
 					"php": serviceconfig.Transport("rest"),
@@ -237,7 +223,7 @@ func TestGapicOpts(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := gapicOpts(test.api, test.apiMetadata, test.grpcConfigPath)
+			got := gapicOpts(test.apiMetadata, test.grpcConfigPath)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
The migration_mode configuration option for PHP is removed from Librarian config as it is not useful. The PHP generator now always uses the default NEW_SURFACE_ONLY migration mode, which is hardcoded in the generator options.
    

Fixes https://github.com/googleapis/librarian/issues/6928