### PR TITLE
fix(cmd/librarian/Dockerfile): go build in Dockerfile not to use Git

### DIFF
--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -107,7 +107,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -o /go/bin/librarian ./cmd/librarian
+    CGO_ENABLED=0 go build -buildvcs=false -o /go/bin/librarian ./cmd/librarian
 
 # ============== Base Stage ==============
 FROM debian:bookworm-slim AS base


### PR DESCRIPTION
The Dockerfile uses an outdated version of Git and our gLinux hosts
started to clone repositories with an "refstorage" extension, which
the old Git does not understand. This incompatibility was causing
the build failure in the `go build` command in Dockerfile.

By supplying `-buildvcs=false` option, the Git incompatibility
does not surface during the build. `suztomo@suztomo:~/librarian-2026/librarian$ docker build   -t librarian-python:${V}   --target python   -f cmd/librarian/Dockerfile --progress=plain   .` succeeded.

As a side effect, the Docker image cannot answer the Git revision:

```
suztomo@suztomo:~/librarian-2026/librarian$ docker run --rm  docker.io/library/librarian-python:v0.28.0 version
librarian version (devel)
```

Fixes https://github.com/googleapis/librarian/issues/6983
