### PR TITLE
chore(tool/cmd/migrate): merge existing config during ruby migration

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -81,7 +81,9 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 			},
 		},
 	}
-	mergeConfig(cfg, repoPath)
+	if err := mergeConfig(cfg, repoPath); err != nil {
+		return err
+	}
 	existingLibs, err := parseExistingLibraries(repoPath)
 	if err != nil {
 		return err
@@ -105,6 +107,9 @@ func parseExistingLibraries(repoPath string) ([]*config.Library, error) {
 	cfg, err := readExistingConfig(repoPath)
 	if err != nil {
 		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
 	}
 	return cfg.Libraries, nil
 }
@@ -286,8 +291,12 @@ func mergeConfig(cfg *config.Config, repoPath string) error {
 		return err
 	}
 	if existingConfig != nil {
-		cfg.Sources = existingConfig.Sources
-		cfg.Tools = existingConfig.Tools
+		if existingConfig.Sources != nil {
+			cfg.Sources = existingConfig.Sources
+		}
+		if existingConfig.Tools != nil {
+			cfg.Tools = existingConfig.Tools
+		}
 	}
 	return nil
 }
@@ -299,7 +308,7 @@ func readExistingConfig(repoPath string) (*config.Config, error) {
 	}
 	cfg, err := yaml.Read[config.Config](absConfigPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return &config.Config{}, nil
+		return nil, nil
 	}
 	if err != nil {
 		return nil, err

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -81,6 +81,7 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 			},
 		},
 	}
+	mergeConfig(cfg, repoPath)
 	existingLibs, err := parseExistingLibraries(repoPath)
 	if err != nil {
 		return err
@@ -101,15 +102,8 @@ func runRubyMigration(ctx context.Context, repoPath string) error {
 }
 
 func parseExistingLibraries(repoPath string) ([]*config.Library, error) {
-	absConfigPath, err := filepath.Abs(filepath.Join(repoPath, config.LibrarianYAML))
+	cfg, err := readExistingConfig(repoPath)
 	if err != nil {
-		return nil, fmt.Errorf("getting absolute path to %s: %w", config.LibrarianYAML, err)
-	}
-	cfg, err := yaml.Read[config.Config](absConfigPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	return cfg.Libraries, nil
@@ -284,4 +278,31 @@ func toMap(libs []*config.Library) map[string]*config.Library {
 		libraryMap[lib.Name] = lib
 	}
 	return libraryMap
+}
+
+func mergeConfig(cfg *config.Config, repoPath string) error {
+	existingConfig, err := readExistingConfig(repoPath)
+	if err != nil {
+		return err
+	}
+	if existingConfig != nil {
+		cfg.Sources = existingConfig.Sources
+		cfg.Tools = existingConfig.Tools
+	}
+	return nil
+}
+
+func readExistingConfig(repoPath string) (*config.Config, error) {
+	absConfigPath, err := filepath.Abs(filepath.Join(repoPath, config.LibrarianYAML))
+	if err != nil {
+		return nil, fmt.Errorf("getting absolute path to %s: %w", config.LibrarianYAML, err)
+	}
+	cfg, err := yaml.Read[config.Config](absConfigPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &config.Config{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -481,3 +481,141 @@ func TestParseExistingLibraries(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeConfig(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		initialCfg *config.Config
+		setup      func(t *testing.T, dir string)
+		want       *config.Config
+	}{
+		{
+			name: "merge existing sources and tools",
+			initialCfg: &config.Config{
+				Language: config.LanguageRuby,
+			},
+			setup: func(t *testing.T, dir string) {
+				cfg := &config.Config{
+					Sources: &config.Sources{
+						Googleapis: &config.Source{
+							Commit: "abcd123",
+							SHA256: "sha123",
+						},
+					},
+					Tools: &config.Tools{
+						Gem: []*config.GemTool{
+							{
+								Name:    "gapic-generator-cloud",
+								Version: "0.49.0",
+							},
+						},
+					},
+				}
+				if err := yaml.Write(filepath.Join(dir, config.LibrarianYAML), cfg); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: &config.Config{
+				Language: config.LanguageRuby,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{
+						Commit: "abcd123",
+						SHA256: "sha123",
+					},
+				},
+				Tools: &config.Tools{
+					Gem: []*config.GemTool{
+						{
+							Name:    "gapic-generator-cloud",
+							Version: "0.49.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "preserve initial tool versions when librarian.yaml has tools",
+			initialCfg: &config.Config{
+				Language: config.LanguageRuby,
+				Tools: &config.Tools{
+						Gem: []*config.GemTool{
+							{
+								Name:    "grpc",
+								Version: "0.49.0",
+							},
+						},
+					},
+			},
+			setup: func(t *testing.T, dir string) {
+				cfg := &config.Config{
+					Sources: &config.Sources{
+						Googleapis: &config.Source{
+							Commit: "abcd123",
+							SHA256: "sha123",
+						},
+					},
+					Tools: &config.Tools{
+						Gem: []*config.GemTool{
+							{
+								Name:    "grpc-tools",
+								Version: "1.2.3",
+							},
+						},
+					},
+				}
+				if err := yaml.Write(filepath.Join(dir, config.LibrarianYAML), cfg); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: &config.Config{
+				Language: config.LanguageRuby,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{
+						Commit: "abcd123",
+						SHA256: "sha123",
+					},
+				},
+				Tools: &config.Tools{
+						Gem: []*config.GemTool{
+							{
+								Name:    "grpc-tools",
+								Version: "1.2.3",
+							},
+						},
+					},
+			},
+		},
+		{
+			name: "non-existent librarian.yaml preserves initial config",
+			initialCfg: &config.Config{
+				Language: config.LanguageRuby,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{
+						Commit: "initial123",
+					},
+				},
+			},
+			setup: func(t *testing.T, dir string) {},
+			want: &config.Config{
+				Language: config.LanguageRuby,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{
+						Commit: "initial123",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			test.setup(t, dir)
+			cfg := test.initialCfg
+			if err := mergeConfig(cfg, dir); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, cfg); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -538,13 +538,13 @@ func TestMergeConfig(t *testing.T) {
 			initialCfg: &config.Config{
 				Language: config.LanguageRuby,
 				Tools: &config.Tools{
-						Gem: []*config.GemTool{
-							{
-								Name:    "grpc",
-								Version: "0.49.0",
-							},
+					Gem: []*config.GemTool{
+						{
+							Name:    "grpc",
+							Version: "0.49.0",
 						},
 					},
+				},
 			},
 			setup: func(t *testing.T, dir string) {
 				cfg := &config.Config{
@@ -576,13 +576,13 @@ func TestMergeConfig(t *testing.T) {
 					},
 				},
 				Tools: &config.Tools{
-						Gem: []*config.GemTool{
-							{
-								Name:    "grpc-tools",
-								Version: "1.2.3",
-							},
+					Gem: []*config.GemTool{
+						{
+							Name:    "grpc-tools",
+							Version: "1.2.3",
 						},
 					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Existing sources and tools sections from librarian.yaml are preserved and merged into the active configuration during Ruby library migration.

For https://github.com/googleapis/librarian/issues/6632
