### PR TITLE
fix(nodejs): isolate staging subdirectories per api version

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -102,9 +102,9 @@ func requireCachedTool(toolName string) (string, error) {
 	return toolPath, nil
 }
 
-func buildStagingSubdirName(index int, apiPath, version string) string {
+func buildStagingSubdirName(index int, apiPath string) string {
 	slug := strings.ReplaceAll(apiPath, "/", "_")
-	return fmt.Sprintf("%d_%s_%s", index, slug, version)
+	return fmt.Sprintf("%d_%s", index, slug)
 }
 
 func generateAPI(ctx context.Context, apiIndex int, api *config.API, library *config.Library, googleapisDir, repoRoot string) error {
@@ -119,8 +119,7 @@ func generateAPI(ctx context.Context, apiIndex int, api *config.API, library *co
 		return err
 	}
 
-	version := filepath.Base(api.Path)
-	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, buildStagingSubdirName(apiIndex, api.Path, version))
+	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, buildStagingSubdirName(apiIndex, api.Path))
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -58,14 +58,14 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 	repoRoot := filepath.Dir(filepath.Dir(outdir))
-	for _, api := range library.APIs {
+	for i, api := range library.APIs {
 		// TODO(https://github.com/googleapis/google-cloud-node/issues/8149): Do not
 		// generate v1small. This package is not meant to be used and will be
 		// deprecated and removed in a future major release. Remove this workaround once resolved.
 		if api.Path == "google/cloud/compute/v1small" {
 			continue
 		}
-		if err := generateAPI(ctx, api, library, googleapisDir, repoRoot); err != nil {
+		if err := generateAPI(ctx, i, api, library, googleapisDir, repoRoot); err != nil {
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
@@ -102,7 +102,12 @@ func requireCachedTool(toolName string) (string, error) {
 	return toolPath, nil
 }
 
-func generateAPI(ctx context.Context, api *config.API, library *config.Library, googleapisDir, repoRoot string) error {
+func buildStagingSubdirName(index int, apiPath, version string) string {
+	slug := strings.ReplaceAll(apiPath, "/", "_")
+	return fmt.Sprintf("%d_%s_%s", index, slug, version)
+}
+
+func generateAPI(ctx context.Context, apiIndex int, api *config.API, library *config.Library, googleapisDir, repoRoot string) error {
 	generatorPath, err := requireCachedTool("gapic-generator-typescript")
 	if err != nil {
 		return err
@@ -115,7 +120,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	}
 
 	version := filepath.Base(api.Path)
-	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, version)
+	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, buildStagingSubdirName(apiIndex, api.Path, version))
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -65,7 +65,13 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		if api.Path == "google/cloud/compute/v1small" {
 			continue
 		}
-		if err := generateAPI(ctx, i, api, library, googleapisDir, repoRoot); err != nil {
+		if err := generateAPI(ctx, generateAPIParams{
+			apiIndex:      i,
+			api:           api,
+			library:       library,
+			googleapisDir: googleapisDir,
+			repoRoot:      repoRoot,
+		}); err != nil {
 			return fmt.Errorf("failed to generate api %q: %w", api.Path, err)
 		}
 	}
@@ -107,7 +113,15 @@ func buildStagingSubdirName(index int, apiPath string) string {
 	return fmt.Sprintf("%d_%s", index, slug)
 }
 
-func generateAPI(ctx context.Context, apiIndex int, api *config.API, library *config.Library, googleapisDir, repoRoot string) error {
+type generateAPIParams struct {
+	apiIndex      int
+	api           *config.API
+	library       *config.Library
+	googleapisDir string
+	repoRoot      string
+}
+
+func generateAPI(ctx context.Context, params generateAPIParams) error {
 	generatorPath, err := requireCachedTool("gapic-generator-typescript")
 	if err != nil {
 		return err
@@ -119,28 +133,28 @@ func generateAPI(ctx context.Context, apiIndex int, api *config.API, library *co
 		return err
 	}
 
-	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, buildStagingSubdirName(apiIndex, api.Path))
+	stagingDir := filepath.Join(params.repoRoot, "owl-bot-staging", params.library.Name, buildStagingSubdirName(params.apiIndex, params.api.Path))
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}
 
-	nodejsAPI := resolveNodejsAPI(library, api)
+	nodejsAPI := resolveNodejsAPI(params.library, params.api)
 
-	googleapisDir, err = filepath.Abs(googleapisDir)
+	absGoogleapisDir, err := filepath.Abs(params.googleapisDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve googleapis directory path: %w", err)
 	}
 
-	apiDir := filepath.Join(googleapisDir, api.Path)
+	apiDir := filepath.Join(absGoogleapisDir, params.api.Path)
 	protos, err := filepath.Glob(apiDir + "/*.proto")
 	if err != nil {
 		return fmt.Errorf("failed to find protos: %w", err)
 	}
 	if len(protos) == 0 {
-		return fmt.Errorf("no protos found in api %q", api.Path)
+		return fmt.Errorf("no protos found in api %q", params.api.Path)
 	}
 	for index := range protos {
-		rel, err := filepath.Rel(googleapisDir, protos[index])
+		rel, err := filepath.Rel(absGoogleapisDir, protos[index])
 		if err != nil {
 			return fmt.Errorf("failed to make path %s relative: %w", protos[index], err)
 		}
@@ -150,7 +164,7 @@ func generateAPI(ctx context.Context, apiIndex int, api *config.API, library *co
 	// Add additional protos from configuration.
 	protos = append(protos, nodejsAPI.AdditionalProtos...)
 
-	args, err := buildGeneratorArgs(generatorPath, api, library, googleapisDir, stagingDir, nodejsAPI)
+	args, err := buildGeneratorArgs(generatorPath, params.api, params.library, absGoogleapisDir, stagingDir, nodejsAPI)
 	if err != nil {
 		return err
 	}
@@ -159,7 +173,7 @@ func generateAPI(ctx context.Context, apiIndex int, api *config.API, library *co
 		return err
 	}
 	cmdArgs := append(args[1:], protos...)
-	return command.RunInDirWithEnv(ctx, googleapisDir, toolsEnv, args[0], cmdArgs...)
+	return command.RunInDirWithEnv(ctx, absGoogleapisDir, toolsEnv, args[0], cmdArgs...)
 }
 
 // resolveNodejsAPI returns the Node.js-specific configuration for the given API,

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -468,14 +468,13 @@ func TestGenerateAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = generateAPI(
-		t.Context(),
-		0,
-		&config.API{Path: "google/cloud/secretmanager/v1"},
-		&config.Library{Name: "google-cloud-secretmanager", Output: outDir},
-		absGoogleapisDir,
-		repoRoot,
-	)
+	err = generateAPI(t.Context(), generateAPIParams{
+		apiIndex:      0,
+		api:           &config.API{Path: "google/cloud/secretmanager/v1"},
+		library:       &config.Library{Name: "google-cloud-secretmanager", Output: outDir},
+		googleapisDir: absGoogleapisDir,
+		repoRoot:      repoRoot,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,7 +512,13 @@ func TestGenerateAPI_MultipleVersions(t *testing.T) {
 
 	for i, api := range library.APIs {
 		t.Run(api.Path, func(t *testing.T) {
-			if err := generateAPI(t.Context(), i, api, library, absGoogleapisDir, repoRoot); err != nil {
+			if err := generateAPI(t.Context(), generateAPIParams{
+				apiIndex:      i,
+				api:           api,
+				library:       library,
+				googleapisDir: absGoogleapisDir,
+				repoRoot:      repoRoot,
+			}); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -1055,7 +1060,13 @@ func TestGenerateAPI_NoProtos(t *testing.T) {
 		Name:   "google-cloud-emptyapi",
 		Output: filepath.Join(repoRoot, "packages", "google-cloud-emptyapi"),
 	}
-	if err := generateAPI(t.Context(), 0, &config.API{Path: apiPath}, library, googleapisDir, repoRoot); err == nil {
+	if err := generateAPI(t.Context(), generateAPIParams{
+		apiIndex:      0,
+		api:           &config.API{Path: apiPath},
+		library:       library,
+		googleapisDir: googleapisDir,
+		repoRoot:      repoRoot,
+	}); err == nil {
 		t.Fatal("expected error for API directory with no proto files")
 	}
 }

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -150,26 +150,23 @@ func TestBuildStagingSubdirName(t *testing.T) {
 		name    string
 		index   int
 		apiPath string
-		version string
 		want    string
 	}{
 		{
 			name:    "single api path",
 			index:   0,
 			apiPath: "google/bigtable/v2",
-			version: "v2",
-			want:    "0_google_bigtable_v2_v2",
+			want:    "0_google_bigtable_v2",
 		},
 		{
 			name:    "second api path same version",
 			index:   1,
 			apiPath: "google/bigtable/admin/v2",
-			version: "v2",
-			want:    "1_google_bigtable_admin_v2_v2",
+			want:    "1_google_bigtable_admin_v2",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := buildStagingSubdirName(test.index, test.apiPath, test.version)
+			got := buildStagingSubdirName(test.index, test.apiPath)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -483,7 +480,7 @@ func TestGenerateAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", "google-cloud-secretmanager", buildStagingSubdirName(0, "google/cloud/secretmanager/v1", "v1"))
+	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", "google-cloud-secretmanager", buildStagingSubdirName(0, "google/cloud/secretmanager/v1"))
 	if _, err := os.Stat(stagingDir); err != nil {
 		t.Errorf("expected staging directory to exist: %v", err)
 	}
@@ -523,7 +520,7 @@ func TestGenerateAPI_MultipleVersions(t *testing.T) {
 	}
 	for i, api := range library.APIs {
 		version := filepath.Base(api.Path)
-		stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, buildStagingSubdirName(i, api.Path, version))
+		stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, buildStagingSubdirName(i, api.Path))
 		if _, err := os.Stat(stagingDir); err != nil {
 			t.Errorf("expected staging directory for %s to exist: %v", version, err)
 		}

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -145,6 +145,38 @@ func TestDerivePackageName(t *testing.T) {
 	}
 }
 
+func TestBuildStagingSubdirName(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		index   int
+		apiPath string
+		version string
+		want    string
+	}{
+		{
+			name:    "single api path",
+			index:   0,
+			apiPath: "google/bigtable/v2",
+			version: "v2",
+			want:    "0_google_bigtable_v2_v2",
+		},
+		{
+			name:    "second api path same version",
+			index:   1,
+			apiPath: "google/bigtable/admin/v2",
+			version: "v2",
+			want:    "1_google_bigtable_admin_v2_v2",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildStagingSubdirName(test.index, test.apiPath, test.version)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestDefaultOutput(t *testing.T) {
 	for _, test := range []struct {
 		name          string
@@ -441,6 +473,7 @@ func TestGenerateAPI(t *testing.T) {
 
 	err = generateAPI(
 		t.Context(),
+		0,
 		&config.API{Path: "google/cloud/secretmanager/v1"},
 		&config.Library{Name: "google-cloud-secretmanager", Output: outDir},
 		absGoogleapisDir,
@@ -450,7 +483,7 @@ func TestGenerateAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", "google-cloud-secretmanager", "v1")
+	stagingDir := filepath.Join(repoRoot, "owl-bot-staging", "google-cloud-secretmanager", buildStagingSubdirName(0, "google/cloud/secretmanager/v1", "v1"))
 	if _, err := os.Stat(stagingDir); err != nil {
 		t.Errorf("expected staging directory to exist: %v", err)
 	}
@@ -481,16 +514,16 @@ func TestGenerateAPI_MultipleVersions(t *testing.T) {
 	}
 	library.Output = outDir
 
-	for _, api := range library.APIs {
+	for i, api := range library.APIs {
 		t.Run(api.Path, func(t *testing.T) {
-			if err := generateAPI(t.Context(), api, library, absGoogleapisDir, repoRoot); err != nil {
+			if err := generateAPI(t.Context(), i, api, library, absGoogleapisDir, repoRoot); err != nil {
 				t.Fatal(err)
 			}
 		})
 	}
-	for _, api := range library.APIs {
+	for i, api := range library.APIs {
 		version := filepath.Base(api.Path)
-		stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, version)
+		stagingDir := filepath.Join(repoRoot, "owl-bot-staging", library.Name, buildStagingSubdirName(i, api.Path, version))
 		if _, err := os.Stat(stagingDir); err != nil {
 			t.Errorf("expected staging directory for %s to exist: %v", version, err)
 		}
@@ -1025,7 +1058,7 @@ func TestGenerateAPI_NoProtos(t *testing.T) {
 		Name:   "google-cloud-emptyapi",
 		Output: filepath.Join(repoRoot, "packages", "google-cloud-emptyapi"),
 	}
-	if err := generateAPI(t.Context(), &config.API{Path: apiPath}, library, googleapisDir, repoRoot); err == nil {
+	if err := generateAPI(t.Context(), 0, &config.API{Path: apiPath}, library, googleapisDir, repoRoot); err == nil {
 		t.Fatal("expected error for API directory with no proto files")
 	}
 }


### PR DESCRIPTION
Construct unique staging subdirectory paths per API pass (owl-bot-staging/<lib>/<index>_<api_slug>_<version>) when generating Node.js libraries. This prevents sequential gapic-generator runs for multi-API packages from overwriting each other before post-processing.

For https://github.com/googleapis/librarian/issues/6969