### PR TITLE
fix(librarian/swift): default library name

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -668,7 +668,7 @@ func TestAddLibrary_Swift(t *testing.T) {
 			swiftDefault: &config.SwiftDefault{DefaultVersion: "1.0.0"},
 			wantFinalLibraries: []*config.Library{
 				{
-					Name:          "GoogleCloudSecretmanagerV1",
+					Name:          "google-cloud-secretmanager-v1",
 					CopyrightYear: copyrightYear,
 					Version:       "1.0.0",
 				},
@@ -679,7 +679,7 @@ func TestAddLibrary_Swift(t *testing.T) {
 			swiftDefault: &config.SwiftDefault{DefaultVersion: "0.1.2-preview"},
 			wantFinalLibraries: []*config.Library{
 				{
-					Name:          "GoogleCloudSecretmanagerV1",
+					Name:          "google-cloud-secretmanager-v1",
 					CopyrightYear: copyrightYear,
 					Version:       "0.1.2-preview",
 				},

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -27,7 +27,6 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	sidekickswift "github.com/googleapis/librarian/internal/sidekick/swift"
 	"github.com/googleapis/librarian/internal/sources"
-	"github.com/iancoleman/strcase"
 )
 
 // Generate generates a Swift client library.
@@ -77,24 +76,12 @@ func Format(ctx context.Context, library *config.Library) error {
 }
 
 // DefaultLibraryName derives a library name from an API path.
-// For example: google/cloud/secretmanager/v1 -> GoogleCloudSecretmanagerV1.
+//
+// Note that what librarian calls "a library" is really a "package" in Swift.
+//
+// For example: google/cloud/secretmanager/v1 -> google-cloud-secretmanager-v1.
 func DefaultLibraryName(api string) string {
-	if clean, ok := strings.CutPrefix(api, "google/cloud/"); ok {
-		return "GoogleCloud" + camelLibraryName(clean)
-	}
-	if clean, ok := strings.CutPrefix(api, "google/"); ok {
-		return "Google" + camelLibraryName(clean)
-	}
-	return "Google" + camelLibraryName(api)
-}
-
-func camelLibraryName(api string) string {
-	parts := strings.Split(api, "/")
-	var name strings.Builder
-	for _, p := range parts {
-		name.WriteString(strcase.ToCamel(p))
-	}
-	return name.String()
+	return strings.ReplaceAll(api, "/", "-")
 }
 
 func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sources.Sources) (*parser.ModelConfig, error) {

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -55,25 +55,6 @@ func defaultSwiftConfig(t *testing.T) *config.SwiftPackage {
 	}
 }
 
-func TestDefaultLibraryName(t *testing.T) {
-	for _, test := range []struct {
-		api  string
-		want string
-	}{
-		{"google/cloud/secretmanager/v1", "GoogleCloudSecretmanagerV1"},
-		{"google/maps/addressvalidation/v1", "GoogleMapsAddressvalidationV1"},
-		{"google/api/v1", "GoogleApiV1"},
-		{"grafeas/v1", "GoogleGrafeasV1"},
-	} {
-		t.Run(test.api, func(t *testing.T) {
-			got := DefaultLibraryName(test.api)
-			if got != test.want {
-				t.Errorf("DefaultLibraryName(%q) = %q, want %q", test.api, got, test.want)
-			}
-		})
-	}
-}
-
 func TestGenerate(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -55,6 +55,25 @@ func defaultSwiftConfig(t *testing.T) *config.SwiftPackage {
 	}
 }
 
+func TestDefaultLibraryName(t *testing.T) {
+	for _, test := range []struct {
+		api  string
+		want string
+	}{
+		{"google/cloud/secretmanager/v1", "google-cloud-secretmanager-v1"},
+		{"google/maps/addressvalidation/v1", "google-maps-addressvalidation-v1"},
+		{"google/api/v1", "google-api-v1"},
+		{"grafeas/v1", "grafeas-v1"},
+	} {
+		t.Run(test.api, func(t *testing.T) {
+			got := DefaultLibraryName(test.api)
+			if got != test.want {
+				t.Errorf("DefaultLibraryName(%q) = %q, want %q", test.api, got, test.want)
+			}
+		})
+	}
+}
+
 func TestGenerate(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 


### PR DESCRIPTION
Simplify the default library name for Swift libraries. Just convert the `/` separators in the API path to `-` separators. So `google/cloud/workflows/v1` becomes `google-cloud-workflows-v1`.

Note that librarian calls this "a library name" but Swift does not use this for the library name. The **package** is named with dashes. For GAPICs, the package happens to contain one library using PascalCase for its name (e.g. `GoogleCloudWorkflowsV1`.

I think I got confused between packages and libraries when I implemented `librian add` for Swift.

Towards #6229 