### PR TITLE
cleanup(sidekick/swift): library vs. package names

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -76,6 +76,11 @@ func NewTestAPI(messages []*Message, enums []*Enum, services []*Service) *API {
 	return model
 }
 
+func (a *API) WithPackageName(name string) *API {
+	a.PackageName = name
+	return a
+}
+
 // parentName returns the parent's name from a fully qualified identifier.
 func parentName(id string) string {
 	if lastIndex := strings.LastIndex(id, "."); lastIndex != -1 {

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestAnnotateEnumValue_WithDocs(t *testing.T) {
-	enum := &api.Enum{Name: "Color"}
+	enum := &api.Enum{Name: "Color", Package: "test"}
 	ev := &api.EnumValue{Name: "COLOR_RED", Number: 1, Documentation: "Red color", Parent: enum}
 	enum.Values = []*api.EnumValue{ev}
 	enum.UniqueNumberValues = enum.Values
@@ -50,7 +50,7 @@ func TestAnnotateEnumValue_WithDocs(t *testing.T) {
 }
 
 func TestAnnotateEnumValue_Multiple(t *testing.T) {
-	enum := &api.Enum{Name: "Color"}
+	enum := &api.Enum{Name: "Color", Package: "test"}
 	enum.Values = []*api.EnumValue{
 		{Name: "COLOR_RED", Number: 1, Parent: enum},
 		{Name: "COLOR_GREEN", Number: 2, Parent: enum},
@@ -86,7 +86,7 @@ func TestAnnotateEnumValue_Multiple(t *testing.T) {
 }
 
 func TestAnnotateEnumValue_Aliases(t *testing.T) {
-	enum := &api.Enum{Name: "Color"}
+	enum := &api.Enum{Name: "Color", Package: "test"}
 	// This may seem weird, but they do happen in Google Cloud APIs, see:
 	//     https://github.com/search?q=repo%3Agoogleapis%2Fgoogleapis+%22option+allow_alias+%3D+true%3B%22&type=code
 	enum.Values = []*api.EnumValue{

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -43,7 +43,7 @@ type fieldAnnotations struct {
 	// ValueType is the value's Swift type for maps and empty otherwise.
 	ValueType string
 
-	// PackageName is the name of the package defining the type of this field.
+	// PackageName is the name of the source specification (Protobuf) package defining the type of this field.
 	PackageName string
 
 	// DocLines is the field documentation broken by lines with any filtering / corrections for Swift.

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -183,35 +183,16 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 		{"escaped default", "Default", "`default`"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			inputType := &api.Message{
-				Name: "Request",
-				ID:   ".test.Request",
-				Fields: []*api.Field{
-					{Name: "key", ID: ".test.Request.key", Typez: api.TypezString},
-				},
-			}
-			outputType := &api.Message{
-				Name: "Response",
-				ID:   ".test.Response",
-				Fields: []*api.Field{
-					{Name: "value", ID: ".test.Request.value", Typez: api.TypezString},
-				},
-			}
-			method := &api.Method{
-				Name:          test.methodName,
-				Documentation: "Test documentation.",
-				PathInfo: &api.PathInfo{
-					Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
-				},
-				InputTypeID:  inputType.ID,
-				InputType:    inputType,
-				OutputTypeID: outputType.ID,
-				OutputType:   outputType,
-			}
-			service := &api.Service{
-				Name:    "TestService",
-				Methods: []*api.Method{method},
-			}
+			inputType := api.NewTestMessage("Request").
+				WithFields(api.NewTestField("key").WithType(api.TypezString))
+			outputType := api.NewTestMessage("Response").
+				WithFields(api.NewTestField("value").WithType(api.TypezString))
+			method := api.NewTestMethod(test.methodName).
+				WithInput(inputType).
+				WithOutput(outputType).
+				WithVerb("GET").WithPathTemplate(&api.PathTemplate{})
+			method.Documentation = "Test documentation."
+			service := api.NewTestService("TestService").WithMethods(method)
 			model := api.NewTestAPI([]*api.Message{inputType, outputType}, nil, []*api.Service{service})
 			if err := api.CrossReference(model); err != nil {
 				t.Fatal(err)
@@ -227,7 +208,7 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 				DocLines:       []string{"Test documentation."},
 				PathExpression: "/",
 				HTTPMethod:     "GET",
-				ReturnType:     "Response",
+				ReturnType:     "GoogleTest.Response",
 			}
 
 			if diff := cmp.Diff(want, method.Codec); diff != "" {

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -26,6 +26,7 @@ import (
 type modelAnnotations struct {
 	CopyrightYear    string
 	BoilerPlate      []string
+	LibraryName      string
 	PackageName      string
 	PackageVersion   string
 	ReleaseLevel     string
@@ -79,6 +80,7 @@ func (c *codec) annotateModel() error {
 	annotations := &modelAnnotations{
 		CopyrightYear:  c.GenerationYear,
 		BoilerPlate:    license.HeaderBulk(),
+		LibraryName:    c.LibraryName,
 		PackageName:    c.PackageName,
 		PackageVersion: c.PackageVersion,
 		ReleaseLevel:   c.ReleaseLevel,
@@ -124,7 +126,7 @@ func (c *codec) annotateModel() error {
 		// The maximum (15) was chosen more or less arbitrarily circa 2026-05. At
 		// the time, only a handful of packages exceeded this number of services.
 		if len(c.Model.Services) > 15 {
-			slog.Warn("package has more than 15 services, consider enabling per-service features", "package", c.PackageName, "count", len(c.Model.Services))
+			slog.Warn("package has more than 15 services, consider enabling per-service features", "package", c.LibraryName, "count", len(c.Model.Services))
 		}
 		return nil
 	}

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -32,7 +32,8 @@ func TestModelAnnotations(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := &modelAnnotations{
-		PackageName:    "GoogleCloudWorkflowsV1",
+		LibraryName:    "GoogleCloudWorkflowsV1",
+		PackageName:    "google-cloud-workflows-v1",
 		PackageVersion: "0.0.0",
 		ReleaseLevel:   "preview",
 		CopyrightYear:  "2038",

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -29,7 +29,7 @@ type serviceAnnotations struct {
 	HostnameShort    string
 	DocLines         []string
 	RestMethods      []*api.Method
-	PackageName      string
+	LibraryName      string
 	QuickstartMethod *api.Method
 	Model            *modelAnnotations
 	DependsOn        map[string]*Dependency
@@ -109,7 +109,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (
 		HostnameShort:    strings.TrimSuffix(service.DefaultHost, ".googleapis.com"),
 		DocLines:         docLines,
 		RestMethods:      restMethods,
-		PackageName:      c.PackageName,
+		LibraryName:      c.LibraryName,
 		QuickstartMethod: quickstartMethod,
 		Model:            model,
 		DependsOn:        map[string]*Dependency{},

--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -123,7 +123,7 @@ func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (
 	// If the dependency is marked as "required_by_services", then we force it
 	// as an import for the generated service files.
 	for _, p := range c.Dependencies {
-		if p.ApiPackage == c.Model.PackageName || p.Name == c.PackageName {
+		if p.ApiPackage == c.Model.PackageName || p.Name == c.LibraryName {
 			continue
 		}
 		if p.RequiredByServices {

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -36,10 +36,11 @@ func TestAnnotateService(t *testing.T) {
 			serviceName: "IAM",
 			doc:         "IAM service documentation.",
 			wantAnnotations: &serviceAnnotations{
-				Name:       "IAM",
-				ClientName: "IAMClient",
-				StubPrefix: "IAM",
-				DocLines:   []string{"IAM service documentation."},
+				Name:        "IAM",
+				LibraryName: "GoogleTest",
+				ClientName:  "IAMClient",
+				StubPrefix:  "IAM",
+				DocLines:    []string{"IAM service documentation."},
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -48,10 +49,11 @@ func TestAnnotateService(t *testing.T) {
 			serviceName: "Protocol",
 			doc:         "Docs are not relevant.",
 			wantAnnotations: &serviceAnnotations{
-				Name:       "Protocol_",
-				ClientName: "ProtocolClient",
-				StubPrefix: "Protocol",
-				DocLines:   []string{"Docs are not relevant."},
+				Name:        "Protocol_",
+				LibraryName: "GoogleTest",
+				ClientName:  "ProtocolClient",
+				StubPrefix:  "Protocol",
+				DocLines:    []string{"Docs are not relevant."},
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -60,10 +62,11 @@ func TestAnnotateService(t *testing.T) {
 			serviceName: "SecretManagerService",
 			doc:         "Secret Manager Service documentation.\nLine 2.",
 			wantAnnotations: &serviceAnnotations{
-				Name:       "SecretManagerService",
-				ClientName: "SecretManagerServiceClient",
-				StubPrefix: "SecretManagerService",
-				DocLines:   []string{"Secret Manager Service documentation.", "Line 2."},
+				Name:        "SecretManagerService",
+				LibraryName: "GoogleTest",
+				ClientName:  "SecretManagerServiceClient",
+				StubPrefix:  "SecretManagerService",
+				DocLines:    []string{"Secret Manager Service documentation.", "Line 2."},
 			},
 			wantImports: []string{"GoogleCloudWkt"},
 		},
@@ -74,13 +77,14 @@ func TestAnnotateService(t *testing.T) {
 				Documentation: test.doc,
 			}
 			model := api.NewTestAPI(nil, nil, []*api.Service{s})
+			model.PackageName = "test"
 			codec := newTestCodec(t, model, nil)
 
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(test.wantAnnotations, s.Codec, cmpopts.IgnoreFields(serviceAnnotations{}, "PackageName", "QuickstartMethod", "Model", "DependsOn")); diff != "" {
+			if diff := cmp.Diff(test.wantAnnotations, s.Codec, cmpopts.IgnoreFields(serviceAnnotations{}, "QuickstartMethod", "Model", "DependsOn")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -75,6 +75,7 @@ func TestAnnotateService(t *testing.T) {
 			s := &api.Service{
 				Name:          test.serviceName,
 				Documentation: test.doc,
+				Package:       "test",
 			}
 			model := api.NewTestAPI(nil, nil, []*api.Service{s})
 			model.PackageName = "test"
@@ -202,6 +203,8 @@ func TestAnnotateService_Quickstart(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			service := &api.Service{
 				Name:             "TestService",
+				Package:          "test",
+				ID:               ".test.TestService",
 				QuickstartMethod: test.quickstartMethod,
 			}
 

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -54,13 +54,22 @@ type codec struct {
 	// library.
 	GenerationYear string
 
-	// The name of the swift package (e.g. "GoogleCloudSecretManagerV1")
+	// LibraryName is the name of the Swift library (e.g. "GoogleCloudSecretManagerV1").
+	//
+	// Note that GAPIC packages contain a single product (the library), which
+	// contains a single target and module with the same names as the library.
+	LibraryName string
+
+	// The name of the Swift package (e.g. "google-cloud-secretmanager-v1").
+	//
+	// Note that GAPIC packages contain a single product (the library), which
+	// contains a single target and module with the same names as the library.
 	PackageName string
 
-	// The package version (e.g. "1.2.3")
+	// The package version (e.g. "1.2.3").
 	PackageVersion string
 
-	// The release level (e.g. "preview" or "stable")
+	// The release level (e.g. "preview" or "stable").
 	ReleaseLevel string
 
 	// The location of the monorepo, relative to the current directory.
@@ -136,6 +145,7 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 	result := &codec{
 		Model:              model,
 		GenerationYear:     fmt.Sprintf("%04d", year),
+		LibraryName:        LibraryName(model, swiftCfg),
 		PackageName:        PackageName(model),
 		PackageVersion:     "0.0.0",
 		ReleaseLevel:       "preview",
@@ -166,7 +176,7 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 		case "release-level":
 			result.ReleaseLevel = definition
 		case "package-name-override":
-			result.PackageName = definition
+			result.LibraryName = definition
 		case "root-name":
 			result.RootName = definition
 		case "module":
@@ -207,7 +217,7 @@ func (c *codec) addDependency(dep *Dependency) (*Dependency, error) {
 		return nil, fmt.Errorf("attempting to add nil dependency")
 	}
 	// Skip including self as a dependency
-	if dep.Name == c.PackageName {
+	if dep.Name == c.LibraryName {
 		return nil, nil
 	}
 	if ann, ok := c.Model.Codec.(*modelAnnotations); ok {

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -145,7 +145,7 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 	result := &codec{
 		Model:              model,
 		GenerationYear:     fmt.Sprintf("%04d", year),
-		LibraryName:        LibraryName(model, swiftCfg),
+		LibraryName:        LibraryName(model),
 		PackageName:        PackageName(model),
 		PackageVersion:     "0.0.0",
 		ReleaseLevel:       "preview",

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -61,9 +61,6 @@ type codec struct {
 	LibraryName string
 
 	// The name of the Swift package (e.g. "google-cloud-secretmanager-v1").
-	//
-	// Note that GAPIC packages contain a single product (the library), which
-	// contains a single target and module with the same names as the library.
 	PackageName string
 
 	// The package version (e.g. "1.2.3").
@@ -142,10 +139,14 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 	if err != nil {
 		return nil, err
 	}
+	libraryName, err := LibraryName(model)
+	if err != nil {
+		return nil, err
+	}
 	result := &codec{
 		Model:              model,
 		GenerationYear:     fmt.Sprintf("%04d", year),
-		LibraryName:        LibraryName(model),
+		LibraryName:        libraryName,
 		PackageName:        PackageName(model),
 		PackageVersion:     "0.0.0",
 		ReleaseLevel:       "preview",
@@ -176,7 +177,7 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 		case "release-level":
 			result.ReleaseLevel = definition
 		case "package-name-override":
-			result.LibraryName = definition
+			result.PackageName = definition
 		case "root-name":
 			result.RootName = definition
 		case "module":

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -42,7 +42,7 @@ func TestParseOptions(t *testing.T) {
 			},
 			want: &codec{
 				GenerationYear:     "2038",
-				PackageName:        "GoogleCloudBigtable",
+				LibraryName:        "GoogleCloudBigtable",
 				PackageVersion:     "0.0.0",
 				ReleaseLevel:       "preview",
 				MonorepoRoot:       ".",
@@ -64,7 +64,7 @@ func TestParseOptions(t *testing.T) {
 			},
 			want: &codec{
 				GenerationYear:     "2038",
-				PackageName:        "GoogleCloudComputeV1",
+				LibraryName:        "GoogleCloudComputeV1",
 				PackageVersion:     "0.0.0",
 				ReleaseLevel:       "preview",
 				MonorepoRoot:       ".",

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestParseOptions(t *testing.T) {
-	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{}).
+		WithPackageName("test")
 	for _, test := range []struct {
 		name string
 		cfg  *parser.ModelConfig
@@ -36,13 +37,14 @@ func TestParseOptions(t *testing.T) {
 			cfg: &parser.ModelConfig{
 				Codec: map[string]string{
 					"copyright-year":        "2038",
-					"package-name-override": "GoogleCloudBigtable",
+					"package-name-override": "google-cloud-bigtable",
 					"root-name":             "test-root",
 				},
 			},
 			want: &codec{
 				GenerationYear:     "2038",
-				LibraryName:        "GoogleCloudBigtable",
+				LibraryName:        "GoogleTest",
+				PackageName:        "google-cloud-bigtable",
 				PackageVersion:     "0.0.0",
 				ReleaseLevel:       "preview",
 				MonorepoRoot:       ".",
@@ -57,14 +59,15 @@ func TestParseOptions(t *testing.T) {
 			cfg: &parser.ModelConfig{
 				Codec: map[string]string{
 					"copyright-year":        "2038",
-					"package-name-override": "GoogleCloudComputeV1",
+					"package-name-override": "google-cloud-compute-v1",
 					"root-name":             "test-root",
 				},
 				SpecificationFormat: config.SpecDiscovery,
 			},
 			want: &codec{
 				GenerationYear:     "2038",
-				LibraryName:        "GoogleCloudComputeV1",
+				LibraryName:        "GoogleTest",
+				PackageName:        "google-cloud-compute-v1",
 				PackageVersion:     "0.0.0",
 				ReleaseLevel:       "preview",
 				MonorepoRoot:       ".",
@@ -98,7 +101,7 @@ func TestNewCodec_WithSwiftCfg(t *testing.T) {
 		},
 	}
 	cfg := &parser.ModelConfig{}
-	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{}).WithPackageName("test")
 	got, err := newCodec(model, cfg, swiftCfg, ".")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/swift/convert_proto_names_test.go
+++ b/internal/sidekick/swift/convert_proto_names_test.go
@@ -126,7 +126,8 @@ func TestMessageAndEnumFileName(t *testing.T) {
 		Parent: parentMsg,
 	}
 
-	model := api.NewTestAPI([]*api.Message{parentMsg, nestedMsg, doubleNestedMsg}, []*api.Enum{topEnum, nestedEnum}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{parentMsg, nestedMsg, doubleNestedMsg}, []*api.Enum{topEnum, nestedEnum}, []*api.Service{}).
+		WithPackageName("test")
 	codec := newTestCodec(t, model, map[string]string{})
 
 	t.Run("message conversion filenames", func(t *testing.T) {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -175,7 +175,7 @@ func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
 		}
 		if m.Package == c.Model.PackageName {
 			// this is the current package
-			return fmt.Sprintf("%s.%s", c.PackageName, name), nil
+			return fmt.Sprintf("%s.%s", c.LibraryName, name), nil
 		}
 		dep, ok := c.ApiPackages[m.Package]
 		if !ok {

--- a/internal/sidekick/swift/format_documentation_test.go
+++ b/internal/sidekick/swift/format_documentation_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func TestFormatDocumentation(t *testing.T) {
-	codec := newTestCodec(t, api.NewTestAPI(nil, nil, nil), nil)
+
+	codec := newTestCodec(t, api.NewTestAPI(nil, nil, nil).WithPackageName("test"), nil)
 
 	for _, test := range []struct {
 		name string

--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -94,7 +94,7 @@ func (c *codec) swiftFilename(basename string) string {
 	if c.Module {
 		return name
 	}
-	return filepath.Join("Sources", c.PackageName, name)
+	return filepath.Join("Sources", c.LibraryName, name)
 }
 
 func (c *codec) generateMessages(outdir string, model *api.API, provider language.TemplateProvider) error {

--- a/internal/sidekick/swift/generate_conversions.go
+++ b/internal/sidekick/swift/generate_conversions.go
@@ -64,7 +64,7 @@ func (c *codec) generateEnumConversions(outdir string, model *api.API, provider 
 		name := c.enumFileName(e)
 		output := filepath.Join("Convert", name+"+Convert.swift")
 		if !c.Module {
-			output = filepath.Join("Sources", c.PackageName, "Convert", name+"+Convert.swift")
+			output = filepath.Join("Sources", c.LibraryName, "Convert", name+"+Convert.swift")
 		}
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_enum_file.swift.mustache",
@@ -88,7 +88,7 @@ func (c *codec) generateMessageConversions(outdir string, model *api.API, provid
 		name := c.messageFileName(m)
 		output := filepath.Join("Convert", name+"+Convert.swift")
 		if !c.Module {
-			output = filepath.Join("Sources", c.PackageName, "Convert", name+"+Convert.swift")
+			output = filepath.Join("Sources", c.LibraryName, "Convert", name+"+Convert.swift")
 		}
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_message_file.swift.mustache",

--- a/internal/sidekick/swift/generate_package_swift_test.go
+++ b/internal/sidekick/swift/generate_package_swift_test.go
@@ -66,6 +66,13 @@ func TestGeneratePackageSwift_WithDependencies(t *testing.T) {
 	}
 	contentStr := string(content)
 
+	gotPackage := extractBlock(t, contentStr, "let package = Package(", "\n  platforms:")
+	wantPackage := `let package = Package(
+  name: "GoogleCloudWorkflowsV1",
+  platforms:`
+	if diff := cmp.Diff(wantPackage, gotPackage); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 	gotPackageDeps := extractBlock(t, contentStr, "  dependencies: [", "\n  ],")
 	wantPackageDeps := `  dependencies: [
     .package(path: "../../packages/gax"),

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -17,10 +17,22 @@ package swift
 import (
 	"strings"
 
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/iancoleman/strcase"
 )
 
-// PackageName returns the Swift package name for the API.
-func PackageName(api *api.API) string {
-	return strings.ReplaceAll(api.PackageName, ".", "-")
+// LibraryName returns the Swift library (and module) name for the API.
+func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) string {
+	// TODO(https://github.com/googleapis/librarian/issues/6229) - use
+	// a better default.
+	parts := strings.Split(api.PackageName, ".")
+	for i, p := range parts {
+		parts[i] = strcase.ToCamel(p)
+	}
+	result := strings.Join(parts, "")
+	if strings.HasPrefix(result, "Google") {
+		return result
+	}
+	return "Google" + result
 }

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -15,6 +15,7 @@
 package swift
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/sidekick/api"
@@ -22,7 +23,10 @@ import (
 )
 
 // LibraryName returns the Swift library (and module) name for the API.
-func LibraryName(api *api.API) string {
+func LibraryName(api *api.API) (string, error) {
+	if api.PackageName == "" {
+		return "", fmt.Errorf("API package name must not be empty")
+	}
 	// TODO(https://github.com/googleapis/librarian/issues/6229) - use
 	// a better default.
 	parts := strings.Split(api.PackageName, ".")
@@ -31,7 +35,7 @@ func LibraryName(api *api.API) string {
 	}
 	result := strings.Join(parts, "")
 	if strings.HasPrefix(result, "Google") {
-		return result
+		return result, nil
 	}
-	return "Google" + result
+	return "Google" + result, nil
 }

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -17,13 +17,12 @@ package swift
 import (
 	"strings"
 
-	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/iancoleman/strcase"
 )
 
 // LibraryName returns the Swift library (and module) name for the API.
-func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) string {
+func LibraryName(api *api.API) string {
 	// TODO(https://github.com/googleapis/librarian/issues/6229) - use
 	// a better default.
 	parts := strings.Split(api.PackageName, ".")

--- a/internal/sidekick/swift/library_name_test.go
+++ b/internal/sidekick/swift/library_name_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
-func TestPackageName(t *testing.T) {
+func TestLibraryName(t *testing.T) {
 	for _, test := range []struct {
 		name  string
 		input string
@@ -29,33 +29,33 @@ func TestPackageName(t *testing.T) {
 		{
 			name:  "cloud storage v2",
 			input: "google.cloud.storage.v2",
-			want:  "google-cloud-storage-v2",
+			want:  "GoogleCloudStorageV2",
 		},
 		{
 			name:  "iam v1",
 			input: "google.iam.v1",
-			want:  "google-iam-v1",
+			want:  "GoogleIamV1",
 		},
 		{
 			name:  "cloud location",
 			input: "google.cloud.location",
-			want:  "google-cloud-location",
+			want:  "GoogleCloudLocation",
 		},
 		{
 			name:  "api",
 			input: "google.api",
-			want:  "google-api",
+			want:  "GoogleApi",
 		},
 		{
 			name:  "grafeas v1",
 			input: "grafeas.v1",
-			want:  "grafeas-v1",
+			want:  "GoogleGrafeasV1",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model := api.NewTestAPI(nil, nil, nil)
 			model.PackageName = test.input
-			got := PackageName(model)
+			got := LibraryName(model, nil)
 			if got != test.want {
 				t.Errorf("mismatch got = %q, want %q", got, test.want)
 			}

--- a/internal/sidekick/swift/library_name_test.go
+++ b/internal/sidekick/swift/library_name_test.go
@@ -55,10 +55,21 @@ func TestLibraryName(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			model := api.NewTestAPI(nil, nil, nil)
 			model.PackageName = test.input
-			got := LibraryName(model)
+			got, err := LibraryName(model)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if got != test.want {
 				t.Errorf("mismatch got = %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestLibraryNameError(t *testing.T) {
+	model := api.NewTestAPI(nil, nil, nil)
+	got, err := LibraryName(model)
+	if err == nil {
+		t.Errorf("Expected an error, got: %s", got)
 	}
 }

--- a/internal/sidekick/swift/library_name_test.go
+++ b/internal/sidekick/swift/library_name_test.go
@@ -55,7 +55,7 @@ func TestLibraryName(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			model := api.NewTestAPI(nil, nil, nil)
 			model.PackageName = test.input
-			got := LibraryName(model, nil)
+			got := LibraryName(model)
 			if got != test.want {
 				t.Errorf("mismatch got = %q, want %q", got, test.want)
 			}

--- a/internal/sidekick/swift/library_name_test.go
+++ b/internal/sidekick/swift/library_name_test.go
@@ -51,6 +51,11 @@ func TestLibraryName(t *testing.T) {
 			input: "grafeas.v1",
 			want:  "GoogleGrafeasV1",
 		},
+		{
+			name:  "corner case",
+			input: "google",
+			want:  "Google",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model := api.NewTestAPI(nil, nil, nil)

--- a/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/client_snippet.swift.mustache
@@ -26,13 +26,13 @@ limitations under the License.
 {{/Codec.IsGated}}
 // snippet.show
 import Foundation
-import {{Codec.PackageName}}
+import {{Codec.LibraryName}}
 {{#Codec.SnippetImports}}
 import {{.}}
 {{/Codec.SnippetImports}}
 
 func sample({{#Codec.QuickstartMethod.SampleInfo}}{{#Codec.Parameters}}{{.}}: String, {{/Codec.Parameters}}{{/Codec.QuickstartMethod.SampleInfo}}) async throws {
-  let client = try {{Codec.PackageName}}.{{Codec.ClientName}}()
+  let client = try {{Codec.LibraryName}}.{{Codec.ClientName}}()
   {{#Codec.QuickstartMethod}}
   {{> /templates/snippet/generic}}
   {{/Codec.QuickstartMethod}}

--- a/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
+++ b/internal/sidekick/swift/templates/common/method_snippet.swift.mustache
@@ -26,7 +26,7 @@ limitations under the License.
 {{/Service.Codec.IsGated}}
 // snippet.show
 import Foundation
-import {{Service.Codec.PackageName}}
+import {{Service.Codec.LibraryName}}
 {{#Service.Codec.SnippetImports}}
 import {{.}}
 {{/Service.Codec.SnippetImports}}
@@ -40,7 +40,7 @@ func sample(client: {{Service.Codec.ClientName}}{{#SampleInfo}}{{#Codec.Paramete
 struct SnippetRunner {
     static func main() async throws {
         do {
-            let client = try {{Service.Codec.PackageName}}.{{Service.Codec.ClientName}}()
+            let client = try {{Service.Codec.LibraryName}}.{{Service.Codec.ClientName}}()
             try await sample(client: client{{#SampleInfo}}{{#Codec.Parameters}}, {{.}}: "[placeholder]"{{/Codec.Parameters}}{{/SampleInfo}})
         } catch {
             print("Error: \(error)")

--- a/internal/sidekick/swift/templates/package/Package.swift.mustache
+++ b/internal/sidekick/swift/templates/package/Package.swift.mustache
@@ -24,11 +24,11 @@ limitations under the License.
 import PackageDescription
 
 let package = Package(
-  name: "{{Codec.PackageName}}",
+  name: "{{Codec.LibraryName}}",
   {{! Linux and Windows are implicit in Swift }}
   platforms: [.macOS(.v15)],
   products: [
-    .library(name: "{{Codec.PackageName}}", targets: ["{{Codec.PackageName}}"])
+    .library(name: "{{Codec.LibraryName}}", targets: ["{{Codec.LibraryName}}"])
   ],
   {{#Codec.HasTraits}}
   traits: [
@@ -65,7 +65,7 @@ let package = Package(
   {{/Codec.HasDependencies}}
   targets: [
     .target(
-      name: "{{Codec.PackageName}}",
+      name: "{{Codec.LibraryName}}",
       {{#Codec.HasDependencies}}
       dependencies: [
         {{#Codec.Dependencies}}


### PR DESCRIPTION
Use different annotations for the package name (e.g. `google-cloud-workflows-v1`) vs. the library name (e.g. `GoogleCloudWorkflowsV1`). In a future PR we will change the default library name and introduce options to override it.

Towards #6229 