### PR TITLE
feat(internal/librarian/ruby): call clean function during generation

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -38,6 +38,9 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if len(library.APIs) == 0 {
 		return errNoAPIs
 	}
+	if err := Clean(library); err != nil {
+		return fmt.Errorf("failed to clean output directory: %w", err)
+	}
 	outDir, err := filepath.Abs(library.Output)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path of output directory: %w", err)

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -324,6 +324,16 @@ func TestGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	outDir := t.TempDir()
+	// AUTHENTICATION.md is a generated file.
+	oldFile := filepath.Join(outDir, "AUTHENTICATION.md")
+	if err := os.WriteFile(oldFile, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// CHANGELOG.md should not be regenerated.
+	changelogFile := filepath.Join(outDir, "CHANGELOG.md")
+	if err := os.WriteFile(changelogFile, []byte("changelog"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	library := &config.Library{
 		Name:   "google-cloud-secret_manager-v1",
 		Output: outDir,
@@ -340,6 +350,12 @@ func TestGenerate(t *testing.T) {
 	wantFile := filepath.Join(outDir, "lib", "google", "cloud", "secret_manager", "v1.rb")
 	if _, err := os.Stat(wantFile); err != nil {
 		t.Errorf("expected generated file %s to exist: %v", wantFile, err)
+	}
+	if _, err := os.Stat(oldFile); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected old generated file %s to be cleaned up", oldFile)
+	}
+	if _, err := os.Stat(changelogFile); err != nil {
+		t.Errorf("expected non-generated file %s to be preserved: %v", changelogFile, err)
 	}
 }
 


### PR DESCRIPTION
Calls `ruby.Clean(library)` at the start of `ruby.Generate()` to clean pre-existing generated files before regenerating a Ruby client library.

### Test Case
In `TestGenerate`, pre-existing files are created in the target output directory to verify cleaning behavior:
- `AUTHENTICATION.md`: A generated root file which is expected to be cleaned up when `Generate()` runs.
- `CHANGELOG.md`: A non-generated root file which should not be regenerated and must be preserved across generation.

For https://github.com/googleapis/librarian/issues/6657