### PR TITLE
feat(internal/librarian/php): parse and populate additional protos in add

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -119,6 +119,12 @@ func resolveDependencies(ctx context.Context, cfg *config.Config, name string) (
 			return nil, err
 		}
 		return java.ResolveMixinDependencies(cfg, lib, sources)
+	case config.LanguagePhp:
+		lib, sources, err := setupResolve(ctx, cfg, name)
+		if err != nil {
+			return nil, err
+		}
+		return php.ResolveMixinDependencies(cfg, lib, sources)
 	case config.LanguageRust:
 		lib, sources, err := setupResolve(ctx, cfg, name)
 		if err != nil {

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -656,6 +656,57 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 	}
 }
 
+func TestAddLibraryCommand_Php(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	cfg := sample.Config()
+	cfg.Language = config.LanguagePhp
+	commonResources := true
+	cfg.Default.PHP = &config.PHPDefault{
+		CommonResources: &commonResources,
+	}
+	cfg.Default.Output = "output"
+	cfg.Libraries = []*config.Library{}
+	cfg.Sources.Googleapis.Dir = googleapisDir
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+		t.Fatal(err)
+	}
+	// developerconnect has Locations mixin in its service.yaml
+	err = runAdd(t.Context(), cfg, "google/cloud/developerconnect/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLibraries := []*config.Library{
+		{
+			Name:          "Developerconnect",
+			CopyrightYear: strconv.Itoa(time.Now().Year()),
+			APIs: []*config.API{
+				{
+					Path: "google/cloud/developerconnect/v1",
+					PHP: &config.PHPAPI{
+						StagingSubdir: "v1",
+						AdditionalProtos: []string{
+							"google/cloud/location/locations.proto",
+						},
+					},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestAddLibrary_Swift(t *testing.T) {
 	copyrightYear := strconv.Itoa(time.Now().Year())
 	for _, test := range []struct {

--- a/internal/librarian/java/resolve.go
+++ b/internal/librarian/java/resolve.go
@@ -42,7 +42,6 @@ func resolveAPIMixinDependencies(lib *config.Library, apiCfg *config.API, srcs *
 	if apiCfg.Java == nil {
 		apiCfg.Java = &config.JavaAPI{}
 	}
-
 	srcCfg := sources.NewSourceConfig(srcs, lib.Roots)
 	primaryRoot := srcCfg.Root(srcCfg.ActiveRoots[0])
 	mixins, err := serviceconfig.ExtractMixinProtos(primaryRoot, apiCfg.Path, config.LanguageJava)

--- a/internal/librarian/php/resolve.go
+++ b/internal/librarian/php/resolve.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package java
+package php
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -22,7 +23,7 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
-// ResolveMixinDependencies automatically resolves mixin dependencies for a Java library.
+// ResolveMixinDependencies automatically resolves mixin dependencies for a PHP library.
 func ResolveMixinDependencies(cfg *config.Config, lib *config.Library, srcs *sources.Sources) (*config.Config, error) {
 	if len(lib.APIs) == 0 {
 		return cfg, nil
@@ -37,42 +38,23 @@ func ResolveMixinDependencies(cfg *config.Config, lib *config.Library, srcs *sou
 
 // resolveAPIMixinDependencies automatically resolves mixin dependencies for a single API.
 // It parses the API's service config to identify and add required mixin dependencies
-// (e.g., locations, IAM policy) to the API's Java configuration.
+// (e.g., locations, IAM policy) to the API's PHP configuration.
 func resolveAPIMixinDependencies(lib *config.Library, apiCfg *config.API, srcs *sources.Sources) error {
-	if apiCfg.Java == nil {
-		apiCfg.Java = &config.JavaAPI{}
+	if apiCfg.PHP == nil {
+		apiCfg.PHP = &config.PHPAPI{}
 	}
 
 	srcCfg := sources.NewSourceConfig(srcs, lib.Roots)
 	primaryRoot := srcCfg.Root(srcCfg.ActiveRoots[0])
-	mixins, err := serviceconfig.ExtractMixinProtos(primaryRoot, apiCfg.Path, config.LanguageJava)
+	mixins, err := serviceconfig.ExtractMixinProtos(primaryRoot, apiCfg.Path, config.LanguagePhp)
 	if err != nil {
 		return err
 	}
 	for _, mixinProto := range mixins {
-		if !hasAdditionalProto(apiCfg.Java.AdditionalProtos, mixinProto) {
-			apiCfg.Java.AdditionalProtos = append(apiCfg.Java.AdditionalProtos, &config.AdditionalProto{
-				Path:                 mixinProto,
-				GenerateProtoClasses: false,
-				CopyToOutput:         false,
-			})
+		if !slices.Contains(apiCfg.PHP.AdditionalProtos, mixinProto) {
+			apiCfg.PHP.AdditionalProtos = append(apiCfg.PHP.AdditionalProtos, mixinProto)
 		}
 	}
-	sortAdditionalProtos(apiCfg.Java.AdditionalProtos)
+	sort.Strings(apiCfg.PHP.AdditionalProtos)
 	return nil
-}
-
-func hasAdditionalProto(protos []*config.AdditionalProto, path string) bool {
-	for _, p := range protos {
-		if p.Path == path {
-			return true
-		}
-	}
-	return false
-}
-
-func sortAdditionalProtos(protos []*config.AdditionalProto) {
-	sort.Slice(protos, func(i, j int) bool {
-		return protos[i].Path < protos[j].Path
-	})
 }

--- a/internal/librarian/php/resolve.go
+++ b/internal/librarian/php/resolve.go
@@ -43,7 +43,6 @@ func resolveAPIMixinDependencies(lib *config.Library, apiCfg *config.API, srcs *
 	if apiCfg.PHP == nil {
 		apiCfg.PHP = &config.PHPAPI{}
 	}
-
 	srcCfg := sources.NewSourceConfig(srcs, lib.Roots)
 	primaryRoot := srcCfg.Root(srcCfg.ActiveRoots[0])
 	mixins, err := serviceconfig.ExtractMixinProtos(primaryRoot, apiCfg.Path, config.LanguagePhp)

--- a/internal/librarian/php/resolve.go
+++ b/internal/librarian/php/resolve.go
@@ -16,7 +16,6 @@ package php
 
 import (
 	"slices"
-	"sort"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
@@ -54,6 +53,6 @@ func resolveAPIMixinDependencies(lib *config.Library, apiCfg *config.API, srcs *
 			apiCfg.PHP.AdditionalProtos = append(apiCfg.PHP.AdditionalProtos, mixinProto)
 		}
 	}
-	sort.Strings(apiCfg.PHP.AdditionalProtos)
+	slices.Sort(apiCfg.PHP.AdditionalProtos)
 	return nil
 }

--- a/internal/librarian/php/resolve_test.go
+++ b/internal/librarian/php/resolve_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sources"
+)
+
+func TestResolveDependencies(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcs := &sources.Sources{
+		Googleapis: googleapisDir,
+	}
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want []string
+	}{
+		{
+			name: "no APIs",
+			lib: &config.Library{
+				APIs: []*config.API{},
+			},
+		},
+		{
+			name: "locations mixin (developerconnect)",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/developerconnect/v1"},
+				},
+			},
+			want: []string{
+				"google/cloud/location/locations.proto",
+			},
+		},
+		{
+			name: "locations mixin (secretmanager)",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: []string{
+				"google/cloud/location/locations.proto",
+			},
+		},
+		{
+			name: "no mixins (dataproc)",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/dataproc/v1"},
+				},
+			},
+		},
+		{
+			name: "preserve existing and sort",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/developerconnect/v1",
+						PHP: &config.PHPAPI{
+							AdditionalProtos: []string{
+								"google/example/v1/example.proto",
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"google/cloud/location/locations.proto",
+				"google/example/v1/example.proto",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ResolveMixinDependencies(&config.Config{}, test.lib, srcs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got []string
+			if len(test.lib.APIs) > 0 && test.lib.APIs[0].PHP != nil {
+				got = test.lib.APIs[0].PHP.AdditionalProtos
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/php/resolve_test.go
+++ b/internal/librarian/php/resolve_test.go
@@ -37,12 +37,6 @@ func TestResolveDependencies(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "no APIs",
-			lib: &config.Library{
-				APIs: []*config.API{},
-			},
-		},
-		{
 			name: "locations mixin (developerconnect)",
 			lib: &config.Library{
 				APIs: []*config.API{
@@ -97,10 +91,7 @@ func TestResolveDependencies(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			var got []string
-			if len(test.lib.APIs) > 0 && test.lib.APIs[0].PHP != nil {
-				got = test.lib.APIs[0].PHP.AdditionalProtos
-			}
+			got := test.lib.APIs[0].PHP.AdditionalProtos
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -313,3 +313,33 @@ func SortAPIs(apis []*config.API) {
 func isStable(v string) bool {
 	return v != "" && !strings.Contains(v, "alpha") && !strings.Contains(v, "beta")
 }
+
+// ExtractMixinProtos finds the service config for the given API path and language,
+// and returns the paths of the mixin protos configured in it.
+func ExtractMixinProtos(primaryRoot, apiPath, language string) ([]string, error) {
+	svcConfig, err := Find(primaryRoot, apiPath, language)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find service config for %s: %w", apiPath, err)
+	}
+	if svcConfig.ServiceConfig == "" {
+		return nil, nil
+	}
+	serviceConfig, err := Read(filepath.Join(primaryRoot, svcConfig.ServiceConfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read service config for %s: %w", apiPath, err)
+	}
+	var mixins []string
+	for _, api := range serviceConfig.GetApis() {
+		var mixinProto string
+		switch api.GetName() {
+		case "google.cloud.location.Locations":
+			mixinProto = "google/cloud/location/locations.proto"
+		case "google.iam.v1.IAMPolicy":
+			mixinProto = "google/iam/v1/iam_policy.proto"
+		default:
+			continue
+		}
+		mixins = append(mixins, mixinProto)
+	}
+	return mixins, nil
+}

--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -33,6 +33,11 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+var (
+	// ErrReadServiceConfig is returned when a service config file cannot be read or parsed.
+	ErrReadServiceConfig = errors.New("failed to read service config")
+)
+
 // Type aliases for genproto service config types.
 type (
 	Service            = serviceconfig.Service
@@ -51,12 +56,12 @@ type (
 func Read(serviceConfigPath string) (*Service, error) {
 	y, err := os.ReadFile(serviceConfigPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read service config %q: %w", serviceConfigPath, err)
+		return nil, fmt.Errorf("%w %q: %w", ErrReadServiceConfig, serviceConfigPath, err)
 	}
 
 	yamlData, err := yaml.Unmarshal[any](y)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse YAML in %q: %w", serviceConfigPath, err)
+		return nil, fmt.Errorf("%w (YAML parse) in %q: %w", ErrReadServiceConfig, serviceConfigPath, err)
 	}
 	j, err := json.Marshal(yamlData)
 	if err != nil {
@@ -326,7 +331,7 @@ func ExtractMixinProtos(primaryRoot, apiPath, language string) ([]string, error)
 	}
 	serviceConfig, err := Read(filepath.Join(primaryRoot, svcConfig.ServiceConfig))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read service config for %s: %w", apiPath, err)
+		return nil, fmt.Errorf("failed to extract mixins for %s: %w", apiPath, err)
 	}
 	var mixins []string
 	for _, api := range serviceConfig.GetApis() {

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -519,6 +519,6 @@ func TestExtractMixinProtos_Error(t *testing.T) {
 	}
 	_, err := ExtractMixinProtos(dir, apiPath, config.LanguageGo)
 	if err == nil {
-		t.Fatal("expected error for invalid service config")
+		t.Error("expected error for invalid service config")
 	}
 }

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -456,3 +456,69 @@ func TestSortAPIs(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractMixinProtos(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		apiPath string
+		want    []string
+	}{
+		{
+			name:    "locations mixin (developerconnect)",
+			apiPath: "google/cloud/developerconnect/v1",
+			want: []string{
+				"google/cloud/location/locations.proto",
+			},
+		},
+		{
+			name:    "locations mixin (secretmanager)",
+			apiPath: "google/cloud/secretmanager/v1",
+			want: []string{
+				"google/cloud/location/locations.proto",
+			},
+		},
+		{
+			name:    "no mixins (dataproc)",
+			apiPath: "google/cloud/dataproc/v1",
+			want:    nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ExtractMixinProtos(googleapisDir, test.apiPath, config.LanguageGo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractMixinProtos_NonexistentAPI(t *testing.T) {
+	got, err := ExtractMixinProtos(googleapisDir, "google/cloud/nonexistent/v1", config.LanguageGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func TestExtractMixinProtos_Error(t *testing.T) {
+	dir := t.TempDir()
+	apiPath := "google/example/v1"
+	apiDir := filepath.Join(dir, apiPath)
+	if err := os.MkdirAll(apiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write an invalid service config (invalid YAML but has correct type header)
+	content := []byte("type: google.api.Service\ninvalid: { {\n")
+	if err := os.WriteFile(filepath.Join(apiDir, "example_v1.yaml"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ExtractMixinProtos(dir, apiPath, config.LanguageGo)
+	if err == nil {
+		t.Fatal("expected error for invalid service config")
+	}
+}

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -15,6 +15,7 @@
 package serviceconfig
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -518,7 +519,7 @@ func TestExtractMixinProtos_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err := ExtractMixinProtos(dir, apiPath, config.LanguageGo)
-	if err == nil {
-		t.Error("expected error for invalid service config")
+	if !errors.Is(err, ErrReadServiceConfig) {
+		t.Errorf("got error %v, wantErr %v", err, ErrReadServiceConfig)
 	}
 }


### PR DESCRIPTION
PHP client libraries now automatically resolve mixin dependencies (Locations and IAMPolicy) during the add command, similar to Java.

To prevent code duplication, extracted common logic into a shared helper function ExtractMixinProtos in the internal/serviceconfig package. 

Fixes https://github.com/googleapis/librarian/issues/6800