### PR TITLE
fix(internal/librarian): set canDeriveAPIPath to false for Ruby

### DIFF
--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -330,7 +330,7 @@ func applyDefaults(language string, lib *config.Library, defaults *config.Defaul
 // derive the API path.
 func canDeriveAPIPath(language string) bool {
 	switch language {
-	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs, config.LanguageJava, config.LanguagePhp:
+	case config.LanguageGo, config.LanguagePython, config.LanguageNodejs, config.LanguageJava, config.LanguagePhp, config.LanguageRuby:
 		return false
 	default:
 		return true

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -867,6 +867,11 @@ func TestCanDeriveAPIPath(t *testing.T) {
 			language: config.LanguageNodejs,
 		},
 		{
+			name:     "ruby",
+			language: config.LanguageRuby,
+			want:     false,
+		},
+		{
 			name:     "rust",
 			language: config.LanguageRust,
 			want:     true,


### PR DESCRIPTION
Updated `canDeriveAPIPath` to return `false` for Ruby because Ruby gem names do not reliably map to googleapis proto paths via simple dash replacement.

### Problem
Before this fix, when we try to run `librarian tidy` on a `librarian.yaml` containing a Ruby library entry with `ruby_cloud_opts`:
```yaml
libraries:
  - name: google-cloud-asset-v1
    apis:
      - path: google/cloud/asset/v1
        ruby:
          ruby_cloud_opts:
            ruby-cloud-env-prefix: ASSET
            ruby-cloud-extra-dependencies: "..."
```
`canDeriveAPIPath("ruby")` returned `true`, causing `tidy` to consider `path: google/cloud/asset/v1` derivable from `google-cloud-asset-v1` and clear `ch.Path = ""`. The empty `path` check then deleted the API entry, stripping the `apis:` section and `ruby_cloud_opts` from `librarian.yaml`.

Furthermore, Ruby gem names frequently contain underscores or belong to different top-level namespaces (e.g., `google-cloud-secret_manager-v1` ➔ `google/cloud/secretmanager/v1`, `google-cloud-access_context_manager-v1` ➔ `google/identity/accesscontextmanager/v1`), so API paths cannot be derived via simple dash replacement.

### Solution
- Set `canDeriveAPIPath` to return `false` for Ruby so `path:` is preserved in `librarian.yaml` alongside `ruby_cloud_opts`.
- Added unit test coverage for Ruby in `TestCanDeriveAPIPath`.

Fixes https://github.com/googleapis/librarian/issues/7003