### PR TITLE
fix(internal/librarian/ruby): handle pre-existing CHANGELOG.md during generation

### DIFF
--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -30,6 +30,10 @@ import (
 var (
 	errNotADirectory = errors.New("output path is not a directory")
 
+	// oneTimeGeneratedRootFiles is the list of files generated only once upon initial library creation.
+	oneTimeGeneratedRootFiles = []string{
+		"CHANGELOG.md",
+	}
 	// generatedRootFiles is the list of specific root files generated for Ruby client gems.
 	generatedRootFiles = []string{
 		"AUTHENTICATION.md",
@@ -87,6 +91,9 @@ func buildKeepSet(keep []string) map[string]bool {
 	for _, keepPath := range keep {
 		cleaned := filepath.ToSlash(filepath.Clean(keepPath))
 		keepSet[cleaned] = true
+	}
+	for _, file := range oneTimeGeneratedRootFiles {
+		keepSet[file] = true
 	}
 	return keepSet
 }

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -67,7 +67,11 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
-	if err := filesystem.MoveAndMerge(tempDir, outDir); err != nil {
+	keepSet := buildKeepSet(library.Keep)
+	keepFunc := func(rel string) bool {
+		return isKept(rel, keepSet)
+	}
+	if err := filesystem.MoveAndMergeWithKeep(tempDir, outDir, outDir, keepFunc); err != nil {
 		return fmt.Errorf("failed to move generated files: %w", err)
 	}
 	return nil

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -349,7 +349,7 @@ func TestGenerate(t *testing.T) {
 	}
 	gotChangelog, err := os.ReadFile(changelogPath)
 	if err != nil {
-		t.Fatalf("failed to read CHANGELOG.md: %v", err)
+		t.Fatal(err)
 	}
 	if diff := cmp.Diff(existingContent, string(gotChangelog)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -352,7 +352,7 @@ func TestGenerate(t *testing.T) {
 		t.Fatalf("failed to read CHANGELOG.md: %v", err)
 	}
 	if diff := cmp.Diff(existingContent, string(gotChangelog)); diff != "" {
-		t.Errorf("CHANGELOG.md content mismatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -294,6 +294,7 @@ done
 if [ -n "$outDir" ]; then
   mkdir -p "$outDir/lib/google/cloud/secret_manager"
   touch "$outDir/lib/google/cloud/secret_manager/v1.rb"
+  touch "$outDir/CHANGELOG.md"
 fi
 exit 0
 `
@@ -324,6 +325,11 @@ func TestGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	outDir := t.TempDir()
+	changelogPath := filepath.Join(outDir, "CHANGELOG.md")
+	const existingContent = "# Initial Changelog Content\n"
+	if err := os.WriteFile(changelogPath, []byte(existingContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	library := &config.Library{
 		Name:   "google-cloud-secret_manager-v1",
 		Output: outDir,
@@ -340,6 +346,13 @@ func TestGenerate(t *testing.T) {
 	wantFile := filepath.Join(outDir, "lib", "google", "cloud", "secret_manager", "v1.rb")
 	if _, err := os.Stat(wantFile); err != nil {
 		t.Errorf("expected generated file %s to exist: %v", wantFile, err)
+	}
+	gotChangelog, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("failed to read CHANGELOG.md: %v", err)
+	}
+	if diff := cmp.Diff(existingContent, string(gotChangelog)); diff != "" {
+		t.Errorf("CHANGELOG.md content mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Add `CHANGELOG.md` to default `keepSet` in `buildKeepSet` and use `MoveAndMergeWithKeep` in `ruby/generate.go` to prevent file collision errors on pre-existing `CHANGELOG.md` files.

Fixes https://github.com/googleapis/librarian/issues/7005