### PR TITLE
fix(internal/librarian/ruby): handle default output directory for Ruby libraries

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -362,6 +362,8 @@ func defaultOutput(language string, name, api, defaultOut string) string {
 		return php.DefaultOutput(name, defaultOut)
 	case config.LanguagePython:
 		return python.DefaultOutput(name, defaultOut)
+	case config.LanguageRuby:
+		return ruby.DefaultOutput(name, defaultOut)
 	case config.LanguageRust:
 		return rust.DefaultOutput(api, defaultOut)
 	case config.LanguageSwift:

--- a/internal/librarian/generate_test.go
+++ b/internal/librarian/generate_test.go
@@ -424,6 +424,14 @@ func TestDefaultOutput(t *testing.T) {
 			want:       "packages/google-cloud-secretmanager",
 		},
 		{
+			name:       "ruby",
+			language:   config.LanguageRuby,
+			libName:    "google-cloud-secret_manager-v1",
+			api:        "google/cloud/secretmanager/v1",
+			defaultOut: "",
+			want:       "google-cloud-secret_manager-v1",
+		},
+		{
 			name:       "unknown language",
 			language:   config.LanguageUnknown,
 			libName:    "google-cloud-secretmanager-v1",

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -33,6 +33,12 @@ import (
 
 var errNoAPIs = errors.New("no apis configured for library")
 
+// DefaultOutput derives an output path from a library name and a default
+// output path.
+func DefaultOutput(name, defaultOutput string) string {
+	return filepath.Join(defaultOutput, name)
+}
+
 // Generate generates a Ruby client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, srcs *sources.Sources) (err error) {
 	if len(library.APIs) == 0 {

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -388,3 +388,32 @@ func TestGenerateAPI_Error(t *testing.T) {
 		t.Error("generateAPI() error = nil, want error")
 	}
 }
+
+func TestDefaultOutput(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		libName       string
+		defaultOutput string
+		want          string
+	}{
+		{
+			name:          "empty default output",
+			libName:       "google-cloud-secret_manager-v1",
+			defaultOutput: "",
+			want:          "google-cloud-secret_manager-v1",
+		},
+		{
+			name:          "with default output directory",
+			libName:       "google-cloud-secret_manager-v1",
+			defaultOutput: "gems",
+			want:          filepath.Join("gems", "google-cloud-secret_manager-v1"),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultOutput(test.libName, test.defaultOutput)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `DefaultOutput` in `ruby/generate.go` and register `LanguageRuby` in `defaultOutput` in `generate.go` so output directory defaults to library target directory instead of repository root.

Fixes https://github.com/googleapis/librarian/issues/7004