### PR TITLE
fix(internal/librarian/ruby): pass lib directory to protoc for ruby_out and grpc_out

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -96,12 +96,19 @@ func generateAPI(ctx context.Context, api *config.API, gemName string, pc *confi
 	if err != nil {
 		return err
 	}
+	// Output --ruby_out and --grpc_out into lib/ so _pb.rb files land under lib/google/...
+	// matching Bazel's ruby_gapic_assembly_pkg_impl:
+	// https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c1/rules_ruby_gapic/ruby_gapic_pkg.bzl#L39-L41
+	libStagingDir := filepath.Join(stagingDir, "lib")
+	if err := os.MkdirAll(libStagingDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create lib staging directory: %w", err)
+	}
 	grpcPluginPath := filepath.Join(installDir, "bin", "grpc_tools_ruby_protoc_plugin")
 	args := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
-		"--ruby_out=" + stagingDir,
-		"--grpc_out=" + stagingDir,
+		"--ruby_out=" + libStagingDir,
+		"--grpc_out=" + libStagingDir,
 		"--plugin=protoc-gen-grpc=" + grpcPluginPath,
 		"--ruby_cloud_out=" + stagingDir,
 	}

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -284,17 +284,22 @@ func setupDummyProtoc(t *testing.T) {
 
 	protocPath := filepath.Join(binDir, "protoc")
 	script := `#!/bin/sh
-outDir=""
+rubyOut=""
+rubyCloudOut=""
 for arg in "$@"; do
   case "$arg" in
-    --ruby_cloud_out=*) outDir="${arg#--ruby_cloud_out=}" ;;
-    --ruby_out=*) if [ -z "$outDir" ]; then outDir="${arg#--ruby_out=}"; fi ;;
+    --ruby_cloud_out=*) rubyCloudOut="${arg#--ruby_cloud_out=}" ;;
+    --ruby_out=*) rubyOut="${arg#--ruby_out=}" ;;
   esac
 done
-if [ -n "$outDir" ]; then
-  mkdir -p "$outDir/lib/google/cloud/secret_manager"
-  touch "$outDir/lib/google/cloud/secret_manager/v1.rb"
-  touch "$outDir/CHANGELOG.md"
+if [ -n "$rubyCloudOut" ]; then
+  mkdir -p "$rubyCloudOut/lib/google/cloud/secret_manager"
+  touch "$rubyCloudOut/lib/google/cloud/secret_manager/v1.rb"
+  touch "$rubyCloudOut/CHANGELOG.md"
+fi
+if [ -n "$rubyOut" ]; then
+  mkdir -p "$rubyOut/google/cloud/secret_manager"
+  touch "$rubyOut/google/cloud/secret_manager/v1_pb.rb"
 fi
 exit 0
 `
@@ -347,6 +352,10 @@ func TestGenerate(t *testing.T) {
 	if _, err := os.Stat(wantFile); err != nil {
 		t.Errorf("expected generated file %s to exist: %v", wantFile, err)
 	}
+	wantPbFile := filepath.Join(outDir, "lib", "google", "cloud", "secret_manager", "v1_pb.rb")
+	if _, err := os.Stat(wantPbFile); err != nil {
+		t.Errorf("expected generated pb file %s to exist: %v", wantPbFile, err)
+	}
 	gotChangelog, err := os.ReadFile(changelogPath)
 	if err != nil {
 		t.Fatal(err)
@@ -374,6 +383,10 @@ func TestGenerateAPI(t *testing.T) {
 	wantFile := filepath.Join(stagingDir, "lib", "google", "cloud", "secret_manager", "v1.rb")
 	if _, err := os.Stat(wantFile); err != nil {
 		t.Errorf("expected generated file %s to exist: %v", wantFile, err)
+	}
+	wantPbFile := filepath.Join(stagingDir, "lib", "google", "cloud", "secret_manager", "v1_pb.rb")
+	if _, err := os.Stat(wantPbFile); err != nil {
+		t.Errorf("expected generated pb file %s to exist: %v", wantPbFile, err)
 	}
 }
 


### PR DESCRIPTION
Ensure `stagingDir/lib` directory exists before executing protoc and pass `libStagingDir` to `--ruby_out` and `--grpc_out` so proto and gRPC files land inside `lib/` rather than creating a root `google/` directory.

### Configuration (`librarian.yaml` in `google-cloud-ruby`)
```yaml
language: ruby
sources:
  googleapis:
    commit: 6145fa8cc2b137bf4c0ed114e2e39c1157ea9722
    sha256: 489923d12c766c9e323b42de057037977b03f20c8a874bc8553d29f9dd3f0e3b
tools:
  gem:
    - name: gapic-generator-cloud
      version: 0.49.0
    - name: grpc-tools
      version: 1.78.1
  protoc:
    version: "33.2"
    sha256: b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf
libraries:
  - name: google-cloud-asset-v1
    apis:
      - path: google/cloud/asset/v1
        ruby:
          ruby_cloud_opts:
            ruby-cloud-env-prefix: ASSET
            ruby-cloud-extra-dependencies: "google-identity-access_context_manager-v1=>0.0+<2.a;google-cloud-os_config-v1=>0.0+<2.a"
```

### Execution Command
```console
$ librarian generate google-cloud-asset-v1
```

### Diffs in Target Repository (`google-cloud-ruby`)
Before this fix, running generation caused `protoc` to output files to `stagingDir/google/cloud/asset/v1/..._pb.rb`, creating an untracked root-level `google/` directory at the repository root (`google-cloud-ruby/google/`).

With this fix, `--ruby_out` and `--grpc_out` receive `stagingDir/lib`, so `..._pb.rb` and `..._services_pb.rb` land correctly in `google-cloud-asset-v1/lib/google/cloud/asset/v1/`:

```diff
diff --git a/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service_services_pb.rb b/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service_services_pb.rb
index a49b5138a0..8b4c8e2e63 100644
--- a/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service_services_pb.rb
+++ b/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service_services_pb.rb
@@ -1,7 +1,7 @@
 # Generated by the protocol buffer compiler.  DO NOT EDIT!
 # Source: google/cloud/asset/v1/asset_service.proto for package 'google.cloud.asset.v1'
 # Original file comments:
-# Copyright 2020 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
```

Fixes https://github.com/googleapis/librarian/issues/7006