### PR TITLE
fix(internal/librarian/ruby): pass ruby-cloud-generate-transports to gapic-generator-cloud

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -143,7 +143,8 @@ func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, e
 		opts = append(opts, "grpc-service-config="+filepath.Join(googleapisDir, gc))
 	}
 	if trans := transport(sc); trans != "" {
-		opts = append(opts, fmt.Sprintf("transport=%s", trans))
+		transports := strings.ReplaceAll(string(trans), "+", ";")
+		opts = append(opts, "ruby-cloud-generate-transports="+transports)
 	}
 	if sc != nil && sc.HasRESTNumericEnums(config.LanguageRuby) {
 		opts = append(opts, "ruby-cloud-rest-numeric-enums=true")

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -53,7 +53,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
-				"transport=grpc+rest",
+				"ruby-cloud-generate-transports=grpc;rest",
 				"ruby-cloud-rest-numeric-enums=true",
 			},
 		},
@@ -66,7 +66,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-compute-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/compute/v1/compute_v1.yaml"),
-				"transport=rest",
+				"ruby-cloud-generate-transports=rest",
 				"ruby-cloud-rest-numeric-enums=true",
 			},
 		},


### PR DESCRIPTION
Pass `ruby-cloud-generate-transports` with `;`-separated values (e.g. `ruby-cloud-generate-transports=grpc;rest`) to `gapic-generator-cloud` so that REST client files and REST tests are correctly generated instead of omitted.

Note that `ruby-cloud-generate-transports=grpc;rest` matches the protoc parameter documented in the design survey at http://go/sdk-librarian-ruby?resourcekey=0-oqhz5UToZVoA4NMHrBQHMQ&tab=t.amahu2t58twt#heading=h.r83qd6anzlaw.

Fixes https://github.com/googleapis/librarian/issues/7012