### PR TITLE
chore(tool/cmd/migrate): parse gem namespace for ruby migration

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -494,6 +494,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `ruby-cloud-env-prefix` | string | Is the environment variable prefix. |
 | `ruby-cloud-extra-dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
+| `ruby-cloud-gem-namespace` | string | Is the root Ruby namespace. |
 | `ruby-cloud-path-override` | string | Overrides file/directory paths under lib/ and proto_docs/. |
 | `ruby-cloud-service-override` | string | Overrides generated service class names when proto package service names don't match desired Ruby conventions. |
 | `ruby-cloud-yard-strict` | string | Enables or disables strict YARD syntax checks during generation. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -853,6 +853,9 @@ type RubyCloudOpts struct {
 	// ExtraDependencies contains extra runtime dependencies to the .gemspec file.
 	ExtraDependencies string `yaml:"ruby-cloud-extra-dependencies,omitempty"`
 
+	// GemNamespace is the root Ruby namespace.
+	GemNamespace string `yaml:"ruby-cloud-gem-namespace,omitempty"`
+
 	// PathOverride overrides file/directory paths under lib/ and proto_docs/.
 	PathOverride string `yaml:"ruby-cloud-path-override,omitempty"`
 

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -49,6 +49,7 @@ type owlbotSrc struct {
 type VersionedBuild struct {
 	EnvPrefix       string
 	ExtraDeps       string
+	GemNamespace    string
 	PathOverride    string
 	ServiceOverride string
 	YardStrict      string
@@ -157,6 +158,7 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 					RubyCloudOpts: &config.RubyCloudOpts{
 						EnvPrefix:         vb.EnvPrefix,
 						ExtraDependencies: vb.ExtraDeps,
+						GemNamespace:      vb.GemNamespace,
 						PathOverride:      vb.PathOverride,
 						ServiceOverride:   vb.ServiceOverride,
 						YardStrict:        vb.YardStrict,
@@ -250,6 +252,8 @@ func parseVersionedBuild(googleapisDir, apiPath string) (*VersionedBuild, error)
 					vb.EnvPrefix, _ = strings.CutPrefix(dep, "ruby-cloud-env-prefix=")
 				case strings.HasPrefix(dep, "ruby-cloud-extra-dependencies="):
 					vb.ExtraDeps, _ = strings.CutPrefix(dep, "ruby-cloud-extra-dependencies=")
+				case strings.HasPrefix(dep, "ruby-cloud-gem-namespace="):
+					vb.GemNamespace, _ = strings.CutPrefix(dep, "ruby-cloud-gem-namespace=")
 				case strings.HasPrefix(dep, "ruby-cloud-path-override="):
 					vb.PathOverride, _ = strings.CutPrefix(dep, "ruby-cloud-path-override=")
 				case strings.HasPrefix(dep, "ruby-cloud-service-override="):

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -274,6 +274,7 @@ func TestParseVersionedBuild(t *testing.T) {
 			googleapisDir: "testdata/googleapis",
 			apiPath:       "google/cloud/alloydb/v1",
 			want: &VersionedBuild{
+				GemNamespace:    "Google::Cloud::AlloyDB::V1",
 				ServiceOverride: "AlloyDBCSQLAdmin=AlloyDBCloudSQLAdmin",
 			},
 		},


### PR DESCRIPTION
`GemNamespace` is added to the `RubyCloudOpts` configuration to specify the root Ruby namespace for generated client libraries.

The Ruby migration command now parses `ruby-cloud-gem-namespace parameters` from `BUILD.bazel` files and populates this field in `librarian.yaml`.

For https://github.com/googleapis/librarian/issues/6632
