### PR TITLE
chore(tool/cmd/migrate): parse namespace override for ruby migration

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -495,6 +495,7 @@ This document describes the schema for the librarian.yaml.
 | `ruby-cloud-env-prefix` | string | Is the environment variable prefix. |
 | `ruby-cloud-extra-dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
 | `ruby-cloud-gem-namespace` | string | Is the root Ruby namespace. |
+| `ruby-cloud-namespace-override` | string | Overrides token / segment replacements applied across all generated module & class paths. |
 | `ruby-cloud-path-override` | string | Overrides file/directory paths under lib/ and proto_docs/. |
 | `ruby-cloud-service-override` | string | Overrides generated service class names when proto package service names don't match desired Ruby conventions. |
 | `ruby-cloud-yard-strict` | string | Enables or disables strict YARD syntax checks during generation. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -856,6 +856,10 @@ type RubyCloudOpts struct {
 	// GemNamespace is the root Ruby namespace.
 	GemNamespace string `yaml:"ruby-cloud-gem-namespace,omitempty"`
 
+	// NamespaceOverride overrides token / segment replacements applied across all generated
+	// module & class paths.
+	NamespaceOverride string `yaml:"ruby-cloud-namespace-override,omitempty"`
+
 	// PathOverride overrides file/directory paths under lib/ and proto_docs/.
 	PathOverride string `yaml:"ruby-cloud-path-override,omitempty"`
 

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -47,12 +47,13 @@ type owlbotSrc struct {
 
 // VersionedBuild represents build configuration parsed from BUILD.bazel for a Ruby API version.
 type VersionedBuild struct {
-	EnvPrefix       string
-	ExtraDeps       string
-	GemNamespace    string
-	PathOverride    string
-	ServiceOverride string
-	YardStrict      string
+	EnvPrefix         string
+	ExtraDeps         string
+	GemNamespace      string
+	NamespaceOverride string
+	PathOverride      string
+	ServiceOverride   string
+	YardStrict        string
 }
 
 func runRubyMigration(ctx context.Context, repoPath string) error {
@@ -159,6 +160,7 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 						EnvPrefix:         vb.EnvPrefix,
 						ExtraDependencies: vb.ExtraDeps,
 						GemNamespace:      vb.GemNamespace,
+						NamespaceOverride: vb.NamespaceOverride,
 						PathOverride:      vb.PathOverride,
 						ServiceOverride:   vb.ServiceOverride,
 						YardStrict:        vb.YardStrict,
@@ -254,6 +256,8 @@ func parseVersionedBuild(googleapisDir, apiPath string) (*VersionedBuild, error)
 					vb.ExtraDeps, _ = strings.CutPrefix(dep, "ruby-cloud-extra-dependencies=")
 				case strings.HasPrefix(dep, "ruby-cloud-gem-namespace="):
 					vb.GemNamespace, _ = strings.CutPrefix(dep, "ruby-cloud-gem-namespace=")
+				case strings.HasPrefix(dep, "ruby-cloud-namespace-override="):
+					vb.NamespaceOverride, _ = strings.CutPrefix(dep, "ruby-cloud-namespace-override=")
 				case strings.HasPrefix(dep, "ruby-cloud-path-override="):
 					vb.PathOverride, _ = strings.CutPrefix(dep, "ruby-cloud-path-override=")
 				case strings.HasPrefix(dep, "ruby-cloud-service-override="):

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -265,6 +265,7 @@ func TestParseVersionedBuild(t *testing.T) {
 			apiPath:       "google/cloud/automl/v1",
 			want: &VersionedBuild{
 				EnvPrefix:    "AUTOML",
+				NamespaceOverride: "AutoMl=AutoML;Automl=AutoML",
 				PathOverride: "auto_ml=automl",
 				YardStrict:   "false",
 			},

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -264,10 +264,10 @@ func TestParseVersionedBuild(t *testing.T) {
 			googleapisDir: "testdata/googleapis",
 			apiPath:       "google/cloud/automl/v1",
 			want: &VersionedBuild{
-				EnvPrefix:    "AUTOML",
+				EnvPrefix:         "AUTOML",
 				NamespaceOverride: "AutoMl=AutoML;Automl=AutoML",
-				PathOverride: "auto_ml=automl",
-				YardStrict:   "false",
+				PathOverride:      "auto_ml=automl",
+				YardStrict:        "false",
 			},
 		},
 		{


### PR DESCRIPTION
`NamespaceOverride` is added to the `RubyCloudOpts` configuration to support overriding token and segment replacements applied across generated module and class paths.

The Ruby migration command now parses `ruby-cloud-namespace-override` parameters from `BUILD.bazel` files and populates this field in `librarian.yaml`.

For https://github.com/googleapis/librarian/issues/6632