### PR TITLE
feat(python): read python tools from librarian.yaml config

### DIFF
--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -123,7 +123,7 @@ Examples:
 			case config.LanguagePhp:
 				return php.Install(ctx, tools)
 			case config.LanguagePython:
-				return python.Install(ctx)
+				return python.Install(ctx, tools)
 			case config.LanguageRuby:
 				return ruby.Install(ctx, tools)
 			case config.LanguageRust:

--- a/internal/librarian/python/install.go
+++ b/internal/librarian/python/install.go
@@ -41,4 +41,3 @@ func Install(ctx context.Context, tools *config.Tools) error {
 	}
 	return pip.Install(ctx, cfg.Tools.Pip)
 }
-

--- a/internal/librarian/python/install.go
+++ b/internal/librarian/python/install.go
@@ -28,7 +28,10 @@ import (
 var librarianYAML []byte
 
 // Install installs Python pip tool dependencies.
-func Install(ctx context.Context) error {
+func Install(ctx context.Context, tools *config.Tools) error {
+	if tools != nil && len(tools.Pip) > 0 {
+		return pip.Install(ctx, tools.Pip)
+	}
 	cfg, err := yaml.Unmarshal[config.Config](librarianYAML)
 	if err != nil {
 		return fmt.Errorf("parsing embedded librarian.yaml: %w", err)
@@ -38,3 +41,4 @@ func Install(ctx context.Context) error {
 	}
 	return pip.Install(ctx, cfg.Tools.Pip)
 }
+

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -28,13 +28,11 @@ func TestInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-
 	t.Run("fallback to embedded librarian.yaml", func(t *testing.T) {
 		if err := Install(t.Context(), nil); err != nil {
 			t.Fatal(err)
 		}
 	})
-
 	t.Run("use tools from config", func(t *testing.T) {
 		tools := &config.Tools{
 			Pip: []*config.PipTool{
@@ -46,4 +44,3 @@ func TestInstall(t *testing.T) {
 		}
 	})
 }
-

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -15,11 +15,13 @@
 package python
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/tool/pip"
 )
 
 func TestInstall(t *testing.T) {
@@ -49,6 +51,51 @@ func TestInstall(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if err := Install(t.Context(), test.tools); err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestInstall_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tools   *config.Tools
+		setup   func(t *testing.T)
+		wantErr error
+	}{
+		{
+			name: "local path not found",
+			tools: &config.Tools{
+				Pip: []*config.PipTool{
+					{LocalPath: "/path/does/not/exist"},
+				},
+			},
+			wantErr: pip.ErrLocalPathNotFound,
+		},
+		{
+			name: "pip execution fails",
+			tools: &config.Tools{
+				Pip: []*config.PipTool{
+					{Name: "invalid-tool"},
+				},
+			},
+			setup: func(t *testing.T) {
+				bin := t.TempDir()
+				if err := os.WriteFile(filepath.Join(bin, "pip"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+			},
+			wantErr: pip.ErrInstall,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			err := Install(t.Context(), test.tools)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -47,7 +47,6 @@ func TestInstall(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := Install(t.Context(), tc.tools)
@@ -57,4 +56,3 @@ func TestInstall(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -29,10 +29,9 @@ func TestInstall(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	tests := []struct {
-		name    string
-		tools   *config.Tools
-		wantErr bool
+	for _, test := range []struct {
+		name  string
+		tools *config.Tools
 	}{
 		{
 			name:  "fallback to embedded librarian.yaml",
@@ -46,12 +45,10 @@ func TestInstall(t *testing.T) {
 				},
 			},
 		},
-	}
-	for _, test := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := Install(t.Context(), tc.tools)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("Install() error = %v, wantErr %v", err, tc.wantErr)
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Install(t.Context(), test.tools); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -28,19 +28,33 @@ func TestInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Run("fallback to embedded librarian.yaml", func(t *testing.T) {
-		if err := Install(t.Context(), nil); err != nil {
-			t.Fatal(err)
-		}
-	})
-	t.Run("use tools from config", func(t *testing.T) {
-		tools := &config.Tools{
-			Pip: []*config.PipTool{
-				{Name: "ruff", Version: "0.14.14"},
+
+	tests := []struct {
+		name    string
+		tools   *config.Tools
+		wantErr bool
+	}{
+		{
+			name:  "fallback to embedded librarian.yaml",
+			tools: nil,
+		},
+		{
+			name: "use tools from config",
+			tools: &config.Tools{
+				Pip: []*config.PipTool{
+					{Name: "ruff", Version: "0.14.14"},
+				},
 			},
-		}
-		if err := Install(t.Context(), tools); err != nil {
-			t.Fatal(err)
-		}
-	})
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Install(t.Context(), tc.tools)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Install() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
 }
+

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -47,7 +47,7 @@ func TestInstall(t *testing.T) {
 			},
 		},
 	}
-	for _, tc := range tests {
+	for _, test := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := Install(t.Context(), tc.tools)
 			if (err != nil) != tc.wantErr {

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestInstall(t *testing.T) {
@@ -27,7 +29,21 @@ func TestInstall(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if err := Install(t.Context()); err != nil {
-		t.Fatal(err)
-	}
+	t.Run("fallback to embedded librarian.yaml", func(t *testing.T) {
+		if err := Install(t.Context(), nil); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("use tools from config", func(t *testing.T) {
+		tools := &config.Tools{
+			Pip: []*config.PipTool{
+				{Name: "ruff", Version: "0.14.14"},
+			},
+		}
+		if err := Install(t.Context(), tools); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
+


### PR DESCRIPTION
First attempt to read Python tools from librarian.yaml if provided in the repository configuration. Falls back to embedded librarian.yaml if no tools are specified in librarian.yaml. 

For #6508