### PR TITLE
fix(internal/librarian/ruby): pass client library version to snippet metadata

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/serviceconfig"
+	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/tool/protoc"
 )
@@ -79,6 +80,11 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}
 	if err := filesystem.MoveAndMergeWithKeep(tempDir, outDir, outDir, keepFunc); err != nil {
 		return fmt.Errorf("failed to move generated files: %w", err)
+	}
+	if library.Version != "" {
+		if err := snippetmetadata.UpdateAllLibraryVersions(outDir, library.Version); err != nil {
+			return fmt.Errorf("failed to update snippet metadata versions: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -81,10 +81,8 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := filesystem.MoveAndMergeWithKeep(tempDir, outDir, outDir, keepFunc); err != nil {
 		return fmt.Errorf("failed to move generated files: %w", err)
 	}
-	if library.Version != "" {
-		if err := snippetmetadata.UpdateAllLibraryVersions(outDir, library.Version); err != nil {
-			return fmt.Errorf("failed to update snippet metadata versions: %w", err)
-		}
+	if err := snippetmetadata.UpdateAllLibraryVersions(outDir, library.Version); err != nil {
+		return fmt.Errorf("failed to update snippet metadata versions: %w", err)
 	}
 	return nil
 }

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -15,6 +15,7 @@
 package ruby
 
 import (
+	"encoding/json"
 	"errors"
 	"io/fs"
 	"os"
@@ -390,8 +391,15 @@ func TestGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantSnippetMetadata := "{\n  \"clientLibrary\": {\n    \"language\": \"RUBY\",\n    \"name\": \"google-cloud-secret_manager-v1\",\n    \"version\": \"1.2.3\"\n  }\n}"
-	if diff := cmp.Diff(wantSnippetMetadata, string(gotSnippetMetadata)); diff != "" {
+	var metadata struct {
+		ClientLibrary struct {
+			Version string `json:"version"`
+		} `json:"clientLibrary"`
+	}
+	if err := json.Unmarshal(gotSnippetMetadata, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff("1.2.3", metadata.ClientLibrary.Version); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
+	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
 )
 
@@ -391,11 +392,7 @@ func TestGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var metadata struct {
-		ClientLibrary struct {
-			Version string `json:"version"`
-		} `json:"clientLibrary"`
-	}
+	var metadata snippetmetadata.SnippetMetadata
 	if err := json.Unmarshal(gotSnippetMetadata, &metadata); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -308,7 +308,15 @@ if [ -n "$rubyCloudOut" ]; then
   touch "$rubyCloudOut/lib/google/cloud/secret_manager/v1.rb"
   touch "$rubyCloudOut/CHANGELOG.md"
   mkdir -p "$rubyCloudOut/snippets"
-  printf '{\n  "clientLibrary": {\n    "name": "google-cloud-secret_manager-v1",\n    "version": "",\n    "language": "RUBY"\n  }\n}' > "$rubyCloudOut/snippets/snippet_metadata_google.cloud.secretmanager.v1.json"
+  cat << 'EOF' > "$rubyCloudOut/snippets/snippet_metadata_google.cloud.secretmanager.v1.json"
+{
+  "clientLibrary": {
+    "name": "google-cloud-secret_manager-v1",
+    "version": "",
+    "language": "RUBY"
+  }
+}
+EOF
 fi
 if [ -n "$rubyOut" ]; then
   mkdir -p "$rubyOut/google/cloud/secret_manager"

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -307,6 +307,8 @@ if [ -n "$rubyCloudOut" ]; then
   mkdir -p "$rubyCloudOut/lib/google/cloud/secret_manager"
   touch "$rubyCloudOut/lib/google/cloud/secret_manager/v1.rb"
   touch "$rubyCloudOut/CHANGELOG.md"
+  mkdir -p "$rubyCloudOut/snippets"
+  printf '{\n  "clientLibrary": {\n    "name": "google-cloud-secret_manager-v1",\n    "version": "",\n    "language": "RUBY"\n  }\n}' > "$rubyCloudOut/snippets/snippet_metadata_google.cloud.secretmanager.v1.json"
 fi
 if [ -n "$rubyOut" ]; then
   mkdir -p "$rubyOut/google/cloud/secret_manager"
@@ -347,8 +349,9 @@ func TestGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	library := &config.Library{
-		Name:   "google-cloud-secret_manager-v1",
-		Output: outDir,
+		Name:    "google-cloud-secret_manager-v1",
+		Version: "1.2.3",
+		Output:  outDir,
 		APIs: []*config.API{
 			{
 				Path: "google/cloud/secretmanager/v1",
@@ -372,6 +375,15 @@ func TestGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(existingContent, string(gotChangelog)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+	snippetMetadataPath := filepath.Join(outDir, "snippets", "snippet_metadata_google.cloud.secretmanager.v1.json")
+	gotSnippetMetadata, err := os.ReadFile(snippetMetadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSnippetMetadata := "{\n  \"clientLibrary\": {\n    \"language\": \"RUBY\",\n    \"name\": \"google-cloud-secret_manager-v1\",\n    \"version\": \"1.2.3\"\n  }\n}"
+	if diff := cmp.Diff(wantSnippetMetadata, string(gotSnippetMetadata)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/snippetmetadata/snippetmetadata.go
+++ b/internal/snippetmetadata/snippetmetadata.go
@@ -34,6 +34,18 @@ var (
 	errSnippetMetadataLink      = errors.New("expected regular file; was a link")
 )
 
+// SnippetMetadata represents the top-level structure of a snippet metadata file.
+type SnippetMetadata struct {
+	ClientLibrary ClientLibrary `json:"clientLibrary"`
+}
+
+// ClientLibrary represents the clientLibrary object inside snippet metadata.
+type ClientLibrary struct {
+	Name     string `json:"name,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Language string `json:"language,omitempty"`
+}
+
 // readMetadata reads and parses the file at the given path as a JSON file.
 func readMetadata(path string) (map[string]any, error) {
 	content, err := os.ReadFile(path)


### PR DESCRIPTION
During librarian generate, snippet metadata files in Ruby libraries were leaving version set to empty string because gapic-generator-ruby outputs version as empty string. Call snippetmetadata.UpdateAllLibraryVersions after generation to set the library version.

Additionally, export the `SnippetMetadata` and `ClientLibrary` struct types in package `snippetmetadata` for typed unmarshaling and test assertions across the codebase.

The exported `snippetmetadata.SnippetMetadata` struct can also benefit existing test fixtures and assertions in:
- `internal/librarian/golang/bump_test.go` (snippet metadata test fixtures and version assertions)
- `internal/librarian/python/bump_test.go` (Python snippet metadata version bump test assertions)
- `internal/librarian/nodejs/generate_test.go` (Node.js generated snippet metadata test assertions)

The changes will be in an upcoming pull request.

Fixes https://github.com/googleapis/librarian/issues/7020