### PR TITLE
test(internal/testhelper): disable gpg signing in test repositories

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -596,4 +597,24 @@ func TestGetCommitSubject_Error(t *testing.T) {
 	if err == nil {
 		t.Fatal("wanted an error; got none")
 	}
+}
+
+func TestGitConfigIgnoreGlobalSigning(t *testing.T) {
+	fakeHome := t.TempDir()
+	gitConfigContent := `
+[gpg]
+	format = ssh
+[commit]
+	gpgSign = true
+[tag]
+	gpgSign = true
+`
+	err := os.WriteFile(filepath.Join(fakeHome, ".gitconfig"), []byte(gitConfigContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", fakeHome)
+
+	testhelper.SetupRepo(t)
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -600,7 +600,7 @@ func TestGetCommitSubject_Error(t *testing.T) {
 }
 
 func TestGitConfigIgnoreGlobalSigning(t *testing.T) {
-	fakeHome := t.TempDir()
+	fakeGlobalConfig := filepath.Join(t.TempDir(), ".gitconfig")
 	gitConfigContent := `
 [gpg]
 	format = ssh
@@ -609,12 +609,12 @@ func TestGitConfigIgnoreGlobalSigning(t *testing.T) {
 [tag]
 	gpgSign = true
 `
-	err := os.WriteFile(filepath.Join(fakeHome, ".gitconfig"), []byte(gitConfigContent), 0644)
+	err := os.WriteFile(fakeGlobalConfig, []byte(gitConfigContent), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", fakeHome)
+	t.Setenv("GIT_CONFIG_GLOBAL", fakeGlobalConfig)
 
 	testhelper.SetupRepo(t)
 }

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -96,6 +96,8 @@ func configNewGitRepository(t *testing.T) {
 	RunGit(t, "config", "user.email", "test@test-only.com")
 	RunGit(t, "config", "user.name", "Test Account")
 	RunGit(t, "config", "gc.auto", "0")
+	RunGit(t, "config", "commit.gpgSign", "false")
+	RunGit(t, "config", "tag.gpgSign", "false")
 	RunGit(t, "remote", "add", TestRemote, testRemoteURL)
 }
 


### PR DESCRIPTION
Explicitly configure commit.gpgSign and tag.gpgSign to false in temporary test repositories. This prevents tests from hanging or failing when run by users who have GPG signing enabled globally in their ~/.gitconfig.

Fixes: #7028