### PR TITLE
fix(internal/librarian/ruby): preserve existing version.rb file on regeneration

### DIFF
--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -78,15 +78,15 @@ func Clean(library *config.Library) error {
 	if !info.IsDir() {
 		return fmt.Errorf("%w: %q", errNotADirectory, dir)
 	}
-	keepSet := buildKeepSet(library.Keep)
+	keepSet := buildKeepSet(library.Name, library.Keep)
 	if err := cleanGeneratedRootFiles(dir, keepSet); err != nil {
 		return err
 	}
 	return cleanGeneratedDirectories(dir, keepSet)
 }
 
-// buildKeepSet builds a set of relative paths to keep from the given keep list.
-func buildKeepSet(keep []string) map[string]bool {
+// buildKeepSet builds a set of relative paths to keep from the given gem name and keep list.
+func buildKeepSet(gemName string, keep []string) map[string]bool {
 	keepSet := make(map[string]bool)
 	for _, keepPath := range keep {
 		cleaned := filepath.ToSlash(filepath.Clean(keepPath))
@@ -94,6 +94,10 @@ func buildKeepSet(keep []string) map[string]bool {
 	}
 	for _, file := range oneTimeGeneratedRootFiles {
 		keepSet[file] = true
+	}
+	if gemName != "" {
+		versionFile := "lib/" + strings.ReplaceAll(gemName, "-", "/") + "/version.rb"
+		keepSet[versionFile] = true
 	}
 	return keepSet
 }

--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -95,10 +95,8 @@ func buildKeepSet(gemName string, keep []string) map[string]bool {
 	for _, file := range oneTimeGeneratedRootFiles {
 		keepSet[file] = true
 	}
-	if gemName != "" {
-		versionFile := "lib/" + strings.ReplaceAll(gemName, "-", "/") + "/version.rb"
-		keepSet[versionFile] = true
-	}
+	versionFile := "lib/" + strings.ReplaceAll(gemName, "-", "/") + "/version.rb"
+	keepSet[versionFile] = true
 	return keepSet
 }
 

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -74,7 +74,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
-	keepSet := buildKeepSet(library.Keep)
+	keepSet := buildKeepSet(library.Name, library.Keep)
 	keepFunc := func(rel string) bool {
 		return isKept(rel, keepSet)
 	}

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -306,7 +306,8 @@ for arg in "$@"; do
   esac
 done
 if [ -n "$rubyCloudOut" ]; then
-  mkdir -p "$rubyCloudOut/lib/google/cloud/secret_manager"
+  mkdir -p "$rubyCloudOut/lib/google/cloud/secret_manager/v1"
+  touch "$rubyCloudOut/lib/google/cloud/secret_manager/v1/version.rb"
   touch "$rubyCloudOut/lib/google/cloud/secret_manager/v1.rb"
   touch "$rubyCloudOut/CHANGELOG.md"
   mkdir -p "$rubyCloudOut/snippets"
@@ -358,6 +359,23 @@ func TestGenerate(t *testing.T) {
 	if err := os.WriteFile(changelogPath, []byte(existingContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	versionPath := filepath.Join(outDir, "lib", "google", "cloud", "secret_manager", "v1", "version.rb")
+	if err := os.MkdirAll(filepath.Dir(versionPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const existingVersionContent = `module Google
+  module Cloud
+    module SecretManager
+      module V1
+        VERSION = "1.2.3"
+      end
+    end
+  end
+end
+`
+	if err := os.WriteFile(versionPath, []byte(existingVersionContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	library := &config.Library{
 		Name:    "google-cloud-secret_manager-v1",
 		Version: "1.2.3",
@@ -385,6 +403,13 @@ func TestGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(existingContent, string(gotChangelog)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+	gotVersion, err := os.ReadFile(versionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(existingVersionContent, string(gotVersion)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	snippetMetadataPath := filepath.Join(outDir, "snippets", "snippet_metadata_google.cloud.secretmanager.v1.json")


### PR DESCRIPTION
During `librarian generate`, `gapic-generator-ruby` outputs `version.rb` with a default initial version string. Add `version.rb` (`lib/<gem_path>/version.rb`) to `buildKeepSet` so that `MoveAndMergeWithKeep` preserves the existing `version.rb` file (which is managed by Release Please).

### How OwlBot Postprocessor Handled This

In legacy `owlbot-ruby`, OwlBot post-processing automatically registered the default modifier [`prevent_overwrite_of_existing_gem_version_file`](https://github.com/googleapis/ruby-common-tools/blob/627339bd54393ba09ec414d7f413f14091eeeaa6/owlbot-postprocessor/lib/owlbot/common_modifiers.rb#L169-L170):

```ruby
prevent_overwrite_of_existing "lib/#{@impl.gem_name.tr '-', '/'}/version.rb",
                              name: "prevent_overwrite_of_existing_gem_version_file"
```

Where [`prevent_overwrite_of_existing`](https://github.com/googleapis/ruby-common-tools/blob/627339bd54393ba09ec414d7f413f14091eeeaa6/owlbot-postprocessor/lib/owlbot/common_modifiers.rb#L130-L135) returned `dest || src`, preserving the existing `version.rb` in the target repository (`dest`) and discarding the newly generated staging file (`src`).

Fixes https://github.com/googleapis/librarian/issues/7031