### PR TITLE
test(internal/snippetmetadata): use SnippetMetadata in language generator tests

### DIFF
--- a/internal/librarian/golang/bump_test.go
+++ b/internal/librarian/golang/bump_test.go
@@ -15,6 +15,7 @@
 package golang
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/snippetmetadata"
 )
 
 func TestBump(t *testing.T) {
@@ -77,7 +79,7 @@ func TestBump(t *testing.T) {
 		{
 			name: "bump snippet metadata",
 			initialFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.1.0\"\n  }\n}\n",
+				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
 			},
 			library: &config.Library{
 				Name: "test-lib",
@@ -92,14 +94,14 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.2.0\"\n  }\n}",
+				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.2.0"),
 			},
 		},
 		{
 			name: "ignore nested module snippets",
 			initialFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json":        "{\n  \"clientLibrary\": {\n    \"version\": \"0.1.0\"\n  }\n}",
-				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.1.0\"\n  }\n}",
+				"test-lib/examples/apiv1/snippet_metadata_foo.json":        snippetMetadataFixture("0.1.0"),
+				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
 			},
 			library: &config.Library{
 				Name: "test-lib",
@@ -114,14 +116,14 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json":        "{\n  \"clientLibrary\": {\n    \"version\": \"0.2.0\"\n  }\n}",
-				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.1.0\"\n  }\n}",
+				"test-lib/examples/apiv1/snippet_metadata_foo.json":        snippetMetadataFixture("0.2.0"),
+				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
 			},
 		},
 		{
 			name: "module path version",
 			initialFiles: map[string]string{
-				"dataproc/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.1.0\"\n  }\n}",
+				"dataproc/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
 			},
 			library: &config.Library{
 				Name: "dataproc",
@@ -139,13 +141,13 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"dataproc/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.2.0\"\n  }\n}",
+				"dataproc/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.2.0"),
 			},
 		},
 		{
 			name: "library without Library.Go field for overrides",
 			initialFiles: map[string]string{
-				"secretmanager/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.1.0\"\n  }\n}",
+				"secretmanager/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
 				"secretmanager/internal/version.go":                      "package internal\n\nconst Version = \"0.1.0\"\n",
 			},
 			library: &config.Library{
@@ -158,7 +160,7 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"secretmanager/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.2.0\"\n  }\n}",
+				"secretmanager/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.2.0"),
 				"secretmanager/internal/version.go":                      "package internal\n\nconst Version = \"0.2.0\"\n",
 			},
 		},
@@ -256,7 +258,7 @@ func TestBump_Error(t *testing.T) {
 		{
 			name: "snippet metadata is read-only",
 			initialFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json": "{\n  \"clientLibrary\": {\n    \"version\": \"0.1.0\"\n  }\n}\n",
+				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
 			},
 			library: &config.Library{
 				Name: "test-lib",
@@ -321,4 +323,16 @@ func TestBump_Error(t *testing.T) {
 			}
 		})
 	}
+}
+
+func snippetMetadataFixture(version string) string {
+	content, err := json.MarshalIndent(snippetmetadata.SnippetMetadata{
+		ClientLibrary: snippetmetadata.ClientLibrary{
+			Version: version,
+		},
+	}, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(content)
 }

--- a/internal/librarian/golang/bump_test.go
+++ b/internal/librarian/golang/bump_test.go
@@ -79,7 +79,7 @@ func TestBump(t *testing.T) {
 		{
 			name: "bump snippet metadata",
 			initialFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
+				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.1.0"),
 			},
 			library: &config.Library{
 				Name: "test-lib",
@@ -94,14 +94,14 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.2.0"),
+				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.2.0"),
 			},
 		},
 		{
 			name: "ignore nested module snippets",
 			initialFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json":        snippetMetadataFixture("0.1.0"),
-				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
+				"test-lib/examples/apiv1/snippet_metadata_foo.json":        snippetMetadataFixture(t, "0.1.0"),
+				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.1.0"),
 			},
 			library: &config.Library{
 				Name: "test-lib",
@@ -116,14 +116,14 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json":        snippetMetadataFixture("0.2.0"),
-				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
+				"test-lib/examples/apiv1/snippet_metadata_foo.json":        snippetMetadataFixture(t, "0.2.0"),
+				"test-lib/nested/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.1.0"),
 			},
 		},
 		{
 			name: "module path version",
 			initialFiles: map[string]string{
-				"dataproc/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
+				"dataproc/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.1.0"),
 			},
 			library: &config.Library{
 				Name: "dataproc",
@@ -141,13 +141,13 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"dataproc/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.2.0"),
+				"dataproc/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.2.0"),
 			},
 		},
 		{
 			name: "library without Library.Go field for overrides",
 			initialFiles: map[string]string{
-				"secretmanager/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
+				"secretmanager/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.1.0"),
 				"secretmanager/internal/version.go":                      "package internal\n\nconst Version = \"0.1.0\"\n",
 			},
 			library: &config.Library{
@@ -160,7 +160,7 @@ func TestBump(t *testing.T) {
 			},
 			version: "0.2.0",
 			wantFiles: map[string]string{
-				"secretmanager/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.2.0"),
+				"secretmanager/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.2.0"),
 				"secretmanager/internal/version.go":                      "package internal\n\nconst Version = \"0.2.0\"\n",
 			},
 		},
@@ -258,7 +258,7 @@ func TestBump_Error(t *testing.T) {
 		{
 			name: "snippet metadata is read-only",
 			initialFiles: map[string]string{
-				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture("0.1.0"),
+				"test-lib/examples/apiv1/snippet_metadata_foo.json": snippetMetadataFixture(t, "0.1.0"),
 			},
 			library: &config.Library{
 				Name: "test-lib",
@@ -325,14 +325,15 @@ func TestBump_Error(t *testing.T) {
 	}
 }
 
-func snippetMetadataFixture(version string) string {
+func snippetMetadataFixture(t *testing.T, version string) string {
+	t.Helper()
 	content, err := json.MarshalIndent(snippetmetadata.SnippetMetadata{
 		ClientLibrary: snippetmetadata.ClientLibrary{
 			Version: version,
 		},
 	}, "", "  ")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	return string(content)
 }

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -978,31 +978,12 @@ func TestCopySamplesFromStaging(t *testing.T) {
 	outDir := t.TempDir()
 
 	for _, v := range []struct {
-		version       string
-		sampleContent string
-		metadata      snippetmetadata.SnippetMetadata
+		version         string
+		sampleContent   string
+		metadataContent string
 	}{
-		{
-			version:       "v1",
-			sampleContent: "console.log('v1');",
-			metadata: snippetmetadata.SnippetMetadata{
-				ClientLibrary: snippetmetadata.ClientLibrary{
-					Name:     "@google-cloud/test",
-					Version:  "1.0.0",
-					Language: "TYPESCRIPT",
-				},
-			},
-		},
-		{
-			version: "v1beta1",
-			metadata: snippetmetadata.SnippetMetadata{
-				ClientLibrary: snippetmetadata.ClientLibrary{
-					Name:     "@google-cloud/test",
-					Version:  "1.0.0",
-					Language: "TYPESCRIPT",
-				},
-			},
-		},
+		{version: "v1", sampleContent: "console.log('v1');", metadataContent: `{"snippets":[]}`},
+		{version: "v1beta1", metadataContent: `{"snippets":["beta"]}`},
 	} {
 		samplesDir := filepath.Join(stagingDir, v.version, "samples", "generated", v.version)
 		if err := os.MkdirAll(samplesDir, 0o755); err != nil {
@@ -1013,11 +994,7 @@ func TestCopySamplesFromStaging(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		metadataContent, err := json.Marshal(v.metadata)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(samplesDir, "snippet_metadata_google.cloud.test."+v.version+".json"), metadataContent, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(samplesDir, "snippet_metadata_google.cloud.test."+v.version+".json"), []byte(v.metadataContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1027,10 +1004,9 @@ func TestCopySamplesFromStaging(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name         string
-		path         string
-		want         string
-		wantMetadata *snippetmetadata.SnippetMetadata
+		name string
+		path string
+		want string
 	}{
 		{
 			name: "v1 sample file",
@@ -1040,24 +1016,12 @@ func TestCopySamplesFromStaging(t *testing.T) {
 		{
 			name: "v1 metadata",
 			path: filepath.Join(outDir, "samples", "generated", "v1", "snippet_metadata_google.cloud.test.v1.json"),
-			wantMetadata: &snippetmetadata.SnippetMetadata{
-				ClientLibrary: snippetmetadata.ClientLibrary{
-					Name:     "@google-cloud/test",
-					Version:  "1.0.0",
-					Language: "TYPESCRIPT",
-				},
-			},
+			want: `{"snippets":[]}`,
 		},
 		{
 			name: "v1beta1 metadata",
 			path: filepath.Join(outDir, "samples", "generated", "v1beta1", "snippet_metadata_google.cloud.test.v1beta1.json"),
-			wantMetadata: &snippetmetadata.SnippetMetadata{
-				ClientLibrary: snippetmetadata.ClientLibrary{
-					Name:     "@google-cloud/test",
-					Version:  "1.0.0",
-					Language: "TYPESCRIPT",
-				},
-			},
+			want: `{"snippets":["beta"]}`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -1065,16 +1029,14 @@ func TestCopySamplesFromStaging(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if test.wantMetadata != nil {
-				var gotMetadata snippetmetadata.SnippetMetadata
-				if err := json.Unmarshal(got, &gotMetadata); err != nil {
-					t.Fatal(err)
-				}
-				if diff := cmp.Diff(*test.wantMetadata, gotMetadata); diff != "" {
-					t.Errorf("mismatch (-want +got):\n%s", diff)
-				}
-			} else if diff := cmp.Diff(test.want, string(got)); diff != "" {
+			if diff := cmp.Diff(test.want, string(got)); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			if strings.HasSuffix(test.path, ".json") {
+				var metadata snippetmetadata.SnippetMetadata
+				if err := json.Unmarshal(got, &metadata); err != nil {
+					t.Errorf("error unmarshaling snippet metadata %s: %v", test.path, err)
+				}
 			}
 		})
 	}

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/repometadata"
 	"github.com/googleapis/librarian/internal/sample"
+	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
@@ -977,12 +978,31 @@ func TestCopySamplesFromStaging(t *testing.T) {
 	outDir := t.TempDir()
 
 	for _, v := range []struct {
-		version         string
-		sampleContent   string
-		metadataContent string
+		version       string
+		sampleContent string
+		metadata      snippetmetadata.SnippetMetadata
 	}{
-		{version: "v1", sampleContent: "console.log('v1');", metadataContent: `{"snippets":[]}`},
-		{version: "v1beta1", metadataContent: `{"snippets":["beta"]}`},
+		{
+			version:       "v1",
+			sampleContent: "console.log('v1');",
+			metadata: snippetmetadata.SnippetMetadata{
+				ClientLibrary: snippetmetadata.ClientLibrary{
+					Name:     "@google-cloud/test",
+					Version:  "1.0.0",
+					Language: "TYPESCRIPT",
+				},
+			},
+		},
+		{
+			version: "v1beta1",
+			metadata: snippetmetadata.SnippetMetadata{
+				ClientLibrary: snippetmetadata.ClientLibrary{
+					Name:     "@google-cloud/test",
+					Version:  "1.0.0",
+					Language: "TYPESCRIPT",
+				},
+			},
+		},
 	} {
 		samplesDir := filepath.Join(stagingDir, v.version, "samples", "generated", v.version)
 		if err := os.MkdirAll(samplesDir, 0o755); err != nil {
@@ -993,7 +1013,11 @@ func TestCopySamplesFromStaging(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err := os.WriteFile(filepath.Join(samplesDir, "snippet_metadata_google.cloud.test."+v.version+".json"), []byte(v.metadataContent), 0o644); err != nil {
+		metadataContent, err := json.Marshal(v.metadata)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(samplesDir, "snippet_metadata_google.cloud.test."+v.version+".json"), metadataContent, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1003,9 +1027,10 @@ func TestCopySamplesFromStaging(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name string
-		path string
-		want string
+		name         string
+		path         string
+		want         string
+		wantMetadata *snippetmetadata.SnippetMetadata
 	}{
 		{
 			name: "v1 sample file",
@@ -1015,12 +1040,24 @@ func TestCopySamplesFromStaging(t *testing.T) {
 		{
 			name: "v1 metadata",
 			path: filepath.Join(outDir, "samples", "generated", "v1", "snippet_metadata_google.cloud.test.v1.json"),
-			want: `{"snippets":[]}`,
+			wantMetadata: &snippetmetadata.SnippetMetadata{
+				ClientLibrary: snippetmetadata.ClientLibrary{
+					Name:     "@google-cloud/test",
+					Version:  "1.0.0",
+					Language: "TYPESCRIPT",
+				},
+			},
 		},
 		{
 			name: "v1beta1 metadata",
 			path: filepath.Join(outDir, "samples", "generated", "v1beta1", "snippet_metadata_google.cloud.test.v1beta1.json"),
-			want: `{"snippets":["beta"]}`,
+			wantMetadata: &snippetmetadata.SnippetMetadata{
+				ClientLibrary: snippetmetadata.ClientLibrary{
+					Name:     "@google-cloud/test",
+					Version:  "1.0.0",
+					Language: "TYPESCRIPT",
+				},
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -1028,7 +1065,15 @@ func TestCopySamplesFromStaging(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, string(got)); diff != "" {
+			if test.wantMetadata != nil {
+				var gotMetadata snippetmetadata.SnippetMetadata
+				if err := json.Unmarshal(got, &gotMetadata); err != nil {
+					t.Fatal(err)
+				}
+				if diff := cmp.Diff(*test.wantMetadata, gotMetadata); diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+			} else if diff := cmp.Diff(test.want, string(got)); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/librarian/python/bump_test.go
+++ b/internal/librarian/python/bump_test.go
@@ -15,6 +15,7 @@
 package python
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -83,6 +84,17 @@ func TestBump(t *testing.T) {
 		if diff := cmp.Diff(want, string(got)); diff != "" {
 			t.Errorf("mismatch in file %s (-want +got):\n%s", file, diff)
 		}
+	}
+	gotSnippetMetadata, err := os.ReadFile(filepath.Join(dir, "samples/generated_samples/snippet_metadata.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata snippetmetadata.SnippetMetadata
+	if err := json.Unmarshal(gotSnippetMetadata, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff("1.2.3", metadata.ClientLibrary.Version); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Use the exported snippetmetadata.SnippetMetadata struct for test fixtures
and version assertions in:
- internal/librarian/golang/bump_test.go
- internal/librarian/python/bump_test.go
- internal/librarian/nodejs/generate_test.go

Fixes https://github.com/googleapis/librarian/issues/7034