### PR TITLE
fix(internal/librarian/php): optimize generated file marker detection

### DIFF
--- a/internal/librarian/php/clean.go
+++ b/internal/librarian/php/clean.go
@@ -30,6 +30,9 @@ import (
 const (
 	gapicMetadataFile = "gapic_metadata.json"
 	phpExtension      = ".php"
+	// Limit reading to 50 lines. In google-cloud-php, markers are found early:
+	// line 2 for Protobuf files and line 19 for GAPIC files.
+	maxLinesToCheck = 50
 )
 
 var (
@@ -99,7 +102,7 @@ func cleanFiles(lib *config.Library, keepSet map[string]bool, subDir string) err
 		if !strings.HasSuffix(d.Name(), phpExtension) {
 			return nil
 		}
-		hasMarker, err := fileHasMarker(path, 50)
+		hasMarker, err := fileHasMarker(path)
 		if err != nil {
 			return err
 		}
@@ -111,15 +114,15 @@ func cleanFiles(lib *config.Library, keepSet map[string]bool, subDir string) err
 }
 
 // fileHasMarker checks if the file at path contains either gapicMarker or
-// protobufMarker within its first maxLines lines.
-func fileHasMarker(path string, maxLines int) (bool, error) {
+// protobufMarker within its first maxLinesToCheck lines.
+func fileHasMarker(path string) (bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return false, err
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
-	for i := 0; i < maxLines && scanner.Scan(); i++ {
+	for i := 0; i < maxLinesToCheck && scanner.Scan(); i++ {
 		line := scanner.Bytes()
 		if bytes.Contains(line, gapicMarker) || bytes.Contains(line, protobufMarker) {
 			return true, nil

--- a/internal/librarian/php/clean.go
+++ b/internal/librarian/php/clean.go
@@ -15,6 +15,7 @@
 package php
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"io/fs"
@@ -98,13 +99,31 @@ func cleanFiles(lib *config.Library, keepSet map[string]bool, subDir string) err
 		if !strings.HasSuffix(d.Name(), phpExtension) {
 			return nil
 		}
-		content, err := os.ReadFile(path)
+		hasMarker, err := fileHasMarker(path, 50)
 		if err != nil {
 			return err
 		}
-		if bytes.Contains(content, gapicMarker) || bytes.Contains(content, protobufMarker) {
+		if hasMarker {
 			return os.Remove(path)
 		}
 		return nil
 	})
+}
+
+// fileHasMarker checks if the file at path contains either gapicMarker or
+// protobufMarker within its first maxLines lines.
+func fileHasMarker(path string, maxLines int) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for i := 0; i < maxLines && scanner.Scan(); i++ {
+		line := scanner.Bytes()
+		if bytes.Contains(line, gapicMarker) || bytes.Contains(line, protobufMarker) {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
 }

--- a/internal/librarian/php/clean.go
+++ b/internal/librarian/php/clean.go
@@ -125,5 +125,10 @@ func fileHasMarker(path string, maxLines int) (bool, error) {
 			return true, nil
 		}
 	}
-	return false, scanner.Err()
+	err = scanner.Err()
+	// A line >64KB is likely not in a generated file. Skip instead of failing.
+	if errors.Is(err, bufio.ErrTooLong) {
+		return false, nil
+	}
+	return false, err
 }

--- a/internal/librarian/php/clean_test.go
+++ b/internal/librarian/php/clean_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -94,6 +95,20 @@ func TestClean(t *testing.T) {
 				"other/V1/ServiceClient.php": "<?php\n// " + string(gapicMarker) + "\nclass ServiceClient {}",
 			},
 			wantDeleted: nil, // 'other' is not in directoriesToClean
+		},
+		{
+			name: "php files with markers beyond limit are not deleted",
+			setupFiles: []string{
+				"src/V1/Client/DeepMarker.php",
+				"src/V1/Client/ShallowMarker.php",
+			},
+			contentMap: map[string]string{
+				"src/V1/Client/DeepMarker.php":    strings.Repeat("\n", 51) + "// " + string(gapicMarker),
+				"src/V1/Client/ShallowMarker.php": strings.Repeat("\n", 48) + "// " + string(gapicMarker),
+			},
+			wantDeleted: []string{
+				"src/V1/Client/ShallowMarker.php",
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/php/clean_test.go
+++ b/internal/librarian/php/clean_test.go
@@ -110,6 +110,16 @@ func TestClean(t *testing.T) {
 				"src/V1/Client/ShallowMarker.php",
 			},
 		},
+		{
+			name: "php files with extremely long lines do not cause failure",
+			setupFiles: []string{
+				"src/V1/LongLine.php",
+			},
+			contentMap: map[string]string{
+				"src/V1/LongLine.php": strings.Repeat("a", 65537) + "\n// " + string(gapicMarker),
+			},
+			wantDeleted: nil,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Marker detection in PHP files is optimized by only reading the first 50 lines of each file instead of loading the entire file content into memory. This reduces I/O and memory usage when cleaning up generated files in large repositories.

In reality from google-cloud-php, markers always appear line 2 for Protobuf files and line 19 for GAPIC files. A limit of 50 lines provides a safe margin.

Fixes #7017