### PR TITLE
test(internal/librarian/php): relax permission check in TestCreateBinWrapper

### DIFF
--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -332,8 +332,12 @@ func TestCreateBinWrapper(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if info.Mode().Perm() != 0o755 {
-				t.Errorf("wrapper permissions = %04o, want 0755", info.Mode().Perm())
+			perm := info.Mode().Perm()
+			if perm&0o700 != 0o700 {
+				t.Errorf("wrapper owner permissions = %04o, want at least 0700 (rwx)", perm&0o700)
+			}
+			if perm&0o022 != 0 {
+				t.Errorf("wrapper should not be writable by group/others: %04o", perm)
 			}
 		})
 	}

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -334,7 +334,7 @@ func TestCreateBinWrapper(t *testing.T) {
 			}
 			perm := info.Mode().Perm()
 			if perm&0o700 != 0o700 {
-				t.Errorf("wrapper owner permissions = %04o, want at least 0700 (rwx)", perm&0o700)
+				t.Errorf("wrapper permissions = %04o, want at least 0700 (rwx) for owner", perm)
 			}
 			if perm&0o022 != 0 {
 				t.Errorf("wrapper should not be writable by group/others: %04o", perm)


### PR DESCRIPTION
The permission check in TestCreateBinWrapper is relaxed to allow permissions restricted by umask.

Previously, the test strictly asserted that the created wrapper file permissions must be exactly 0755. This caused failures in environments with a restrictive umask (e.g., 0027, which results in 0750 permissions) even though the file was created correctly. The test now verifies that the owner has full permissions (read, write, execute) and that group and others do not have write access.

Fixes #7027