### PR TITLE
test(php): skip when `composer` is missing

### DIFF
--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/testhelper"
 )
 
 func TestInstallDir(t *testing.T) {
@@ -136,6 +137,7 @@ func TestInstall(t *testing.T) {
 }
 
 func TestInstall_Error(t *testing.T) {
+	testhelper.RequireCommand(t, "composer")
 	for _, test := range []struct {
 		name    string
 		tools   *config.Tools


### PR DESCRIPTION
One of the tests failed if `composer` was not installed. Skip the test instead.