### PR TITLE
feat(dart): export rpc exceptions

### DIFF
--- a/internal/sidekick/dart/templates/lib/main.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/main.dart.mustache
@@ -33,8 +33,8 @@ library;
 
 {{#Codec.HasServices}}
 export 'package:google_cloud_rpc/exceptions.dart';
-{{/Codec.HasServices}}
 
+{{/Codec.HasServices}}
 export 'src/api.g.dart' 
 {{#Codec.FakeList}}
 hide {{Codec.FakeList}}

--- a/internal/sidekick/dart/templates/lib/main.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/main.dart.mustache
@@ -31,6 +31,10 @@ library;
 // ignore_for_file: lines_longer_than_80_chars {{! TODO(#25): improve the generated dartdocs }}
 // ignore_for_file: unintended_html_in_doc_comment {{! TODO(#25): improve the generated dartdocs }}
 
+{{#Codec.HasServices}}
+export 'package:google_cloud_rpc/exceptions.dart';
+{{/Codec.HasServices}}
+
 export 'src/api.g.dart' 
 {{#Codec.FakeList}}
 hide {{Codec.FakeList}}


### PR DESCRIPTION
I asked gemini to generate a friction log when using a generated package and having to find where exceptions live was the biggest issue.