### PR TITLE
fix(sidekick/swift): modules and library name

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -76,6 +76,7 @@ func NewTestAPI(messages []*Message, enums []*Enum, services []*Service) *API {
 	return model
 }
 
+// WithPackageName changes the package name of an API instance.
 func (a *API) WithPackageName(name string) *API {
 	a.PackageName = name
 	return a

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -139,14 +139,9 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 	if err != nil {
 		return nil, err
 	}
-	libraryName, err := LibraryName(model)
-	if err != nil {
-		return nil, err
-	}
 	result := &codec{
 		Model:              model,
 		GenerationYear:     fmt.Sprintf("%04d", year),
-		LibraryName:        libraryName,
 		PackageName:        PackageName(model),
 		PackageVersion:     "0.0.0",
 		ReleaseLevel:       "preview",
@@ -191,6 +186,13 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 		default:
 			// Ignore other options.
 		}
+	}
+	if !result.Module {
+		libraryName, err := LibraryName(model)
+		if err != nil {
+			return nil, err
+		}
+		result.LibraryName = libraryName
 	}
 	return result, nil
 }

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -55,6 +55,51 @@ func TestParseOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "module",
+			cfg: &parser.ModelConfig{
+				Codec: map[string]string{
+					"copyright-year": "2038",
+					"module":         "true",
+					"module-path":    "GoogleTestProtos",
+				},
+			},
+			want: &codec{
+				Module:             true,
+				GenerationYear:     "2038",
+				PackageName:        "test",
+				PackageVersion:     "0.0.0",
+				ReleaseLevel:       "preview",
+				MonorepoRoot:       ".",
+				RootName:           "googleapis",
+				Model:              model,
+				ModulePath:         "GoogleTestProtos",
+				ApiPackages:        map[string]*Dependency{},
+				DependenciesByName: map[string]*Dependency{},
+			},
+		},
+		{
+			name: "module with local root",
+			cfg: &parser.ModelConfig{
+				Codec: map[string]string{
+					"copyright-year": "2038",
+					"module":         "true",
+					"root-name":      "Tests/ProtoJSON/protos",
+				},
+			},
+			want: &codec{
+				Module:             true,
+				GenerationYear:     "2038",
+				PackageName:        "test",
+				PackageVersion:     "0.0.0",
+				ReleaseLevel:       "preview",
+				MonorepoRoot:       ".",
+				RootName:           "Tests/ProtoJSON/protos",
+				Model:              model,
+				ApiPackages:        map[string]*Dependency{},
+				DependenciesByName: map[string]*Dependency{},
+			},
+		},
+		{
 			name: "discovery",
 			cfg: &parser.ModelConfig{
 				Codec: map[string]string{
@@ -208,8 +253,7 @@ func makeGatedTestModel() *api.API {
 		[]*api.Message{sharedMessage, s1Message, s2Message, unusedMessage},
 		[]*api.Enum{sharedEnum, s1Enum, s2Enum, unusedEnum},
 		[]*api.Service{s1, s2},
-	)
-	model.PackageName = "google.cloud.test.v1"
+	).WithPackageName("google.cloud.test.v1")
 	api.CrossReference(model)
 	return model
 }


### PR DESCRIPTION
I made a mistake when introducing library names: modules cannot have library names, so they should not try to set the value.

Towards #6229 