### PR TITLE
fix(sidekick/rust): support oneof fields in binding substitutions

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -76,6 +76,7 @@ func NewTestAPI(messages []*Message, enums []*Enum, services []*Service) *API {
 	return model
 }
 
+// WithPackageName changes the package name of an API instance.
 func (a *API) WithPackageName(name string) *API {
 	a.PackageName = name
 	return a

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -406,7 +406,9 @@ func makeAccessors(fields []string, m *api.Method) ([]string, error) {
 		if field == nil {
 			return nil, fmt.Errorf("invalid routing/path field (%q) for request message %s", rustFieldName, message.ID)
 		}
-		if field.Optional {
+		if field.IsOneOf {
+			accessors = append(accessors, fmt.Sprintf(".and_then(|m| m.%s())", rustFieldName))
+		} else if field.Optional {
 			accessors = append(accessors, fmt.Sprintf(".and_then(|m| m.%s.as_ref())", rustFieldName))
 		} else {
 			accessors = append(accessors, fmt.Sprintf(".map(|m| &m.%s)", rustFieldName))

--- a/internal/sidekick/rust/annotate_path_info_test.go
+++ b/internal/sidekick/rust/annotate_path_info_test.go
@@ -225,6 +225,14 @@ func TestPathBindingAnnotations(t *testing.T) {
 		Optional: true,
 	}
 
+	f_oneof := &api.Field{
+		Name:     "oneofField",
+		JSONName: "oneofField",
+		ID:       ".test.Request.oneofField",
+		Typez:    api.TypezString,
+		IsOneOf:  true,
+	}
+
 	request := &api.Message{
 		Name:    "Request",
 		Package: "test",
@@ -236,6 +244,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 			f_id,
 			f_optional,
 			f_child,
+			f_oneof,
 		},
 	}
 	response := &api.Message{
@@ -349,6 +358,24 @@ func TestPathBindingAnnotations(t *testing.T) {
 		PathFmt:     "/v2/foos",
 		QueryParams: []*api.Field{f_name, f_optional, f_child},
 	}
+	b4 := &api.PathBinding{
+		Verb: "POST",
+		PathTemplate: (&api.PathTemplate{}).
+			WithLiteral("v1").
+			WithLiteral("projects").
+			WithVariableNamed("oneofField").
+			WithVerb("actionOnOneof"),
+	}
+	want_b4 := &pathBindingAnnotation{
+		PathFmt: "/v1/projects/{}:actionOnOneof",
+		Substitutions: []*bindingSubstitution{
+			{
+				FieldAccessor: "Some(&req).and_then(|m| m.oneof_field()).map(|s| s.as_str())",
+				FieldName:     "oneof_field",
+				Template:      []string{"*"},
+			},
+		},
+	}
 	method := &api.Method{
 		Name:         "DoFoo",
 		ID:           ".test.Service.DoFoo",
@@ -356,7 +383,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 		InputTypeID:  ".test.Request",
 		OutputTypeID: ".test.Response",
 		PathInfo: &api.PathInfo{
-			Bindings: []*api.PathBinding{b0, b1, b2, b3},
+			Bindings: []*api.PathBinding{b0, b1, b2, b3, b4},
 		},
 	}
 	service := &api.Service{
@@ -385,6 +412,10 @@ func TestPathBindingAnnotations(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want_b3, b3.Codec); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(want_b4, b4.Codec); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Support oneof fields in a binding substitution.

The accessor for them returns on `Option<&T>`, so we need to chain that.

Here is the diff in `google-maps-geocode-v4`, which now builds clean:

https://github.com/dbolduc/google-cloud-rust/commit/da7ab7f99434cd8938bb530159ac8bc232ec99ba

cc: @noahdietz 

## Testing

The unit testing is fine. We at least verify that different code is produced for a oneof. But the real verification is that the code compiles.

I think ideally, we would want a gapic-showcase request with a oneof field to verify the code not only compiles, but is correct, but eh, I am too lazy for that.

Fixes #7045 