### PR TITLE
refactor(sidekick/swift): configure codec using structs

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -642,6 +642,7 @@ This document describes the schema for the librarian.yaml.
 | (embedded) | [SwiftDefault](#swiftdefault-configuration) |  |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]). |
 | `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, and output location. |
+| `package_name_override` | string | Overrides the package name. |
 | `per_service_traits` | bool | Enables per-service compile-time flags. |
 | `default_traits` | list of string | Is a list of compile-time traits enabled by default. |
 | `discovery` | SwiftDiscovery (optional) | Contains discovery-specific configuration for LRO polling. |

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -38,6 +38,9 @@ type SwiftPackage struct {
 	// Each module defines a source proto path, and output location.
 	Modules []*SwiftModule `yaml:"modules,omitempty"`
 
+	// PackageNameOverride overrides the package name.
+	PackageNameOverride string `yaml:"package_name_override,omitempty"`
+
 	// PerServiceTraits enables per-service compile-time flags.
 	PerServiceTraits bool `yaml:"per_service_traits,omitempty"`
 

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -39,6 +39,10 @@ type SwiftPackage struct {
 	Modules []*SwiftModule `yaml:"modules,omitempty"`
 
 	// PackageNameOverride overrides the package name.
+	//
+	// This may be useful if the protobuf package lacks the necessary prefixes,
+	// e.g. `grafeas.v1` may be published as `google-grafeas-v1` to match the
+	// other packages.
 	PackageNameOverride string `yaml:"package_name_override,omitempty"`
 
 	// PerServiceTraits enables per-service compile-time flags.

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -45,7 +45,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return err
 	}
-	return sidekickswift.Generate(ctx, model, library.Output, modelConfig, library.Swift)
+	return sidekickswift.Generate(ctx, model, library.Output, library, nil)
 }
 
 // Format formats a generated Swift library.
@@ -99,18 +99,12 @@ func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sour
 		specFormat = library.SpecificationFormat
 	}
 
-	releaseLevel := svcConfig.ReleaseLevel(config.LanguageSwift, library.Version)
 	modelCfg := &parser.ModelConfig{
 		Language:            config.LanguageSwift,
 		SpecificationFormat: specFormat,
 		ServiceConfig:       svcConfig.ServiceConfig,
 		SpecificationSource: apiCfg.Path,
 		Source:              sourceConfig,
-		Codec: map[string]string{
-			"copyright-year": library.CopyrightYear,
-			"version":        library.Version,
-			"release-level":  releaseLevel,
-		},
 	}
 	if library.Swift != nil && library.Swift.Discovery != nil {
 		pollers := make([]*api.Poller, len(library.Swift.Discovery.Pollers))

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -41,7 +41,7 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 			if err != nil {
 				return err
 			}
-			if err := sidekickswift.GenerateConversions(ctx, model, module.Output, modelConfig, library.Swift); err != nil {
+			if err := sidekickswift.GenerateConversions(ctx, model, module.Output, library, module); err != nil {
 				return err
 			}
 		case "", "default":
@@ -50,7 +50,7 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 			if err != nil {
 				return err
 			}
-			if err := sidekickswift.Generate(ctx, model, module.Output, modelConfig, library.Swift); err != nil {
+			if err := sidekickswift.Generate(ctx, model, module.Output, library, module); err != nil {
 				return err
 			}
 		default:
@@ -70,18 +70,9 @@ func moduleToModelConfig(library *config.Library, module *config.SwiftModule, sr
 		specFormat = library.SpecificationFormat
 	}
 
-	codecMap := map[string]string{
-		"copyright-year": library.CopyrightYear,
-		"module":         "true",
-	}
-	if module.ModulePath != "" {
-		codecMap["module-path"] = module.ModulePath
-	}
-
 	return &parser.ModelConfig{
 		SpecificationFormat: specFormat,
 		SpecificationSource: module.APIPath,
 		Source:              sourceConfig,
-		Codec:               codecMap,
 	}
 }

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -36,10 +36,9 @@ func TestGenerateModule(t *testing.T) {
 	}
 	outDir := t.TempDir()
 	library := &config.Library{
-		Name:          "GoogleTypeModule",
-		CopyrightYear: "2038",
-		Swift:         defaultSwiftConfig(t),
-		Output:        outDir,
+		Name:   "GoogleTypeModule",
+		Swift:  defaultSwiftConfig(t),
+		Output: outDir,
 	}
 	library.Swift.Modules = []*config.SwiftModule{
 		{
@@ -83,10 +82,9 @@ func TestGenerateModule_SwiftProtobuf(t *testing.T) {
 	}
 	outDir := t.TempDir()
 	library := &config.Library{
-		Name:          "GoogleTypeModule",
-		CopyrightYear: "2038",
-		Swift:         defaultSwiftConfig(t),
-		Output:        outDir,
+		Name:   "GoogleTypeModule",
+		Swift:  defaultSwiftConfig(t),
+		Output: outDir,
 	}
 	library.Swift.Modules = []*config.SwiftModule{
 		{
@@ -131,10 +129,6 @@ func TestModuleToModelConfig(t *testing.T) {
 					Sources:     &sources.Sources{},
 					ActiveRoots: []string{"googleapis"},
 				},
-				Codec: map[string]string{
-					"copyright-year": "",
-					"module":         "true",
-				},
 			},
 		},
 		{
@@ -153,10 +147,6 @@ func TestModuleToModelConfig(t *testing.T) {
 					ActiveRoots: []string{"googleapis"},
 					IncludeList: []string{"a.proto", "b.proto"},
 				},
-				Codec: map[string]string{
-					"copyright-year": "",
-					"module":         "true",
-				},
 			},
 		},
 		{
@@ -170,36 +160,11 @@ func TestModuleToModelConfig(t *testing.T) {
 					Sources:     &sources.Sources{},
 					ActiveRoots: []string{"googleapis"},
 				},
-				Codec: map[string]string{
-					"copyright-year": "",
-					"module":         "true",
-				},
-			},
-		},
-		{
-			name: "with copyright year",
-			lib: &config.Library{
-				CopyrightYear: "2038",
-				Swift:         &config.SwiftPackage{},
-			},
-			module: &config.SwiftModule{APIPath: "foo"},
-			want: &parser.ModelConfig{
-				SpecificationFormat: config.SpecProtobuf,
-				SpecificationSource: "foo",
-				Source: &sources.SourceConfig{
-					Sources:     &sources.Sources{},
-					ActiveRoots: []string{"googleapis"},
-				},
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"module":         "true",
-				},
 			},
 		},
 		{
 			name: "discovery",
 			lib: &config.Library{
-				CopyrightYear:       "2038",
 				Swift:               &config.SwiftPackage{},
 				SpecificationFormat: config.SpecDiscovery,
 				Roots:               []string{"discovery"},
@@ -211,10 +176,6 @@ func TestModuleToModelConfig(t *testing.T) {
 				Source: &sources.SourceConfig{
 					Sources:     &sources.Sources{},
 					ActiveRoots: []string{"discovery"},
-				},
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"module":         "true",
 				},
 			},
 		},
@@ -230,10 +191,9 @@ func TestModuleToModelConfig(t *testing.T) {
 
 func TestGenerateModule_UnsupportedModuleType(t *testing.T) {
 	library := &config.Library{
-		Name:          "UnsupportedModule",
-		CopyrightYear: "2038",
-		Swift:         defaultSwiftConfig(t),
-		Output:        t.TempDir(),
+		Name:   "UnsupportedModule",
+		Swift:  defaultSwiftConfig(t),
+		Output: t.TempDir(),
 	}
 	library.Swift.Modules = []*config.SwiftModule{
 		{
@@ -257,10 +217,9 @@ func TestGenerateModule_UnsupportedModuleType(t *testing.T) {
 
 func TestGenerateModule_NoProtos(t *testing.T) {
 	library := &config.Library{
-		Name:          "NoProtosModule",
-		CopyrightYear: "2038",
-		Swift:         defaultSwiftConfig(t),
-		Output:        t.TempDir(),
+		Name:   "NoProtosModule",
+		Swift:  defaultSwiftConfig(t),
+		Output: t.TempDir(),
 	}
 	googleapisDir := t.TempDir()
 	emptyAPIPath := "google/empty"

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -86,7 +86,6 @@ func TestGenerate(t *testing.T) {
 		{
 			Name:                "GoogleType",
 			APIs:                []*config.API{{Path: "google/type"}},
-			CopyrightYear:       "2038",
 			SpecificationFormat: config.SpecProtobuf,
 			Swift:               defaultSwiftConfig(t),
 		},
@@ -171,9 +170,8 @@ func TestLibraryToModelConfig(t *testing.T) {
 		{
 			name: "minimal config",
 			library: &config.Library{
-				Name:          "google-cloud-secretmanager",
-				CopyrightYear: "2038",
-				Version:       "1.2.3",
+				Name:    "google-cloud-secretmanager",
+				Version: "1.2.3",
 			},
 			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",
@@ -183,11 +181,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 				SpecificationFormat: config.SpecProtobuf,
 				SpecificationSource: "google/cloud/secretmanager/v1",
 				ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"release-level":  "stable",
-					"version":        "1.2.3",
-				},
 				Source: &sources.SourceConfig{
 					ActiveRoots: []string{"googleapis"},
 				},
@@ -196,9 +189,8 @@ func TestLibraryToModelConfig(t *testing.T) {
 		{
 			name: "minimal config preview",
 			library: &config.Library{
-				Name:          "google-cloud-secretmanager",
-				CopyrightYear: "2038",
-				Version:       "0.2.3",
+				Name:    "google-cloud-secretmanager",
+				Version: "0.2.3",
 			},
 			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",
@@ -208,11 +200,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 				SpecificationFormat: config.SpecProtobuf,
 				SpecificationSource: "google/cloud/secretmanager/v1",
 				ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"release-level":  "preview",
-					"version":        "0.2.3",
-				},
 				Source: &sources.SourceConfig{
 					ActiveRoots: []string{"googleapis"},
 				},
@@ -222,7 +209,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 			name: "explicit specification format",
 			library: &config.Library{
 				Name:                "google-cloud-secretmanager",
-				CopyrightYear:       "2038",
 				Version:             "1.2.3",
 				SpecificationFormat: config.SpecProtobuf,
 			},
@@ -234,11 +220,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 				SpecificationFormat: config.SpecProtobuf,
 				SpecificationSource: "google/cloud/secretmanager/v1",
 				ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"release-level":  "stable",
-					"version":        "1.2.3",
-				},
 				Source: &sources.SourceConfig{
 					ActiveRoots: []string{"googleapis"},
 				},
@@ -248,7 +229,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 			name: "discovery config",
 			library: &config.Library{
 				Name:                "google-cloud-compute-v1",
-				CopyrightYear:       "2038",
 				Version:             "1.2.3",
 				Roots:               []string{"discovery", "googleapis"},
 				SpecificationFormat: config.SpecDiscovery,
@@ -261,11 +241,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 				SpecificationFormat: config.SpecDiscovery,
 				SpecificationSource: "discoveries/compute.v1.json",
 				ServiceConfig:       "google/cloud/compute/v1/compute_v1.yaml",
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"release-level":  "stable",
-					"version":        "1.2.3",
-				},
 				Source: &sources.SourceConfig{
 					ActiveRoots: []string{"discovery", "googleapis"},
 				},
@@ -275,7 +250,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 			name: "discovery config with LRO",
 			library: &config.Library{
 				Name:                "google-cloud-compute-v1",
-				CopyrightYear:       "2038",
 				Version:             "1.2.3",
 				Roots:               []string{"discovery", "googleapis"},
 				SpecificationFormat: config.SpecDiscovery,
@@ -299,11 +273,6 @@ func TestLibraryToModelConfig(t *testing.T) {
 				SpecificationFormat: config.SpecDiscovery,
 				SpecificationSource: "discoveries/compute.v1.json",
 				ServiceConfig:       "google/cloud/compute/v1/compute_v1.yaml",
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"release-level":  "stable",
-					"version":        "1.2.3",
-				},
 				Source: &sources.SourceConfig{
 					ActiveRoots: []string{"discovery", "googleapis"},
 				},

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -98,7 +99,7 @@ func TestAnnotateEnum(t *testing.T) {
 				ev.Parent = enum
 			}
 			model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
@@ -117,7 +118,7 @@ func TestAnnotateEnum_Error(t *testing.T) {
 		Package: "test",
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{})
+	codec := newTestCodec(t, model, nil)
 
 	err := codec.annotateModel()
 	if err == nil {
@@ -188,9 +189,10 @@ func TestAnnotateEnum_ModulePath(t *testing.T) {
 		ev.Parent = enum
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{
-		"module-path": "TestProtos",
-	})
+	codec, err := newCodec(model, &config.Library{}, &config.SwiftModule{ModulePath: "TestProtos"}, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}
@@ -229,9 +231,10 @@ func TestAnnotateEnum_NestedModulePath(t *testing.T) {
 		ev.Parent = enum
 	}
 	model := api.NewTestAPI([]*api.Message{parent}, []*api.Enum{enum}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{
-		"module-path": "TestProtos",
-	})
+	codec, err := newCodec(model, &config.Library{}, &config.SwiftModule{ModulePath: "TestProtos"}, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/swift/annotate_enum_value_test.go
+++ b/internal/sidekick/swift/annotate_enum_value_test.go
@@ -28,7 +28,7 @@ func TestAnnotateEnumValue_WithDocs(t *testing.T) {
 	enum.UniqueNumberValues = enum.Values
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{})
+	codec := newTestCodec(t, model, nil)
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestAnnotateEnumValue_Multiple(t *testing.T) {
 	enum.UniqueNumberValues = enum.Values
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{})
+	codec := newTestCodec(t, model, nil)
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestAnnotateEnumValue_Aliases(t *testing.T) {
 	enum.UniqueNumberValues = []*api.EnumValue{enum.Values[0]}
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec := newTestCodec(t, model, map[string]string{})
+	codec := newTestCodec(t, model, nil)
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -81,7 +81,7 @@ func TestAnnotateField(t *testing.T) {
 			}
 			field.Parent = msg
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
@@ -197,7 +197,7 @@ func TestAnnotateField_Discovery(t *testing.T) {
 			test.input.Parent = msg
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 			model.AddMessage(mapMessage)
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			codec.UrlSafeForBytes = true
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
@@ -235,7 +235,7 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 			}
 			field.Parent = msg
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
@@ -277,7 +277,7 @@ func TestAnnotateField_PackageName(t *testing.T) {
 	field.Parent = msg
 	model := api.NewTestAPI([]*api.Message{msg, referencedMsg}, nil, nil)
 	model.PackageName = "test"
-	codec := newTestCodec(t, model, map[string]string{})
+	codec := newTestCodec(t, model, nil)
 	codec.withExtraDependencies(t, []config.SwiftDependency{
 		{
 			ApiPackage: "google.cloud.external.v1",
@@ -378,7 +378,7 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			}
 
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -168,7 +168,7 @@ func TestAnnotateMessage(t *testing.T) {
 				f.Parent = test.message
 			}
 			model := api.NewTestAPI([]*api.Message{test.message}, []*api.Enum{}, []*api.Service{})
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
@@ -312,7 +312,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 			}
 			model := api.NewTestAPI([]*api.Message{test.message}, []*api.Enum{}, []*api.Service{})
 			model.AddMessage(mapMessage)
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			codec.UrlSafeForBytes = true
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
@@ -372,7 +372,7 @@ func TestAnnotateMessage_DiscoveryRequests(t *testing.T) {
 			servicePlaceholder.Messages = append(servicePlaceholder.Messages, test.request)
 			model := api.NewTestAPI([]*api.Message{servicePlaceholder}, []*api.Enum{}, []*api.Service{test.service})
 			model.AddMessage(test.request)
-			codec := newTestCodec(t, model, map[string]string{})
+			codec := newTestCodec(t, model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/sidekick/swift/annotate_model.go
+++ b/internal/sidekick/swift/annotate_model.go
@@ -29,7 +29,6 @@ type modelAnnotations struct {
 	LibraryName      string
 	PackageName      string
 	PackageVersion   string
-	ReleaseLevel     string
 	MonorepoRoot     string
 	DependsOn        map[string]*Dependency
 	WktPackage       string
@@ -83,7 +82,6 @@ func (c *codec) annotateModel() error {
 		LibraryName:    c.LibraryName,
 		PackageName:    c.PackageName,
 		PackageVersion: c.PackageVersion,
-		ReleaseLevel:   c.ReleaseLevel,
 		MonorepoRoot:   c.MonorepoRoot,
 		DependsOn:      map[string]*Dependency{},
 		WktPackage:     wellKnownSwiftPackage,

--- a/internal/sidekick/swift/annotate_model_test.go
+++ b/internal/sidekick/swift/annotate_model_test.go
@@ -27,7 +27,7 @@ func TestModelAnnotations(t *testing.T) {
 	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{},
 		[]*api.Service{{Name: "Workflows", Package: "google.cloud.workflows.v1"}})
-	codec := newTestCodec(t, model, map[string]string{"copyright-year": "2038"})
+	codec := newTestCodec(t, model, &config.Library{CopyrightYear: "2038"})
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,6 @@ func TestModelAnnotations(t *testing.T) {
 		LibraryName:    "GoogleCloudWorkflowsV1",
 		PackageName:    "google-cloud-workflows-v1",
 		PackageVersion: "0.0.0",
-		ReleaseLevel:   "preview",
 		CopyrightYear:  "2038",
 		MonorepoRoot:   ".",
 		WktPackage:     "GoogleCloudWkt",
@@ -69,7 +68,7 @@ func TestModelAnnotations_MessagesWithWkt(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			codec := newTestCodec(t, test.model, map[string]string{})
+			codec := newTestCodec(t, test.model, nil)
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/sidekick/swift/annotate_oneof_test.go
+++ b/internal/sidekick/swift/annotate_oneof_test.go
@@ -34,7 +34,7 @@ func TestAnnotateOneOf(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{message}, nil, nil)
 	model.PackageName = "google.cloud.test.v1"
-	codec := newTestCodec(t, model, map[string]string{})
+	codec := newTestCodec(t, model, nil)
 	if err := codec.annotateModel(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -17,12 +17,10 @@ package swift
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 const (
@@ -66,18 +64,11 @@ type codec struct {
 	// The package version (e.g. "1.2.3").
 	PackageVersion string
 
-	// The release level (e.g. "preview" or "stable").
-	ReleaseLevel string
-
 	// The location of the monorepo, relative to the current directory.
 	//
 	// Recall that sidekick only generates clients within a monorepo, so this
 	// always makes sense.
 	MonorepoRoot string
-
-	// Most libraries are generated from `googleapis`. Rarely, we use protobuf,
-	// gapic-showcase, or a different root.
-	RootName string
 
 	// Modules have a different directory structure.
 	Module bool
@@ -122,7 +113,7 @@ type codec struct {
 	ModulePath string
 }
 
-func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPackage, outdir string) (*codec, error) {
+func newCodec(model *api.API, library *config.Library, module *config.SwiftModule, outdir string) (*codec, error) {
 	year, _, _ := time.Now().Date()
 	absOutdir, err := filepath.Abs(outdir)
 	if err != nil {
@@ -139,18 +130,37 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 	if err != nil {
 		return nil, err
 	}
+
+	generationYear := library.CopyrightYear
+	if generationYear == "" {
+		generationYear = fmt.Sprintf("%04d", year)
+	}
+
+	packageVersion := library.Version
+	if packageVersion == "" {
+		packageVersion = "0.0.0"
+	}
+
+	packageName := ""
+	if library.Swift != nil {
+		packageName = library.Swift.PackageNameOverride
+	}
+	if packageName == "" {
+		packageName = PackageName(model)
+	}
+
 	result := &codec{
 		Model:              model,
-		GenerationYear:     fmt.Sprintf("%04d", year),
-		PackageName:        PackageName(model),
-		PackageVersion:     "0.0.0",
-		ReleaseLevel:       "preview",
+		GenerationYear:     generationYear,
+		PackageName:        packageName,
+		PackageVersion:     packageVersion,
 		MonorepoRoot:       rel,
-		RootName:           "googleapis",
 		ApiPackages:        map[string]*Dependency{},
 		DependenciesByName: map[string]*Dependency{},
-		UrlSafeForBytes:    cfg.SpecificationFormat == config.SpecDiscovery,
+		UrlSafeForBytes:    library.SpecificationFormat == config.SpecDiscovery,
 	}
+
+	swiftCfg := library.Swift
 	if swiftCfg != nil {
 		for _, d := range swiftCfg.Dependencies {
 			dependency := Dependency{SwiftDependency: d}
@@ -163,30 +173,12 @@ func newCodec(model *api.API, cfg *parser.ModelConfig, swiftCfg *config.SwiftPac
 		result.PerServiceTraits = swiftCfg.PerServiceTraits
 		result.DefaultTraits = swiftCfg.DefaultTraits
 	}
-	for key, definition := range cfg.Codec {
-		switch key {
-		case "copyright-year":
-			result.GenerationYear = definition
-		case "version":
-			result.PackageVersion = definition
-		case "release-level":
-			result.ReleaseLevel = definition
-		case "package-name-override":
-			result.PackageName = definition
-		case "root-name":
-			result.RootName = definition
-		case "module":
-			value, err := strconv.ParseBool(definition)
-			if err != nil {
-				return nil, fmt.Errorf("cannot convert `module` value %q to boolean: %w", definition, err)
-			}
-			result.Module = value
-		case "module-path":
-			result.ModulePath = definition
-		default:
-			// Ignore other options.
-		}
+
+	if module != nil {
+		result.Module = true
+		result.ModulePath = module.ModulePath
 	}
+
 	if !result.Module {
 		libraryName, err := LibraryName(model)
 		if err != nil {

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -21,24 +21,39 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestParseOptions(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{}).
 		WithPackageName("test")
 	for _, test := range []struct {
-		name string
-		cfg  *parser.ModelConfig
-		want *codec
+		name    string
+		library *config.Library
+		module  *config.SwiftModule
+		want    *codec
 	}{
 		{
 			name: "baseline",
-			cfg: &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year":        "2038",
-					"package-name-override": "google-cloud-bigtable",
-					"root-name":             "test-root",
+			library: &config.Library{
+				CopyrightYear: "2038",
+			},
+			want: &codec{
+				GenerationYear:     "2038",
+				LibraryName:        "GoogleTest",
+				PackageName:        "test",
+				PackageVersion:     "0.0.0",
+				MonorepoRoot:       ".",
+				Model:              model,
+				ApiPackages:        map[string]*Dependency{},
+				DependenciesByName: map[string]*Dependency{},
+			},
+		},
+		{
+			name: "package name override",
+			library: &config.Library{
+				CopyrightYear: "2038",
+				Swift: &config.SwiftPackage{
+					PackageNameOverride: "google-cloud-bigtable",
 				},
 			},
 			want: &codec{
@@ -46,9 +61,7 @@ func TestParseOptions(t *testing.T) {
 				LibraryName:        "GoogleTest",
 				PackageName:        "google-cloud-bigtable",
 				PackageVersion:     "0.0.0",
-				ReleaseLevel:       "preview",
 				MonorepoRoot:       ".",
-				RootName:           "test-root",
 				Model:              model,
 				ApiPackages:        map[string]*Dependency{},
 				DependenciesByName: map[string]*Dependency{},
@@ -56,21 +69,18 @@ func TestParseOptions(t *testing.T) {
 		},
 		{
 			name: "module",
-			cfg: &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"module":         "true",
-					"module-path":    "GoogleTestProtos",
-				},
+			library: &config.Library{
+				CopyrightYear: "2038",
+			},
+			module: &config.SwiftModule{
+				ModulePath: "GoogleTestProtos",
 			},
 			want: &codec{
 				Module:             true,
 				GenerationYear:     "2038",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
-				ReleaseLevel:       "preview",
 				MonorepoRoot:       ".",
-				RootName:           "googleapis",
 				Model:              model,
 				ModulePath:         "GoogleTestProtos",
 				ApiPackages:        map[string]*Dependency{},
@@ -78,45 +88,17 @@ func TestParseOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "module with local root",
-			cfg: &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year": "2038",
-					"module":         "true",
-					"root-name":      "Tests/ProtoJSON/protos",
-				},
-			},
-			want: &codec{
-				Module:             true,
-				GenerationYear:     "2038",
-				PackageName:        "test",
-				PackageVersion:     "0.0.0",
-				ReleaseLevel:       "preview",
-				MonorepoRoot:       ".",
-				RootName:           "Tests/ProtoJSON/protos",
-				Model:              model,
-				ApiPackages:        map[string]*Dependency{},
-				DependenciesByName: map[string]*Dependency{},
-			},
-		},
-		{
 			name: "discovery",
-			cfg: &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year":        "2038",
-					"package-name-override": "google-cloud-compute-v1",
-					"root-name":             "test-root",
-				},
+			library: &config.Library{
+				CopyrightYear:       "2038",
 				SpecificationFormat: config.SpecDiscovery,
 			},
 			want: &codec{
 				GenerationYear:     "2038",
 				LibraryName:        "GoogleTest",
-				PackageName:        "google-cloud-compute-v1",
+				PackageName:        "test",
 				PackageVersion:     "0.0.0",
-				ReleaseLevel:       "preview",
 				MonorepoRoot:       ".",
-				RootName:           "test-root",
 				Model:              model,
 				ApiPackages:        map[string]*Dependency{},
 				DependenciesByName: map[string]*Dependency{},
@@ -125,7 +107,7 @@ func TestParseOptions(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := newCodec(model, test.cfg, nil, ".")
+			got, err := newCodec(model, test.library, test.module, ".")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -145,9 +127,11 @@ func TestNewCodec_WithSwiftCfg(t *testing.T) {
 			},
 		},
 	}
-	cfg := &parser.ModelConfig{}
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{}).WithPackageName("test")
-	got, err := newCodec(model, cfg, swiftCfg, ".")
+	got, err := newCodec(model, library, nil, ".")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,21 +153,23 @@ func TestNewCodec_WithSwiftCfg(t *testing.T) {
 }
 
 // newTestCodec creates a simple codec for the tests.
-func newTestCodec(t *testing.T, model *api.API, options map[string]string) *codec {
+func newTestCodec(t *testing.T, model *api.API, library *config.Library) *codec {
 	t.Helper()
-	cfg := &parser.ModelConfig{
-		Codec: options,
+	if library == nil {
+		library = &config.Library{}
 	}
-	// Configure the package for well-known types by default.
-	swiftCfg := &config.SwiftPackage{
-		SwiftDefault: config.SwiftDefault{
-			Dependencies: []config.SwiftDependency{
-				{Name: wellKnownSwiftPackage, ApiPackage: wellKnownProtobufPackage},
-				{Name: paginationSwiftPackage, RequiredByServices: true},
+	if library.Swift == nil {
+		// Configure the package for well-known types by default.
+		library.Swift = &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{Name: wellKnownSwiftPackage, ApiPackage: wellKnownProtobufPackage},
+					{Name: paginationSwiftPackage, RequiredByServices: true},
+				},
 			},
-		},
+		}
 	}
-	codec, err := newCodec(model, cfg, swiftCfg, ".")
+	codec, err := newCodec(model, library, nil, ".")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/swift/convert_proto_names_test.go
+++ b/internal/sidekick/swift/convert_proto_names_test.go
@@ -17,6 +17,7 @@ package swift
 import (
 	"testing"
 
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
@@ -48,7 +49,7 @@ func TestProtoMessageAndEnumTypeName(t *testing.T) {
 	model.PackageName = "test"
 
 	t.Run("with empty ModulePath", func(t *testing.T) {
-		codec := newTestCodec(t, model, map[string]string{})
+		codec := newTestCodec(t, model, nil)
 
 		gotMsg := codec.protoMessageTypeName(parentMsg)
 		wantMsg := "Test_OuterMessage"
@@ -76,9 +77,10 @@ func TestProtoMessageAndEnumTypeName(t *testing.T) {
 	})
 
 	t.Run("with populated ModulePath", func(t *testing.T) {
-		codec := newTestCodec(t, model, map[string]string{
-			"module-path": "TestProtos",
-		})
+		codec, err := newCodec(model, &config.Library{}, &config.SwiftModule{ModulePath: "TestProtos"}, ".")
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		gotMsg := codec.protoMessageTypeName(parentMsg)
 		wantMsg := "TestProtos.Test_OuterMessage"
@@ -128,7 +130,7 @@ func TestMessageAndEnumFileName(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{parentMsg, nestedMsg, doubleNestedMsg}, []*api.Enum{topEnum, nestedEnum}, []*api.Service{}).
 		WithPackageName("test")
-	codec := newTestCodec(t, model, map[string]string{})
+	codec := newTestCodec(t, model, nil)
 
 	t.Run("message conversion filenames", func(t *testing.T) {
 		gotParent := codec.messageFileName(parentMsg)

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -88,7 +88,7 @@ func TestFieldTypeName_BaseMessage(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{outer, simple}, nil, nil)
 	model.AddMessage(nested)
-	c := newTestCodec(t, model, map[string]string{})
+	c := newTestCodec(t, model, nil)
 
 	for _, test := range []struct {
 		name  string
@@ -148,7 +148,7 @@ func TestFieldTypeName_BaseEnum(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{outer}, []*api.Enum{simple}, nil)
 	model.AddEnum(nested)
-	c := newTestCodec(t, model, map[string]string{})
+	c := newTestCodec(t, model, nil)
 
 	for _, test := range []struct {
 		name  string
@@ -358,7 +358,7 @@ func TestFieldTypeName_Map(t *testing.T) {
 	model := api.NewTestAPI(nil, nil, nil)
 	model.PackageName = mapEntry.Package
 	model.AddMessage(mapEntry)
-	c := newTestCodec(t, model, map[string]string{})
+	c := newTestCodec(t, model, nil)
 
 	field := &api.Field{
 		Typez:   api.TypezMessage,

--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -25,15 +25,14 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/language"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 //go:embed all:templates
 var templates embed.FS
 
 // Generate generates code from the model.
-func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.ModelConfig, swiftCfg *config.SwiftPackage) error {
-	codec, err := newCodec(model, cfg, swiftCfg, outdir)
+func Generate(ctx context.Context, model *api.API, outdir string, library *config.Library, module *config.SwiftModule) error {
+	codec, err := newCodec(model, library, module, outdir)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/swift/generate_apiversion_test.go
+++ b/internal/sidekick/swift/generate_apiversion_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateService_APIVersion(t *testing.T) {
@@ -90,12 +89,14 @@ func TestGenerateService_APIVersion(t *testing.T) {
 			service := api.NewTestService("TestService").WithMethods(method)
 			model := api.NewTestAPI([]*api.Message{requestType, responseType}, nil, []*api.Service{service})
 			model.PackageName = "test"
-			cfg := &parser.ModelConfig{}
 			swiftCfg := swiftConfig(t, []config.SwiftDependency{
 				{Name: "GoogleCloudGax", RequiredByServices: true},
 			})
 
-			if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+			library := &config.Library{
+				Swift: swiftCfg,
+			}
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_conversions.go
+++ b/internal/sidekick/swift/generate_conversions.go
@@ -22,12 +22,11 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/language"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 // GenerateConversions generates the user-facing clean types and conversion mappings.
-func GenerateConversions(ctx context.Context, model *api.API, outdir string, cfg *parser.ModelConfig, swiftCfg *config.SwiftPackage) error {
-	codec, err := newCodec(model, cfg, swiftCfg, outdir)
+func GenerateConversions(ctx context.Context, model *api.API, outdir string, library *config.Library, module *config.SwiftModule) error {
+	codec, err := newCodec(model, library, module, outdir)
 	if err != nil {
 		return err
 	}

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateConversions_MissingModulePath(t *testing.T) {
@@ -30,9 +30,7 @@ func TestGenerateConversions_MissingModulePath(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{}
-
-	err := GenerateConversions(t.Context(), model, outDir, cfg, nil)
+	err := GenerateConversions(t.Context(), model, outDir, &config.Library{}, nil)
 	if err == nil {
 		t.Fatal("GenerateConversions expected error due to missing module-path, got nil")
 	}
@@ -75,15 +73,12 @@ func TestGenerateConversions_Message(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{folder}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.storage.control.v2"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-			"module-path":    "StorageControlProtos",
-			"module":         "true",
-		},
+	library := &config.Library{}
+	module := &config.SwiftModule{
+		ModulePath: "StorageControlProtos",
 	}
 
-	if err := GenerateConversions(t.Context(), model, outDir, cfg, nil); err != nil {
+	if err := GenerateConversions(t.Context(), model, outDir, library, module); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_deprecated_enum_test.go
+++ b/internal/sidekick/swift/generate_deprecated_enum_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateEnum_Deprecated(t *testing.T) {
@@ -84,8 +84,7 @@ func TestGenerateEnum_Deprecated(t *testing.T) {
 
 			model := api.NewTestAPI(nil, []*api.Enum{enum}, nil)
 			model.PackageName = "google.cloud.test.v1"
-			cfg := &parser.ModelConfig{}
-			if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+			if err := Generate(t.Context(), model, outDir, &config.Library{}, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_deprecated_field_test.go
+++ b/internal/sidekick/swift/generate_deprecated_field_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateField_Deprecated(t *testing.T) {
@@ -75,8 +75,7 @@ func TestGenerateField_Deprecated(t *testing.T) {
 
 			model := api.NewTestAPI([]*api.Message{msg}, nil, nil)
 			model.PackageName = "google.cloud.test.v1"
-			cfg := &parser.ModelConfig{}
-			if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+			if err := Generate(t.Context(), model, outDir, &config.Library{}, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_deprecated_message_test.go
+++ b/internal/sidekick/swift/generate_deprecated_message_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateMessage_Deprecated(t *testing.T) {
@@ -83,8 +83,7 @@ func TestGenerateMessage_Deprecated(t *testing.T) {
 
 			model := api.NewTestAPI([]*api.Message{top}, nil, nil)
 			model.PackageName = "google.cloud.test.v1"
-			cfg := &parser.ModelConfig{}
-			if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+			if err := Generate(t.Context(), model, outDir, &config.Library{}, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_deprecated_method_test.go
+++ b/internal/sidekick/swift/generate_deprecated_method_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 type expectedBlock struct {
@@ -188,12 +187,6 @@ func TestGenerateService_DeprecatedMethods(t *testing.T) {
 			}, nil, []*api.Service{service})
 			model.PackageName = "test"
 
-			cfg := &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year": "2038",
-				},
-			}
-
 			swiftCfg := swiftConfig(t, []config.SwiftDependency{
 				{Name: "GoogleCloudGax", RequiredByServices: true},
 				{Name: "GoogleCloudAuth", RequiredByServices: true},
@@ -201,7 +194,11 @@ func TestGenerateService_DeprecatedMethods(t *testing.T) {
 				{ApiPackage: "google.rpc", Name: "GoogleRpc"},
 			})
 
-			if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+			library := &config.Library{
+				Swift: swiftCfg,
+			}
+
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_deprecated_oneof_test.go
+++ b/internal/sidekick/swift/generate_deprecated_oneof_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateOneOf_Deprecated(t *testing.T) {
@@ -90,8 +90,7 @@ func TestGenerateOneOf_Deprecated(t *testing.T) {
 
 			model := api.NewTestAPI([]*api.Message{msg, inner}, nil, nil)
 			model.PackageName = "google.cloud.test.v1"
-			cfg := &parser.ModelConfig{}
-			if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+			if err := Generate(t.Context(), model, outDir, &config.Library{}, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_deprecated_service_test.go
+++ b/internal/sidekick/swift/generate_deprecated_service_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateService_Deprecated(t *testing.T) {
@@ -56,8 +56,10 @@ func TestGenerateService_Deprecated(t *testing.T) {
 
 			model := api.NewTestAPI(nil, nil, []*api.Service{service})
 			model.PackageName = "test"
-			cfg := &parser.ModelConfig{}
-			if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+			library := &config.Library{
+				Swift: swiftConfig(t, nil),
+			}
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_enum_swift_test.go
+++ b/internal/sidekick/swift/generate_enum_swift_test.go
@@ -15,13 +15,14 @@
 package swift
 
 import (
+	"github.com/googleapis/librarian/internal/config"
+
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateEnum_Files(t *testing.T) {
@@ -44,8 +45,8 @@ func TestGenerateEnum_Files(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{color, kind, clash0, clash1}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{}
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	library := &config.Library{}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,8 +78,8 @@ func TestGenerateEnum_UniqueNumbers(t *testing.T) {
 
 	model := api.NewTestAPI(nil, []*api.Enum{kind}, nil)
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{}
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	library := &config.Library{}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,8 +124,8 @@ func TestGenerateEnum_DocComments(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{color}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{}
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	library := &config.Library{}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_field_swift_test.go
+++ b/internal/sidekick/swift/generate_field_swift_test.go
@@ -15,13 +15,14 @@
 package swift
 
 import (
+	"github.com/googleapis/librarian/internal/config"
+
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateField_InitFromDecoder(t *testing.T) {
@@ -56,13 +57,10 @@ func TestGenerateField_InitFromDecoder(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,9 +121,9 @@ func TestGenerateField_DocComments(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{}
 
-	if err := Generate(t.Context(), model, outDir, cfg, nil); err != nil {
+	library := &config.Library{}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_message_swift_test.go
+++ b/internal/sidekick/swift/generate_message_swift_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func swiftConfig(t *testing.T, extraDependencies []config.SwiftDependency) *config.SwiftPackage {
@@ -51,13 +50,10 @@ func TestGenerateMessage_Files(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{secret, volume, clash0, clash1, clash2}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -92,13 +88,10 @@ func TestGenerateMessage_WithNestedMessages(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{withNested}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -165,13 +158,10 @@ func TestGenerateMessage_WithNestedEnum(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{withNested}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -221,12 +211,6 @@ func TestGenerateMessage_WithExternalImports(t *testing.T) {
 	model.PackageName = "google.cloud.test.v1"
 	model.AddMessage(externalMessage)
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := swiftConfig(t, []config.SwiftDependency{
 		{
 			ApiPackage: "google.cloud.external.v1",
@@ -238,7 +222,10 @@ func TestGenerateMessage_WithExternalImports(t *testing.T) {
 		},
 	})
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -300,13 +287,10 @@ func TestGenerateMessage_WithRecursiveTypes(t *testing.T) {
 	// Run LabelRecursiveFields to mark recursive fields
 	api.LabelRecursiveFields(model)
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -356,13 +340,10 @@ func TestGenerateMessage_SelfRecursive(t *testing.T) {
 	// Run LabelRecursiveFields to mark recursive fields
 	api.LabelRecursiveFields(model)
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -443,13 +424,10 @@ func TestGenerateMessage_RecursiveChain(t *testing.T) {
 	// Run LabelRecursiveFields to mark recursive fields
 	api.LabelRecursiveFields(model)
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -524,9 +502,11 @@ func TestGenerateMessage_DocComments(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{}
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_method_signatures_test.go
+++ b/internal/sidekick/swift/generate_method_signatures_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateService_MethodSignatures(t *testing.T) {
@@ -167,7 +166,6 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
 			model := newModelWithSignatures(t)
-			cfg := &parser.ModelConfig{}
 			swiftCfg := swiftConfig(t, []config.SwiftDependency{
 				{Name: "GoogleCloudGax", RequiredByServices: true},
 				{Name: "GoogleCloudAuth", RequiredByServices: true},
@@ -175,7 +173,10 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 				{ApiPackage: "google.rpc", Name: "GoogleRpc"},
 			})
 
-			if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+			library := &config.Library{
+				Swift: swiftCfg,
+			}
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_oneof_test.go
+++ b/internal/sidekick/swift/generate_oneof_test.go
@@ -15,6 +15,8 @@
 package swift
 
 import (
+	"github.com/googleapis/librarian/internal/config"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +24,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateOneOf(t *testing.T) {
@@ -84,8 +85,10 @@ func TestGenerateOneOf(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{outer, inner}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{}
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -251,8 +254,10 @@ func TestGenerateOneOfWithKeyword(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{jwtLocation}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "google.api"
-	cfg := &parser.ModelConfig{}
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_package_swift_test.go
+++ b/internal/sidekick/swift/generate_package_swift_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGeneratePackageSwift_WithDependencies(t *testing.T) {
@@ -39,12 +38,6 @@ func TestGeneratePackageSwift_WithDependencies(t *testing.T) {
 	model := api.NewTestAPI(nil, nil, []*api.Service{service})
 	model.PackageName = "google.cloud.workflows.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := &config.SwiftPackage{
 		SwiftDefault: config.SwiftDefault{
 			Dependencies: []config.SwiftDependency{
@@ -55,7 +48,10 @@ func TestGeneratePackageSwift_WithDependencies(t *testing.T) {
 		},
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_pagination_swift_test.go
+++ b/internal/sidekick/swift/generate_pagination_swift_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateService_MapPagination(t *testing.T) {
@@ -118,12 +117,6 @@ func TestGenerateService_MapPagination(t *testing.T) {
 			model := api.NewTestAPI([]*api.Message{inputType, outputType, secretType, mapEntryType}, nil, []*api.Service{iam})
 			model.PackageName = "google.cloud.secretmanager.v1"
 
-			cfg := &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year": "2038",
-				},
-			}
-
 			swiftCfg := swiftConfig(t, []config.SwiftDependency{
 				{
 					Name:               "GoogleCloudGax",
@@ -135,7 +128,10 @@ func TestGenerateService_MapPagination(t *testing.T) {
 				},
 			})
 
-			if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+			library := &config.Library{
+				Swift: swiftCfg,
+			}
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/sidekick/swift/generate_service_comments_test.go
+++ b/internal/sidekick/swift/generate_service_comments_test.go
@@ -15,13 +15,14 @@
 package swift
 
 import (
+	"github.com/googleapis/librarian/internal/config"
+
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateService_DocComments(t *testing.T) {
@@ -79,9 +80,11 @@ func TestGenerateService_DocComments(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{req, res}, []*api.Enum{}, []*api.Service{service})
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{}
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -41,13 +41,8 @@ func TestGenerateService_Files(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{clash0}, nil, []*api.Service{iam, secretManager, clash1})
 	model.PackageName = "test"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	library := &config.Library{Swift: swiftConfig(t, nil)}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -82,13 +77,10 @@ func TestGenerateServiceSwift_SnippetReference(t *testing.T) {
 	model := api.NewTestAPI(nil, nil, []*api.Service{service})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,19 +140,16 @@ func TestGenerateService_Delegation(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{request, response}, nil, []*api.Service{iam})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := swiftConfig(t, []config.SwiftDependency{
 		{
 			Name:       "SomeTestPackage",
 			ApiPackage: "test",
 		},
 	})
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -215,13 +204,10 @@ func TestGenerateService_SnippetFiles(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{dummyMessage}, nil, []*api.Service{iam, secretManager})
 	model.PackageName = packageName
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
+	library := &config.Library{
+		Swift: swiftConfig(t, nil),
 	}
-
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -280,12 +266,6 @@ func TestGenerateService_WithImports(t *testing.T) {
 	model.PackageName = "google.cloud.test.v1"
 	model.AddMessage(externalMessage)
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := swiftConfig(t, []config.SwiftDependency{
 		{
 			Name:               "GoogleCloudGax",
@@ -301,7 +281,10 @@ func TestGenerateService_WithImports(t *testing.T) {
 		},
 	})
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -433,13 +416,10 @@ func TestGenerateService_PathParameters(t *testing.T) {
 			model := api.NewTestAPI([]*api.Message{requestMessage, secretMessage}, nil, []*api.Service{iam})
 			model.PackageName = "google.cloud.secretmanager.v1"
 
-			cfg := &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year": "2038",
-				},
+			library := &config.Library{
+				Swift: swiftConfig(t, nil),
 			}
-
-			if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -538,12 +518,6 @@ func TestGenerateService_Pagination(t *testing.T) {
 			model := api.NewTestAPI([]*api.Message{inputType, outputType, secretType}, nil, []*api.Service{iam})
 			model.PackageName = "google.cloud.secretmanager.v1"
 
-			cfg := &parser.ModelConfig{
-				Codec: map[string]string{
-					"copyright-year": "2038",
-				},
-			}
-
 			swiftCfg := swiftConfig(t, []config.SwiftDependency{
 				{
 					Name:               "GoogleCloudGax",
@@ -555,7 +529,10 @@ func TestGenerateService_Pagination(t *testing.T) {
 				},
 			})
 
-			if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+			library := &config.Library{
+				Swift: swiftCfg,
+			}
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -735,12 +712,6 @@ func TestGenerateService_LRO(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{inputType, workflowType, metadataType, operationType, getOperationInputType}, nil, []*api.Service{workflows})
 	model.PackageName = "google.cloud.workflows.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := swiftConfig(t, []config.SwiftDependency{
 		{
 			Name:               "GoogleCloudGax",
@@ -760,7 +731,10 @@ func TestGenerateService_LRO(t *testing.T) {
 		},
 	})
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -852,12 +826,6 @@ func TestGenerateService_LRO_Empty(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{inputType, metadataType, operationType, getOperationInputType}, nil, []*api.Service{workflows})
 	model.PackageName = "google.cloud.workflows.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := swiftConfig(t, []config.SwiftDependency{
 		{
 			Name:               "GoogleCloudGax",
@@ -877,7 +845,10 @@ func TestGenerateService_LRO_Empty(t *testing.T) {
 		},
 	})
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -910,16 +881,17 @@ func TestGenerateDiscoveryService_Files(t *testing.T) {
 		SpecificationFormat: config.SpecDiscovery,
 		ServiceConfig:       filepath.Join(testdataDir, "googleapis/google/cloud/compute/v1/small-compute_v1.yaml"),
 		SpecificationSource: filepath.Join(testdataDir, "discovery/small-compute.v1.json"),
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
 	}
 	model, err := parser.CreateModel(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	library := &config.Library{
+		SpecificationFormat: config.SpecDiscovery,
+		Swift:               swiftConfig(t, nil),
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_service_telemetry_test.go
+++ b/internal/sidekick/swift/generate_service_telemetry_test.go
@@ -15,13 +15,14 @@
 package swift
 
 import (
+	"github.com/googleapis/librarian/internal/config"
+
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateService_Telemetry(t *testing.T) {
@@ -58,12 +59,11 @@ func TestGenerateService_Telemetry(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{req, res}, []*api.Enum{}, []*api.Service{service})
 	model.PackageName = "google.cloud.test.v1"
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"version": "1.2.3-preview",
-		},
+	library := &config.Library{
+		Version: "1.2.3-preview",
+		Swift:   swiftConfig(t, nil),
 	}
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 	checkClientsContents(t, outDir)

--- a/internal/sidekick/swift/generate_snippets_test.go
+++ b/internal/sidekick/swift/generate_snippets_test.go
@@ -15,13 +15,14 @@
 package swift
 
 import (
+	"github.com/googleapis/librarian/internal/config"
+
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateSnippets(t *testing.T) {
@@ -120,8 +121,10 @@ func TestGenerateSnippets(t *testing.T) {
 			if err := api.CrossReference(model); err != nil {
 				t.Fatal(err)
 			}
-			cfg := &parser.ModelConfig{}
-			if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+			library := &config.Library{
+				Swift: swiftConfig(t, nil),
+			}
+			if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 				t.Fatal(err)
 			}
 			contentsBytes, err := os.ReadFile(filepath.Join(outDir, "Snippets", test.file))

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
 func TestGenerateService_StubStructure(t *testing.T) {
@@ -60,19 +59,16 @@ func TestGenerateService_StubStructure(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{request, response}, nil, []*api.Service{service})
 	model.PackageName = "google.cloud.test.v1"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := swiftConfig(t, []config.SwiftDependency{
 		{
 			Name:       "SomeTestPackage",
 			ApiPackage: "test",
 		},
 	})
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -179,14 +175,11 @@ func TestGenerateService_QueryParameters(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{request, response}, nil, []*api.Service{service})
 	model.PackageName = "test"
 
-	cfg := &parser.ModelConfig{
-		Codec: map[string]string{
-			"copyright-year": "2038",
-		},
-	}
-
 	swiftCfg := swiftConfig(t, []config.SwiftDependency{})
-	if err := Generate(t.Context(), model, outDir, cfg, swiftCfg); err != nil {
+	library := &config.Library{
+		Swift: swiftCfg,
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sidekick/swift/generate_test.go
+++ b/internal/sidekick/swift/generate_test.go
@@ -58,7 +58,12 @@ func TestFromProtobuf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Generate(t.Context(), model, outDir, cfg, swiftConfig(t, nil)); err != nil {
+	library := &config.Library{
+		Version:             "0.1.0",
+		SpecificationFormat: config.SpecProtobuf,
+		Swift:               swiftConfig(t, nil),
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 		t.Fatal(err)
 	}
 	filename := filepath.Join(outDir, "README.md")


### PR DESCRIPTION
For historical reasons the `Swift` codec was receiving some configuration parameters via the `Codec` map, and some configuration parameters via structures in the `config.*` package.

With this change we stop using the `Codec` map. Less parsing and conversions this way.

A lot of the tests were setting the `copyright-year` parameter, but it was not needed, so I removed it too.

Towards #6229 