### PR TITLE
fix(internal/librarian): relax unique API path validation for Ruby

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -173,7 +173,9 @@ func validateLibraries(cfg *config.Config) error {
 		}
 	}
 	for path, count := range pathCount {
-		if count > 1 {
+		// Relax unique API path validation for Ruby because wrapper libraries share
+		// API paths with the versioned libraries they wrap.
+		if count > 1 && cfg.Language != config.LanguageRuby {
 			errs = append(errs, fmt.Errorf("%w: %s (appears %d times)", errDuplicateAPIPath, path, count))
 		}
 	}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -81,6 +81,21 @@ func TestValidateLibraries(t *testing.T) {
 			language: config.LanguagePython,
 			wantErr:  errDuplicateAPIPath,
 		},
+		{
+			name: "allowed duplicate api paths for ruby",
+			libraries: []*config.Library{
+				{
+					Name: "google-cloud-example",
+					APIs: []*config.API{{Path: "google/cloud/example/v1"}},
+
+				},
+				{
+					Name: "google-cloud-example-v1",
+					APIs: []*config.API{{Path: "google/cloud/example/v1"}},
+				},
+			},
+			language: config.LanguageRuby,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := &config.Config{

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -87,7 +87,6 @@ func TestValidateLibraries(t *testing.T) {
 				{
 					Name: "google-cloud-example",
 					APIs: []*config.API{{Path: "google/cloud/example/v1"}},
-
 				},
 				{
 					Name: "google-cloud-example-v1",


### PR DESCRIPTION
Unique API path validation is relaxed during configuration tidy validation for Ruby client libraries. In Ruby client library configurations, unversioned wrapper libraries share the same versioned API path with the underlying versioned libraries they wrap.

Fixes https://github.com/googleapis/librarian/issues/7054
For #6632
