### PR TITLE
fix(sidekick/swift): docc warnings in generated code

### DIFF
--- a/internal/sidekick/swift/generate_enum_swift_test.go
+++ b/internal/sidekick/swift/generate_enum_swift_test.go
@@ -89,7 +89,7 @@ func TestGenerateEnum_UniqueNumbers(t *testing.T) {
 	got := extractBlock(t, string(contentsB), "/// Initialize from an integer value.", "\n  }")
 	want := `/// Initialize from an integer value.
   ///
-  /// If the value is unknown, this initializes to ` + "``.unknownIntValue(_:)``." + `
+  /// If the value is unknown, this initializes to ` + "[`unknownIntValue`](doc:Kind/unknownIntValue(_:))." + `
   public init(intValue: Int) {
     switch intValue {
     case 0: self = .test

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -74,7 +74,7 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
 
   /// Initialize from a string value.
   ///
-  /// If the value is unknown, this initializes to [{{Codec.UnknownStringName}}](doc:{{Codec.Name}}/{{Codec.UnknownStringName}}(_:)).
+  /// If the value is unknown, this initializes to [`{{Codec.UnknownStringName}}`](doc:{{Codec.Name}}/{{Codec.UnknownStringName}}(_:)).
   public init(stringValue: Swift.String) {
     switch stringValue {
     {{#Values}}
@@ -86,7 +86,7 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
 
   /// Initialize from an integer value.
   ///
-  /// If the value is unknown, this initializes to [{{Codec.UnknownIntName}}](doc:{{Codec.Name}}/{{Codec.UnknownIntName}}(_:)).
+  /// If the value is unknown, this initializes to [`{{Codec.UnknownIntName}}`](doc:{{Codec.Name}}/{{Codec.UnknownIntName}}(_:)).
   public init(intValue: Int) {
     switch intValue {
     {{#UniqueNumberValues}}

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -74,7 +74,7 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
 
   /// Initialize from a string value.
   ///
-  /// If the value is unknown, this initializes to ``.{{Codec.UnknownStringName}}(_:)``.
+  /// If the value is unknown, this initializes to [{{Codec.UnknownStringName}}](doc:{{Codec.Name}}/{{Codec.UnknownStringName}}(_:)).
   public init(stringValue: Swift.String) {
     switch stringValue {
     {{#Values}}
@@ -86,7 +86,7 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
 
   /// Initialize from an integer value.
   ///
-  /// If the value is unknown, this initializes to ``.{{Codec.UnknownIntName}}(_:)``.
+  /// If the value is unknown, this initializes to [{{Codec.UnknownIntName}}](doc:{{Codec.Name}}/{{Codec.UnknownIntName}}(_:)).
   public init(intValue: Int) {
     switch intValue {
     {{#UniqueNumberValues}}


### PR DESCRIPTION
Fix the cross-reference links in enums, they were not working as I expected.

Towards googleapis/google-cloud-swift#12 