### PR TITLE
test(internal/librarian): separate TestValidateLibraries success and error

### DIFF
--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -33,7 +33,6 @@ func TestValidateLibraries(t *testing.T) {
 		name      string
 		libraries []*config.Library
 		language  string
-		wantErr   error
 	}{
 		{
 			name: "valid libraries",
@@ -41,14 +40,6 @@ func TestValidateLibraries(t *testing.T) {
 				{Name: "google-cloud-secretmanager-v1"},
 				{Name: "google-cloud-storage-v1"},
 			},
-		},
-		{
-			name: "duplicate library names",
-			libraries: []*config.Library{
-				{Name: "google-cloud-secretmanager-v1"},
-				{Name: "google-cloud-secretmanager-v1"},
-			},
-			wantErr: errDuplicateLibraryName,
 		},
 		{
 			name: "skipped duplicate api paths",
@@ -65,21 +56,6 @@ func TestValidateLibraries(t *testing.T) {
 				},
 			},
 			language: config.LanguageJava,
-		},
-		{
-			name: "duplicate api paths not skipped for non-java",
-			libraries: []*config.Library{
-				{
-					Name: "lib1",
-					APIs: []*config.API{{Path: "google/iam/v1"}},
-				},
-				{
-					Name: "lib2",
-					APIs: []*config.API{{Path: "google/iam/v1"}},
-				},
-			},
-			language: config.LanguagePython,
-			wantErr:  errDuplicateAPIPath,
 		},
 		{
 			name: "allowed duplicate api paths for ruby",
@@ -108,16 +84,57 @@ func TestValidateLibraries(t *testing.T) {
 					},
 				}
 			}
-			err := validateLibraries(cfg)
-			if test.wantErr == nil {
-				if err != nil {
-					t.Fatal(err)
+			if err := validateLibraries(cfg); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateLibraries_Error(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		libraries []*config.Library
+		language  string
+		wantErr   error
+	}{
+		{
+			name: "duplicate library names",
+			libraries: []*config.Library{
+				{Name: "google-cloud-secretmanager-v1"},
+				{Name: "google-cloud-secretmanager-v1"},
+			},
+			wantErr: errDuplicateLibraryName,
+		},
+		{
+			name: "duplicate api paths not skipped for non-java",
+			libraries: []*config.Library{
+				{
+					Name: "lib1",
+					APIs: []*config.API{{Path: "google/iam/v1"}},
+				},
+				{
+					Name: "lib2",
+					APIs: []*config.API{{Path: "google/iam/v1"}},
+				},
+			},
+			language: config.LanguagePython,
+			wantErr:  errDuplicateAPIPath,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Language:  test.language,
+				Libraries: test.libraries,
+			}
+			if test.language == config.LanguageJava {
+				cfg.Default = &config.Default{
+					Java: &config.JavaDefault{
+						LibrariesBOMVersion: "1.2.3",
+					},
 				}
-				return
 			}
-			if err == nil {
-				t.Fatalf("expected %v, got nil", test.wantErr)
-			}
+			err := validateLibraries(cfg)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("expected %v, got %v", test.wantErr, err)
 			}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -30,61 +30,60 @@ import (
 
 func TestValidateLibraries(t *testing.T) {
 	for _, test := range []struct {
-		name      string
-		libraries []*config.Library
-		language  string
+		name string
+		cfg  *config.Config
 	}{
 		{
 			name: "valid libraries",
-			libraries: []*config.Library{
-				{Name: "google-cloud-secretmanager-v1"},
-				{Name: "google-cloud-storage-v1"},
+			cfg: &config.Config{
+				Libraries: []*config.Library{
+					{Name: "google-cloud-secretmanager-v1"},
+					{Name: "google-cloud-storage-v1"},
+				},
 			},
 		},
 		{
 			name: "skipped duplicate api paths",
-			libraries: []*config.Library{
-				{
-					Name: "lib1",
-					APIs: []*config.API{{Path: "google/iam/v1"}},
-					Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
-				},
-				{
-					Name: "lib2",
-					APIs: []*config.API{{Path: "google/iam/v1"}},
-					Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
-				},
-			},
-			language: config.LanguageJava,
-		},
-		{
-			name: "allowed duplicate api paths for ruby",
-			libraries: []*config.Library{
-				{
-					Name: "google-cloud-example",
-					APIs: []*config.API{{Path: "google/cloud/example/v1"}},
-				},
-				{
-					Name: "google-cloud-example-v1",
-					APIs: []*config.API{{Path: "google/cloud/example/v1"}},
-				},
-			},
-			language: config.LanguageRuby,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			cfg := &config.Config{
-				Language:  test.language,
-				Libraries: test.libraries,
-			}
-			if test.language == config.LanguageJava {
-				cfg.Default = &config.Default{
+			cfg: &config.Config{
+				Language: config.LanguageJava,
+				Default: &config.Default{
 					Java: &config.JavaDefault{
 						LibrariesBOMVersion: "1.2.3",
 					},
-				}
-			}
-			if err := validateLibraries(cfg); err != nil {
+				},
+				Libraries: []*config.Library{
+					{
+						Name: "lib1",
+						APIs: []*config.API{{Path: "google/iam/v1"}},
+						Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
+					},
+					{
+						Name: "lib2",
+						APIs: []*config.API{{Path: "google/iam/v1"}},
+						Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed duplicate api paths for ruby",
+			cfg: &config.Config{
+				Language: config.LanguageRuby,
+				Libraries: []*config.Library{
+					{
+						Name: "google-cloud-example",
+						APIs: []*config.API{{Path: "google/cloud/example/v1"}},
+					},
+					{
+						Name: "google-cloud-example-v1",
+						APIs: []*config.API{{Path: "google/cloud/example/v1"}},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateLibraries(test.cfg); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -117,7 +116,7 @@ func TestValidateLibraries_Error(t *testing.T) {
 					APIs: []*config.API{{Path: "google/iam/v1"}},
 				},
 			},
-			wantErr:  errDuplicateAPIPath,
+			wantErr: errDuplicateAPIPath,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -95,7 +95,6 @@ func TestValidateLibraries_Error(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		libraries []*config.Library
-		language  string
 		wantErr   error
 	}{
 		{
@@ -118,21 +117,12 @@ func TestValidateLibraries_Error(t *testing.T) {
 					APIs: []*config.API{{Path: "google/iam/v1"}},
 				},
 			},
-			language: config.LanguagePython,
 			wantErr:  errDuplicateAPIPath,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := &config.Config{
-				Language:  test.language,
 				Libraries: test.libraries,
-			}
-			if test.language == config.LanguageJava {
-				cfg.Default = &config.Default{
-					Java: &config.JavaDefault{
-						LibrariesBOMVersion: "1.2.3",
-					},
-				}
 			}
 			err := validateLibraries(cfg)
 			if !errors.Is(err, test.wantErr) {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -106,7 +106,7 @@ func TestValidateLibraries_Error(t *testing.T) {
 			wantErr: errDuplicateLibraryName,
 		},
 		{
-			name: "duplicate api paths not skipped for non-java",
+			name: "duplicate api paths",
 			libraries: []*config.Library{
 				{
 					Name: "lib1",


### PR DESCRIPTION
The TestValidateLibraries unit test in `tidy_test.go` is separated into `TestValidateLibraries` for valid configuration cases and `TestValidateLibraries_Error` for failure cases.

This separation simplifies the test loop structures and allows each test runner to use focused, direct assertions without conditional error-checking logic.
