### PR TITLE
ci(.github): increate java integration timeout

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -36,7 +36,7 @@ jobs:
             sparse: true
           - job-name: 'Integration Test'
             task: 'integration'
-            timeout: 60
+            timeout: 120
             sparse: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Increase timeout for Java integration test from 60 mins to 120 mins.