### PR TITLE
feat(sidekick/swift): support overrides for library names

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -618,7 +618,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `name` | string | Is an identifier for the package within the project.<br><br>For example, `swift-protobuf`. This is usually the last component of the path or the URL. |
+| `name` | string | Is the module imported from the dependency.<br><br>Examples:<br>- to import `Logging` from the `swift-log` package, create a dependency: {Name: "Logging", Version: "1.14.0", URL: "https://github.com/apple/swift-log"},<br>- to import `GoogleIamV1` from the `google-iam-v1` package. {Name: "GoogleIamV1", Path: "generated/google-iam-v1"} |
 | `path` | string | Configures the path for local (to the monorepo) packages.<br><br>For example, the authentication package definition will set this to `packages/auth`, which would generate the following snippet in the `Package.swift` files:<br><br>``` .package(path: "../../packages/auth") ``` |
 | `url` | string | Configures the `url:` parameter in the package definition.<br><br>For example, `https://github.com/apple/swift-protobuf` would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf") ``` |
 | `version` | string | Configures the minimum version for external package definitions.<br><br>For example, if the `swift-protobuf` package used `1.36.1`, then the codec would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf", from: "1.36.1") ``` |
@@ -640,6 +640,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | (embedded) | [SwiftDefault](#swiftdefault-configuration) |  |
+| `library_name_override` | string | Overrides the default library name.<br><br>In Swift, each GAPIC package consists of a single product (the library), which contains a single target and module name. For example, the package for the google/cloud/secretmanager/v1 API is called google-cloud-secretmanager-v1, and contains a single product: `GoogleCloudSecretManagerV1`, which in turn contains a single target and module of the same name.<br><br>To use the library applications use this import:<br><br>``` import GoogleCloudSecretManagerV1 ```<br><br>Normally the name is derived from:<br>- If the Protobuf namespace overrides for PHP, Ruby, and C# are consistent, sidekick uses this name.<br>- Otherwise, the name implied by the Protobuf package<br>- Or the package set in the service config yaml file |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]). |
 | `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, and output location. |
 | `package_name_override` | string | Overrides the package name.<br><br>This may be useful if the protobuf package lacks the necessary prefixes, e.g. `grafeas.v1` may be published as `google-grafeas-v1` to match the other packages. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -618,7 +618,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `name` | string | Is the module imported from the dependency.<br><br>Examples:<br>- to import `Logging` from the `swift-log` package, create a dependency: {Name: "Logging", Version: "1.14.0", URL: "https://github.com/apple/swift-log"},<br>- to import `GoogleIamV1` from the `google-iam-v1` package. {Name: "GoogleIamV1", Path: "generated/google-iam-v1"} |
+| `name` | string | Is the module imported from the dependency.<br><br>Examples:<br>- to import `Logging` from the `swift-log` package, create a dependency: {name: "Logging", version: "1.14.0", url: "https://github.com/apple/swift-log"},<br>- to import `GoogleIamV1` from the `google-iam-v1` package. {name: "GoogleIamV1", path: "generated/google-iam-v1"} |
 | `path` | string | Configures the path for local (to the monorepo) packages.<br><br>For example, the authentication package definition will set this to `packages/auth`, which would generate the following snippet in the `Package.swift` files:<br><br>``` .package(path: "../../packages/auth") ``` |
 | `url` | string | Configures the `url:` parameter in the package definition.<br><br>For example, `https://github.com/apple/swift-protobuf` would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf") ``` |
 | `version` | string | Configures the minimum version for external package definitions.<br><br>For example, if the `swift-protobuf` package used `1.36.1`, then the codec would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf", from: "1.36.1") ``` |

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -29,6 +29,25 @@ type SwiftDefault struct {
 type SwiftPackage struct {
 	SwiftDefault `yaml:",inline"`
 
+	// LibraryNameOverride overrides the default library name.
+	//
+	// In Swift, each GAPIC package consists of a single product (the library),
+	// which contains a single target and module name. For example, the package for
+	// the google/cloud/secretmanager/v1 API is called google-cloud-secretmanager-v1, and
+	// contains a single product: `GoogleCloudSecretManagerV1`, which in turn contains a single target and module of the same name.
+	//
+	// To use the library applications use this import:
+	//
+	// ```
+	// import GoogleCloudSecretManagerV1
+	// ```
+	//
+	// Normally the name is derived from:
+	// - If the Protobuf namespace overrides for PHP, Ruby, and C# are consistent, sidekick uses this name.
+	// - Otherwise, the name implied by the Protobuf package
+	// - Or the package set in the service config yaml file
+	LibraryNameOverride string `yaml:"library_name_override,omitempty"`
+
 	// IncludeList is a subset of proto files under the target API path to
 	// include (e.g., ["date.proto", "expr.proto"]).
 	IncludeList []string `yaml:"include_list,omitempty"`
@@ -57,9 +76,13 @@ type SwiftPackage struct {
 
 // SwiftDependency represents a dependency in Swift Package Manager.
 type SwiftDependency struct {
-	// Name is an identifier for the package within the project.
+	// Name is the module imported from the dependency.
 	//
-	// For example, `swift-protobuf`. This is usually the last component of the path or the URL.
+	// Examples:
+	// - to import `Logging` from the `swift-log` package, create a dependency:
+	//     {Name: "Logging", Version: "1.14.0", URL: "https://github.com/apple/swift-log"},
+	// - to import `GoogleIamV1` from the `google-iam-v1` package.
+	//     {Name: "GoogleIamV1", Path: "generated/google-iam-v1"}
 	Name string `yaml:"name"`
 	// Path configures the path for local (to the monorepo) packages.
 	//

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -80,9 +80,9 @@ type SwiftDependency struct {
 	//
 	// Examples:
 	// - to import `Logging` from the `swift-log` package, create a dependency:
-	//     {Name: "Logging", Version: "1.14.0", URL: "https://github.com/apple/swift-log"},
+	//     {name: "Logging", version: "1.14.0", url: "https://github.com/apple/swift-log"},
 	// - to import `GoogleIamV1` from the `google-iam-v1` package.
-	//     {Name: "GoogleIamV1", Path: "generated/google-iam-v1"}
+	//     {name: "GoogleIamV1", path: "generated/google-iam-v1"}
 	Name string `yaml:"name"`
 	// Path configures the path for local (to the monorepo) packages.
 	//

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -66,7 +66,7 @@ func TestAnnotateMethod(t *testing.T) {
 				DocLines:       []string{"Gets a thing.", "", "Test multiple comment lines.", ""},
 				HTTPMethod:     "GET",
 				HasBody:        false,
-				ReturnType:     "GoogleTest.Response",
+				ReturnType:     "Test.Response",
 			},
 		},
 		{
@@ -90,7 +90,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HasBody:        true,
 				IsBodyWildcard: false,
 				BodyField:      "key",
-				ReturnType:     "GoogleTest.Response",
+				ReturnType:     "Test.Response",
 			},
 		},
 		{
@@ -113,7 +113,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HTTPMethod:     "POST",
 				HasBody:        true,
 				IsBodyWildcard: true,
-				ReturnType:     "GoogleTest.Response",
+				ReturnType:     "Test.Response",
 			},
 		},
 		{
@@ -138,7 +138,7 @@ func TestAnnotateMethod(t *testing.T) {
 				HTTPMethod:     "GET",
 				HasBody:        false,
 				QueryParams:    []*api.Field{keyField},
-				ReturnType:     "GoogleTest.Response",
+				ReturnType:     "Test.Response",
 			},
 		},
 	} {
@@ -208,7 +208,7 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 				DocLines:       []string{"Test documentation."},
 				PathExpression: "/",
 				HTTPMethod:     "GET",
-				ReturnType:     "GoogleTest.Response",
+				ReturnType:     "Test.Response",
 			}
 
 			if diff := cmp.Diff(want, method.Codec); diff != "" {
@@ -342,7 +342,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		Pagination: &paginationAnnotations{
 			ItemType: "Item",
 		},
-		ReturnType: "GoogleTest.ListResponse",
+		ReturnType: "Test.ListResponse",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -454,7 +454,7 @@ func TestAnnotateMethod_LRO(t *testing.T) {
 			MetadataType:    "LroMetadata",
 			ResponseIsEmpty: false,
 		},
-		ReturnType: "GoogleTest.Operation",
+		ReturnType: "Test.Operation",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -525,7 +525,7 @@ func TestAnnotateMethod_LRO_Empty(t *testing.T) {
 			MetadataType:    "LroMetadata",
 			ResponseIsEmpty: true,
 		},
-		ReturnType: "GoogleTest.Operation",
+		ReturnType: "Test.Operation",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -37,7 +37,7 @@ func TestAnnotateService(t *testing.T) {
 			doc:         "IAM service documentation.",
 			wantAnnotations: &serviceAnnotations{
 				Name:        "IAM",
-				LibraryName: "GoogleTest",
+				LibraryName: "Test",
 				ClientName:  "IAMClient",
 				StubPrefix:  "IAM",
 				DocLines:    []string{"IAM service documentation."},
@@ -50,7 +50,7 @@ func TestAnnotateService(t *testing.T) {
 			doc:         "Docs are not relevant.",
 			wantAnnotations: &serviceAnnotations{
 				Name:        "Protocol_",
-				LibraryName: "GoogleTest",
+				LibraryName: "Test",
 				ClientName:  "ProtocolClient",
 				StubPrefix:  "Protocol",
 				DocLines:    []string{"Docs are not relevant."},
@@ -63,7 +63,7 @@ func TestAnnotateService(t *testing.T) {
 			doc:         "Secret Manager Service documentation.\nLine 2.",
 			wantAnnotations: &serviceAnnotations{
 				Name:        "SecretManagerService",
-				LibraryName: "GoogleTest",
+				LibraryName: "Test",
 				ClientName:  "SecretManagerServiceClient",
 				StubPrefix:  "SecretManagerService",
 				DocLines:    []string{"Secret Manager Service documentation.", "Line 2."},

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -180,7 +180,7 @@ func newCodec(model *api.API, library *config.Library, module *config.SwiftModul
 	}
 
 	if !result.Module {
-		libraryName, err := LibraryName(model)
+		libraryName, err := LibraryName(model, swiftCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -39,7 +39,7 @@ func TestParseOptions(t *testing.T) {
 			},
 			want: &codec{
 				GenerationYear:     "2038",
-				LibraryName:        "GoogleTest",
+				LibraryName:        "Test",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -58,7 +58,7 @@ func TestParseOptions(t *testing.T) {
 			},
 			want: &codec{
 				GenerationYear:     "2038",
-				LibraryName:        "GoogleTest",
+				LibraryName:        "Test",
 				PackageName:        "google-cloud-bigtable",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -95,7 +95,7 @@ func TestParseOptions(t *testing.T) {
 			},
 			want: &codec{
 				GenerationYear:     "2038",
-				LibraryName:        "GoogleTest",
+				LibraryName:        "Test",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",

--- a/internal/sidekick/swift/generate_apiversion_test.go
+++ b/internal/sidekick/swift/generate_apiversion_test.go
@@ -100,7 +100,7 @@ func TestGenerateService_APIVersion(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			filename := filepath.Join(outDir, "Sources", "GoogleTest", "TestService+Stub.swift")
+			filename := filepath.Join(outDir, "Sources", "Test", "TestService+Stub.swift")
 			content, err := os.ReadFile(filename)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/sidekick/swift/generate_deprecated_method_test.go
+++ b/internal/sidekick/swift/generate_deprecated_method_test.go
@@ -75,13 +75,13 @@ func TestGenerateService_DeprecatedMethods(t *testing.T) {
 			want: []expectedBlock{
 				{
 					start: "    /// See `TestServiceClient.simpleMethod`.",
-					end:   "-> GoogleTest.Response",
-					want:  "    /// See `TestServiceClient.simpleMethod`.\n    @available(*, deprecated)\n    func simpleMethod(request: Request) async throws -> GoogleTest.Response",
+					end:   "-> Test.Response",
+					want:  "    /// See `TestServiceClient.simpleMethod`.\n    @available(*, deprecated)\n    func simpleMethod(request: Request) async throws -> Test.Response",
 				},
 				{
 					start: "  /// -- simple marker --",
-					end:   "async throws -> GoogleTest.Response",
-					want:  "  /// -- simple marker --\n  ///\n  /// @Snippet(path: \"TestService_SimpleMethod\")\n  @available(*, deprecated)\n  public func simpleMethod(\n    request: Request, options: GoogleCloudGax.RequestOptions\n) async throws -> GoogleTest.Response",
+					end:   "async throws -> Test.Response",
+					want:  "  /// -- simple marker --\n  ///\n  /// @Snippet(path: \"TestService_SimpleMethod\")\n  @available(*, deprecated)\n  public func simpleMethod(\n    request: Request, options: GoogleCloudGax.RequestOptions\n) async throws -> Test.Response",
 				},
 			},
 		},
@@ -102,12 +102,12 @@ func TestGenerateService_DeprecatedMethods(t *testing.T) {
 				{
 					start: "    /// See `TestServiceClient.paginationMethod`.",
 					end:   "-> any AsyncSequence<Item, Swift.Error>",
-					want:  "    /// See `TestServiceClient.paginationMethod`.\n    @available(*, deprecated)\n    func paginationMethod(request: Request) async throws -> GoogleTest.PaginationResponse\n\n    /// See `TestServiceClient.paginationMethod`.\n    @available(*, deprecated)\n    func paginationMethod(\n  byItem: Request\n) throws -> any AsyncSequence<Item, Swift.Error>",
+					want:  "    /// See `TestServiceClient.paginationMethod`.\n    @available(*, deprecated)\n    func paginationMethod(request: Request) async throws -> Test.PaginationResponse\n\n    /// See `TestServiceClient.paginationMethod`.\n    @available(*, deprecated)\n    func paginationMethod(\n  byItem: Request\n) throws -> any AsyncSequence<Item, Swift.Error>",
 				},
 				{
 					start: "  /// -- pagination marker --",
 					end:   "-> any AsyncSequence<Item, Swift.Error>",
-					want:  "  /// -- pagination marker --\n  ///\n  /// @Snippet(path: \"TestService_PaginationMethod\")\n  @available(*, deprecated)\n  public func paginationMethod(\n    request: Request, options: GoogleCloudGax.RequestOptions\n) async throws -> GoogleTest.PaginationResponse\n {\n      try await self.inner.paginationMethod(request: request, options: options)\n  }\n\n  /// -- pagination marker --\n  ///\n  /// @Snippet(path: \"TestService_PaginationMethod\")\n  @available(*, deprecated)\n  public func paginationMethod(\n    byItem: Request, options: GoogleCloudGax.RequestOptions\n) throws -> any AsyncSequence<Item, Swift.Error>",
+					want:  "  /// -- pagination marker --\n  ///\n  /// @Snippet(path: \"TestService_PaginationMethod\")\n  @available(*, deprecated)\n  public func paginationMethod(\n    request: Request, options: GoogleCloudGax.RequestOptions\n) async throws -> Test.PaginationResponse\n {\n      try await self.inner.paginationMethod(request: request, options: options)\n  }\n\n  /// -- pagination marker --\n  ///\n  /// @Snippet(path: \"TestService_PaginationMethod\")\n  @available(*, deprecated)\n  public func paginationMethod(\n    byItem: Request, options: GoogleCloudGax.RequestOptions\n) throws -> any AsyncSequence<Item, Swift.Error>",
 				},
 			},
 		},
@@ -155,13 +155,13 @@ func TestGenerateService_DeprecatedMethods(t *testing.T) {
 			want: []expectedBlock{
 				{
 					start: "    /// See `TestServiceClient.notDeprecatedMethod`.",
-					end:   "-> GoogleTest.Response",
-					want:  "    /// See `TestServiceClient.notDeprecatedMethod`.\n    func notDeprecatedMethod(request: Request) async throws -> GoogleTest.Response",
+					end:   "-> Test.Response",
+					want:  "    /// See `TestServiceClient.notDeprecatedMethod`.\n    func notDeprecatedMethod(request: Request) async throws -> Test.Response",
 				},
 				{
 					start: "  /// -- not deprecated marker --",
-					end:   "async throws -> GoogleTest.Response",
-					want:  "  /// -- not deprecated marker --\n  ///\n  /// @Snippet(path: \"TestService_NotDeprecatedMethod\")\n  public func notDeprecatedMethod(\n    request: Request, options: GoogleCloudGax.RequestOptions\n) async throws -> GoogleTest.Response",
+					end:   "async throws -> Test.Response",
+					want:  "  /// -- not deprecated marker --\n  ///\n  /// @Snippet(path: \"TestService_NotDeprecatedMethod\")\n  public func notDeprecatedMethod(\n    request: Request, options: GoogleCloudGax.RequestOptions\n) async throws -> Test.Response",
 				},
 			},
 		},
@@ -202,7 +202,7 @@ func TestGenerateService_DeprecatedMethods(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			filename := filepath.Join(outDir, "Sources", "GoogleTest", "TestService.swift")
+			filename := filepath.Join(outDir, "Sources", "Test", "TestService.swift")
 			content, err := os.ReadFile(filename)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/sidekick/swift/generate_deprecated_service_test.go
+++ b/internal/sidekick/swift/generate_deprecated_service_test.go
@@ -63,7 +63,7 @@ func TestGenerateService_Deprecated(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			filename := filepath.Join(outDir, "Sources", "GoogleTest", "DeprecatedService.swift")
+			filename := filepath.Join(outDir, "Sources", "Test", "DeprecatedService.swift")
 			content, err := os.ReadFile(filename)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/sidekick/swift/generate_method_signatures_test.go
+++ b/internal/sidekick/swift/generate_method_signatures_test.go
@@ -39,7 +39,7 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 					want: `public func simpleMethod(
   name: Swift.String,
   optionalField: Swift.String?,
-) async throws -> GoogleTest.Response
+) async throws -> Test.Response
  {
     let request = Request().with {
       $0.name = name
@@ -53,7 +53,7 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 					want: `public func simpleMethod(
   name: Swift.String,
   normalField: Swift.String,
-) async throws -> GoogleTest.Response
+) async throws -> Test.Response
  {
     let request = Request().with {
       $0.name = name
@@ -180,7 +180,7 @@ func TestGenerateService_MethodSignatures(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			filename := filepath.Join(outDir, "Sources", "GoogleTest", "TestService.swift")
+			filename := filepath.Join(outDir, "Sources", "Test", "TestService.swift")
 			content, err := os.ReadFile(filename)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -46,7 +46,7 @@ func TestGenerateService_Files(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedDir := filepath.Join(outDir, "Sources", "GoogleTest")
+	expectedDir := filepath.Join(outDir, "Sources", "Test")
 	wantFiles := []string{
 		"IAM.swift",
 		"Clients.swift",

--- a/internal/sidekick/swift/generate_snippets_test.go
+++ b/internal/sidekick/swift/generate_snippets_test.go
@@ -37,7 +37,7 @@ func TestGenerateSnippets(t *testing.T) {
 			repeated: false,
 			file:     "TestServiceQuickstart.swift",
 			want: `func sample(name: String, ) async throws {
-  let client = try GoogleTest.TestServiceClient()
+  let client = try Test.TestServiceClient()
   let response = try await client.getThing(
     request: GetThingRequest()
   .with {
@@ -52,7 +52,7 @@ func TestGenerateSnippets(t *testing.T) {
 			repeated: true,
 			file:     "TestServiceQuickstart.swift",
 			want: `func sample(name: String, ) async throws {
-  let client = try GoogleTest.TestServiceClient()
+  let client = try Test.TestServiceClient()
   let response = try await client.getThing(
     request: GetThingRequest()
   .with {

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -183,7 +183,7 @@ func TestGenerateService_QueryParameters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	filename := filepath.Join(outDir, "Sources", "GoogleTest", "Service+Stub.swift")
+	filename := filepath.Join(outDir, "Sources", "Test", "Service+Stub.swift")
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -18,24 +18,24 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/iancoleman/strcase"
 )
 
 // LibraryName returns the Swift library (and module) name for the API.
-func LibraryName(api *api.API) (string, error) {
+func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) (string, error) {
+	if swiftCfg != nil && swiftCfg.LibraryNameOverride != "" {
+		return swiftCfg.LibraryNameOverride, nil
+	}
 	if api.PackageName == "" {
 		return "", fmt.Errorf("API package name must not be empty")
 	}
 	// TODO(https://github.com/googleapis/librarian/issues/6229) - use
-	// a better default.
+	// the api.PackageNamePascalCase
 	parts := strings.Split(api.PackageName, ".")
 	for i, p := range parts {
 		parts[i] = strcase.ToCamel(p)
 	}
-	result := strings.Join(parts, "")
-	if strings.HasPrefix(result, "Google") {
-		return result, nil
-	}
-	return "Google" + result, nil
+	return strings.Join(parts, ""), nil
 }

--- a/internal/sidekick/swift/library_name_test.go
+++ b/internal/sidekick/swift/library_name_test.go
@@ -17,39 +17,52 @@ package swift
 import (
 	"testing"
 
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
 
 func TestLibraryName(t *testing.T) {
 	for _, test := range []struct {
-		name  string
-		input string
-		want  string
+		name   string
+		input  string
+		config *config.SwiftPackage
+		want   string
 	}{
 		{
-			name:  "cloud storage v2",
-			input: "google.cloud.storage.v2",
-			want:  "GoogleCloudStorageV2",
+			name:   "cloud storage v2",
+			input:  "google.cloud.storage.v2",
+			config: nil,
+			want:   "GoogleCloudStorageV2",
 		},
 		{
-			name:  "iam v1",
-			input: "google.iam.v1",
-			want:  "GoogleIamV1",
+			name:   "iam v1",
+			input:  "google.iam.v1",
+			config: nil,
+			want:   "GoogleIamV1",
 		},
 		{
-			name:  "cloud location",
-			input: "google.cloud.location",
-			want:  "GoogleCloudLocation",
+			name:   "cloud location",
+			input:  "google.cloud.location",
+			config: nil,
+			want:   "GoogleCloudLocation",
 		},
 		{
-			name:  "api",
-			input: "google.api",
-			want:  "GoogleApi",
+			name:   "api",
+			input:  "google.api",
+			config: nil,
+			want:   "GoogleApi",
 		},
 		{
-			name:  "grafeas v1",
-			input: "grafeas.v1",
-			want:  "GoogleGrafeasV1",
+			name:   "grafeas v1",
+			input:  "grafeas.v1",
+			config: nil,
+			want:   "GrafeasV1",
+		},
+		{
+			name:   "grafeas v1",
+			input:  "grafeas.v1",
+			config: &config.SwiftPackage{LibraryNameOverride: "GoogleGrafeasV1"},
+			want:   "GoogleGrafeasV1",
 		},
 		{
 			name:  "corner case",
@@ -60,7 +73,7 @@ func TestLibraryName(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			model := api.NewTestAPI(nil, nil, nil)
 			model.PackageName = test.input
-			got, err := LibraryName(model)
+			got, err := LibraryName(model, test.config)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +86,7 @@ func TestLibraryName(t *testing.T) {
 
 func TestLibraryNameError(t *testing.T) {
 	model := api.NewTestAPI(nil, nil, nil)
-	got, err := LibraryName(model)
+	got, err := LibraryName(model, nil)
 	if err == nil {
 		t.Errorf("Expected an error, got: %s", got)
 	}


### PR DESCRIPTION
With this PR, we can override the library (in the Swift sense) name. That is, if we set:

```yaml
swift:
  library_name_override: GoogleCloudSecretManagerV1
```

Then the application can write:

```swift
import GoogleCloudSecretManagerV1
```

which is better than the default `GoogleCloudSecretmanagerV1` (note the lower case `m`in `manager`).

Towards #6229 