### PR TITLE
test(internal/librarian): separate TestValidateTools success and error

### DIFF
--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -133,9 +133,8 @@ func TestValidateLibraries_Error(t *testing.T) {
 
 func TestValidateTools(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		config  *config.Config
-		wantErr error
+		name   string
+		config *config.Config
 	}{
 		{
 			name:   "no tools",
@@ -151,6 +150,21 @@ func TestValidateTools(t *testing.T) {
 				},
 			},
 		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateTools(test.config); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateTools_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		config  *config.Config
+		wantErr error
+	}{
 		{
 			name: "missing version",
 			config: &config.Config{
@@ -165,15 +179,6 @@ func TestValidateTools(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := validateTools(test.config)
-			if test.wantErr == nil {
-				if err != nil {
-					t.Fatal(err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected %v, got nil", test.wantErr)
-			}
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("expected %v, got %v", test.wantErr, err)
 			}


### PR DESCRIPTION
The TestValidateTools unit test in `tidy_test.go` is separated into `TestValidateTools` for valid tool configurations and `TestValidateTools_Error `for failure cases.

This separation simplifies the test loop structures and allows each test runner to use focused, direct assertions without conditional error-checking logic.
