### PR TITLE
feat(internal/librarian/php): fill default staging subdir

### DIFF
--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
@@ -356,6 +357,8 @@ func fillLibraryDefaults(language string, lib *config.Library) (*config.Library,
 		return golang.Fill(lib)
 	case config.LanguageJava:
 		return java.Fill(lib)
+	case config.LanguagePhp:
+		return php.Fill(lib), nil
 	case config.LanguagePython:
 		return python.Fill(lib)
 	default:

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -778,7 +778,7 @@ func TestApplyDefaults(t *testing.T) {
 			wantOutput:  "java-google-cloud-secretmanager-v1",
 		},
 		{
-			name: "php fills library defaults",
+			name:     "php fills library defaults",
 			language: config.LanguagePhp,
 			apis: []*config.API{
 				{

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -777,6 +777,16 @@ func TestApplyDefaults(t *testing.T) {
 			nilDefaults: true,
 			wantOutput:  "java-google-cloud-secretmanager-v1",
 		},
+		{
+			name: "php fills library defaults",
+			language: config.LanguagePhp,
+			apis: []*config.API{
+				{
+					Path: "google/cloud/secretmanager/v1",
+				},
+			},
+			wantOutput: "src/generated/google-cloud-secretmanager-v1",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			lib := &config.Library{

--- a/internal/librarian/php/default.go
+++ b/internal/librarian/php/default.go
@@ -20,6 +20,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+// Fill populates default PHP configuration values for the library.
 func Fill(lib *config.Library) *config.Library {
 	fillStagingSubdir(lib)
 	return lib
@@ -27,11 +28,11 @@ func Fill(lib *config.Library) *config.Library {
 
 func fillStagingSubdir(lib *config.Library) {
 	if lib.PHP == nil {
-		return
+		lib.PHP = &config.PHPPackage{}
 	}
 	for _, api := range lib.APIs {
 		// Do not override existing library configuration.
-		if api.PHP == nil || api.PHP.StagingSubdir != "" {
+		if api.PHP.StagingSubdir != "" {
 			continue
 		}
 		name := filepath.Base(api.Path)

--- a/internal/librarian/php/default.go
+++ b/internal/librarian/php/default.go
@@ -27,10 +27,10 @@ func Fill(lib *config.Library) *config.Library {
 }
 
 func fillStagingSubdir(lib *config.Library) {
-	if lib.PHP == nil {
-		lib.PHP = &config.PHPPackage{}
-	}
 	for _, api := range lib.APIs {
+		if api.PHP == nil {
+			api.PHP = &config.PHPAPI{}
+		}
 		// Do not override existing library configuration.
 		if api.PHP.StagingSubdir != "" {
 			continue

--- a/internal/librarian/php/default.go
+++ b/internal/librarian/php/default.go
@@ -22,11 +22,10 @@ import (
 
 // Fill populates default PHP configuration values for the library.
 func Fill(lib *config.Library) *config.Library {
-	fillStagingSubdir(lib)
-	return lib
+	return fillStagingSubdir(lib)
 }
 
-func fillStagingSubdir(lib *config.Library) {
+func fillStagingSubdir(lib *config.Library) *config.Library {
 	for _, api := range lib.APIs {
 		if api.PHP == nil {
 			api.PHP = &config.PHPAPI{}
@@ -38,4 +37,5 @@ func fillStagingSubdir(lib *config.Library) {
 		name := filepath.Base(api.Path)
 		api.PHP.StagingSubdir = name
 	}
+	return lib
 }

--- a/internal/librarian/php/default.go
+++ b/internal/librarian/php/default.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func Fill(lib *config.Library) *config.Library {
+	fillStagingSubdir(lib)
+	return lib
+}
+
+func fillStagingSubdir(lib *config.Library) {
+	if lib.PHP == nil {
+		return
+	}
+	for _, api := range lib.APIs {
+		// Do not override existing library configuration.
+		if api.PHP == nil || api.PHP.StagingSubdir != "" {
+			continue
+		}
+		name := filepath.Base(api.Path)
+		api.PHP.StagingSubdir = name
+	}
+}

--- a/internal/librarian/php/default_test.go
+++ b/internal/librarian/php/default_test.go
@@ -28,42 +28,9 @@ func TestFillStagingSubdir(t *testing.T) {
 		want *config.Library
 	}{
 		{
-			name: "lib.PHP is nil",
-			lib: &config.Library{
-				Name: "google-cloud-secretmanager",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1", PHP: &config.PHPAPI{}},
-				},
-			},
-			want: &config.Library{
-				Name: "google-cloud-secretmanager",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1", PHP: &config.PHPAPI{}},
-				},
-			},
-		},
-		{
-			name: "api.PHP is nil",
-			lib: &config.Library{
-				Name: "google-cloud-secretmanager",
-				PHP:  &config.PHPPackage{},
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			want: &config.Library{
-				Name: "google-cloud-secretmanager",
-				PHP:  &config.PHPPackage{},
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-		},
-		{
 			name: "preserve existing staging subdir",
 			lib: &config.Library{
 				Name: "google-cloud-secretmanager",
-				PHP:  &config.PHPPackage{},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -75,7 +42,6 @@ func TestFillStagingSubdir(t *testing.T) {
 			},
 			want: &config.Library{
 				Name: "google-cloud-secretmanager",
-				PHP:  &config.PHPPackage{},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -90,17 +56,14 @@ func TestFillStagingSubdir(t *testing.T) {
 			name: "fill empty staging subdir",
 			lib: &config.Library{
 				Name: "google-cloud-secretmanager",
-				PHP:  &config.PHPPackage{},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
-						PHP:  &config.PHPAPI{},
 					},
 				},
 			},
 			want: &config.Library{
 				Name: "google-cloud-secretmanager",
-				PHP:  &config.PHPPackage{},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -115,11 +78,9 @@ func TestFillStagingSubdir(t *testing.T) {
 			name: "multiple apis mixed",
 			lib: &config.Library{
 				Name: "google-cloud-example",
-				PHP:  &config.PHPPackage{},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/example/v1",
-						PHP:  &config.PHPAPI{},
 					},
 					{
 						Path: "google/cloud/example/v2",
@@ -129,13 +90,11 @@ func TestFillStagingSubdir(t *testing.T) {
 					},
 					{
 						Path: "google/cloud/example/v3beta1",
-						PHP:  &config.PHPAPI{},
 					},
 				},
 			},
 			want: &config.Library{
 				Name: "google-cloud-example",
-				PHP:  &config.PHPPackage{},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/example/v1",

--- a/internal/librarian/php/default_test.go
+++ b/internal/librarian/php/default_test.go
@@ -126,32 +126,3 @@ func TestFillStagingSubdir(t *testing.T) {
 		})
 	}
 }
-
-func TestFill(t *testing.T) {
-	lib := &config.Library{
-		Name: "google-cloud-secretmanager",
-		PHP:  &config.PHPPackage{},
-		APIs: []*config.API{
-			{
-				Path: "google/cloud/secretmanager/v1",
-				PHP:  &config.PHPAPI{},
-			},
-		},
-	}
-	want := &config.Library{
-		Name: "google-cloud-secretmanager",
-		PHP:  &config.PHPPackage{},
-		APIs: []*config.API{
-			{
-				Path: "google/cloud/secretmanager/v1",
-				PHP: &config.PHPAPI{
-					StagingSubdir: "v1",
-				},
-			},
-		},
-	}
-	got := Fill(lib)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}

--- a/internal/librarian/php/default_test.go
+++ b/internal/librarian/php/default_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package php
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestFillStagingSubdir(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want *config.Library
+	}{
+		{
+			name: "lib.PHP is nil",
+			lib: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1", PHP: &config.PHPAPI{}},
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1", PHP: &config.PHPAPI{}},
+				},
+			},
+		},
+		{
+			name: "api.PHP is nil",
+			lib: &config.Library{
+				Name: "google-cloud-secretmanager",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+		},
+		{
+			name: "preserve existing staging subdir",
+			lib: &config.Library{
+				Name: "google-cloud-secretmanager",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "custom-dir",
+						},
+					},
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "custom-dir",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fill empty staging subdir",
+			lib: &config.Library{
+				Name: "google-cloud-secretmanager",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP:  &config.PHPAPI{},
+					},
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple apis mixed",
+			lib: &config.Library{
+				Name: "google-cloud-example",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/example/v1",
+						PHP:  &config.PHPAPI{},
+					},
+					{
+						Path: "google/cloud/example/v2",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "custom-v2",
+						},
+					},
+					{
+						Path: "google/cloud/example/v3beta1",
+						PHP:  &config.PHPAPI{},
+					},
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-example",
+				PHP:  &config.PHPPackage{},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/example/v1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+					{
+						Path: "google/cloud/example/v2",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "custom-v2",
+						},
+					},
+					{
+						Path: "google/cloud/example/v3beta1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v3beta1",
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fillStagingSubdir(test.lib)
+			if diff := cmp.Diff(test.want, test.lib); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFill(t *testing.T) {
+	lib := &config.Library{
+		Name: "google-cloud-secretmanager",
+		PHP:  &config.PHPPackage{},
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP:  &config.PHPAPI{},
+			},
+		},
+	}
+	want := &config.Library{
+		Name: "google-cloud-secretmanager",
+		PHP:  &config.PHPPackage{},
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					StagingSubdir: "v1",
+				},
+			},
+		},
+	}
+	got := Fill(lib)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/librarian/php/default_test.go
+++ b/internal/librarian/php/default_test.go
@@ -119,8 +119,8 @@ func TestFillStagingSubdir(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			fillStagingSubdir(test.lib)
-			if diff := cmp.Diff(test.want, test.lib); diff != "" {
+			got := fillStagingSubdir(test.lib)
+			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Default configuration filling is implemented for PHP libraries, automatically deriving the staging subdirectory for each API when it is not explicitly specified in librarian.yaml.

This ensures PHP library configurations have consistent staging paths without requiring manual specification for every API.

For https://github.com/googleapis/librarian/issues/6896 
