### PR TITLE
feat(sidekick/rust): add used_if: hybrid_services dependency resolution

### DIFF
--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -178,8 +178,16 @@ func newLibraryCodec(library *config.Library) map[string]string {
 		codec["package-name-override"] = library.Name
 	}
 	if library.Rust != nil {
+		depsByName := make(map[string][]string)
+		var names []string
 		for _, dep := range library.Rust.PackageDependencies {
-			codec["package:"+dep.Name] = formatPackageDependency(dep)
+			if _, seen := depsByName[dep.Name]; !seen {
+				names = append(names, dep.Name)
+			}
+			depsByName[dep.Name] = append(depsByName[dep.Name], formatPackageDependency(dep))
+		}
+		for _, name := range names {
+			codec["package:"+name] = strings.Join(depsByName[name], ";")
 		}
 		if len(library.Rust.DisabledRustdocWarnings) > 0 {
 			codec["disabled-rustdoc-warnings"] = strings.Join(library.Rust.DisabledRustdocWarnings, ",")

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -123,7 +123,7 @@ func (m *modelAnnotations) ReleaseLevelIsGA() bool {
 func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	codec.hasServices = len(model.Services) > 0
 
-	resolveUsedPackages(model, codec.extraPackages)
+	resolveUsedPackages(model, codec.extraPackages, codec.includeBidiStreamingMethods)
 	// Annotate enums and messages that we intend to generate. In the
 	// process we discover the external dependencies and trim the list of
 	// packages used by this API.

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -383,8 +383,8 @@ type packagez struct {
 	usedIf []string
 }
 
-func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
-	hasServices := len(model.Services) > 0
+func resolveUsedPackages(model *api.API, extraPackages []*packagez, includeBidiStreamingMethods bool) {
+	hasHybridServices := false
 	hasLROs := false
 	hasAutoPopulation := false
 	for _, s := range model.Services {
@@ -399,14 +399,22 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
 			if len(m.AutoPopulated) != 0 {
 				hasAutoPopulation = true
 			}
+			if includeBidiStreamingMethods && m.ClientSideStreaming && m.ServerSideStreaming {
+				hasHybridServices = true
+			}
 		}
 	}
+	hasServices := len(model.Services) > 0 && !hasHybridServices
 	for _, pkg := range extraPackages {
 		if pkg.used {
 			continue
 		}
 		for _, namedFeature := range pkg.usedIf {
 			if namedFeature == "services" && hasServices {
+				pkg.used = true
+				break
+			}
+			if namedFeature == "hybrid_services" && hasHybridServices {
 				pkg.used = true
 				break
 			}

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -106,13 +106,15 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 		case key == "release-level":
 			codec.releaseLevel = definition
 		case strings.HasPrefix(key, "package:"):
-			pkgOption, err := parsePackageOption(key, definition)
+			pkgOptions, err := parsePackageOptions(key, definition)
 			if err != nil {
 				return nil, err
 			}
-			codec.extraPackages = append(codec.extraPackages, pkgOption.pkg)
-			for _, source := range pkgOption.otherNames {
-				codec.packageMapping[source] = pkgOption.pkg
+			for _, pkgOption := range pkgOptions {
+				codec.extraPackages = append(codec.extraPackages, pkgOption.pkg)
+				for _, source := range pkgOption.otherNames {
+					codec.packageMapping[source] = pkgOption.pkg
+				}
 			}
 		case key == "disabled-rustdoc-warnings":
 			codec.disabledRustdocWarnings = splitOption(definition)
@@ -219,7 +221,19 @@ type packageOption struct {
 	otherNames []string
 }
 
-func parsePackageOption(key, definition string) (*packageOption, error) {
+func parsePackageOptions(key, definition string) ([]*packageOption, error) {
+	var opts []*packageOption
+	for def := range strings.SplitSeq(definition, ";") {
+		pkgOpt, err := parseSinglePackageOption(key, def)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, pkgOpt)
+	}
+	return opts, nil
+}
+
+func parseSinglePackageOption(key, definition string) (*packageOption, error) {
 	var specificationPackages []string
 	pkg := &packagez{
 		name: strings.TrimPrefix(key, "package:"),
@@ -384,6 +398,8 @@ type packagez struct {
 }
 
 func resolveUsedPackages(model *api.API, extraPackages []*packagez, includeBidiStreamingMethods bool) {
+	hasServices := len(model.Services) > 0
+
 	hasHybridServices := false
 	hasLROs := false
 	hasAutoPopulation := false
@@ -404,7 +420,6 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez, includeBidiS
 			}
 		}
 	}
-	hasServices := len(model.Services) > 0 && !hasHybridServices
 	for _, pkg := range extraPackages {
 		if pkg.used {
 			continue
@@ -1460,15 +1475,41 @@ func requiredPackageLine(pkg *packagez) string {
 	return fmt.Sprintf("%-20s = true", pkg.name+".workspace")
 }
 
+func mergePackages(extraPackages []*packagez) []*packagez {
+	var merged []*packagez
+	indexByName := make(map[string]int)
+
+	for _, pkg := range extraPackages {
+		if pkg.ignore || !pkg.used {
+			continue
+		}
+		idx, found := indexByName[pkg.name]
+		if !found {
+			p := &packagez{
+				ignore:      pkg.ignore,
+				packageName: pkg.packageName,
+				features:    append([]string{}, pkg.features...),
+				used:        pkg.used,
+				usedIf:      append([]string{}, pkg.usedIf...),
+				name:        pkg.name,
+			}
+			indexByName[pkg.name] = len(merged)
+			merged = append(merged, p)
+		} else {
+			m := merged[idx]
+			for _, f := range pkg.features {
+				if !slices.Contains(m.features, f) {
+					m.features = append(m.features, f)
+				}
+			}
+		}
+	}
+	return merged
+}
+
 func requiredPackages(extraPackages []*packagez) []string {
 	lines := []string{}
-	for _, pkg := range extraPackages {
-		if pkg.ignore {
-			continue
-		}
-		if !pkg.used {
-			continue
-		}
+	for _, pkg := range mergePackages(extraPackages) {
 		lines = append(lines, requiredPackageLine(pkg))
 	}
 	sort.Strings(lines)
@@ -1477,10 +1518,7 @@ func requiredPackages(extraPackages []*packagez) []string {
 
 func externPackages(extraPackages []*packagez) []string {
 	names := []string{}
-	for _, pkg := range extraPackages {
-		if pkg.ignore || !pkg.used {
-			continue
-		}
+	for _, pkg := range mergePackages(extraPackages) {
 		names = append(names, packageNameToRootModule(pkg.name))
 	}
 	sort.Strings(names)

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -422,13 +422,30 @@ func TestParsePackageOptionError(t *testing.T) {
 		{Definition: "--invalid--=a,package=b"},
 	} {
 		t.Run(test.Definition, func(t *testing.T) {
-			if got, err := parsePackageOption("package:test", test.Definition); err == nil {
+			if got, err := parsePackageOptions("package:test", test.Definition); err == nil {
 				t.Errorf("expected an error parsing the options, got=%v, options=%v", got, test.Definition)
 			}
 		})
 	}
-	if got, err := parsePackageOption("package:", "unused"); err == nil {
+	if got, err := parsePackageOptions("package:", "unused"); err == nil {
 		t.Errorf("expected an error parsing the options, got=%v", got)
+	}
+}
+
+func TestParsePackageOptionsMultiple(t *testing.T) {
+	definition := "package=google-cloud-gax-internal,used-if=services,feature=_internal-http-client;package=google-cloud-gax-internal,used-if=hybrid_services,feature=_internal-grpc-client"
+	got, err := parsePackageOptions("package:gaxi", definition)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 package options, got %d", len(got))
+	}
+	if got[0].pkg.name != "gaxi" || got[0].pkg.features[0] != "_internal-http-client" {
+		t.Errorf("unexpected first package option: %+v", got[0].pkg)
+	}
+	if got[1].pkg.name != "gaxi" || got[1].pkg.features[0] != "_internal-grpc-client" {
+		t.Errorf("unexpected second package option: %+v", got[1].pkg)
 	}
 }
 

--- a/internal/sidekick/rust/used_by_test.go
+++ b/internal/sidekick/rust/used_by_test.go
@@ -36,7 +36,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
 	want := []*packagez{
 		{
 			name:        "location",
@@ -64,7 +64,7 @@ func TestUsedByServicesNoServices(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
 	want := []*packagez{
 		{
 			name:        "location",
@@ -100,7 +100,7 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
 	want := []*packagez{
 		{
 			name:        "location",
@@ -136,7 +136,7 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
 	want := []*packagez{
 		{
 			name:        "location",
@@ -176,7 +176,7 @@ func TestUsedByUuidWithAutoPopulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
 	want := []*packagez{
 		{
 			name:        "location",
@@ -213,7 +213,7 @@ func TestUsedByUuidWithoutAutoPopulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
 	want := []*packagez{
 		{
 			name:        "location",
@@ -399,6 +399,88 @@ func TestFindUsedPackages_MapFields(t *testing.T) {
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
 	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUsedByHybridServices(t *testing.T) {
+	service := &api.Service{
+		Name: "TestService",
+		ID:   ".test.Service",
+		Methods: []*api.Method{
+			{
+				Name:                "BidiStream",
+				ID:                  ".test.Service.BidiStream",
+				ServerSideStreaming: true,
+				ClientSideStreaming: true,
+			},
+		},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	extraPackages := []*packagez{
+		{
+			name:        "gaxi",
+			packageName: "google-cloud-gax-internal",
+			features:    []string{"_internal-http-client"},
+			usedIf:      []string{"services"},
+		},
+		{
+			name:        "gaxi",
+			packageName: "google-cloud-gax-internal",
+			features:    []string{"_internal-http-client", "_internal-grpc-client"},
+			usedIf:      []string{"hybrid_services"},
+		},
+	}
+	c := &codec{
+		includeBidiStreamingMethods: true,
+		extraPackages:               extraPackages,
+	}
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
+	got := requiredPackages(extraPackages)
+	want := []string{
+		"gaxi                 = { workspace = true, features = [\"_internal-http-client\", \"_internal-grpc-client\"] }",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUsedByServicesWithHybridServicesConfigured(t *testing.T) {
+	service := &api.Service{
+		Name: "TestService",
+		ID:   ".test.Service",
+		Methods: []*api.Method{
+			{
+				Name: "UnaryRpc",
+				ID:   ".test.Service.UnaryRpc",
+			},
+		},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	extraPackages := []*packagez{
+		{
+			name:        "gaxi",
+			packageName: "google-cloud-gax-internal",
+			features:    []string{"_internal-http-client"},
+			usedIf:      []string{"services"},
+		},
+		{
+			name:        "gaxi",
+			packageName: "google-cloud-gax-internal",
+			features:    []string{"_internal-http-client", "_internal-grpc-client"},
+			usedIf:      []string{"hybrid_services"},
+		},
+	}
+	c := &codec{
+		includeBidiStreamingMethods: true,
+		extraPackages:               extraPackages,
+	}
+	resolveUsedPackages(model, c.extraPackages, c.includeBidiStreamingMethods)
+	got := requiredPackages(extraPackages)
+	want := []string{
+		"gaxi                 = { workspace = true, features = [\"_internal-http-client\"] }",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/rust/used_by_test.go
+++ b/internal/sidekick/rust/used_by_test.go
@@ -427,7 +427,7 @@ func TestUsedByHybridServices(t *testing.T) {
 		{
 			name:        "gaxi",
 			packageName: "google-cloud-gax-internal",
-			features:    []string{"_internal-http-client", "_internal-grpc-client"},
+			features:    []string{"_internal-grpc-client"},
 			usedIf:      []string{"hybrid_services"},
 		},
 	}
@@ -467,7 +467,7 @@ func TestUsedByServicesWithHybridServicesConfigured(t *testing.T) {
 		{
 			name:        "gaxi",
 			packageName: "google-cloud-gax-internal",
-			features:    []string{"_internal-http-client", "_internal-grpc-client"},
+			features:    []string{"_internal-grpc-client"},
 			usedIf:      []string{"hybrid_services"},
 		},
 	}


### PR DESCRIPTION
Support used_if: hybrid_services in package_dependencies configuration to
allow conditionally enabling gaxi features for hybrid REST+gRPC crates.

When include_bidi_streaming_methods is enabled and a service contains
bidirectional streaming RPCs, packages configured with used_if: hybrid_services
are activated additively alongside used_if: services rules.

This will be used in librarian.yaml to enable the _internal-grpc-client
feature on google-cloud-gax-internal for hybrid services alongside the
standard _internal-http-client feature.

To support multiple package_dependencies rules for the same dependency name
without option map collisions, librarian joins definitions using a semicolon
delimiter in codec["package:<name>"]. Sidekick parses semicolon-delimited
package options into separate rules and merges all active features for the
package into a single Cargo.toml entry.

For #6835 