### PR TITLE
feat(internal/librarian/ruby): preserve repo metadata release level, library type, and custom fields

### DIFF
--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -33,6 +33,7 @@ var (
 	// oneTimeGeneratedRootFiles is the list of files generated only once upon initial library creation.
 	oneTimeGeneratedRootFiles = []string{
 		"CHANGELOG.md",
+		".repo-metadata.json",
 	}
 	// generatedRootFiles is the list of specific root files generated for Ruby client gems.
 	generatedRootFiles = []string{

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -77,6 +77,9 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
+	if err := updateRepoMetadata(outDir, tempDir, library.Name); err != nil {
+		return fmt.Errorf("failed to update repo metadata: %w", err)
+	}
 	keepSet := buildKeepSet(library.Name, library.Keep)
 	keepFunc := func(rel string) bool {
 		return isKept(rel, keepSet)

--- a/internal/librarian/ruby/repometadata.go
+++ b/internal/librarian/ruby/repometadata.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/googleapis/librarian/internal/repometadata"
+)
+
+func updateRepoMetadata(outputDir, stagingDir, gemName string) error {
+	stagingPath := filepath.Join(stagingDir, gemName, ".repo-metadata.json")
+	outputPath := filepath.Join(outputDir, gemName, ".repo-metadata.json")
+	writeDir := filepath.Join(stagingDir, gemName)
+
+	stagingData, err := os.ReadFile(stagingPath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to read staging repo metadata: %w", err)
+		}
+		stagingPath = filepath.Join(stagingDir, ".repo-metadata.json")
+		outputPath = filepath.Join(outputDir, ".repo-metadata.json")
+		writeDir = stagingDir
+		stagingData, err = os.ReadFile(stagingPath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("failed to read staging repo metadata: %w", err)
+		}
+	}
+
+	var newMap map[string]any
+	if err := json.Unmarshal(stagingData, &newMap); err != nil {
+		return fmt.Errorf("failed to unmarshal staging repo metadata: %w", err)
+	}
+	if newMap == nil {
+		newMap = make(map[string]any)
+	}
+
+	if outputData, err := os.ReadFile(outputPath); err == nil {
+		var existingMap map[string]any
+		if err := json.Unmarshal(outputData, &existingMap); err == nil && existingMap != nil {
+			for key, val := range existingMap {
+				if _, ok := newMap[key]; !ok {
+					newMap[key] = val
+				}
+			}
+			if rl, ok := existingMap["release_level"].(string); ok && rl != "" {
+				newMap["release_level"] = rl
+			}
+			if lt, ok := existingMap["library_type"].(string); ok && lt != "" {
+				newMap["library_type"] = lt
+			}
+		}
+	}
+
+	return repometadata.WriteJSON(newMap, "    ", writeDir, ".repo-metadata.json")
+}

--- a/internal/librarian/ruby/repometadata_test.go
+++ b/internal/librarian/ruby/repometadata_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUpdateRepoMetadata(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		gemName     string
+		stagingJSON string
+		outputJSON  string
+		wantJSON    string
+	}{
+		{
+			name:        "preserves release_level, library_type, and custom fields from existing metadata",
+			gemName:     "google-cloud-asset-v1",
+			stagingJSON: `{"api_id":"cloudasset.googleapis.com","release_level":"unreleased","ruby-cloud-description":"new description","library_type":"GAPIC_AUTO"}`,
+			outputJSON:  `{"api_id":"cloudasset.googleapis.com","release_level":"stable","product_documentation":"https://cloud.google.com/asset-inventory/","ruby-cloud-product-url":"https://cloud.google.com/asset-inventory/","library_type":"GAPIC_COMBO"}`,
+			wantJSON: `{
+    "api_id": "cloudasset.googleapis.com",
+    "library_type": "GAPIC_COMBO",
+    "product_documentation": "https://cloud.google.com/asset-inventory/",
+    "release_level": "stable",
+    "ruby-cloud-description": "new description",
+    "ruby-cloud-product-url": "https://cloud.google.com/asset-inventory/"
+}`,
+		},
+		{
+			name:        "new library without existing metadata uses staging values",
+			gemName:     "google-cloud-vision-v1",
+			stagingJSON: `{"api_id":"vision.googleapis.com","release_level":"unreleased","library_type":"GAPIC_AUTO"}`,
+			outputJSON:  "",
+			wantJSON: `{
+    "api_id": "vision.googleapis.com",
+    "library_type": "GAPIC_AUTO",
+    "release_level": "unreleased"
+}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			stagingDir := t.TempDir()
+
+			stagingFile := filepath.Join(stagingDir, ".repo-metadata.json")
+			if err := os.WriteFile(stagingFile, []byte(test.stagingJSON), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if test.outputJSON != "" {
+				outputFile := filepath.Join(outputDir, ".repo-metadata.json")
+				if err := os.WriteFile(outputFile, []byte(test.outputJSON), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := updateRepoMetadata(outputDir, stagingDir, test.gemName); err != nil {
+				t.Fatal(err)
+			}
+
+			gotData, err := os.ReadFile(stagingFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var gotMap, wantMap map[string]any
+			if err := json.Unmarshal(gotData, &gotMap); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(test.wantJSON), &wantMap); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(wantMap, gotMap); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUpdateRepoMetadata_Subdirectory(t *testing.T) {
+	outputDir := t.TempDir()
+	stagingDir := t.TempDir()
+	gemName := "google-cloud-asset-v1"
+
+	if err := os.MkdirAll(filepath.Join(stagingDir, gemName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(outputDir, gemName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stagingFile := filepath.Join(stagingDir, gemName, ".repo-metadata.json")
+	stagingJSON := `{"api_id":"cloudasset.googleapis.com","release_level":"unreleased","library_type":"GAPIC_AUTO"}`
+	if err := os.WriteFile(stagingFile, []byte(stagingJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputFile := filepath.Join(outputDir, gemName, ".repo-metadata.json")
+	outputJSON := `{"api_id":"cloudasset.googleapis.com","release_level":"stable","product_documentation":"https://cloud.google.com/asset-inventory/","library_type":"GAPIC_COMBO"}`
+	if err := os.WriteFile(outputFile, []byte(outputJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateRepoMetadata(outputDir, stagingDir, gemName); err != nil {
+		t.Fatal(err)
+	}
+
+	gotData, err := os.ReadFile(stagingFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotMap, wantMap map[string]any
+	if err := json.Unmarshal(gotData, &gotMap); err != nil {
+		t.Fatal(err)
+	}
+	wantJSON := `{
+    "api_id": "cloudasset.googleapis.com",
+    "library_type": "GAPIC_COMBO",
+    "product_documentation": "https://cloud.google.com/asset-inventory/",
+    "release_level": "stable"
+}`
+	if err := json.Unmarshal([]byte(wantJSON), &wantMap); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(wantMap, gotMap); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateRepoMetadata_NoStagingFile(t *testing.T) {
+	outputDir := t.TempDir()
+	stagingDir := t.TempDir()
+
+	if err := updateRepoMetadata(outputDir, stagingDir, "google-cloud-asset-v1"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Preserve existing release_level, library_type, and custom fields (such as product_documentation
and ruby-cloud-product-url) in .repo-metadata.json during Ruby client generation.

Fixes https://github.com/googleapis/librarian/issues/7058