### PR TITLE
feat(sidekick/rust): implement bidi streaming transport stubs

### DIFF
--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -236,6 +236,14 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 			bidiStreamingServices = append(bidiStreamingServices, s)
 		}
 	}
+	hasBidiStreaming := codec.templateOverride == "" && codec.includeBidiStreamingMethods && slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
+	if hasBidiStreaming {
+		for _, pkg := range codec.extraPackages {
+			if pkg.name == "gaxi" && !slices.Contains(pkg.features, "_internal-grpc-client") {
+				pkg.features = append(pkg.features, "_internal-grpc-client")
+			}
+		}
+	}
 
 	ann := &modelAnnotations{
 		PackageName:           codec.packageName(model),
@@ -245,7 +253,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		RequiredPackages:      requiredPackages(codec.extraPackages),
 		ExternPackages:        externPackages(codec.extraPackages),
 		HasLROs:               hasLROs,
-		HasBidiStreaming:      codec.templateOverride == "" && codec.includeBidiStreamingMethods && len(bidiStreamingServices) > 0,
+		HasBidiStreaming:      hasBidiStreaming,
 		BidiStreamingServices: bidiStreamingServices,
 		CopyrightYear:         codec.generationYear,
 		BoilerPlate: append(license.HeaderBulk(),

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -30,6 +30,8 @@ import (
 // errQuickstartServiceNotFound is returned when the requested quickstart service override is not found.
 var errQuickstartServiceNotFound = errors.New("quickstart_service_override not found")
 
+const gaxiPackageName = "gaxi"
+
 type modelAnnotations struct {
 	PackageName           string
 	PackageVersion        string
@@ -239,7 +241,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	hasBidiStreaming := codec.templateOverride == "" && codec.includeBidiStreamingMethods && slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
 	if hasBidiStreaming {
 		for _, pkg := range codec.extraPackages {
-			if pkg.name == "gaxi" && !slices.Contains(pkg.features, "_internal-grpc-client") {
+			if pkg.name == gaxiPackageName && !slices.Contains(pkg.features, "_internal-grpc-client") {
 				pkg.features = append(pkg.features, "_internal-grpc-client")
 			}
 		}

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -16,6 +16,7 @@ package rust
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -552,24 +553,28 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name    string
-		service *api.Service
-		options map[string]string
-		want    bool
+		name             string
+		service          *api.Service
+		options          map[string]string
+		want             bool
+		wantGaxiFeatures []string
 	}{
 		{
 			name:    "bidi streaming enabled with bidi method",
 			service: bidiService,
 			options: map[string]string{
 				"include-bidi-streaming-methods": "true",
+				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 			},
-			want: true,
+			want:             true,
+			wantGaxiFeatures: []string{"_internal-grpc-client"},
 		},
 		{
 			name:    "bidi streaming disabled with bidi method",
 			service: bidiService,
 			options: map[string]string{
 				"include-bidi-streaming-methods": "false",
+				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 			},
 			want: false,
 		},
@@ -578,6 +583,7 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			service: unaryService,
 			options: map[string]string{
 				"include-bidi-streaming-methods": "true",
+				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 			},
 			want: false,
 		},
@@ -587,6 +593,7 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			options: map[string]string{
 				"include-bidi-streaming-methods": "true",
 				"template-override":              "templates/tonic",
+				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 			},
 			want: false,
 		},
@@ -603,6 +610,21 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			}
 			if got.HasBidiStreaming != test.want {
 				t.Errorf("HasBidiStreaming = %v, want %v", got.HasBidiStreaming, test.want)
+			}
+			if len(test.wantGaxiFeatures) > 0 {
+				var gaxiPkg *packagez
+				for _, pkg := range codec.extraPackages {
+					if pkg.name == "gaxi" {
+						gaxiPkg = pkg
+						break
+					}
+				}
+				if gaxiPkg == nil {
+					t.Fatalf("gaxi package not found in extraPackages")
+				}
+				if !slices.Equal(gaxiPkg.features, test.wantGaxiFeatures) {
+					t.Errorf("gaxi features = %v, want %v", gaxiPkg.features, test.wantGaxiFeatures)
+				}
 			}
 		})
 	}

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -612,18 +612,14 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				t.Errorf("HasBidiStreaming = %v, want %v", got.HasBidiStreaming, test.want)
 			}
 			if len(test.wantGaxiFeatures) > 0 {
-				var gaxiPkg *packagez
-				for _, pkg := range codec.extraPackages {
-					if pkg.name == "gaxi" {
-						gaxiPkg = pkg
-						break
-					}
-				}
-				if gaxiPkg == nil {
+				idx := slices.IndexFunc(codec.extraPackages, func(pkg *packagez) bool {
+					return pkg.name == gaxiPackageName
+				})
+				if idx == -1 {
 					t.Fatalf("gaxi package not found in extraPackages")
 				}
-				if !slices.Equal(gaxiPkg.features, test.wantGaxiFeatures) {
-					t.Errorf("gaxi features = %v, want %v", gaxiPkg.features, test.wantGaxiFeatures)
+				if diff := cmp.Diff(test.wantGaxiFeatures, codec.extraPackages[idx].features); diff != "" {
+					t.Errorf("gaxi features mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -619,7 +619,7 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 					t.Fatalf("gaxi package not found in extraPackages")
 				}
 				if diff := cmp.Diff(test.wantGaxiFeatures, codec.extraPackages[idx].features); diff != "" {
-					t.Errorf("gaxi features mismatch (-want +got):\n%s", diff)
+					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -68,6 +68,10 @@ all-features = true
 # TODO(#6838): Make prost and prost-types optional dependencies gated by the streaming feature flag.
 prost.workspace = true
 prost-types.workspace = true
+futures.workspace = true
+http.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
 {{/Codec.HasBidiStreaming}}
 {{#Codec.RequiredPackages}}
 {{{.}}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -131,13 +131,78 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
-        _options: crate::RequestOptions,
+        options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
     ) {
-        {{! TODO(#6835) - implement the body }}
-        unimplemented!()
+        use gaxi::prost::{FromProto, ToProto};
+        use futures::stream::StreamExt as _;
+
+        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel::<{{InputType.Codec.QualifiedName}}>(100);
+        let (resp_tx, resp_rx) = tokio::sync::mpsc::channel::<crate::Result<{{OutputType.Codec.QualifiedName}}>>(100);
+
+        let grpc_client = self.grpc_inner.clone();
+        tokio::spawn(async move {
+            let first_req = match req_rx.recv().await {
+                Some(req) => req,
+                None => return,
+            };
+
+            let req_stream = futures::stream::once(async move { first_req })
+                .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx))
+                .map(|v| v.to_proto().expect("request serialization failed"));
+
+            let extensions = {
+                let mut e = gaxi::grpc::tonic::Extensions::new();
+                e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                    "{{SourceService.Package}}.{{SourceService.Name}}",
+                    "{{Name}}",
+                ));
+                e
+            };
+            let path = http::uri::PathAndQuery::from_static(
+                "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}"
+            );
+            {{! TODO(#6835) - derive request params from initial request }}
+            let x_goog_request_params = "";
+
+            let result = grpc_client
+                .bidi_stream::<
+                    crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
+                    crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
+                >(
+                    extensions,
+                    path,
+                    req_stream,
+                    options,
+                    &crate::info::X_GOOG_API_CLIENT_HEADER,
+                    x_goog_request_params,
+                )
+                .await;
+
+            match result {
+                Ok(response) => {
+                    let mut response_stream = response.into_inner();
+                    while let Some(res) = response_stream.next().await {
+                        let item = res
+                            .map_err(gaxi::grpc::from_status::to_gax_error)
+                            .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser));
+                        if resp_tx.send(item).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(err) => {
+                    let _ = resp_tx.send(Err(err.into())).await;
+                }
+            }
+        });
+
+        (
+            google_cloud_gax::streaming::RequestSender::new(req_tx),
+            google_cloud_gax::streaming::ResponseReceiver::new(resp_rx),
+        )
     }
 
     {{/Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -139,8 +139,9 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         use gaxi::prost::{FromProto, ToProto};
         use futures::stream::StreamExt as _;
 
-        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel::<{{InputType.Codec.QualifiedName}}>(100);
-        let (resp_tx, resp_rx) = tokio::sync::mpsc::channel::<crate::Result<{{OutputType.Codec.QualifiedName}}>>(100);
+        {{! TODO(#6835) - provide a way to configure the channel size }}
+        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel::<{{InputType.Codec.QualifiedName}}>(16);
+        let (resp_tx, resp_rx) = tokio::sync::mpsc::channel::<crate::Result<{{OutputType.Codec.QualifiedName}}>>(16);
 
         let grpc_client = self.grpc_inner.clone();
         tokio::spawn(async move {
@@ -188,7 +189,8 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                     while let Some(res) = response_stream.next().await {
                         let item = res
                             .map_err(gaxi::grpc::from_status::to_gax_error)
-                            .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser));
+                            .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
+                            .map_err(Into::into);
                         if resp_tx.send(item).await.is_err() {
                             break;
                         }

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -149,6 +149,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 None => return,
             };
 
+            {{! TODO(#6835) - propagate request serialization errors back to send() instead of using expect() }}
             let req_stream = futures::stream::once(async move { first_req })
                 .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx))
                 .map(|v| v.to_proto().expect("request serialization failed"));
@@ -194,6 +195,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                     }
                 }
                 Err(err) => {
+                    {{! TODO(#6835) - propagate stream setup errors (result of bidi_stream) back to send() }}
                     let _ = resp_tx.send(Err(err.into())).await;
                 }
             }


### PR DESCRIPTION
Implement bidirectional streaming transport stubs in generated Rust crates and add required workspace dependencies (`futures`, `http`, `tokio`, `tokio-stream`, and the `_internal-grpc-client` feature on `gaxi`) behind `#[cfg(google_cloud_unstable_gapic_streaming)]`.

Also add TODOs for follow-up work to propagate request serialization and stream setup errors to `RequestSender::send()`. This will require changes to the constructor and likely will move the proto conversion
to the RequestSender, if we can manage this while erasing the prost types.

For #6835 