### PR TITLE
refactor(internal/librarian/ruby): pass library and config to generateAPI and buildGAPICOpts

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -73,7 +73,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	// TODO(https://github.com/googleapis/librarian/issues/6885): Implement main client gem wrapper generation
 	// for libraries configured with `ruby.wrapper_of`.
 	for _, api := range library.APIs {
-		if err := generateAPI(ctx, api, library.Name, pc, googleapisDir, tempDir); err != nil {
+		if err := generateAPI(ctx, api, library, cfg, pc, googleapisDir, tempDir); err != nil {
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
@@ -90,7 +90,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
-func generateAPI(ctx context.Context, api *config.API, gemName string, pc *config.Protoc, googleapisDir, stagingDir string) error {
+func generateAPI(ctx context.Context, api *config.API, library *config.Library, cfg *config.Config, pc *config.Protoc, googleapisDir, stagingDir string) error {
 	additionalProtos := []string{commonResourcesProto}
 	if api.Ruby != nil {
 		additionalProtos = append(additionalProtos, api.Ruby.AdditionalProtos...)
@@ -99,7 +99,7 @@ func generateAPI(ctx context.Context, api *config.API, gemName string, pc *confi
 	if err != nil {
 		return err
 	}
-	gapicOpts, err := buildGAPICOpts(api, gemName, googleapisDir)
+	gapicOpts, err := buildGAPICOpts(api, library, cfg, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,8 @@ func generateAPI(ctx context.Context, api *config.API, gemName string, pc *confi
 	return nil
 }
 
-func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, error) {
+func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config, googleapisDir string) ([]string, error) {
+	_ = cfg
 	sc, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
 	if err != nil {
 		return nil, err
@@ -156,8 +157,8 @@ func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, e
 		return nil, err
 	}
 	var opts []string
-	if gemName != "" {
-		opts = append(opts, "ruby-cloud-gem-name="+gemName)
+	if library != nil && library.Name != "" {
+		opts = append(opts, "ruby-cloud-gem-name="+library.Name)
 	}
 	if sc != nil && sc.ServiceConfig != "" {
 		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, sc.ServiceConfig))

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -42,7 +42,8 @@ func TestBuildGAPICOpts(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		api     *config.API
-		gemName string
+		library *config.Library
+		cfg     *config.Config
 		want    []string
 	}{
 		{
@@ -50,7 +51,9 @@ func TestBuildGAPICOpts(t *testing.T) {
 			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",
 			},
-			gemName: "google-cloud-secret_manager-v1",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager-v1",
+			},
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
@@ -64,7 +67,9 @@ func TestBuildGAPICOpts(t *testing.T) {
 			api: &config.API{
 				Path: "google/cloud/compute/v1",
 			},
-			gemName: "google-cloud-compute-v1",
+			library: &config.Library{
+				Name: "google-cloud-compute-v1",
+			},
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-compute-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/compute/v1/compute_v1.yaml"),
@@ -74,7 +79,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := buildGAPICOpts(test.api, test.gemName, googleapisDir)
+			got, err := buildGAPICOpts(test.api, test.library, test.cfg, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -443,9 +448,9 @@ func TestGenerateAPI(t *testing.T) {
 	}
 	stagingDir := t.TempDir()
 	api := &config.API{Path: "google/cloud/secretmanager/v1"}
-	gemName := "google-cloud-secret_manager-v1"
+	library := &config.Library{Name: "google-cloud-secret_manager-v1"}
 
-	err = generateAPI(t.Context(), api, gemName, nil, googleapisDir, stagingDir)
+	err = generateAPI(t.Context(), api, library, nil, nil, googleapisDir, stagingDir)
 	if err != nil {
 		t.Fatalf("generateAPI() error = %v", err)
 	}
@@ -469,7 +474,8 @@ func TestGenerateAPI_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 	api := &config.API{Path: "non/existent/path"}
-	err = generateAPI(t.Context(), api, "gem-name", nil, googleapisDir, t.TempDir())
+	library := &config.Library{Name: "gem-name"}
+	err = generateAPI(t.Context(), api, library, nil, nil, googleapisDir, t.TempDir())
 	if err == nil {
 		t.Error("generateAPI() error = nil, want error")
 	}


### PR DESCRIPTION
Update `generateAPI` and `buildGAPICOpts` signatures and calls in `internal/librarian/ruby/generate.go` to accept `library *config.Library` and `cfg *config.Config`.

This refactoring prepares for main client gem wrapper generation (`ruby.wrapper_of`).

For https://github.com/googleapis/librarian/issues/6885