### PR TITLE
feat(internal/librarian/ruby): support ruby-cloud-migration-version in librarian.yaml

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -496,7 +496,7 @@ This document describes the schema for the librarian.yaml.
 | `ruby-cloud-env-prefix` | string | Is the environment variable prefix. |
 | `ruby-cloud-extra-dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
 | `ruby-cloud-gem-namespace` | string | Is the root Ruby namespace. |
-| `ruby-cloud-migration-version` | string | Specifies the gem version milestone at which the library was migrated to GAPIC. |
+| `ruby-cloud-migration-version` | string | Specifies the gem version milestone at which the library was migrated to GAPIC, generating a migration section in the README file. |
 | `ruby-cloud-namespace-override` | string | Overrides token / segment replacements applied across all generated module & class paths. |
 | `ruby-cloud-path-override` | string | Overrides file/directory paths under lib/ and proto_docs/. |
 | `ruby-cloud-service-override` | string | Overrides generated service class names when proto package service names don't match desired Ruby conventions. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -496,6 +496,7 @@ This document describes the schema for the librarian.yaml.
 | `ruby-cloud-env-prefix` | string | Is the environment variable prefix. |
 | `ruby-cloud-extra-dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
 | `ruby-cloud-gem-namespace` | string | Is the root Ruby namespace. |
+| `ruby-cloud-migration-version` | string | Specifies the gem version milestone at which the library was migrated to GAPIC. |
 | `ruby-cloud-namespace-override` | string | Overrides token / segment replacements applied across all generated module & class paths. |
 | `ruby-cloud-path-override` | string | Overrides file/directory paths under lib/ and proto_docs/. |
 | `ruby-cloud-service-override` | string | Overrides generated service class names when proto package service names don't match desired Ruby conventions. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -856,7 +856,7 @@ type RubyCloudOpts struct {
 	// GemNamespace is the root Ruby namespace.
 	GemNamespace string `yaml:"ruby-cloud-gem-namespace,omitempty"`
 
-	// MigrationVersion specifies the gem version milestone at which the library was migrated to GAPIC.
+	// MigrationVersion specifies the gem version milestone at which the library was migrated to GAPIC, generating a migration section in the README file.
 	MigrationVersion string `yaml:"ruby-cloud-migration-version,omitempty"`
 
 	// NamespaceOverride overrides token / segment replacements applied across all generated

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -856,6 +856,9 @@ type RubyCloudOpts struct {
 	// GemNamespace is the root Ruby namespace.
 	GemNamespace string `yaml:"ruby-cloud-gem-namespace,omitempty"`
 
+	// MigrationVersion specifies the gem version milestone at which the library was migrated to GAPIC.
+	MigrationVersion string `yaml:"ruby-cloud-migration-version,omitempty"`
+
 	// NamespaceOverride overrides token / segment replacements applied across all generated
 	// module & class paths.
 	NamespaceOverride string `yaml:"ruby-cloud-namespace-override,omitempty"`

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -179,6 +179,9 @@ func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, e
 		if api.Ruby.RubyCloudOpts.ExtraDependencies != "" {
 			opts = append(opts, "ruby-cloud-extra-dependencies="+api.Ruby.RubyCloudOpts.ExtraDependencies)
 		}
+		if api.Ruby.RubyCloudOpts.MigrationVersion != "" {
+			opts = append(opts, "ruby-cloud-migration-version="+api.Ruby.RubyCloudOpts.MigrationVersion)
+		}
 	}
 	return opts, nil
 }

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -72,6 +72,26 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"ruby-cloud-rest-numeric-enums=true",
 			},
 		},
+		{
+			name: "ruby cloud opts with migration version",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Ruby: &config.RubyAPI{
+					RubyCloudOpts: &config.RubyCloudOpts{
+						MigrationVersion: "1.0",
+					},
+				},
+			},
+			gemName: "google-cloud-secret_manager",
+			want: []string{
+				"ruby-cloud-gem-name=google-cloud-secret_manager",
+				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
+				"ruby-cloud-generate-transports=grpc;rest",
+				"ruby-cloud-rest-numeric-enums=true",
+				"ruby-cloud-migration-version=1.0",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := buildGAPICOpts(test.api, test.gemName, googleapisDir)


### PR DESCRIPTION
Add `MigrationVersion` field (`ruby-cloud-migration-version`) to `RubyCloudOpts` in `internal/config/language.go` and pass `ruby-cloud-migration-version=...` to protoc in `internal/librarian/ruby/generate.go`.

### Detailed Role of `ruby-cloud-migration-version`

The `ruby-cloud-migration-version` protoc plugin option specifies the gem version milestone at which a Ruby client library was migrated from legacy handwritten/Synthtool code to GAPIC-generated code.

In `gapic-generator-ruby` (at commit [`8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75`](https://github.com/googleapis/gapic-generator-ruby/tree/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75)):

1. **Parameter Parsing**: Maps `ruby-cloud-migration-version` to `:gem.:migration_version`:
   [`cloud_generator_parameters.rb#L43`](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/gapic-generator-cloud/lib/gapic/generators/cloud_generator_parameters.rb#L43)
   ```ruby
   "ruby-cloud-migration-version" => ":gem.:migration_version",
   ```

2. **Presenter Methods**: Exposes `migration?`, `migration_version`, and `pre_migration_version` (e.g. `0.x` or `pre-1.0`):
   [`wrapper_gem_presenter.rb#L65-L95`](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb#L65-L95)
   ```ruby
   def migration_version
     gem_config :migration_version
   end

   def pre_migration_version
     match = /^(\d)+\.0/.match migration_version.to_s
     if match
       major = match[1].to_i
       return "#{major - 1}.x" if major.positive?
     end
     "pre-#{migration_version}"
   end

   def migration?
     migration_version ? true : false
   end
   ```

3. **README Section Generation**: When `gem.migration?` is true, the generator renders a dedicated *"Migrating from <pre_migration_version> versions"* section in the generated `README.md`:
   [`readme.text.erb#L70-L79`](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.text.erb#L70-L79)
   ```erb
   <%- if gem.migration? %>
   ## Migrating from <%= gem.pre_migration_version %> versions

   The <%= gem.migration_version %> release of the <%= gem.name %> client is a significant upgrade
   based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),
   and includes substantial interface changes. Existing code written for earlier
   versions of this library will likely require updates to use this version.
   See the {file:MIGRATING.md MIGRATING.md} document for more information.

   <%- end -%>
   ```

### Real-World Example in `google-cloud-asset`

When `ruby-cloud-migration-version=1.0` is specified for `google-cloud-asset`, the generated [`google-cloud-asset/README.md`](https://github.com/googleapis/google-cloud-ruby/blob/main/google-cloud-asset/README.md#migrating-from-0x-versions) contains:

```markdown
## Migrating from 0.x versions

The 1.0 release of the google-cloud-asset client is a significant upgrade
based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),
and includes substantial interface changes. Existing code written for earlier
versions of this library will likely require updates to use this version.
See the {file:MIGRATING.md MIGRATING.md} document for more information.
```

---

### Changes in this PR
1. Added `MigrationVersion string yaml:"ruby-cloud-migration-version,omitempty"` to `RubyCloudOpts` in `internal/config/language.go`.
2. Updated `buildGAPICOpts` in `internal/librarian/ruby/generate.go` to append `ruby-cloud-migration-version=...` to protoc flags when configured.
3. Added unit tests in `internal/librarian/ruby/generate_test.go`.
4. Updated `doc/config-schema.md` via `go run ./cmd/config_doc_generate.go`.

For https://github.com/googleapis/librarian/issues/6885
