### PR TITLE
refactor(internal/librarian/java): remove python and pip tooling

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -79,22 +79,13 @@ jobs:
           java-version: "17"
           distribution: "temurin"
           cache: "maven"
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-      - name: Cache Librarian Tools & Venv
+      - name: Cache Librarian Tools
         id: cache-tools
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/librarian
-            venv
-          key: librarian-java-tools-v2-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**', 'google-cloud-java/sdk-platform-java/hermetic_build/library_generation/**') }}
-      - name: Create Python virtual environment
-        if: steps.cache-tools.outputs.cache-hit != 'true'
-        run: python3 -m venv venv
-      - name: Activate virtual environment
-        run: echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+          key: librarian-java-tools-v2-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-java/librarian.yaml', 'google-cloud-java/sdk-platform-java/gapic-generator-java/**') }}
       - name: Verify Java and Maven installation
         if: steps.cache-tools.outputs.cache-hit != 'true'
         run: |
@@ -123,14 +114,10 @@ jobs:
       - name: Generate a single library (smoke test)
         if: matrix.task == 'smoke-test' && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
         working-directory: google-cloud-java
-        env:
-          PYTHONPATH: ${{ github.workspace }}/google-cloud-java/sdk-platform-java/hermetic_build/library_generation/owlbot
         run: librarian generate secretmanager
       - name: Run librarian generate all (integration test)
         if: matrix.task == 'integration' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: google-cloud-java
-        env:
-          PYTHONPATH: ${{ github.workspace }}/google-cloud-java/sdk-platform-java/hermetic_build/library_generation/owlbot
         run: librarian generate --all
   create-issue-on-failure:
     needs: [build-and-test]

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -73,6 +73,7 @@ ARG NODEJS_PROTOBUFJS_VERSION=7.5.8
 ARG JAVA_PROTOC_VERSION=33.2
 ARG JAVA_PROTOC_CHECKSUM=8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5
 ARG JAVA_VERSION=17
+ARG JAVA_PYTHON_VERSION=3.12
 ARG NODEJS_NVM_VERSION=0.40.4
 ARG NODEJS_NVM_CHECKSUM=a8e082d8d1a9b61a09e5d3e1902d2930e5b1b84a86f9777c7d2eb50ea204c0141f6a97c54a860bc3282e7b000f1c669c755f5e0db7bd6d492072744c302c0a21
 ARG NODEJS_NODE_VERSION=22
@@ -339,7 +340,8 @@ RUN pnpm add -g \
     pnpm add -g "$PWD"
 
 # ============== Java Stage ==============
-FROM base AS java
+ARG JAVA_PYTHON_VERSION
+FROM python:${JAVA_PYTHON_VERSION}-slim AS java
 ARG JAVA_PROTOC_VERSION
 ARG JAVA_PROTOC_CHECKSUM
 ARG JAVA_VERSION
@@ -371,16 +373,27 @@ RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
     echo "${JAVA_PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip
 
+# Configure pip for external sources (PyPI) globally
+RUN pip config set global.extra-index-url https://pypi.org/simple
+
 # Setup dynamic target directories inside the persistent volume.
+# This ensures that Python packages are persisted alongside Java tools,
+# while completely bypassing dynamic caller permissions.
 ENV LIBRARIAN_INSTALL_DIR=/usr/local/java_tools/bin
 ENV PATH=${LIBRARIAN_INSTALL_DIR}:${PATH}
+
+# Redirect all pip installations to be stored directly inside the volume
+ENV PYTHONPATH=/usr/local/java_tools/python-packages
+ENV PATH=${PYTHONPATH}/bin:${PATH}
+ENV PIP_TARGET=${PYTHONPATH}
+ENV PIP_NO_CACHE_DIR=1
 
 # Persist repository downloads inside the volume cache to save bandwidth and build time
 ENV LIBRARIAN_CACHE=/usr/local/java_tools/cache
 
 # Create java_tools directory and grant broad write permissions.
 # This allows any arbitrary UID running the container (like librarianops) to
-# execute `librarian install java` and write tools to the global path.
+# execute `librarian install java` and write tools and packages to the global path.
 RUN mkdir -p /usr/local/java_tools && \
     chmod -R a+rwx /usr/local/java_tools
 

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -73,7 +73,6 @@ ARG NODEJS_PROTOBUFJS_VERSION=7.5.8
 ARG JAVA_PROTOC_VERSION=33.2
 ARG JAVA_PROTOC_CHECKSUM=8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5
 ARG JAVA_VERSION=17
-ARG JAVA_PYTHON_VERSION=3.12
 ARG NODEJS_NVM_VERSION=0.40.4
 ARG NODEJS_NVM_CHECKSUM=a8e082d8d1a9b61a09e5d3e1902d2930e5b1b84a86f9777c7d2eb50ea204c0141f6a97c54a860bc3282e7b000f1c669c755f5e0db7bd6d492072744c302c0a21
 ARG NODEJS_NODE_VERSION=22
@@ -340,8 +339,7 @@ RUN pnpm add -g \
     pnpm add -g "$PWD"
 
 # ============== Java Stage ==============
-ARG JAVA_PYTHON_VERSION
-FROM python:${JAVA_PYTHON_VERSION}-slim AS java
+FROM base AS java
 ARG JAVA_PROTOC_VERSION
 ARG JAVA_PROTOC_CHECKSUM
 ARG JAVA_VERSION
@@ -373,27 +371,16 @@ RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
     echo "${JAVA_PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip
 
-# Configure pip for external sources (PyPI) globally
-RUN pip config set global.extra-index-url https://pypi.org/simple
-
 # Setup dynamic target directories inside the persistent volume.
-# This ensures that Python packages are persisted alongside Java tools,
-# while completely bypassing dynamic caller permissions.
 ENV LIBRARIAN_INSTALL_DIR=/usr/local/java_tools/bin
 ENV PATH=${LIBRARIAN_INSTALL_DIR}:${PATH}
-
-# Redirect all pip installations to be stored directly inside the volume
-ENV PYTHONPATH=/usr/local/java_tools/python-packages
-ENV PATH=${PYTHONPATH}/bin:${PATH}
-ENV PIP_TARGET=${PYTHONPATH}
-ENV PIP_NO_CACHE_DIR=1
 
 # Persist repository downloads inside the volume cache to save bandwidth and build time
 ENV LIBRARIAN_CACHE=/usr/local/java_tools/cache
 
 # Create java_tools directory and grant broad write permissions.
 # This allows any arbitrary UID running the container (like librarianops) to
-# execute `librarian install java` and write tools and packages to the global path.
+# execute `librarian install java` and write tools to the global path.
 RUN mkdir -p /usr/local/java_tools && \
     chmod -R a+rwx /usr/local/java_tools
 

--- a/internal/librarian/java/install.go
+++ b/internal/librarian/java/install.go
@@ -27,7 +27,6 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
-	"github.com/googleapis/librarian/internal/tool/pip"
 )
 
 const (
@@ -43,17 +42,12 @@ var errNoToolsSpecified = errors.New("no tools specified in configuration")
 // - bin/ ($LIBRARIAN_BIN/java_tools/bin) stores the generated executable wrapper scripts.
 // - lib/ ($LIBRARIAN_BIN/java_tools/lib) isolates the downloaded compiled .jar/.exe files.
 func Install(ctx context.Context, tools *config.Tools) error {
-	if tools == nil || (len(tools.Maven) == 0 && len(tools.Pip) == 0) {
+	if tools == nil || len(tools.Maven) == 0 {
 		return errNoToolsSpecified
 	}
-	for _, cmd := range []string{"java", "mvn", "pip"} {
+	for _, cmd := range []string{"java", "mvn"} {
 		if _, err := exec.LookPath(cmd); err != nil {
 			return fmt.Errorf("%s is not installed or not in PATH, which is required for Java tool installation: %w", cmd, err)
-		}
-	}
-	if len(tools.Pip) > 0 {
-		if err := pip.Install(ctx, tools.Pip); err != nil {
-			return fmt.Errorf("failed to install pip tools: %w", err)
 		}
 	}
 	binDir, err := getBinDir()

--- a/internal/librarian/java/install_test.go
+++ b/internal/librarian/java/install_test.go
@@ -30,10 +30,6 @@ func TestInstall(t *testing.T) {
 	t.Chdir(tmpDir)
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
-	localPkgDir := filepath.Join(tmpDir, "sdk-platform-java", "hermetic_build", "library_generation")
-	if err := os.MkdirAll(localPkgDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
 	localMvnDir := filepath.Join(tmpDir, "sdk-platform-java", "gapic-generator-java")
 	if err := os.MkdirAll(filepath.Join(localMvnDir, "target"), 0o755); err != nil {
 		t.Fatal(err)
@@ -74,11 +70,6 @@ func TestInstall(t *testing.T) {
 		logFilename string
 		wantArgs    string
 	}{
-		{
-			name:        "pip",
-			logFilename: "pip_invocations.log",
-			wantArgs:    "pip install PyYAML==6.0.2 jinja2==3.1.6 " + localPkgDir,
-		},
 		{
 			name:        "mvn",
 			logFilename: "mvn_invocations.log",
@@ -126,20 +117,6 @@ func TestInstall(t *testing.T) {
 				LocalPath: "sdk-platform-java/gapic-generator-java",
 				MainClass: "com.google.api.generator.Main",
 				Packaging: "jar",
-			},
-		},
-		Pip: []*config.PipTool{
-			{
-				Name:    "PyYAML",
-				Version: "6.0.2",
-			},
-			{
-				Name:    "jinja2",
-				Version: "3.1.6",
-			},
-			{
-				Name:      "synthtool",
-				LocalPath: "sdk-platform-java/hermetic_build/library_generation",
 			},
 		},
 	}


### PR DESCRIPTION
This change removes python and pip dependencies from the Java installer and CI configuration.

Fixes https://github.com/googleapis/librarian/issues/7065