### PR TITLE
fix(internal/librarian/ruby): preserve snippet metadata files during regeneration

### DIFF
--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -186,6 +186,10 @@ func cleanSubdirectory(libraryDir, subDirPath string, keepSet map[string]bool) e
 // isKept returns true if the specified relative path or any of its parent
 // directories is present in keepSet.
 func isKept(relSlash string, keepSet map[string]bool) bool {
+	// TODO(https://github.com/googleapis/librarian/issues/7055): Remove this logic once after snippet metadata deprecation.
+	if strings.HasPrefix(relSlash, "snippets/snippet_metadata_") && strings.HasSuffix(relSlash, ".json") {
+		return true
+	}
 	currentPath := relSlash
 	for currentPath != "." {
 		if keepSet[currentPath] {

--- a/internal/librarian/ruby/clean_test.go
+++ b/internal/librarian/ruby/clean_test.go
@@ -76,6 +76,12 @@ func TestClean(t *testing.T) {
 			keep:      nil,
 			wantFiles: []string{"CHANGELOG.md"},
 		},
+		{
+			name:      "preserves snippet metadata files",
+			files:     []string{"CHANGELOG.md", "snippets/snippet_metadata_google.cloud.asset.v1.json", "snippets/s1.rb", "lib/foo.rb"},
+			keep:      nil,
+			wantFiles: []string{"CHANGELOG.md", "snippets/snippet_metadata_google.cloud.asset.v1.json"},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -28,7 +28,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
 	"github.com/googleapis/librarian/internal/serviceconfig"
-	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/tool/protoc"
 )
@@ -83,9 +82,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}
 	if err := filesystem.MoveAndMergeWithKeep(tempDir, outDir, outDir, keepFunc); err != nil {
 		return fmt.Errorf("failed to move generated files: %w", err)
-	}
-	if err := snippetmetadata.UpdateAllLibraryVersions(outDir, library.Version); err != nil {
-		return fmt.Errorf("failed to update snippet metadata versions: %w", err)
 	}
 	return nil
 }

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -15,7 +15,6 @@
 package ruby
 
 import (
-	"encoding/json"
 	"errors"
 	"io/fs"
 	"os"
@@ -27,7 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
-	"github.com/googleapis/librarian/internal/snippetmetadata"
 	"github.com/googleapis/librarian/internal/sources"
 )
 
@@ -409,6 +407,14 @@ end
 	if err := os.WriteFile(versionPath, []byte(existingVersionContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	snippetMetadataPath := filepath.Join(outDir, "snippets", "snippet_metadata_google.cloud.secretmanager.v1.json")
+	if err := os.MkdirAll(filepath.Dir(snippetMetadataPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const existingSnippetMetadataContent = "{\n  \"client_library\": {\n    \"version\": \"1.2.0\"\n  }\n}\n"
+	if err := os.WriteFile(snippetMetadataPath, []byte(existingSnippetMetadataContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	library := &config.Library{
 		Name:    "google-cloud-secret_manager-v1",
 		Version: "1.2.3",
@@ -452,16 +458,11 @@ end
 	if diff := cmp.Diff(existingVersionContent, string(gotVersion)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
-	snippetMetadataPath := filepath.Join(outDir, "snippets", "snippet_metadata_google.cloud.secretmanager.v1.json")
 	gotSnippetMetadata, err := os.ReadFile(snippetMetadataPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var metadata snippetmetadata.SnippetMetadata
-	if err := json.Unmarshal(gotSnippetMetadata, &metadata); err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff("1.2.3", metadata.ClientLibrary.Version); diff != "" {
+	if diff := cmp.Diff(existingSnippetMetadataContent, string(gotSnippetMetadata)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Preserves snippet metadata JSON files (`snippets/snippet_metadata_*.json`) during Ruby client gem cleaning and generation passes. Because we will deprecate the snippet metadata in Ruby (https://github.com/googleapis/librarian/issues/7055), there's no point in adding the snippet metadata-related logic in Librarian Ruby.

### Verification & Confirmation

1. **Unit Tests**:
   - Added test case to `internal/librarian/ruby/clean_test.go` verifying `snippets/snippet_metadata_*.json` preservation.
   - Verified `go test ./internal/librarian/ruby/...` passes.
   - Verified `go test -run TestGolangCILint .` passes cleanly.

2. **End-to-End Confirmation (`google-cloud-asset-v1`)**:
   - Built `/tmp/librarian` binary from this branch.
   - Executed `/tmp/librarian generate google-cloud-asset-v1` in `google-cloud-ruby`.
   - **Result**: Confirmed `snippets/snippet_metadata_google.cloud.asset.v1.json` is preserved completely untouched, resulting in **0 diffs** (`working tree clean`).

Fixes https://github.com/googleapis/librarian/issues/7084
For https://github.com/googleapis/librarian/issues/7055