### PR TITLE
feat(sidekick): capture C#, PHP, and Ruby file options

### DIFF
--- a/internal/sidekick/api/api.go
+++ b/internal/sidekick/api/api.go
@@ -58,6 +58,50 @@ type API struct {
 	enumByID map[string]*Enum
 	// resourceByType returns a resource that is associated with the API.
 	resourceByType map[string]*Resource
+
+	// RubyPackage captures the package name override for Ruby.
+	//
+	// Normally, the Protobuf package name is capitalized element by element and
+	// then used to construct the Ruby package name. For example,
+	// `google.cloud.secretmanager.v1` becomes
+	// `Google::Cloud::Secretmanager::V1`. In this example,
+	// `Google::Cloud::SecretManager::V1` would be more idiomatic. The Protobuf
+	// file options can set this override.
+	//
+	// In sidekick, a codec for Ruby might use this field directly. The codec
+	// for Swift uses this to emit warnings if: (1) the Ruby override differs
+	// from the standard name, and (2) there is no override in the
+	// `librarian.yaml` file.
+	RubyPackage string
+
+	// PhpNamespace captures the namespace override for PHP.
+	//
+	// Normally, the Protobuf package name is capitalized element by element and
+	// then used to construct the PHP namespace. For example,
+	// `google.cloud.secretmanager.v1` becomes
+	// `Google\\Cloud\\Secretmanager\\V1`. In this example,
+	// `Google\\Cloud\\SecretManager\\V1` would be more idiomatic. The Protobuf
+	// file options can set this override.
+	//
+	// In sidekick, a codec for PHP might use this field directly. The codec
+	// for Swift uses this to emit warnings if: (1) the PHP override differs
+	// from the standard name, and (2) there is no override in the
+	// `librarian.yaml` file.
+	PhpNamespace string
+
+	// CshapNamespace captures the namespace override for C#.
+	//
+	// Normally, the Protobuf package name is capitalized element by element and
+	// then used to construct the C# namespace. For example,
+	// `google.cloud.secretmanager.v1` becomes `Google.Cloud.Secretmanager.V1`.
+	// In this example, `Google.Cloud.SecretManager.V1` would be more idiomatic.
+	// The Protobuf file options can set this override.
+	//
+	// In sidekick, a codec for C# might use this field directly. The codec
+	// for Swift uses this to emit warnings if: (1) the C# override differs
+	// from the standard name, and (2) there is no override in the
+	// `librarian.yaml` file.
+	CsharpNamespace string
 }
 
 // ModelOverride holds configuration overrides for an API model.

--- a/internal/sidekick/api/api.go
+++ b/internal/sidekick/api/api.go
@@ -89,7 +89,7 @@ type API struct {
 	// `librarian.yaml` file.
 	PhpNamespace string
 
-	// CshapNamespace captures the namespace override for C#.
+	// CsharpNamespace captures the namespace override for C#.
 	//
 	// Normally, the Protobuf package name is capitalized element by element and
 	// then used to construct the C# namespace. For example,

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -328,6 +328,21 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		var fileServices []*api.Service
 		fFQN := "." + f.GetPackage()
 
+		if value, err := protobufUpdateFileOption(result.CsharpNamespace, f.GetOptions().GetCsharpNamespace()); err == nil {
+			result.CsharpNamespace = value
+		} else {
+			return nil, err
+		}
+		if value, err := protobufUpdateFileOption(result.PhpNamespace, f.GetOptions().GetPhpNamespace()); err == nil {
+			result.PhpNamespace = value
+		} else {
+			return nil, err
+		}
+		// TODO(https://github.com/googleapis/librarian/issues/7091) - also use protobufUpdateFileOption() for Ruby
+		if result.RubyPackage == "" {
+			result.RubyPackage = f.GetOptions().GetRubyPackage()
+		}
+
 		// Messages
 		for _, m := range f.MessageType {
 			mFQN := fFQN + "." + m.GetName()
@@ -476,6 +491,24 @@ var descriptorpbToTypez = map[descriptorpb.FieldDescriptorProto_Type]api.Typez{
 	descriptorpb.FieldDescriptorProto_TYPE_GROUP:    api.TypezGroup,
 	descriptorpb.FieldDescriptorProto_TYPE_MESSAGE:  api.TypezMessage,
 	descriptorpb.FieldDescriptorProto_TYPE_ENUM:     api.TypezEnum,
+}
+
+// protobufUpdateFileOption validates an update of `current` to `got`.
+//
+// This returns an error if `current` != "" and `current` != got.
+func protobufUpdateFileOption(current, got string) (string, error) {
+	if current == "" {
+		return got, nil
+	}
+	if current == got {
+		return got, nil
+	}
+	// The Well-Known Types have inconsistent annotations for C#. Just ignore
+	// the inconsistency, it is not a real problem.
+	if got == "" || strings.HasPrefix(got, "Google.Protobuf.") {
+		return current, nil
+	}
+	return "", fmt.Errorf("mismatched file option value, want=%s got=%s", current, got)
 }
 
 func normalizeTypes(model *api.API, in *descriptorpb.FieldDescriptorProto, field *api.Field) {

--- a/internal/sidekick/parser/protobuf_file_options_test.go
+++ b/internal/sidekick/parser/protobuf_file_options_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+)
+
+func TestProtobuf_FileOptions(t *testing.T) {
+	requireProtoc(t)
+
+	serviceConfig := &serviceconfig.Service{
+		Name:  "testdata.googleapis.com",
+		Title: "A test-only API",
+	}
+	got, err := makeAPIForProtobuf(serviceConfig, newTestCodeGeneratorRequest(t, "file_options.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &api.API{
+		Name:            "testdata",
+		Title:           "A test-only API",
+		CsharpNamespace: "Google.Cloud.TestData.V1",
+		PhpNamespace:    "Google\\Cloud\\TestData\\V1",
+		RubyPackage:     "Google::Cloud::TestData::V1",
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(api.API{})); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProtobuf_InconsistentFileOptions(t *testing.T) {
+	requireProtoc(t)
+
+	for _, test := range []struct {
+		name      string
+		filenames []string
+	}{
+		{
+			name:      "C#",
+			filenames: []string{"file_options.proto", "file_options_bad_csharp.proto"},
+		},
+		{
+			name:      "PHP",
+			filenames: []string{"file_options.proto", "file_options_bad_php.proto"},
+		},
+		// TODO(https://github.com/googleapis/librarian/issues/7091) - enable this
+		// {
+		// 	name:      "Ruby",
+		// 	filenames: []string{"file_options.proto", "file_options_bad_ruby.proto"},
+		// },
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			serviceConfig := &serviceconfig.Service{
+				Name:  "testdata.googleapis.com",
+				Title: "A test-only API",
+			}
+			model, err := makeAPIForProtobuf(serviceConfig, newTestCodeGeneratorRequest(t, test.filenames...))
+			if err == nil {
+				t.Errorf("expected an error, got=%+v", model)
+			}
+		})
+	}
+}
+
+func TestProtobuf_UpdateFileOption(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		current string
+		update  string
+		want    string
+	}{
+		{"initial", "", "Value", "Value"},
+		{"no update", "Value", "", "Value"},
+		{"matches", "Value", "Value", "Value"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := protobufUpdateFileOption(test.current, test.update)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestProtobuf_UpdateFileOptionError(t *testing.T) {
+	got, err := protobufUpdateFileOption("Value", "InconsistentValue")
+	if err == nil {
+		t.Errorf("expected an error, got=%s", got)
+	}
+}

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -2159,7 +2159,7 @@ func TestProtobuf_ParseBadFiles(t *testing.T) {
 	}
 }
 
-func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
+func newTestCodeGeneratorRequest(t *testing.T, filename ...string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	src := &sources.SourceConfig{
 		Sources: &sources.Sources{
@@ -2167,7 +2167,7 @@ func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGe
 			ProtobufSrc: "testdata",
 		},
 		ActiveRoots: []string{"googleapis", "protobuf-src"},
-		IncludeList: []string{filename},
+		IncludeList: append([]string{}, filename...),
 	}
 	request, err := codeGeneratorRequestFromSource("testdata", src)
 	if err != nil {

--- a/internal/sidekick/parser/testdata/file_options.proto
+++ b/internal/sidekick/parser/testdata/file_options.proto
@@ -1,0 +1,20 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package testdata;
+
+option csharp_namespace = "Google.Cloud.TestData.V1";
+option php_namespace = "Google\\Cloud\\TestData\\V1";
+option ruby_package = "Google::Cloud::TestData::V1";

--- a/internal/sidekick/parser/testdata/file_options_bad_csharp.proto
+++ b/internal/sidekick/parser/testdata/file_options_bad_csharp.proto
@@ -1,0 +1,20 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package testdata;
+
+option csharp_namespace = "Inconsistent";
+option php_namespace = "Google\\Cloud\\TestData\\V1";
+option ruby_package = "Google::Cloud::TestData::V1";

--- a/internal/sidekick/parser/testdata/file_options_bad_php.proto
+++ b/internal/sidekick/parser/testdata/file_options_bad_php.proto
@@ -1,0 +1,20 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package testdata;
+
+option csharp_namespace = "Google.Cloud.TestData.V1";
+option php_namespace = "Inconsistent";
+option ruby_package = "Google::Cloud::TestData::V1";

--- a/internal/sidekick/parser/testdata/file_options_bad_ruby.proto
+++ b/internal/sidekick/parser/testdata/file_options_bad_ruby.proto
@@ -1,0 +1,20 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package testdata;
+
+option csharp_namespace = "Google.Cloud.TestData.V1";
+option php_namespace = "Google\\Cloud\\TestData\\V1";
+option ruby_package = "Inconsistent";


### PR DESCRIPTION
These options contain alternative names for the package or namespace containing all the types for an API. We will use these to emit warnings in Swift when the default name does not match the overrides for these languages.

The idea is that C#, PHP, and Ruby better capture the intent of some human on how to style `secretmanager`: `SecretManager` is better, but the generator cannot know without help.

The person on the librarian rotation can silence the warnings by setting the name override.

----
This is my second attempt (see #7081) I have fixed the problems in that attempt, and I tested against the Rust and Swift monorepos.

Towards #6229 