### PR TITLE
fix(sidekick/rust): fix prost oneof field conversion in templates

### DIFF
--- a/internal/sidekick/rust/templates/convert-prost/oneof.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/oneof.mustache
@@ -36,10 +36,15 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
         match self {
             {{#Fields}}
             {{^IsEnum}}
-            Self::{{Codec.BranchName}}(v) => Ok(T::from_{{Codec.SetterName}}(v.cnv()?)),
+            {{^Codec.IsBoxed}}
+            Self::{{Codec.BranchName}}(v) => Ok(T::{{Codec.BranchName}}(v.cnv()?)),
+            {{/Codec.IsBoxed}}
+            {{#Codec.IsBoxed}}
+            Self::{{Codec.BranchName}}(v) => Ok(T::{{Codec.BranchName}}(std::boxed::Box::new(v.cnv()?))),
+            {{/Codec.IsBoxed}}
             {{/IsEnum}}
             {{#IsEnum}}
-            Self::{{Codec.BranchName}}(v) => Ok(T::from_{{Codec.SetterName}}(v)),
+            Self::{{Codec.BranchName}}(v) => Ok(T::{{Codec.BranchName}}(v.into())),
             {{/IsEnum}}
             {{/Fields}}
         }


### PR DESCRIPTION
Update the prost conversion template for oneof fields to construct the model enum variant directly rather than invoking a setter method, which we don't generate universally.

For #6835 