### PR TITLE
refactor(cmd/librarian): use debian base image for java container stage

### DIFF
--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -344,12 +344,6 @@ ARG JAVA_PROTOC_VERSION
 ARG JAVA_PROTOC_CHECKSUM
 ARG JAVA_VERSION
 
-# Copy librarian from build stage
-COPY --from=build /go/bin/librarian /app/librarian
-
-WORKDIR /app
-ENTRYPOINT ["/app/librarian"]
-
 # Configure Adoptium APT repository and install Temurin 17 JDK, Maven, and runtime tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \

--- a/cmd/librarian/Dockerfile
+++ b/cmd/librarian/Dockerfile
@@ -73,7 +73,6 @@ ARG NODEJS_PROTOBUFJS_VERSION=7.5.8
 ARG JAVA_PROTOC_VERSION=33.2
 ARG JAVA_PROTOC_CHECKSUM=8c0a8577311720cc83488f813aeb5046d69cb9824cbf39cb7447e0c5132d677952d5bb7c1130d9df381835eee7352828878d409873ebb407d7a4649ea2a4aee5
 ARG JAVA_VERSION=17
-ARG JAVA_PYTHON_VERSION=3.12
 ARG NODEJS_NVM_VERSION=0.40.4
 ARG NODEJS_NVM_CHECKSUM=a8e082d8d1a9b61a09e5d3e1902d2930e5b1b84a86f9777c7d2eb50ea204c0141f6a97c54a860bc3282e7b000f1c669c755f5e0db7bd6d492072744c302c0a21
 ARG NODEJS_NODE_VERSION=22
@@ -340,8 +339,7 @@ RUN pnpm add -g \
     pnpm add -g "$PWD"
 
 # ============== Java Stage ==============
-ARG JAVA_PYTHON_VERSION
-FROM python:${JAVA_PYTHON_VERSION}-slim AS java
+FROM base AS java
 ARG JAVA_PROTOC_VERSION
 ARG JAVA_PROTOC_CHECKSUM
 ARG JAVA_VERSION
@@ -373,27 +371,16 @@ RUN curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip \
     echo "${JAVA_PROTOC_CHECKSUM} /tmp/protoc.zip" | sha512sum -c - && \
     cd /usr/local && unzip -o /tmp/protoc.zip && rm /tmp/protoc.zip
 
-# Configure pip for external sources (PyPI) globally
-RUN pip config set global.extra-index-url https://pypi.org/simple
-
 # Setup dynamic target directories inside the persistent volume.
-# This ensures that Python packages are persisted alongside Java tools,
-# while completely bypassing dynamic caller permissions.
 ENV LIBRARIAN_INSTALL_DIR=/usr/local/java_tools/bin
 ENV PATH=${LIBRARIAN_INSTALL_DIR}:${PATH}
-
-# Redirect all pip installations to be stored directly inside the volume
-ENV PYTHONPATH=/usr/local/java_tools/python-packages
-ENV PATH=${PYTHONPATH}/bin:${PATH}
-ENV PIP_TARGET=${PYTHONPATH}
-ENV PIP_NO_CACHE_DIR=1
 
 # Persist repository downloads inside the volume cache to save bandwidth and build time
 ENV LIBRARIAN_CACHE=/usr/local/java_tools/cache
 
 # Create java_tools directory and grant broad write permissions.
 # This allows any arbitrary UID running the container (like librarianops) to
-# execute `librarian install java` and write tools and packages to the global path.
+# execute `librarian install java` and write tools to the global path.
 RUN mkdir -p /usr/local/java_tools && \
     chmod -R a+rwx /usr/local/java_tools
 


### PR DESCRIPTION
This change updates the Java container stage in Dockerfile to inherit from debian:bookworm-slim instead of python:3.12-slim, removing obsolete pip environment variables.

Fixes https://github.com/googleapis/librarian/issues/7065