### PR TITLE
feat(rust): exclude non-streaming types from prost generation

### DIFF
--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -39,7 +39,7 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 		return nil
 	}
 
-	hybridModel, err := filterModelToStreaming(model)
+	hybridModel, unusedTypes, err := filterModelToStreaming(model)
 	if err != nil {
 		return err
 	}
@@ -50,6 +50,9 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 		hybridConfig.Codec = make(map[string]string)
 	}
 	hybridConfig.Codec["convert-include-package"] = model.PackageName
+	if len(unusedTypes) > 0 {
+		hybridConfig.Codec["unused-types"] = strings.Join(unusedTypes, "\n")
+	}
 	prostOutDir := filepath.Join(outdir, "src", "prost")
 	if err := rust_prost.Generate(ctx, hybridModel, prostOutDir, "prost", &hybridConfig); err != nil {
 		return fmt.Errorf("generating prost module: %w", err)
@@ -66,9 +69,10 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 }
 
 // filterModelToStreaming constructs a hybrid api.API model containing only
-// bidirectional streaming RPC types for prost conversion generation.
-// Errors if Any is encountered.
-func filterModelToStreaming(model *api.API) (*api.API, error) {
+// bidirectional streaming RPC types for prost conversion generation. It also returns
+// a sorted slice of all non-WKT unused type IDs to exclude via prost_build extern_path.
+// Errors if Any is encountered in the streaming reachability path.
+func filterModelToStreaming(model *api.API) (*api.API, []string, error) {
 	type streamingTypeItem struct {
 		id       string
 		rpc      string
@@ -122,7 +126,7 @@ func filterModelToStreaming(model *api.API) (*api.API, error) {
 		}
 
 		if isAnyType(item.id) {
-			return nil, anyError(item.path)
+			return nil, nil, anyError(item.path)
 		}
 
 		msg := model.Message(item.id)
@@ -131,7 +135,7 @@ func filterModelToStreaming(model *api.API) (*api.API, error) {
 			for _, f := range msg.Fields {
 				fieldPath := item.path + "." + f.Name
 				if isAnyType(f.TypezID) {
-					return nil, anyError(fieldPath)
+					return nil, nil, anyError(fieldPath)
 				}
 				if f.Typez == api.TypezMessage && f.TypezID != "" {
 					queue = append(queue, streamingTypeItem{
@@ -149,7 +153,7 @@ func filterModelToStreaming(model *api.API) (*api.API, error) {
 				for _, f := range o.Fields {
 					fieldPath := item.path + "." + o.Name + "." + f.Name
 					if isAnyType(f.TypezID) {
-						return nil, anyError(fieldPath)
+						return nil, nil, anyError(fieldPath)
 					}
 					if f.Typez == api.TypezMessage && f.TypezID != "" {
 						queue = append(queue, streamingTypeItem{
@@ -206,9 +210,27 @@ func filterModelToStreaming(model *api.API) (*api.API, error) {
 	for _, r := range hybridModel.ResourceDefinitions {
 		hybridModel.AddResource(r)
 	}
-	return &hybridModel, nil
+
+	var unusedTypes []string
+	for m := range model.AllMessages() {
+		if m.ID != "" && !isWKT(m.ID) && !streamingMsgs[m.ID] {
+			unusedTypes = append(unusedTypes, m.ID)
+		}
+	}
+	for e := range model.AllEnums() {
+		if e.ID != "" && !isWKT(e.ID) && !streamingEnums[e.ID] {
+			unusedTypes = append(unusedTypes, e.ID)
+		}
+	}
+	slices.Sort(unusedTypes)
+
+	return &hybridModel, slices.Compact(unusedTypes), nil
 }
 
 func isAnyType(id string) bool {
 	return strings.TrimPrefix(id, ".") == "google.protobuf.Any"
+}
+
+func isWKT(id string) bool {
+	return strings.HasPrefix(strings.TrimPrefix(id, "."), "google.protobuf.")
 }

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -136,13 +136,16 @@ func TestFilterModelToStreaming(t *testing.T) {
 	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
 	model := api.NewTestAPI([]*api.Message{streamingMsg, unusedMsg}, []*api.Enum{}, []*api.Service{bidiService})
 
-	filtered, err := filterModelToStreaming(model)
+	filtered, unused, err := filterModelToStreaming(model)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if len(filtered.Messages) != 1 || filtered.Messages[0].ID != streamingMsg.ID {
 		t.Errorf("got messages %v, want [%s]", filtered.Messages, streamingMsg.ID)
+	}
+	if len(unused) != 1 || unused[0] != unusedMsg.ID {
+		t.Errorf("got unused %v, want [%s]", unused, unusedMsg.ID)
 	}
 
 	if got := filtered.Message(unusedMsg.ID); got != unusedMsg {
@@ -169,7 +172,7 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{streamMsg, unaryReq, childData}, []*api.Enum{}, []*api.Service{bidiService, unaryService})
 
-	filtered, err := filterModelToStreaming(model)
+	filtered, _, err := filterModelToStreaming(model)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -202,7 +205,7 @@ func TestFilterModelToStreamingAnyError(t *testing.T) {
 
 	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
 
-	_, err := filterModelToStreaming(anyModel)
+	_, _, err := filterModelToStreaming(anyModel)
 	if err == nil {
 		t.Fatal("expected error for google.protobuf.Any, got nil")
 	}

--- a/internal/sidekick/rust_prost/annotate.go
+++ b/internal/sidekick/rust_prost/annotate.go
@@ -39,6 +39,10 @@ type modelAnnotations struct {
 	// and build.rs appends the convert module inclusion after the specified package's
 	// include line. Used for generating conversion traits in hybrid crates.
 	ConvertIncludePackage string
+	// UnusedTypes is a list of proto type IDs that are not used in streaming RPCs.
+	// They are configured with prost_build's extern_path to be mapped to a nonexistent
+	// type so prost omits them from generation.
+	UnusedTypes []string
 }
 
 type serviceAnnotations struct {
@@ -67,6 +71,7 @@ func (codec *codec) annotateModel(model *api.API, cfg *parser.ModelConfig) error
 		Files:                 files,
 		PostProcessProtos:     codec.PostProcessProtos,
 		ConvertIncludePackage: codec.ConvertIncludePackage,
+		UnusedTypes:           codec.UnusedTypes,
 	}
 	for _, s := range model.Services {
 		codec.annotateService(s)

--- a/internal/sidekick/rust_prost/codec.go
+++ b/internal/sidekick/rust_prost/codec.go
@@ -37,6 +37,10 @@ type codec struct {
 	// and build.rs appends the convert module inclusion after the specified package's
 	// include line. Used for generating conversion traits in hybrid crates.
 	ConvertIncludePackage string
+	// UnusedTypes is a list of proto type IDs that are not used in streaming RPCs.
+	// They are configured with prost_build's extern_path to be mapped to a nonexistent
+	// type so prost omits them from generation.
+	UnusedTypes []string
 }
 
 func newCodec(cfg *parser.ModelConfig) *codec {
@@ -58,6 +62,10 @@ func newCodec(cfg *parser.ModelConfig) *codec {
 			result.RootName = definition
 		case "convert-include-package":
 			result.ConvertIncludePackage = definition
+		case "unused-types":
+			if definition != "" {
+				result.UnusedTypes = strings.Split(definition, "\n")
+			}
 		default:
 			// Ignore other options.
 		}

--- a/internal/sidekick/rust_prost/templates/prost/build.rs.mustache
+++ b/internal/sidekick/rust_prost/templates/prost/build.rs.mustache
@@ -36,6 +36,9 @@ fn main() {
         config.disable_comments(&["."]);
         config.enable_type_names();
         config.type_name_domain(&["."], "type.googleapis.com");
+        {{#Codec.UnusedTypes}}
+        config.extern_path("{{{.}}}", "crate::prost::unused::NonexistentType");
+        {{/Codec.UnusedTypes}}
         {{#Codec.ConvertIncludePackage}}
         config.include_file("includes.rs");
         {{/Codec.ConvertIncludePackage}}


### PR DESCRIPTION
Exclude non-streaming protobuf message and enum types from generated prost output files when hybrid streaming generation is enabled.

The filterModelToStreaming helper now collects all non-well-known-type IDs that are unreachable from bidirectional streaming RPCs. These unused type IDs are passed to the sidekick rust_prost generator and configured with prost_build extern_path mappings to crate::prost::unused::NonexistentType, preventing prost from emitting unused struct definitions and unused output files.

For #6835 