### PR TITLE
fix: variaible shadowing bug in secretsClient

### DIFF
--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -35,16 +35,17 @@ type SecretsClient interface {
 // the secret payload is a UTF-8 string.
 func Get(ctx context.Context, project string, secretName string, secretsClient SecretsClient) (_ string, err error) {
 	if secretsClient == nil {
-		secretsClient, err := secretmanager.NewClient(ctx)
-		if err != nil {
-			return "", err
+		client, clientErr := secretmanager.NewClient(ctx)
+		if clientErr != nil {
+			return "", clientErr
 		}
 		defer func() {
-			cerr := secretsClient.Close()
+			cerr := client.Close()
 			if err == nil {
 				err = cerr
 			}
 		}()
+		secretsClient = client
 	}
 	request := &secretmanagerpb.AccessSecretVersionRequest{
 		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", project, secretName),


### PR DESCRIPTION
The `secretsClient` function parameter was being shadowed by a local variable via `:=` (it. This inadvertently left the actual parameter `nil`, causing a crash on the subsequent `AccessSecretVersion` API call. See [STACK OVEFLOW](https://stackoverflow.com/questions/17110268/go-declare-both-a-new-variable-and-overwrite-a-variable-from-a-higher-scope-ho)
