### PR TITLE
chore(tool/cmd/migrate): parse keep files from `.owlbot.rb` for ruby

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -166,7 +166,7 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 			return nil, err
 		}
 		lib.Keep = keep
-		keepFromOwlbot, err := parseKeepFromOwlbotRb(filepath.Join(repoPath, name, "owlbot.rb"))
+		keepFromOwlbot, err := parseKeepFromOwlbotRb(filepath.Join(repoPath, name, ".owlbot.rb"))
 		if err != nil {
 			return nil, err
 		}

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -464,7 +464,10 @@ func parseKeepFromOwlbotRb(path string) ([]string, error) {
 	var keep []string
 	for line := range strings.SplitSeq(string(data), "\n") {
 		if keepFile, ok := strings.CutPrefix(line, "OwlBot.prevent_overwrite_of_existing"); ok {
-			keep = append(keep, strings.TrimSpace(keepFile))
+			keepFile = strings.TrimSpace(keepFile)
+			keepFile, _ = strings.CutPrefix(keepFile, "\"")
+			keepFile, _ = strings.CutSuffix(keepFile, "\"")
+			keep = append(keep, keepFile)
 		}
 	}
 	return keep, nil

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -166,6 +166,11 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 			return nil, err
 		}
 		lib.Keep = keep
+		keepFromOwlbot, err := parseKeepFromOwlbotRb(filepath.Join(repoPath, name, "owlbot.rb"))
+		if err != nil {
+			return nil, err
+		}
+		lib.Keep = append(lib.Keep, keepFromOwlbot...)
 		api, isWrapper, err := parseAPIFromOwlBot(owlBotPath)
 		if err != nil {
 			return nil, err
@@ -446,4 +451,21 @@ func parseKeepFromManifest(path string) ([]string, error) {
 		return s == ".OwlBot.yaml"
 	})
 	return manifest.Static, nil
+}
+
+func parseKeepFromOwlbotRb(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var keep []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if keepFile, ok := strings.CutPrefix(line, "OwlBot.prevent_overwrite_of_existing"); ok {
+			keep = append(keep, strings.TrimSpace(keepFile))
+		}
+	}
+	return keep, nil
 }

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -822,3 +822,49 @@ func TestParseKeepFromManifest(t *testing.T) {
 		})
 	}
 }
+
+func TestParseKeepFromOwlbotRb(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "parses single prevent_overwrite_of_existing statement",
+			content: `OwlBot.prevent_overwrite_of_existing "lib/google/cloud/automl/v1/helpers.rb"`,
+			want:    []string{`"lib/google/cloud/automl/v1/helpers.rb"`},
+		},
+		{
+			name: "parses multiple prevent_overwrite_of_existing statements",
+			content: `OwlBot.prevent_overwrite_of_existing "lib/file1.rb"
+OwlBot.prevent_overwrite_of_existing 'lib/file2.rb'`,
+			want: []string{`"lib/file1.rb"`, `'lib/file2.rb'`},
+		},
+		{
+			name:    "no matching statements",
+			content: `# Standard owlbot.rb file without prevent_overwrite_of_existing`,
+			want:    nil,
+		},
+		{
+			name: "file does not exist",
+			want: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "owlbot.rb")
+			if test.content != "" {
+				if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := parseKeepFromOwlbotRb(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -852,7 +852,7 @@ OwlBot.prevent_overwrite_of_existing 'lib/file2.rb'`,
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			path := filepath.Join(dir, "owlbot.rb")
+			path := filepath.Join(dir, ".owlbot.rb")
 			if test.content != "" {
 				if err := os.WriteFile(path, []byte(test.content), 0o644); err != nil {
 					t.Fatal(err)

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -832,13 +832,13 @@ func TestParseKeepFromOwlbotRb(t *testing.T) {
 		{
 			name:    "parses single prevent_overwrite_of_existing statement",
 			content: `OwlBot.prevent_overwrite_of_existing "lib/google/cloud/automl/v1/helpers.rb"`,
-			want:    []string{`"lib/google/cloud/automl/v1/helpers.rb"`},
+			want:    []string{"lib/google/cloud/automl/v1/helpers.rb"},
 		},
 		{
 			name: "parses multiple prevent_overwrite_of_existing statements",
 			content: `OwlBot.prevent_overwrite_of_existing "lib/file1.rb"
-OwlBot.prevent_overwrite_of_existing 'lib/file2.rb'`,
-			want: []string{`"lib/file1.rb"`, `'lib/file2.rb'`},
+OwlBot.prevent_overwrite_of_existing "lib/file2.rb"`,
+			want: []string{"lib/file1.rb", "lib/file2.rb"},
 		},
 		{
 			name:    "no matching statements",


### PR DESCRIPTION
During Ruby client library migration, file paths specified in `OwlBot.prevent_overwrite_of_existing statements` within .`owlbot.rb` are now parsed and appended to each library's keep configuration in librarian.yaml. 

This ensures that customized files configured to avoid overwrite during OwlBot post-processing are preserved when migrating Ruby libraries to Librarian.

For #6632
