### PR TITLE
fix(internal/librarian/ruby): pass documentation summary as ruby-cloud-description option

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -158,6 +158,9 @@ func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, e
 	if sc != nil && sc.ServiceConfig != "" {
 		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, sc.ServiceConfig))
 	}
+	if sc != nil && sc.Description != "" {
+		opts = append(opts, "ruby-cloud-description="+escapeRubyCloudOptValue(sc.Description))
+	}
 	if gc != "" {
 		opts = append(opts, "grpc-service-config="+filepath.Join(googleapisDir, gc))
 	}
@@ -236,4 +239,16 @@ func toolsEnv() (map[string]string, error) {
 		env["GEM_PATH"] = installDir
 	}
 	return env, nil
+}
+
+// escapeRubyCloudOptValue escapes backslashes and commas in generator option values
+// (such as ruby-cloud-description) so that protoc and gapic-generator-ruby parameter parsers
+// do not incorrectly split option strings when options are joined with commas.
+func escapeRubyCloudOptValue(val string) string {
+	// This follows the same escaping convention as Bazel's _escape_config_value in rules_ruby_gapic
+	// (rules_ruby_gapic/private/ruby_gapic_library_internal.bzl#L120-L121 in gapic-generator-ruby
+	// at commit 8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75) and gapic-generator-ruby's unescaping
+	// logic in RequestParamParser (gapic-generator/lib/gapic/schema/request_param_parser.rb#L30-L32).
+	val = strings.ReplaceAll(val, "\\", "\\\\")
+	return strings.ReplaceAll(val, ",", "\\,")
 }

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -52,6 +52,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"ruby-cloud-generate-transports=grpc;rest",
 				"ruby-cloud-rest-numeric-enums=true",
@@ -66,6 +67,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-compute-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/compute/v1/compute_v1.yaml"),
+				"ruby-cloud-description=Compute Engine is an infrastructure as a service (IaaS) product that offers self-managed virtual machine (VM) instances and bare metal instances.",
 				"ruby-cloud-generate-transports=rest",
 				"ruby-cloud-rest-numeric-enums=true",
 			},
@@ -84,6 +86,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"ruby-cloud-generate-transports=grpc;rest",
 				"ruby-cloud-rest-numeric-enums=true",
@@ -530,6 +533,37 @@ func TestDefaultOutput(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := DefaultOutput(test.libName, test.defaultOutput)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEscapeRubyCloudOptValue(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text",
+			input: "Cloud Asset API",
+			want:  "Cloud Asset API",
+		},
+		{
+			name:  "contains commas",
+			input: "API keys, passwords, and certificates.",
+			want:  `API keys\, passwords\, and certificates.`,
+		},
+		{
+			name:  "contains backslashes and commas",
+			input: `path\to\file, and more`,
+			want:  `path\\to\\file\, and more`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := escapeRubyCloudOptValue(test.input)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Pass the API description (parsed from `documentation.summary` in `service.yaml`) via the `ruby-cloud-description` option when generating Ruby client libraries. This prevents `gapic-generator-cloud` from falling back to `documentation.overview`, which often contains Markdown headers (such as `# Cloud Asset API`).

To handle descriptions containing commas or backslashes without breaking protoc option parsing when options are joined with commas, option values are escaped via `escapeRubyCloudOptValue`. This follows the exact same escaping design as Bazel's `_escape_config_value` in `rules_ruby_gapic` ([`ruby_gapic_library_internal.bzl#L120-L121`](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/rules_ruby_gapic/private/ruby_gapic_library_internal.bzl#L120-L121)) and `gapic-generator-ruby`'s parameter unescaping logic in `RequestParamParser` ([`request_param_parser.rb#L30-L32`](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/gapic-generator/lib/gapic/schema/request_param_parser.rb#L30-L32)).

### Verification & Generation Confirmation

Ran the verification steps from [librarian#6633](https://github.com/googleapis/librarian/issues/6633) against `google-cloud-ruby`:

```bash
librarian update sources.googleapis
librarian generate google-cloud-asset-v1
librarian tidy
```

**Result**:
1. `google-cloud-asset-v1/google-cloud-asset-v1.gemspec`:
   ```diff
   - gem.description   = "# Cloud Asset API The Cloud Asset API keeps a history of Google Cloud asset metadata..."
   + gem.description   = "The Cloud Asset API manages the history and inventory of Google Cloud resources. Note that google-cloud-asset-v1 is a version-specific client library..."
   ```
2. `google-cloud-asset-v1/README.md`:
   The duplicate overview `# Cloud Asset API` header is cleanly omitted because `gem.summary == gem.description`.

### Comparison Across Languages in Librarian

| Language | Primary Field Used from `service.yaml` | Where it is Used (Code References with SHA) |
| :--- | :--- | :--- |
| **Go** | `title` / `documentation.summary` | • Uses `api.Title` for `.repo-metadata.json`: [`internal/librarian/golang/repometadata.go#L32`](https://github.com/googleapis/librarian/blob/d250f2b67dfe92ea331962fd91d9a4144d236e59/internal/librarian/golang/repometadata.go#L32)<br>• Passes `service-yaml` option to `protoc-gen-go_gapic`: [`internal/librarian/golang/generate.go#L173`](https://github.com/googleapis/librarian/blob/d250f2b67dfe92ea331962fd91d9a4144d236e59/internal/librarian/golang/generate.go#L173)<br>• **`gapic-generator-go`** extracts `documentation.summary` via `GetDocumentation().GetSummary()` for package docstrings in `doc.go`: [`internal/gengapic/doc_file.go#L49-L51`](https://github.com/googleapis/gapic-generator-go/blob/dc50141169c20edf4104c6dfdb730fd894ed38c8/internal/gengapic/doc_file.go#L49-L51) |
| **NodeJS** | `documentation.summary` | • Passes `--service-yaml` option to `gapic-generator-typescript`: [`internal/librarian/nodejs/generate.go#L271`](https://github.com/googleapis/librarian/blob/d250f2b67dfe92ea331962fd91d9a4144d236e59/internal/librarian/nodejs/generate.go#L271)<br>• **`gapic-generator-typescript`** parses `service.yaml` (`ServiceYaml` interface) to extract `documentation.summary` for package description and README docs: [`typescript/src/serviceyaml.ts`](https://github.com/googleapis/gapic-generator-typescript/blob/ed34a7351630e0c9003c6f68a2725d744055066f/typescript/src/serviceyaml.ts) |
| **Ruby** | `documentation.summary` | • Passes `ruby-cloud-description` (`sc.Description`, from `documentation.summary` parsed in [`internal/serviceconfig/serviceconfig.go#L185`](https://github.com/googleapis/librarian/blob/d250f2b67dfe92ea331962fd91d9a4144d236e59/internal/serviceconfig/serviceconfig.go#L185)) option to `gapic-generator-cloud`: [`internal/librarian/ruby/generate.go#L165`](https://github.com/googleapis/librarian/blob/a78f3f1a/internal/librarian/ruby/generate.go#L165) |

Fixes https://github.com/googleapis/librarian/issues/7104
