### PR TITLE
feat(sidekick/swift): error on suspect library names

### DIFF
--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -82,6 +82,24 @@ func (a *API) WithPackageName(name string) *API {
 	return a
 }
 
+// WithCsharpNamespace changes the CsharpNamespace of an API instance.
+func (a *API) WithCsharpNamespace(name string) *API {
+	a.CsharpNamespace = name
+	return a
+}
+
+// WithPhpNamespace changes the PhpNamespace of an API instance.
+func (a *API) WithPhpNamespace(name string) *API {
+	a.PhpNamespace = name
+	return a
+}
+
+// WithRubyPackage changes the RubyNamespace of an API instance.
+func (a *API) WithRubyPackage(name string) *API {
+	a.RubyPackage = name
+	return a
+}
+
 // parentName returns the parent's name from a fully qualified identifier.
 func parentName(id string) string {
 	if lastIndex := strings.LastIndex(id, "."); lastIndex != -1 {

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -23,6 +23,8 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
+const requiresLibraryNameOverrideFormat = "Other languages with PascalCase style use different names for the %s library.\nConsider these alternatives and use library_name_override to silence this error:\n%s"
+
 // LibraryName returns the Swift library (and module) name for the API.
 func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) (string, error) {
 	if swiftCfg != nil && swiftCfg.LibraryNameOverride != "" {
@@ -31,11 +33,28 @@ func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) (string, error) {
 	if api.PackageName == "" {
 		return "", fmt.Errorf("API package name must not be empty")
 	}
-	// TODO(https://github.com/googleapis/librarian/issues/6229) - use
-	// the api.PackageNamePascalCase
 	parts := strings.Split(api.PackageName, ".")
 	for i, p := range parts {
 		parts[i] = strcase.ToCamel(p)
 	}
-	return strings.Join(parts, ""), nil
+	libraryName := strings.Join(parts, "")
+	alternatives := map[string]string{
+		"C#":   strings.ReplaceAll(api.CsharpNamespace, ".", ""),
+		"PHP":  strings.ReplaceAll(api.PhpNamespace, "\\", ""),
+		"Ruby": strings.ReplaceAll(api.RubyPackage, "::", ""),
+	}
+	var messages []string
+	for lang, alt := range alternatives {
+		if alt == "" {
+			continue
+		}
+		if alt != libraryName {
+			messages = append(messages, fmt.Sprintf("%s suggests using %s", lang, alt))
+		}
+	}
+	if len(messages) != 0 {
+		return "", fmt.Errorf(requiresLibraryNameOverrideFormat, api.PackageName, strings.Join(messages, "\n"))
+	}
+
+	return libraryName, nil
 }

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -23,7 +23,10 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-const requiresLibraryNameOverrideFormat = "Other languages with PascalCase style use different names for the %s library.\nConsider these alternatives and use library_name_override to silence this error:\n%s"
+const requiresLibraryNameOverrideFormat = `default library name for %s needs override.
+Other languages with PascalCase style deviate from the default name for this library,
+most likely, that indicates the default library name is not a good choice. Consider
+these alternatives and use library_name_override to silence this error:\n%s`
 
 // LibraryName returns the Swift library (and module) name for the API.
 func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) (string, error) {

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -27,8 +27,7 @@ const requiresLibraryNameOverrideFormat = `default library name for %s needs ove
 Other languages with PascalCase style deviate from the default name for this library,
 most likely, that indicates the default library name is not a good choice. Consider
 these alternatives and use library_name_override to silence this error:
-%s
-`
+%s`
 
 // LibraryName returns the Swift library (and module) name for the API.
 func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) (string, error) {

--- a/internal/sidekick/swift/library_name.go
+++ b/internal/sidekick/swift/library_name.go
@@ -26,7 +26,9 @@ import (
 const requiresLibraryNameOverrideFormat = `default library name for %s needs override.
 Other languages with PascalCase style deviate from the default name for this library,
 most likely, that indicates the default library name is not a good choice. Consider
-these alternatives and use library_name_override to silence this error:\n%s`
+these alternatives and use library_name_override to silence this error:
+%s
+`
 
 // LibraryName returns the Swift library (and module) name for the API.
 func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) (string, error) {
@@ -41,18 +43,21 @@ func LibraryName(api *api.API, swiftCfg *config.SwiftPackage) (string, error) {
 		parts[i] = strcase.ToCamel(p)
 	}
 	libraryName := strings.Join(parts, "")
-	alternatives := map[string]string{
-		"C#":   strings.ReplaceAll(api.CsharpNamespace, ".", ""),
-		"PHP":  strings.ReplaceAll(api.PhpNamespace, "\\", ""),
-		"Ruby": strings.ReplaceAll(api.RubyPackage, "::", ""),
+	alternatives := []struct {
+		lang  string
+		value string
+	}{
+		{"C#", strings.ReplaceAll(api.CsharpNamespace, ".", "")},
+		{"PHP", strings.ReplaceAll(api.PhpNamespace, "\\", "")},
+		{"Ruby", strings.ReplaceAll(api.RubyPackage, "::", "")},
 	}
 	var messages []string
-	for lang, alt := range alternatives {
-		if alt == "" {
+	for _, alt := range alternatives {
+		if alt.value == "" {
 			continue
 		}
-		if alt != libraryName {
-			messages = append(messages, fmt.Sprintf("%s suggests using %s", lang, alt))
+		if alt.value != libraryName {
+			messages = append(messages, fmt.Sprintf("%s suggests using %s", alt.lang, alt.value))
 		}
 	}
 	if len(messages) != 0 {

--- a/internal/sidekick/swift/library_name_test.go
+++ b/internal/sidekick/swift/library_name_test.go
@@ -17,6 +17,7 @@ package swift
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
@@ -89,5 +90,53 @@ func TestLibraryNameError(t *testing.T) {
 	got, err := LibraryName(model, nil)
 	if err == nil {
 		t.Errorf("Expected an error, got: %s", got)
+	}
+}
+
+func TestLibraryNameConflicts(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		model *api.API
+	}{
+		{
+			name:  "C#",
+			model: api.NewTestAPI(nil, nil, nil).WithCsharpNamespace("Conflict"),
+		},
+		{
+			name:  "PHP",
+			model: api.NewTestAPI(nil, nil, nil).WithPhpNamespace("Conflict"),
+		},
+		{
+			name:  "Ruby",
+			model: api.NewTestAPI(nil, nil, nil).WithRubyPackage("Conflict"),
+		},
+		{
+			name: "Multiple",
+			model: api.NewTestAPI(nil, nil, nil).
+				WithCsharpNamespace("CsharpConflict").
+				WithPhpNamespace("PHPConflict").
+				WithRubyPackage("RubyConflict"),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := LibraryName(test.model, nil)
+			if err == nil {
+				t.Errorf("expected an error, got=%+v", got)
+			}
+		})
+	}
+}
+
+func TestLibraryNameOverrideSilencesConflict(t *testing.T) {
+	model := api.NewTestAPI(nil, nil, nil).
+		WithCsharpNamespace("CsharpConflict").
+		WithPhpNamespace("PHPConflict").
+		WithRubyPackage("RubyConflict")
+	got, err := LibraryName(model, &config.SwiftPackage{LibraryNameOverride: "Override"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff("Override", got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
If the library name (e.g. `GoogleCloudSecretmanagerV1`) is suspect, then stop the generation and ask the human to manually override the name. Many library names are bad because their capitalization is wrong. In the example, `manager` should be spelled with an uppercase `M`, but the generator only has `secretmanager` as a source and does not speak English.

Fortunately, we have a good source of alternative names: the C#, PHP, and Ruby annotations. When these annotations do not match the default name, we generate an error. The human running `generate` can override the name.

We prefer a manual override over automatically using the annotations for other languages because it would be sad to break Swift just because C# renamed something.

Towards #6229 