### PR TITLE
fix(tool/cmd/migrate): exclude `.owlbot.rb` from ruby keep list

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -448,7 +448,7 @@ func parseKeepFromManifest(path string) ([]string, error) {
 		return nil, fmt.Errorf("unmarshaling owlbot manifest %s: %w", path, err)
 	}
 	manifest.Static = slices.DeleteFunc(manifest.Static, func(s string) bool {
-		return s == ".OwlBot.yaml"
+		return s == ".OwlBot.yaml" || s == ".owlbot.rb"
 	})
 	return manifest.Static, nil
 }

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -795,6 +795,11 @@ func TestParseKeepFromManifest(t *testing.T) {
 			want:    []string{},
 		},
 		{
+			name:    "filters out .OwlBot.yaml and .owlbot.rb",
+			content: `{"static": [".OwlBot.yaml", "file1.rb", ".owlbot.rb", "file2.rb"]}`,
+			want:    []string{"file1.rb", "file2.rb"},
+		},
+		{
 			name:    "empty static list",
 			content: `{"static": []}`,
 			want:    []string{},


### PR DESCRIPTION
When parsing static files from `.owlbot-manifest.json` during Ruby client library migration, `.owlbot.rb` is now filtered out alongside `.OwlBot.yaml`. 

This prevents legacy OwlBot configuration scripts from being erroneously preserved in the keep list of librarian.yaml.

For #6632
