### PR TITLE
feat(internal/tool/composer): add verification for composer tools

### DIFF
--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -30,8 +30,14 @@ import (
 // ErrMissingRepo indicates that a repository URL is missing for a Composer tool.
 var ErrMissingRepo = errors.New("repo URL missing")
 
+// errInvalidTool indicates that a Composer tool configuration is invalid.
+var errInvalidTool = errors.New("invalid tool configuration")
+
 // Install installs a list of Composer tools into the environment.
 func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin string) error {
+	if err := verify(tools); err != nil {
+		return err
+	}
 	for _, tool := range tools {
 		if tool.Repo == "" {
 			return fmt.Errorf("%w: composer tool %s", ErrMissingRepo, tool.Name)
@@ -79,6 +85,15 @@ func createBinWrapper(wrapperName, content, binDir string) error {
 	_ = os.Remove(wrapperPath)
 	if err := os.WriteFile(wrapperPath, []byte(content), 0o755); err != nil {
 		return fmt.Errorf("failed to write wrapper script: %w", err)
+	}
+	return nil
+}
+
+func verify(tools []*config.ComposerTool) error {
+	for _, tool := range tools {
+		if tool.Name == "" || tool.Version == "" {
+			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidTool, tool)
+		}
 	}
 	return nil
 }

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -39,9 +39,6 @@ func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin str
 		return err
 	}
 	for _, tool := range tools {
-		if tool.Repo == "" {
-			return fmt.Errorf("%w: composer tool %s", ErrMissingRepo, tool.Name)
-		}
 		dir, err := fetch.Repo(ctx, tool.Repo, tool.Version, tool.SHA256)
 		if err != nil {
 			return fmt.Errorf("fetching %s: %w", tool.Name, err)
@@ -93,6 +90,9 @@ func verify(tools []*config.ComposerTool) error {
 	for _, tool := range tools {
 		if tool.Name == "" || tool.Version == "" {
 			return fmt.Errorf("%w: name and version must be specified: %+v", ErrInvalidTool, tool)
+		}
+		if tool.Repo == "" {
+			return fmt.Errorf("%w: composer tool %s", ErrMissingRepo, tool.Name)
 		}
 	}
 	return nil

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -30,8 +30,8 @@ import (
 // ErrMissingRepo indicates that a repository URL is missing for a Composer tool.
 var ErrMissingRepo = errors.New("repo URL missing")
 
-// errInvalidTool indicates that a Composer tool configuration is invalid.
-var errInvalidTool = errors.New("invalid tool configuration")
+// ErrInvalidTool indicates that a Composer tool configuration is invalid.
+var ErrInvalidTool = errors.New("invalid tool configuration")
 
 // Install installs a list of Composer tools into the environment.
 func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin string) error {
@@ -92,7 +92,7 @@ func createBinWrapper(wrapperName, content, binDir string) error {
 func verify(tools []*config.ComposerTool) error {
 	for _, tool := range tools {
 		if tool.Name == "" || tool.Version == "" {
-			return fmt.Errorf("%w: name and version must be specified: %+v", errInvalidTool, tool)
+			return fmt.Errorf("%w: name and version must be specified: %+v", ErrInvalidTool, tool)
 		}
 	}
 	return nil

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -27,11 +27,13 @@ import (
 	"github.com/googleapis/librarian/internal/fetch"
 )
 
-// ErrMissingRepo indicates that a repository URL is missing for a Composer tool.
-var ErrMissingRepo = errors.New("repo URL missing")
+var (
+	// ErrMissingRepo indicates that a repository URL is missing for a Composer tool.
+	ErrMissingRepo = errors.New("repo URL missing")
 
-// ErrInvalidTool indicates that a Composer tool configuration is invalid.
-var ErrInvalidTool = errors.New("invalid tool configuration")
+	// ErrInvalidTool indicates that a Composer tool configuration is invalid.
+	ErrInvalidTool = errors.New("invalid tool configuration")
+)
 
 // Install installs a list of Composer tools into the environment.
 func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin string) error {

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -49,7 +49,7 @@ func TestInstall(t *testing.T) {
 			name: "invalid tool configuration",
 			tools: []*config.ComposerTool{
 				{
-					Name: "",
+					Name:    "",
 					Version: "1.0.0",
 				},
 			},

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -155,7 +155,7 @@ func TestCreateBinWrapper(t *testing.T) {
 
 func TestVerify(t *testing.T) {
 	tools := []*config.ComposerTool{
-		{Name: "gapic-generator-php", Version: "1.0.0"},
+		{Name: "gapic-generator-php", Version: "1.0.0", Repo: "github.com/googleapis/gapic-generator-php"},
 	}
 	if err := verify(tools); err != nil {
 		t.Errorf("verify() error = %v, want nil", err)
@@ -171,16 +171,23 @@ func TestVerify_Error(t *testing.T) {
 		{
 			name: "missing name",
 			tools: []*config.ComposerTool{
-				{Name: "", Version: "1.0.0"},
+				{Name: "", Version: "1.0.0", Repo: "github.com"},
 			},
 			wantErr: ErrInvalidTool,
 		},
 		{
 			name: "missing version",
 			tools: []*config.ComposerTool{
-				{Name: "gapic-generator-php", Version: ""},
+				{Name: "gapic-generator-php", Version: "", Repo: "github.com"},
 			},
 			wantErr: ErrInvalidTool,
+		},
+		{
+			name: "missing repo",
+			tools: []*config.ComposerTool{
+				{Name: "gapic-generator-php", Version: "1.0.0", Repo: ""},
+			},
+			wantErr: ErrMissingRepo,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -162,7 +162,7 @@ func TestVerify(t *testing.T) {
 	}
 }
 
-func TestVerifyError(t *testing.T) {
+func TestVerify_Error(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		tools   []*config.ComposerTool

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -142,3 +142,42 @@ func TestCreateBinWrapper(t *testing.T) {
 		})
 	}
 }
+
+func TestVerify(t *testing.T) {
+	tools := []*config.ComposerTool{
+		{Name: "gapic-generator-php", Version: "1.0.0"},
+	}
+	if err := verify(tools); err != nil {
+		t.Errorf("verify() error = %v, want nil", err)
+	}
+}
+
+func TestVerify_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tools   []*config.ComposerTool
+		wantErr error
+	}{
+		{
+			name: "missing name",
+			tools: []*config.ComposerTool{
+				{Name: "", Version: "1.0.0"},
+			},
+			wantErr: errInvalidTool,
+		},
+		{
+			name: "missing version",
+			tools: []*config.ComposerTool{
+				{Name: "gapic-generator-php", Version: ""},
+			},
+			wantErr: errInvalidTool,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := verify(test.tools)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("verify() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -36,16 +36,6 @@ func TestInstall(t *testing.T) {
 		check   func(t *testing.T, binDir string)
 	}{
 		{
-			name: "missing repo URL",
-			tools: []*config.ComposerTool{
-				{
-					Name:    "gapic-generator-php",
-					Version: "1.0.0",
-				},
-			},
-			wantErr: ErrMissingRepo,
-		},
-		{
 			name: "invalid tool configuration",
 			tools: []*config.ComposerTool{
 				{
@@ -98,9 +88,9 @@ func TestInstall(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t, binDir)
 			}
-			err := Install(t.Context(), test.tools, "php", binDir)
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
+			gotErr := Install(t.Context(), test.tools, "php", binDir)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Fatalf("Install() error = %v, wantErr = %v", gotErr, test.wantErr)
 			}
 			if test.check != nil {
 				test.check(t, binDir)
@@ -191,9 +181,9 @@ func TestVerify_Error(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := verify(test.tools)
-			if !errors.Is(err, test.wantErr) {
-				t.Errorf("verify() error = %v, wantErr = %v", err, test.wantErr)
+			gotErr := verify(test.tools)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Errorf("verify() error = %v, wantErr = %v", gotErr, test.wantErr)
 			}
 		})
 	}

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -46,6 +46,16 @@ func TestInstall(t *testing.T) {
 			wantErr: ErrMissingRepo,
 		},
 		{
+			name: "invalid tool configuration",
+			tools: []*config.ComposerTool{
+				{
+					Name: "",
+					Version: "1.0.0",
+				},
+			},
+			wantErr: ErrInvalidTool,
+		},
+		{
 			name: "success",
 			tools: []*config.ComposerTool{
 				{
@@ -152,7 +162,7 @@ func TestVerify(t *testing.T) {
 	}
 }
 
-func TestVerify_Error(t *testing.T) {
+func TestVerifyError(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		tools   []*config.ComposerTool
@@ -163,14 +173,14 @@ func TestVerify_Error(t *testing.T) {
 			tools: []*config.ComposerTool{
 				{Name: "", Version: "1.0.0"},
 			},
-			wantErr: errInvalidTool,
+			wantErr: ErrInvalidTool,
 		},
 		{
 			name: "missing version",
 			tools: []*config.ComposerTool{
 				{Name: "gapic-generator-php", Version: ""},
 			},
-			wantErr: errInvalidTool,
+			wantErr: ErrInvalidTool,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This change modifies Librarian to verify the configuration of composer tools before installation. It checks that essential fields such as the tool name and version are provided, bubbling up an error if the configuration is invalid.

For https://github.com/googleapis/librarian/issues/6824