### PR TITLE
feat(internal/librarian/ruby): support ruby.wrapper_of main client gem wrapper generation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -508,7 +508,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `wrapper_of` | list of string | Contains the names of versioned libraries that this library wraps. |
+| `wrapper_of` | list of string | Contains the API versions (e.g. "v1:0.29") of versioned libraries that this library wraps. |
 
 ## RustCrate Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -840,7 +840,7 @@ type PHPAPI struct {
 
 // RubyPackage contains Ruby-specific library configuration.
 type RubyPackage struct {
-	// WrapperOf contains the names of versioned libraries that this library wraps.
+	// WrapperOf contains the API versions (e.g. "v1:0.29") of versioned libraries that this library wraps.
 	WrapperOf []string `yaml:"wrapper_of,omitempty"`
 }
 

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -108,7 +108,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err := os.MkdirAll(libStagingDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create lib staging directory: %w", err)
 	}
-	isWrapper := library != nil && library.Ruby != nil && len(library.Ruby.WrapperOf) > 0
+	isWrapper := library.Ruby != nil && len(library.Ruby.WrapperOf) > 0
 	args := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
@@ -155,7 +155,7 @@ func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config
 		return nil, err
 	}
 	var opts []string
-	if library != nil && library.Name != "" {
+	if library.Name != "" {
 		opts = append(opts, "ruby-cloud-gem-name="+library.Name)
 	}
 	if sc != nil && sc.ServiceConfig != "" {
@@ -185,9 +185,8 @@ func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config
 			opts = append(opts, "ruby-cloud-migration-version="+api.Ruby.RubyCloudOpts.MigrationVersion)
 		}
 	}
-	if library != nil && library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
-		wrapperOfOpt := buildWrapperOfOpt(cfg, library.Ruby.WrapperOf)
-		if wrapperOfOpt != "" {
+	if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
+		if wrapperOfOpt := buildWrapperOfOpt(cfg, library.Ruby.WrapperOf); wrapperOfOpt != "" {
 			opts = append(opts, "ruby-cloud-wrapper-of="+wrapperOfOpt)
 		}
 	}

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -155,9 +155,8 @@ func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config
 	if err != nil {
 		return nil, err
 	}
-	var opts []string
-	if library.Name != "" {
-		opts = append(opts, "ruby-cloud-gem-name="+library.Name)
+	opts := []string{
+		"ruby-cloud-gem-name=" + library.Name,
 	}
 	if sc != nil && sc.ServiceConfig != "" {
 		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, sc.ServiceConfig))

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -108,14 +108,19 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err := os.MkdirAll(libStagingDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create lib staging directory: %w", err)
 	}
-	grpcPluginPath := filepath.Join(installDir, "bin", "grpc_tools_ruby_protoc_plugin")
+	isWrapper := library != nil && library.Ruby != nil && len(library.Ruby.WrapperOf) > 0
 	args := []string{
 		"--experimental_allow_proto3_optional",
 		"-I=" + googleapisDir,
-		"--ruby_out=" + libStagingDir,
-		"--grpc_out=" + libStagingDir,
-		"--plugin=protoc-gen-grpc=" + grpcPluginPath,
 		"--ruby_cloud_out=" + stagingDir,
+	}
+	if !isWrapper {
+		grpcPluginPath := filepath.Join(installDir, "bin", "grpc_tools_ruby_protoc_plugin")
+		args = append(args,
+			"--ruby_out="+libStagingDir,
+			"--grpc_out="+libStagingDir,
+			"--plugin=protoc-gen-grpc="+grpcPluginPath,
+		)
 	}
 	if len(gapicOpts) > 0 {
 		args = append(args, "--ruby_cloud_opt="+strings.Join(gapicOpts, ","))
@@ -128,11 +133,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err := protoc.RunOrSystem(ctx, env, pc, args...); err != nil {
 		return err
 	}
-	if library != nil && library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
-		if err := removeProtoPBFiles(stagingDir); err != nil {
-			return fmt.Errorf("failed to remove pb files for wrapper gem: %w", err)
-		}
-	} else {
+	if !isWrapper {
 		// Remove google/cloud/common_resources_pb.rb from staging after generation.
 		// Because librarian passes all protoFiles (including common_resources.proto) to protoc
 		// in a single invocation, protoc outputs common_resources_pb.rb into the lib/ directory.
@@ -144,24 +145,6 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 		}
 	}
 	return nil
-}
-
-func removeProtoPBFiles(stagingDir string) error {
-	libDir := filepath.Join(stagingDir, "lib")
-	return filepath.WalkDir(libDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil
-			}
-			return err
-		}
-		if !d.IsDir() && strings.HasSuffix(d.Name(), "_pb.rb") {
-			if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-				return err
-			}
-		}
-		return nil
-	})
 }
 
 func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config, googleapisDir string) ([]string, error) {

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -133,16 +133,14 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err := protoc.RunOrSystem(ctx, env, pc, args...); err != nil {
 		return err
 	}
-	if !isWrapper {
-		// Remove google/cloud/common_resources_pb.rb from staging after generation.
-		// Because librarian passes all protoFiles (including common_resources.proto) to protoc
-		// in a single invocation, protoc outputs common_resources_pb.rb into the lib/ directory.
-		// We delete it unconditionally so individual client gems do not bundle unused shared
-		// protobuf definitions, which would cause class redefinition warnings and collisions.
-		commonResourcesPB := filepath.Join(stagingDir, "lib", "google", "cloud", "common_resources_pb.rb")
-		if err := os.Remove(commonResourcesPB); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to remove %s: %w", commonResourcesPB, err)
-		}
+	// Remove google/cloud/common_resources_pb.rb from staging after generation.
+	// Because librarian passes all protoFiles (including common_resources.proto) to protoc
+	// in a single invocation, protoc outputs common_resources_pb.rb into the lib/ directory.
+	// We delete it unconditionally so individual client gems do not bundle unused shared
+	// protobuf definitions, which would cause class redefinition warnings and collisions.
+	commonResourcesPB := filepath.Join(stagingDir, "lib", "google", "cloud", "common_resources_pb.rb")
+	if err := os.Remove(commonResourcesPB); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to remove %s: %w", commonResourcesPB, err)
 	}
 	return nil
 }
@@ -196,6 +194,8 @@ func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config
 	return opts, nil
 }
 
+// buildWrapperOfOpt converts library wrapper definitions (e.g., ["google-cloud-asset-v1:0.29"])
+// into the format expected by gapic-generator-cloud (e.g., "v1:0.29").
 func buildWrapperOfOpt(cfg *config.Config, wrapperOf []string) string {
 	var parts []string
 	for _, raw := range wrapperOf {

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -108,6 +108,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err := os.MkdirAll(libStagingDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create lib staging directory: %w", err)
 	}
+	// A main client is a wrapper of a versioned client
 	isWrapper := library.Ruby != nil && len(library.Ruby.WrapperOf) > 0
 	args := []string{
 		"--experimental_allow_proto3_optional",

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -69,10 +69,8 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		pc = cfg.Tools.Protoc
 	}
 
-	// TODO(https://github.com/googleapis/librarian/issues/6885): Implement main client gem wrapper generation
-	// for libraries configured with `ruby.wrapper_of`.
 	for _, api := range library.APIs {
-		if err := generateAPI(ctx, api, library.Name, pc, googleapisDir, tempDir); err != nil {
+		if err := generateAPI(ctx, api, library, cfg, pc, googleapisDir, tempDir); err != nil {
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
@@ -86,7 +84,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
-func generateAPI(ctx context.Context, api *config.API, gemName string, pc *config.Protoc, googleapisDir, stagingDir string) error {
+func generateAPI(ctx context.Context, api *config.API, library *config.Library, cfg *config.Config, pc *config.Protoc, googleapisDir, stagingDir string) error {
 	additionalProtos := []string{commonResourcesProto}
 	if api.Ruby != nil {
 		additionalProtos = append(additionalProtos, api.Ruby.AdditionalProtos...)
@@ -95,7 +93,7 @@ func generateAPI(ctx context.Context, api *config.API, gemName string, pc *confi
 	if err != nil {
 		return err
 	}
-	gapicOpts, err := buildGAPICOpts(api, gemName, googleapisDir)
+	gapicOpts, err := buildGAPICOpts(api, library, cfg, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -142,7 +140,7 @@ func generateAPI(ctx context.Context, api *config.API, gemName string, pc *confi
 	return nil
 }
 
-func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, error) {
+func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config, googleapisDir string) ([]string, error) {
 	sc, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
 	if err != nil {
 		return nil, err
@@ -152,8 +150,8 @@ func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, e
 		return nil, err
 	}
 	var opts []string
-	if gemName != "" {
-		opts = append(opts, "ruby-cloud-gem-name="+gemName)
+	if library != nil && library.Name != "" {
+		opts = append(opts, "ruby-cloud-gem-name="+library.Name)
 	}
 	if sc != nil && sc.ServiceConfig != "" {
 		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, sc.ServiceConfig))
@@ -182,7 +180,41 @@ func buildGAPICOpts(api *config.API, gemName, googleapisDir string) ([]string, e
 			opts = append(opts, "ruby-cloud-migration-version="+api.Ruby.RubyCloudOpts.MigrationVersion)
 		}
 	}
+	if library != nil && library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
+		wrapperOfOpt := buildWrapperOfOpt(cfg, library.Ruby.WrapperOf)
+		if wrapperOfOpt != "" {
+			opts = append(opts, "ruby-cloud-wrapper-of="+wrapperOfOpt)
+		}
+	}
 	return opts, nil
+}
+
+func buildWrapperOfOpt(cfg *config.Config, wrapperOf []string) string {
+	var parts []string
+	for _, raw := range wrapperOf {
+		target, minVersion, hasVersion := strings.Cut(raw, ":")
+		if !hasVersion {
+			minVersion = "0.0"
+		}
+		apiVersion := ""
+		if cfg != nil {
+			for _, lib := range cfg.Libraries {
+				if lib.Name == target && len(lib.APIs) > 0 {
+					apiVersion = filepath.Base(lib.APIs[0].Path)
+					break
+				}
+			}
+		}
+		if apiVersion == "" {
+			if idx := strings.LastIndex(target, "-"); idx != -1 {
+				apiVersion = target[idx+1:]
+			} else {
+				apiVersion = target
+			}
+		}
+		parts = append(parts, apiVersion+":"+minVersion)
+	}
+	return strings.Join(parts, ";")
 }
 
 func transport(sc *serviceconfig.API) serviceconfig.Transport {

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -128,16 +128,40 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err := protoc.RunOrSystem(ctx, env, pc, args...); err != nil {
 		return err
 	}
-	// Remove google/cloud/common_resources_pb.rb from staging after generation.
-	// Because librarian passes all protoFiles (including common_resources.proto) to protoc
-	// in a single invocation, protoc outputs common_resources_pb.rb into the lib/ directory.
-	// We delete it unconditionally so individual client gems do not bundle unused shared
-	// protobuf definitions, which would cause class redefinition warnings and collisions.
-	commonResourcesPB := filepath.Join(stagingDir, "lib", "google", "cloud", "common_resources_pb.rb")
-	if err := os.Remove(commonResourcesPB); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to remove %s: %w", commonResourcesPB, err)
+	if library != nil && library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
+		if err := removeProtoPBFiles(stagingDir); err != nil {
+			return fmt.Errorf("failed to remove pb files for wrapper gem: %w", err)
+		}
+	} else {
+		// Remove google/cloud/common_resources_pb.rb from staging after generation.
+		// Because librarian passes all protoFiles (including common_resources.proto) to protoc
+		// in a single invocation, protoc outputs common_resources_pb.rb into the lib/ directory.
+		// We delete it unconditionally so individual client gems do not bundle unused shared
+		// protobuf definitions, which would cause class redefinition warnings and collisions.
+		commonResourcesPB := filepath.Join(stagingDir, "lib", "google", "cloud", "common_resources_pb.rb")
+		if err := os.Remove(commonResourcesPB); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to remove %s: %w", commonResourcesPB, err)
+		}
 	}
 	return nil
+}
+
+func removeProtoPBFiles(stagingDir string) error {
+	libDir := filepath.Join(stagingDir, "lib")
+	return filepath.WalkDir(libDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), "_pb.rb") {
+			if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config, googleapisDir string) ([]string, error) {

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -188,6 +188,7 @@ func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config
 	}
 	if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
 		if wrapperOfOpt := buildWrapperOfOpt(cfg, library.Ruby.WrapperOf); wrapperOfOpt != "" {
+			// This controls the dependency range declaration in the gemspec file.
 			opts = append(opts, "ruby-cloud-wrapper-of="+wrapperOfOpt)
 		}
 	}

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -70,7 +70,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}
 
 	for _, api := range library.APIs {
-		if err := generateAPI(ctx, api, library, cfg, pc, googleapisDir, tempDir); err != nil {
+		if err := generateAPI(ctx, api, library, pc, googleapisDir, tempDir); err != nil {
 			return fmt.Errorf("api %q: %w", api.Path, err)
 		}
 	}
@@ -84,7 +84,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	return nil
 }
 
-func generateAPI(ctx context.Context, api *config.API, library *config.Library, cfg *config.Config, pc *config.Protoc, googleapisDir, stagingDir string) error {
+func generateAPI(ctx context.Context, api *config.API, library *config.Library, pc *config.Protoc, googleapisDir, stagingDir string) error {
 	additionalProtos := []string{commonResourcesProto}
 	if api.Ruby != nil {
 		additionalProtos = append(additionalProtos, api.Ruby.AdditionalProtos...)
@@ -93,7 +93,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err != nil {
 		return err
 	}
-	gapicOpts, err := buildGAPICOpts(api, library, cfg, googleapisDir)
+	gapicOpts, err := buildGAPICOpts(api, library, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	return nil
 }
 
-func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config, googleapisDir string) ([]string, error) {
+func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir string) ([]string, error) {
 	sc, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
 	if err != nil {
 		return nil, err
@@ -186,42 +186,10 @@ func buildGAPICOpts(api *config.API, library *config.Library, cfg *config.Config
 		}
 	}
 	if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
-		if wrapperOfOpt := buildWrapperOfOpt(cfg, library.Ruby.WrapperOf); wrapperOfOpt != "" {
-			// This controls the dependency range declaration in the gemspec file.
-			opts = append(opts, "ruby-cloud-wrapper-of="+wrapperOfOpt)
-		}
+		// This controls the dependency range declaration in the gemspec file.
+		opts = append(opts, "ruby-cloud-wrapper-of="+strings.Join(library.Ruby.WrapperOf, ";"))
 	}
 	return opts, nil
-}
-
-// buildWrapperOfOpt converts library wrapper definitions (e.g., ["google-cloud-asset-v1:0.29"])
-// into the format expected by gapic-generator-cloud (e.g., "v1:0.29").
-func buildWrapperOfOpt(cfg *config.Config, wrapperOf []string) string {
-	var parts []string
-	for _, raw := range wrapperOf {
-		target, minVersion, hasVersion := strings.Cut(raw, ":")
-		if !hasVersion {
-			minVersion = "0.0"
-		}
-		apiVersion := ""
-		if cfg != nil {
-			for _, lib := range cfg.Libraries {
-				if lib.Name == target && len(lib.APIs) > 0 {
-					apiVersion = filepath.Base(lib.APIs[0].Path)
-					break
-				}
-			}
-		}
-		if apiVersion == "" {
-			if idx := strings.LastIndex(target, "-"); idx != -1 {
-				apiVersion = target[idx+1:]
-			} else {
-				apiVersion = target
-			}
-		}
-		parts = append(parts, apiVersion+":"+minVersion)
-	}
-	return strings.Join(parts, ";")
 }
 
 func transport(sc *serviceconfig.API) serviceconfig.Transport {

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -108,17 +108,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 			library: &config.Library{
 				Name: "google-cloud-secret_manager",
 				Ruby: &config.RubyPackage{
-					WrapperOf: []string{"google-cloud-secret_manager-v1:0.29"},
-				},
-			},
-			cfg: &config.Config{
-				Libraries: []*config.Library{
-					{
-						Name: "google-cloud-secret_manager-v1",
-						APIs: []*config.API{
-							{Path: "google/cloud/secretmanager/v1"},
-						},
-					},
+					WrapperOf: []string{"v1:0.29"},
 				},
 			},
 			want: []string{
@@ -133,7 +123,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := buildGAPICOpts(test.api, test.library, test.cfg, googleapisDir)
+			got, err := buildGAPICOpts(test.api, test.library, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -519,7 +509,7 @@ func TestGenerateAPI(t *testing.T) {
 	api := &config.API{Path: "google/cloud/secretmanager/v1"}
 	library := &config.Library{Name: "google-cloud-secret_manager-v1"}
 
-	err = generateAPI(t.Context(), api, library, nil, nil, googleapisDir, stagingDir)
+	err = generateAPI(t.Context(), api, library, nil, googleapisDir, stagingDir)
 	if err != nil {
 		t.Fatalf("generateAPI() error = %v", err)
 	}
@@ -544,67 +534,9 @@ func TestGenerateAPI_Error(t *testing.T) {
 	}
 	api := &config.API{Path: "non/existent/path"}
 	library := &config.Library{Name: "gem-name"}
-	err = generateAPI(t.Context(), api, library, nil, nil, googleapisDir, t.TempDir())
+	err = generateAPI(t.Context(), api, library, nil, googleapisDir, t.TempDir())
 	if err == nil {
 		t.Error("generateAPI() error = nil, want error")
-	}
-}
-
-func TestBuildWrapperOfOpt(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name: "google-cloud-asset-v1",
-				APIs: []*config.API{
-					{Path: "google/cloud/asset/v1"},
-				},
-			},
-			{
-				Name: "google-cloud-asset-v1p1beta1",
-				APIs: []*config.API{
-					{Path: "google/cloud/asset/v1p1beta1"},
-				},
-			},
-		},
-	}
-
-	for _, test := range []struct {
-		name      string
-		cfg       *config.Config
-		wrapperOf []string
-		want      string
-	}{
-		{
-			name:      "single target resolved via cfg",
-			cfg:       cfg,
-			wrapperOf: []string{"google-cloud-asset-v1:0.29"},
-			want:      "v1:0.29",
-		},
-		{
-			name:      "multiple targets resolved via cfg",
-			cfg:       cfg,
-			wrapperOf: []string{"google-cloud-asset-v1:0.29", "google-cloud-asset-v1p1beta1:0.10"},
-			want:      "v1:0.29;v1p1beta1:0.10",
-		},
-		{
-			name:      "without minimal version defaulted to 0.0",
-			cfg:       cfg,
-			wrapperOf: []string{"google-cloud-asset-v1"},
-			want:      "v1:0.0",
-		},
-		{
-			name:      "fallback extraction from target string",
-			cfg:       nil,
-			wrapperOf: []string{"google-cloud-asset-v1:0.29"},
-			want:      "v1:0.29",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := buildWrapperOfOpt(test.cfg, test.wrapperOf)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
 	}
 }
 

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -40,7 +40,8 @@ func TestBuildGAPICOpts(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		api     *config.API
-		gemName string
+		library *config.Library
+		cfg     *config.Config
 		want    []string
 	}{
 		{
@@ -48,7 +49,9 @@ func TestBuildGAPICOpts(t *testing.T) {
 			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",
 			},
-			gemName: "google-cloud-secret_manager-v1",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager-v1",
+			},
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
@@ -63,7 +66,9 @@ func TestBuildGAPICOpts(t *testing.T) {
 			api: &config.API{
 				Path: "google/cloud/compute/v1",
 			},
-			gemName: "google-cloud-compute-v1",
+			library: &config.Library{
+				Name: "google-cloud-compute-v1",
+			},
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-compute-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/compute/v1/compute_v1.yaml"),
@@ -82,7 +87,9 @@ func TestBuildGAPICOpts(t *testing.T) {
 					},
 				},
 			},
-			gemName: "google-cloud-secret_manager",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+			},
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
@@ -93,9 +100,40 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"ruby-cloud-migration-version=1.0",
 			},
 		},
+		{
+			name: "wrapper library with wrapper_of option",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+			},
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"google-cloud-secret_manager-v1:0.29"},
+				},
+			},
+			cfg: &config.Config{
+				Libraries: []*config.Library{
+					{
+						Name: "google-cloud-secret_manager-v1",
+						APIs: []*config.API{
+							{Path: "google/cloud/secretmanager/v1"},
+						},
+					},
+				},
+			},
+			want: []string{
+				"ruby-cloud-gem-name=google-cloud-secret_manager",
+				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
+				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
+				"ruby-cloud-generate-transports=grpc;rest",
+				"ruby-cloud-rest-numeric-enums=true",
+				"ruby-cloud-wrapper-of=v1:0.29",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := buildGAPICOpts(test.api, test.gemName, googleapisDir)
+			got, err := buildGAPICOpts(test.api, test.library, test.cfg, googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -479,9 +517,9 @@ func TestGenerateAPI(t *testing.T) {
 	}
 	stagingDir := t.TempDir()
 	api := &config.API{Path: "google/cloud/secretmanager/v1"}
-	gemName := "google-cloud-secret_manager-v1"
+	library := &config.Library{Name: "google-cloud-secret_manager-v1"}
 
-	err = generateAPI(t.Context(), api, gemName, nil, googleapisDir, stagingDir)
+	err = generateAPI(t.Context(), api, library, nil, nil, googleapisDir, stagingDir)
 	if err != nil {
 		t.Fatalf("generateAPI() error = %v", err)
 	}
@@ -505,9 +543,68 @@ func TestGenerateAPI_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 	api := &config.API{Path: "non/existent/path"}
-	err = generateAPI(t.Context(), api, "gem-name", nil, googleapisDir, t.TempDir())
+	library := &config.Library{Name: "gem-name"}
+	err = generateAPI(t.Context(), api, library, nil, nil, googleapisDir, t.TempDir())
 	if err == nil {
 		t.Error("generateAPI() error = nil, want error")
+	}
+}
+
+func TestBuildWrapperOfOpt(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name: "google-cloud-asset-v1",
+				APIs: []*config.API{
+					{Path: "google/cloud/asset/v1"},
+				},
+			},
+			{
+				Name: "google-cloud-asset-v1p1beta1",
+				APIs: []*config.API{
+					{Path: "google/cloud/asset/v1p1beta1"},
+				},
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name      string
+		cfg       *config.Config
+		wrapperOf []string
+		want      string
+	}{
+		{
+			name:      "single target resolved via cfg",
+			cfg:       cfg,
+			wrapperOf: []string{"google-cloud-asset-v1:0.29"},
+			want:      "v1:0.29",
+		},
+		{
+			name:      "multiple targets resolved via cfg",
+			cfg:       cfg,
+			wrapperOf: []string{"google-cloud-asset-v1:0.29", "google-cloud-asset-v1p1beta1:0.10"},
+			want:      "v1:0.29;v1p1beta1:0.10",
+		},
+		{
+			name:      "without minimal version defaulted to 0.0",
+			cfg:       cfg,
+			wrapperOf: []string{"google-cloud-asset-v1"},
+			want:      "v1:0.0",
+		},
+		{
+			name:      "fallback extraction from target string",
+			cfg:       nil,
+			wrapperOf: []string{"google-cloud-asset-v1:0.29"},
+			want:      "v1:0.29",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildWrapperOfOpt(test.cfg, test.wrapperOf)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -550,33 +550,6 @@ func TestGenerateAPI_Error(t *testing.T) {
 	}
 }
 
-func TestRemoveProtoPBFiles(t *testing.T) {
-	stagingDir := t.TempDir()
-	libDir := filepath.Join(stagingDir, "lib", "google", "cloud", "asset", "v1")
-	if err := os.MkdirAll(libDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	pbFile := filepath.Join(libDir, "asset_service_pb.rb")
-	if err := os.WriteFile(pbFile, []byte("# pb content"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	rbFile := filepath.Join(libDir, "asset_service.rb")
-	if err := os.WriteFile(rbFile, []byte("# rb content"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := removeProtoPBFiles(stagingDir); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Stat(pbFile); !errors.Is(err, fs.ErrNotExist) {
-		t.Errorf("expected pb file %s to be removed, got err = %v", pbFile, err)
-	}
-	if _, err := os.Stat(rbFile); err != nil {
-		t.Errorf("expected non-pb file %s to exist, got err = %v", rbFile, err)
-	}
-}
-
 func TestBuildWrapperOfOpt(t *testing.T) {
 	cfg := &config.Config{
 		Libraries: []*config.Library{

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -550,6 +550,33 @@ func TestGenerateAPI_Error(t *testing.T) {
 	}
 }
 
+func TestRemoveProtoPBFiles(t *testing.T) {
+	stagingDir := t.TempDir()
+	libDir := filepath.Join(stagingDir, "lib", "google", "cloud", "asset", "v1")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pbFile := filepath.Join(libDir, "asset_service_pb.rb")
+	if err := os.WriteFile(pbFile, []byte("# pb content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rbFile := filepath.Join(libDir, "asset_service.rb")
+	if err := os.WriteFile(rbFile, []byte("# rb content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeProtoPBFiles(stagingDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(pbFile); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected pb file %s to be removed, got err = %v", pbFile, err)
+	}
+	if _, err := os.Stat(rbFile); err != nil {
+		t.Errorf("expected non-pb file %s to exist, got err = %v", rbFile, err)
+	}
+}
+
 func TestBuildWrapperOfOpt(t *testing.T) {
 	cfg := &config.Config{
 		Libraries: []*config.Library{


### PR DESCRIPTION
Support main / wrapper client gem code generation in `ruby.Generate` when `ruby.wrapper_of` is specified in `librarian.yaml`.

Passes the `--ruby_cloud_opt=ruby-cloud-wrapper-of=...` option directly to `gapic-generator-cloud` using the API version entries (e.g. `v1:0.29`) specified in `ruby.wrapper_of`.

---

### How to Confirm & Generate Changes in `google-cloud-ruby`

To verify wrapper client generation end-to-end (demonstrated in [google-cloud-ruby#35034](https://github.com/googleapis/google-cloud-ruby/pull/35034)):

1. **Build `librarian` CLI**:
   ```bash
   go build -o /tmp/librarian ./cmd/librarian
   ```

2. **Add Wrapper Library Configuration to `librarian.yaml`**:
   ```yaml
   libraries:
     - name: google-cloud-asset-v1
       version: 1.9.0
       apis:
         - path: google/cloud/asset/v1
     - name: google-cloud-asset
       version: 1.10.0
       apis:
         - path: google/cloud/asset/v1
           ruby:
             ruby_cloud_opts:
               ruby-cloud-env-prefix: ASSET
               ruby-cloud-migration-version: "1.0"
       ruby:
         wrapper_of:
           - v1:0.29
   ```

3. **Run Code Generation**:
   ```bash
   /tmp/librarian generate google-cloud-asset
   ```

4. **Verify Output**:
   - Generates main wrapper gem files (`lib/google/cloud/asset.rb`, `lib/google-cloud-asset.rb`, `README.md`, `google-cloud-asset.gemspec`, `Rakefile`, `.toys.rb`, `test/`).
   - Confirms zero compiled `*_pb.rb` protobuf files are produced under `google-cloud-asset/lib/google/cloud/asset/v1/`.

---

### Optimization & Alignment with Bazel

For **main / wrapper client gems** (where `ruby.wrapper_of` is set):
- `librarian` **omits** `--ruby_out`, `--grpc_out`, and `--plugin=protoc-gen-grpc` from the `protoc` command.
- Only `--ruby_cloud_out` and `--ruby_cloud_opt=...` are passed to `protoc`.
- `protoc` executes only `gapic-generator-cloud` and avoids generating unused `*_pb.rb` or `*_services_pb.rb` compiled protobuf files in the first place, aligning directly with Bazel's wrapper target assembly (`ruby_gapic_assembly_pkg` omitting `ruby_proto_library` and `grpc_ruby_proto_library`).

---

### Implementation Details:
- Updated `generateAPI` and `buildGAPICOpts` in `internal/librarian/ruby/generate.go` to accept `library *config.Library`.
- Directly join `library.Ruby.WrapperOf` entries (e.g. `v1:0.29`) and pass as `--ruby_cloud_opt=ruby-cloud-wrapper-of=...`.
- Conditionally omit `--ruby_out`, `--grpc_out`, and `--plugin=protoc-gen-grpc` when `library.Ruby.WrapperOf` is set.
- Added unit test cases for `ruby-cloud-wrapper-of` in `generate_test.go`.

Fixes https://github.com/googleapis/librarian/issues/6885
