### PR TITLE
refactor(internal/librarian/php): remove unused wantErr from install test in PHP

### DIFF
--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -55,11 +55,10 @@ func TestBinDir(t *testing.T) {
 
 func TestInstall(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		tools   *config.Tools
-		setup   func(t *testing.T)
-		wantErr error
-		check   func(t *testing.T)
+		name  string
+		tools *config.Tools
+		setup func(t *testing.T)
+		check func(t *testing.T)
 	}{
 
 		{
@@ -117,8 +116,8 @@ func TestInstall(t *testing.T) {
 				test.setup(t)
 			}
 			err := Install(t.Context(), test.tools)
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
+			if err != nil {
+				t.Fatalf("Install() error = %v", err)
 			}
 			if test.check != nil {
 				test.check(t)

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -117,7 +117,7 @@ func TestInstall(t *testing.T) {
 			}
 			err := Install(t.Context(), test.tools)
 			if err != nil {
-				t.Fatalf("Install() error = %v", err)
+				t.Fatal(err)
 			}
 			if test.check != nil {
 				test.check(t)

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -29,11 +29,22 @@ import (
 func TestInstall(t *testing.T) {
 	testhelper.RequireCommand(t, "composer")
 	for _, test := range []struct {
-		name  string
-		tools []*config.ComposerTool
-		setup func(t *testing.T, binDir string)
-		check func(t *testing.T, binDir string)
+		name    string
+		tools   []*config.ComposerTool
+		setup   func(t *testing.T, binDir string)
+		wantErr error
+		check   func(t *testing.T, binDir string)
 	}{
+		{
+			name: "invalid tool configuration",
+			tools: []*config.ComposerTool{
+				{
+					Name:    "",
+					Version: "1.0.0",
+				},
+			},
+			wantErr: ErrInvalidTool,
+		},
 		{
 			name: "success",
 			tools: []*config.ComposerTool{
@@ -78,42 +89,11 @@ func TestInstall(t *testing.T) {
 				test.setup(t, binDir)
 			}
 			gotErr := Install(t.Context(), test.tools, "php", binDir)
-			if gotErr != nil {
-				t.Fatalf("Install() error = %v", gotErr)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Fatalf("Install() error = %v, wantErr = %v", gotErr, test.wantErr)
 			}
 			if test.check != nil {
 				test.check(t, binDir)
-			}
-		})
-	}
-}
-
-func TestInstall_Error(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		tools   []*config.ComposerTool
-		setup   func(t *testing.T, binDir string)
-		wantErr error
-	}{
-		{
-			name: "invalid tool configuration",
-			tools: []*config.ComposerTool{
-				{
-					Name:    "",
-					Version: "1.0.0",
-				},
-			},
-			wantErr: ErrInvalidTool,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			binDir := t.TempDir()
-			if test.setup != nil {
-				test.setup(t, binDir)
-			}
-			gotErr := Install(t.Context(), test.tools, "php", binDir)
-			if !errors.Is(gotErr, test.wantErr) {
-				t.Fatalf("Install() error = %v, wantErr = %v", gotErr, test.wantErr)
 			}
 		})
 	}

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -29,22 +29,11 @@ import (
 func TestInstall(t *testing.T) {
 	testhelper.RequireCommand(t, "composer")
 	for _, test := range []struct {
-		name    string
-		tools   []*config.ComposerTool
-		setup   func(t *testing.T, binDir string)
-		wantErr error
-		check   func(t *testing.T, binDir string)
+		name  string
+		tools []*config.ComposerTool
+		setup func(t *testing.T, binDir string)
+		check func(t *testing.T, binDir string)
 	}{
-		{
-			name: "invalid tool configuration",
-			tools: []*config.ComposerTool{
-				{
-					Name:    "",
-					Version: "1.0.0",
-				},
-			},
-			wantErr: ErrInvalidTool,
-		},
 		{
 			name: "success",
 			tools: []*config.ComposerTool{
@@ -89,11 +78,42 @@ func TestInstall(t *testing.T) {
 				test.setup(t, binDir)
 			}
 			gotErr := Install(t.Context(), test.tools, "php", binDir)
-			if !errors.Is(gotErr, test.wantErr) {
-				t.Fatalf("Install() error = %v, wantErr = %v", gotErr, test.wantErr)
+			if gotErr != nil {
+				t.Fatalf("Install() error = %v", gotErr)
 			}
 			if test.check != nil {
 				test.check(t, binDir)
+			}
+		})
+	}
+}
+
+func TestInstall_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tools   []*config.ComposerTool
+		setup   func(t *testing.T, binDir string)
+		wantErr error
+	}{
+		{
+			name: "invalid tool configuration",
+			tools: []*config.ComposerTool{
+				{
+					Name:    "",
+					Version: "1.0.0",
+				},
+			},
+			wantErr: ErrInvalidTool,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, binDir)
+			}
+			gotErr := Install(t.Context(), test.tools, "php", binDir)
+			if !errors.Is(gotErr, test.wantErr) {
+				t.Fatalf("Install() error = %v, wantErr = %v", gotErr, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
This change removes the unused wantErr field from the TestInstall test cases.  Since TestInstall only covers the happy path, we do not need to assert on  specific errors. Therefore, explicitly checking if the error is not nil is functionally identical to the previous check against an empty wantErr.

This is the final PR towards #6824 

Fixes #6824 