### PR TITLE
feat(internal/librarian/php): implement code formatting using prettier

### DIFF
--- a/internal/librarian/php/format.go
+++ b/internal/librarian/php/format.go
@@ -16,12 +16,48 @@ package php
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/librarian/nodejs"
 )
 
 // Format formats a generated PHP library.
 func Format(ctx context.Context, library *config.Library) error {
-	// TODO(https://github.com/googleapis/librarian/issues/6629): implement PHP formatting
-	return nil
+	nodeInstallDir, err := nodejs.InstallDir()
+	if err != nil {
+		return err
+	}
+	prettierPath := filepath.Join(nodeInstallDir, "bin", "prettier")
+	if _, err := os.Stat(prettierPath); err != nil {
+		return fmt.Errorf("prettier not found at %s: %w", prettierPath, err)
+	}
+
+	outdir, err := filepath.Abs(library.Output)
+	if err != nil {
+		return fmt.Errorf("failed to resolve output directory path: %w", err)
+	}
+
+	binDir := filepath.Dir(prettierPath)
+	env := map[string]string{
+		"PATH": binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	// In pnpm 8, global packages are installed in PNPM_HOME/global/5.
+	// In librarian, PNPM_HOME is configured to nodeInstallDir/bin.
+	// Note: pnpm 9+ uses hashed directories for global packages, which is not supported by this path resolution.
+	pluginPath := filepath.Join(nodeInstallDir, "bin", "global", "5", "node_modules", "@prettier", "plugin-php")
+
+	// Run prettier '**/Client/*' --write --parser=php --single-quote --print-width=120 --plugin=<pluginPath>
+	return command.RunInDirWithEnv(ctx, outdir, env, prettierPath,
+		"**/Client/*",
+		"--write",
+		"--parser=php",
+		"--single-quote",
+		"--print-width=120",
+		"--plugin="+pluginPath,
+	)
 }

--- a/internal/librarian/php/format.go
+++ b/internal/librarian/php/format.go
@@ -25,34 +25,20 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
 )
 
+const envPath = "PATH"
+
 // Format formats a generated PHP library.
 func Format(ctx context.Context, library *config.Library) error {
-	nodeInstallDir, err := nodejs.InstallDir()
+	prettierPath, pluginPath, err := prettierToolPaths()
 	if err != nil {
 		return err
 	}
-	prettierPath := filepath.Join(nodeInstallDir, "bin", "prettier")
-	if _, err := os.Stat(prettierPath); err != nil {
-		return fmt.Errorf("prettier not found at %s: %w", prettierPath, err)
-	}
-
 	outdir, err := filepath.Abs(library.Output)
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
-
-	binDir := filepath.Dir(prettierPath)
-	env := map[string]string{
-		"PATH": binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
-	}
-
-	// In pnpm 8, global packages are installed in PNPM_HOME/global/5.
-	// In librarian, PNPM_HOME is configured to nodeInstallDir/bin.
-	// Note: pnpm 9+ uses hashed directories for global packages, which is not supported by this path resolution.
-	pluginPath := filepath.Join(nodeInstallDir, "bin", "global", "5", "node_modules", "@prettier", "plugin-php")
-
 	// Run prettier '**/Client/*' --write --parser=php --single-quote --print-width=120 --plugin=<pluginPath>
-	return command.RunInDirWithEnv(ctx, outdir, env, prettierPath,
+	return command.RunInDirWithEnv(ctx, outdir, prettierEnv(prettierPath), prettierPath,
 		"**/Client/*",
 		"--write",
 		"--parser=php",
@@ -60,4 +46,32 @@ func Format(ctx context.Context, library *config.Library) error {
 		"--print-width=120",
 		"--plugin="+pluginPath,
 	)
+}
+
+// prettierToolPaths resolves and validates the paths for prettier and its PHP plugin.
+func prettierToolPaths() (string, string, error) {
+	nodeInstallDir, err := nodejs.InstallDir()
+	if err != nil {
+		return "", "", err
+	}
+	prettierPath := filepath.Join(nodeInstallDir, "bin", "prettier")
+	if _, err := os.Stat(prettierPath); err != nil {
+		return "", "", fmt.Errorf("prettier not found at %s: %w", prettierPath, err)
+	}
+	// In pnpm 8, global packages are installed in PNPM_HOME/global/5.
+	// In librarian, PNPM_HOME is configured to nodeInstallDir/bin.
+	// Note: pnpm 9+ uses hashed directories for global packages, which is not supported by this path resolution.
+	pluginPath := filepath.Join(nodeInstallDir, "bin", "global", "5", "node_modules", "@prettier", "plugin-php")
+	if _, err := os.Stat(pluginPath); err != nil {
+		return "", "", fmt.Errorf("prettier PHP plugin not found at %s: %w", pluginPath, err)
+	}
+
+	return prettierPath, pluginPath, nil
+}
+
+// prettierEnv returns the environment variables required to run prettier.
+func prettierEnv(prettierPath string) map[string]string {
+	return map[string]string{
+		envPath: filepath.Dir(prettierPath),
+	}
 }

--- a/internal/librarian/php/format.go
+++ b/internal/librarian/php/format.go
@@ -58,7 +58,7 @@ func prettierToolPaths() (string, string, error) {
 	if _, err := os.Stat(prettierPath); err != nil {
 		return "", "", fmt.Errorf("prettier not found at %s: %w", prettierPath, err)
 	}
-	// In pnpm 8, global packages are installed in PNPM_HOME/global/5.
+	// In pnpm 7.16+ and pnpm 8, global packages are installed in PNPM_HOME/global/5.
 	// In librarian, PNPM_HOME is configured to nodeInstallDir/bin.
 	// Note: pnpm 9+ uses hashed directories for global packages, which is not supported by this path resolution.
 	pluginPath := filepath.Join(nodeInstallDir, "bin", "global", "5", "node_modules", "@prettier", "plugin-php")

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -86,6 +86,15 @@ func TestFormat_ErrorPrettierMissing(t *testing.T) {
 		t.Fatalf("Format() error = %v, want wrap of %v", err, fs.ErrNotExist)
 	}
 }
+func TestPrettierEnv(t *testing.T) {
+	got := prettierEnv("/path/to/bin/prettier")
+	want := map[string]string{
+		"PATH": "/path/to/bin",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
 
 func phpSupported(ctx context.Context, prettierPath string) bool {
 	var stdout bytes.Buffer
@@ -108,15 +117,5 @@ func requirePrettier(t *testing.T) {
 	}
 	if !phpSupported(t.Context(), prettierPath) {
 		t.Skip("prettier does not support PHP (missing plugin?)")
-	}
-}
-
-func TestPrettierEnv(t *testing.T) {
-	got := prettierEnv("/path/to/bin/prettier")
-	want := map[string]string{
-		"PATH": "/path/to/bin",
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -17,6 +17,8 @@ package php
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,29 +27,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/librarian/nodejs"
 )
 
 func TestFormat(t *testing.T) {
-	nodeInstallDir, err := nodejs.InstallDir()
-	if err != nil {
-		t.Skipf("nodejs InstallDir failed: %v", err)
-	}
-	prettierPath := filepath.Join(nodeInstallDir, "bin", "prettier")
-	if _, err := os.Stat(prettierPath); err != nil {
-		t.Skipf("prettier not found at %s: %v", prettierPath, err)
-	}
-
-	if !phpSupported(t.Context(), prettierPath) {
-		t.Skip("prettier does not support PHP (missing plugin?)")
-	}
-
+	requirePrettier(t)
 	tmpDir := t.TempDir()
 	library := &config.Library{
 		Name:   "test-library",
 		Output: tmpDir,
 	}
-
 	// Write an unformatted PHP file.
 	unformatted := `<?php
 class Foo {
@@ -67,7 +55,6 @@ class Foo
     }
 }
 `
-
 	targetFile := filepath.Join(tmpDir, "Client", "Foo.php")
 	if err := os.MkdirAll(filepath.Dir(targetFile), 0o755); err != nil {
 		t.Fatal(err)
@@ -75,19 +62,44 @@ class Foo
 	if err := os.WriteFile(targetFile, []byte(unformatted), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
 	if err := Format(t.Context(), library); err != nil {
-		t.Fatalf("Format() failed: %v", err)
+		t.Fatal(err)
 	}
-
 	gotBytes, err := os.ReadFile(targetFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 	got := string(gotBytes)
-
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFormat_Error(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		librarianBin string
+		wantErr      error
+	}{
+		{
+			name:         "prettier missing",
+			librarianBin: t.TempDir(),
+			wantErr:      fs.ErrNotExist,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.librarianBin != "" {
+				t.Setenv("LIBRARIAN_BIN", test.librarianBin)
+			}
+			library := &config.Library{
+				Name:   "test-library",
+				Output: t.TempDir(),
+			}
+			err := Format(t.Context(), library)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Format() error = %v, want wrap of %v", err, test.wantErr)
+			}
+		})
 	}
 }
 
@@ -99,4 +111,26 @@ func phpSupported(ctx context.Context, prettierPath string) bool {
 		return false
 	}
 	return strings.Contains(stdout.String(), `"PHP"`)
+}
+
+// requirePrettier skips the test if prettier or the PHP plugin is not available.
+func requirePrettier(t *testing.T) {
+	t.Helper()
+	prettierPath, _, err := prettierToolPaths()
+	if err != nil {
+		t.Skipf("prettier tools not available: %v", err)
+	}
+	if !phpSupported(t.Context(), prettierPath) {
+		t.Skip("prettier does not support PHP (missing plugin?)")
+	}
+}
+
+func TestPrettierEnv(t *testing.T) {
+	got := prettierEnv("/path/to/bin/prettier")
+	want := map[string]string{
+		"PATH": "/path/to/bin",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -15,9 +15,9 @@
 package php
 
 import (
-	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -46,7 +46,6 @@ class Foo {
 `
 	// Prettier PHP formatting should standardize spaces and convert double quotes to single quotes.
 	want := `<?php
-
 class Foo
 {
     public function bar($a, $b)
@@ -96,14 +95,16 @@ func TestPrettierEnv(t *testing.T) {
 	}
 }
 
-func phpSupported(ctx context.Context, prettierPath string) bool {
-	var stdout bytes.Buffer
-	cmd := exec.CommandContext(ctx, prettierPath, "--support-info")
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return false
-	}
-	return strings.Contains(stdout.String(), `"PHP"`)
+// phpSupported checks if prettier supports PHP by attempting to format a dummy snippet.
+// We must test actual formatting with the --plugin flag because:
+// 1. pnpm's symlinked node_modules structure prevents automatic plugin discovery.
+// 2. Prettier 2's --support-info command ignores the --plugin flag, so we cannot query it directly.
+func phpSupported(ctx context.Context, prettierPath, pluginPath string) bool {
+	cmd := exec.CommandContext(ctx, prettierPath, "--plugin="+pluginPath, "--parser=php")
+	cmd.Stdin = strings.NewReader("<?php class Foo {}")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
 }
 
 // requirePrettier skips the test if prettier or the PHP plugin is not available.
@@ -111,11 +112,11 @@ func requirePrettier(t *testing.T) {
 	t.Helper()
 	// TODO(https://github.com/googleapis/librarian/issues/7118):
 	// Use testhelper.RequireCommand once it supports cached tools.
-	prettierPath, _, err := prettierToolPaths()
+	prettierPath, pluginPath, err := prettierToolPaths()
 	if err != nil {
 		t.Skipf("prettier tools not available: %v", err)
 	}
-	if !phpSupported(t.Context(), prettierPath) {
+	if !phpSupported(t.Context(), prettierPath, pluginPath) {
 		t.Skip("prettier does not support PHP (missing plugin?)")
 	}
 }

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -15,16 +15,88 @@
 package php
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/librarian/nodejs"
 )
 
 func TestFormat(t *testing.T) {
-	ctx := t.Context()
-	lib := &config.Library{}
-
-	if err := Format(ctx, lib); err != nil {
-		t.Errorf("Format() returned error: %v", err)
+	nodeInstallDir, err := nodejs.InstallDir()
+	if err != nil {
+		t.Skipf("nodejs InstallDir failed: %v", err)
 	}
+	prettierPath := filepath.Join(nodeInstallDir, "bin", "prettier")
+	if _, err := os.Stat(prettierPath); err != nil {
+		t.Skipf("prettier not found at %s: %v", prettierPath, err)
+	}
+
+	if !phpSupported(t.Context(), prettierPath) {
+		t.Skip("prettier does not support PHP (missing plugin?)")
+	}
+
+	tmpDir := t.TempDir()
+	library := &config.Library{
+		Name:   "test-library",
+		Output: tmpDir,
+	}
+
+	// Write an unformatted PHP file.
+	unformatted := `<?php
+class Foo {
+    public function bar( $a, $b ) {
+        return "hello" ;
+    }
+}
+`
+	// Prettier PHP formatting should standardize spaces and convert double quotes to single quotes.
+	want := `<?php
+
+class Foo
+{
+    public function bar($a, $b)
+    {
+        return 'hello';
+    }
+}
+`
+
+	targetFile := filepath.Join(tmpDir, "Client", "Foo.php")
+	if err := os.MkdirAll(filepath.Dir(targetFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetFile, []byte(unformatted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Format(t.Context(), library); err != nil {
+		t.Fatalf("Format() failed: %v", err)
+	}
+
+	gotBytes, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotBytes)
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func phpSupported(ctx context.Context, prettierPath string) bool {
+	var stdout bytes.Buffer
+	cmd := exec.CommandContext(ctx, prettierPath, "--support-info")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return strings.Contains(stdout.String(), `"PHP"`)
 }

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -75,31 +75,15 @@ class Foo
 	}
 }
 
-func TestFormat_Error(t *testing.T) {
-	for _, test := range []struct {
-		name         string
-		librarianBin string
-		wantErr      error
-	}{
-		{
-			name:         "prettier missing",
-			librarianBin: t.TempDir(),
-			wantErr:      fs.ErrNotExist,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if test.librarianBin != "" {
-				t.Setenv("LIBRARIAN_BIN", test.librarianBin)
-			}
-			library := &config.Library{
-				Name:   "test-library",
-				Output: t.TempDir(),
-			}
-			err := Format(t.Context(), library)
-			if !errors.Is(err, test.wantErr) {
-				t.Errorf("Format() error = %v, want wrap of %v", err, test.wantErr)
-			}
-		})
+func TestFormat_ErrorPrettierMissing(t *testing.T) {
+	t.Setenv("LIBRARIAN_BIN", t.TempDir())
+	library := &config.Library{
+		Name:   "test-library",
+		Output: t.TempDir(),
+	}
+	err := Format(t.Context(), library)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Format() error = %v, want wrap of %v", err, fs.ErrNotExist)
 	}
 }
 
@@ -116,7 +100,7 @@ func phpSupported(ctx context.Context, prettierPath string) bool {
 // requirePrettier skips the test if prettier or the PHP plugin is not available.
 func requirePrettier(t *testing.T) {
 	t.Helper()
-	// TODO(https://github.com/googleapis/librarian/issues/7118): 
+	// TODO(https://github.com/googleapis/librarian/issues/7118):
 	// Use testhelper.RequireCommand once it supports cached tools.
 	prettierPath, _, err := prettierToolPaths()
 	if err != nil {

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -116,6 +116,8 @@ func phpSupported(ctx context.Context, prettierPath string) bool {
 // requirePrettier skips the test if prettier or the PHP plugin is not available.
 func requirePrettier(t *testing.T) {
 	t.Helper()
+	// TODO(https://github.com/googleapis/librarian/issues/7118): 
+	// Use testhelper.RequireCommand once it supports cached tools.
 	prettierPath, _, err := prettierToolPaths()
 	if err != nil {
 		t.Skipf("prettier tools not available: %v", err)


### PR DESCRIPTION
Formatting support for generated PHP libraries is implemented using Prettier and the @prettier/plugin-php plugin. The formatter is executed in the output directory on files matching **/Client/*. Options for running the formatter intended to keep consistent with the current status of on-the-fly invocation in [owlbot.py](https://github.com/googleapis/google-cloud-php/blob/bb0e3de6a995221c212af207c705ae2bcd9efab4/Ces/owlbot.py#L36-L47)

Fixes https://github.com/googleapis/librarian/issues/6774