### PR TITLE
feat(rust): publish crates in batches

### DIFF
--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -40,28 +40,34 @@ type semverData struct {
 	verbose         bool
 }
 
-// semverCheckCPUDivisor scales the concurrency limit based on available CPUs to balance
-// throughput against resource contention.
-//
-// Why a limit?
-// `cargo semver-checks` is internally multithreaded during the compilation phase.
-// Running it completely unbounded, or even 1:1 with CPU cores, can cause severe CPU
-// thrashing and RAM exhaustion, as multiple instances of the Rust compiler
-// compete for the same physical cores and memory bandwidth.
-//
-// Why a divisor of 8?
-// Performance testing on 64-core workstations revealed a "sweet spot":
-// Running 8 concurrent jobs (64 cores / 8) reduced execution time from ~2 hours
-// down to ~17 minutes. Pushing concurrency higher yielded negligible gains (e.g.,
-// 15 mins at 16-way) but massively increased system load and OOM (Out Of Memory) risks.
-//
-// By using a divisor instead of a hard cap, we dynamically apply this optimal 1/8th
-// ratio across varied hardware. This prevents smaller CI runners or local dev machines
-// from being overwhelmed while still safely maximizing throughput on larger workstations.
 const (
-	semverCheckCPUDivisor  = 8
+	// semverCheckCPUDivisor scales the concurrency limit based on available CPUs to balance
+	// throughput against resource contention.
+	//
+	// Why a limit?
+	// `cargo semver-checks` is internally multithreaded during the compilation phase.
+	// Running it completely unbounded, or even 1:1 with CPU cores, can cause severe CPU
+	// thrashing and RAM exhaustion, as multiple instances of the Rust compiler
+	// compete for the same physical cores and memory bandwidth.
+	//
+	// Why a divisor of 8?
+	// Performance testing on 64-core workstations revealed a "sweet spot":
+	// Running 8 concurrent jobs (64 cores / 8) reduced execution time from ~2 hours
+	// down to ~17 minutes. Pushing concurrency higher yielded negligible gains (e.g.,
+	// 15 mins at 16-way) but massively increased system load and OOM (Out Of Memory) risks.
+	//
+	// By using a divisor instead of a hard cap, we dynamically apply this optimal 1/8th
+	// ratio across varied hardware. This prevents smaller CI runners or local dev machines
+	// from being overwhelmed while still safely maximizing throughput on larger workstations.
+	semverCheckCPUDivisor = 8
+	// defaultPublishInterval is the pause in seconds between publish batches.
+	// A 60-second delay helps ensure that crates published in a batch have propagated to the
+	// crates.io registry index before subsequent batches depending on them are compiled/published.
 	defaultPublishInterval = 60
-	defaultBatchSize       = 5
+	// defaultBatchSize is the maximum number of independent crates published in a single batch.
+	// Publishing 5 crates per batch with a 60-second interval results in ~5 publishes/minute,
+	// staying safely below crates.io API rate limits (30 publishes/minute).
+	defaultBatchSize = 5
 )
 
 // errSemverCheck is returned when a semver check fails.

--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -19,13 +19,16 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/git"
+	"github.com/pelletier/go-toml/v2"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -55,7 +58,11 @@ type semverData struct {
 // By using a divisor instead of a hard cap, we dynamically apply this optimal 1/8th
 // ratio across varied hardware. This prevents smaller CI runners or local dev machines
 // from being overwhelmed while still safely maximizing throughput on larger workstations.
-const semverCheckCPUDivisor = 8
+const (
+	semverCheckCPUDivisor  = 8
+	defaultPublishInterval = 60
+	defaultBatchSize       = 5
+)
 
 // errSemverCheck is returned when a semver check fails.
 var errSemverCheck = errors.New("semver check failed")
@@ -74,6 +81,10 @@ type PublishParams struct {
 	Verbose bool
 	// IgnoredChanges is a list of file paths/patterns to ignore when detecting changed crates.
 	IgnoredChanges []string
+	// PublishInterval is the number of seconds to wait between publish batches.
+	PublishInterval int
+	// BatchSize is the maximum number of crates to publish in a single batch.
+	BatchSize int
 }
 
 // Publish finds all the crates that should be published. It can optionally
@@ -134,16 +145,136 @@ func publishCrates(ctx context.Context, params PublishParams, lastTag string, fi
 			return err
 		}
 	}
-	args := []string{"workspaces", "publish", "--skip-published", "--publish-interval=60", "--no-git-commit", "--from-git", "skip"}
-	if params.DryRunKeepGoing {
-		args = append(args, "--dry-run", "--keep-going")
-	} else if params.DryRun {
+	interval := params.PublishInterval
+	if interval <= 0 {
+		interval = defaultPublishInterval
+	}
+	batchSize := params.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+
+	batches, err := batchCrates(plannedCrates, manifests, batchSize)
+	if err != nil {
+		return err
+	}
+
+	for i, batch := range batches {
+		for _, crate := range batch {
+			if err := publishSingleCrate(ctx, params, crate); err != nil {
+				if params.DryRunKeepGoing {
+					slog.Warn("publish failed, but continuing due to --keep-going", "crate", crate, "error", err)
+					continue
+				}
+				return err
+			}
+		}
+		if i < len(batches)-1 && interval > 0 {
+			slog.Info("waiting between publish batches", "seconds", interval, "completed_batch", i+1, "total_batches", len(batches))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Duration(interval) * time.Second):
+			}
+		}
+	}
+	return nil
+}
+
+// publishSingleCrate publishes an individual crate using cargo publish.
+func publishSingleCrate(ctx context.Context, params PublishParams, crate string) error {
+	args := []string{"publish", "-p", crate}
+	if params.DryRun || params.DryRunKeepGoing {
 		args = append(args, "--dry-run")
 	}
 	if params.Verbose {
 		return command.RunStreaming(ctx, command.Cargo, args...)
 	}
 	return command.Run(ctx, command.Cargo, args...)
+}
+
+type cargoManifestDependencies struct {
+	Dependencies      map[string]any `toml:"dependencies"`
+	DevDependencies   map[string]any `toml:"dev-dependencies"`
+	BuildDependencies map[string]any `toml:"build-dependencies"`
+}
+
+type crateInfo struct {
+	name string
+	deps map[string]bool
+}
+
+// crateWorkspaceDeps reads a manifest file and returns workspace crate dependencies wrapped in crateInfo.
+func crateWorkspaceDeps(crate string, manifestPath string, workspaceCrates map[string]string) (crateInfo, error) {
+	contents, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return crateInfo{}, err
+	}
+	var manifest cargoManifestDependencies
+	if err := toml.Unmarshal(contents, &manifest); err != nil {
+		return crateInfo{}, err
+	}
+	info := crateInfo{
+		name: crate,
+		deps: make(map[string]bool),
+	}
+	addDeps := func(m map[string]any) {
+		for name := range m {
+			if _, ok := workspaceCrates[name]; ok {
+				info.deps[name] = true
+			}
+		}
+	}
+	addDeps(manifest.Dependencies)
+	addDeps(manifest.DevDependencies)
+	addDeps(manifest.BuildDependencies)
+	return info, nil
+}
+
+// batchCrates splits planned crates into batches of up to batchSize, ensuring no crate in a batch
+// depends on another crate in the same batch.
+func batchCrates(plannedCrates []string, manifests map[string]string, batchSize int) ([][]string, error) {
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	crateInfos := make(map[string]crateInfo, len(plannedCrates))
+	for _, crate := range plannedCrates {
+		manifest := manifests[crate]
+		info, err := crateWorkspaceDeps(crate, manifest, manifests)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read dependencies for %s: %w", crate, err)
+		}
+		crateInfos[crate] = info
+	}
+
+	var batches [][]string
+	var currBatch []string
+	currBatchSet := map[string]bool{}
+
+	for _, crate := range plannedCrates {
+		info := crateInfos[crate]
+		hasIntraBatchDep := false
+		for dep := range info.deps {
+			if currBatchSet[dep] {
+				hasIntraBatchDep = true
+				break
+			}
+		}
+		if len(currBatch) >= batchSize || hasIntraBatchDep {
+			if len(currBatch) > 0 {
+				batches = append(batches, currBatch)
+			}
+			currBatch = []string{crate}
+			currBatchSet = map[string]bool{crate: true}
+		} else {
+			currBatch = append(currBatch, crate)
+			currBatchSet[crate] = true
+		}
+	}
+	if len(currBatch) > 0 {
+		batches = append(batches, currBatch)
+	}
+	return batches, nil
 }
 
 // runSemverChecks iterates through manifests and runs semver checks for each.

--- a/internal/librarian/rust/publish_test.go
+++ b/internal/librarian/rust/publish_test.go
@@ -296,7 +296,7 @@ func TestPublishCratesDryRunKeepGoing(t *testing.T) {
 	script := `#!/bin/bash
 if [ "$1" == "workspaces" ] && [ "$2" == "plan" ]; then
 	echo "google-cloud-storage"
-elif [ "$1" == "workspaces" ] && [ "$2" == "publish" ]; then
+elif [ "$1" == "publish" ]; then
 	echo $@ >> "` + filepath.Join(tmpDir, "cargo_args.txt") + `"
 else
 	exit 0
@@ -321,13 +321,13 @@ fi
 		t.Fatal(err)
 	}
 
-	// Verify that arguments were passed to cargo workspaces publish.
+	// Verify that arguments were passed to cargo publish.
 	output, err := os.ReadFile(filepath.Join(tmpDir, "cargo_args.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(output), "--keep-going") {
-		t.Errorf("expected cargo command to contain '--keep-going', got: %s", string(output))
+	if !strings.Contains(string(output), "-p google-cloud-storage") {
+		t.Errorf("expected cargo command to contain '-p google-cloud-storage', got: %s", string(output))
 	}
 	if count := strings.Count(string(output), "--dry-run"); count != 1 {
 		t.Errorf("expected cargo command to contain '--dry-run' once, but found %d times: %s", count, string(output))
@@ -511,4 +511,74 @@ func setupFakeCargoScript(t *testing.T, script string) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestBatchCrates(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	crateADir := filepath.Join(tmpDir, "crate-a")
+	crateBDir := filepath.Join(tmpDir, "crate-b")
+	crateCDir := filepath.Join(tmpDir, "crate-c")
+
+	if err := os.MkdirAll(crateADir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(crateBDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(crateCDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	manifestA := filepath.Join(crateADir, "Cargo.toml")
+	manifestB := filepath.Join(crateBDir, "Cargo.toml")
+	manifestC := filepath.Join(crateCDir, "Cargo.toml")
+
+	if err := os.WriteFile(manifestA, []byte(`[package]
+name = "crate-a"
+version = "0.1.0"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(manifestB, []byte(`[package]
+name = "crate-b"
+version = "0.1.0"
+
+[dependencies]
+crate-a = { path = "../crate-a", version = "0.1.0" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(manifestC, []byte(`[package]
+name = "crate-c"
+version = "0.1.0"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifests := map[string]string{
+		"crate-a": manifestA,
+		"crate-b": manifestB,
+		"crate-c": manifestC,
+	}
+
+	plannedCrates := []string{"crate-a", "crate-b", "crate-c"}
+
+	// When batchSize = 5, crate-a and crate-b cannot be in the same batch because crate-b depends on crate-a.
+	// Therefore, crate-a is in Batch 1, and crate-b & crate-c are in Batch 2.
+	batches, err := batchCrates(plannedCrates, manifests, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := [][]string{
+		{"crate-a"},
+		{"crate-b", "crate-c"},
+	}
+
+	if diff := cmp.Diff(want, batches); diff != "" {
+		t.Errorf("batchCrates() mismatch (-want +got):\n%s", diff)
+	}
 }


### PR DESCRIPTION
Refactor Rust crate publishing to publish crates in batches of up to 5 instead of sequentially publishing the entire workspace in a single command.

Previously, publish invoked `cargo workspaces publish`, which processed all crates sequentially with a mandatory 60-second delay after each crate. For large releases containing 250–300 crates, this resulted in publishing runs taking upwards of 4 to 5 hours.

This change uses `cargo workspaces plan --skip-published` to retrieve the topological ordering of unpublished crates and partitions them into batches of up to 5 crates. Each crate within a batch is published using `cargo publish -p <crate>`, and a 60-second interval is maintained between batches to accommodate crates.io registry index propagation. Crate dependency analysis guarantees that no crate in a batch depends on another crate in the same batch.

Fixes #7120