### PR TITLE
feat(sidekick/swift): use polling policies

### DIFF
--- a/internal/sidekick/swift/annotate_service.go
+++ b/internal/sidekick/swift/annotate_service.go
@@ -78,6 +78,14 @@ func (ann *serviceAnnotations) SnippetImports() []string {
 	return result
 }
 
+// HasLROs returns true if one of the methods is an LRO.
+func (ann *serviceAnnotations) HasLROs() bool {
+	return slices.ContainsFunc(ann.RestMethods, func(m *api.Method) bool {
+		ma := m.Codec.(*methodAnnotations)
+		return ma != nil && (ma.LRO != nil || ma.DiscoveryLRO != nil)
+	})
+}
+
 func (c *codec) annotateService(service *api.Service, model *modelAnnotations) (*serviceAnnotations, error) {
 	docLines, err := c.formatDocumentation(service.Documentation, service.Scopes())
 	if err != nil {

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -149,8 +149,8 @@ func TestAnnotateService_SkipNoBindings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	serviceCodec := service.Codec.(*serviceAnnotations)
-	if serviceCodec == nil {
+	serviceCodec, ok := service.Codec.(*serviceAnnotations)
+	if !ok {
 		t.Fatalf("mismatched service annotations, got=%T", service.Codec)
 	}
 	if serviceCodec.HasLROs() {
@@ -364,9 +364,9 @@ func TestAnnotateService_LRO(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	annotations := service.Codec.(*serviceAnnotations)
-	if annotations == nil {
-		t.Fatalf("expected `serviceAnnotations`, got=%T", service.Codec)
+	annotations, ok := service.Codec.(*serviceAnnotations)
+	if !ok {
+		t.Fatalf("expected `serviceAnnotations`, got %T", service.Codec)
 	}
 	if !annotations.HasLROs() {
 		t.Errorf("expected HasLROs() == true, annotations=%+v", annotations)

--- a/internal/sidekick/swift/annotate_service_test.go
+++ b/internal/sidekick/swift/annotate_service_test.go
@@ -150,6 +150,12 @@ func TestAnnotateService_SkipNoBindings(t *testing.T) {
 	}
 
 	serviceCodec := service.Codec.(*serviceAnnotations)
+	if serviceCodec == nil {
+		t.Fatalf("mismatched service annotations, got=%T", service.Codec)
+	}
+	if serviceCodec.HasLROs() {
+		t.Errorf("expected HasLROs() == false, annotations=%+v", serviceCodec)
+	}
 	var gotNames []string
 	for _, m := range serviceCodec.RestMethods {
 		gotNames = append(gotNames, m.Name)
@@ -359,6 +365,12 @@ func TestAnnotateService_LRO(t *testing.T) {
 	}
 
 	annotations := service.Codec.(*serviceAnnotations)
+	if annotations == nil {
+		t.Fatalf("expected `serviceAnnotations`, got=%T", service.Codec)
+	}
+	if !annotations.HasLROs() {
+		t.Errorf("expected HasLROs() == true, annotations=%+v", annotations)
+	}
 	wantImports := []string{"GoogleCloudExternal", "GoogleCloudWkt", "GoogleLongrunning", "GoogleRpc"}
 	if diff := cmp.Diff(wantImports, annotations.ServiceImports()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -739,22 +739,32 @@ func TestGenerateService_LRO(t *testing.T) {
 	}
 
 	filename := filepath.Join(outDir, "Sources", "GoogleCloudWorkflowsV1", "WorkflowsService.swift")
-	content, err := os.ReadFile(filename)
+	contentBytes, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
 	}
-	contentStr := string(content)
+	content := string(contentBytes)
 
 	wantContains := []string{
 		"import GoogleRpc",
 		"public func createWorkflow(withPolling: CreateWorkflowRequest) async throws -> any GoogleCloudGax.PollableOperation<Workflow>",
-		"GoogleCloudGax._PollableOperationImpl(initialState: initialState, poll: poll)",
 		"self.getOperation(request: .init().with { $0.name = rawOp.name }, options: options)",
 	}
 	for _, want := range wantContains {
-		if !strings.Contains(contentStr, want) {
-			t.Errorf("expected %q in WorkflowsService.swift, got:\n%s", want, contentStr)
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %q in WorkflowsService.swift, got:\n%s", want, content)
 		}
+	}
+
+	got := extractBlock(t, content, "GoogleCloudGax._PollableOperationImpl(", "\n    )")
+	want := `GoogleCloudGax._PollableOperationImpl(
+      initialState: initialState,
+      polling: options.pollingErrorPolicy ?? self.pollingErrorPolicy,
+      backoff: options.pollingBackoffPolicy ?? self.pollingBackoffPolicy,
+      poll: poll,
+    )`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sidekick/swift/templates/common/method_body/discovery_lro.mustache
+++ b/internal/sidekick/swift/templates/common/method_body/discovery_lro.mustache
@@ -38,4 +38,9 @@ let op = try await self.getOperation(request: .init().with {
   }, options: options)
   return try extractStatus(op)
 }
-return GoogleCloudGax._PollableOperationImpl(initialState: initialState, poll: poll)
+return GoogleCloudGax._PollableOperationImpl(
+  initialState: initialState,
+  polling: options.pollingErrorPolicy ?? self.pollingErrorPolicy,
+  backoff: options.pollingBackoffPolicy ?? self.pollingBackoffPolicy,
+  poll: poll
+)

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -43,6 +43,10 @@ import GoogleCloudGax
 {{/Deprecated}}
 public class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol {
   let inner: any Clients.{{Codec.StubPrefix}}Stub
+  {{#Codec.HasLROs}}
+  let pollingErrorPolicy: GoogleCloudGax.PollingErrorPolicy
+  let pollingBackoffPolicy: GoogleCloudGax.BackoffPolicy
+  {{/Codec.HasLROs}}
 
   /// Creates a new `{{Codec.ClientName}}` instance.
   public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {
@@ -52,6 +56,10 @@ public class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol {
       inner = Clients.{{Codec.StubPrefix}}Logging(inner, logger: logger)
     }
     self.inner = inner
+    {{#Codec.HasLROs}}
+    self.pollingErrorPolicy = options.pollingErrorPolicy
+    self.pollingBackoffPolicy = options.pollingBackoffPolicy
+    {{/Codec.HasLROs}}
   }
   {{#Codec.RestMethods}}
 
@@ -134,7 +142,12 @@ public class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol {
       let op = try await self.getOperation(request: .init().with { $0.name = rawOp.name }, options: options)
       return try extractStatus(op)
     }
-    return GoogleCloudGax._PollableOperationImpl(initialState: initialState, poll: poll)
+    return GoogleCloudGax._PollableOperationImpl(
+      initialState: initialState,
+      polling: options.pollingErrorPolicy ?? self.pollingErrorPolicy,
+      backoff: options.pollingBackoffPolicy ?? self.pollingBackoffPolicy,
+      poll: poll,
+    )
   }
   {{/Codec.LRO}}
   {{#Codec.DiscoveryLRO}}


### PR DESCRIPTION
Change the generated code to use polling policies when initializing `_PollableOperationImpl`.

Fixes #5268 