### PR TITLE
fix(tool/cmd/migrate): parse WrapperOf from BUILD.bazel

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -236,7 +236,6 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 			libraries = append(libraries, lib)
 		}
 	}
-	parseWrapperOf(libraries)
 	return libraries, nil
 }
 
@@ -268,40 +267,6 @@ func parseAPIFromOwlBot(owlBotPath string) (string, bool, error) {
 	}
 	// Versioned library
 	return basePath + "/" + version, false, nil
-}
-
-// parseWrapperOf sets the WrapperOf field for wrapper libraries.
-func parseWrapperOf(libraries []*config.Library) {
-	slices.SortFunc(libraries, func(a, b *config.Library) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-	for i, lib := range libraries {
-		var wrapperOf []string
-		prefix := lib.Name + "-"
-		// Since libraries are sorted by name, the wrapped libraries
-		// are guaranteed to appear after the wrapper library.
-		for j := i + 1; j < len(libraries); j++ {
-			other := libraries[j]
-			if !strings.HasPrefix(other.Name, prefix) {
-				// Since libraries are sorted by name, the wrapped libraries
-				// must be consecutive.
-				break
-			}
-			suffix := strings.TrimPrefix(other.Name, prefix)
-			// Verify that the suffix after the prefix represents a valid version,
-			// e.g., starting with v followed by a digit.
-			// We use simple, string comparison because the migration tool will
-			// be removed after language onboarding.
-			if len(suffix) > 1 && suffix[0] == 'v' && suffix[1] >= '0' && suffix[1] <= '9' {
-				wrapperOf = append(wrapperOf, other.Name)
-			}
-		}
-		if len(wrapperOf) > 0 {
-			lib.Ruby = &config.RubyPackage{
-				WrapperOf: wrapperOf,
-			}
-		}
-	}
 }
 
 func parseVersionedBuild(googleapisDir, apiPath string) (*ExtraProtoParams, error) {

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -307,8 +307,9 @@ func parseExtraProtoParams(file *build.File) (*ExtraProtoParams, error) {
 		case strings.HasPrefix(dep, "ruby-cloud-wrapper-gem-override="):
 			vb.WrapperGemOverride, _ = strings.CutPrefix(dep, "ruby-cloud-wrapper-gem-override=")
 		case strings.HasPrefix(dep, "ruby-cloud-wrapper-of="):
-			wrapperOf, _ := strings.CutPrefix(dep, "ruby-cloud-wrapper-of=")
-			vb.WrapperOf = strings.Split(wrapperOf, ";")
+			if wrapperOf, _ := strings.CutPrefix(dep, "ruby-cloud-wrapper-of="); wrapperOf != "" {
+				vb.WrapperOf = strings.Split(wrapperOf, ";")
+			}
 		case strings.HasPrefix(dep, "ruby-cloud-yard-strict="):
 			vb.YardStrict, _ = strings.CutPrefix(dep, "ruby-cloud-yard-strict=")
 		}

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -74,6 +74,7 @@ type ExtraProtoParams struct {
 	PathOverride        string
 	ServiceOverride     string
 	WrapperGemOverride  string
+	WrapperOf []string
 	YardStrict          string
 }
 
@@ -224,6 +225,12 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 						},
 					}
 					lib.APIs = append(lib.APIs, rubyAPI)
+					if wb.Params != nil && len(wb.Params.WrapperOf) > 0 {
+						if lib.Ruby == nil {
+							lib.Ruby = &config.RubyPackage{}
+						}
+						lib.Ruby.WrapperOf = wb.Params.WrapperOf
+					}
 				}
 			}
 			libraries = append(libraries, lib)
@@ -334,9 +341,11 @@ func parseExtraProtoParams(file *build.File) (*ExtraProtoParams, error) {
 			vb.ServiceOverride, _ = strings.CutPrefix(dep, "ruby-cloud-service-override=")
 		case strings.HasPrefix(dep, "ruby-cloud-wrapper-gem-override="):
 			vb.WrapperGemOverride, _ = strings.CutPrefix(dep, "ruby-cloud-wrapper-gem-override=")
+		case strings.HasPrefix(dep, "ruby-cloud-wrapper-of="):
+			wrapperOf, _ := strings.CutPrefix(dep, "ruby-cloud-wrapper-of=")
+			vb.WrapperOf = strings.Split(wrapperOf, ";")
 		case strings.HasPrefix(dep, "ruby-cloud-yard-strict="):
 			vb.YardStrict, _ = strings.CutPrefix(dep, "ruby-cloud-yard-strict=")
-
 		}
 	}
 	return vb, nil

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -74,7 +74,7 @@ type ExtraProtoParams struct {
 	PathOverride        string
 	ServiceOverride     string
 	WrapperGemOverride  string
-	WrapperOf []string
+	WrapperOf           []string
 	YardStrict          string
 }
 

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -166,7 +166,7 @@ func TestFindRubyLibraries(t *testing.T) {
 					Path: "google/cloud/speech/v2",
 					Ruby: &config.RubyAPI{
 						RubyCloudOpts: &config.RubyCloudOpts{
-							EnvPrefix:    "SPEECH",
+							EnvPrefix: "SPEECH",
 						},
 					},
 				},

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -317,7 +317,7 @@ func TestParseUnversionedBuild(t *testing.T) {
 				Params: &ExtraProtoParams{
 					EnvPrefix:    "SECRET_MANAGER",
 					GemNamespace: "Google::Cloud::SecretManager",
-					WrapperOf:          []string{"v1:1.2"},
+					WrapperOf:    []string{"v1:1.2"},
 				},
 			},
 		},
@@ -370,7 +370,7 @@ func TestParseUnversionedBuild(t *testing.T) {
 				Params: &ExtraProtoParams{
 					EnvPrefix:        "ASSET",
 					MigrationVersion: "1.0",
-					WrapperOf:          []string{"v1:0.29"},
+					WrapperOf:        []string{"v1:0.29"},
 				},
 			},
 		},
@@ -383,7 +383,7 @@ func TestParseUnversionedBuild(t *testing.T) {
 				Params: &ExtraProtoParams{
 					EnvPrefix:           "BILLING",
 					FactoryMethodSuffix: "_service",
-					WrapperOf:          []string{"v1:0.17"},
+					WrapperOf:           []string{"v1:0.17"},
 				},
 			},
 		},

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -317,6 +317,7 @@ func TestParseUnversionedBuild(t *testing.T) {
 				Params: &ExtraProtoParams{
 					EnvPrefix:    "SECRET_MANAGER",
 					GemNamespace: "Google::Cloud::SecretManager",
+					WrapperOf:          []string{"v1:1.2"},
 				},
 			},
 		},
@@ -330,6 +331,7 @@ func TestParseUnversionedBuild(t *testing.T) {
 					EnvPrefix:          "COMPUTE",
 					ExtraDeps:          "google-cloud-common=~> 1.0",
 					WrapperGemOverride: "google-cloud-compute",
+					WrapperOf:          []string{"v1:2.15"},
 				},
 			},
 		},
@@ -368,6 +370,7 @@ func TestParseUnversionedBuild(t *testing.T) {
 				Params: &ExtraProtoParams{
 					EnvPrefix:        "ASSET",
 					MigrationVersion: "1.0",
+					WrapperOf:          []string{"v1:0.29"},
 				},
 			},
 		},
@@ -380,6 +383,7 @@ func TestParseUnversionedBuild(t *testing.T) {
 				Params: &ExtraProtoParams{
 					EnvPrefix:           "BILLING",
 					FactoryMethodSuffix: "_service",
+					WrapperOf:          []string{"v1:0.17"},
 				},
 			},
 		},

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -107,7 +107,7 @@ func TestFindRubyLibraries(t *testing.T) {
 			},
 			Ruby: &config.RubyPackage{
 				WrapperOf: []string{
-					"google-cloud-compute-v1",
+					"v1:2.15",
 				},
 			},
 		},
@@ -141,7 +141,7 @@ func TestFindRubyLibraries(t *testing.T) {
 			},
 			Ruby: &config.RubyPackage{
 				WrapperOf: []string{
-					"google-cloud-secret_manager-v1",
+					"v1:1.2",
 				},
 			},
 		},
@@ -206,74 +206,6 @@ func TestParseAPIFromOwlBot(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.wantWrapper, gotWrapper); diff != "" {
 				t.Errorf("wrapper mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestParseWrapperOf(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		libraries []*config.Library
-		want      []*config.Library
-	}{
-		{
-			name: "wrapper library with multiple versioned libraries",
-			libraries: []*config.Library{
-				{Name: "google-cloud-secret_manager-v1", APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}}},
-				{Name: "google-cloud-secret_manager-v1beta1", APIs: []*config.API{{Path: "google/cloud/secretmanager/v1beta1"}}},
-				{Name: "google-cloud-secret_manager"},
-			},
-			want: []*config.Library{
-				{
-					Name: "google-cloud-secret_manager",
-					Ruby: &config.RubyPackage{
-						WrapperOf: []string{
-							"google-cloud-secret_manager-v1",
-							"google-cloud-secret_manager-v1beta1",
-						},
-					},
-				},
-				{Name: "google-cloud-secret_manager-v1", APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}}},
-				{Name: "google-cloud-secret_manager-v1beta1", APIs: []*config.API{{Path: "google/cloud/secretmanager/v1beta1"}}},
-			},
-		},
-		{
-			name: "library with APIs set is not treated as wrapper",
-			libraries: []*config.Library{
-				{Name: "google-cloud-storage-v2", APIs: []*config.API{{Path: "google/cloud/storage/v2"}}},
-				{Name: "google-cloud-storage-v1", APIs: []*config.API{{Path: "google/cloud/storage/v1"}}},
-			},
-			want: []*config.Library{
-				{Name: "google-cloud-storage-v1", APIs: []*config.API{{Path: "google/cloud/storage/v1"}}},
-				{Name: "google-cloud-storage-v2", APIs: []*config.API{{Path: "google/cloud/storage/v2"}}},
-			},
-		},
-		{
-			name: "wrapper library with no matching versioned gems",
-			libraries: []*config.Library{
-				{Name: "google-cloud-storage"},
-			},
-			want: []*config.Library{
-				{Name: "google-cloud-storage"},
-			},
-		},
-		{
-			name: "ignore libraries with non-version suffix",
-			libraries: []*config.Library{
-				{Name: "google-cloud-storage"},
-				{Name: "google-cloud-storage-transfer-v1", APIs: []*config.API{{Path: "google/cloud/storage/transfer/v1"}}},
-			},
-			want: []*config.Library{
-				{Name: "google-cloud-storage"},
-				{Name: "google-cloud-storage-transfer-v1", APIs: []*config.API{{Path: "google/cloud/storage/transfer/v1"}}},
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			parseWrapperOf(test.libraries)
-			if diff := cmp.Diff(test.want, test.libraries); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -158,6 +158,26 @@ func TestFindRubyLibraries(t *testing.T) {
 				},
 			},
 		},
+		{
+			// This test verifies multiple WrapperOf entries are parsed correctly.
+			Name: "google-cloud-speech",
+			APIs: []*config.API{
+				{
+					Path: "google/cloud/speech/v2",
+					Ruby: &config.RubyAPI{
+						RubyCloudOpts: &config.RubyCloudOpts{
+							EnvPrefix:    "SPEECH",
+						},
+					},
+				},
+			},
+			Ruby: &config.RubyPackage{
+				WrapperOf: []string{
+					"v2:1.0",
+					"v1:1.2",
+				},
+			},
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/tool/cmd/migrate/testdata/google-cloud-ruby/google-cloud-speech/.OwlBot.yaml
+++ b/tool/cmd/migrate/testdata/google-cloud-ruby/google-cloud-speech/.OwlBot.yaml
@@ -1,0 +1,3 @@
+deep-copy-regex:
+  - source: /google/cloud/speech/[^/]+-ruby/(.*)
+    dest: /owl-bot-staging/google-cloud-speech/$1

--- a/tool/cmd/migrate/testdata/google-cloud-ruby/google-cloud-speech/.OwlBot.yaml
+++ b/tool/cmd/migrate/testdata/google-cloud-ruby/google-cloud-speech/.OwlBot.yaml
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 deep-copy-regex:
   - source: /google/cloud/speech/[^/]+-ruby/(.*)
     dest: /owl-bot-staging/google-cloud-speech/$1

--- a/tool/cmd/migrate/testdata/googleapis/google/cloud/compute/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/googleapis/google/cloud/compute/BUILD.bazel
@@ -22,8 +22,16 @@ ruby_cloud_gapic_library(
     name = "compute_ruby_wrapper",
     srcs = ["//google/cloud/compute/v1:compute_proto_with_info"],
     extra_protoc_parameters = [
+        "ruby-cloud-gem-name=google-cloud-compute",
+        "ruby-cloud-wrapper-of=v1:2.15",
+        "ruby-cloud-product-url=https://cloud.google.com/compute/",
+        "ruby-cloud-api-id=compute.googleapis.com",
+        "ruby-cloud-api-shortname=compute",
+        "ruby-cloud-generate-transports=rest",
         "ruby-cloud-env-prefix=COMPUTE",
         "ruby-cloud-wrapper-gem-override=google-cloud-compute",
         "ruby-cloud-extra-dependencies=google-cloud-common=~> 1.0",
     ],
+    ruby_cloud_description = "google-cloud-compute is the official client library for the Google Cloud Compute API.",
+    ruby_cloud_title = "Google Cloud Compute",
 )

--- a/tool/cmd/migrate/testdata/googleapis/google/cloud/secretmanager/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/googleapis/google/cloud/secretmanager/BUILD.bazel
@@ -22,8 +22,14 @@ ruby_cloud_gapic_library(
     name = "secretmanager_ruby_wrapper",
     srcs = ["//google/cloud/secretmanager/v1:secretmanager_proto_with_info"],
     extra_protoc_parameters = [
+        "ruby-cloud-gem-name=google-cloud-secret_manager",
         "ruby-cloud-env-prefix=SECRET_MANAGER",
+        "ruby-cloud-wrapper-of=v1:1.2",
+        "ruby-cloud-product-url=https://cloud.google.com/secret-manager",
+        "ruby-cloud-api-id=secretmanager.googleapis.com",
+        "ruby-cloud-api-shortname=secretmanager",
         "ruby-cloud-gem-namespace=Google::Cloud::SecretManager",
-        "ruby-cloud-wrapper-of=v1",
     ],
+    ruby_cloud_description = "Secret Manager is a secure and convenient storage system for API keys, passwords, certificates, and other sensitive data. Secret Manager provides a central place and single source of truth to manage, access, and audit secrets across Google Cloud.",
+    ruby_cloud_title = "Secret Manager",
 )

--- a/tool/cmd/migrate/testdata/googleapis/google/cloud/speech/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/googleapis/google/cloud/speech/BUILD.bazel
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This build file includes a target for the Ruby wrapper library for
+# google-cloud-speech.
+
+# This is an API workspace, having public visibility by default makes perfect sense.
+package(default_visibility = ["//visibility:public"])
+
+# Export yaml configs.
+exports_files(glob(["*.yaml"]))
+
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "ruby_cloud_gapic_library",
+    "ruby_gapic_assembly_pkg",
+    "nodejs_gapic_combined_pkg"
+)
+
+# Generates a Ruby wrapper client for speech.
+# Ruby wrapper clients are versionless, but are generated from source protos
+# for a particular service version, v2 in this case.
+ruby_cloud_gapic_library(
+    name = "speech_ruby_wrapper",
+    srcs = ["//google/cloud/speech/v2:speech_proto_with_info"],
+    extra_protoc_parameters = [
+        "ruby-cloud-gem-name=google-cloud-speech",
+        "ruby-cloud-env-prefix=SPEECH",
+        "ruby-cloud-wrapper-of=v2:1.0;v1:1.2",
+        "ruby-cloud-product-url=https://cloud.google.com/speech-to-text",
+        "ruby-cloud-api-id=speech.googleapis.com",
+        "ruby-cloud-api-shortname=speech",
+    ],
+    ruby_cloud_description = "Google Speech-to-Text enables developers to convert audio to text by applying powerful neural network models in an easy-to-use API. The API recognizes more than 120 languages and variants to support your global user base. You can enable voice command-and-control, transcribe audio from call centers, and more. It can process real-time streaming or prerecorded audio, using Google's machine learning technology.",
+    ruby_cloud_title = "Cloud Speech-to-Text",
+    transport = "grpc+rest",
+)
+
+# Open Source package.
+ruby_gapic_assembly_pkg(
+    name = "google-cloud-speech-ruby",
+    deps = [
+        ":speech_ruby_wrapper",
+    ],
+)
+
+nodejs_gapic_combined_pkg(
+    name = "google-cloud-speech-nodejs",
+    default_version = "v1",
+    release_level = "stable",
+    templates_excludes = ["package.json", "src/index.ts", ".OwlBot.yaml"],
+    deps = [
+        "//google/cloud/speech/v1:speech-v1-nodejs",
+        "//google/cloud/speech/v1p1beta1:speech-v1p1beta1-nodejs",
+        "//google/cloud/speech/v2:speech-v2-nodejs"
+    ],
+)

--- a/tool/cmd/migrate/testdata/googleapis/google/cloud/speech/BUILD.bazel
+++ b/tool/cmd/migrate/testdata/googleapis/google/cloud/speech/BUILD.bazel
@@ -12,22 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This build file includes a target for the Ruby wrapper library for
-# google-cloud-speech.
-
-# This is an API workspace, having public visibility by default makes perfect sense.
-package(default_visibility = ["//visibility:public"])
-
-# Export yaml configs.
-exports_files(glob(["*.yaml"]))
-
-load(
-    "@com_google_googleapis_imports//:imports.bzl",
-    "ruby_cloud_gapic_library",
-    "ruby_gapic_assembly_pkg",
-    "nodejs_gapic_combined_pkg"
-)
-
 # Generates a Ruby wrapper client for speech.
 # Ruby wrapper clients are versionless, but are generated from source protos
 # for a particular service version, v2 in this case.
@@ -52,17 +36,5 @@ ruby_gapic_assembly_pkg(
     name = "google-cloud-speech-ruby",
     deps = [
         ":speech_ruby_wrapper",
-    ],
-)
-
-nodejs_gapic_combined_pkg(
-    name = "google-cloud-speech-nodejs",
-    default_version = "v1",
-    release_level = "stable",
-    templates_excludes = ["package.json", "src/index.ts", ".OwlBot.yaml"],
-    deps = [
-        "//google/cloud/speech/v1:speech-v1-nodejs",
-        "//google/cloud/speech/v1p1beta1:speech-v1p1beta1-nodejs",
-        "//google/cloud/speech/v2:speech-v2-nodejs"
     ],
 )


### PR DESCRIPTION
The Ruby migration tool now extracts wrapper library configurations directly from the `ruby-cloud-wrapper-of` parameter in `BUILD.bazel` files.

Fixes #7127
For #6632
