### PR TITLE
fix(sidekick/swift): discovery enums encoding

### DIFF
--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -35,6 +35,12 @@ type methodAnnotations struct {
 	LRO            *lroAnnotations
 	DiscoveryLRO   *discoveryLroAnnotations
 	ReturnType     string
+
+	// ResponseEncoding sets the `$alt` query parameter value.
+	//
+	// To understand the motivation, see the field by the same in the the
+	// `codec` data structure.
+	ResponseEncoding string
 }
 
 type paginationAnnotations struct {
@@ -185,19 +191,20 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 		}
 	}
 	method.Codec = &methodAnnotations{
-		Name:           camelCase(method.Name),
-		DocLines:       docLines,
-		PathExpression: pathExpression(binding.PathTemplate),
-		PathVariables:  pathVariables,
-		HTTPMethod:     binding.Verb,
-		HasBody:        hasBody,
-		IsBodyWildcard: isBodyWildcard,
-		BodyField:      bodyField,
-		QueryParams:    language.QueryParams(method, binding),
-		Pagination:     pagination,
-		LRO:            lro,
-		ReturnType:     returnType,
-		DiscoveryLRO:   discoveryLRO,
+		Name:             camelCase(method.Name),
+		DocLines:         docLines,
+		PathExpression:   pathExpression(binding.PathTemplate),
+		PathVariables:    pathVariables,
+		HTTPMethod:       binding.Verb,
+		HasBody:          hasBody,
+		IsBodyWildcard:   isBodyWildcard,
+		BodyField:        bodyField,
+		QueryParams:      language.QueryParams(method, binding),
+		Pagination:       pagination,
+		LRO:              lro,
+		ReturnType:       returnType,
+		DiscoveryLRO:     discoveryLRO,
+		ResponseEncoding: c.ResponseEncoding,
 	}
 	if method.SampleInfo != nil {
 		c.annotateSampleInfo(method)

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -61,12 +61,13 @@ func TestAnnotateMethod(t *testing.T) {
 				},
 			},
 			want: &methodAnnotations{
-				Name:           "getOperation",
-				PathExpression: "/v1/operations",
-				DocLines:       []string{"Gets a thing.", "", "Test multiple comment lines.", ""},
-				HTTPMethod:     "GET",
-				HasBody:        false,
-				ReturnType:     "Test.Response",
+				Name:             "getOperation",
+				PathExpression:   "/v1/operations",
+				DocLines:         []string{"Gets a thing.", "", "Test multiple comment lines.", ""},
+				HTTPMethod:       "GET",
+				HasBody:          false,
+				ReturnType:       "Test.Response",
+				ResponseEncoding: "json;enum-encoding=int",
 			},
 		},
 		{
@@ -84,13 +85,14 @@ func TestAnnotateMethod(t *testing.T) {
 				},
 			},
 			want: &methodAnnotations{
-				Name:           "createKey",
-				PathExpression: "/v1/keys",
-				HTTPMethod:     "POST",
-				HasBody:        true,
-				IsBodyWildcard: false,
-				BodyField:      "key",
-				ReturnType:     "Test.Response",
+				Name:             "createKey",
+				PathExpression:   "/v1/keys",
+				HTTPMethod:       "POST",
+				HasBody:          true,
+				IsBodyWildcard:   false,
+				BodyField:        "key",
+				ReturnType:       "Test.Response",
+				ResponseEncoding: "json;enum-encoding=int",
 			},
 		},
 		{
@@ -108,12 +110,13 @@ func TestAnnotateMethod(t *testing.T) {
 				},
 			},
 			want: &methodAnnotations{
-				Name:           "uploadData",
-				PathExpression: "/v1/data",
-				HTTPMethod:     "POST",
-				HasBody:        true,
-				IsBodyWildcard: true,
-				ReturnType:     "Test.Response",
+				Name:             "uploadData",
+				PathExpression:   "/v1/data",
+				HTTPMethod:       "POST",
+				HasBody:          true,
+				IsBodyWildcard:   true,
+				ReturnType:       "Test.Response",
+				ResponseEncoding: "json;enum-encoding=int",
 			},
 		},
 		{
@@ -132,13 +135,14 @@ func TestAnnotateMethod(t *testing.T) {
 				},
 			},
 			want: &methodAnnotations{
-				Name:           "listThings",
-				PathExpression: "/v1/things",
-				DocLines:       []string{"Lists things."},
-				HTTPMethod:     "GET",
-				HasBody:        false,
-				QueryParams:    []*api.Field{keyField},
-				ReturnType:     "Test.Response",
+				Name:             "listThings",
+				PathExpression:   "/v1/things",
+				DocLines:         []string{"Lists things."},
+				HTTPMethod:       "GET",
+				HasBody:          false,
+				QueryParams:      []*api.Field{keyField},
+				ReturnType:       "Test.Response",
+				ResponseEncoding: "json;enum-encoding=int",
 			},
 		},
 	} {
@@ -204,11 +208,12 @@ func TestAnnotateMethod_EscapedName(t *testing.T) {
 			}
 
 			want := &methodAnnotations{
-				Name:           test.wantName,
-				DocLines:       []string{"Test documentation."},
-				PathExpression: "/",
-				HTTPMethod:     "GET",
-				ReturnType:     "Test.Response",
+				Name:             test.wantName,
+				DocLines:         []string{"Test documentation."},
+				PathExpression:   "/",
+				HTTPMethod:       "GET",
+				ReturnType:       "Test.Response",
+				ResponseEncoding: "json;enum-encoding=int",
 			}
 
 			if diff := cmp.Diff(want, method.Codec); diff != "" {
@@ -342,7 +347,8 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		Pagination: &paginationAnnotations{
 			ItemType: "Item",
 		},
-		ReturnType: "Test.ListResponse",
+		ReturnType:       "Test.ListResponse",
+		ResponseEncoding: "json;enum-encoding=int",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -454,7 +460,8 @@ func TestAnnotateMethod_LRO(t *testing.T) {
 			MetadataType:    "LroMetadata",
 			ResponseIsEmpty: false,
 		},
-		ReturnType: "Test.Operation",
+		ReturnType:       "Test.Operation",
+		ResponseEncoding: "json;enum-encoding=int",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -525,7 +532,8 @@ func TestAnnotateMethod_LRO_Empty(t *testing.T) {
 			MetadataType:    "LroMetadata",
 			ResponseIsEmpty: true,
 		},
-		ReturnType: "Test.Operation",
+		ReturnType:       "Test.Operation",
+		ResponseEncoding: "json;enum-encoding=int",
 	}
 	if diff := cmp.Diff(wantMethod, gotMethod); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -111,7 +111,20 @@ type codec struct {
 	// The name of the private module containing raw stubs (e.g. "StorageControlProtos").
 	// Used by convert-swift to generate internal imports and prefix raw types.
 	ModulePath string
+
+	// ResponseEncoding sets the `$alt` query parameter value.
+	//
+	// All RPCS over HTTP sent the `$alt` query parameter. In Google cloud this
+	// query parameter controls the format of the response. For most client
+	// libraries we use `json;enum-encoding=int`, but for discovery we need to
+	// use just `json` as the integer values for enums may not match our values.
+	ResponseEncoding string
 }
+
+const (
+	defaultResponseEncoding   = "json;enum-encoding=int"
+	discoveryResponseEncoding = "json"
+)
 
 func newCodec(model *api.API, library *config.Library, module *config.SwiftModule, outdir string) (*codec, error) {
 	year, _, _ := time.Now().Date()
@@ -148,7 +161,10 @@ func newCodec(model *api.API, library *config.Library, module *config.SwiftModul
 	if packageName == "" {
 		packageName = PackageName(model)
 	}
-
+	responseEncoding := defaultResponseEncoding
+	if library.SpecificationFormat == config.SpecDiscovery {
+		responseEncoding = discoveryResponseEncoding
+	}
 	result := &codec{
 		Model:              model,
 		GenerationYear:     generationYear,
@@ -158,6 +174,7 @@ func newCodec(model *api.API, library *config.Library, module *config.SwiftModul
 		ApiPackages:        map[string]*Dependency{},
 		DependenciesByName: map[string]*Dependency{},
 		UrlSafeForBytes:    library.SpecificationFormat == config.SpecDiscovery,
+		ResponseEncoding:   responseEncoding,
 	}
 
 	swiftCfg := library.Swift

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -46,6 +46,7 @@ func TestParseOptions(t *testing.T) {
 				Model:              model,
 				ApiPackages:        map[string]*Dependency{},
 				DependenciesByName: map[string]*Dependency{},
+				ResponseEncoding:   defaultResponseEncoding,
 			},
 		},
 		{
@@ -65,6 +66,7 @@ func TestParseOptions(t *testing.T) {
 				Model:              model,
 				ApiPackages:        map[string]*Dependency{},
 				DependenciesByName: map[string]*Dependency{},
+				ResponseEncoding:   defaultResponseEncoding,
 			},
 		},
 		{
@@ -85,6 +87,7 @@ func TestParseOptions(t *testing.T) {
 				ModulePath:         "GoogleTestProtos",
 				ApiPackages:        map[string]*Dependency{},
 				DependenciesByName: map[string]*Dependency{},
+				ResponseEncoding:   defaultResponseEncoding,
 			},
 		},
 		{
@@ -103,6 +106,7 @@ func TestParseOptions(t *testing.T) {
 				ApiPackages:        map[string]*Dependency{},
 				DependenciesByName: map[string]*Dependency{},
 				UrlSafeForBytes:    true,
+				ResponseEncoding:   discoveryResponseEncoding,
 			},
 		},
 	} {

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -237,7 +237,7 @@ func TestGenerateStub_Discovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contentBytes, err := os.ReadFile(filepath.Join(outDir, "Sources", "GoogleCloudComputeV1", "addresses+Stub.swift"))
+	contentBytes, err := os.ReadFile(filepath.Join(outDir, "Sources", "GoogleCloudComputeV1", "Addresses+Stub.swift"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -22,9 +22,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
 )
 
-func TestGenerateService_StubStructure(t *testing.T) {
+func TestGenerateStub_Structure(t *testing.T) {
 	outDir := t.TempDir()
 
 	request := &api.Message{
@@ -104,9 +105,15 @@ func TestGenerateService_StubStructure(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
+
+	got = extractBlock(t, contentStr, `URLQueryItem(name: "$alt",`, ")")
+	want = `URLQueryItem(name: "$alt", value: "json;enum-encoding=int")`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 }
 
-func TestGenerateService_QueryParameters(t *testing.T) {
+func TestGenerateStub_QueryParameters(t *testing.T) {
 	outDir := t.TempDir()
 
 	oneof := &api.OneOf{Name: "expiration"}
@@ -200,6 +207,42 @@ func TestGenerateService_QueryParameters(t *testing.T) {
 	want = `request.expiration.flatMap { (oneof) -> Swift.String? in
             if case let .ttlDays(v) = oneof { v } else { nil }
           }, prefix: "ttlDays")`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGenerateStub_Discovery(t *testing.T) {
+	testdataDir, err := filepath.Abs("../../testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outDir := t.TempDir()
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: config.SpecDiscovery,
+		ServiceConfig:       filepath.Join(testdataDir, "googleapis/google/cloud/compute/v1/small-compute_v1.yaml"),
+		SpecificationSource: filepath.Join(testdataDir, "discovery/small-compute.v1.json"),
+	}
+	model, err := parser.CreateModel(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	library := &config.Library{
+		SpecificationFormat: config.SpecDiscovery,
+		Swift:               swiftConfig(t, nil),
+	}
+	if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	contentBytes, err := os.ReadFile(filepath.Join(outDir, "Sources", "GoogleCloudComputeV1", "addresses+Stub.swift"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := extractBlock(t, string(contentBytes), `URLQueryItem(name: "$alt",`, ")")
+	want := `URLQueryItem(name: "$alt", value: "json")`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -59,7 +59,7 @@ extension Clients {
       }()
       {{#Codec.HasQueryParams}}
       var query = [
-        URLQueryItem(name: "$alt", value: "json;enum-encoding=int"),
+        URLQueryItem(name: "$alt", value: "{{{Codec.ResponseEncoding}}}"),
         {{#APIVersion}}
         URLQueryItem(name: "$apiVersion", value: "{{.}}"),
         {{/APIVersion}}
@@ -68,7 +68,7 @@ extension Clients {
       {{/Codec.HasQueryParams}}
       {{^Codec.HasQueryParams}}
       let query = [
-        URLQueryItem(name: "$alt", value: "json;enum-encoding=int"),
+        URLQueryItem(name: "$alt", value: "{{{Codec.ResponseEncoding}}}"),
         {{#APIVersion}}
         URLQueryItem(name: "$apiVersion", value: "{{.}}"),
         {{/APIVersion}}


### PR DESCRIPTION
For discovery-based APIs, we should request string encoding (the default) for enums. This is because the enums have numeric values in the `proto2` protos used to generate the discovery docs, but these numeric values are lost in the discovery doc translation.

Fixes #6517 for realsies this time.
