### PR TITLE
feat(swift): Improve module generation

### DIFF
--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -62,7 +62,12 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 
 func moduleToModelConfig(library *config.Library, module *config.SwiftModule, src *sources.Sources) *parser.ModelConfig {
 	sourceConfig := sources.NewSourceConfig(src, library.Roots)
-	if library.Swift != nil && len(library.Swift.IncludeList) > 0 {
+	// Prefer the module-specific include list if configured, allowing per-module filtering
+	// (e.g., selecting only specific dependency `.proto` files for conversion generation).
+	// Fall back to the library-wide include list if the module does not define its own.
+	if len(module.IncludeList) > 0 {
+		sourceConfig.IncludeList = module.IncludeList
+	} else if library.Swift != nil && len(library.Swift.IncludeList) > 0 {
 		sourceConfig.IncludeList = library.Swift.IncludeList
 	}
 	specFormat := config.SpecProtobuf

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -150,6 +150,46 @@ func TestModuleToModelConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "with module include list",
+			lib: &config.Library{
+				Swift: &config.SwiftPackage{},
+			},
+			module: &config.SwiftModule{
+				APIPath:     "foo",
+				IncludeList: []string{"mod_a.proto", "mod_b.proto"},
+			},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+					IncludeList: []string{"mod_a.proto", "mod_b.proto"},
+				},
+			},
+		},
+		{
+			name: "with module include list overriding library include list",
+			lib: &config.Library{
+				Swift: &config.SwiftPackage{
+					IncludeList: []string{"lib_a.proto", "lib_b.proto"},
+				},
+			},
+			module: &config.SwiftModule{
+				APIPath:     "foo",
+				IncludeList: []string{"mod_a.proto"},
+			},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+					IncludeList: []string{"mod_a.proto"},
+				},
+			},
+		},
+		{
 			name:   "nil swift",
 			lib:    &config.Library{},
 			module: &config.SwiftModule{APIPath: "foo"},

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -158,8 +158,12 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	}
 
 	// Ensure the entire package depends on the package this message belongs to.
-	if _, err := c.addApiPackageDependency(message.Package); err != nil {
+	dep, err := c.addApiPackageDependency(message.Package)
+	if err != nil {
 		return err
+	}
+	if dep != nil {
+		annotations.DependsOn[dep.Name] = dep
 	}
 	// All messages require the well known types for GoogleCloudWkt._AnyPackable.
 	wktDep, err := c.addApiPackageDependency(wellKnownProtobufPackage)

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -212,7 +212,7 @@ func (c *codec) addDependency(dep *Dependency) (*Dependency, error) {
 		return nil, fmt.Errorf("attempting to add nil dependency")
 	}
 	// Skip including self as a dependency
-	if dep.Name == c.LibraryName {
+	if dep.Name == c.LibraryName || (c.Module && dep.Name == c.ModulePath) {
 		return nil, nil
 	}
 	if ann, ok := c.Model.Codec.(*modelAnnotations); ok {

--- a/internal/sidekick/swift/field_type_name.go
+++ b/internal/sidekick/swift/field_type_name.go
@@ -175,6 +175,14 @@ func (c *codec) fullyQualifiedMessageTypeName(m *api.Message) (string, error) {
 		}
 		if m.Package == c.Model.PackageName {
 			// this is the current package
+			if c.Module || c.LibraryName == "" {
+				// LibraryName is intentionally left empty when generating a module
+				// (c.Module == true) because modules cannot have top-level library names.
+				// Without this check, formatting "%s.%s" with an empty LibraryName
+				// emits an illegal Swift type starting with a leading dot (e.g., "-> .IntelligenceConfig").
+				// Whenever we are generating a module or LibraryName is unset, use the bare type name.
+				return name, nil
+			}
 			return fmt.Sprintf("%s.%s", c.LibraryName, name), nil
 		}
 		dep, ok := c.ApiPackages[m.Package]

--- a/internal/sidekick/swift/field_type_name_test.go
+++ b/internal/sidekick/swift/field_type_name_test.go
@@ -484,3 +484,43 @@ func TestFieldTypeName_ExternalNestedMessage(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestFullyQualifiedMessageTypeName(t *testing.T) {
+	msg := &api.Message{
+		Name:    "TestMessage",
+		Package: "google.cloud.test.v1",
+		ID:      ".google.cloud.test.v1.TestMessage",
+	}
+	model := api.NewTestAPI([]*api.Message{msg}, nil, nil)
+	model.PackageName = "google.cloud.test.v1"
+
+	t.Run("standalone library with LibraryName", func(t *testing.T) {
+		c := newTestCodec(t, model, nil)
+		c.LibraryName = "TestLibrary"
+		c.Module = false
+
+		got, err := c.fullyQualifiedMessageTypeName(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "TestLibrary.TestMessage"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("module with empty LibraryName", func(t *testing.T) {
+		c := newTestCodec(t, model, nil)
+		c.LibraryName = ""
+		c.Module = true
+
+		got, err := c.fullyQualifiedMessageTypeName(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "TestMessage"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/internal/sidekick/swift/generate_conversions.go
+++ b/internal/sidekick/swift/generate_conversions.go
@@ -17,7 +17,6 @@ package swift
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
@@ -43,12 +42,6 @@ func GenerateConversions(ctx context.Context, model *api.API, outdir string, lib
 		}
 		return string(contents), nil
 	}
-	if err := codec.generateMessages(outdir, model, provider); err != nil {
-		return err
-	}
-	if err := codec.generateEnums(outdir, model, provider); err != nil {
-		return err
-	}
 	if err := codec.generateEnumConversions(outdir, model, provider); err != nil {
 		return err
 	}
@@ -61,10 +54,7 @@ func GenerateConversions(ctx context.Context, model *api.API, outdir string, lib
 func (c *codec) generateEnumConversions(outdir string, model *api.API, provider language.TemplateProvider) error {
 	for _, e := range model.Enums {
 		name := c.enumFileName(e)
-		output := filepath.Join("Convert", name+"+Convert.swift")
-		if !c.Module {
-			output = filepath.Join("Sources", c.LibraryName, "Convert", name+"+Convert.swift")
-		}
+		output := c.conversionOutputPath(name)
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_enum_file.swift.mustache",
 			OutputPath:   output,
@@ -85,10 +75,7 @@ func (c *codec) generateMessageConversions(outdir string, model *api.API, provid
 			continue
 		}
 		name := c.messageFileName(m)
-		output := filepath.Join("Convert", name+"+Convert.swift")
-		if !c.Module {
-			output = filepath.Join("Sources", c.LibraryName, "Convert", name+"+Convert.swift")
-		}
+		output := c.conversionOutputPath(name)
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_message_file.swift.mustache",
 			OutputPath:   output,
@@ -98,4 +85,8 @@ func (c *codec) generateMessageConversions(outdir string, model *api.API, provid
 		}
 	}
 	return nil
+}
+
+func (c *codec) conversionOutputPath(typeName string) string {
+	return typeName + "+Convert.swift"
 }

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -15,9 +15,9 @@
 package swift
 
 import (
-	"strings"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -15,7 +15,7 @@
 package swift
 
 import (
-	"bytes"
+	"strings"
 	"os"
 	"path/filepath"
 	"testing"
@@ -82,26 +82,25 @@ func TestGenerateConversions_Message(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	filename := filepath.Join(outDir, "Convert", "Folder+Convert.swift")
-	content, err := os.ReadFile(filename)
+	b, err := os.ReadFile(filepath.Join(outDir, "Folder+Convert.swift"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	contentStr := string(content)
+	gotContent := string(b)
 
 	// Check output imports
-	if !bytes.Contains(content, []byte("internal import StorageControlProtos")) {
+	if !strings.Contains(gotContent, "internal import StorageControlProtos") {
 		t.Errorf("expected generated file to import StorageControlProtos")
 	}
 
 	// Check conversion logic
-	got := extractBlock(t, contentStr, "  internal init(proto: ProtoType) throws {", "\n  }")
-	wantInit := "  internal init(proto: ProtoType) throws {\n    self.name = proto.name\n    self.metageneration = proto.metageneration\n    self.self_ = proto.hasSelf_p ? proto.self_p : nil\n  }"
+	got := extractBlock(t, gotContent, "  internal init(proto: ProtoType) throws {", "\n  }")
+	wantInit := "  internal init(proto: ProtoType) throws {\n    self.init()\n    self.name = proto.name\n    self.metageneration = proto.metageneration\n    self.self_ = proto.hasSelf_p ? proto.self_p : nil\n  }"
 	if diff := cmp.Diff(wantInit, got); diff != "" {
 		t.Errorf("init(proto:) mismatch (-want +got):\n%s", diff)
 	}
 
-	got = extractBlock(t, contentStr, "  internal func toProto() throws -> ProtoType {", "\n  }")
+	got = extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
 	wantToProto := "  internal func toProto() throws -> ProtoType {\n    var proto = ProtoType()\n    proto.name = self.name\n    proto.metageneration = self.metageneration\n    if let self_ = self.self_ { proto.self_p = self_ }\n    return proto\n  }"
 	if diff := cmp.Diff(wantToProto, got); diff != "" {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -17,6 +17,7 @@ extension {{Codec.ParameterTypeName}} {
   internal typealias ProtoType = {{Codec.ProtoTypeName}}
 
   internal init(proto: ProtoType) throws {
+    self.init()
     {{#Fields}}
     {{#Codec.ProtoFieldName}}
     {{#Optional}}


### PR DESCRIPTION
Remove default message conversions from the conversion logic.

Separate gapic generation from conversion generation.

Some changes to ensure imports are correct for dependencies.

Generates https://github.com/googleapis/google-cloud-swift/pull/76 