### PR TITLE
feat(internal/tool/composer): support local_path in ComposerTool configuration

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -61,7 +61,7 @@ This document describes the schema for the librarian.yaml.
 | `version` | string | Is the version to install. |
 | `repo` | string | Is the GitHub repository to fetch the tool from (e.g. github.com/googleapis/gapic-generator-php). |
 | `sha256` | string | Is the SHA256 checksum of the package. |
-| `local_path` | string | Is the path to a local composer project. When present, Name, Version, Repo, and SHA256 are ignored. |
+| `local_path` | string | Is the path to a local composer project. When present, Version, Repo, and SHA256 are ignored. |
 
 ## GemTool Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -61,6 +61,7 @@ This document describes the schema for the librarian.yaml.
 | `version` | string | Is the version to install. |
 | `repo` | string | Is the GitHub repository to fetch the tool from (e.g. github.com/googleapis/gapic-generator-php). |
 | `sha256` | string | Is the SHA256 checksum of the package. |
+| `local_path` | string | Is the path to a local composer project. When present, Name, Version, Repo, and SHA256 are ignored. |
 
 ## GemTool Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,10 @@ type ComposerTool struct {
 
 	// SHA256 is the SHA256 checksum of the package.
 	SHA256 string `yaml:"sha256,omitempty"`
+
+	// LocalPath is the path to a local composer project.
+	// When present, Name, Version, Repo, and SHA256 are ignored.
+	LocalPath string `yaml:"local_path,omitempty"`
 }
 
 // GemTool defines a tool to install via gem.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,7 +143,7 @@ type ComposerTool struct {
 	SHA256 string `yaml:"sha256,omitempty"`
 
 	// LocalPath is the path to a local composer project.
-	// When present, Name, Version, Repo, and SHA256 are ignored.
+	// When present, Version, Repo, and SHA256 are ignored.
 	LocalPath string `yaml:"local_path,omitempty"`
 }
 

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -41,6 +41,19 @@ func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin str
 		return err
 	}
 	for _, tool := range tools {
+		if tool.LocalPath != "" {
+			absPath, err := filepath.Abs(tool.LocalPath)
+			if err != nil {
+				return fmt.Errorf("failed to resolve absolute path for %s: %w", tool.LocalPath, err)
+			}
+			if _, err := os.Stat(absPath); err != nil {
+				return fmt.Errorf("local composer path not found: %w", err)
+			}
+			if err := command.RunInDir(ctx, absPath, "composer", "install", "--no-interaction", "--prefer-dist"); err != nil {
+				return fmt.Errorf("failed to run composer install: %w", err)
+			}
+			continue
+		}
 		dir, err := fetch.Repo(ctx, tool.Repo, tool.Version, tool.SHA256)
 		if err != nil {
 			return fmt.Errorf("fetching %s: %w", tool.Name, err)
@@ -90,11 +103,21 @@ func createBinWrapper(wrapperName, content, binDir string) error {
 
 func verify(tools []*config.ComposerTool) error {
 	for _, tool := range tools {
-		if tool.Name == "" || tool.Version == "" {
-			return fmt.Errorf("%w: name and version must be specified: %+v", ErrInvalidTool, tool)
+		hasLocal := tool.LocalPath != ""
+		hasRemote := tool.Name != "" || tool.Version != "" || tool.Repo != ""
+		if hasLocal && hasRemote {
+			return fmt.Errorf("%w: cannot specify both local_path and name/version/repo: %+v", ErrInvalidTool, tool)
 		}
-		if tool.Repo == "" {
-			return fmt.Errorf("%w: composer tool %s", ErrMissingRepo, tool.Name)
+		if !hasLocal && !hasRemote {
+			return fmt.Errorf("%w: must specify either local_path or name/version/repo: %+v", ErrInvalidTool, tool)
+		}
+		if hasRemote {
+			if tool.Name == "" || tool.Version == "" {
+				return fmt.Errorf("%w: name and version must be specified: %+v", ErrInvalidTool, tool)
+			}
+			if tool.Repo == "" {
+				return fmt.Errorf("%w: composer tool %s", ErrMissingRepo, tool.Name)
+			}
 		}
 	}
 	return nil

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -64,7 +64,7 @@ func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin str
 		if err := command.RunInDir(ctx, dir, "composer", "install", "--no-interaction", "--prefer-dist"); err != nil {
 			return fmt.Errorf("failed to run composer install: %w", err)
 		}
-		wrapperName := tool.Name
+		wrapperName := filepath.Base(tool.Name)
 		if wrapperName == "gapic-generator-php" {
 			// Currently, this assumes the tool is the gapic-generator-php. This specific
 			// wrapper logic will not work for generic Composer tools because:

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -61,11 +61,9 @@ func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin str
 			}
 			dir = fetchedDir
 		}
-
 		if err := command.RunInDir(ctx, dir, "composer", "install", "--no-interaction", "--prefer-dist"); err != nil {
 			return fmt.Errorf("failed to run composer install: %w", err)
 		}
-
 		wrapperName := tool.Name
 		if wrapperName == "gapic-generator-php" {
 			// Currently, this assumes the tool is the gapic-generator-php. This specific

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -112,12 +112,12 @@ func verify(tools []*config.ComposerTool) error {
 			return fmt.Errorf("%w: name must be specified: %+v", ErrInvalidTool, tool)
 		}
 		hasLocal := tool.LocalPath != ""
-		hasRemote := tool.Version != "" || tool.Repo != ""
+		hasRemote := tool.Version != "" || tool.Repo != "" || tool.SHA256 != ""
 		if hasLocal && hasRemote {
-			return fmt.Errorf("%w: cannot specify both local_path and version/repo: %+v", ErrInvalidTool, tool)
+			return fmt.Errorf("%w: cannot specify both local_path and version/repo/sha256: %+v", ErrInvalidTool, tool)
 		}
 		if !hasLocal && !hasRemote {
-			return fmt.Errorf("%w: must specify either local_path or version/repo: %+v", ErrInvalidTool, tool)
+			return fmt.Errorf("%w: must specify either local_path or version/repo/sha256: %+v", ErrInvalidTool, tool)
 		}
 		if hasRemote {
 			if tool.Version == "" {

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -42,24 +42,17 @@ func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin str
 	}
 	for _, tool := range tools {
 		var dir string
+		var err error
 		if tool.LocalPath != "" {
-			absPath, err := filepath.Abs(tool.LocalPath)
-			if err != nil {
-				return fmt.Errorf("failed to resolve absolute path for %s: %w", tool.LocalPath, err)
-			}
-			if _, err := os.Stat(absPath); err != nil {
-				if errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("local composer path not found: %w", err)
-				}
-				return fmt.Errorf("failed to stat local composer path: %w", err)
-			}
-			dir = absPath
+			dir, err = localPath(tool.LocalPath)
 		} else {
-			fetchedDir, err := fetch.Repo(ctx, tool.Repo, tool.Version, tool.SHA256)
+			dir, err = fetch.Repo(ctx, tool.Repo, tool.Version, tool.SHA256)
 			if err != nil {
-				return fmt.Errorf("fetching %s: %w", tool.Name, err)
+				err = fmt.Errorf("fetching %s: %w", tool.Name, err)
 			}
-			dir = fetchedDir
+		}
+		if err != nil {
+			return err
 		}
 		if err := command.RunInDir(ctx, dir, "composer", "install", "--no-interaction", "--prefer-dist"); err != nil {
 			return fmt.Errorf("failed to run composer install: %w", err)
@@ -84,6 +77,21 @@ func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin str
 		}
 	}
 	return nil
+}
+
+// localPath resolves and validates the absolute path for a local composer tool.
+func localPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path for %s: %w", path, err)
+	}
+	if _, err := os.Stat(absPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("local composer path not found: %w", err)
+		}
+		return "", fmt.Errorf("failed to stat local composer path: %w", err)
+	}
+	return absPath, nil
 }
 
 // phpWrapperContent generates the bash script content for the PHP tool wrapper.
@@ -123,6 +131,9 @@ func verify(tools []*config.ComposerTool) error {
 			}
 			if tool.Repo == "" {
 				return fmt.Errorf("%w: composer tool %s", ErrMissingRepo, tool.Name)
+			}
+			if tool.SHA256 == "" {
+				return fmt.Errorf("%w: sha256 must be specified: %+v", ErrInvalidTool, tool)
 			}
 		}
 	}

--- a/internal/tool/composer/composer.go
+++ b/internal/tool/composer/composer.go
@@ -41,27 +41,32 @@ func Install(ctx context.Context, tools []*config.ComposerTool, phpPath, bin str
 		return err
 	}
 	for _, tool := range tools {
+		var dir string
 		if tool.LocalPath != "" {
 			absPath, err := filepath.Abs(tool.LocalPath)
 			if err != nil {
 				return fmt.Errorf("failed to resolve absolute path for %s: %w", tool.LocalPath, err)
 			}
 			if _, err := os.Stat(absPath); err != nil {
-				return fmt.Errorf("local composer path not found: %w", err)
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("local composer path not found: %w", err)
+				}
+				return fmt.Errorf("failed to stat local composer path: %w", err)
 			}
-			if err := command.RunInDir(ctx, absPath, "composer", "install", "--no-interaction", "--prefer-dist"); err != nil {
-				return fmt.Errorf("failed to run composer install: %w", err)
+			dir = absPath
+		} else {
+			fetchedDir, err := fetch.Repo(ctx, tool.Repo, tool.Version, tool.SHA256)
+			if err != nil {
+				return fmt.Errorf("fetching %s: %w", tool.Name, err)
 			}
-			continue
+			dir = fetchedDir
 		}
-		dir, err := fetch.Repo(ctx, tool.Repo, tool.Version, tool.SHA256)
-		if err != nil {
-			return fmt.Errorf("fetching %s: %w", tool.Name, err)
-		}
+
 		if err := command.RunInDir(ctx, dir, "composer", "install", "--no-interaction", "--prefer-dist"); err != nil {
 			return fmt.Errorf("failed to run composer install: %w", err)
 		}
-		wrapperName := filepath.Base(tool.Repo)
+
+		wrapperName := tool.Name
 		if wrapperName == "gapic-generator-php" {
 			// Currently, this assumes the tool is the gapic-generator-php. This specific
 			// wrapper logic will not work for generic Composer tools because:
@@ -103,17 +108,20 @@ func createBinWrapper(wrapperName, content, binDir string) error {
 
 func verify(tools []*config.ComposerTool) error {
 	for _, tool := range tools {
+		if tool.Name == "" {
+			return fmt.Errorf("%w: name must be specified: %+v", ErrInvalidTool, tool)
+		}
 		hasLocal := tool.LocalPath != ""
-		hasRemote := tool.Name != "" || tool.Version != "" || tool.Repo != ""
+		hasRemote := tool.Version != "" || tool.Repo != ""
 		if hasLocal && hasRemote {
-			return fmt.Errorf("%w: cannot specify both local_path and name/version/repo: %+v", ErrInvalidTool, tool)
+			return fmt.Errorf("%w: cannot specify both local_path and version/repo: %+v", ErrInvalidTool, tool)
 		}
 		if !hasLocal && !hasRemote {
-			return fmt.Errorf("%w: must specify either local_path or name/version/repo: %+v", ErrInvalidTool, tool)
+			return fmt.Errorf("%w: must specify either local_path or version/repo: %+v", ErrInvalidTool, tool)
 		}
 		if hasRemote {
-			if tool.Name == "" || tool.Version == "" {
-				return fmt.Errorf("%w: name and version must be specified: %+v", ErrInvalidTool, tool)
+			if tool.Version == "" {
+				return fmt.Errorf("%w: version must be specified: %+v", ErrInvalidTool, tool)
 			}
 			if tool.Repo == "" {
 				return fmt.Errorf("%w: composer tool %s", ErrMissingRepo, tool.Name)

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -121,7 +121,7 @@ func TestCreateBinWrapper(t *testing.T) {
 
 func TestVerify(t *testing.T) {
 	tools := []*config.ComposerTool{
-		{Name: "gapic-generator-php", Version: "1.0.0", Repo: "github.com/googleapis/gapic-generator-php"},
+		{Name: "gapic-generator-php", Version: "1.0.0", Repo: "github.com/googleapis/gapic-generator-php", SHA256: "somehash"},
 	}
 	if err := verify(tools); err != nil {
 		t.Errorf("verify() error = %v, want nil", err)
@@ -137,28 +137,35 @@ func TestVerify_Error(t *testing.T) {
 		{
 			name: "missing name",
 			tools: []*config.ComposerTool{
-				{Name: "", Version: "1.0.0", Repo: "github.com"},
+				{Name: "", Version: "1.0.0", Repo: "github.com", SHA256: "somehash"},
 			},
 			wantErr: ErrInvalidTool,
 		},
 		{
 			name: "missing version",
 			tools: []*config.ComposerTool{
-				{Name: "gapic-generator-php", Version: "", Repo: "github.com"},
+				{Name: "gapic-generator-php", Version: "", Repo: "github.com", SHA256: "somehash"},
 			},
 			wantErr: ErrInvalidTool,
 		},
 		{
 			name: "missing repo",
 			tools: []*config.ComposerTool{
-				{Name: "gapic-generator-php", Version: "1.0.0", Repo: ""},
+				{Name: "gapic-generator-php", Version: "1.0.0", Repo: "", SHA256: "somehash"},
 			},
 			wantErr: ErrMissingRepo,
 		},
 		{
+			name: "missing sha256",
+			tools: []*config.ComposerTool{
+				{Name: "gapic-generator-php", Version: "1.0.0", Repo: "github.com", SHA256: ""},
+			},
+			wantErr: ErrInvalidTool,
+		},
+		{
 			name: "both local path and remote provided",
 			tools: []*config.ComposerTool{
-				{Name: "gapic-generator-php", Version: "1.0.0", Repo: "github.com", LocalPath: "."},
+				{Name: "gapic-generator-php", Version: "1.0.0", Repo: "github.com", SHA256: "somehash", LocalPath: "."},
 			},
 			wantErr: ErrInvalidTool,
 		},

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -165,7 +165,7 @@ func TestVerify_Error(t *testing.T) {
 		{
 			name: "neither local path nor remote provided",
 			tools: []*config.ComposerTool{
-				{},
+				{Name: "gapic-generator-php"},
 			},
 			wantErr: ErrInvalidTool,
 		},
@@ -189,6 +189,7 @@ func TestInstall_LocalPath(t *testing.T) {
 	localDir := t.TempDir()
 	tools := []*config.ComposerTool{
 		{
+			Name:      "gapic-generator-php",
 			LocalPath: localDir,
 		},
 	}
@@ -208,6 +209,7 @@ func TestInstall_LocalPath_Error(t *testing.T) {
 	localDir := t.TempDir()
 	tools := []*config.ComposerTool{
 		{
+			Name:      "gapic-generator-php",
 			LocalPath: localDir,
 		},
 	}

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -197,6 +197,16 @@ func TestInstall_LocalPath(t *testing.T) {
 	if err := Install(t.Context(), tools, "php", binDir); err != nil {
 		t.Fatalf("Install() with LocalPath error = %v", err)
 	}
+	wrapperPath := filepath.Join(binDir, "gapic-generator-php")
+	b, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destPath := filepath.Join(localDir, "src", "Main.php")
+	want := phpWrapperContent("php", destPath)
+	if diff := cmp.Diff(want, string(b)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestInstall_LocalPath_Error(t *testing.T) {

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -155,6 +155,20 @@ func TestVerify_Error(t *testing.T) {
 			},
 			wantErr: ErrMissingRepo,
 		},
+		{
+			name: "both local path and remote provided",
+			tools: []*config.ComposerTool{
+				{Name: "gapic-generator-php", Version: "1.0.0", Repo: "github.com", LocalPath: "."},
+			},
+			wantErr: ErrInvalidTool,
+		},
+		{
+			name: "neither local path nor remote provided",
+			tools: []*config.ComposerTool{
+				{},
+			},
+			wantErr: ErrInvalidTool,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			gotErr := verify(test.tools)
@@ -162,5 +176,43 @@ func TestVerify_Error(t *testing.T) {
 				t.Errorf("verify() error = %v, wantErr = %v", gotErr, test.wantErr)
 			}
 		})
+	}
+}
+
+func TestInstall_LocalPath(t *testing.T) {
+	testhelper.RequireCommand(t, "composer")
+	bin := t.TempDir()
+	// Create a dummy composer executable that just exits 0 to simulate success.
+	testhelper.WriteExecutable(t, filepath.Join(bin, "composer"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	localDir := t.TempDir()
+	tools := []*config.ComposerTool{
+		{
+			LocalPath: localDir,
+		},
+	}
+	binDir := t.TempDir()
+	if err := Install(t.Context(), tools, "php", binDir); err != nil {
+		t.Fatalf("Install() with LocalPath error = %v", err)
+	}
+}
+
+func TestInstall_LocalPath_Error(t *testing.T) {
+	testhelper.RequireCommand(t, "composer")
+	bin := t.TempDir()
+	// Create a dummy composer executable that exits 1 to simulate failure.
+	testhelper.WriteExecutable(t, filepath.Join(bin, "composer"), "#!/bin/sh\nexit 1\n")
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	localDir := t.TempDir()
+	tools := []*config.ComposerTool{
+		{
+			LocalPath: localDir,
+		},
+	}
+	binDir := t.TempDir()
+	if err := Install(t.Context(), tools, "php", binDir); err == nil {
+		t.Fatal("Install() with LocalPath error = nil, want error")
 	}
 }


### PR DESCRIPTION
This change adds `local_path` support to the Composer tool configuration (analogous to the pip tool) so that we can support more installation cases (specifically, installing dependencies in the monorepo). This is split out from https://github.com/googleapis/librarian/pull/7122#discussion_r3678409656.

Fixes https://github.com/googleapis/librarian/issues/7132