### PR TITLE
fix(internal/librarian/ruby): normalize newlines into spaces in description and summary options

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -162,7 +162,7 @@ func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir stri
 		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, sc.ServiceConfig))
 	}
 	if sc != nil && sc.Description != "" {
-		desc := escapeRubyCloudOptValue(sc.Description)
+		desc := escapeRubyCloudOptValue(strings.Join(strings.Fields(sc.Description), " "))
 		opts = append(opts, "ruby-cloud-description="+desc, "ruby-cloud-summary="+desc)
 	}
 	if gc != "" {

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -55,8 +55,8 @@ func TestBuildGAPICOpts(t *testing.T) {
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager-v1",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
-				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
-				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"ruby-cloud-generate-transports=grpc;rest",
 				"ruby-cloud-rest-numeric-enums=true",
@@ -95,8 +95,8 @@ func TestBuildGAPICOpts(t *testing.T) {
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
-				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
-				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"ruby-cloud-generate-transports=grpc;rest",
 				"ruby-cloud-rest-numeric-enums=true",
@@ -117,8 +117,8 @@ func TestBuildGAPICOpts(t *testing.T) {
 			want: []string{
 				"ruby-cloud-gem-name=google-cloud-secret_manager",
 				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
-				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
-				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates.\nProvides convenience while improving security.",
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
 				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
 				"ruby-cloud-generate-transports=grpc;rest",
 				"ruby-cloud-rest-numeric-enums=true",


### PR DESCRIPTION
Collapse multiline whitespace and line breaks into single spaces when constructing `ruby-cloud-description` and `ruby-cloud-summary` generator options from service config documentation summary.

Fixes https://github.com/googleapis/librarian/issues/7133

### Verification

Built `librarian` from this branch and ran `librarian generate` on both target libraries in `google-cloud-ruby`:

1. **Main Client (`google-cloud-asset`)**:
   Regenerated `google-cloud-asset` in `google-cloud-ruby` (PR https://github.com/googleapis/google-cloud-ruby/pull/35034):
   ```diff
   --- a/google-cloud-asset/google-cloud-asset.gemspec
   +++ b/google-cloud-asset/google-cloud-asset.gemspec
   @@ -13,1 +13,1 @@
   -  gem.summary       = "The Cloud Asset API manages the history and inventory of Google Cloud\nresources."
   +  gem.summary       = "The Cloud Asset API manages the history and inventory of Google Cloud resources."
   ```

2. **Versioned Client (`google-cloud-asset-v1`)**:
   Regenerated `google-cloud-asset-v1` in `google-cloud-ruby` (PR https://github.com/googleapis/google-cloud-ruby/pull/35014):
   ```diff
   --- a/google-cloud-asset-v1/google-cloud-asset-v1.gemspec
   +++ b/google-cloud-asset-v1/google-cloud-asset-v1.gemspec
   @@ -13,1 +13,1 @@
   -  gem.summary       = "The Cloud Asset API manages the history and inventory of Google Cloud\nresources."
   +  gem.summary       = "The Cloud Asset API manages the history and inventory of Google Cloud resources."
   ```

In both cases, `gem.summary` in `.gemspec` files is normalized to a single line without embedded line breaks (`\n`).
