### PR TITLE
feat(librarian/swift): implement bump command

### DIFF
--- a/internal/librarian/bump.go
+++ b/internal/librarian/bump.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/rust"
+	"github.com/googleapis/librarian/internal/librarian/swift"
 	"github.com/googleapis/librarian/internal/semver"
 	"github.com/googleapis/librarian/internal/yaml"
 	"github.com/urfave/cli/v3"
@@ -47,6 +48,9 @@ var (
 		config.LanguageRust: {
 			BumpVersionCore:       true,
 			DowngradePreGAChanges: true,
+		},
+		config.LanguageSwift: {
+			BumpVersionCore: true,
 		},
 	}
 	// IgnoredChanges defines the list of the files that are
@@ -113,7 +117,10 @@ func runBump(ctx context.Context, cfg *config.Config, all bool, libraryName, ver
 		return err
 	}
 	if cfg.Language == config.LanguageRust {
-		return legacyRustBump(ctx, cfg, all, libraryName, versionOverride)
+		return legacySidekickBump(ctx, cfg, all, libraryName, versionOverride)
+	}
+	if cfg.Language == config.LanguageSwift {
+		return legacySidekickBump(ctx, cfg, all, libraryName, versionOverride)
 	}
 
 	librariesToBump, err := findLibrariesToBump(ctx, cfg, all, libraryName)
@@ -342,18 +349,20 @@ func findLatestReleaseCommitHash(ctx context.Context) (string, error) {
 	return "", errReleaseCommitNotFound
 }
 
-// legacyRustBump applies the legacy (but still in use) logic for Rust
-// releasing. This is separated from the main logic to allow non-Rust languages
-// to work on the newer "tag-per-library" logic without interrupting Rust
+// legacySidekickBump applies the legacy (but still in use) Sidekick logic for
+// releasing.
+//
+// This is separated from the main logic to allow non-Rust languages to work on
+// the newer "tag-per-library" logic without interrupting Rust and Swift
 // releases. The "fake" language is still valid here, for testing purposes.
-func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride string) error {
+func legacySidekickBump(ctx context.Context, cfg *config.Config, all bool, libraryName, versionOverride string) error {
 	lastTag, err := git.GetLastTag(ctx, command.Git, config.RemoteUpstream, config.BranchMain)
 	if err != nil {
 		return err
 	}
 
 	if all {
-		if err := legacyRustBumpAll(ctx, cfg, lastTag); err != nil {
+		if err := legacySidekickBumpAll(ctx, cfg, lastTag); err != nil {
 			return err
 		}
 	} else {
@@ -361,7 +370,7 @@ func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryNa
 		if err != nil {
 			return err
 		}
-		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, versionOverride); err != nil {
+		if err := legacySidekickBumpLibrary(ctx, cfg, lib, lastTag, versionOverride); err != nil {
 			return err
 		}
 	}
@@ -372,11 +381,14 @@ func legacyRustBump(ctx context.Context, cfg *config.Config, all bool, libraryNa
 	return RunTidyOnConfig(ctx, ".", cfg)
 }
 
-// legacyRustBumpAll applies the legacy (but still in use) "bump all" approach
-// of assuming a single tag for the latest release, and checking everything
-// since that tag. (Compare this with findLibrariesToBump, which expects each
-// library to have its own tag for its last release.)
-func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag string) error {
+// legacySidekickBumpAll applies the legacy (but still in use) sidekick logic to
+// bump all.
+//
+// Sidekick (for Rust and Swift) assumes a single tag in the monorepo for the
+// latest release, and finds any changes since that tag. Compare this with
+// findLibrariesToBump, which expects each library to have its own tag for its
+// last release.
+func legacySidekickBumpAll(ctx context.Context, cfg *config.Config, lastTag string) error {
 	filesChanged, err := git.FilesChangedSince(ctx, command.Git, lastTag, IgnoredChanges)
 	if err != nil {
 		return err
@@ -389,18 +401,19 @@ func legacyRustBumpAll(ctx context.Context, cfg *config.Config, lastTag string) 
 		if !hasChangesIn(output, "", filesChanged) {
 			continue
 		}
-		if err := legacyRustBumpLibrary(ctx, cfg, lib, lastTag, ""); err != nil {
+		if err := legacySidekickBumpLibrary(ctx, cfg, lib, lastTag, ""); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// legacyRustBumpLibrary applies the legacy (but still in use) approach of
+// legacySidekickBumpLibrary applies the legacy (but still in use) approach of
 // assuming a single tag for the latest release, and passing that tag into the
-// rust.Bump code. (Compare this with bumpLibrary, which only uses git to derive
-// the next version.)
-func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, lastTag, versionOverride string) error {
+// rust.Bump code.
+//
+// Compare this with bumpLibrary, which only uses git to derive the next version.
+func legacySidekickBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.Library, lastTag, versionOverride string) error {
 	opts := languageVersioningOptions[cfg.Language]
 	version, err := deriveNextVersion(lib, opts, versionOverride)
 	if err != nil {
@@ -410,11 +423,13 @@ func legacyRustBumpLibrary(ctx context.Context, cfg *config.Config, lib *config.
 	switch cfg.Language {
 	case config.LanguageRust:
 		return rust.Bump(ctx, lib, output, version, command.Git, lastTag)
+	case config.LanguageSwift:
+		return swift.Bump(ctx, lib, output, version, command.Git, lastTag)
 	case config.LanguageFake:
 		lib.Version = version
 		return fakeBumpLibrary(output, version)
 	default:
-		return fmt.Errorf("%q should not be using legacyRustBumpLibrary", cfg.Language)
+		return fmt.Errorf("%q should not be using legacySidekickBumpLibrary", cfg.Language)
 	}
 }
 

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -1287,7 +1287,7 @@ func TestLegacySwiftBump(t *testing.T) {
 			opts := testhelper.SetupOptions{
 				Clone:       true,
 				Config:      cfg,
-				Tags:        []string{sample.InitialLegacySwiftTag},
+				Tags:        []string{sample.InitialSwiftTag},
 				WithChanges: test.withChanges,
 			}
 			testhelper.Setup(t, opts)
@@ -1346,11 +1346,11 @@ func TestLegacySwiftBumpAll(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			targetCfg := test.cfg
 			targetCfg.Language = config.LanguageSwift
-			sinceTag := sample.InitialLegacySwiftTag
+			sinceTag := sample.InitialSwiftTag
 			opts := testhelper.SetupOptions{
 				Clone:       true,
 				Config:      test.cfg,
-				Tags:        []string{sample.InitialLegacySwiftTag},
+				Tags:        []string{sample.InitialSwiftTag},
 				WithChanges: test.withChanges,
 			}
 			testhelper.Setup(t, opts)

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -1229,7 +1229,7 @@ func TestLegacySwiftBumpLibrary(t *testing.T) {
 			// Unused string param: lastTag.
 			err := legacySidekickBumpLibrary(t.Context(), test.cfg, targetLibCfg, testUnusedStringParam, test.versionOverride)
 			if err != nil {
-				t.Fatalf("legacyRustBumpLibrary() error = %v", err)
+				t.Fatalf("legacySidekickBumpLibrary() error = %v", err)
 			}
 			if targetLibCfg.Version != test.wantVersion {
 				t.Errorf("library %q version mismatch: want %q, got %q", targetLibCfg.Name, test.wantVersion, targetLibCfg.Version)

--- a/internal/librarian/bump_test.go
+++ b/internal/librarian/bump_test.go
@@ -661,6 +661,27 @@ func TestDeriveNextVersion(t *testing.T) {
 			wantVersion: sample.NextVersion,
 		},
 		{
+			name: "swift library next non-GA version",
+			cfg: func() *config.Config {
+				c := sample.Config()
+				c.Language = config.LanguageSwift
+				c.Libraries[0].Version = sample.SwiftNonGAVersion
+				return c
+			}(),
+			versionOpts: languageVersioningOptions[config.LanguageSwift],
+			wantVersion: sample.SwiftNextNonGAVersion,
+		},
+		{
+			name: "swift library next GA version",
+			cfg: func() *config.Config {
+				c := sample.Config()
+				c.Language = config.LanguageSwift
+				return c
+			}(),
+			versionOpts: languageVersioningOptions[config.LanguageSwift],
+			wantVersion: sample.NextVersion,
+		},
+		{
 			name:        "default semver options next GA version",
 			cfg:         sample.Config(),
 			wantVersion: sample.NextVersion,
@@ -1030,7 +1051,7 @@ func TestLegacyRustBumpLibrary(t *testing.T) {
 
 			targetLibCfg := test.cfg.Libraries[0]
 			// Unused string param: lastTag.
-			err := legacyRustBumpLibrary(t.Context(), test.cfg, targetLibCfg, testUnusedStringParam, test.versionOverride)
+			err := legacySidekickBumpLibrary(t.Context(), test.cfg, targetLibCfg, testUnusedStringParam, test.versionOverride)
 			if err != nil {
 				t.Fatalf("legacyRustBumpLibrary() error = %v", err)
 			}
@@ -1094,7 +1115,7 @@ func TestLegacyRustBump(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			if err := legacyRustBump(t.Context(), cfg, test.all, test.libraryName, test.versionOverride); err != nil {
+			if err := legacySidekickBump(t.Context(), cfg, test.all, test.libraryName, test.versionOverride); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1156,7 +1177,185 @@ func TestLegacyRustBumpAll(t *testing.T) {
 			}
 			testhelper.Setup(t, opts)
 
-			err := legacyRustBumpAll(t.Context(), targetCfg, sinceTag)
+			err := legacySidekickBumpAll(t.Context(), targetCfg, sinceTag)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// releaseAll directly modifies the config provided, so we use it as
+			// our "got".
+			gotVersion := targetCfg.Libraries[0].Version
+			if gotVersion != test.wantVersion {
+				t.Errorf("got version %s, want %s", gotVersion, test.wantVersion)
+			}
+		})
+	}
+}
+
+func TestLegacySwiftBumpLibrary(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+
+	tests := []struct {
+		name            string
+		cfg             *config.Config
+		versionOverride string
+		wantVersion     string
+	}{
+		{
+			name:        "library released",
+			cfg:         sample.Config(),
+			wantVersion: sample.NextVersion,
+		},
+		{
+			name: "version override",
+			cfg: func() *config.Config {
+				c := sample.Config()
+				c.Libraries[0].Version = "1.3.0"
+				return c
+			}(),
+			versionOverride: "2.0.0",
+			wantVersion:     "2.0.0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := testhelper.SetupOptions{
+				Clone:  true,
+				Config: test.cfg,
+			}
+			testhelper.Setup(t, opts)
+
+			targetLibCfg := test.cfg.Libraries[0]
+			// Unused string param: lastTag.
+			err := legacySidekickBumpLibrary(t.Context(), test.cfg, targetLibCfg, testUnusedStringParam, test.versionOverride)
+			if err != nil {
+				t.Fatalf("legacyRustBumpLibrary() error = %v", err)
+			}
+			if targetLibCfg.Version != test.wantVersion {
+				t.Errorf("library %q version mismatch: want %q, got %q", targetLibCfg.Name, test.wantVersion, targetLibCfg.Version)
+			}
+		})
+	}
+}
+
+func TestLegacySwiftBump(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+
+	lib1Change := filepath.Join(sample.Lib1Output, "Package.swift")
+	lib2Change := filepath.Join(sample.Lib2Output, "Package.swift")
+
+	for _, test := range []struct {
+		name            string
+		libraryName     string
+		versionOverride string
+		all             bool
+		withChanges     []string
+		wantVersions    map[string]string
+	}{
+		{
+			name:         "library name",
+			libraryName:  sample.Lib1Name,
+			withChanges:  []string{lib1Change},
+			wantVersions: map[string]string{sample.Lib1Name: sample.NextVersion},
+		},
+		{
+			name:            "library name and explicit version",
+			libraryName:     sample.Lib1Name,
+			versionOverride: "1.2.3",
+			withChanges:     []string{lib1Change},
+			wantVersions:    map[string]string{sample.Lib1Name: "1.2.3"},
+		},
+		{
+			name:        "all flag all have changes",
+			all:         true,
+			withChanges: []string{lib1Change, lib2Change},
+			wantVersions: map[string]string{
+				sample.Lib1Name: sample.NextVersion,
+				sample.Lib2Name: sample.NextVersion,
+			},
+		},
+		{
+			name:         "all flag 1 has changes",
+			all:          true,
+			withChanges:  []string{lib1Change},
+			wantVersions: map[string]string{sample.Lib1Name: sample.NextVersion},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := sample.Config()
+			cfg.Language = config.LanguageSwift
+			opts := testhelper.SetupOptions{
+				Clone:       true,
+				Config:      cfg,
+				Tags:        []string{sample.InitialLegacySwiftTag},
+				WithChanges: test.withChanges,
+			}
+			testhelper.Setup(t, opts)
+
+			if err := legacySidekickBump(t.Context(), cfg, test.all, test.libraryName, test.versionOverride); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := yaml.Read[config.Config](config.LibrarianYAML)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, lib := range got.Libraries {
+				if want, ok := test.wantVersions[lib.Name]; ok {
+					if lib.Version != want {
+						t.Errorf("library %s: got version %q, want %q", lib.Name, lib.Version, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLegacySwiftBumpAll(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+
+	for _, test := range []struct {
+		name        string
+		cfg         *config.Config
+		withChanges []string
+		skipPublish bool
+		wantVersion string
+	}{
+		{
+			name:        "library has changes",
+			cfg:         sample.Config(),
+			withChanges: []string{filepath.Join(sample.Lib1Output, "Package.swift")},
+			wantVersion: sample.NextVersion,
+		},
+		{
+			name:        "library does not have any changes",
+			cfg:         sample.Config(),
+			wantVersion: sample.InitialVersion,
+		},
+		{
+			name: "library has changes but skipPublish is true",
+			cfg: func() *config.Config {
+				c := sample.Config()
+				c.Libraries[0].SkipRelease = true
+				return c
+			}(),
+			withChanges: []string{filepath.Join(sample.Lib1Output, "Package.swift")},
+			wantVersion: sample.InitialVersion,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			targetCfg := test.cfg
+			targetCfg.Language = config.LanguageSwift
+			sinceTag := sample.InitialLegacySwiftTag
+			opts := testhelper.SetupOptions{
+				Clone:       true,
+				Config:      test.cfg,
+				Tags:        []string{sample.InitialLegacySwiftTag},
+				WithChanges: test.withChanges,
+			}
+			testhelper.Setup(t, opts)
+
+			err := legacySidekickBumpAll(t.Context(), targetCfg, sinceTag)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/rust/update_manifest_test.go
+++ b/internal/librarian/rust/update_manifest_test.go
@@ -99,7 +99,7 @@ func TestShouldBumpManifestVersionBadDiff(t *testing.T) {
 	testhelper.SetupForVersionBump(t, tag)
 	name := path.Join("src", "storage", "Cargo.toml")
 	if updated, err := shouldBumpManifestVersion(t.Context(), "git", "not-a-valid-tag", name); err == nil {
-		t.Errorf("expected an error with an valid tag, got=%v", updated)
+		t.Errorf("expected an error with an invalid tag, got=%v", updated)
 	}
 }
 

--- a/internal/librarian/swift/bump.go
+++ b/internal/librarian/swift/bump.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+var (
+	errMissingVersion = errors.New("must provide version")
+	manifestFile      = "Clients.swift"
+)
+
+// Bump checks if a version bump is required and performs it.
+// It returns without error if no bump is needed (version already updated since lastTag).
+func Bump(ctx context.Context, library *config.Library, output, version, gitExe, lastTag string) error {
+	if version == "" {
+		return errMissingVersion
+	}
+	// The location of the version file requires parsing the protos (or discovery doc), as the convention in Swift is to put the files for FooLibrary in the FooLibrary directory.
+	var actualFile string
+	err := filepath.WalkDir(filepath.Join(output, "Sources"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Base(path) == manifestFile {
+			actualFile = path
+		}
+		return nil
+	})
+	if actualFile == "" {
+		return nil
+	}
+	skip, err := versionAlreadyBumped(ctx, gitExe, lastTag, actualFile)
+	if err != nil {
+		return err
+	}
+	if skip {
+		return nil
+	}
+	library.Version = version
+	return nil
+}
+
+// versionAlreadyBumped checks if the version was bumped since the last release.
+//
+// `librarian bump` should be idempotent until the next release. That makes it
+// safe to run the command multiple times until a release is out, and allows
+// manual tweaks of the version if needed.
+func versionAlreadyBumped(ctx context.Context, gitExe, lastTag, versionFile string) (bool, error) {
+	delta := fmt.Sprintf("%s..HEAD", lastTag)
+	contents, err := command.Output(ctx, gitExe, "diff", delta, "--", versionFile)
+	if err != nil {
+		return false, err
+	}
+	lines := strings.Split(contents, "\n")
+	found := slices.ContainsFunc(lines, func(line string) bool {
+		return strings.HasPrefix(line, "+") && strings.Contains(line, "packageVersion:")
+	})
+	return found, nil
+}

--- a/internal/librarian/swift/bump.go
+++ b/internal/librarian/swift/bump.go
@@ -49,6 +49,9 @@ func Bump(ctx context.Context, library *config.Library, output, version, gitExe,
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 	if actualFile == "" {
 		return nil
 	}

--- a/internal/librarian/swift/bump_test.go
+++ b/internal/librarian/swift/bump_test.go
@@ -67,7 +67,7 @@ func TestVersionAlreadyBumpedNewPackage(t *testing.T) {
 	testhelper.RunGit(t, "add", ".")
 	testhelper.RunGit(t, "commit", "-m", "new package", ".")
 
-	name := testManifest()
+	name := path.Join(testPackageName, "Sources", "GoogleCloudNew", manifestFile)
 	bumped, err := versionAlreadyBumped(t.Context(), "git", tag, name)
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func TestVersionAlreadyBumpedBadDiff(t *testing.T) {
 	setupForSwiftVersionBump(t, tag)
 	name := testManifest()
 	if updated, err := versionAlreadyBumped(t.Context(), "git", "not-a-valid-tag", name); err == nil {
-		t.Errorf("expected an error with an valid tag, got=%v", updated)
+		t.Errorf("expected an error with an invalid tag, got=%v", updated)
 	}
 }
 
@@ -107,7 +107,7 @@ func TestVersionBadDirectory(t *testing.T) {
 	setupForSwiftVersionBump(t, tag)
 	name := path.Join("not-the-right-package", "Sources", "NotTheRightLibrary", manifestFile)
 	if updated, err := versionAlreadyBumped(t.Context(), "git", "not-a-valid-tag", name); err == nil {
-		t.Errorf("expected an error with an valid tag, got=%v", updated)
+		t.Errorf("expected an error with an invalid tag, got=%v", updated)
 	}
 }
 

--- a/internal/librarian/swift/bump_test.go
+++ b/internal/librarian/swift/bump_test.go
@@ -82,12 +82,12 @@ func TestVersionAlreadyBumpedNoChange(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 	setupForSwiftVersionBump(t, tag)
 	name := testManifest()
-	ok, err := versionAlreadyBumped(t.Context(), "git", tag, name)
+	bumped, err := versionAlreadyBumped(t.Context(), "git", tag, name)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok {
-		t.Errorf("expected versionAlreadyBumped() == true, got false")
+	if bumped {
+		t.Errorf("expected versionAlreadyBumped() == false, got true")
 	}
 }
 

--- a/internal/librarian/swift/bump_test.go
+++ b/internal/librarian/swift/bump_test.go
@@ -40,6 +40,9 @@ func TestVersionAlreadyBumpedSuccess(t *testing.T) {
 
 	name := testManifest()
 	contents, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
 	contents = bytes.ReplaceAll(contents, []byte("1.0.0"), []byte("2.3.4"))
 	if err := os.WriteFile(name, contents, 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/librarian/swift/bump_test.go
+++ b/internal/librarian/swift/bump_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"bytes"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+const (
+	testLibraryName = "GoogleCloudSecretManagerV1"
+	testPackageName = "google-cloud-secretmanager-v1"
+)
+
+func testManifest() string {
+	return path.Join(testPackageName, "Sources", testLibraryName, manifestFile)
+}
+
+func TestVersionAlreadyBumpedSuccess(t *testing.T) {
+	const tag = "package-version-update-success"
+	testhelper.RequireCommand(t, "git")
+	setupForSwiftVersionBump(t, tag)
+
+	name := testManifest()
+	contents, err := os.ReadFile(name)
+	contents = bytes.ReplaceAll(contents, []byte("1.0.0"), []byte("2.3.4"))
+	if err := os.WriteFile(name, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testhelper.RunGit(t, "commit", "-m", "updated version", ".")
+
+	bumped, err := versionAlreadyBumped(t.Context(), "git", tag, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bumped {
+		t.Errorf("expected versionAlreadyBumped() == true, got false")
+	}
+}
+
+func TestVersionAlreadyBumpedNewPackage(t *testing.T) {
+	const tag = "package-version-update-new-package"
+	testhelper.RequireCommand(t, "git")
+	setupForSwiftVersionBump(t, tag)
+
+	testhelper.AddSwiftPackage(t, "google-cloud-new", "GoogleCloudNew")
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "new package", ".")
+
+	name := testManifest()
+	bumped, err := versionAlreadyBumped(t.Context(), "git", tag, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bumped {
+		t.Errorf("expected versionAlreadyBumped() == false on a new package, got true")
+	}
+}
+
+func TestVersionAlreadyBumpedNoChange(t *testing.T) {
+	const tag = "package-version-update-no-change"
+	testhelper.RequireCommand(t, "git")
+	setupForSwiftVersionBump(t, tag)
+	name := testManifest()
+	ok, err := versionAlreadyBumped(t.Context(), "git", tag, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Errorf("expected versionAlreadyBumped() == true, got false")
+	}
+}
+
+func TestVersionAlreadyBumpedBadDiff(t *testing.T) {
+	const tag = "package-version-update-success"
+	testhelper.RequireCommand(t, "git")
+	setupForSwiftVersionBump(t, tag)
+	name := testManifest()
+	if updated, err := versionAlreadyBumped(t.Context(), "git", "not-a-valid-tag", name); err == nil {
+		t.Errorf("expected an error with an valid tag, got=%v", updated)
+	}
+}
+
+func TestVersionBadDirectory(t *testing.T) {
+	const tag = "package-version-update-success"
+	testhelper.RequireCommand(t, "git")
+	setupForSwiftVersionBump(t, tag)
+	name := path.Join("not-the-right-package", "Sources", "NotTheRightLibrary", manifestFile)
+	if updated, err := versionAlreadyBumped(t.Context(), "git", "not-a-valid-tag", name); err == nil {
+		t.Errorf("expected an error with an valid tag, got=%v", updated)
+	}
+}
+
+func setupForSwiftVersionBump(t *testing.T, wantTag string) {
+	remoteDir := t.TempDir()
+	testhelper.ContinueInNewGitRepository(t, remoteDir)
+	testhelper.AddSwiftPackage(t, testPackageName, testLibraryName)
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "initial version")
+	testhelper.RunGit(t, "tag", wantTag)
+	cloneDir := t.TempDir()
+	t.Chdir(cloneDir)
+	testhelper.RunGit(t, "clone", remoteDir, ".")
+	testhelper.RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
+	testhelper.ConfigNewGitRepository(t)
+}

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -59,10 +59,10 @@ const (
 	// RustNextNonGAVersion is the next version of non-GA Rust client library
 	// starting from [RustNonGAVersion].
 	RustNextNonGAVersion = "0.1.1-beta"
-	// SwiftNonGAVersion is a non-GA client library version typical of a Rust
+	// SwiftNonGAVersion is a non-GA client library version typical of a Swift
 	// client library.
 	SwiftNonGAVersion = "0.1.0-preview"
-	// SwiftNextNonGAVersion is the next version of non-GA Rust client library
+	// SwiftNextNonGAVersion is the next version of non-GA Swift client library
 	// starting from [RustNonGAVersion].
 	SwiftNextNonGAVersion = "0.2.0-preview"
 )

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -32,6 +32,9 @@ const (
 	// InitialLegacyRustTag is the tag form of [InitialVersion] for use in
 	// tests of the legacy Rust behavior where each release has a single tag.
 	InitialLegacyRustTag = "v1.0.0"
+	// InitialLegacyRustTag is the tag form of [InitialVersion] for use in
+	// tests of the legacy Rust behavior where each release has a single tag.
+	InitialLegacySwiftTag = "v1.0.0"
 	// InitialLib1Tag is the tag form of [Lib1Name] [InitialVersion] for use in
 	// tests.
 	InitialLib1Tag = "google-cloud-storage/v1.0.0"
@@ -56,6 +59,12 @@ const (
 	// RustNextNonGAVersion is the next version of non-GA Rust client library
 	// starting from [RustNonGAVersion].
 	RustNextNonGAVersion = "0.1.1-beta"
+	// SwiftNonGAVersion is a non-GA client library version typical of a Rust
+	// client library.
+	SwiftNonGAVersion = "0.1.0-preview"
+	// SwiftNextNonGAVersion is the next version of non-GA Rust client library
+	// starting from [RustNonGAVersion].
+	SwiftNextNonGAVersion = "0.2.0-preview"
 )
 
 var (

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -32,9 +32,9 @@ const (
 	// InitialLegacyRustTag is the tag form of [InitialVersion] for use in
 	// tests of the legacy Rust behavior where each release has a single tag.
 	InitialLegacyRustTag = "v1.0.0"
-	// InitialLegacyRustTag is the tag form of [InitialVersion] for use in
-	// tests of the legacy Rust behavior where each release has a single tag.
-	InitialLegacySwiftTag = "v1.0.0"
+	// InitialSwiftTag is the tag form of [InitialVersion] for use in
+	// tests of the Swift behavior where each release has a single tag.
+	InitialSwiftTag = "preview-20260809"
 	// InitialLib1Tag is the tag form of [Lib1Name] [InitialVersion] for use in
 	// tests.
 	InitialLib1Tag = "google-cloud-storage/v1.0.0"

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -163,7 +163,7 @@ func AddCrate(t *testing.T, location, name string) {
 func AddSwiftPackage(t *testing.T, location, name string) {
 	t.Helper()
 	_ = os.MkdirAll(path.Join(location, "Sources", name), 0o755)
-	contents := fmt.Appendf(nil, InitialCargoContents, name)
+	contents := fmt.Appendf(nil, "// Swift package %s\n", name)
 	if err := os.WriteFile(path.Join(location, "Package.swift"), contents, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -67,6 +67,13 @@ version = "1.0.0"
 
 	// testRemoteURL is the URL set for the [TestRemote] in the test repository.
 	testRemoteURL = "https://example.com/git.git"
+
+	// initialClientsSwiftContents defines the initial content for a Clients.swift file.
+	initialClientsSwiftContents = `import GoogleCloudGax
+
+public enum Clients {
+  static let clientHeader: Swift.String = GoogleCloudGax._gapicApiClientHeader(packageVersion: "1.0.0")
+}`
 )
 
 // SetupForVersionBump sets up a git repository for testing version bumping scenarios.
@@ -79,7 +86,7 @@ func SetupForVersionBump(t *testing.T, wantTag string) {
 	t.Chdir(cloneDir)
 	RunGit(t, "clone", remoteDir, ".")
 	RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
-	configNewGitRepository(t)
+	ConfigNewGitRepository(t)
 }
 
 // ContinueInNewGitRepository initializes a new git repository in a temporary directory
@@ -89,10 +96,11 @@ func ContinueInNewGitRepository(t *testing.T, tmpDir string) {
 	RequireCommand(t, command.Git)
 	t.Chdir(tmpDir)
 	RunGit(t, "init", "-b", config.BranchMain)
-	configNewGitRepository(t)
+	ConfigNewGitRepository(t)
 }
 
-func configNewGitRepository(t *testing.T) {
+// ConfigNewGitRepository configures a test repository so we can commit changes.
+func ConfigNewGitRepository(t *testing.T) {
 	RunGit(t, "config", "user.email", "test@test-only.com")
 	RunGit(t, "config", "user.name", "Test Account")
 	RunGit(t, "config", "gc.auto", "0")
@@ -111,6 +119,18 @@ func initRepositoryContents(t *testing.T) {
 	AddCrate(t, sample.Lib2Output, sample.Lib2Name)
 	AddCrate(t, path.Join(sample.Lib2Output, "echo-server"), "echo-server")
 	addGeneratedCrate(t, path.Join("src", "generated", "cloud", "secretmanager", "v1"), "google-cloud-secretmanager-v1")
+	RunGit(t, "add", ".")
+	RunGit(t, "commit", "-m", "initial version")
+}
+
+func initSwiftRepositoryContents(t *testing.T) {
+	t.Helper()
+	RequireCommand(t, command.Git)
+	if err := os.WriteFile(ReadmeFile, []byte(ReadmeContents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	AddSwiftPackage(t, sample.Lib1Output, sample.Lib1Name)
+	AddSwiftPackage(t, sample.Lib2Output, sample.Lib2Name)
 	RunGit(t, "add", ".")
 	RunGit(t, "commit", "-m", "initial version")
 }
@@ -139,12 +159,37 @@ func AddCrate(t *testing.T, location, name string) {
 	}
 }
 
+// AddSwiftPackage creates a new Swift package at the specified location with the given name.
+func AddSwiftPackage(t *testing.T, location, name string) {
+	t.Helper()
+	_ = os.MkdirAll(path.Join(location, "Sources", name), 0o755)
+	contents := fmt.Appendf(nil, InitialCargoContents, name)
+	if err := os.WriteFile(path.Join(location, "Package.swift"), contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(location, "Sources", name, "Clients.swift"), []byte(initialClientsSwiftContents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(location, ".repo-metadata.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // SetupRepo creates a git repository for testing with some initial content. It
 // returns the path of the remote repository.
 func SetupRepo(t *testing.T) string {
 	remoteDir := t.TempDir()
 	ContinueInNewGitRepository(t, remoteDir)
 	initRepositoryContents(t)
+	return remoteDir
+}
+
+// SetupRepo creates a git repository for testing with some initial content. It
+// returns the path of the remote repository.
+func SetupSwiftRepo(t *testing.T) string {
+	remoteDir := t.TempDir()
+	ContinueInNewGitRepository(t, remoteDir)
+	initSwiftRepositoryContents(t)
 	return remoteDir
 }
 
@@ -175,8 +220,11 @@ type SetupOptions struct {
 // configured [SetupOptions].
 func Setup(t *testing.T, opts SetupOptions) {
 	t.Helper()
-	dir := SetupRepo(t)
-	opts.remoteDir = dir
+	if opts.Config != nil && opts.Config.Language == config.LanguageSwift {
+		opts.remoteDir = SetupSwiftRepo(t)
+	} else {
+		opts.remoteDir = SetupRepo(t)
+	}
 	setup(t, opts)
 }
 
@@ -259,7 +307,7 @@ func CloneRepositoryBranch(t *testing.T, remoteDir, branch string) {
 	t.Chdir(cloneDir)
 	RunGit(t, "clone", "--branch", branch, remoteDir, ".")
 	RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
-	configNewGitRepository(t)
+	ConfigNewGitRepository(t)
 }
 
 // RunGit runs git with the specified arguments, aborting the test on any error.

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -184,8 +184,14 @@ func SetupRepo(t *testing.T) string {
 	return remoteDir
 }
 
-// SetupRepo creates a git repository for testing with some initial content. It
-// returns the path of the remote repository.
+// SetupSwiftRepo creates a git repository configured to test the `bump` command.
+//
+// In the tests we need a repository with:
+// - An upstream remote
+// - A previous tag
+// - The minimal contents to simulate some package version bumps
+//
+// Returns the path of the remote repository.
 func SetupSwiftRepo(t *testing.T) string {
 	remoteDir := t.TempDir()
 	ContinueInNewGitRepository(t, remoteDir)


### PR DESCRIPTION
Implement a `bump` command for Swith. At least at the moment, Swift uses the same strategy as Rust: a single tag marks the latest release, and we bump the packages that have not received a bump since that tag.

Towards googleapis/google-cloud-swift#450 