### PR TITLE
fix(swift): fix sub-module imports

### DIFF
--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -267,7 +267,6 @@ func (c *codec) skipDependency(dep *Dependency) bool {
 	// During conversion generation, the raw Protobuf stubs module (c.ModulePath, e.g., "StorageControlProtos")
 	// is already statically imported via internal import statements in the conversion file template.
 	// We skip it dynamically to avoid emitting duplicate "import StorageControlProtos" statements.
-	// if c.Module && dep.Name == c.ModulePath {
 	if c.Module && dep.Name == c.ModulePath {
 		return true
 	}

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -58,16 +58,16 @@ type codec struct {
 	// contains a single target and module with the same names as the library.
 	LibraryName string
 
-	// TargetPackageName is the PascalCase name of the Swift SPM target/package being built
+	// TargetLibraryName is the PascalCase name of the Swift SPM target/library being built
 	// (e.g. "GoogleCloudSecretManagerV1", "GoogleCloudStorage", or "GoogleCloudWkt").
 	//
-	// We need TargetPackageName to correctly identify self-imports in skipDependency.
+	// We need TargetLibraryName to correctly identify self-imports in skipDependency.
 	//
 	// In librarian.yaml, "modules" refers to individual generator
 	// sub-components (such as messages, or convert-swift for wkt/google.type). However,
-	// all those generated files are compiled into a single overarching Swift package target
+	// all those generated files are compiled into a single overarching Swift library target
 	// named after the PascalCase version of library.Name.
-	TargetPackageName string
+	TargetLibraryName string
 
 	// The name of the Swift package (e.g. "google-cloud-secretmanager-v1").
 	PackageName string
@@ -207,17 +207,15 @@ func newCodec(model *api.API, library *config.Library, module *config.SwiftModul
 		result.ModulePath = module.ModulePath
 	}
 
-	if result.Module {
-		if library != nil && library.Name != "" {
-			result.TargetPackageName = pascalCaseNoMangling(library.Name)
-		}
-	} else {
-		libraryName, err := LibraryName(model, swiftCfg)
-		if err != nil {
-			return nil, err
-		}
+	libraryName, err := LibraryName(model, swiftCfg)
+	if err != nil {
+		return nil, err
+	}
+	result.TargetLibraryName = libraryName
+
+	if !result.Module {
+		// Modules cannot have library names, so they should not try to set the value.
 		result.LibraryName = libraryName
-		result.TargetPackageName = libraryName
 	}
 	return result, nil
 }
@@ -259,8 +257,8 @@ func (c *codec) skipDependency(dep *Dependency) bool {
 		return true
 	}
 
-	// Do not import the Swift SPM package target that we are currently compiling into.
-	if c.TargetPackageName != "" && dep.Name == c.TargetPackageName {
+	// Do not import the Swift SPM library target that we are currently compiling into.
+	if c.TargetLibraryName != "" && dep.Name == c.TargetLibraryName {
 		return true
 	}
 

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -58,6 +58,17 @@ type codec struct {
 	// contains a single target and module with the same names as the library.
 	LibraryName string
 
+	// TargetPackageName is the PascalCase name of the Swift SPM target/package being built
+	// (e.g. "GoogleCloudSecretManagerV1", "GoogleCloudStorage", or "GoogleCloudWkt").
+	//
+	// We need TargetPackageName to correctly identify self-imports in skipDependency.
+	//
+	// In librarian.yaml, "modules" refers to individual generator
+	// sub-components (such as messages, or convert-swift for wkt/google.type). However,
+	// all those generated files are compiled into a single overarching Swift package target
+	// named after the PascalCase version of library.Name.
+	TargetPackageName string
+
 	// The name of the Swift package (e.g. "google-cloud-secretmanager-v1").
 	PackageName string
 
@@ -196,12 +207,17 @@ func newCodec(model *api.API, library *config.Library, module *config.SwiftModul
 		result.ModulePath = module.ModulePath
 	}
 
-	if !result.Module {
+	if result.Module {
+		if library != nil && library.Name != "" {
+			result.TargetPackageName = pascalCaseNoMangling(library.Name)
+		}
+	} else {
 		libraryName, err := LibraryName(model, swiftCfg)
 		if err != nil {
 			return nil, err
 		}
 		result.LibraryName = libraryName
+		result.TargetPackageName = libraryName
 	}
 	return result, nil
 }
@@ -228,12 +244,33 @@ func (c *codec) addDependency(dep *Dependency) (*Dependency, error) {
 	if dep == nil {
 		return nil, fmt.Errorf("attempting to add nil dependency")
 	}
-	// Skip including self as a dependency
-	if dep.Name == c.LibraryName || (c.Module && dep.Name == c.ModulePath) {
+	if c.skipDependency(dep) {
 		return nil, nil
 	}
 	if ann, ok := c.Model.Codec.(*modelAnnotations); ok {
 		ann.DependsOn[dep.Name] = dep
 	}
 	return dep, nil
+}
+
+// skipDependency returns true if the dependency should be omitted from imports and dependency lists.
+func (c *codec) skipDependency(dep *Dependency) bool {
+	if dep == nil {
+		return true
+	}
+
+	// Do not import the Swift SPM package target that we are currently compiling into.
+	if c.TargetPackageName != "" && dep.Name == c.TargetPackageName {
+		return true
+	}
+
+	// During conversion generation, the raw Protobuf stubs module (c.ModulePath, e.g., "StorageControlProtos")
+	// is already statically imported via internal import statements in the conversion file template.
+	// We skip it dynamically to avoid emitting duplicate "import StorageControlProtos" statements.
+	// if c.Module && dep.Name == c.ModulePath {
+	if c.Module && dep.Name == c.ModulePath {
+		return true
+	}
+
+	return false
 }

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -40,6 +40,7 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				GenerationYear:     "2038",
 				LibraryName:        "Test",
+				TargetPackageName:  "Test",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -60,6 +61,7 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				GenerationYear:     "2038",
 				LibraryName:        "Test",
+				TargetPackageName:  "Test",
 				PackageName:        "google-cloud-bigtable",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -72,6 +74,7 @@ func TestParseOptions(t *testing.T) {
 		{
 			name: "module",
 			library: &config.Library{
+				Name:          "google-cloud-wkt",
 				CopyrightYear: "2038",
 			},
 			module: &config.SwiftModule{
@@ -80,6 +83,7 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				Module:             true,
 				GenerationYear:     "2038",
+				TargetPackageName:  "GoogleCloudWkt",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -99,6 +103,7 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				GenerationYear:     "2038",
 				LibraryName:        "Test",
+				TargetPackageName:  "Test",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -302,4 +307,66 @@ func makeRequiredServicesTestModel() *api.API {
 	model.AddService(externalService)
 	api.CrossReference(model)
 	return model
+}
+
+func TestSkipDependency(t *testing.T) {
+	tests := []struct {
+		name              string
+		targetPackageName string
+		libraryName       string
+		packageName       string
+		module            bool
+		depName           string
+		wantSkip          bool
+	}{
+		{
+			name:              "multi-module self import skipped (e.g. wkt messages importing GoogleCloudWkt)",
+			targetPackageName: "GoogleCloudWkt",
+			packageName:       "google-protobuf",
+			module:            true,
+			depName:           "GoogleCloudWkt",
+			wantSkip:          true,
+		},
+		{
+			name:              "multi-module non-self import preserved (e.g. storage convert importing GoogleType)",
+			targetPackageName: "GoogleCloudStorage",
+			packageName:       "GoogleType",
+			module:            true,
+			depName:           "GoogleType",
+			wantSkip:          false,
+		},
+		{
+			name:              "single-module self import skipped",
+			targetPackageName: "GoogleCloudSecretManagerV1",
+			libraryName:       "GoogleCloudSecretManagerV1",
+			packageName:       "google-cloud-secretmanager-v1",
+			module:            false,
+			depName:           "GoogleCloudSecretManagerV1",
+			wantSkip:          true,
+		},
+		{
+			name:              "single-module non-self import preserved",
+			targetPackageName: "GoogleCloudSecretManagerV1",
+			libraryName:       "GoogleCloudSecretManagerV1",
+			packageName:       "google-cloud-secretmanager-v1",
+			module:            false,
+			depName:           "GoogleCloudGax",
+			wantSkip:          false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &codec{
+				TargetPackageName: tc.targetPackageName,
+				LibraryName:       tc.libraryName,
+				PackageName:       tc.packageName,
+				Module:            tc.module,
+			}
+			dep := &Dependency{SwiftDependency: config.SwiftDependency{Name: tc.depName}}
+			got := c.skipDependency(dep)
+			if got != tc.wantSkip {
+				t.Errorf("skipDependency(%q) = %v, want %v", tc.depName, got, tc.wantSkip)
+			}
+		})
+	}
 }

--- a/internal/sidekick/swift/codec_test.go
+++ b/internal/sidekick/swift/codec_test.go
@@ -40,7 +40,7 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				GenerationYear:     "2038",
 				LibraryName:        "Test",
-				TargetPackageName:  "Test",
+				TargetLibraryName:  "Test",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -61,7 +61,7 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				GenerationYear:     "2038",
 				LibraryName:        "Test",
-				TargetPackageName:  "Test",
+				TargetLibraryName:  "Test",
 				PackageName:        "google-cloud-bigtable",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -76,6 +76,9 @@ func TestParseOptions(t *testing.T) {
 			library: &config.Library{
 				Name:          "google-cloud-wkt",
 				CopyrightYear: "2038",
+				Swift: &config.SwiftPackage{
+					LibraryNameOverride: "GoogleCloudWkt",
+				},
 			},
 			module: &config.SwiftModule{
 				ModulePath: "GoogleTestProtos",
@@ -83,8 +86,35 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				Module:             true,
 				GenerationYear:     "2038",
-				TargetPackageName:  "GoogleCloudWkt",
+				TargetLibraryName:  "GoogleCloudWkt",
 				PackageName:        "test",
+				PackageVersion:     "0.0.0",
+				MonorepoRoot:       ".",
+				Model:              model,
+				ModulePath:         "GoogleTestProtos",
+				ApiPackages:        map[string]*Dependency{},
+				DependenciesByName: map[string]*Dependency{},
+				ResponseEncoding:   defaultResponseEncoding,
+			},
+		},
+		{
+			name: "module with library name override",
+			library: &config.Library{
+				Name:          "google-cloud-bigquery",
+				CopyrightYear: "2038",
+				Swift: &config.SwiftPackage{
+					PackageNameOverride: "GoogleCloudBigQuery",
+					LibraryNameOverride: "GoogleCloudBigQuery",
+				},
+			},
+			module: &config.SwiftModule{
+				ModulePath: "GoogleTestProtos",
+			},
+			want: &codec{
+				Module:             true,
+				GenerationYear:     "2038",
+				TargetLibraryName:  "GoogleCloudBigQuery",
+				PackageName:        "GoogleCloudBigQuery",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
 				Model:              model,
@@ -103,7 +133,7 @@ func TestParseOptions(t *testing.T) {
 			want: &codec{
 				GenerationYear:     "2038",
 				LibraryName:        "Test",
-				TargetPackageName:  "Test",
+				TargetLibraryName:  "Test",
 				PackageName:        "test",
 				PackageVersion:     "0.0.0",
 				MonorepoRoot:       ".",
@@ -310,9 +340,9 @@ func makeRequiredServicesTestModel() *api.API {
 }
 
 func TestSkipDependency(t *testing.T) {
-	tests := []struct {
+	for _, tc := range []struct {
 		name              string
-		targetPackageName string
+		targetLibraryName string
 		libraryName       string
 		packageName       string
 		module            bool
@@ -321,7 +351,7 @@ func TestSkipDependency(t *testing.T) {
 	}{
 		{
 			name:              "multi-module self import skipped (e.g. wkt messages importing GoogleCloudWkt)",
-			targetPackageName: "GoogleCloudWkt",
+			targetLibraryName: "GoogleCloudWkt",
 			packageName:       "google-protobuf",
 			module:            true,
 			depName:           "GoogleCloudWkt",
@@ -329,7 +359,7 @@ func TestSkipDependency(t *testing.T) {
 		},
 		{
 			name:              "multi-module non-self import preserved (e.g. storage convert importing GoogleType)",
-			targetPackageName: "GoogleCloudStorage",
+			targetLibraryName: "GoogleCloudStorage",
 			packageName:       "GoogleType",
 			module:            true,
 			depName:           "GoogleType",
@@ -337,7 +367,7 @@ func TestSkipDependency(t *testing.T) {
 		},
 		{
 			name:              "single-module self import skipped",
-			targetPackageName: "GoogleCloudSecretManagerV1",
+			targetLibraryName: "GoogleCloudSecretManagerV1",
 			libraryName:       "GoogleCloudSecretManagerV1",
 			packageName:       "google-cloud-secretmanager-v1",
 			module:            false,
@@ -346,18 +376,17 @@ func TestSkipDependency(t *testing.T) {
 		},
 		{
 			name:              "single-module non-self import preserved",
-			targetPackageName: "GoogleCloudSecretManagerV1",
+			targetLibraryName: "GoogleCloudSecretManagerV1",
 			libraryName:       "GoogleCloudSecretManagerV1",
 			packageName:       "google-cloud-secretmanager-v1",
 			module:            false,
 			depName:           "GoogleCloudGax",
 			wantSkip:          false,
 		},
-	}
-	for _, tc := range tests {
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &codec{
-				TargetPackageName: tc.targetPackageName,
+				TargetLibraryName: tc.targetLibraryName,
 				LibraryName:       tc.libraryName,
 				PackageName:       tc.packageName,
 				Module:            tc.module,


### PR DESCRIPTION
Fix incorrect dependency import generation for module. 

Introducing `TargetPackageName` to `codec` and updating `skipDependency()` to evaluate self-imports against the Swift SPM target name. 

yields https://github.com/googleapis/google-cloud-swift/pull/76