### PR TITLE
fix(java): batch formatting and run GJF twice

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -245,9 +245,9 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 			if err := java.Generate(ctx, cfg, library, src); err != nil {
 				return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
 			}
-			if err := java.Format(ctx, library); err != nil {
-				return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
-			}
+		}
+		if err := java.FormatLibraries(ctx, libraries); err != nil {
+			return fmt.Errorf("format libraries (%s): %w", cfg.Language, err)
 		}
 		return java.PostGenerate(ctx, ".", cfg)
 	case config.LanguageNodejs:

--- a/internal/librarian/java/format.go
+++ b/internal/librarian/java/format.go
@@ -25,22 +25,32 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-// Format formats a Java client library using google-java-format.
-func Format(ctx context.Context, library *config.Library) error {
-	files, err := collectJavaFiles(library.Output)
-	if err != nil {
-		return fmt.Errorf("failed to find java files for formatting: %w", err)
+// FormatLibraries formats multiple Java client libraries using google-java-format in a single batch.
+func FormatLibraries(ctx context.Context, libraries []*config.Library) error {
+	var allFiles []string
+	for _, library := range libraries {
+		files, err := collectJavaFiles(library.Output)
+		if err != nil {
+			return fmt.Errorf("failed to find java files for formatting in %q: %w", library.Output, err)
+		}
+		allFiles = append(allFiles, files...)
 	}
-	if len(files) == 0 {
+	if len(allFiles) == 0 {
 		return nil
 	}
-	args := append([]string{"--replace"}, files...)
+	args := append([]string{"--replace"}, allFiles...)
 	env, err := getToolsEnv()
 	if err != nil {
 		return err
 	}
+	// Run google-java-format twice.
+	// The first run removes unused imports but might leave extra empty lines.
+	// The second run collapses those empty lines.
 	if err := command.RunWithEnv(ctx, env, "google-java-format", args...); err != nil {
-		return fmt.Errorf("failed to format files: %w", err)
+		return fmt.Errorf("failed to format files (pass 1): %w", err)
+	}
+	if err := command.RunWithEnv(ctx, env, "google-java-format", args...); err != nil {
+		return fmt.Errorf("failed to format files (pass 2): %w", err)
 	}
 	return nil
 }

--- a/internal/librarian/java/format.go
+++ b/internal/librarian/java/format.go
@@ -46,6 +46,7 @@ func FormatLibraries(ctx context.Context, libraries []*config.Library) error {
 	// Run google-java-format twice.
 	// The first run removes unused imports but might leave extra empty lines.
 	// The second run collapses those empty lines.
+	// TODO(https://github.com/google/google-java-format/issues/1436): Remove second pass once fixed upstream.
 	if err := command.RunWithEnv(ctx, env, "google-java-format", args...); err != nil {
 		return fmt.Errorf("failed to format files (pass 1): %w", err)
 	}

--- a/internal/librarian/java/format_test.go
+++ b/internal/librarian/java/format_test.go
@@ -15,6 +15,7 @@
 package java
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"sort"
@@ -73,8 +74,8 @@ func TestFormat(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			test.setup(t, tmpDir)
-			if err := Format(t.Context(), &config.Library{Output: tmpDir}); err != nil {
-				t.Errorf("Format() error = %v, want nil", err)
+			if err := FormatLibraries(t.Context(), []*config.Library{{Output: tmpDir}}); err != nil {
+				t.Errorf("FormatLibraries() error = %v, want nil", err)
 			}
 		})
 	}
@@ -86,9 +87,9 @@ func TestFormat_LookPathError(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", "")
-	err := Format(t.Context(), &config.Library{Output: tmpDir})
+	err := FormatLibraries(t.Context(), []*config.Library{{Output: tmpDir}})
 	if err == nil {
-		t.Fatal(err)
+		t.Fatal("expected error, got nil")
 	}
 }
 
@@ -126,5 +127,48 @@ func TestCollectJavaFiles(t *testing.T) {
 	sort.Strings(want)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFormatLibraries_MultipleLibraries(t *testing.T) {
+	testhelper.RequireCommand(t, "google-java-format")
+	t.Parallel()
+	tmpDir1 := t.TempDir()
+	tmpDir2 := t.TempDir()
+	// Create unformatted files in both directories.
+	// They have extra blank lines which should be collapsed.
+	content1 := []byte("package test;\n\n\npublic class One {}")
+	content2 := []byte("package test;\n\n\npublic class Two {}")
+	file1 := filepath.Join(tmpDir1, "One.java")
+	file2 := filepath.Join(tmpDir2, "Two.java")
+	if err := os.WriteFile(file1, content1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file2, content2, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	libraries := []*config.Library{
+		{Output: tmpDir1},
+		{Output: tmpDir2},
+	}
+	if err := FormatLibraries(t.Context(), libraries); err != nil {
+		t.Fatalf("FormatLibraries() error = %v, want nil", err)
+	}
+	// Verify both files were formatted (empty lines collapsed).
+	wantContent1 := []byte("package test;\n\npublic class One {}\n")
+	wantContent2 := []byte("package test;\n\npublic class Two {}\n")
+	gotContent1, err := os.ReadFile(file1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotContent2, err := os.ReadFile(file2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotContent1, wantContent1) {
+		t.Errorf("file1 content mismatch\ngot:  %q\nwant: %q", gotContent1, wantContent1)
+	}
+	if !bytes.Equal(gotContent2, wantContent2) {
+		t.Errorf("file2 content mismatch\ngot:  %q\nwant: %q", gotContent2, wantContent2)
 	}
 }


### PR DESCRIPTION
An upstream google-java-format bug leaves extra blank lines when removing unused imports generated in some gRPC stubs, causing CI lint failures.

This PR temporarily fix by running GJF twice to collapse the leftover whitespace. It also  implements a batch formatting optimization that runs GJF once for all generated libraries.

For https://github.com/googleapis/librarian/issues/7146