### PR TITLE
chore(nodejs): remove .OwlBot.yaml reference from clean list

### DIFF
--- a/internal/librarian/nodejs/clean.go
+++ b/internal/librarian/nodejs/clean.go
@@ -32,8 +32,6 @@ var (
 		"protos/protos.d.ts",
 		"protos/protos.js",
 		"protos/protos.json",
-		// TODO(https://github.com/googleapis/librarian/issues/6049): remove
-		// files that are no longer being generated, e.g. .OwlBot.yaml
 		"samples/package.json",
 		"package.json",
 		"tsconfig.json",
@@ -42,7 +40,6 @@ var (
 		".gitignore",
 		".nycrc",
 		"README.md",
-		".OwlBot.yaml",
 	}
 	sourceDirectoriesToClean = []string{
 		"samples",


### PR DESCRIPTION
Remove `.OwlBot.yaml` from the `simpleFilesToClean` cleanup array in `internal/librarian/nodejs/clean.go`.

During legacy onboarding and library generation, OwlBot required `.OwlBot.yaml` configuration files to execute synthtool post-processing. Verification across `googleapis/google-cloud-node` confirms that `.OwlBot.yaml` files are no longer generated or present in automated GAPIC packages, having been completely replaced by centralized `librarian.yaml` workflows. Removing this legacy file reference eliminates unnecessary filesystem inspection during generation runs.

For https://github.com/googleapis/librarian/issues/6049