### PR TITLE
refactor(internal/librarian/php): move `DefaultOutput` to internal/librarian/php/defaut.go

### DIFF
--- a/internal/librarian/php/default.go
+++ b/internal/librarian/php/default.go
@@ -20,6 +20,12 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+// DefaultOutput derives an output path from a library name and a default
+// output directory.
+func DefaultOutput(name, defaultOutput string) string {
+	return filepath.Join(defaultOutput, name)
+}
+
 // Fill populates default PHP configuration values for the library.
 func Fill(lib *config.Library) *config.Library {
 	return fillStagingSubdir(lib)

--- a/internal/librarian/php/default_test.go
+++ b/internal/librarian/php/default_test.go
@@ -21,6 +21,35 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+func TestDefaultOutput(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		libName       string
+		defaultOutput string
+		want          string
+	}{
+		{
+			name:          "standard",
+			libName:       "Ces",
+			defaultOutput: "packages",
+			want:          "packages/Ces",
+		},
+		{
+			name:          "empty default",
+			libName:       "Ces",
+			defaultOutput: "",
+			want:          "Ces",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultOutput(test.libName, test.defaultOutput)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestFillStagingSubdir(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -297,9 +297,3 @@ func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigPath string) []string {
 	}
 	return opts
 }
-
-// DefaultOutput derives an output path from a library name and a default
-// output directory.
-func DefaultOutput(name, defaultOutput string) string {
-	return filepath.Join(defaultOutput, name)
-}

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -400,32 +400,3 @@ func TestBuildProtoProtocArgs(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
-
-func TestDefaultOutput(t *testing.T) {
-	for _, test := range []struct {
-		name          string
-		libName       string
-		defaultOutput string
-		want          string
-	}{
-		{
-			name:          "standard",
-			libName:       "Ces",
-			defaultOutput: "packages",
-			want:          "packages/Ces",
-		},
-		{
-			name:          "empty default",
-			libName:       "Ces",
-			defaultOutput: "",
-			want:          "Ces",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := DefaultOutput(test.libName, test.defaultOutput)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}


### PR DESCRIPTION
Move DefaultOutput to internal/librarian/php/defaut.go.

This will leave `generate.go` only contains generate-related functions.