### PR TITLE
chore(internal/librarian/ruby): keep Gemfile.lock

### DIFF
--- a/internal/librarian/ruby/clean.go
+++ b/internal/librarian/ruby/clean.go
@@ -40,7 +40,6 @@ var (
 	generatedRootFiles = []string{
 		"AUTHENTICATION.md",
 		"Gemfile",
-		"Gemfile.lock",
 		"LICENSE",
 		"LICENSE.md",
 		"README.md",

--- a/internal/librarian/ruby/clean_test.go
+++ b/internal/librarian/ruby/clean_test.go
@@ -48,9 +48,9 @@ func TestClean(t *testing.T) {
 		},
 		{
 			name:      "removes generated root files except keep list",
-			files:     []string{"CHANGELOG.md", ".repo-metadata.json", "README.md", "AUTHENTICATION.md", "lib/foo.rb"},
+			files:     []string{"CHANGELOG.md", ".repo-metadata.json", "README.md", "AUTHENTICATION.md", "lib/foo.rb", "Gemfile.lock"},
 			keep:      []string{"README.md"},
-			wantFiles: []string{"CHANGELOG.md", ".repo-metadata.json", "README.md"},
+			wantFiles: []string{"CHANGELOG.md", ".repo-metadata.json", "README.md", "Gemfile.lock"},
 		},
 		{
 			name:      "keep is nil",


### PR DESCRIPTION
Do not clean `Gemfile.lock` b/c it will be managed by renovate Bot.

Internal reference: b/509981628

Fixes #7161