### PR TITLE
feat(swift): support optional, nested fields

### DIFF
--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -47,13 +47,11 @@ type enumAnnotations struct {
 	// The full name of the raw proto enum under the private module target.
 	ProtoTypeName string
 
-	// ExtensionTypeName is the parent-qualified Swift name used for top-level extension declarations.
+	// FullyQualifiedName is the parent-qualified Swift name (e.g. `FindingSummary.SummaryDetails.ResourceType` or `Color`).
 	//
-	// In Swift, extensions cannot be nested inside structs or other extensions. For nested enums
-	// (e.g. `FindingSummary.SummaryDetails.ResourceType`), the extension declaration must be emitted
-	// at the top-level of the file using its fully qualified parent path:
-	// `extension FindingSummary.SummaryDetails.ResourceType { ... }`.
-	ExtensionTypeName string
+	// In Swift, extensions cannot be nested inside structs or other extensions. For nested enums,
+	// top-level extension declarations use FullyQualifiedName: `extension FindingSummary.SummaryDetails.ResourceType { ... }`.
+	FullyQualifiedName string
 }
 
 // IsGated returns true if this message is gated by some package traits.
@@ -137,15 +135,15 @@ func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
 		return err
 	}
 	annotations := &enumAnnotations{
-		Model:             model,
-		Name:              pascalCase(enum.Name),
-		ExtensionTypeName: extensionTypeName,
-		DocLines:          docLines,
-		DefaultCaseName:   defaultCaseName,
-		UnknownIntName:    uniqueCaseName("unknownIntValue"),
-		UnknownStringName: uniqueCaseName("unknownStringValue"),
-		ModulePath:        c.ModulePath,
-		ProtoTypeName:     c.protoEnumTypeName(enum),
+		Model:              model,
+		Name:               pascalCase(enum.Name),
+		FullyQualifiedName: extensionTypeName,
+		DocLines:           docLines,
+		DefaultCaseName:    defaultCaseName,
+		UnknownIntName:     uniqueCaseName("unknownIntValue"),
+		UnknownStringName:  uniqueCaseName("unknownStringValue"),
+		ModulePath:         c.ModulePath,
+		ProtoTypeName:      c.protoEnumTypeName(enum),
 	}
 
 	enum.Codec = annotations

--- a/internal/sidekick/swift/annotate_enum.go
+++ b/internal/sidekick/swift/annotate_enum.go
@@ -46,6 +46,14 @@ type enumAnnotations struct {
 
 	// The full name of the raw proto enum under the private module target.
 	ProtoTypeName string
+
+	// ExtensionTypeName is the parent-qualified Swift name used for top-level extension declarations.
+	//
+	// In Swift, extensions cannot be nested inside structs or other extensions. For nested enums
+	// (e.g. `FindingSummary.SummaryDetails.ResourceType`), the extension declaration must be emitted
+	// at the top-level of the file using its fully qualified parent path:
+	// `extension FindingSummary.SummaryDetails.ResourceType { ... }`.
+	ExtensionTypeName string
 }
 
 // IsGated returns true if this message is gated by some package traits.
@@ -124,9 +132,14 @@ func (c *codec) annotateEnum(enum *api.Enum, model *modelAnnotations) error {
 	if err != nil {
 		return err
 	}
+	extensionTypeName, err := c.enumTypeName(enum)
+	if err != nil {
+		return err
+	}
 	annotations := &enumAnnotations{
 		Model:             model,
 		Name:              pascalCase(enum.Name),
+		ExtensionTypeName: extensionTypeName,
 		DocLines:          docLines,
 		DefaultCaseName:   defaultCaseName,
 		UnknownIntName:    uniqueCaseName("unknownIntValue"),

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -41,6 +41,7 @@ func TestAnnotateEnum(t *testing.T) {
 			},
 			want: &enumAnnotations{
 				Name:              "Color",
+				ExtensionTypeName: "Color",
 				DocLines:          []string{"A color enum.", "With two lines."},
 				DefaultCaseName:   "unspecified",
 				UnknownIntName:    "unknownIntValue",
@@ -58,6 +59,7 @@ func TestAnnotateEnum(t *testing.T) {
 			},
 			want: &enumAnnotations{
 				Name:              "Protocol_",
+				ExtensionTypeName: "Protocol_",
 				DocLines:          []string{"An enum named Protocol."},
 				DefaultCaseName:   "unspecified",
 				UnknownIntName:    "unknownIntValue",
@@ -77,6 +79,7 @@ func TestAnnotateEnum(t *testing.T) {
 			},
 			want: &enumAnnotations{
 				Name:              "Weird",
+				ExtensionTypeName: "Weird",
 				DocLines:          []string{"An enum named Weird."},
 				DefaultCaseName:   "unspecified",
 				UnknownIntName:    "unknownIntValue_",
@@ -199,6 +202,7 @@ func TestAnnotateEnum_ModulePath(t *testing.T) {
 
 	want := &enumAnnotations{
 		Name:              "Color",
+		ExtensionTypeName: "Color",
 		DefaultCaseName:   "unspecified",
 		UnknownIntName:    "unknownIntValue",
 		UnknownStringName: "unknownStringValue",
@@ -241,6 +245,7 @@ func TestAnnotateEnum_NestedModulePath(t *testing.T) {
 
 	want := &enumAnnotations{
 		Name:              "InnerEnum",
+		ExtensionTypeName: "OuterMessage.InnerEnum",
 		DefaultCaseName:   "unspecified",
 		UnknownIntName:    "unknownIntValue",
 		UnknownStringName: "unknownStringValue",

--- a/internal/sidekick/swift/annotate_enum_test.go
+++ b/internal/sidekick/swift/annotate_enum_test.go
@@ -40,14 +40,14 @@ func TestAnnotateEnum(t *testing.T) {
 				{Name: "COLOR_RED", Number: 1},
 			},
 			want: &enumAnnotations{
-				Name:              "Color",
-				ExtensionTypeName: "Color",
-				DocLines:          []string{"A color enum.", "With two lines."},
-				DefaultCaseName:   "unspecified",
-				UnknownIntName:    "unknownIntValue",
-				UnknownStringName: "unknownStringValue",
-				ProtoTypeName:     "Test_Color",
-				ModulePath:        "",
+				Name:               "Color",
+				FullyQualifiedName: "Color",
+				DocLines:           []string{"A color enum.", "With two lines."},
+				DefaultCaseName:    "unspecified",
+				UnknownIntName:     "unknownIntValue",
+				UnknownStringName:  "unknownStringValue",
+				ProtoTypeName:      "Test_Color",
+				ModulePath:         "",
 			},
 		},
 		{
@@ -58,14 +58,14 @@ func TestAnnotateEnum(t *testing.T) {
 				{Name: "PROTOCOL_UNSPECIFIED", Number: 0},
 			},
 			want: &enumAnnotations{
-				Name:              "Protocol_",
-				ExtensionTypeName: "Protocol_",
-				DocLines:          []string{"An enum named Protocol."},
-				DefaultCaseName:   "unspecified",
-				UnknownIntName:    "unknownIntValue",
-				UnknownStringName: "unknownStringValue",
-				ProtoTypeName:     "Test_Protocol_",
-				ModulePath:        "",
+				Name:               "Protocol_",
+				FullyQualifiedName: "Protocol_",
+				DocLines:           []string{"An enum named Protocol."},
+				DefaultCaseName:    "unspecified",
+				UnknownIntName:     "unknownIntValue",
+				UnknownStringName:  "unknownStringValue",
+				ProtoTypeName:      "Test_Protocol_",
+				ModulePath:         "",
 			},
 		},
 		{
@@ -78,14 +78,14 @@ func TestAnnotateEnum(t *testing.T) {
 				{Name: "UNKNOWN_STRING_VALUE", Number: 2},
 			},
 			want: &enumAnnotations{
-				Name:              "Weird",
-				ExtensionTypeName: "Weird",
-				DocLines:          []string{"An enum named Weird."},
-				DefaultCaseName:   "unspecified",
-				UnknownIntName:    "unknownIntValue_",
-				UnknownStringName: "unknownStringValue_",
-				ProtoTypeName:     "Test_Weird",
-				ModulePath:        "",
+				Name:               "Weird",
+				FullyQualifiedName: "Weird",
+				DocLines:           []string{"An enum named Weird."},
+				DefaultCaseName:    "unspecified",
+				UnknownIntName:     "unknownIntValue_",
+				UnknownStringName:  "unknownStringValue_",
+				ProtoTypeName:      "Test_Weird",
+				ModulePath:         "",
 			},
 		},
 	} {
@@ -201,13 +201,13 @@ func TestAnnotateEnum_ModulePath(t *testing.T) {
 	}
 
 	want := &enumAnnotations{
-		Name:              "Color",
-		ExtensionTypeName: "Color",
-		DefaultCaseName:   "unspecified",
-		UnknownIntName:    "unknownIntValue",
-		UnknownStringName: "unknownStringValue",
-		ModulePath:        "TestProtos",
-		ProtoTypeName:     "TestProtos.Test_Color",
+		Name:               "Color",
+		FullyQualifiedName: "Color",
+		DefaultCaseName:    "unspecified",
+		UnknownIntName:     "unknownIntValue",
+		UnknownStringName:  "unknownStringValue",
+		ModulePath:         "TestProtos",
+		ProtoTypeName:      "TestProtos.Test_Color",
 	}
 	if diff := cmp.Diff(want, enum.Codec, cmpopts.IgnoreFields(enumAnnotations{}, "Model")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -244,13 +244,13 @@ func TestAnnotateEnum_NestedModulePath(t *testing.T) {
 	}
 
 	want := &enumAnnotations{
-		Name:              "InnerEnum",
-		ExtensionTypeName: "OuterMessage.InnerEnum",
-		DefaultCaseName:   "unspecified",
-		UnknownIntName:    "unknownIntValue",
-		UnknownStringName: "unknownStringValue",
-		ModulePath:        "TestProtos",
-		ProtoTypeName:     "TestProtos.Test_OuterMessage.InnerEnum",
+		Name:               "InnerEnum",
+		FullyQualifiedName: "OuterMessage.InnerEnum",
+		DefaultCaseName:    "unspecified",
+		UnknownIntName:     "unknownIntValue",
+		UnknownStringName:  "unknownStringValue",
+		ModulePath:         "TestProtos",
+		ProtoTypeName:      "TestProtos.Test_OuterMessage.InnerEnum",
 	}
 	if diff := cmp.Diff(want, enum.Codec, cmpopts.IgnoreFields(enumAnnotations{}, "Model")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -210,7 +210,11 @@ func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*field
 			annotations.UrlSafeValue = true
 		}
 	}
-	c.computeFieldConversionStatements(field, annotations, parts)
+	if !field.IsOneOf && !field.Map && !field.Repeated {
+		annotations.ProtoFieldName = protoFieldName(field.Name)
+		annotations.ProtoFieldNamePascal = protoFieldNamePascal(field.Name)
+		annotations.PrimitiveFieldType = parts.Base
+	}
 	field.Codec = annotations
 	return annotations, nil
 }
@@ -252,15 +256,4 @@ func (c *codec) fieldPackage(field *api.Field) (string, error) {
 		return e.Package, nil
 	}
 	return "", nil
-}
-
-func (c *codec) computeFieldConversionStatements(field *api.Field, ann *fieldAnnotations, parts *fieldTypeNames) {
-	if field.IsOneOf || field.Map || field.Repeated {
-		// TODO(#5272): Map, Repeated, and OneOf fields are handled in subsequent PRs.
-		return
-	}
-
-	ann.ProtoFieldName = protoFieldName(field.Name)
-	ann.ProtoFieldNamePascal = protoFieldNamePascal(field.Name)
-	ann.PrimitiveFieldType = parts.Base
 }

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -75,6 +75,14 @@ type fieldAnnotations struct {
 
 	// The PascalCase name of the field on the underlying SwiftProtobuf type (used for hasField helpers).
 	ProtoFieldNamePascal string
+
+	// PrimitiveFieldType is the raw Swift type name without any decorators or boxing wrappers (e.g. `Node`).
+	//
+	// This differs from `BaseFieldType` for recursive message fields: for recursive fields,
+	// `BaseFieldType` is boxed as `GoogleCloudWkt.Recursive<Node>` for struct property declarations,
+	// whereas `PrimitiveFieldType` remains the raw unwrapped type `Node` so that conversions can call
+	// `WktPackage.Recursive(value: try Node(proto: proto.childNode))`.
+	PrimitiveFieldType string
 }
 
 // DecodingStyle defines an enumeration for decoding fields.
@@ -202,7 +210,9 @@ func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*field
 			annotations.UrlSafeValue = true
 		}
 	}
-	c.computeFieldConversionStatements(field, annotations)
+	if err := c.computeFieldConversionStatements(field, annotations, parts); err != nil {
+		return nil, err
+	}
 	field.Codec = annotations
 	return annotations, nil
 }
@@ -246,21 +256,14 @@ func (c *codec) fieldPackage(field *api.Field) (string, error) {
 	return "", nil
 }
 
-func (c *codec) computeFieldConversionStatements(field *api.Field, ann *fieldAnnotations) {
-	if field.IsOneOf {
-		// TODO(#5272): Oneof fields are handled in a subsequent PR.
-		return
-	}
-	if field.Map || field.Repeated {
-		// TODO(#5272): Map and Repeated fields are handled in subsequent PRs.
-		return
-	}
-	switch field.Typez {
-	case api.TypezMessage, api.TypezEnum:
-		// TODO(#5272): Nested Message and Enum type fields are handled in a subsequent PR.
-		return
+func (c *codec) computeFieldConversionStatements(field *api.Field, ann *fieldAnnotations, parts *fieldTypeNames) error {
+	if field.IsOneOf || field.Map || field.Repeated {
+		// TODO(#5272): Map, Repeated, and OneOf fields are handled in subsequent PRs.
+		return nil
 	}
 
 	ann.ProtoFieldName = protoFieldName(field.Name)
 	ann.ProtoFieldNamePascal = protoFieldNamePascal(field.Name)
+	ann.PrimitiveFieldType = parts.Base
+	return nil
 }

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -210,9 +210,7 @@ func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*field
 			annotations.UrlSafeValue = true
 		}
 	}
-	if err := c.computeFieldConversionStatements(field, annotations, parts); err != nil {
-		return nil, err
-	}
+	c.computeFieldConversionStatements(field, annotations, parts)
 	field.Codec = annotations
 	return annotations, nil
 }
@@ -256,14 +254,13 @@ func (c *codec) fieldPackage(field *api.Field) (string, error) {
 	return "", nil
 }
 
-func (c *codec) computeFieldConversionStatements(field *api.Field, ann *fieldAnnotations, parts *fieldTypeNames) error {
+func (c *codec) computeFieldConversionStatements(field *api.Field, ann *fieldAnnotations, parts *fieldTypeNames) {
 	if field.IsOneOf || field.Map || field.Repeated {
 		// TODO(#5272): Map, Repeated, and OneOf fields are handled in subsequent PRs.
-		return nil
+		return
 	}
 
 	ann.ProtoFieldName = protoFieldName(field.Name)
 	ann.ProtoFieldNamePascal = protoFieldNamePascal(field.Name)
 	ann.PrimitiveFieldType = parts.Base
-	return nil
 }

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -39,6 +39,7 @@ func TestAnnotateField(t *testing.T) {
 				BaseFieldType:        "Swift.String",
 				ProtoFieldName:       "secretPayload",
 				ProtoFieldNamePascal: "SecretPayload",
+				PrimitiveFieldType:   "Swift.String",
 			},
 		},
 		{
@@ -51,6 +52,7 @@ func TestAnnotateField(t *testing.T) {
 				Decoding:             DecodingOptional,
 				ProtoFieldName:       "secretPayload",
 				ProtoFieldNamePascal: "SecretPayload",
+				PrimitiveFieldType:   "Swift.String",
 			},
 		},
 		{
@@ -122,6 +124,7 @@ func TestAnnotateField_Discovery(t *testing.T) {
 				UrlSafeValue:         true,
 				ProtoFieldName:       "name",
 				ProtoFieldNamePascal: "Name",
+				PrimitiveFieldType:   "Foundation.Data",
 			},
 		},
 		{
@@ -136,6 +139,7 @@ func TestAnnotateField_Discovery(t *testing.T) {
 				BaseFieldType:        "Swift.String",
 				ProtoFieldName:       "name",
 				ProtoFieldNamePascal: "Name",
+				PrimitiveFieldType:   "Swift.String",
 			},
 		},
 		{
@@ -153,6 +157,7 @@ func TestAnnotateField_Discovery(t *testing.T) {
 				Decoding:             DecodingOptional,
 				ProtoFieldName:       "name",
 				ProtoFieldNamePascal: "Name",
+				PrimitiveFieldType:   "Foundation.Data",
 			},
 		},
 		{
@@ -247,6 +252,7 @@ func TestAnnotateField_TypeNames(t *testing.T) {
 				Model:                model.Codec.(*modelAnnotations),
 				ProtoFieldName:       "testField",
 				ProtoFieldNamePascal: "TestField",
+				PrimitiveFieldType:   test.wantType,
 			}
 			if diff := cmp.Diff(want, field.Codec); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -289,12 +295,15 @@ func TestAnnotateField_PackageName(t *testing.T) {
 	}
 	got := field.Codec.(*fieldAnnotations)
 	want := &fieldAnnotations{
-		Name:          "externalMessage",
-		FieldType:     "GoogleCloudExternalV1.SomeMessage",
-		BaseFieldType: "GoogleCloudExternalV1.SomeMessage",
-		PackageName:   "google.cloud.external.v1",
-		DocLines:      []string{"The external message."},
-		Model:         model.Codec.(*modelAnnotations),
+		Name:                 "externalMessage",
+		FieldType:            "GoogleCloudExternalV1.SomeMessage",
+		BaseFieldType:        "GoogleCloudExternalV1.SomeMessage",
+		PackageName:          "google.cloud.external.v1",
+		DocLines:             []string{"The external message."},
+		Model:                model.Codec.(*modelAnnotations),
+		ProtoFieldName:       "externalMessage",
+		ProtoFieldNamePascal: "ExternalMessage",
+		PrimitiveFieldType:   "GoogleCloudExternalV1.SomeMessage",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -316,10 +325,28 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			repeated: false,
 			isOneOf:  false,
 			want: &fieldAnnotations{
-				FieldType:     "GoogleCloudWkt.Recursive<Node>?",
-				BaseFieldType: "GoogleCloudWkt.Recursive<Node>",
-				Recursive:     true,
-				Decoding:      DecodingOptional,
+				FieldType:            "GoogleCloudWkt.Recursive<Node>?",
+				BaseFieldType:        "GoogleCloudWkt.Recursive<Node>",
+				Recursive:            true,
+				Decoding:             DecodingOptional,
+				ProtoFieldName:       "childNode",
+				ProtoFieldNamePascal: "ChildNode",
+				PrimitiveFieldType:   "Node",
+			},
+		},
+		{
+			name:     "singular non-optional recursive",
+			optional: false,
+			repeated: false,
+			isOneOf:  false,
+			want: &fieldAnnotations{
+				FieldType:            "GoogleCloudWkt.Recursive<Node>?",
+				BaseFieldType:        "GoogleCloudWkt.Recursive<Node>",
+				Recursive:            true,
+				Decoding:             DecodingOptional,
+				ProtoFieldName:       "childNode",
+				ProtoFieldNamePascal: "ChildNode",
+				PrimitiveFieldType:   "Node",
 			},
 		},
 		{

--- a/internal/sidekick/swift/generate_conversions.go
+++ b/internal/sidekick/swift/generate_conversions.go
@@ -42,22 +42,36 @@ func GenerateConversions(ctx context.Context, model *api.API, outdir string, lib
 		}
 		return string(contents), nil
 	}
-	if err := codec.generateEnumConversions(outdir, model, provider); err != nil {
+
+	var messages []*api.Message
+	for _, m := range model.Messages {
+		if m.Parent == nil && !m.IsMap && !m.ServicePlaceholder {
+			messages = append(messages, m)
+		}
+	}
+
+	var enums []*api.Enum
+	for _, e := range model.Enums {
+		if e.Parent == nil {
+			enums = append(enums, e)
+		}
+	}
+
+	if err := codec.generateEnumConversions(outdir, enums, provider); err != nil {
 		return err
 	}
-	if err := codec.generateMessageConversions(outdir, model, provider); err != nil {
+	if err := codec.generateMessageConversions(outdir, messages, provider); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c *codec) generateEnumConversions(outdir string, model *api.API, provider language.TemplateProvider) error {
-	for _, e := range model.Enums {
+func (c *codec) generateEnumConversions(outdir string, enums []*api.Enum, provider language.TemplateProvider) error {
+	for _, e := range enums {
 		name := c.enumFileName(e)
-		output := c.conversionOutputPath(name)
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_enum_file.swift.mustache",
-			OutputPath:   output,
+			OutputPath:   conversionFileName(name),
 		}
 		if err := language.GenerateEnum(outdir, e, provider, generated); err != nil {
 			return err
@@ -66,19 +80,12 @@ func (c *codec) generateEnumConversions(outdir string, model *api.API, provider 
 	return nil
 }
 
-func (c *codec) generateMessageConversions(outdir string, model *api.API, provider language.TemplateProvider) error {
-	for _, m := range model.Messages {
-		if m.IsMap {
-			continue
-		}
-		if m.ServicePlaceholder {
-			continue
-		}
+func (c *codec) generateMessageConversions(outdir string, messages []*api.Message, provider language.TemplateProvider) error {
+	for _, m := range messages {
 		name := c.messageFileName(m)
-		output := c.conversionOutputPath(name)
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_message_file.swift.mustache",
-			OutputPath:   output,
+			OutputPath:   conversionFileName(name),
 		}
 		if err := language.GenerateMessage(outdir, m, provider, generated); err != nil {
 			return err
@@ -87,6 +94,7 @@ func (c *codec) generateMessageConversions(outdir string, model *api.API, provid
 	return nil
 }
 
-func (c *codec) conversionOutputPath(typeName string) string {
+func conversionFileName(typeName string) string {
 	return typeName + "+Convert.swift"
 }
+

--- a/internal/sidekick/swift/generate_conversions.go
+++ b/internal/sidekick/swift/generate_conversions.go
@@ -43,35 +43,25 @@ func GenerateConversions(ctx context.Context, model *api.API, outdir string, lib
 		return string(contents), nil
 	}
 
-	var messages []*api.Message
-	for _, m := range model.Messages {
-		if m.Parent == nil && !m.IsMap && !m.ServicePlaceholder {
-			messages = append(messages, m)
-		}
-	}
-
-	var enums []*api.Enum
-	for _, e := range model.Enums {
-		if e.Parent == nil {
-			enums = append(enums, e)
-		}
-	}
-
-	if err := codec.generateEnumConversions(outdir, enums, provider); err != nil {
+	if err := codec.generateEnumConversions(outdir, provider); err != nil {
 		return err
 	}
-	if err := codec.generateMessageConversions(outdir, messages, provider); err != nil {
+	if err := codec.generateMessageConversions(outdir, provider); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c *codec) generateEnumConversions(outdir string, enums []*api.Enum, provider language.TemplateProvider) error {
-	for _, e := range enums {
+func (c *codec) generateEnumConversions(outdir string, provider language.TemplateProvider) error {
+	for _, e := range c.Model.Enums {
+		if e.Parent != nil {
+			continue
+		}
 		name := c.enumFileName(e)
+		output := c.conversionOutputPath(name)
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_enum_file.swift.mustache",
-			OutputPath:   conversionFileName(name),
+			OutputPath:   output,
 		}
 		if err := language.GenerateEnum(outdir, e, provider, generated); err != nil {
 			return err
@@ -80,12 +70,16 @@ func (c *codec) generateEnumConversions(outdir string, enums []*api.Enum, provid
 	return nil
 }
 
-func (c *codec) generateMessageConversions(outdir string, messages []*api.Message, provider language.TemplateProvider) error {
-	for _, m := range messages {
+func (c *codec) generateMessageConversions(outdir string, provider language.TemplateProvider) error {
+	for _, m := range c.Model.Messages {
+		if m.Parent != nil || m.IsMap || m.ServicePlaceholder {
+			continue
+		}
 		name := c.messageFileName(m)
+		output := c.conversionOutputPath(name)
 		generated := language.GeneratedFile{
 			TemplatePath: "templates/convert/convert_message_file.swift.mustache",
-			OutputPath:   conversionFileName(name),
+			OutputPath:   output,
 		}
 		if err := language.GenerateMessage(outdir, m, provider, generated); err != nil {
 			return err
@@ -94,7 +88,7 @@ func (c *codec) generateMessageConversions(outdir string, messages []*api.Messag
 	return nil
 }
 
-func conversionFileName(typeName string) string {
+func (c *codec) conversionOutputPath(typeName string) string {
 	return typeName + "+Convert.swift"
 }
 

--- a/internal/sidekick/swift/generate_conversions.go
+++ b/internal/sidekick/swift/generate_conversions.go
@@ -91,4 +91,3 @@ func (c *codec) generateMessageConversions(outdir string, provider language.Temp
 func (c *codec) conversionOutputPath(typeName string) string {
 	return typeName + "+Convert.swift"
 }
-

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -169,8 +169,8 @@ func TestGenerateConversions_RecursiveMessage(t *testing.T) {
 	got := extractBlock(t, gotContent, "  internal init(proto: ProtoType) throws {", "\n  }")
 	wantInit := `  internal init(proto: ProtoType) throws {
     self.init()
-    self.childNode = proto.hasChildNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.childNode)) : nil
-    self.nextNode = proto.hasNextNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.nextNode)) : nil
+    self.childNode = proto.hasChildNode ? GoogleCloudWkt.Recursive(value: try .init(proto: proto.childNode)) : nil
+    self.nextNode = proto.hasNextNode ? GoogleCloudWkt.Recursive(value: try .init(proto: proto.nextNode)) : nil
   }`
 	if diff := cmp.Diff(wantInit, got); diff != "" {
 		t.Errorf("init(proto:) mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -95,13 +95,24 @@ func TestGenerateConversions_Message(t *testing.T) {
 
 	// Check conversion logic
 	got := extractBlock(t, gotContent, "  internal init(proto: ProtoType) throws {", "\n  }")
-	wantInit := "  internal init(proto: ProtoType) throws {\n    self.init()\n    self.name = proto.name\n    self.metageneration = proto.metageneration\n    self.self_ = proto.hasSelf_p ? proto.self_p : nil\n  }"
+	wantInit := `  internal init(proto: ProtoType) throws {
+    self.init()
+    self.name = proto.name
+    self.metageneration = proto.metageneration
+    self.self_ = proto.hasSelf_p ? proto.self_p : nil
+  }`
 	if diff := cmp.Diff(wantInit, got); diff != "" {
 		t.Errorf("init(proto:) mismatch (-want +got):\n%s", diff)
 	}
 
 	got = extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
-	wantToProto := "  internal func toProto() throws -> ProtoType {\n    var proto = ProtoType()\n    proto.name = self.name\n    proto.metageneration = self.metageneration\n    if let self_ = self.self_ { proto.self_p = self_ }\n    return proto\n  }"
+	wantToProto := `  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.name = self.name
+    proto.metageneration = self.metageneration
+    if let self_ = self.self_ { proto.self_p = self_ }
+    return proto
+  }`
 	if diff := cmp.Diff(wantToProto, got); diff != "" {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
 	}
@@ -156,13 +167,22 @@ func TestGenerateConversions_RecursiveMessage(t *testing.T) {
 	gotContent := string(b)
 
 	got := extractBlock(t, gotContent, "  internal init(proto: ProtoType) throws {", "\n  }")
-	wantInit := "  internal init(proto: ProtoType) throws {\n    self.init()\n    self.childNode = proto.hasChildNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.childNode)) : nil\n    self.nextNode = proto.hasNextNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.nextNode)) : nil\n  }"
+	wantInit := `  internal init(proto: ProtoType) throws {
+    self.init()
+    self.childNode = proto.hasChildNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.childNode)) : nil
+    self.nextNode = proto.hasNextNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.nextNode)) : nil
+  }`
 	if diff := cmp.Diff(wantInit, got); diff != "" {
 		t.Errorf("init(proto:) mismatch (-want +got):\n%s", diff)
 	}
 
 	got = extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
-	wantToProto := "  internal func toProto() throws -> ProtoType {\n    var proto = ProtoType()\n    if let childNode = self.childNode { proto.childNode = try childNode.value.toProto() }\n    if let nextNode = self.nextNode { proto.nextNode = try nextNode.value.toProto() }\n    return proto\n  }"
+	wantToProto := `  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    if let childNode = self.childNode { proto.childNode = try childNode.value.toProto() }
+    if let nextNode = self.nextNode { proto.nextNode = try nextNode.value.toProto() }
+    return proto
+  }`
 	if diff := cmp.Diff(wantToProto, got); diff != "" {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -167,4 +167,3 @@ func TestGenerateConversions_RecursiveMessage(t *testing.T) {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
 	}
 }
-

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -106,3 +106,65 @@ func TestGenerateConversions_Message(t *testing.T) {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestGenerateConversions_RecursiveMessage(t *testing.T) {
+	outDir := t.TempDir()
+
+	field1 := &api.Field{
+		Name:          "child_node",
+		ID:            ".test.Node.child_node",
+		Typez:         api.TypezMessage,
+		TypezID:       ".test.Node",
+		Documentation: "Non-optional recursive child.",
+		Optional:      false,
+		Recursive:     true,
+	}
+	field2 := &api.Field{
+		Name:          "next_node",
+		ID:            ".test.Node.next_node",
+		Typez:         api.TypezMessage,
+		TypezID:       ".test.Node",
+		Documentation: "Optional recursive child.",
+		Optional:      true,
+		Recursive:     true,
+	}
+	node := &api.Message{
+		Name:    "Node",
+		Package: "test",
+		ID:      ".test.Node",
+		Fields:  []*api.Field{field1, field2},
+	}
+	field1.Parent = node
+	field2.Parent = node
+
+	model := api.NewTestAPI([]*api.Message{node}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "test"
+
+	library := &config.Library{}
+	module := &config.SwiftModule{
+		ModulePath: "TestProtos",
+	}
+
+	if err := GenerateConversions(t.Context(), model, outDir, library, module); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(outDir, "Node+Convert.swift"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotContent := string(b)
+
+	got := extractBlock(t, gotContent, "  internal init(proto: ProtoType) throws {", "\n  }")
+	wantInit := "  internal init(proto: ProtoType) throws {\n    self.init()\n    self.childNode = proto.hasChildNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.childNode)) : nil\n    self.nextNode = proto.hasNextNode ? GoogleCloudWkt.Recursive(value: try Node(proto: proto.nextNode)) : nil\n  }"
+	if diff := cmp.Diff(wantInit, got); diff != "" {
+		t.Errorf("init(proto:) mismatch (-want +got):\n%s", diff)
+	}
+
+	got = extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
+	wantToProto := "  internal func toProto() throws -> ProtoType {\n    var proto = ProtoType()\n    if let childNode = self.childNode { proto.childNode = try childNode.value.toProto() }\n    if let nextNode = self.nextNode { proto.nextNode = try nextNode.value.toProto() }\n    return proto\n  }"
+	if diff := cmp.Diff(wantToProto, got); diff != "" {
+		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
+	}
+}
+

--- a/internal/sidekick/swift/templates/convert/convert_enum.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_enum.mustache
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-extension {{Codec.Name}} {
+extension {{Codec.ExtensionTypeName}} {
   internal init(proto: {{Codec.ProtoTypeName}}) {
     switch proto {
     {{#UniqueNumberValues}}
@@ -34,7 +34,7 @@ extension {{Codec.Name}} {
       return {{Codec.ProtoTypeName}}(rawValue: val)
         ?? .UNRECOGNIZED(val)
     case .{{Codec.UnknownStringName}}(let str):
-      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(enumType: "{{Codec.Name}}", stringValue: str)
+      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(enumType: "{{Codec.ExtensionTypeName}}", stringValue: str)
     }
   }
 }

--- a/internal/sidekick/swift/templates/convert/convert_enum.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_enum.mustache
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-extension {{Codec.ExtensionTypeName}} {
+extension {{Codec.FullyQualifiedName}} {
   internal init(proto: {{Codec.ProtoTypeName}}) {
     switch proto {
     {{#UniqueNumberValues}}
@@ -34,7 +34,7 @@ extension {{Codec.ExtensionTypeName}} {
       return {{Codec.ProtoTypeName}}(rawValue: val)
         ?? .UNRECOGNIZED(val)
     case .{{Codec.UnknownStringName}}(let str):
-      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(enumType: "{{Codec.ExtensionTypeName}}", stringValue: str)
+      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(enumType: "{{Codec.FullyQualifiedName}}", stringValue: str)
     }
   }
 }

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -24,14 +24,14 @@ extension {{Codec.ParameterTypeName}} {
     {{^Optional}}
     {{#IsObject}}
     {{#Codec.Recursive}}
-    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.Model.WktPackage}}.Recursive(value: try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})) : nil
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.Model.WktPackage}}.Recursive(value: try .init(proto: proto.{{Codec.ProtoFieldName}})) : nil
     {{/Codec.Recursive}}
     {{^Codec.Recursive}}
-    self.{{Codec.Name}} = try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})
+    self.{{Codec.Name}} = try .init(proto: proto.{{Codec.ProtoFieldName}})
     {{/Codec.Recursive}}
     {{/IsObject}}
     {{#IsEnum}}
-    self.{{Codec.Name}} = {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})
+    self.{{Codec.Name}} = .init(proto: proto.{{Codec.ProtoFieldName}})
     {{/IsEnum}}
     {{^IsObject}}
     {{^IsEnum}}
@@ -42,14 +42,14 @@ extension {{Codec.ParameterTypeName}} {
     {{#Optional}}
     {{#IsObject}}
     {{#Codec.Recursive}}
-    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.Model.WktPackage}}.Recursive(value: try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})) : nil
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.Model.WktPackage}}.Recursive(value: try .init(proto: proto.{{Codec.ProtoFieldName}})) : nil
     {{/Codec.Recursive}}
     {{^Codec.Recursive}}
-    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}}) : nil
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? try .init(proto: proto.{{Codec.ProtoFieldName}}) : nil
     {{/Codec.Recursive}}
     {{/IsObject}}
     {{#IsEnum}}
-    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}}) : nil
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? .init(proto: proto.{{Codec.ProtoFieldName}}) : nil
     {{/IsEnum}}
     {{^IsObject}}
     {{^IsEnum}}

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -19,29 +19,100 @@ extension {{Codec.ParameterTypeName}} {
   internal init(proto: ProtoType) throws {
     self.init()
     {{#Fields}}
-    {{#Codec.ProtoFieldName}}
-    {{#Optional}}
-    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? proto.{{Codec.ProtoFieldName}} : nil
-    {{/Optional}}
+    {{^IsOneOf}}
+    {{#Singular}}
     {{^Optional}}
+    {{#IsObject}}
+    {{#Codec.Recursive}}
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.Model.WktPackage}}.Recursive(value: try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})) : nil
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
+    self.{{Codec.Name}} = try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})
+    {{/Codec.Recursive}}
+    {{/IsObject}}
+    {{#IsEnum}}
+    self.{{Codec.Name}} = {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})
+    {{/IsEnum}}
+    {{^IsObject}}
+    {{^IsEnum}}
     self.{{Codec.Name}} = proto.{{Codec.ProtoFieldName}}
+    {{/IsEnum}}
+    {{/IsObject}}
     {{/Optional}}
-    {{/Codec.ProtoFieldName}}
+    {{#Optional}}
+    {{#IsObject}}
+    {{#Codec.Recursive}}
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.Model.WktPackage}}.Recursive(value: try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}})) : nil
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? try {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}}) : nil
+    {{/Codec.Recursive}}
+    {{/IsObject}}
+    {{#IsEnum}}
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? {{Codec.PrimitiveFieldType}}(proto: proto.{{Codec.ProtoFieldName}}) : nil
+    {{/IsEnum}}
+    {{^IsObject}}
+    {{^IsEnum}}
+    self.{{Codec.Name}} = proto.has{{Codec.ProtoFieldNamePascal}} ? proto.{{Codec.ProtoFieldName}} : nil
+    {{/IsEnum}}
+    {{/IsObject}}
+    {{/Optional}}
+    {{/Singular}}
+    {{/IsOneOf}}
     {{/Fields}}
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     {{#Fields}}
-    {{#Codec.ProtoFieldName}}
-    {{#Optional}}
-    if let {{Codec.Name}} = self.{{Codec.Name}} { proto.{{Codec.ProtoFieldName}} = {{Codec.Name}} }
-    {{/Optional}}
+    {{^IsOneOf}}
+    {{#Singular}}
     {{^Optional}}
+    {{#IsObject}}
+    {{#Codec.Recursive}}
+    if let {{Codec.Name}} = self.{{Codec.Name}} { proto.{{Codec.ProtoFieldName}} = try {{Codec.Name}}.value.toProto() }
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
+    proto.{{Codec.ProtoFieldName}} = try self.{{Codec.Name}}.toProto()
+    {{/Codec.Recursive}}
+    {{/IsObject}}
+    {{#IsEnum}}
+    proto.{{Codec.ProtoFieldName}} = try self.{{Codec.Name}}.toProto()
+    {{/IsEnum}}
+    {{^IsObject}}
+    {{^IsEnum}}
     proto.{{Codec.ProtoFieldName}} = self.{{Codec.Name}}
+    {{/IsEnum}}
+    {{/IsObject}}
     {{/Optional}}
-    {{/Codec.ProtoFieldName}}
+    {{#Optional}}
+    {{#IsObject}}
+    {{#Codec.Recursive}}
+    if let {{Codec.Name}} = self.{{Codec.Name}} { proto.{{Codec.ProtoFieldName}} = try {{Codec.Name}}.value.toProto() }
+    {{/Codec.Recursive}}
+    {{^Codec.Recursive}}
+    if let {{Codec.Name}} = self.{{Codec.Name}} { proto.{{Codec.ProtoFieldName}} = try {{Codec.Name}}.toProto() }
+    {{/Codec.Recursive}}
+    {{/IsObject}}
+    {{#IsEnum}}
+    if let {{Codec.Name}} = self.{{Codec.Name}} { proto.{{Codec.ProtoFieldName}} = try {{Codec.Name}}.toProto() }
+    {{/IsEnum}}
+    {{^IsObject}}
+    {{^IsEnum}}
+    if let {{Codec.Name}} = self.{{Codec.Name}} { proto.{{Codec.ProtoFieldName}} = {{Codec.Name}} }
+    {{/IsEnum}}
+    {{/IsObject}}
+    {{/Optional}}
+    {{/Singular}}
+    {{/IsOneOf}}
     {{/Fields}}
     return proto
   }
 }
+
+{{#Messages}}
+{{> /templates/convert/convert_message}}
+{{/Messages}}
+{{#Enums}}
+{{> /templates/convert/convert_enum}}
+{{/Enums}}


### PR DESCRIPTION
Implement Swift Protobuf conversion code generation for optional fields,
nested message fields, recursive fields, and imported common types.

- Introduced PrimitiveFieldType to separate unwrapped base types (e.g. Node)
  from boxed struct property types (e.g. GoogleCloudWkt.Recursive<Node>).
- Added ExtensionTypeName to annotate parent-qualified names for top-level Swift
  extension declarations on nested enums (e.g. FindingSummary.SummaryDetails.ResourceType).

`librarian generate --all` generates https://github.com/googleapis/google-cloud-swift/pull/112 
