### PR TITLE
chore(internal/librarian/php): derive component name from namespace

### DIFF
--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -61,6 +61,12 @@ func namespace(googleapisDir, apiPath string) (string, error) {
 	return backupNamespace(apiPath), nil
 }
 
+// component returns the component name from a namespace.
+func component(namespace string) string {
+	namespace = strings.TrimPrefix(namespace, `Google\Cloud\`)
+	return strings.TrimPrefix(namespace, `Google\`)
+}
+
 // searchForProto finds the first .proto file in the API directory.
 func searchForProto(googleapisDir, apiPath string) (string, error) {
 	dir := filepath.Join(googleapisDir, apiPath)

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -61,13 +61,13 @@ func namespace(googleapisDir, apiPath string) (string, error) {
 	return backupNamespace(apiPath), nil
 }
 
-// component returns the component name from a namespace.
-func component(namespace string) string {
-	if component, ok := strings.CutPrefix(namespace, `Google\Cloud\`); ok {
-		return component
+// componentName returns the component name from a namespace.
+func componentName(namespace string) string {
+	if comp, ok := strings.CutPrefix(namespace, `Google\Cloud\`); ok {
+		return comp
 	}
-	component := strings.TrimPrefix(namespace, `Google\`)
-	return strings.ReplaceAll(component, `\`, "")
+	comp := strings.TrimPrefix(namespace, `Google\`)
+	return strings.ReplaceAll(comp, `\`, "")
 }
 
 // searchForProto finds the first .proto file in the API directory.

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -63,8 +63,11 @@ func namespace(googleapisDir, apiPath string) (string, error) {
 
 // component returns the component name from a namespace.
 func component(namespace string) string {
-	namespace = strings.TrimPrefix(namespace, `Google\Cloud\`)
-	return strings.TrimPrefix(namespace, `Google\`)
+	if component, ok := strings.CutPrefix(namespace, `Google\Cloud\`); ok {
+		return component
+	}
+	component := strings.TrimPrefix(namespace, `Google\`)
+	return strings.ReplaceAll(component, `\`, "")
 }
 
 // searchForProto finds the first .proto file in the API directory.

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -129,3 +129,29 @@ func TestNamespace_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestComponent(t *testing.T) {
+		for _, test := range []struct {
+			name string
+			namespace string
+			want string
+		}{
+			{
+				name: "google cloud component",
+				namespace: "Google\\Cloud\\SecretManager",
+				want: "SecretManager",
+			},
+			{
+				name: "non cloud",
+				namespace: "Google\\Ads\\GoogleAds",
+				want: "AdsGoogleAds",
+			},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				got := component(test.namespace)
+				if diff := cmp.Diff(test.want, got); diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+	}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -130,7 +130,7 @@ func TestNamespace_Error(t *testing.T) {
 	}
 }
 
-func TestComponent(t *testing.T) {
+func TestComponentName(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		namespace string
@@ -148,7 +148,7 @@ func TestComponent(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := component(test.namespace)
+			got := componentName(test.namespace)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -142,7 +142,7 @@ func TestComponentName(t *testing.T) {
 			want:      "SecretManager",
 		},
 		{
-			name:      "non cloud",
+			name:      "google ads",
 			namespace: `Google\Ads\GoogleAds`,
 			want:      "AdsGoogleAds",
 		},

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -146,6 +146,11 @@ func TestComponentName(t *testing.T) {
 			namespace: `Google\Ads\GoogleAds`,
 			want:      "AdsGoogleAds",
 		},
+		{
+			name:      "google shopping",
+			namespace: `Google\Shopping\Merchant\Conversions`,
+			want:      "ShoppingMerchantConversions",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := componentName(test.namespace)

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -138,12 +138,12 @@ func TestComponent(t *testing.T) {
 	}{
 		{
 			name:      "google cloud component",
-			namespace: "Google\\Cloud\\SecretManager",
+			namespace: `Google\Cloud\SecretManager`,
 			want:      "SecretManager",
 		},
 		{
 			name:      "non cloud",
-			namespace: "Google\\Ads\\GoogleAds",
+			namespace: `Google\Ads\GoogleAds`,
 			want:      "AdsGoogleAds",
 		},
 	} {

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -131,27 +131,27 @@ func TestNamespace_Error(t *testing.T) {
 }
 
 func TestComponent(t *testing.T) {
-		for _, test := range []struct {
-			name string
-			namespace string
-			want string
-		}{
-			{
-				name: "google cloud component",
-				namespace: "Google\\Cloud\\SecretManager",
-				want: "SecretManager",
-			},
-			{
-				name: "non cloud",
-				namespace: "Google\\Ads\\GoogleAds",
-				want: "AdsGoogleAds",
-			},
-		} {
-			t.Run(test.name, func(t *testing.T) {
-				got := component(test.namespace)
-				if diff := cmp.Diff(test.want, got); diff != "" {
-					t.Errorf("mismatch (-want +got):\n%s", diff)
-				}
-			})
-		}
+	for _, test := range []struct {
+		name      string
+		namespace string
+		want      string
+	}{
+		{
+			name:      "google cloud component",
+			namespace: "Google\\Cloud\\SecretManager",
+			want:      "SecretManager",
+		},
+		{
+			name:      "non cloud",
+			namespace: "Google\\Ads\\GoogleAds",
+			want:      "AdsGoogleAds",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := component(test.namespace)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
+}


### PR DESCRIPTION
A component resolution helper is added to the PHP package to determine the library component name directly from its PHP namespace.

See go/cloud-sdk-php-new-component-heuristics on how to derive component name.

Fixes #7151
