### PR TITLE
fix(internal/librarian/rust): preserve parent messages of used types

### DIFF
--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -115,7 +115,49 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 
 	// Discover all transitively reachable messages and enums.
 	visited := make(map[string]bool)
+	var enqueueMsg func(m *api.Message, rpc, methodID, path string)
+	var enqueueEnum func(e *api.Enum, rpc, methodID, path string)
+
+	// enqueueMsg marks a message as used in streaming and enqueues it for field
+	// traversal. It recursively enqueues all parent ancestor messages to ensure:
+	// 1. Parent messages are not placed in unusedTypes (which would cause prost_build's
+	//    prefix-matching extern_path to hijack nested types like Partition.TemporalPartition).
+	// 2. Parent messages are enqueued for field traversal so their sibling field types
+	//    (e.g., Partition.SpatialPartition) are also included in streamingMsgs rather than
+	//    placed in unusedTypes, preventing missing type errors in convert.rs.
+	enqueueMsg = func(m *api.Message, rpc, methodID, path string) {
+		if m == nil {
+			return
+		}
+		if !streamingMsgs[m.ID] {
+			streamingMsgs[m.ID] = true
+			queue = append(queue, streamingTypeItem{
+				id:       m.ID,
+				rpc:      rpc,
+				methodID: methodID,
+				path:     path,
+			})
+		}
+		if m.Parent != nil {
+			enqueueMsg(m.Parent, rpc, methodID, path)
+		}
+	}
+
+	// enqueueEnum marks an enum as used in streaming. If the enum is nested inside a message,
+	// it recursively enqueues parent ancestor messages to ensure they and their sibling field
+	// types are not placed in unusedTypes.
+	enqueueEnum = func(e *api.Enum, rpc, methodID, path string) {
+		if e == nil {
+			return
+		}
+		streamingEnums[e.ID] = true
+		if e.Parent != nil {
+			enqueueMsg(e.Parent, rpc, methodID, path)
+		}
+	}
+
 	hasGoogleRpcStatus := false
+
 	for len(queue) > 0 {
 		item := queue[0]
 		queue = queue[1:]
@@ -145,6 +187,7 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 				hasGoogleRpcStatus = true
 				continue
 			}
+			enqueueMsg(msg, item.rpc, item.methodID, item.path)
 			for _, f := range msg.Fields {
 				fieldPath := item.path + "." + f.Name
 				if isAnyType(f.TypezID) {
@@ -159,7 +202,7 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 					})
 				}
 				if f.Typez == api.TypezEnum && f.TypezID != "" {
-					streamingEnums[f.TypezID] = true
+					enqueueEnum(model.Enum(f.TypezID), item.rpc, item.methodID, fieldPath)
 				}
 			}
 			for _, o := range msg.OneOfs {
@@ -177,7 +220,7 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 						})
 					}
 					if f.Typez == api.TypezEnum && f.TypezID != "" {
-						streamingEnums[f.TypezID] = true
+						enqueueEnum(model.Enum(f.TypezID), item.rpc, item.methodID, fieldPath)
 					}
 				}
 			}
@@ -185,7 +228,7 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 
 		enum := model.Enum(item.id)
 		if enum != nil {
-			streamingEnums[enum.ID] = true
+			enqueueEnum(enum, item.rpc, item.methodID, item.path)
 		}
 	}
 

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -266,3 +266,48 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
+	parent := api.NewTestMessage("Parent").WithPackage("google.test.v1")
+	child := api.NewTestMessage("Child").WithPackage("google.test.v1")
+	sibling := api.NewTestMessage("Sibling").WithPackage("google.test.v1")
+	child.Parent = parent
+
+	parent.Fields = []*api.Field{
+		{
+			Name:    "sibling_ref",
+			TypezID: sibling.ID,
+			Typez:   api.TypezMessage,
+		},
+	}
+
+	streamReq := api.NewTestMessage("StreamReq").WithPackage("google.test.v1").WithFields(
+		&api.Field{
+			Name:    "child_ref",
+			TypezID: child.ID,
+			Typez:   api.TypezMessage,
+		},
+	)
+
+	chatMethod := api.NewTestMethod("Chat").WithInput(streamReq).WithOutput(streamReq).WithBidiStreaming()
+	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
+
+	model := api.NewTestAPI([]*api.Message{parent, child, sibling, streamReq}, []*api.Enum{}, []*api.Service{bidiService})
+
+	_, unusedTypes, _, err := filterModelToStreaming(model)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, unused := range unusedTypes {
+		if unused == parent.ID {
+			t.Errorf("parent message %q should not be in unusedTypes", parent.ID)
+		}
+		if unused == child.ID {
+			t.Errorf("child message %q should not be in unusedTypes", child.ID)
+		}
+		if unused == sibling.ID {
+			t.Errorf("sibling field message %q of parent should not be in unusedTypes", sibling.ID)
+		}
+	}
+}


### PR DESCRIPTION
When generating hybrid Rust crates, unused types are configured with prost_build's extern_path to map to a nonexistent type. When a nested message or enum is used in a streaming RPC, its parent message must not be placed in unusedTypes. Because prost_build uses prefix-based matching for extern_path, marking an unused parent message hides all of its nested child types and replaces references to them with nonexistent_type.

Previously, filterModelToStreaming only tracked types directly referenced by streaming request and response fields without traversing parent pointers. As a result, parent messages without direct field references were marked as unused, causing prost_build to omit nested child structs that were actually used in streaming RPCs.

Fixes #7143 