### PR TITLE
fix(swift): use let for messages without converted fields

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -36,7 +36,7 @@ type messageAnnotations struct {
 	// HasConvertedFields is true if any field in the message emits code in
 	// toProto(), which currently includes only singular, non-oneof fields.
 	// This prevents the Swift compiler error "variable 'proto' was never mutated"
-	// for messages containing only repeated or oneof fields by emitting "let"
+	// for messages containing only repeated, map, or oneof fields by emitting "let"
 	// instead of "var" in convert_message.mustache.
 	// This is a temporary workaround until protobuf conversions support repeated,
 	// map, and oneof fields.
@@ -149,7 +149,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	}
 	hasConvertedFields := false
 	for _, f := range message.Fields {
-		if !f.IsOneOf && !f.Repeated {
+		if !f.IsOneOf && f.Singular() {
 			hasConvertedFields = true
 			break
 		}

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -33,6 +33,16 @@ type messageAnnotations struct {
 	TypeURL             string
 	CustomSerialization bool
 
+	// HasConvertedFields is true if any field in the message emits code in
+	// toProto(), which currently includes only singular, non-oneof fields.
+	// This prevents the Swift compiler error "variable 'proto' was never mutated"
+	// for messages containing only repeated or oneof fields by emitting "let"
+	// instead of "var" in convert_message.mustache.
+	// This is a temporary workaround until protobuf conversions support repeated,
+	// map, and oneof fields.
+	// TODO(#5272): remove HasConvertedFields once all field types are converted.
+	HasConvertedFields bool
+
 	IsPaginatedResponse bool
 	PageableItemField   string
 	PageableItemType    string
@@ -137,6 +147,13 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if len(message.Fields) != 0 {
 		sampleField = camelCase(message.Fields[0].Name)
 	}
+	hasConvertedFields := false
+	for _, f := range message.Fields {
+		if !f.IsOneOf && !f.Repeated {
+			hasConvertedFields = true
+			break
+		}
+	}
 	parameterTypeName, err := c.messageTypeName(message)
 	if err != nil {
 		return err
@@ -147,6 +164,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		Model:               model,
 		TypeURL:             typeURLPrefix + strings.TrimPrefix(message.ID, "."),
 		CustomSerialization: len(message.OneOfs) > 0,
+		HasConvertedFields:  hasConvertedFields,
 		DependsOn:           map[string]*Dependency{},
 		SampleField:         sampleField,
 		ParameterTypeName:   parameterTypeName,

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -147,13 +147,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if len(message.Fields) != 0 {
 		sampleField = camelCase(message.Fields[0].Name)
 	}
-	hasConvertedFields := false
-	for _, f := range message.Fields {
-		if !f.IsOneOf && f.Singular() {
-			hasConvertedFields = true
-			break
-		}
-	}
+	hasConvertedFields := slices.IndexFunc(message.Fields, func(f *api.Field) bool { return !f.IsOneOf && f.Singular() }) != -1
 	parameterTypeName, err := c.messageTypeName(message)
 	if err != nil {
 		return err

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -172,7 +172,7 @@ func TestAnnotateMessage(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
+			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.wantImports, test.message.Codec.(*messageAnnotations).MessageImports()); diff != "" {
@@ -317,7 +317,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
+			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -376,7 +376,7 @@ func TestAnnotateMessage_DiscoveryRequests(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, test.request.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
+			if diff := cmp.Diff(test.want, test.request.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -456,7 +456,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		ProtoTypeName:     "Google_Cloud_Secretmanager_V1_ListSecretsRequest",
 		ModulePath:        "",
 	}
-	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
+	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantRequestImports := []string{"GoogleCloudWkt"}
@@ -477,7 +477,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		ProtoTypeName:       "Google_Cloud_Secretmanager_V1_ListSecretsResponse",
 		ModulePath:          "",
 	}
-	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
+	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantResponseImports := []string{"GoogleCloudGax", "GoogleCloudWkt"}
@@ -532,7 +532,7 @@ func TestAnnotateMessage_RecursiveNested(t *testing.T) {
 		ProtoTypeName:     "Google_Cloud_Secretmanager_V1_OuterMessage",
 		ModulePath:        "",
 	}
-	if diff := cmp.Diff(wantOuter, gotOuter, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
+	if diff := cmp.Diff(wantOuter, gotOuter, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -365,7 +365,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		SampleField:       "pageSize",
 		ParameterTypeName: "ListRequest",
 	}
-	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath")); diff != "" {
+	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantRequestImports := []string{"GoogleCloudWkt"}
@@ -384,7 +384,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		SampleField:         "items",
 		ParameterTypeName:   "ListResponse",
 	}
-	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath")); diff != "" {
+	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	// Response type is a paginated response which depends on gax

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -197,13 +197,20 @@ func TestGenerateConversions_NoConvertedFields(t *testing.T) {
 		Repeated: true,
 		Typez:    api.TypezString,
 	}
+	field2 := &api.Field{
+		Name:  "labels",
+		ID:    "2",
+		Map:   true,
+		Typez: api.TypezString,
+	}
 	msg := &api.Message{
 		Name:    "EmptyOrRepeatedOnly",
 		ID:      ".test.EmptyOrRepeatedOnly",
-		Fields:  []*api.Field{field1},
+		Fields:  []*api.Field{field1, field2},
 		Package: "test",
 	}
 	field1.Parent = msg
+	field2.Parent = msg
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "test"
 

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -187,3 +187,47 @@ func TestGenerateConversions_RecursiveMessage(t *testing.T) {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestGenerateConversions_NoConvertedFields(t *testing.T) {
+	outDir := t.TempDir()
+
+	field1 := &api.Field{
+		Name:     "locations",
+		ID:       "1",
+		Repeated: true,
+		Typez:    api.TypezString,
+	}
+	msg := &api.Message{
+		Name:    "EmptyOrRepeatedOnly",
+		ID:      ".test.EmptyOrRepeatedOnly",
+		Fields:  []*api.Field{field1},
+		Package: "test",
+	}
+	field1.Parent = msg
+	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "test"
+
+	library := &config.Library{
+		Name: "GoogleCloudStorage",
+	}
+	module := &config.SwiftModule{
+		ModulePath: "StorageControlProtos",
+	}
+	if err := GenerateConversions(t.Context(), model, outDir, library, module); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(outDir, "EmptyOrRepeatedOnly+Convert.swift"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotContent := string(b)
+	got := extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
+	wantToProto := `  internal func toProto() throws -> ProtoType {
+    let proto = ProtoType()
+    return proto
+  }`
+	if diff := cmp.Diff(wantToProto, got); diff != "" {
+		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -63,7 +63,12 @@ extension {{Codec.ParameterTypeName}} {
   }
 
   internal func toProto() throws -> ProtoType {
+    {{#Codec.HasConvertedFields}}
     var proto = ProtoType()
+    {{/Codec.HasConvertedFields}}
+    {{^Codec.HasConvertedFields}}
+    let proto = ProtoType()
+    {{/Codec.HasConvertedFields}}
     {{#Fields}}
     {{^IsOneOf}}
     {{#Singular}}


### PR DESCRIPTION
Conditionally emit `let proto = ProtoType()` instead of `var proto = ProtoType()`
in `toProto()` when a message contains no fields that emit conversion statements
(such as messages with only repeated or oneof fields, or zero fields).

generates: https://github.com/googleapis/google-cloud-swift/pull/112 