### PR TITLE
impl(internal/sidekick/rust): remove useless conversion and move TODO

### DIFF
--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -65,7 +65,7 @@ all-features = true
 
 [dependencies]
 {{#Codec.HasBidiStreaming}}
-# TODO(#6838): Make prost and prost-types optional dependencies gated by the streaming feature flag.
+{{! TODO(#6835) - Make prost and prost-types optional dependencies gated by the streaming feature flag. }}
 prost.workspace = true
 prost-types.workspace = true
 futures.workspace = true

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -189,8 +189,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                     while let Some(res) = response_stream.next().await {
                         let item = res
                             .map_err(gaxi::grpc::from_status::to_gax_error)
-                            .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
-                            .map_err(Into::into);
+                            .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser));
                         if resp_tx.send(item).await.is_err() {
                             break;
                         }
@@ -198,7 +197,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 }
                 Err(err) => {
                     {{! TODO(#6835) - propagate stream setup errors (result of bidi_stream) back to send() }}
-                    let _ = resp_tx.send(Err(err.into())).await;
+                    let _ = resp_tx.send(Err(err)).await;
                 }
             }
         });


### PR DESCRIPTION
For #6835