### PR TITLE
Revert "fix(java): batch formatting and run GJF twice"

### DIFF
--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -245,9 +245,9 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 			if err := java.Generate(ctx, cfg, library, src); err != nil {
 				return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
 			}
-		}
-		if err := java.FormatLibraries(ctx, libraries); err != nil {
-			return fmt.Errorf("format libraries (%s): %w", cfg.Language, err)
+			if err := java.Format(ctx, library); err != nil {
+				return fmt.Errorf("format library %q (%s): %w", library.Name, cfg.Language, err)
+			}
 		}
 		return java.PostGenerate(ctx, ".", cfg)
 	case config.LanguageNodejs:

--- a/internal/librarian/java/format.go
+++ b/internal/librarian/java/format.go
@@ -25,33 +25,22 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-// FormatLibraries formats multiple Java client libraries using google-java-format in a single batch.
-func FormatLibraries(ctx context.Context, libraries []*config.Library) error {
-	var allFiles []string
-	for _, library := range libraries {
-		files, err := collectJavaFiles(library.Output)
-		if err != nil {
-			return fmt.Errorf("failed to find java files for formatting in %q: %w", library.Output, err)
-		}
-		allFiles = append(allFiles, files...)
+// Format formats a Java client library using google-java-format.
+func Format(ctx context.Context, library *config.Library) error {
+	files, err := collectJavaFiles(library.Output)
+	if err != nil {
+		return fmt.Errorf("failed to find java files for formatting: %w", err)
 	}
-	if len(allFiles) == 0 {
+	if len(files) == 0 {
 		return nil
 	}
-	args := append([]string{"--replace"}, allFiles...)
+	args := append([]string{"--replace"}, files...)
 	env, err := getToolsEnv()
 	if err != nil {
 		return err
 	}
-	// Run google-java-format twice.
-	// The first run removes unused imports but might leave extra empty lines.
-	// The second run collapses those empty lines.
-	// TODO(https://github.com/google/google-java-format/issues/1436): Remove second pass once fixed upstream.
 	if err := command.RunWithEnv(ctx, env, "google-java-format", args...); err != nil {
-		return fmt.Errorf("failed to format files (pass 1): %w", err)
-	}
-	if err := command.RunWithEnv(ctx, env, "google-java-format", args...); err != nil {
-		return fmt.Errorf("failed to format files (pass 2): %w", err)
+		return fmt.Errorf("failed to format files: %w", err)
 	}
 	return nil
 }

--- a/internal/librarian/java/format_test.go
+++ b/internal/librarian/java/format_test.go
@@ -15,7 +15,6 @@
 package java
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"sort"
@@ -74,8 +73,8 @@ func TestFormat(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			test.setup(t, tmpDir)
-			if err := FormatLibraries(t.Context(), []*config.Library{{Output: tmpDir}}); err != nil {
-				t.Errorf("FormatLibraries() error = %v, want nil", err)
+			if err := Format(t.Context(), &config.Library{Output: tmpDir}); err != nil {
+				t.Errorf("Format() error = %v, want nil", err)
 			}
 		})
 	}
@@ -87,9 +86,9 @@ func TestFormat_LookPathError(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", "")
-	err := FormatLibraries(t.Context(), []*config.Library{{Output: tmpDir}})
+	err := Format(t.Context(), &config.Library{Output: tmpDir})
 	if err == nil {
-		t.Fatal("expected error, got nil")
+		t.Fatal(err)
 	}
 }
 
@@ -127,48 +126,5 @@ func TestCollectJavaFiles(t *testing.T) {
 	sort.Strings(want)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}
-
-func TestFormatLibraries_MultipleLibraries(t *testing.T) {
-	testhelper.RequireCommand(t, "google-java-format")
-	t.Parallel()
-	tmpDir1 := t.TempDir()
-	tmpDir2 := t.TempDir()
-	// Create unformatted files in both directories.
-	// They have extra blank lines which should be collapsed.
-	content1 := []byte("package test;\n\n\npublic class One {}")
-	content2 := []byte("package test;\n\n\npublic class Two {}")
-	file1 := filepath.Join(tmpDir1, "One.java")
-	file2 := filepath.Join(tmpDir2, "Two.java")
-	if err := os.WriteFile(file1, content1, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(file2, content2, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	libraries := []*config.Library{
-		{Output: tmpDir1},
-		{Output: tmpDir2},
-	}
-	if err := FormatLibraries(t.Context(), libraries); err != nil {
-		t.Fatalf("FormatLibraries() error = %v, want nil", err)
-	}
-	// Verify both files were formatted (empty lines collapsed).
-	wantContent1 := []byte("package test;\n\npublic class One {}\n")
-	wantContent2 := []byte("package test;\n\npublic class Two {}\n")
-	gotContent1, err := os.ReadFile(file1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	gotContent2, err := os.ReadFile(file2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(gotContent1, wantContent1) {
-		t.Errorf("file1 content mismatch\ngot:  %q\nwant: %q", gotContent1, wantContent1)
-	}
-	if !bytes.Equal(gotContent2, wantContent2) {
-		t.Errorf("file2 content mismatch\ngot:  %q\nwant: %q", gotContent2, wantContent2)
 	}
 }


### PR DESCRIPTION
Reverts googleapis/librarian#7155

The #7155 changes FormatLibraries to collect every .java file across all modules into a single allFiles slice, Passing all file paths as discrete CLI arguments in a single command exceeds the OS's maximum command-line argument size limit.

Fixes https://github.com/googleapis/librarian/issues/7177