### PR TITLE
feat(internal/librarian/php): resolve API short name and product URLs

### DIFF
--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -21,12 +21,42 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/repometadata"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
 var (
 	namespaceRe     = regexp.MustCompile(`php_namespace\)?\s*=\s*"([^"]+)"`)
 	versionSuffixRe = regexp.MustCompile(`\\V\d+.*$`)
 )
+
+type initParams struct {
+	apiShortName    string
+	productDocs     string
+	productHomepage string
+}
+
+func newInitParams(googleapisDir, apiPath string) (*initParams, error) {
+	api, err := serviceconfig.Find(googleapisDir, apiPath, config.LanguagePhp)
+	if err != nil {
+		return nil, err
+	}
+	var apiShortName, productDocs, productHomepage string
+	if api != nil {
+		apiShortName = api.ShortName
+		productDocs = api.DocumentationURI
+		if productDocs != "" {
+			productHomepage = repometadata.ExtractBaseProductURL(productDocs)
+		}
+	}
+	return &initParams{
+		apiShortName:    apiShortName,
+		productDocs:     productDocs,
+		productHomepage: productHomepage,
+	}, nil
+}
 
 // namespace reads the php_namespace option from the first .proto file in the API directory.
 // If the option is not found, it generates a fallback namespace from the API path.

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -43,18 +43,10 @@ func newInitParams(googleapisDir, apiPath string) (*initParams, error) {
 	if err != nil {
 		return nil, err
 	}
-	var apiShortName, productDocs, productHomepage string
-	if api != nil {
-		apiShortName = api.ShortName
-		productDocs = api.DocumentationURI
-		if productDocs != "" {
-			productHomepage = repometadata.ExtractBaseProductURL(productDocs)
-		}
-	}
 	return &initParams{
-		apiShortName:    apiShortName,
-		productDocs:     productDocs,
-		productHomepage: productHomepage,
+		apiShortName:    api.ShortName,
+		productDocs:     api.DocumentationURI,
+		productHomepage: repometadata.ExtractBaseProductURL(api.DocumentationURI),
 	}, nil
 }
 

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -160,3 +160,21 @@ func TestComponentName(t *testing.T) {
 		})
 	}
 }
+
+func TestNewInitParams(t *testing.T) {
+	t.Parallel()
+	googleapisDir := filepath.Join("..", "..", "testdata", "googleapis")
+	apiPath := "google/cloud/secretmanager/v1"
+	params, err := newInitParams(googleapisDir, apiPath)
+	if err != nil {
+		t.Fatalf("newInitParams failed: %v", err)
+	}
+	want := &initParams{
+		apiShortName:    "secretmanager",
+		productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
+		productHomepage: "https://cloud.google.com/secret-manager/",
+	}
+	if diff := cmp.Diff(want, params, cmp.AllowUnexported(initParams{})); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/repometadata/repometadata.go
+++ b/internal/repometadata/repometadata.go
@@ -159,7 +159,7 @@ func fromAPI(cfg *config.Config, api *serviceconfig.API, library *config.Library
 		Language:             cfg.Language,
 		Name:                 api.ShortName,
 		NamePretty:           cleanTitle(api.Title),
-		ProductDocumentation: extractBaseProductURL(api.DocumentationURI),
+		ProductDocumentation: ExtractBaseProductURL(api.DocumentationURI),
 		ReleaseLevel:         api.ReleaseLevel(cfg.Language, library.Version),
 		Repo:                 cfg.Repo,
 		Transport:            transport,
@@ -167,9 +167,9 @@ func fromAPI(cfg *config.Config, api *serviceconfig.API, library *config.Library
 	}
 }
 
-// extractBaseProductURL extracts the base product URL from a documentation URI.
+// ExtractBaseProductURL extracts the base product URL from a documentation URI.
 // Example: "https://cloud.google.com/secret-manager/docs/overview" -> "https://cloud.google.com/secret-manager/"
-func extractBaseProductURL(docURI string) string {
+func ExtractBaseProductURL(docURI string) string {
 	// Strip off /docs/* suffix to get base product URL
 	if base, _, found := strings.Cut(docURI, "/docs/"); found {
 		return base + "/"

--- a/internal/repometadata/repometadata_test.go
+++ b/internal/repometadata/repometadata_test.go
@@ -190,7 +190,7 @@ func TestExtractBaseProductURL(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := extractBaseProductURL(test.docURI)
+			got := ExtractBaseProductURL(test.docURI)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Add initParams struct and newInitParams constructor in the PHP package to resolve apiShortName, productDocs, and productHomepage from the service configuration.      
  
The product homepage URL is derived by reusing ExtractBaseProductURL from the internal/repometadata package.

Fixes #7150