### PR TITLE
feat(internal/librarian/ruby): add library initialization and wrappers

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -271,7 +271,11 @@ func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config,
 	case config.LanguagePhp:
 		lib = php.Add(lib)
 	case config.LanguageRuby:
-		lib = ruby.Add(cfg, lib)
+		var err error
+		lib, err = ruby.Add(cfg, lib)
+		if err != nil {
+			return "", nil, err
+		}
 	case config.LanguageFake:
 		lib = fakeAdd(lib, defaultVersion)
 	}

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
 	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/librarian/python"
+	"github.com/googleapis/librarian/internal/librarian/ruby"
 	"github.com/googleapis/librarian/internal/librarian/rust"
 	"github.com/googleapis/librarian/internal/librarian/swift"
 	"github.com/googleapis/librarian/internal/semver"
@@ -269,6 +270,8 @@ func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config,
 		lib = swift.Add(lib, cfg)
 	case config.LanguagePhp:
 		lib = php.Add(lib)
+	case config.LanguageRuby:
+		lib = ruby.Add(cfg, lib)
 	case config.LanguageFake:
 		lib = fakeAdd(lib, defaultVersion)
 	}

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -14,11 +14,62 @@
 
 package ruby
 
-import "github.com/googleapis/librarian/internal/config"
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/serviceconfig"
+)
 
 const defaultVersion = "0.0.1"
 
-func Add(cfg *config.Config, lib *config.Library) *config.Library {
+var (
+	errRequiresOneAPI = errors.New("must provide exactly one API path for a Ruby library")
+	errNoVersionedAPI    = errors.New("no versioned API found")
+
+)
+
+func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	lib.Version = defaultVersion
-	return lib
+	newLib, err := addWrapper(cfg, lib)
+	if err != nil {
+		return nil, err
+	}
+	return newLib, nil
+}
+
+func addWrapper(cfg *config.Config, lib *config.Library) (*config.Library, error) {
+	if len(lib.APIs) != 1 {
+		return nil, fmt.Errorf("ruby libraries must have a single API. %w, got %d", errRequiresOneAPI, len(lib.APIs))
+	}
+	apiPath := lib.APIs[0].Path
+	// No need to add wrapperOf for a versioned client.
+	if serviceconfig.ExtractVersion(apiPath) != "" {
+		return lib, nil
+	}
+	versionedAPI, err := searchVersionedAPI(cfg, apiPath)
+	if err != nil {
+		return nil, err
+	}
+	lib = &config.Library{
+		APIs: []*config.API{{Path: versionedAPI}},
+		Ruby: &config.RubyPackage{
+			WrapperOf: []string{fmt.Sprintf("%s:0.0", filepath.Base(versionedAPI))},
+		},
+	}
+	return lib, nil
+}
+
+func searchVersionedAPI(cfg *config.Config, apiPath string) (string, error) {
+	for _, lib := range cfg.Libraries {
+		for _, api := range lib.APIs {
+			if strings.HasPrefix(api.Path, apiPath+"/v") {
+				return api.Path, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("%w: %q", errNoVersionedAPI, apiPath)
 }

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -28,8 +28,7 @@ const defaultVersion = "0.0.1"
 
 var (
 	errRequiresOneAPI = errors.New("must provide exactly one API path for a Ruby library")
-	errNoVersionedAPI    = errors.New("no versioned API found")
-
+	errNoVersionedAPI = errors.New("no versioned API found")
 )
 
 func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -41,6 +41,7 @@ func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	return newLib, nil
 }
 
+// addWrapper initializes a new Ruby main client library configuration.
 func addWrapper(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	if len(lib.APIs) != 1 {
 		return nil, fmt.Errorf("ruby libraries must have a single API. %w, got %d", errRequiresOneAPI, len(lib.APIs))
@@ -58,6 +59,8 @@ func addWrapper(cfg *config.Config, lib *config.Library) (*config.Library, error
 	return lib, nil
 }
 
+// searchVersionedAPI finds a versioned API in the config that is a prefix of the given API path,
+// otherwise it returns an error.
 func searchVersionedAPI(cfg *config.Config, apiPath string) (string, error) {
 	for _, lib := range cfg.Libraries {
 		for _, api := range lib.APIs {
@@ -69,6 +72,7 @@ func searchVersionedAPI(cfg *config.Config, apiPath string) (string, error) {
 	return "", fmt.Errorf("%w: %q", errNoVersionedAPI, apiPath)
 }
 
+// update updates the library to be a main client.
 func update(lib *config.Library, versionedAPI string) {
 	lib.APIs = []*config.API{{Path: versionedAPI}}
 	lib.Ruby = &config.RubyPackage{

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -55,7 +55,7 @@ func addWrapper(cfg *config.Config, lib *config.Library) (*config.Library, error
 	if err != nil {
 		return nil, err
 	}
-	update(lib, versionedAPI)
+	configureWrapper(lib, versionedAPI)
 	return lib, nil
 }
 
@@ -72,8 +72,8 @@ func searchVersionedAPI(cfg *config.Config, apiPath string) (string, error) {
 	return "", fmt.Errorf("%w: %q", errNoVersionedAPI, apiPath)
 }
 
-// update updates the library to be a main client.
-func update(lib *config.Library, versionedAPI string) {
+// configureWrapper configures the library to be a main client.
+func configureWrapper(lib *config.Library, versionedAPI string) {
 	lib.APIs = []*config.API{{Path: versionedAPI}}
 	lib.Ruby = &config.RubyPackage{
 		WrapperOf: []string{fmt.Sprintf("%s:0.0", filepath.Base(versionedAPI))},

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -27,7 +27,7 @@ import (
 const defaultVersion = "0.0.1"
 
 var (
-	errRequiresOneAPI = errors.New("must provide exactly one API path for a Ruby library")
+	errRequiresOneAPI = errors.New("ruby libraries must have a single API")
 	errNoVersionedAPI = errors.New("no versioned API found")
 )
 
@@ -44,7 +44,7 @@ func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 // addWrapper initializes a new Ruby main client library configuration.
 func addWrapper(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	if len(lib.APIs) != 1 {
-		return nil, fmt.Errorf("ruby libraries must have a single API. %w, got %d", errRequiresOneAPI, len(lib.APIs))
+		return nil, fmt.Errorf("%w: got %d", errRequiresOneAPI, len(lib.APIs))
 	}
 	apiPath := lib.APIs[0].Path
 	// No need to add wrapperOf for a versioned client.

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -31,6 +31,7 @@ var (
 	errNoVersionedAPI = errors.New("no versioned API found")
 )
 
+// Add initializes a new Ruby library configuration.
 func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	lib.Version = defaultVersion
 	newLib, err := addWrapper(cfg, lib)

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -54,12 +54,7 @@ func addWrapper(cfg *config.Config, lib *config.Library) (*config.Library, error
 	if err != nil {
 		return nil, err
 	}
-	lib = &config.Library{
-		APIs: []*config.API{{Path: versionedAPI}},
-		Ruby: &config.RubyPackage{
-			WrapperOf: []string{fmt.Sprintf("%s:0.0", filepath.Base(versionedAPI))},
-		},
-	}
+	update(lib, versionedAPI)
 	return lib, nil
 }
 
@@ -72,4 +67,11 @@ func searchVersionedAPI(cfg *config.Config, apiPath string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("%w: %q", errNoVersionedAPI, apiPath)
+}
+
+func update(lib *config.Library, versionedAPI string) {
+	lib.APIs = []*config.API{{Path: versionedAPI}}
+	lib.Ruby = &config.RubyPackage{
+		WrapperOf: []string{fmt.Sprintf("%s:0.0", filepath.Base(versionedAPI))},
+	}
 }

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import "github.com/googleapis/librarian/internal/config"
+
+const defaultVersion = "0.0.1"
+
+func Add(cfg *config.Config, lib *config.Library) *config.Library {
+	lib.Version = defaultVersion
+	return lib
+}

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -21,63 +21,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func TestSearchVersionedAPI(t *testing.T) {
-
-	for _, test := range []struct {
-		name    string
-		apiPath string
-		want    string
-	}{
-		{
-			name:    "v1 api found",
-			apiPath: "google/cloud/secretmanager",
-			want:    "google/cloud/secretmanager/v1",
-		},
-		{
-			name:    "beta api found",
-			apiPath: "google/cloud/dialogflow/cx",
-			want:    "google/cloud/dialogflow/cx/v3beta1",
-		},
-		{
-			name:    "second api in library matched",
-			apiPath: "google/cloud/asset",
-			want:    "google/cloud/asset/v1",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			cfg := &config.Config{
-				Libraries: []*config.Library{
-					{
-						APIs: []*config.API{
-							{Path: "google/cloud/secretmanager/v1"},
-						},
-					},
-					{
-						APIs: []*config.API{
-							{Path: "google/cloud/dialogflow/cx/v3beta1"},
-						},
-					},
-					{
-						APIs: []*config.API{
-							{Path: "google/cloud/unrelated/v1"},
-							{Path: "google/cloud/asset/v1"},
-						},
-					},
-				},
-			}
-			got, err := searchVersionedAPI(cfg, test.apiPath)
-			if err != nil {
-				t.Fatalf("searchVersionedAPI() error = %v", err)
-			}
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestAddWrapper(t *testing.T) {
-
 	for _, test := range []struct {
 		name string
 		in   *config.Library
@@ -151,6 +95,60 @@ func TestAddWrapper(t *testing.T) {
 			got, err := addWrapper(cfg, test.in)
 			if err != nil {
 				t.Fatalf("addWrapper() error = %v", err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSearchVersionedAPI(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		apiPath string
+		want    string
+	}{
+		{
+			name:    "v1 api found",
+			apiPath: "google/cloud/secretmanager",
+			want:    "google/cloud/secretmanager/v1",
+		},
+		{
+			name:    "beta api found",
+			apiPath: "google/cloud/dialogflow/cx",
+			want:    "google/cloud/dialogflow/cx/v3beta1",
+		},
+		{
+			name:    "second api in library matched",
+			apiPath: "google/cloud/asset",
+			want:    "google/cloud/asset/v1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Libraries: []*config.Library{
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/secretmanager/v1"},
+						},
+					},
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/dialogflow/cx/v3beta1"},
+						},
+					},
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/unrelated/v1"},
+							{Path: "google/cloud/asset/v1"},
+						},
+					},
+				},
+			}
+			got, err := searchVersionedAPI(cfg, test.apiPath)
+			if err != nil {
+				t.Fatalf("searchVersionedAPI() error = %v", err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestSearchVersionedAPI(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			{
+				APIs: []*config.API{
+					{Path: "google/cloud/dialogflow/cx/v3beta1"},
+				},
+			},
+			{
+				APIs: []*config.API{
+					{Path: "google/cloud/unrelated/v1"},
+					{Path: "google/cloud/asset/v1"},
+				},
+			},
+		},
+	}
+	for _, test := range []struct {
+		name    string
+		apiPath string
+		want    string
+	}{
+		{
+			name:    "v1 api found",
+			apiPath: "google/cloud/secretmanager",
+			want:    "google/cloud/secretmanager/v1",
+		},
+		{
+			name:    "beta api found",
+			apiPath: "google/cloud/dialogflow/cx",
+			want:    "google/cloud/dialogflow/cx/v3beta1",
+		},
+		{
+			name:    "second api in library matched",
+			apiPath: "google/cloud/asset",
+			want:    "google/cloud/asset/v1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := searchVersionedAPI(cfg, test.apiPath)
+			if err != nil {
+				t.Fatalf("searchVersionedAPI() error = %v", err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -22,6 +22,29 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+func TestAdd(t *testing.T) {
+	in := &config.Library{
+		Name: "google-cloud-secretmanager-v1",
+		APIs: []*config.API{
+			{Path: "google/cloud/secretmanager/v1"},
+		},
+	}
+	want := &config.Library{
+		Name:    "google-cloud-secretmanager-v1",
+		Version: "0.0.1",
+		APIs: []*config.API{
+			{Path: "google/cloud/secretmanager/v1"},
+		},
+	}
+	got, err := Add(&config.Config{}, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestAddWrapper(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -22,26 +22,7 @@ import (
 )
 
 func TestSearchVersionedAPI(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			{
-				APIs: []*config.API{
-					{Path: "google/cloud/dialogflow/cx/v3beta1"},
-				},
-			},
-			{
-				APIs: []*config.API{
-					{Path: "google/cloud/unrelated/v1"},
-					{Path: "google/cloud/asset/v1"},
-				},
-			},
-		},
-	}
+
 	for _, test := range []struct {
 		name    string
 		apiPath string
@@ -64,9 +45,112 @@ func TestSearchVersionedAPI(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Libraries: []*config.Library{
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/secretmanager/v1"},
+						},
+					},
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/dialogflow/cx/v3beta1"},
+						},
+					},
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/unrelated/v1"},
+							{Path: "google/cloud/asset/v1"},
+						},
+					},
+				},
+			}
 			got, err := searchVersionedAPI(cfg, test.apiPath)
 			if err != nil {
 				t.Fatalf("searchVersionedAPI() error = %v", err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddWrapper(t *testing.T) {
+
+	for _, test := range []struct {
+		name string
+		in   *config.Library
+		want *config.Library
+	}{
+		{
+			name: "versioned client untouched",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager-v1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager-v1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+		},
+		{
+			name: "wrapper client configured for v1",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager"},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v1:0.0"},
+				},
+			},
+		},
+		{
+			name: "wrapper client configured for beta",
+			in: &config.Library{
+				Name: "google-cloud-dialogflow-cx",
+				APIs: []*config.API{
+					{Path: "google/cloud/dialogflow/cx"},
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{Path: "google/cloud/dialogflow/cx/v3beta1"},
+				},
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v3beta1:0.0"},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Libraries: []*config.Library{
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/secretmanager/v1"},
+						},
+					},
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/dialogflow/cx/v3beta1"},
+						},
+					},
+				},
+			}
+			got, err := addWrapper(cfg, test.in)
+			if err != nil {
+				t.Fatalf("addWrapper() error = %v", err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -15,6 +15,7 @@
 package ruby
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -98,6 +99,59 @@ func TestAddWrapper(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddWrapper_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		in      *config.Library
+		wantErr error
+	}{
+		{
+			name: "no APIs",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager",
+			},
+			wantErr: errRequiresOneAPI,
+		},
+		{
+			name: "multiple APIs",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+					{Path: "google/cloud/secretmanager/v2"},
+				},
+			},
+			wantErr: errRequiresOneAPI,
+		},
+		{
+			name: "missing versioned API for wrapper",
+			in: &config.Library{
+				Name: "google-cloud-nonexistent",
+				APIs: []*config.API{
+					{Path: "google/cloud/nonexistent"},
+				},
+			},
+			wantErr: errNoVersionedAPI,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Libraries: []*config.Library{
+					{
+						APIs: []*config.API{
+							{Path: "google/cloud/secretmanager/v1"},
+						},
+					},
+				},
+			}
+			_, err := addWrapper(cfg, test.in)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("addWrapper() error = %v, wantErr = %v", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -75,6 +75,7 @@ func TestAddWrapper(t *testing.T) {
 				},
 			},
 			want: &config.Library{
+				Name: "google-cloud-secretmanager",
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
@@ -92,6 +93,7 @@ func TestAddWrapper(t *testing.T) {
 				},
 			},
 			want: &config.Library{
+				Name: "google-cloud-dialogflow-cx",
 				APIs: []*config.API{
 					{Path: "google/cloud/dialogflow/cx/v3beta1"},
 				},

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -95,7 +95,7 @@ func TestAddWrapper(t *testing.T) {
 			}
 			got, err := addWrapper(cfg, test.in)
 			if err != nil {
-				t.Fatalf("addWrapper() error = %v", err)
+				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -202,7 +202,7 @@ func TestSearchVersionedAPI(t *testing.T) {
 			}
 			got, err := searchVersionedAPI(cfg, test.apiPath)
 			if err != nil {
-				t.Fatalf("searchVersionedAPI() error = %v", err)
+				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Support for onboarding new Ruby client libraries is implemented in the `add` command.

Newly added libraries are assigned a default starting version of 0.0.1. See an onboarding [PR](https://github.com/googleapis/google-cloud-ruby/pull/34720) in google-cloud-ruby.

Main client are automatically configured by searching the existing configuration for matching versioned APIs and populating the appropriate wrapper dependency mapping.

Fixes #7182
For #6635
