### PR TITLE
chore(tool/cmd/migrate): set skip_generate on migrated ruby libraries

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -161,6 +161,7 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 		}
 		lib := &config.Library{
 			Name: name,
+			SkipGenerate: true,
 		}
 		keep, err := parseKeepFromManifest(filepath.Join(repoPath, name, ".owlbot-manifest.json"))
 		if err != nil {

--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -160,7 +160,7 @@ func findRubyLibraries(googleapisPath, repoPath string) ([]*config.Library, erro
 			return nil, fmt.Errorf("checking OwlBot config: %w", err)
 		}
 		lib := &config.Library{
-			Name: name,
+			Name:         name,
 			SkipGenerate: true,
 		}
 		keep, err := parseKeepFromManifest(filepath.Join(repoPath, name, ".owlbot-manifest.json"))

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -105,6 +105,7 @@ func TestFindRubyLibraries(t *testing.T) {
 					},
 				},
 			},
+			SkipGenerate: true,
 			Ruby: &config.RubyPackage{
 				WrapperOf: []string{
 					"v1:2.15",
@@ -125,6 +126,7 @@ func TestFindRubyLibraries(t *testing.T) {
 					},
 				},
 			},
+			SkipGenerate: true,
 		},
 		{
 			Name: "google-cloud-secret_manager",
@@ -139,6 +141,7 @@ func TestFindRubyLibraries(t *testing.T) {
 					},
 				},
 			},
+			SkipGenerate: true,
 			Ruby: &config.RubyPackage{
 				WrapperOf: []string{
 					"v1:1.2",
@@ -157,6 +160,7 @@ func TestFindRubyLibraries(t *testing.T) {
 					},
 				},
 			},
+			SkipGenerate: true,
 		},
 		{
 			// This test verifies multiple WrapperOf entries are parsed correctly.
@@ -171,6 +175,7 @@ func TestFindRubyLibraries(t *testing.T) {
 					},
 				},
 			},
+			SkipGenerate: true,
 			Ruby: &config.RubyPackage{
 				WrapperOf: []string{
 					"v2:1.0",


### PR DESCRIPTION
Ruby libraries imported via the migration tool are configured to skip
code generation by default.

For #6632
