### PR TITLE
feat(internal/librarian/ruby): support release please synchronization

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -103,8 +103,8 @@ func runAdd(ctx context.Context, cfg *config.Config, api string) error {
 		return err
 	}
 	if cfg.Language == config.LanguageGo ||
-		cfg.Language == config.LanguagePython ||
 		cfg.Language == config.LanguageNodejs ||
+		cfg.Language == config.LanguagePython ||
 		cfg.Language == config.LanguageRuby {
 		if hasReleasePleaseConfigs(".", cfg) {
 			if err := syncToReleasePlease(".", cfg, name); err != nil {

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -102,7 +102,10 @@ func runAdd(ctx context.Context, cfg *config.Config, api string) error {
 	if err != nil {
 		return err
 	}
-	if cfg.Language == config.LanguageGo || cfg.Language == config.LanguagePython || cfg.Language == config.LanguageNodejs {
+	if cfg.Language == config.LanguageGo ||
+		cfg.Language == config.LanguagePython ||
+		cfg.Language == config.LanguageNodejs ||
+		cfg.Language == config.LanguageRuby {
 		if hasReleasePleaseConfigs(".", cfg) {
 			if err := syncToReleasePlease(".", cfg, name); err != nil {
 				return err

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/python"
+	"github.com/googleapis/librarian/internal/librarian/ruby"
 )
 
 const (
@@ -127,7 +128,9 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 		// component value in package.
 		component = ""
 	}
-
+	if cfg.Language == config.LanguageRuby {
+		manifest = ruby.AddManifest(manifest, pkgPath)
+	}
 	if err := syncPackageToReleasePlease(manifest, packages, pkgPath, lib.Version, component, extraFiles); err != nil {
 		return err
 	}

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -130,6 +130,7 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 	}
 	if cfg.Language == config.LanguageRuby {
 		manifest = ruby.AddManifest(manifest, pkgPath)
+		packages = ruby.AddPackage(packages, pkgPath)
 	}
 	if err := syncPackageToReleasePlease(manifest, packages, pkgPath, lib.Version, component, extraFiles); err != nil {
 		return err

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -39,6 +39,12 @@ const (
 	defaultReleasePleaseVersion = "0.0.0"
 )
 
+type extraFile struct {
+	path   string
+	isMap  bool
+	rawMap map[string]any
+}
+
 func hasReleasePleaseConfigs(dir string, cfg *config.Config) bool {
 	manifestFile, configFile := releasePleaseFiles(cfg)
 	_, errM := os.Stat(filepath.Join(dir, manifestFile))
@@ -197,12 +203,6 @@ func syncPackageToReleasePlease(manifest map[string]string, packages map[string]
 		pkgCfg["extra-files"] = merged
 	}
 	return nil
-}
-
-type extraFile struct {
-	path   string
-	isMap  bool
-	rawMap map[string]any
 }
 
 // mergeExtraFiles merges existing and derived extra-files list while removing duplicates.

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -129,7 +129,7 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 		component = ""
 	}
 	if cfg.Language == config.LanguageRuby {
-		manifest = ruby.AddManifest(manifest, pkgPath)
+		manifest = ruby.AddManifest(manifest, pkgPath, lib.Version)
 		packages = ruby.AddPackage(packages, pkgPath)
 	}
 	if err := syncPackageToReleasePlease(manifest, packages, pkgPath, lib.Version, component, extraFiles); err != nil {

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -49,7 +49,7 @@ func hasReleasePleaseConfigs(dir string, cfg *config.Config) bool {
 // releasePleaseFiles returns the file names for the Release Please manifest file
 // and config file in this order, depending on the SDK language.
 func releasePleaseFiles(cfg *config.Config) (string, string) {
-	// google-cloud-node uses the default Release Please files to add a new library.
+	// google-cloud-node and google-cloud-ruby use the default Release Please files to add a new library.
 	// google-cloud-python uses the "-individual-" files initially for new libraries.
 	// google-cloud-go uses the "-bulk-" files.
 	manifestFile := bulkManifestFile
@@ -58,7 +58,7 @@ func releasePleaseFiles(cfg *config.Config) (string, string) {
 	case config.LanguagePython:
 		manifestFile = individualManifestFile
 		configFile = individualConfigFile
-	case config.LanguageNodejs:
+	case config.LanguageNodejs, config.LanguageRuby:
 		manifestFile = defaultManifestFile
 		configFile = defaultConfigFile
 	}

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -381,8 +381,8 @@ func TestSyncToReleasePlease(t *testing.T) {
 			}`,
 		},
 		{
-			name:            "new ruby main client",
-			language:        config.LanguageRuby,
+			name:     "new ruby main client",
+			language: config.LanguageRuby,
 			initialManifest: `{
 				"google-cloud-secret_manager-v1": "0.0.1",
 				"google-cloud-secret_manager-v1+FILLER": "0.0.0"

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -380,6 +380,47 @@ func TestSyncToReleasePlease(t *testing.T) {
 				}
 			}`,
 		},
+		{
+			name:            "new ruby main client",
+			language:        config.LanguageRuby,
+			initialManifest: `{
+				"google-cloud-secret_manager-v1": "0.0.1",
+				"google-cloud-secret_manager-v1+FILLER": "0.0.0"
+			}`,
+			initialConfig: `{
+				"packages": {
+					"google-cloud-secret_manager-v1": {
+						"component": "google-cloud-secret_manager-v1",
+						"version_file": "lib/google/cloud/secret_manager/v1/version.rb"
+					}
+				}
+			}`,
+			library: &config.Library{
+				Name:    "google-cloud-secret_manager",
+				Version: "0.0.1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			wantManifest: `{
+				"google-cloud-secret_manager": "0.0.1",
+				"google-cloud-secret_manager+FILLER": "0.0.0",
+				"google-cloud-secret_manager-v1": "0.0.1",
+				"google-cloud-secret_manager-v1+FILLER": "0.0.0"
+			}`,
+			wantConfig: `{
+				"packages": {
+					"google-cloud-secret_manager": {
+						"component": "google-cloud-secret_manager",
+						"version_file": "lib/google/cloud/secret_manager/version.rb"
+					},
+					"google-cloud-secret_manager-v1": {
+						"component": "google-cloud-secret_manager-v1",
+						"version_file": "lib/google/cloud/secret_manager/v1/version.rb"
+					}
+				}
+			}`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmp := t.TempDir()

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -316,7 +316,6 @@ func TestSyncToReleasePlease(t *testing.T) {
 				}
 			}`,
 		},
-
 		{
 			name:            "replace existing string extra-files with map if same path",
 			language:        config.LanguagePython,
@@ -352,6 +351,31 @@ func TestSyncToReleasePlease(t *testing.T) {
 								"type": "json"
 							}
 						]
+					}
+				}
+			}`,
+		},
+		{
+			name:            "new ruby versioned library",
+			language:        config.LanguageRuby,
+			initialManifest: `{}`,
+			initialConfig:   `{"packages": {}}`,
+			library: &config.Library{
+				Name:    "google-cloud-secret_manager-v1",
+				Version: "0.0.1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			wantManifest: `{
+				"google-cloud-secret_manager-v1": "0.0.1",
+				"google-cloud-secret_manager-v1+FILLER": "0.0.0"
+			}`,
+			wantConfig: `{
+				"packages": {
+					"google-cloud-secret_manager-v1": {
+						"component": "google-cloud-secret_manager-v1",
+						"version_file": "lib/google/cloud/secret_manager/v1/version.rb"
 					}
 				}
 			}`,

--- a/internal/librarian/ruby/release_please.go
+++ b/internal/librarian/ruby/release_please.go
@@ -14,6 +14,16 @@
 
 package ruby
 
+import (
+	"fmt"
+	"strings"
+)
+
+type packageEntry struct {
+	component    string
+	version_file string
+}
+
 // AddManifest inserts a new package and its filler entry into a Release Please manifest map.
 func AddManifest(manifest map[string]string, name string) map[string]string {
 	if _, ok := manifest[name]; ok {
@@ -22,4 +32,20 @@ func AddManifest(manifest map[string]string, name string) map[string]string {
 	manifest[name] = defaultVersion
 	manifest[name+"+FILLER"] = "0.0.0"
 	return manifest
+}
+
+// AddPackage inserts a new package into a Release Please packages map.
+func AddPackage(packages map[string]any, name string) map[string]any {
+	if _, ok := packages[name]; ok {
+		return packages
+	}
+	packages[name] = &packageEntry{
+		component:    name,
+		version_file: toVersionFile(name),
+	}
+	return packages
+}
+
+func toVersionFile(name string) string {
+	return fmt.Sprintf("lib/%s/version.rb", strings.ReplaceAll(name, "-", "/"))
 }

--- a/internal/librarian/ruby/release_please.go
+++ b/internal/librarian/ruby/release_please.go
@@ -20,11 +20,11 @@ import (
 )
 
 // AddManifest inserts a new package and its filler entry into a Release Please manifest map.
-func AddManifest(manifest map[string]string, name string) map[string]string {
+func AddManifest(manifest map[string]string, name, version string) map[string]string {
 	if _, ok := manifest[name]; ok {
 		return manifest
 	}
-	manifest[name] = defaultVersion
+	manifest[name] = version
 	manifest[name+"+FILLER"] = "0.0.0"
 	return manifest
 }

--- a/internal/librarian/ruby/release_please.go
+++ b/internal/librarian/ruby/release_please.go
@@ -19,11 +19,6 @@ import (
 	"strings"
 )
 
-type packageEntry struct {
-	component    string
-	version_file string
-}
-
 // AddManifest inserts a new package and its filler entry into a Release Please manifest map.
 func AddManifest(manifest map[string]string, name string) map[string]string {
 	if _, ok := manifest[name]; ok {
@@ -39,9 +34,9 @@ func AddPackage(packages map[string]any, name string) map[string]any {
 	if _, ok := packages[name]; ok {
 		return packages
 	}
-	packages[name] = &packageEntry{
-		component:    name,
-		version_file: toVersionFile(name),
+	packages[name] = map[string]any{
+		"component":    name,
+		"version_file": toVersionFile(name),
 	}
 	return packages
 }

--- a/internal/librarian/ruby/release_please.go
+++ b/internal/librarian/ruby/release_please.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+func AddManifest(manifest map[string]string, name string) map[string]string {
+	if _, ok := manifest[name]; ok {
+		return manifest
+	}
+	manifest[name] = defaultVersion
+	manifest[name+"+FILLER"] = "0.0.0"
+	return manifest
+}

--- a/internal/librarian/ruby/release_please.go
+++ b/internal/librarian/ruby/release_please.go
@@ -14,6 +14,7 @@
 
 package ruby
 
+// AddManifest inserts a new package and its filler entry into a Release Please manifest map.
 func AddManifest(manifest map[string]string, name string) map[string]string {
 	if _, ok := manifest[name]; ok {
 		return manifest

--- a/internal/librarian/ruby/release_please_test.go
+++ b/internal/librarian/ruby/release_please_test.go
@@ -25,12 +25,14 @@ func TestAddManifest(t *testing.T) {
 		name     string
 		manifest map[string]string
 		pkgName  string
+		version  string
 		want     map[string]string
 	}{
 		{
 			name:     "add new package to empty manifest",
 			manifest: map[string]string{},
 			pkgName:  "google-cloud-secret_manager-v1",
+			version:  "0.0.1",
 			want: map[string]string{
 				"google-cloud-secret_manager-v1":        "0.0.1",
 				"google-cloud-secret_manager-v1+FILLER": "0.0.0",
@@ -42,9 +44,10 @@ func TestAddManifest(t *testing.T) {
 				"google-cloud-asset": "1.0.0",
 			},
 			pkgName: "google-cloud-secret_manager",
+			version: "0.1.0",
 			want: map[string]string{
 				"google-cloud-asset":                 "1.0.0",
-				"google-cloud-secret_manager":        "0.0.1",
+				"google-cloud-secret_manager":        "0.1.0",
 				"google-cloud-secret_manager+FILLER": "0.0.0",
 			},
 		},
@@ -55,6 +58,7 @@ func TestAddManifest(t *testing.T) {
 				"google-cloud-secret_manager+FILLER": "0.0.0",
 			},
 			pkgName: "google-cloud-secret_manager",
+			version: "2.1.0",
 			want: map[string]string{
 				"google-cloud-secret_manager":        "2.1.0",
 				"google-cloud-secret_manager+FILLER": "0.0.0",
@@ -62,7 +66,7 @@ func TestAddManifest(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := AddManifest(test.manifest, test.pkgName)
+			got := AddManifest(test.manifest, test.pkgName, test.version)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/librarian/ruby/release_please_test.go
+++ b/internal/librarian/ruby/release_please_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAddManifest(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		manifest map[string]string
+		pkgName  string
+		want     map[string]string
+	}{
+		{
+			name:     "add new package to empty manifest",
+			manifest: map[string]string{},
+			pkgName:  "google-cloud-secret_manager",
+			want: map[string]string{
+				"google-cloud-secret_manager":        "0.0.1",
+				"google-cloud-secret_manager+FILLER": "0.0.0",
+			},
+		},
+		{
+			name: "add new package preserving existing entries",
+			manifest: map[string]string{
+				"google-cloud-asset": "1.0.0",
+			},
+			pkgName: "google-cloud-secret_manager",
+			want: map[string]string{
+				"google-cloud-asset":                 "1.0.0",
+				"google-cloud-secret_manager":        "0.0.1",
+				"google-cloud-secret_manager+FILLER": "0.0.0",
+			},
+		},
+		{
+			name: "existing package unchanged",
+			manifest: map[string]string{
+				"google-cloud-secret_manager":        "2.1.0",
+				"google-cloud-secret_manager+FILLER": "0.0.0",
+			},
+			pkgName: "google-cloud-secret_manager",
+			want: map[string]string{
+				"google-cloud-secret_manager":        "2.1.0",
+				"google-cloud-secret_manager+FILLER": "0.0.0",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := AddManifest(test.manifest, test.pkgName)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/ruby/release_please_test.go
+++ b/internal/librarian/ruby/release_please_test.go
@@ -30,10 +30,10 @@ func TestAddManifest(t *testing.T) {
 		{
 			name:     "add new package to empty manifest",
 			manifest: map[string]string{},
-			pkgName:  "google-cloud-secret_manager",
+			pkgName:  "google-cloud-secret_manager-v1",
 			want: map[string]string{
-				"google-cloud-secret_manager":        "0.0.1",
-				"google-cloud-secret_manager+FILLER": "0.0.0",
+				"google-cloud-secret_manager-v1":        "0.0.1",
+				"google-cloud-secret_manager-v1+FILLER": "0.0.0",
 			},
 		},
 		{

--- a/internal/librarian/ruby/release_please_test.go
+++ b/internal/librarian/ruby/release_please_test.go
@@ -69,3 +69,67 @@ func TestAddManifest(t *testing.T) {
 		})
 	}
 }
+
+func TestAddPackage(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		packages map[string]any
+		pkgName  string
+		want     map[string]any
+	}{
+		{
+			name:     "add new versioned package",
+			packages: map[string]any{},
+			pkgName:  "google-cloud-secret_manager-v1",
+			want: map[string]any{
+				"google-cloud-secret_manager-v1": map[string]any{
+					"component":    "google-cloud-secret_manager-v1",
+					"version_file": "lib/google/cloud/secret_manager/v1/version.rb",
+				},
+			},
+		},
+		{
+			name: "add new unversioned package preserving existing entries",
+			packages: map[string]any{
+				"google-cloud-asset-v1": map[string]any{
+					"component":    "google-cloud-asset-v1",
+					"version_file": "lib/google/cloud/asset/v1/version.rb",
+				},
+			},
+			pkgName: "google-cloud-secret_manager",
+			want: map[string]any{
+				"google-cloud-asset-v1": map[string]any{
+					"component":    "google-cloud-asset-v1",
+					"version_file": "lib/google/cloud/asset/v1/version.rb",
+				},
+				"google-cloud-secret_manager": map[string]any{
+					"component":    "google-cloud-secret_manager",
+					"version_file": "lib/google/cloud/secret_manager/version.rb",
+				},
+			},
+		},
+		{
+			name: "existing package unchanged",
+			packages: map[string]any{
+				"google-cloud-secret_manager-v1": map[string]any{
+					"component":    "custom-component",
+					"version_file": "custom/path/version.rb",
+				},
+			},
+			pkgName: "google-cloud-secret_manager-v1",
+			want: map[string]any{
+				"google-cloud-secret_manager-v1": map[string]any{
+					"component":    "custom-component",
+					"version_file": "custom/path/version.rb",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := AddPackage(test.packages, test.pkgName)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Release Please synchronization logic is added for Ruby SDK repositories so that newly onboarded libraries are properly tracked in release automation configurations.

Manifest entries are recorded alongside their corresponding zero-version filler records to maintain structural parity.

Package configuration mapping automatically resolves component names and derives version file paths by converting hyphenated library identifiers into standard Ruby module directory layouts.

See an onboarding [PR](https://github.com/googleapis/google-cloud-ruby/pull/34720) for example release-please configuration changes. 

Fixes #7185
For #6635
