### PR TITLE
feat(swift): support repeated fields in Protobuf conversions

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -210,7 +210,7 @@ func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*field
 			annotations.UrlSafeValue = true
 		}
 	}
-	if !field.IsOneOf && !field.Map && !field.Repeated {
+	if !field.IsOneOf && !field.Map {
 		annotations.ProtoFieldName = protoFieldName(field.Name)
 		annotations.ProtoFieldNamePascal = protoFieldNamePascal(field.Name)
 		annotations.PrimitiveFieldType = parts.Base

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -60,9 +60,11 @@ func TestAnnotateField(t *testing.T) {
 			optional: false,
 			repeated: true,
 			want: &fieldAnnotations{
-				FieldType:     "[Swift.String]",
-				BaseFieldType: "Swift.String",
-				// Map and Repeated fields are not annotated for conversions yet
+				FieldType:            "[Swift.String]",
+				BaseFieldType:        "Swift.String",
+				ProtoFieldName:       "secretPayload",
+				ProtoFieldNamePascal: "SecretPayload",
+				PrimitiveFieldType:   "Swift.String",
 			},
 		},
 	} {
@@ -169,9 +171,12 @@ func TestAnnotateField_Discovery(t *testing.T) {
 				Typez:    api.TypezBytes,
 			},
 			want: &fieldAnnotations{
-				FieldType:     "[Foundation.Data]",
-				BaseFieldType: "Foundation.Data",
-				UrlSafeValue:  true,
+				FieldType:            "[Foundation.Data]",
+				BaseFieldType:        "Foundation.Data",
+				UrlSafeValue:         true,
+				ProtoFieldName:       "name",
+				ProtoFieldNamePascal: "Name",
+				PrimitiveFieldType:   "Foundation.Data",
 			},
 		},
 		{
@@ -355,9 +360,12 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			repeated: true,
 			isOneOf:  false,
 			want: &fieldAnnotations{
-				FieldType:     "[Node]",
-				BaseFieldType: "Node",
-				Recursive:     false,
+				FieldType:            "[Node]",
+				BaseFieldType:        "Node",
+				Recursive:            false,
+				ProtoFieldName:       "childNode",
+				ProtoFieldNamePascal: "ChildNode",
+				PrimitiveFieldType:   "Node",
 			},
 		},
 		{

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -147,7 +147,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if len(message.Fields) != 0 {
 		sampleField = camelCase(message.Fields[0].Name)
 	}
-	hasConvertedFields := slices.IndexFunc(message.Fields, func(f *api.Field) bool { return !f.IsOneOf && f.Singular() }) != -1
+	hasConvertedFields := slices.IndexFunc(message.Fields, func(f *api.Field) bool { return !f.IsOneOf && !f.Map }) != -1
 	parameterTypeName, err := c.messageTypeName(message)
 	if err != nil {
 		return err

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -622,3 +622,79 @@ func TestAnnotateMessage_PlaceholderGating(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotateMessage_HasConvertedFields(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		fields []*api.Field
+		want   bool
+	}{
+		{
+			name:   "empty_message",
+			fields: []*api.Field{},
+			want:   false,
+		},
+		{
+			name: "singular_field",
+			fields: []*api.Field{
+				{Name: "field1", ID: "1", Typez: api.TypezString},
+			},
+			want: true,
+		},
+		{
+			name: "repeated_field",
+			fields: []*api.Field{
+				{Name: "field1", ID: "1", Typez: api.TypezString, Repeated: true},
+			},
+			want: true,
+		},
+		{
+			name: "map_field",
+			fields: []*api.Field{
+				{Name: "field1", ID: "1", Typez: api.TypezString, Map: true},
+			},
+			want: false,
+		},
+		{
+			name: "oneof_field",
+			fields: []*api.Field{
+				{Name: "field1", ID: "1", Typez: api.TypezString, IsOneOf: true},
+			},
+			want: false,
+		},
+		{
+			name: "map_and_repeated_fields",
+			fields: []*api.Field{
+				{Name: "labels", ID: "1", Typez: api.TypezString, Map: true},
+				{Name: "names", ID: "2", Typez: api.TypezString, Repeated: true},
+			},
+			want: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			msg := &api.Message{
+				Name:    "TestMessage",
+				ID:      ".test.TestMessage",
+				Package: "test",
+				Fields:  test.fields,
+			}
+			for _, f := range msg.Fields {
+				f.Parent = msg
+			}
+			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+			model.PackageName = "test"
+			codec := newTestCodec(t, model, nil)
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
+			}
+			ann, ok := msg.Codec.(*messageAnnotations)
+			if !ok {
+				t.Fatalf("expected msg.Codec to be *messageAnnotations, got %T", msg.Codec)
+			}
+			if ann.HasConvertedFields != test.want {
+				t.Errorf("HasConvertedFields = %v, want %v", ann.HasConvertedFields, test.want)
+			}
+		})
+	}
+}
+

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -697,4 +697,3 @@ func TestAnnotateMessage_HasConvertedFields(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -192,25 +192,18 @@ func TestGenerateConversions_NoConvertedFields(t *testing.T) {
 	outDir := t.TempDir()
 
 	field1 := &api.Field{
-		Name:     "locations",
-		ID:       "1",
-		Repeated: true,
-		Typez:    api.TypezString,
-	}
-	field2 := &api.Field{
 		Name:  "labels",
-		ID:    "2",
+		ID:    "1",
 		Map:   true,
 		Typez: api.TypezString,
 	}
 	msg := &api.Message{
-		Name:    "EmptyOrRepeatedOnly",
-		ID:      ".test.EmptyOrRepeatedOnly",
-		Fields:  []*api.Field{field1, field2},
+		Name:    "EmptyOrMapOnly",
+		ID:      ".test.EmptyOrMapOnly",
+		Fields:  []*api.Field{field1},
 		Package: "test",
 	}
 	field1.Parent = msg
-	field2.Parent = msg
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "test"
 
@@ -220,18 +213,111 @@ func TestGenerateConversions_NoConvertedFields(t *testing.T) {
 	module := &config.SwiftModule{
 		ModulePath: "StorageControlProtos",
 	}
+
 	if err := GenerateConversions(t.Context(), model, outDir, library, module); err != nil {
 		t.Fatal(err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(outDir, "EmptyOrRepeatedOnly+Convert.swift"))
+	b, err := os.ReadFile(filepath.Join(outDir, "EmptyOrMapOnly+Convert.swift"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	gotContent := string(b)
+
 	got := extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
 	wantToProto := `  internal func toProto() throws -> ProtoType {
     let proto = ProtoType()
+    return proto
+  }`
+	if diff := cmp.Diff(wantToProto, got); diff != "" {
+		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGenerateConversions_RepeatedFields(t *testing.T) {
+	outDir := t.TempDir()
+
+	enumVal := &api.EnumValue{Name: "UNSPECIFIED", Number: 0}
+	enum := &api.Enum{
+		Name:               "Category",
+		ID:                 ".test.Category",
+		Package:            "test",
+		Values:             []*api.EnumValue{enumVal},
+		UniqueNumberValues: []*api.EnumValue{enumVal},
+	}
+	enumVal.Parent = enum
+
+	item := &api.Message{
+		Name:    "Item",
+		Package: "test",
+		ID:      ".test.Item",
+	}
+
+	field1 := &api.Field{
+		Name:     "names",
+		ID:       ".test.Container.names",
+		Typez:    api.TypezString,
+		Repeated: true,
+	}
+	field2 := &api.Field{
+		Name:     "items",
+		ID:       ".test.Container.items",
+		Typez:    api.TypezMessage,
+		TypezID:  ".test.Item",
+		Repeated: true,
+	}
+	field3 := &api.Field{
+		Name:     "categories",
+		ID:       ".test.Container.categories",
+		Typez:    api.TypezEnum,
+		TypezID:  ".test.Category",
+		Repeated: true,
+	}
+	container := &api.Message{
+		Name:    "Container",
+		Package: "test",
+		ID:      ".test.Container",
+		Fields:  []*api.Field{field1, field2, field3},
+	}
+	field1.Parent = container
+	field2.Parent = container
+	field3.Parent = container
+
+	model := api.NewTestAPI([]*api.Message{item, container}, []*api.Enum{enum}, []*api.Service{})
+	model.PackageName = "test"
+
+	library := &config.Library{}
+	module := &config.SwiftModule{
+		ModulePath: "TestProtos",
+	}
+
+	if err := GenerateConversions(t.Context(), model, outDir, library, module); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(outDir, "Container+Convert.swift"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotContent := string(b)
+
+	got := extractBlock(t, gotContent, "  internal init(proto: ProtoType) throws {", "\n  }")
+	wantInit := `  internal init(proto: ProtoType) throws {
+    self.init()
+    self.names = proto.names
+    self.items = try proto.items.map { try .init(proto: $0) }
+    self.categories = proto.categories.map { .init(proto: $0) }
+  }`
+	if diff := cmp.Diff(wantInit, got); diff != "" {
+		t.Errorf("init(proto:) mismatch (-want +got):\n%s", diff)
+	}
+
+	got = extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
+	wantToProto := `  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.names = self.names
+    proto.items = try self.items.map { try $0.toProto() }
+    proto.categories = try self.categories.map { try $0.toProto() }
     return proto
   }`
 	if diff := cmp.Diff(wantToProto, got); diff != "" {

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -58,6 +58,21 @@ extension {{Codec.ParameterTypeName}} {
     {{/IsObject}}
     {{/Optional}}
     {{/Singular}}
+    {{#Repeated}}
+    {{^Map}}
+    {{#IsObject}}
+    self.{{Codec.Name}} = try proto.{{Codec.ProtoFieldName}}.map { try .init(proto: $0) }
+    {{/IsObject}}
+    {{#IsEnum}}
+    self.{{Codec.Name}} = proto.{{Codec.ProtoFieldName}}.map { .init(proto: $0) }
+    {{/IsEnum}}
+    {{^IsObject}}
+    {{^IsEnum}}
+    self.{{Codec.Name}} = proto.{{Codec.ProtoFieldName}}
+    {{/IsEnum}}
+    {{/IsObject}}
+    {{/Map}}
+    {{/Repeated}}
     {{/IsOneOf}}
     {{/Fields}}
   }
@@ -109,6 +124,21 @@ extension {{Codec.ParameterTypeName}} {
     {{/IsObject}}
     {{/Optional}}
     {{/Singular}}
+    {{#Repeated}}
+    {{^Map}}
+    {{#IsObject}}
+    proto.{{Codec.ProtoFieldName}} = try self.{{Codec.Name}}.map { try $0.toProto() }
+    {{/IsObject}}
+    {{#IsEnum}}
+    proto.{{Codec.ProtoFieldName}} = try self.{{Codec.Name}}.map { try $0.toProto() }
+    {{/IsEnum}}
+    {{^IsObject}}
+    {{^IsEnum}}
+    proto.{{Codec.ProtoFieldName}} = self.{{Codec.Name}}
+    {{/IsEnum}}
+    {{/IsObject}}
+    {{/Map}}
+    {{/Repeated}}
     {{/IsOneOf}}
     {{/Fields}}
     return proto

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -59,7 +59,6 @@ extension {{Codec.ParameterTypeName}} {
     {{/Optional}}
     {{/Singular}}
     {{#Repeated}}
-    {{^Map}}
     {{#IsObject}}
     self.{{Codec.Name}} = try proto.{{Codec.ProtoFieldName}}.map { try .init(proto: $0) }
     {{/IsObject}}
@@ -71,7 +70,6 @@ extension {{Codec.ParameterTypeName}} {
     self.{{Codec.Name}} = proto.{{Codec.ProtoFieldName}}
     {{/IsEnum}}
     {{/IsObject}}
-    {{/Map}}
     {{/Repeated}}
     {{/IsOneOf}}
     {{/Fields}}
@@ -125,7 +123,6 @@ extension {{Codec.ParameterTypeName}} {
     {{/Optional}}
     {{/Singular}}
     {{#Repeated}}
-    {{^Map}}
     {{#IsObject}}
     proto.{{Codec.ProtoFieldName}} = try self.{{Codec.Name}}.map { try $0.toProto() }
     {{/IsObject}}
@@ -137,7 +134,6 @@ extension {{Codec.ParameterTypeName}} {
     proto.{{Codec.ProtoFieldName}} = self.{{Codec.Name}}
     {{/IsEnum}}
     {{/IsObject}}
-    {{/Map}}
     {{/Repeated}}
     {{/IsOneOf}}
     {{/Fields}}


### PR DESCRIPTION
Extend the Swift sidekick generator to support converting `Repeated` (collection) fields (`Repeated == true && Map == false`) between generated Swift struct models and SwiftProtobuf types.

generates https://github.com/googleapis/google-cloud-swift/pull/133 