### PR TITLE
feat(sidekick/rust): bigquery skipped fields via librarian.yaml

### DIFF
--- a/internal/sidekick/rust/bigquery.go
+++ b/internal/sidekick/rust/bigquery.go
@@ -104,7 +104,7 @@ func (m *unifiedMessage) fieldGroupList() []*fieldGroup {
 func newRunQuery(c *codec, model *api.API, skippedFields []string) (*unifiedMessage, error) {
 	msg, err := newUnifiedMessage(c, model, []string{"QueryRequest", "JobConfigurationQuery", "JobConfiguration"}, func(f *api.Field) bool {
 		// skip fields that are output only or explicitly skipped
-		return slices.Contains(skippedFields, f.Name) || slices.Contains(f.Behavior, api.FieldBehaviorOutputOnly)
+		return slices.Contains(skippedFields, f.Name) || slices.Contains(skippedFields, f.ID) || slices.Contains(f.Behavior, api.FieldBehaviorOutputOnly)
 	})
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func newRunQuery(c *codec, model *api.API, skippedFields []string) (*unifiedMess
 
 func newQueryMetadata(c *codec, model *api.API, skippedFields []string) (*unifiedMessage, error) {
 	return newUnifiedMessage(c, model, []string{"GetQueryResultsResponse", "QueryResponse"}, func(f *api.Field) bool {
-		return slices.Contains(skippedFields, f.Name)
+		return slices.Contains(skippedFields, f.Name) || slices.Contains(skippedFields, f.ID)
 	})
 }
 

--- a/internal/sidekick/rust/bigquery_test.go
+++ b/internal/sidekick/rust/bigquery_test.go
@@ -73,12 +73,13 @@ func TestBigQueryFiltering(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newTestField := func(name string, outputOnly bool) *api.Field {
+	newTestField := func(name, id string, outputOnly bool) *api.Field {
 		b := []api.FieldBehavior{}
 		if outputOnly {
 			b = append(b, api.FieldBehaviorOutputOnly)
 		}
 		return &api.Field{
+			ID:       id,
 			Name:     name,
 			Behavior: b,
 			Codec:    &fieldAnnotations{},
@@ -93,12 +94,22 @@ func TestBigQueryFiltering(t *testing.T) {
 		}
 	}
 
-	qrMsg := newTestMsg("QueryRequest", []*api.Field{newTestField("output_only", true), newTestField("foo", false)})
-	jcqMsg := newTestMsg("JobConfigurationQuery", []*api.Field{newTestField("output_only", true), newTestField("foo", false)})
-	jcMsg := newTestMsg("JobConfiguration", []*api.Field{newTestField("output_only", true), newTestField("skip", false)})
+	qrMsg := newTestMsg("QueryRequest", []*api.Field{
+		newTestField("output_only", ".google.cloud.bigquery.v2.QueryRequest.output_only", true),
+		newTestField("foo", ".google.cloud.bigquery.v2.QueryRequest.foo", false),
+	})
+	jcqMsg := newTestMsg("JobConfigurationQuery", []*api.Field{
+		newTestField("output_only", ".google.cloud.bigquery.v2.JobConfigurationQuery.output_only", true),
+		newTestField("foo", ".google.cloud.bigquery.v2.JobConfigurationQuery.foo", false),
+		newTestField("skip", ".google.cloud.bigquery.v2.JobConfigurationQuery.skip", false),
+	})
+	jcMsg := newTestMsg("JobConfiguration", []*api.Field{
+		newTestField("output_only", ".google.cloud.bigquery.v2.JobConfiguration.output_only", true),
+		newTestField("skip", ".google.cloud.bigquery.v2.JobConfiguration.skip", false),
+	})
 
 	model := api.NewTestAPI([]*api.Message{qrMsg, jcqMsg, jcMsg}, []*api.Enum{}, []*api.Service{})
-	builder, err := newRunQuery(c, model, []string{"skip"})
+	builder, err := newRunQuery(c, model, []string{"skip", ".google.cloud.bigquery.v2.JobConfigurationQuery.skip"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +119,9 @@ func TestBigQueryFiltering(t *testing.T) {
 		fieldNames = append(fieldNames, f.FieldName())
 	}
 
-	// "output_only" and "skip" must be skipped; "foo" must be present.
+	// "output_only", "skip" from JobConfiguration (by name) and "skip" from
+	// JobConfigurationQuery (by ID) must be filtered out.
+	// "foo" must be present.
 	want := []string{"foo"}
 	if diff := cmp.Diff(want, fieldNames); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/rust/generate.go
+++ b/internal/sidekick/rust/generate.go
@@ -85,12 +85,9 @@ func GenerateBigQueryBuilder(ctx context.Context, outdir string, model *api.API,
 		return err
 	}
 
-	// TODO(googleapis/google-cloud-rust#5844): move this list to come from librarian.yaml
-	skippedFields := []string{
-		"copy", "load", "extract", // skip non job types
-		"format_options",   // we want to control format options on veneer
-		"kind", "job_type", // output only but not properly marked on protos
-	}
+	// configured via librarian.yaml
+	skippedFields := cfg.Override.SkippedIDs
+
 	runQuery, err := newRunQuery(c, model, skippedFields)
 	if err != nil {
 		return err
@@ -105,10 +102,6 @@ func GenerateBigQueryBuilder(ctx context.Context, outdir string, model *api.API,
 		return err
 	}
 
-	// TODO(googleapis/google-cloud-rust#5844): move this list to come from librarian.yaml
-	skippedFields = []string{
-		"rows", // skip rows since it takes a lot of memory
-	}
 	queryMetadata, err := newQueryMetadata(c, model, skippedFields)
 	if err != nil {
 		return err


### PR DESCRIPTION
Remove hardcoded field filtering from sidekick template code and allow it to be changed from librarian.yaml.

This is the equivalent filters to be added to librarian.yaml to keep same behavior.
```
- name: google-cloud-bigquery
    version: 0.16.0-preview
    copyright_year: "2026"
    output: src/bigquery
    rust:
      modules:
        - output: src/bigquery/src/generated
          api_path: google/cloud/bigquery/v2
          template: bigquery
          skipped_ids:
            # skip non job type fields
            - .google.cloud.bigquery.v2.JobConfiguration.copy
            - .google.cloud.bigquery.v2.JobConfiguration.load
            - .google.cloud.bigquery.v2.JobConfiguration.extract
            # we want to control format options on veneer
            - .google.cloud.bigquery.v2.QueryRequest.format_options
            - .google.cloud.bigquery.v2.GetQueryResultsRequest.format_options
            # output only but not properly marked on protos
            - .google.cloud.bigquery.v2.QueryRequest.kind
            - .google.cloud.bigquery.v2.JobConfiguration.kind
            - .google.cloud.bigquery.v2.JobConfiguration.job_type
            # skip rows since it takes a lot of memory
            - .google.cloud.bigquery.v2.GetQueryResultsResponse.rows
            - .google.cloud.bigquery.v2.QueryResponse.rows
```

Towards googleapis/google-cloud-rust#5844