### PR TITLE
fix(sdk.yaml): fix all shopping merchant titles

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1272,6 +1272,64 @@
 - path: google/shopping/css/v1
   release_level:
     go: preview
+- path: google/shopping/merchant/accounts/v1
+  title: Shopping Merchant Accounts API
+- path: google/shopping/merchant/accounts/v1alpha
+  title: Shopping Merchant Accounts API
+- path: google/shopping/merchant/accounts/v1beta
+  title: Shopping Merchant Accounts API
+- path: google/shopping/merchant/conversions/v1
+  title: Shopping Merchant Conversions API
+- path: google/shopping/merchant/conversions/v1beta
+  title: Shopping Merchant Conversions API
+- path: google/shopping/merchant/datasources/v1
+  title: Shopping Merchant Data Sources API
+- path: google/shopping/merchant/datasources/v1beta
+  title: Shopping Merchant Data Sources API
+- path: google/shopping/merchant/inventories/v1
+  title: Shopping Merchant Inventories API
+- path: google/shopping/merchant/inventories/v1beta
+  title: Shopping Merchant Inventories API
+- path: google/shopping/merchant/issueresolution/v1
+  title: Shopping Merchant Issue Resolution API
+- path: google/shopping/merchant/issueresolution/v1beta
+  title: Shopping Merchant Issue Resolution API
+- path: google/shopping/merchant/lfp/v1
+  title: Shopping Merchant LFP API
+- path: google/shopping/merchant/lfp/v1beta
+  title: Shopping Merchant LFP API
+- path: google/shopping/merchant/notifications/v1
+  title: Shopping Merchant Notifications API
+- path: google/shopping/merchant/notifications/v1beta
+  title: Shopping Merchant Notifications API
+- path: google/shopping/merchant/ordertracking/v1
+  title: Shopping Merchant Order Tracking API
+- path: google/shopping/merchant/ordertracking/v1beta
+  title: Shopping Merchant Order Tracking API
+- path: google/shopping/merchant/products/v1
+  title: Shopping Merchant Products API
+- path: google/shopping/merchant/products/v1beta
+  title: Shopping Merchant Products API
+- path: google/shopping/merchant/productstudio/v1alpha
+  title: Shopping Merchant Product Studio API
+- path: google/shopping/merchant/promotions/v1
+  title: Shopping Merchant Promotions API
+- path: google/shopping/merchant/promotions/v1beta
+  title: Shopping Merchant Promotions API
+- path: google/shopping/merchant/quota/v1
+  title: Shopping Merchant Quota API
+- path: google/shopping/merchant/quota/v1beta
+  title: Shopping Merchant Quota API
+- path: google/shopping/merchant/reports/v1
+  title: Shopping Merchant Reports API
+- path: google/shopping/merchant/reports/v1alpha
+  title: Shopping Merchant Reports API
+- path: google/shopping/merchant/reports/v1beta
+  title: Shopping Merchant Reports API
+- path: google/shopping/merchant/reviews/v1beta
+  title: Shopping Merchant Reviews API
+- path: google/shopping/merchant/youtube/v1alpha
+  title: Shopping Merchant YouTube API
 - path: google/shopping/type
   documentation_uri: https://developers.google.com/merchant/api
   skip_rest_numeric_enums:


### PR DESCRIPTION
All of the `google/shopping/merchant` sub APIs have an identical `title` property that is simply `Merchant API`. This ends up in client library readmes, docs, etc. and is too abstract, especially for those clients that are shipped as individual libraries rather than grouped in a single unit.

Override the `title` of every `google/shopping/merchant` API path to use a more appropriate `title`.

This will have downstream code changes, but only in documentation.

Note: We should consider if we want to work with the API team to change this upstream, though that may be non-trivial as it is an uber API. Alternatively, we could devise some "title derivation" feature in `librarian` to make this config go away and future proof future `google/shopping/merchant` API publications.