### PR TITLE
feat(librarian/swift): modules with service configs

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -633,6 +633,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `output` | string | Is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated"). |
+| `service_config` | string | Is the path to the service config file (e.g., "google/storage/control/v2/storage_v2.yaml"). |
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
 | `module_type` | string | Is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty/"default" for standard GAPIC). |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include. This is typically reserved for special cases to avoid generating unused/dead code. For example, in Storage we need Protobuf gencode for a subset of the protos in the google/type directory. This code is private to the package (google-cloud-storage in Rust, GoogleCloudStorage in Swift). All other files in google/type would be dead code. |

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -139,6 +139,9 @@ type SwiftModule struct {
 	// Output is the directory where generated code is written (e.g., "Tests/ProtoJSON/generated").
 	Output string `yaml:"output"`
 
+	// ServiceConfig is the path to the service config file (e.g., "google/storage/control/v2/storage_v2.yaml").
+	ServiceConfig string `yaml:"service_config,omitempty"`
+
 	// APIPath is the proto path to generate from (e.g., "google/storage/v2").
 	APIPath string `yaml:"api_path"`
 

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -78,6 +78,7 @@ func moduleToModelConfig(library *config.Library, module *config.SwiftModule, sr
 	return &parser.ModelConfig{
 		SpecificationFormat: specFormat,
 		SpecificationSource: module.APIPath,
+		ServiceConfig:       module.ServiceConfig,
 		Source:              sourceConfig,
 	}
 }

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -190,6 +190,27 @@ func TestModuleToModelConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "with service config",
+			lib: &config.Library{
+				Swift: &config.SwiftPackage{},
+			},
+			module: &config.SwiftModule{
+				APIPath:       "foo",
+				ServiceConfig: "foo/foo_v7.yaml",
+				IncludeList:   []string{"mod_a.proto"},
+			},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				ServiceConfig:       "foo/foo_v7.yaml",
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+					IncludeList: []string{"mod_a.proto"},
+				},
+			},
+		},
+		{
 			name:   "nil swift",
 			lib:    &config.Library{},
 			module: &config.SwiftModule{APIPath: "foo"},


### PR DESCRIPTION
To generate modules for Cloud Storage (and probably other APIs in the future) we need the mixins configured as part of the service config yaml.