### PR TITLE
feat(internal/config): support php component_name config and migration override

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -462,6 +462,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `component_name` | string | Overrides the derived component name used for output/staging. |
 
 ## PythonDefault Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -823,6 +823,8 @@ type PHPDefault struct {
 
 // PHPPackage contains PHP-specific library configuration.
 type PHPPackage struct {
+	// ComponentName overrides the derived component name used for output/staging.
+	ComponentName string `yaml:"component_name,omitempty"`
 }
 
 // PHPAPI represents configuration for a single API within a PHP package.

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -245,7 +245,10 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 		libs = append(libs, &config.Library{
 			Name:    name,
 			Version: version,
-			APIs:    apis,
+			PHP: &config.PHPPackage{
+				ComponentName: name,
+			},
+			APIs: apis,
 		})
 	}
 	return libs, nil

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -110,6 +110,9 @@ deep-copy-regex:
 			{
 				Name:    "SecretManager",
 				Version: "2.3.0",
+				PHP: &config.PHPPackage{
+					ComponentName: "SecretManager",
+				},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -460,6 +463,9 @@ deep-copy-regex:
 				{
 					Name:    "SecretManager",
 					Version: "2.3.0",
+					PHP: &config.PHPPackage{
+						ComponentName: "SecretManager",
+					},
 					APIs: []*config.API{
 						{
 							Path: "google/cloud/secretmanager/v1",


### PR DESCRIPTION
Add the component_name configuration field to PHPPackage in internal/config to allow overriding the derived PHP component name used for staging and output paths.
  
 Update the PHP migration tool to populate component_name with the existing component directory name for all migrated PHP libraries. This prepares for decoupling library names from staging directory paths.

For #7025