### PR TITLE
feat(internal/librarian/php): derive component name with config override in generate

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -82,7 +82,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}
 	srcCfg := sources.NewSourceConfig(src, library.Roots)
 	googleapisDir := srcCfg.Root("googleapis")
-	componentName, err := ComponentNameForLibrary(googleapisDir, library)
+	componentName, err := componentNameForLibrary(googleapisDir, library)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -75,18 +75,27 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		}
 	}()
 
-	stagingDir := filepath.Join(owlBotStagingDir, library.Name)
+	for _, api := range library.APIs {
+		if api.PHP == nil || api.PHP.StagingSubdir == "" {
+			return fmt.Errorf("API %q: %w", api.Path, errMissingStagingSubdir)
+		}
+	}
+
+	srcCfg := sources.NewSourceConfig(src, library.Roots)
+	googleapisDir := srcCfg.Root("googleapis")
+	componentName, err := ComponentNameForLibrary(googleapisDir, library)
+	if err != nil {
+		return err
+	}
+
+	stagingDir := filepath.Join(owlBotStagingDir, componentName)
 	if err := os.RemoveAll(stagingDir); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}
-	srcCfg := sources.NewSourceConfig(src, library.Roots)
 	for _, api := range library.APIs {
-		if api.PHP == nil || api.PHP.StagingSubdir == "" {
-			return fmt.Errorf("API %q: %w", api.Path, errMissingStagingSubdir)
-		}
 		gapicDestDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
 		protoDestDir := filepath.Join(gapicDestDir, "proto/src")
 
@@ -104,7 +113,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return err
 		}
 	}
-	if err := postProcessLibrary(ctx, library); err != nil {
+	if err := postProcessLibrary(ctx, library, componentName); err != nil {
 		return fmt.Errorf("failed to postprocess: %w", err)
 	}
 	return nil

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -80,14 +80,12 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 			return fmt.Errorf("API %q: %w", api.Path, errMissingStagingSubdir)
 		}
 	}
-
 	srcCfg := sources.NewSourceConfig(src, library.Roots)
 	googleapisDir := srcCfg.Root("googleapis")
 	componentName, err := ComponentNameForLibrary(googleapisDir, library)
 	if err != nil {
 		return err
 	}
-
 	stagingDir := filepath.Join(owlBotStagingDir, componentName)
 	if err := os.RemoveAll(stagingDir); err != nil {
 		return err

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -121,6 +121,9 @@ func TestGenerate_Error(t *testing.T) {
 			name: "missing common_resources config",
 			lib: &config.Library{
 				Name: "SecretManager",
+				PHP: &config.PHPPackage{
+					ComponentName: "SecretManager",
+				},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -16,6 +16,7 @@ package php
 
 import (
 	"bufio"
+	"fmt"
 	"io/fs"
 	"os"
 	"path"
@@ -53,6 +54,23 @@ func newInitParams(googleapisDir string, api *config.API) (*initParams, error) {
 		protoPackage:    protoPackage(api),
 		apiVersion:      serviceconfig.ExtractVersion(api.Path),
 	}, nil
+}
+
+// ComponentNameForLibrary resolves the component name for a PHP library.
+// If library.PHP.ComponentName is set, it is returned as an explicit override.
+// Otherwise, the component name is derived on the fly from the php_namespace of the library's primary API.
+func ComponentNameForLibrary(googleapisDir string, library *config.Library) (string, error) {
+	if library.PHP != nil && library.PHP.ComponentName != "" {
+		return library.PHP.ComponentName, nil
+	}
+	if len(library.APIs) == 0 {
+		return "", fmt.Errorf("no apis configured for library %q", library.Name)
+	}
+	ns, err := namespace(googleapisDir, library.APIs[0].Path)
+	if err != nil {
+		return "", err
+	}
+	return componentName(ns), nil
 }
 
 // namespace reads the php_namespace option from the first .proto file in the API directory.

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -56,10 +56,10 @@ func newInitParams(googleapisDir string, api *config.API) (*initParams, error) {
 	}, nil
 }
 
-// ComponentNameForLibrary resolves the component name for a PHP library.
+// componentNameForLibrary resolves the component name for a PHP library.
 // If library.PHP.ComponentName is set, it is returned as an explicit override.
 // Otherwise, the component name is derived on the fly from the php_namespace of the library's primary API.
-func ComponentNameForLibrary(googleapisDir string, library *config.Library) (string, error) {
+func componentNameForLibrary(googleapisDir string, library *config.Library) (string, error) {
 	if library.PHP != nil && library.PHP.ComponentName != "" {
 		return library.PHP.ComponentName, nil
 	}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -266,3 +266,46 @@ func TestProtoPackage(t *testing.T) {
 		})
 	}
 }
+
+func TestComponentNameForLibrary(t *testing.T) {
+	googleapisDir := filepath.Join("..", "..", "testdata", "googleapis")
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		want    string
+	}{
+		{
+			name: "derived from proto namespace",
+			library: &config.Library{
+				Name: "SecretManager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: "SecretManager",
+		},
+		{
+			name: "explicit config override",
+			library: &config.Library{
+				Name: "AccessContextManager",
+				PHP: &config.PHPPackage{
+					ComponentName: "AccessContextManager",
+				},
+				APIs: []*config.API{
+					{Path: "google/identity/accesscontextmanager/v1"},
+				},
+			},
+			want: "AccessContextManager",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ComponentNameForLibrary(googleapisDir, test.library)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("ComponentNameForLibrary() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -299,7 +299,7 @@ func TestComponentNameForLibrary(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := ComponentNameForLibrary(googleapisDir, test.library)
+			got, err := componentNameForLibrary(googleapisDir, test.library)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -30,8 +30,8 @@ var (
 	errOwlBotNotFound = errors.New("owlbot.py not found")
 )
 
-func postProcessLibrary(ctx context.Context, library *config.Library) (err error) {
-	stagingDir := filepath.Join(owlBotStagingDir, library.Name)
+func postProcessLibrary(ctx context.Context, library *config.Library, componentName string) (err error) {
+	stagingDir := filepath.Join(owlBotStagingDir, componentName)
 	defer func() {
 		if cleanupErr := os.RemoveAll(stagingDir); cleanupErr != nil {
 			err = errors.Join(err, cleanupErr)

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -31,8 +31,11 @@ func TestPostProcess_MissingOwlBot(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
+		PHP: &config.PHPPackage{
+			ComponentName: "SecretManager",
+		},
 	}
-	err := postProcessLibrary(ctx, lib)
+	err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName)
 	if !errors.Is(err, errOwlBotNotFound) {
 		t.Errorf("postProcessLibrary() error = %v, want = %v", err, errOwlBotNotFound)
 	}
@@ -58,8 +61,11 @@ func TestPostProcess_OwlBot(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
+		PHP: &config.PHPPackage{
+			ComponentName: "SecretManager",
+		},
 	}
-	if err := postProcessLibrary(ctx, lib); err != nil {
+	if err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName); err != nil {
 		t.Fatal(err)
 	}
 	// Verify owlbot.py ran
@@ -85,8 +91,11 @@ func TestPostProcess_OwlBotError(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
+		PHP: &config.PHPPackage{
+			ComponentName: "SecretManager",
+		},
 	}
-	err := postProcessLibrary(ctx, lib)
+	err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName)
 	if err == nil {
 		t.Fatal("postProcessLibrary() expected error, got nil")
 	}
@@ -117,8 +126,11 @@ func TestPostProcess_StatError(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: inaccessibleDir,
+		PHP: &config.PHPPackage{
+			ComponentName: "SecretManager",
+		},
 	}
-	err := postProcessLibrary(ctx, lib)
+	err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName)
 	if !errors.Is(err, os.ErrPermission) {
 		t.Errorf("expected permission error, got: %v", err)
 	}
@@ -155,8 +167,11 @@ func TestPostProcess_CleanupError(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
+		PHP: &config.PHPPackage{
+			ComponentName: "SecretManager",
+		},
 	}
-	err := postProcessLibrary(ctx, lib)
+	err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName)
 	if !errors.Is(err, os.ErrPermission) {
 		t.Errorf("expected permission error, got: %v", err)
 	}

--- a/internal/librarian/php/testdata/owlbot_copy.py
+++ b/internal/librarian/php/testdata/owlbot_copy.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import sys
 
-staging = "../owl-bot-staging/secretmanager/v1"
+staging = "../owl-bot-staging/SecretManager/v1"
 if not os.path.exists(staging):
     sys.exit(0)
 for item in os.listdir(staging):


### PR DESCRIPTION
Add ComponentNameForLibrary to resolve the PHP component name for staging and output paths. Use component_name as override if explicitly set. Otherwise, the component name is derived on the fly from the php_namespace option of the primary API proto file.
    
Update Generate and postProcessLibrary to use the resolved component name when creating and cleaning up owl-bot-staging directories.


For #7025