### PR TITLE
feat(internal/librarian/php): derive proto package and version in initParams

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -450,6 +450,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
+| `proto_package` | string | Overrides the derived proto package for the API. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -834,6 +834,9 @@ type PHPAPI struct {
 	// Must be configured either globally or per-API.
 	CommonResources *bool `yaml:"common_resources,omitempty"`
 
+	// ProtoPackage overrides the derived proto package for the API.
+	ProtoPackage string `yaml:"proto_package,omitempty"`
+
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.
 	StagingSubdir string `yaml:"staging_subdir,omitempty"`
 }

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -122,7 +123,10 @@ func backupNamespace(apiPath string) string {
 	return versionSuffixRe.ReplaceAllString(ns, "")
 }
 
-// protoPackage returns the versioned proto package from the API path.
+// protoPackage returns the unversioned proto package from the API path.
 func protoPackage(apiPath string) string {
+	if serviceconfig.ExtractVersion(apiPath) != "" {
+		apiPath = path.Dir(apiPath)
+	}
 	return strings.ReplaceAll(apiPath, "/", ".")
 }

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -41,17 +41,17 @@ type initParams struct {
 	apiVersion      string
 }
 
-func newInitParams(googleapisDir, apiPath string) (*initParams, error) {
-	api, err := serviceconfig.Find(googleapisDir, apiPath, config.LanguagePhp)
+func newInitParams(googleapisDir string, api *config.API) (*initParams, error) {
+	svcAPI, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguagePhp)
 	if err != nil {
 		return nil, err
 	}
 	return &initParams{
-		apiShortName:    api.ShortName,
-		productDocs:     api.DocumentationURI,
-		productHomepage: repometadata.ExtractBaseProductURL(api.DocumentationURI),
-		protoPackage:    protoPackage(apiPath),
-		apiVersion:      serviceconfig.ExtractVersion(apiPath),
+		apiShortName:    svcAPI.ShortName,
+		productDocs:     svcAPI.DocumentationURI,
+		productHomepage: repometadata.ExtractBaseProductURL(svcAPI.DocumentationURI),
+		protoPackage:    protoPackage(api),
+		apiVersion:      serviceconfig.ExtractVersion(api.Path),
 	}, nil
 }
 
@@ -123,8 +123,12 @@ func backupNamespace(apiPath string) string {
 	return versionSuffixRe.ReplaceAllString(ns, "")
 }
 
-// protoPackage returns the unversioned proto package from the API path.
-func protoPackage(apiPath string) string {
+// protoPackage returns the unversioned proto package from the API configuration or derived from the path.
+func protoPackage(api *config.API) string {
+	if api.PHP != nil && api.PHP.ProtoPackage != "" {
+		return api.PHP.ProtoPackage
+	}
+	apiPath := api.Path
 	if serviceconfig.ExtractVersion(apiPath) != "" {
 		apiPath = path.Dir(apiPath)
 	}

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -36,6 +36,8 @@ type initParams struct {
 	apiShortName    string
 	productDocs     string
 	productHomepage string
+	protoPackage    string
+	apiVersion      string
 }
 
 func newInitParams(googleapisDir, apiPath string) (*initParams, error) {
@@ -47,6 +49,8 @@ func newInitParams(googleapisDir, apiPath string) (*initParams, error) {
 		apiShortName:    api.ShortName,
 		productDocs:     api.DocumentationURI,
 		productHomepage: repometadata.ExtractBaseProductURL(api.DocumentationURI),
+		protoPackage:    protoPackage(apiPath),
+		apiVersion:      serviceconfig.ExtractVersion(apiPath),
 	}, nil
 }
 
@@ -116,4 +120,9 @@ func backupNamespace(apiPath string) string {
 	ns := strings.Join(parts, `\`)
 	// Stripe the version suffix.
 	return versionSuffixRe.ReplaceAllString(ns, "")
+}
+
+// protoPackage returns the versioned proto package from the API path.
+func protoPackage(apiPath string) string {
+	return strings.ReplaceAll(apiPath, "/", ".")
 }

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -167,13 +167,13 @@ func TestNewInitParams(t *testing.T) {
 	apiPath := "google/cloud/secretmanager/v1"
 	params, err := newInitParams(googleapisDir, apiPath)
 	if err != nil {
-		t.Fatalf("newInitParams failed: %v", err)
+		t.Fatal(err)
 	}
 	want := &initParams{
 		apiShortName:    "secretmanager",
 		productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
 		productHomepage: "https://cloud.google.com/secret-manager/",
-		protoPackage:    "google.cloud.secretmanager.v1",
+		protoPackage:    "google.cloud.secretmanager",
 		apiVersion:      "v1",
 	}
 	if diff := cmp.Diff(want, params, cmp.AllowUnexported(initParams{})); diff != "" {
@@ -190,17 +190,22 @@ func TestProtoPackage(t *testing.T) {
 		{
 			name:    "speech v2",
 			apiPath: "google/cloud/speech/v2",
-			want:    "google.cloud.speech.v2",
+			want:    "google.cloud.speech",
 		},
 		{
 			name:    "privateca v1",
 			apiPath: "google/cloud/security/privateca/v1",
-			want:    "google.cloud.security.privateca.v1",
+			want:    "google.cloud.security.privateca",
 		},
 		{
 			name:    "generativelanguage v1alpha",
 			apiPath: "google/ai/generativelanguage/v1alpha",
-			want:    "google.ai.generativelanguage.v1alpha",
+			want:    "google.ai.generativelanguage",
+		},
+		{
+			name:    "unversioned path",
+			apiPath: "google/identity/accesscontextmanager/type",
+			want:    "google.identity.accesscontextmanager.type",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -173,8 +173,41 @@ func TestNewInitParams(t *testing.T) {
 		apiShortName:    "secretmanager",
 		productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
 		productHomepage: "https://cloud.google.com/secret-manager/",
+		protoPackage:    "google.cloud.secretmanager.v1",
+		apiVersion:      "v1",
 	}
 	if diff := cmp.Diff(want, params, cmp.AllowUnexported(initParams{})); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProtoPackage(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		apiPath string
+		want    string
+	}{
+		{
+			name:    "speech v2",
+			apiPath: "google/cloud/speech/v2",
+			want:    "google.cloud.speech.v2",
+		},
+		{
+			name:    "privateca v1",
+			apiPath: "google/cloud/security/privateca/v1",
+			want:    "google.cloud.security.privateca.v1",
+		},
+		{
+			name:    "generativelanguage v1alpha",
+			apiPath: "google/ai/generativelanguage/v1alpha",
+			want:    "google.ai.generativelanguage.v1alpha",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := protoPackage(test.apiPath)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
 )
 
 func TestNamespace(t *testing.T) {
@@ -164,52 +165,101 @@ func TestComponentName(t *testing.T) {
 func TestNewInitParams(t *testing.T) {
 	t.Parallel()
 	googleapisDir := filepath.Join("..", "..", "testdata", "googleapis")
-	apiPath := "google/cloud/secretmanager/v1"
-	params, err := newInitParams(googleapisDir, apiPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := &initParams{
-		apiShortName:    "secretmanager",
-		productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
-		productHomepage: "https://cloud.google.com/secret-manager/",
-		protoPackage:    "google.cloud.secretmanager",
-		apiVersion:      "v1",
-	}
-	if diff := cmp.Diff(want, params, cmp.AllowUnexported(initParams{})); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	for _, test := range []struct {
+		name string
+		api  *config.API
+		want *initParams
+	}{
+		{
+			name: "default derived protoPackage",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+			},
+			want: &initParams{
+				apiShortName:    "secretmanager",
+				productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
+				productHomepage: "https://cloud.google.com/secret-manager/",
+				protoPackage:    "google.cloud.secretmanager",
+				apiVersion:      "v1",
+			},
+		},
+		{
+			name: "custom protoPackage override",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					ProtoPackage: "google.cloud.secrets",
+				},
+			},
+			want: &initParams{
+				apiShortName:    "secretmanager",
+				productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
+				productHomepage: "https://cloud.google.com/secret-manager/",
+				protoPackage:    "google.cloud.secrets",
+				apiVersion:      "v1",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			params, err := newInitParams(googleapisDir, test.api)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, params, cmp.AllowUnexported(initParams{})); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
 func TestProtoPackage(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		apiPath string
-		want    string
+		name string
+		api  *config.API
+		want string
 	}{
 		{
-			name:    "speech v2",
-			apiPath: "google/cloud/speech/v2",
-			want:    "google.cloud.speech",
+			name: "speech v2",
+			api: &config.API{
+				Path: "google/cloud/speech/v2",
+			},
+			want: "google.cloud.speech",
 		},
 		{
-			name:    "privateca v1",
-			apiPath: "google/cloud/security/privateca/v1",
-			want:    "google.cloud.security.privateca",
+			name: "privateca v1",
+			api: &config.API{
+				Path: "google/cloud/security/privateca/v1",
+			},
+			want: "google.cloud.security.privateca",
 		},
 		{
-			name:    "generativelanguage v1alpha",
-			apiPath: "google/ai/generativelanguage/v1alpha",
-			want:    "google.ai.generativelanguage",
+			name: "generativelanguage v1alpha",
+			api: &config.API{
+				Path: "google/ai/generativelanguage/v1alpha",
+			},
+			want: "google.ai.generativelanguage",
 		},
 		{
-			name:    "unversioned path",
-			apiPath: "google/identity/accesscontextmanager/type",
-			want:    "google.identity.accesscontextmanager.type",
+			name: "unversioned path",
+			api: &config.API{
+				Path: "google/identity/accesscontextmanager/type",
+			},
+			want: "google.identity.accesscontextmanager.type",
+		},
+		{
+			name: "protoPackage override",
+			api: &config.API{
+				Path: "google/cloud/speech/v2",
+				PHP: &config.PHPAPI{
+					ProtoPackage: "google.cloud.speech.custom",
+				},
+			},
+			want: "google.cloud.speech.custom",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := protoPackage(test.apiPath)
+			got := protoPackage(test.api)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -41,6 +41,20 @@ var protoMappings = map[string]string{
 	"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
 }
 
+// protoPackageOverrides maps API paths to explicit proto_package overrides.
+// These legacy APIs have declared proto package names that differ from their directory paths:
+//   - "google/maps/fleetengine/v1" uses "package maps.fleetengine.v1;" (omits "google.")
+//   - "google/maps/fleetengine/delivery/v1" uses "package maps.fleetengine.delivery.v1;" (omits "google.")
+//   - "google/cloud/translate/v3" uses "package google.cloud.translation.v3;" ("translation" vs "translate")
+//
+// Dynamic derivation would inspect the first .proto file in googleapisDir/apiPath and set
+// api.PHP.ProtoPackage if the package (excluding version) differs from [path.Dir](apiPath).
+var protoPackageOverrides = map[string]string{
+	"google/maps/fleetengine/v1":          "maps.fleetengine",
+	"google/maps/fleetengine/delivery/v1": "maps.fleetengine.delivery",
+	"google/cloud/translate/v3":           "google.cloud.translation",
+}
+
 var (
 	errUnableToResolveStagingSubdir = errors.New("unable to resolve staging subdir")
 )
@@ -152,11 +166,15 @@ func createAPIConfig(path string, dest string) (*config.API, error) {
 		return nil, fmt.Errorf("%w: path %s from destination %q", errUnableToResolveStagingSubdir, path, dest)
 	}
 	normalizedStagingSubdir := normalizeStagingSubdir(path, stagingSubdir)
+	phpAPI := &config.PHPAPI{
+		StagingSubdir: normalizedStagingSubdir,
+	}
+	if override, ok := protoPackageOverrides[path]; ok {
+		phpAPI.ProtoPackage = override
+	}
 	return &config.API{
 		Path: path,
-		PHP: &config.PHPAPI{
-			StagingSubdir: normalizedStagingSubdir,
-		},
+		PHP:  phpAPI,
 	}, nil
 }
 

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -270,6 +270,30 @@ api-name: GeoCommonProtos
 				},
 			},
 		},
+		{
+			name: "api path with proto package override",
+			setupFile: func(dir string) string {
+				content := `
+deep-copy-regex:
+  - source: /google/cloud/translate/(v3)/.*-php/(.*)
+    dest: /owl-bot-staging/Translate/$1/$2
+api-name: Translate
+`
+				path := filepath.Join(dir, ".OwlBot.yaml")
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			want: []*config.API{
+				{
+					Path: "google/cloud/translate/v3",
+					PHP: &config.PHPAPI{
+						ProtoPackage: "google.cloud.translation",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()


### PR DESCRIPTION
Adds protoPackage and apiVersion fields  to initParams and populates them in from API path. 

The protoPackage is derived as an unversioned proto package prefix by stripping the version from the API path, and  allow an explicit override using the `proto_package` field  in PHP API configuration.
  
The PHP migration tool is also updated to include explicit protoPackage overrides for existing APIs whose declared proto package names differ from their directory paths, specifically MapsFleetEngine, MapsFleetEngineDelivery, and Translate.
    

Fixes https://github.com/googleapis/librarian/issues/7152