### PR TITLE
chore(tool/cmd/migrate): ignore `Gemfile.lock` when building keep list

### DIFF
--- a/tool/cmd/migrate/ruby.go
+++ b/tool/cmd/migrate/ruby.go
@@ -424,7 +424,7 @@ func parseKeepFromManifest(path string) ([]string, error) {
 		return nil, fmt.Errorf("unmarshaling owlbot manifest %s: %w", path, err)
 	}
 	manifest.Static = slices.DeleteFunc(manifest.Static, func(s string) bool {
-		return s == ".OwlBot.yaml" || s == ".owlbot.rb"
+		return s == ".OwlBot.yaml" || s == ".owlbot.rb" || s == "Gemfile.lock"
 	})
 	return manifest.Static, nil
 }

--- a/tool/cmd/migrate/ruby_test.go
+++ b/tool/cmd/migrate/ruby_test.go
@@ -761,6 +761,11 @@ func TestParseKeepFromManifest(t *testing.T) {
 			want:    []string{"file1.rb", "file2.rb"},
 		},
 		{
+			name:    "filters out Gemfile.lock",
+			content: `{"static": ["Gemfile.lock", "file1.rb", "file2.rb"]}`,
+			want:    []string{"file1.rb", "file2.rb"},
+		},
+		{
 			name:    "empty static list",
 			content: `{"static": []}`,
 			want:    []string{},


### PR DESCRIPTION
Ignore `Gemfile.lock` when building keep list.

This file is no longer a generated file (removed via https://github.com/googleapis/librarian/pull/7163) so we don't need to list it in the keep.

For #6632