### PR TITLE
feat(swift): protobuf conversions support oneofs

### DIFF
--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -54,6 +54,9 @@ type fieldAnnotations struct {
 	// This is empty for fields that are not part of a oneof group.
 	OneOfChecker string
 
+	// OneOfPropertyName is the Swift property name of the oneof enum containing this field.
+	OneOfPropertyName string
+
 	// Recursive is true if the field is a recursive reference to another message.
 	Recursive bool
 
@@ -200,6 +203,7 @@ func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*field
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {
 			annotations.OneOfChecker = oneofAnn.Checker
+			annotations.OneOfPropertyName = oneofAnn.PropertyName
 		}
 	}
 	if c.UrlSafeForBytes {
@@ -210,7 +214,7 @@ func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*field
 			annotations.UrlSafeValue = true
 		}
 	}
-	if !field.IsOneOf && !field.Map {
+	if !field.Map {
 		annotations.ProtoFieldName = protoFieldName(field.Name)
 		annotations.ProtoFieldNamePascal = protoFieldNamePascal(field.Name)
 		annotations.PrimitiveFieldType = parts.Base

--- a/internal/sidekick/swift/annotate_field.go
+++ b/internal/sidekick/swift/annotate_field.go
@@ -54,9 +54,6 @@ type fieldAnnotations struct {
 	// This is empty for fields that are not part of a oneof group.
 	OneOfChecker string
 
-	// OneOfPropertyName is the Swift property name of the oneof enum containing this field.
-	OneOfPropertyName string
-
 	// Recursive is true if the field is a recursive reference to another message.
 	Recursive bool
 
@@ -203,7 +200,6 @@ func (c *codec) annotateField(field *api.Field, model *modelAnnotations) (*field
 	if field.IsOneOf && field.Group != nil {
 		if oneofAnn, ok := field.Group.Codec.(*oneOfAnnotations); ok {
 			annotations.OneOfChecker = oneofAnn.Checker
-			annotations.OneOfPropertyName = oneofAnn.PropertyName
 		}
 	}
 	if c.UrlSafeForBytes {

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -379,7 +379,6 @@ func TestAnnotateField_Recursive(t *testing.T) {
 				BaseFieldType:        "Node",
 				Recursive:            false,
 				OneOfChecker:         "alternativesCheckAndSet",
-				OneOfPropertyName:    "alternatives",
 				ProtoFieldName:       "childNode",
 				ProtoFieldNamePascal: "ChildNode",
 				PrimitiveFieldType:   "Node",

--- a/internal/sidekick/swift/annotate_field_test.go
+++ b/internal/sidekick/swift/annotate_field_test.go
@@ -375,10 +375,14 @@ func TestAnnotateField_Recursive(t *testing.T) {
 			isOneOf:       true,
 			oneofProperty: "alternatives",
 			want: &fieldAnnotations{
-				FieldType:     "Node",
-				BaseFieldType: "Node",
-				Recursive:     false,
-				OneOfChecker:  "alternativesCheckAndSet",
+				FieldType:            "Node",
+				BaseFieldType:        "Node",
+				Recursive:            false,
+				OneOfChecker:         "alternativesCheckAndSet",
+				OneOfPropertyName:    "alternatives",
+				ProtoFieldName:       "childNode",
+				ProtoFieldNamePascal: "ChildNode",
+				PrimitiveFieldType:   "Node",
 			},
 		},
 	} {

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -147,7 +147,7 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if len(message.Fields) != 0 {
 		sampleField = camelCase(message.Fields[0].Name)
 	}
-	hasConvertedFields := slices.IndexFunc(message.Fields, func(f *api.Field) bool { return !f.IsOneOf && !f.Map }) != -1
+	hasConvertedFields := slices.IndexFunc(message.Fields, func(f *api.Field) bool { return !f.Map }) != -1
 	parameterTypeName, err := c.messageTypeName(message)
 	if err != nil {
 		return err

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -660,7 +660,7 @@ func TestAnnotateMessage_HasConvertedFields(t *testing.T) {
 			fields: []*api.Field{
 				{Name: "field1", ID: "1", Typez: api.TypezString, IsOneOf: true},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "map_and_repeated_fields",

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -324,3 +324,98 @@ func TestGenerateConversions_RepeatedFields(t *testing.T) {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestGenerateConversions_OneOf(t *testing.T) {
+	outDir := t.TempDir()
+
+	inner := &api.Message{
+		Name:    "Inner",
+		Package: "test",
+		ID:      ".test.Inner",
+	}
+
+	oneof := &api.OneOf{
+		Name: "choice",
+	}
+
+	field1 := &api.Field{
+		Name:    "string_field",
+		ID:      ".test.Outer.string_field",
+		Typez:   api.TypezString,
+		IsOneOf: true,
+		Group:   oneof,
+	}
+	field2 := &api.Field{
+		Name:    "message_field",
+		ID:      ".test.Outer.message_field",
+		Typez:   api.TypezMessage,
+		TypezID: ".test.Inner",
+		IsOneOf: true,
+		Group:   oneof,
+	}
+
+	outer := &api.Message{
+		Name:    "Outer",
+		Package: "test",
+		ID:      ".test.Outer",
+		Fields:  []*api.Field{field1, field2},
+		OneOfs:  []*api.OneOf{oneof},
+	}
+	oneof.Fields = []*api.Field{field1, field2}
+	field1.Parent = outer
+	field2.Parent = outer
+
+	model := api.NewTestAPI([]*api.Message{inner, outer}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "test"
+
+	library := &config.Library{}
+	module := &config.SwiftModule{
+		ModulePath: "TestProtos",
+	}
+
+	if err := GenerateConversions(t.Context(), model, outDir, library, module); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(outDir, "Outer+Convert.swift"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotContent := string(b)
+
+	got := extractBlock(t, gotContent, "  internal init(proto: ProtoType) throws {", "\n  }")
+	wantInit := `  internal init(proto: ProtoType) throws {
+    self.init()
+    if let oneof = proto.choice {
+      switch oneof {
+      case .stringField(let value):
+        self.choice = .stringField(value)
+      case .messageField(let value):
+        self.choice = .messageField(try .init(proto: value))
+      }
+    }
+  }`
+	if diff := cmp.Diff(wantInit, got); diff != "" {
+		t.Errorf("init(proto:) mismatch (-want +got):\n%s", diff)
+	}
+
+	got = extractBlock(t, gotContent, "  internal func toProto() throws -> ProtoType {", "\n  }")
+	wantToProto := `  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    if let oneof = self.choice {
+      switch oneof {
+      case .stringField(let value):
+        proto.choice = .stringField(value)
+      case .messageField(let value):
+        if let value = value {
+          proto.choice = .messageField(try value.toProto())
+        }
+      }
+    }
+    return proto
+  }`
+	if diff := cmp.Diff(wantToProto, got); diff != "" {
+		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
+	}
+}
+

--- a/internal/sidekick/swift/generate_conversions_test.go
+++ b/internal/sidekick/swift/generate_conversions_test.go
@@ -418,4 +418,3 @@ func TestGenerateConversions_OneOf(t *testing.T) {
 		t.Errorf("toProto() mismatch (-want +got):\n%s", diff)
 	}
 }
-

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -73,6 +73,26 @@ extension {{Codec.ParameterTypeName}} {
     {{/Repeated}}
     {{/IsOneOf}}
     {{/Fields}}
+    {{#OneOfs}}
+    if let oneof = proto.{{Codec.PropertyName}} {
+      switch oneof {
+      {{#Fields}}
+      case .{{Codec.ProtoFieldName}}(let value):
+        {{#IsObject}}
+        self.{{Codec.OneOfPropertyName}} = .{{Codec.Name}}(try .init(proto: value))
+        {{/IsObject}}
+        {{#IsEnum}}
+        self.{{Codec.OneOfPropertyName}} = .{{Codec.Name}}(.init(proto: value))
+        {{/IsEnum}}
+        {{^IsObject}}
+        {{^IsEnum}}
+        self.{{Codec.OneOfPropertyName}} = .{{Codec.Name}}(value)
+        {{/IsEnum}}
+        {{/IsObject}}
+      {{/Fields}}
+      }
+    }
+    {{/OneOfs}}
   }
 
   internal func toProto() throws -> ProtoType {
@@ -137,6 +157,28 @@ extension {{Codec.ParameterTypeName}} {
     {{/Repeated}}
     {{/IsOneOf}}
     {{/Fields}}
+    {{#OneOfs}}
+    if let oneof = self.{{Codec.PropertyName}} {
+      switch oneof {
+      {{#Fields}}
+      case .{{Codec.Name}}(let value):
+        {{#IsObject}}
+        if let value = value {
+          proto.{{Codec.OneOfPropertyName}} = .{{Codec.ProtoFieldName}}(try value.toProto())
+        }
+        {{/IsObject}}
+        {{#IsEnum}}
+        proto.{{Codec.OneOfPropertyName}} = .{{Codec.ProtoFieldName}}(try value.toProto())
+        {{/IsEnum}}
+        {{^IsObject}}
+        {{^IsEnum}}
+        proto.{{Codec.OneOfPropertyName}} = .{{Codec.ProtoFieldName}}(value)
+        {{/IsEnum}}
+        {{/IsObject}}
+      {{/Fields}}
+      }
+    }
+    {{/OneOfs}}
     return proto
   }
 }

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -79,14 +79,14 @@ extension {{Codec.ParameterTypeName}} {
       {{#Fields}}
       case .{{Codec.ProtoFieldName}}(let value):
         {{#IsObject}}
-        self.{{Codec.OneOfPropertyName}} = .{{Codec.Name}}(try .init(proto: value))
+        self.{{Group.Codec.PropertyName}} = .{{Codec.Name}}(try .init(proto: value))
         {{/IsObject}}
         {{#IsEnum}}
-        self.{{Codec.OneOfPropertyName}} = .{{Codec.Name}}(.init(proto: value))
+        self.{{Group.Codec.PropertyName}} = .{{Codec.Name}}(.init(proto: value))
         {{/IsEnum}}
         {{^IsObject}}
         {{^IsEnum}}
-        self.{{Codec.OneOfPropertyName}} = .{{Codec.Name}}(value)
+        self.{{Group.Codec.PropertyName}} = .{{Codec.Name}}(value)
         {{/IsEnum}}
         {{/IsObject}}
       {{/Fields}}
@@ -164,15 +164,15 @@ extension {{Codec.ParameterTypeName}} {
       case .{{Codec.Name}}(let value):
         {{#IsObject}}
         if let value = value {
-          proto.{{Codec.OneOfPropertyName}} = .{{Codec.ProtoFieldName}}(try value.toProto())
+          proto.{{Group.Codec.PropertyName}} = .{{Codec.ProtoFieldName}}(try value.toProto())
         }
         {{/IsObject}}
         {{#IsEnum}}
-        proto.{{Codec.OneOfPropertyName}} = .{{Codec.ProtoFieldName}}(try value.toProto())
+        proto.{{Group.Codec.PropertyName}} = .{{Codec.ProtoFieldName}}(try value.toProto())
         {{/IsEnum}}
         {{^IsObject}}
         {{^IsEnum}}
-        proto.{{Codec.OneOfPropertyName}} = .{{Codec.ProtoFieldName}}(value)
+        proto.{{Group.Codec.PropertyName}} = .{{Codec.ProtoFieldName}}(value)
         {{/IsEnum}}
         {{/IsObject}}
       {{/Fields}}


### PR DESCRIPTION
Extend the Swift sidekick generator to support converting Protobuf `oneof` fields between clean Swift struct models and `SwiftProtobuf` message types.

generates https://github.com/googleapis/google-cloud-swift/pull/167 