### PR TITLE
feat(swift): support skipped_ids in configuration

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -639,6 +639,7 @@ This document describes the schema for the librarian.yaml.
 | `api_path` | string | Is the proto path to generate from (e.g., "google/storage/v2"). |
 | `module_type` | string | Is the type of module to generate (e.g., "swift-protobuf", "convert-swift", or empty/"default" for standard GAPIC). |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include. This is typically reserved for special cases to avoid generating unused/dead code. For example, in Storage we need Protobuf gencode for a subset of the protos in the google/type directory. This code is private to the package (google-cloud-storage in Rust, GoogleCloudStorage in Swift). All other files in google/type would be dead code. |
+| `skipped_ids` | list of string | Is a list of proto IDs to skip in generation for this module. |
 | `module_path` | string | Is the module import path or target containing stubs (used by convert-swift). |
 
 ## SwiftPackage Configuration
@@ -648,6 +649,7 @@ This document describes the schema for the librarian.yaml.
 | (embedded) | [SwiftDefault](#swiftdefault-configuration) |  |
 | `library_name_override` | string | Overrides the default library name.<br><br>In Swift, each GAPIC package consists of a single product (the library), which contains a single target and module name. For example, the package for the google/cloud/secretmanager/v1 API is called google-cloud-secretmanager-v1, and contains a single product: `GoogleCloudSecretManagerV1`, which in turn contains a single target and module of the same name.<br><br>To use the library applications use this import:<br><br>``` import GoogleCloudSecretManagerV1 ```<br><br>Normally the name is derived from:<br>- If the Protobuf namespace overrides for PHP, Ruby, and C# are consistent, sidekick uses this name.<br>- Otherwise, the name implied by the Protobuf package<br>- Or the package set in the service config yaml file |
 | `include_list` | list of string | Is a subset of proto files under the target API path to include (e.g., ["date.proto", "expr.proto"]). |
+| `skipped_ids` | list of string | Is a list of proto IDs to skip in generation for the package. |
 | `modules` | list of [SwiftModule](#swiftmodule-configuration) (optional) | Specifies generation targets for veneers and test packages.<br><br>Each module defines a source proto path, and output location. |
 | `package_name_override` | string | Overrides the package name.<br><br>This may be useful if the protobuf package lacks the necessary prefixes, e.g. `grafeas.v1` may be published as `google-grafeas-v1` to match the other packages. |
 | `per_service_traits` | bool | Enables per-service compile-time flags. |

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -52,6 +52,9 @@ type SwiftPackage struct {
 	// include (e.g., ["date.proto", "expr.proto"]).
 	IncludeList []string `yaml:"include_list,omitempty"`
 
+	// SkippedIds is a list of proto IDs to skip in generation for the package.
+	SkippedIds []string `yaml:"skipped_ids,omitempty"`
+
 	// Modules specifies generation targets for veneers and test packages.
 	//
 	// Each module defines a source proto path, and output location.
@@ -154,6 +157,9 @@ type SwiftModule struct {
 	// directory. This code is private to the package (google-cloud-storage in Rust, GoogleCloudStorage
 	// in Swift). All other files in google/type would be dead code.
 	IncludeList []string `yaml:"include_list,omitempty"`
+
+	// SkippedIds is a list of proto IDs to skip in generation for this module.
+	SkippedIds []string `yaml:"skipped_ids,omitempty"`
 
 	// ModulePath is the module import path or target containing stubs (used by convert-swift).
 	ModulePath string `yaml:"module_path,omitempty"`

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -111,12 +111,20 @@ func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sour
 		specFormat = library.SpecificationFormat
 	}
 
+	var skippedIDs []string
+	if library.Swift != nil && len(library.Swift.SkippedIds) > 0 {
+		skippedIDs = library.Swift.SkippedIds
+	}
+
 	modelCfg := &parser.ModelConfig{
 		Language:            config.LanguageSwift,
 		SpecificationFormat: specFormat,
 		ServiceConfig:       svcConfig.ServiceConfig,
 		SpecificationSource: apiCfg.Path,
 		Source:              sourceConfig,
+		Override: api.ModelOverride{
+			SkippedIDs: skippedIDs,
+		},
 	}
 	if library.Swift != nil && library.Swift.Discovery != nil {
 		pollers := make([]*api.Poller, len(library.Swift.Discovery.Pollers))

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	sidekickswift "github.com/googleapis/librarian/internal/sidekick/swift"
 	"github.com/googleapis/librarian/internal/sources"
@@ -70,6 +71,14 @@ func moduleToModelConfig(library *config.Library, module *config.SwiftModule, sr
 	} else if library.Swift != nil && len(library.Swift.IncludeList) > 0 {
 		sourceConfig.IncludeList = library.Swift.IncludeList
 	}
+
+	var skippedIDs []string
+	if len(module.SkippedIds) > 0 {
+		skippedIDs = module.SkippedIds
+	} else if library.Swift != nil && len(library.Swift.SkippedIds) > 0 {
+		skippedIDs = library.Swift.SkippedIds
+	}
+
 	specFormat := config.SpecProtobuf
 	if library.SpecificationFormat != "" {
 		specFormat = library.SpecificationFormat
@@ -80,5 +89,8 @@ func moduleToModelConfig(library *config.Library, module *config.SwiftModule, sr
 		SpecificationSource: module.APIPath,
 		ServiceConfig:       module.ServiceConfig,
 		Source:              sourceConfig,
+		Override: api.ModelOverride{
+			SkippedIDs: skippedIDs,
+		},
 	}
 }

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -308,3 +308,40 @@ func TestGenerateModule_NoProtos(t *testing.T) {
 		t.Errorf("got error %q, want it to contain 'no proto files found in'", err.Error())
 	}
 }
+
+func TestModuleToModelConfig_SkippedIds(t *testing.T) {
+	src := &sources.Sources{}
+
+	t.Run("module level skipped_ids", func(t *testing.T) {
+		library := &config.Library{
+			Swift: &config.SwiftPackage{
+				SkippedIds: []string{".google.type.Color"},
+			},
+		}
+		module := &config.SwiftModule{
+			APIPath:    "google/type",
+			SkippedIds: []string{".google.type.Money"},
+		}
+		modelCfg := moduleToModelConfig(library, module, src)
+		expected := []string{".google.type.Money"}
+		if diff := cmp.Diff(expected, modelCfg.Override.SkippedIDs); diff != "" {
+			t.Errorf("moduleToModelConfig() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("library level fallback skipped_ids", func(t *testing.T) {
+		library := &config.Library{
+			Swift: &config.SwiftPackage{
+				SkippedIds: []string{".google.type.Color"},
+			},
+		}
+		module := &config.SwiftModule{
+			APIPath: "google/type",
+		}
+		modelCfg := moduleToModelConfig(library, module, src)
+		expected := []string{".google.type.Color"}
+		if diff := cmp.Diff(expected, modelCfg.Override.SkippedIDs); diff != "" {
+			t.Errorf("moduleToModelConfig() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
This unblocks storage v2 generation by providing the ability to skip duplicated object types.

Example librarian.yaml usage:
```yaml
libraries:
  - name: google-cloud-storage
    swift:
      modules:
        - output: packages/storage/Sources/GoogleCloudStorage/generated/Storage
          api_path: google/storage/v2
          skipped_ids:
            - .google.storage.v2.Storage
```

helps generate https://github.com/googleapis/google-cloud-swift/pull/150 