### PR TITLE
fix(internal/sidekick/rust): use from for repeated enum conversions in convert-prost

### DIFF
--- a/internal/sidekick/rust/templates/convert-prost/message.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/message.mustache
@@ -84,7 +84,7 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
                     .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
                 {{/IsEnum}}
                 {{#IsEnum}}
-                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|v| v.into()))
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map({{Codec.PrimitiveFieldType}}::from))
                 {{/IsEnum}}
                 {{/Repeated}}
                 {{#Map}}
@@ -96,7 +96,7 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
                     https://protobuf.dev/programming-guides/proto3/#maps
                 }}
                 {{#Codec.ValueType.IsEnum}}
-                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|(k, v)| (k.cnv(), v.into())))
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|(k, v)| (k.cnv(), {{Codec.ValueType.PrimitiveFieldType}}::from(v))))
                 {{/Codec.ValueType.IsEnum}}
                 {{^Codec.ValueType.IsEnum}}
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter()

--- a/internal/sidekick/rust/templates/convert-prost/message.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/message.mustache
@@ -96,7 +96,10 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
                     https://protobuf.dev/programming-guides/proto3/#maps
                 }}
                 {{#Codec.ValueType.IsEnum}}
-                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|(k, v)| (k.cnv(), {{Codec.ValueType.PrimitiveFieldType}}::from(v))))
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), Ok({{Codec.ValueType.PrimitiveFieldType}}::from(v)))
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
                 {{/Codec.ValueType.IsEnum}}
                 {{^Codec.ValueType.IsEnum}}
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter()


### PR DESCRIPTION
Repeated enum fields in convert-prost templates were using v.into(), which caused rustc type inference error because GAPIC builder setters for repeated fields are generic over any collection T and item V where V: Into<TargetEnum>. Replacing v.into() with PrimitiveFieldType::from explicitly specifies the target enum type and resolves the ambiguity.

This has no effect on the current code that is generated since none end up using this branch. This was discovered while trying to generate google-cloud-dialogflow-v2.