### PR TITLE
feat(internal/librarian/rust): support external type conversions 

### DIFF
--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -15,6 +15,7 @@
 package rust
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -232,6 +233,30 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 		}
 	}
 
+	// Collect external top-level messages (e.g. google.type.LatLng) referenced by streaming RPCs.
+	// We sort external types by ID because model.AllMessages() iterates over a map whose
+	// iteration order is randomized by the Go runtime.
+	var externalMessages []*api.Message
+	for m := range model.AllMessages() {
+		if m.ID != "" && streamingMsgs[m.ID] && !isWKT(m.ID) && m.ID != ".google.rpc.Status" && !m.IsMap && m.Parent == nil {
+			if m.Package != model.PackageName && m.Package != api.ReservedPackageName {
+				externalMessages = append(externalMessages, m)
+			}
+		}
+	}
+	slices.SortFunc(externalMessages, func(a, b *api.Message) int { return cmp.Compare(a.ID, b.ID) })
+
+	// Collect external top-level enums referenced by streaming RPCs.
+	var externalEnums []*api.Enum
+	for e := range model.AllEnums() {
+		if e.ID != "" && streamingEnums[e.ID] && !isWKT(e.ID) && e.Parent == nil {
+			if e.Package != model.PackageName && e.Package != api.ReservedPackageName {
+				externalEnums = append(externalEnums, e)
+			}
+		}
+	}
+	slices.SortFunc(externalEnums, func(a, b *api.Enum) int { return cmp.Compare(a.ID, b.ID) })
+
 	// Construct hybridModel for prost conversion code generation.
 	hybridModel := api.API{
 		Name:        model.Name,
@@ -239,11 +264,14 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 		Title:       model.Title,
 		Description: model.Description,
 		Revision:    model.Revision,
-		// Services, Messages and Enums slices are filtered to only streaming types so convert.rs
+		// Services, Messages, and Enums slices are filtered to only streaming types so convert.rs
 		// only contains conversion implementations for streaming RPCs.
+		// Filtering model.Messages and model.Enums preserves their original deterministic file order.
 		Services:            language.FilterSlice(model.Services, (*api.Service).HasBidiStreaming),
 		Messages:            language.FilterSlice(model.Messages, func(m *api.Message) bool { return streamingMsgs[m.ID] }),
+		ExternalMessages:    externalMessages,
 		Enums:               language.FilterSlice(model.Enums, func(e *api.Enum) bool { return streamingEnums[e.ID] }),
+		ExternalEnums:       externalEnums,
 		ResourceDefinitions: model.ResourceDefinitions,
 		QuickstartService:   model.QuickstartService,
 		Codec:               model.Codec,

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -191,6 +191,50 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 	}
 }
 
+func TestFilterModelToStreamingExternalTypes(t *testing.T) {
+	streamMsg := api.NewTestMessage("StreamMsg").WithPackage("google.test.v1")
+	externalMsg := api.NewTestMessage("LatLng").WithPackage("google.type")
+	externalEnum := &api.Enum{Name: "DayOfWeek", ID: ".google.type.DayOfWeek", Package: "google.type"}
+
+	streamMsg.Fields = []*api.Field{
+		{
+			Name:    "location",
+			TypezID: externalMsg.ID,
+			Typez:   api.TypezMessage,
+		},
+		{
+			Name:    "day",
+			TypezID: externalEnum.ID,
+			Typez:   api.TypezEnum,
+		},
+	}
+
+	chatMethod := api.NewTestMethod("Chat").WithInput(streamMsg).WithOutput(streamMsg).WithBidiStreaming()
+	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
+
+	model := api.NewTestAPI([]*api.Message{streamMsg}, []*api.Enum{}, []*api.Service{bidiService})
+	model.AddMessage(externalMsg)
+	model.AddEnum(externalEnum)
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+
+	filtered, _, _, err := filterModelToStreaming(model)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(filtered.Messages) != 1 || filtered.Messages[0].ID != streamMsg.ID {
+		t.Errorf("got package messages %v, want [%s]", filtered.Messages, streamMsg.ID)
+	}
+	if len(filtered.ExternalMessages) != 1 || filtered.ExternalMessages[0].ID != externalMsg.ID {
+		t.Errorf("got ExternalMessages %v, want [%s]", filtered.ExternalMessages, externalMsg.ID)
+	}
+	if len(filtered.ExternalEnums) != 1 || filtered.ExternalEnums[0].ID != externalEnum.ID {
+		t.Errorf("got ExternalEnums %v, want [%s]", filtered.ExternalEnums, externalEnum.ID)
+	}
+}
+
 func TestFilterModelToStreamingAnyError(t *testing.T) {
 	// Verify google.protobuf.Any in streaming path returns error with recommendation
 	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(

--- a/internal/sidekick/api/api.go
+++ b/internal/sidekick/api/api.go
@@ -38,8 +38,12 @@ type API struct {
 	// Messages are a collection of messages used to process request and
 	// responses in the API.
 	Messages []*Message
+	// ExternalMessages are top-level messages from external packages (e.g. google.type.LatLng).
+	ExternalMessages []*Message
 	// Enums
 	Enums []*Enum
+	// ExternalEnums are top-level enums from external packages.
+	ExternalEnums []*Enum
 	// ResourceDefinitions contains the data from the `google.api.resource_definition` annotation.
 	ResourceDefinitions []*Resource
 	// QuickstartService is the service that will be used to generate the quickstart sample

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -137,10 +137,28 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 			return nil, err
 		}
 	}
+	for _, e := range model.ExternalEnums {
+		if err := codec.annotateEnum(e, model, true); err != nil {
+			return nil, err
+		}
+		// ExternalEnums (e.g. google.type.Date) are populated for convert-prost generation in hybrid crates.
+		// Override RelativeName so ToProto and FromProto resolve to crate::prost::<pkg>::<TypeName>.
+		ann := e.Codec.(*enumAnnotation)
+		ann.RelativeName = "crate::prost::" + packageToModuleName(e.Package) + "::" + enumName(e)
+	}
 	for _, m := range model.Messages {
 		if err := codec.annotateMessage(m, model, true); err != nil {
 			return nil, err
 		}
+	}
+	for _, m := range model.ExternalMessages {
+		if err := codec.annotateMessage(m, model, true); err != nil {
+			return nil, err
+		}
+		// ExternalMessages (e.g. google.type.LatLng) are populated for convert-prost generation in hybrid crates.
+		// Override RelativeName so ToProto and FromProto resolve to crate::prost::<pkg>::<TypeName>.
+		ann := m.Codec.(*messageAnnotation)
+		ann.RelativeName = "crate::prost::" + packageToModuleName(m.Package) + "::" + toPascal(m.Name)
 	}
 	// External enums and messages get only basic annotations
 	// used for sample generation.

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -658,3 +658,37 @@ func TestModelAnnotationsBidiStreamingServices(t *testing.T) {
 		t.Errorf("expected BidiStreamingServices[0].Name == %q, got %q", "BidiService", got.BidiStreamingServices[0].Name)
 	}
 }
+
+func TestExternalTypesAnnotations(t *testing.T) {
+	extMsg := api.NewTestMessage("LatLng").WithPackage("google.type")
+	extEnum := &api.Enum{Name: "DayOfWeek", ID: ".google.type.DayOfWeek", Package: "google.type"}
+
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model.ExternalMessages = []*api.Message{extMsg}
+	model.ExternalEnums = []*api.Enum{extEnum}
+
+	codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{
+		"template-override": "templates/convert-prost",
+	})
+	codec.packageMapping["google.type"] = &packagez{name: "google_cloud_type", packageName: "google.type"}
+
+	if _, err := annotateModel(model, codec); err != nil {
+		t.Fatal(err)
+	}
+
+	msgAnn, ok := extMsg.Codec.(*messageAnnotation)
+	if !ok {
+		t.Fatalf("expected messageAnnotation on extMsg")
+	}
+	if want := "crate::prost::google::r#type::LatLng"; msgAnn.RelativeName != want {
+		t.Errorf("msgAnn.RelativeName = %q, want %q", msgAnn.RelativeName, want)
+	}
+
+	enumAnn, ok := extEnum.Codec.(*enumAnnotation)
+	if !ok {
+		t.Fatalf("expected enumAnnotation on extEnum")
+	}
+	if want := "crate::prost::google::r#type::DayOfWeek"; enumAnn.RelativeName != want {
+		t.Errorf("enumAnn.RelativeName = %q, want %q", enumAnn.RelativeName, want)
+	}
+}

--- a/internal/sidekick/rust/templates/convert-prost/convert.rs.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/convert.rs.mustache
@@ -31,6 +31,12 @@ use crate as gaxi;
 {{#Enums}}
 {{> enum}}
 {{/Enums}}
+{{#ExternalEnums}}
+{{> enum}}
+{{/ExternalEnums}}
 {{#Messages}}
 {{> message}}
 {{/Messages}}
+{{#ExternalMessages}}
+{{> message}}
+{{/ExternalMessages}}


### PR DESCRIPTION
External message and enum types referenced by bidirectional streaming RPCs in hybrid crates were not being generated in convert.rs because filterModelToStreaming only included messages in the target package.

Populate ExternalMessages and ExternalEnums in hybridModel for external top-level messages and enums. Override RelativeName for ExternalMessages and ExternalEnums so ToProto and FromProto implementations generate cleanly.

Fixes #7144 