### PR TITLE
feat(internal/librarian/php): derive lowercase hyphenated php library names from api path

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -591,9 +591,9 @@ func TestDeriveLibraryName(t *testing.T) {
 		{config.LanguageNodejs, "google/cloud/secretmanager/v1beta2", "google-cloud-secretmanager"},
 		{config.LanguageNodejs, "google/cloud/storage/v2alpha", "google-cloud-storage"},
 		{config.LanguageNodejs, "google/maps/addressvalidation/v1", "google-maps-addressvalidation"},
-		{config.LanguagePhp, "google/cloud/secretmanager/v1", "Secretmanager"},
-		{config.LanguagePhp, "google/cloud/security/privateca/v1", "SecurityPrivateca"},
-		{config.LanguagePhp, "google/pubsub/v1", "Pubsub"},
+		{config.LanguagePhp, "google/cloud/secretmanager/v1", "secretmanager"},
+		{config.LanguagePhp, "google/cloud/security/privateca/v1", "security-privateca"},
+		{config.LanguagePhp, "google/pubsub/v1", "pubsub"},
 	} {
 		t.Run(test.language+"/"+test.apiPath, func(t *testing.T) {
 			got := deriveLibraryName(test.language, test.apiPath)
@@ -687,7 +687,7 @@ func TestAddLibraryCommand_Php(t *testing.T) {
 	}
 	wantLibraries := []*config.Library{
 		{
-			Name:          "Developerconnect",
+			Name:          "developerconnect",
 			CopyrightYear: strconv.Itoa(time.Now().Year()),
 			APIs: []*config.API{
 				{

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -20,21 +20,19 @@ import (
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
-	"github.com/iancoleman/strcase"
 )
 
-// DefaultLibraryName derives the library name (component name) for PHP purely from the API path.
-// E.g., "google/cloud/speech/v2" -> "Speech"
-// E.g., "google/cloud/security/privateca/v1" -> "SecurityPrivateca".
+// DefaultLibraryName derives the library name for PHP purely from the API path.
+// E.g., "google/cloud/speech/v2" -> "speech"
+// E.g., "google/cloud/security/privateca/v1" -> "security-privateca".
 func DefaultLibraryName(apiPath string) string {
 	apiPath = strings.TrimPrefix(apiPath, "google/cloud/")
 	apiPath = strings.TrimPrefix(apiPath, "google/")
 	if serviceconfig.ExtractVersion(apiPath) != "" {
 		apiPath = path.Dir(apiPath)
 	}
-	// Replace slash with underscore for strcase.ToCamel to handle nested paths
-	apiPath = strings.ReplaceAll(apiPath, "/", "_")
-	return strcase.ToCamel(apiPath)
+	apiPath = strings.ReplaceAll(apiPath, "/", "-")
+	return strings.ToLower(apiPath)
 }
 
 // Add populates PHP-specific default configuration for all APIs in the library.

--- a/internal/librarian/php/add_test.go
+++ b/internal/librarian/php/add_test.go
@@ -28,31 +28,31 @@ func TestDefaultLibraryName(t *testing.T) {
 	}{
 		{
 			apiPath: "google/cloud/speech/v2",
-			want:    "Speech",
+			want:    "speech",
 		},
 		{
 			apiPath: "google/cloud/security/privateca/v1",
-			want:    "SecurityPrivateca",
+			want:    "security-privateca",
 		},
 		{
 			apiPath: "google/cloud/bigquery/datatransfer/v1",
-			want:    "BigqueryDatatransfer",
+			want:    "bigquery-datatransfer",
 		},
 		{
 			apiPath: "google/pubsub/v1",
-			want:    "Pubsub",
+			want:    "pubsub",
 		},
 		{
 			apiPath: "google/cloud/vision",
-			want:    "Vision",
+			want:    "vision",
 		},
 		{
 			apiPath: "google/cloud/vision/v1",
-			want:    "Vision",
+			want:    "vision",
 		},
 		{
 			apiPath: "google/cloud/vision/v1p1beta1",
-			want:    "Vision",
+			want:    "vision",
 		},
 	} {
 		t.Run(test.apiPath, func(t *testing.T) {

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
+	"github.com/googleapis/librarian/internal/librarian/php"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -260,8 +261,10 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 			continue
 		}
 
+		libraryName := php.DefaultLibraryName(apis[0].Path)
+
 		libs = append(libs, &config.Library{
-			Name:    name,
+			Name:    libraryName,
 			Version: version,
 			PHP: &config.PHPPackage{
 				ComponentName: name,

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -260,9 +260,7 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 		if len(apis) == 0 {
 			continue
 		}
-
 		libraryName := php.DefaultLibraryName(apis[0].Path)
-
 		libs = append(libs, &config.Library{
 			Name:    libraryName,
 			Version: version,

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -108,7 +108,7 @@ deep-copy-regex:
 		},
 		Libraries: []*config.Library{
 			{
-				Name:    "SecretManager",
+				Name:    "secretmanager",
 				Version: "2.3.0",
 				PHP: &config.PHPPackage{
 					ComponentName: "SecretManager",
@@ -485,7 +485,7 @@ deep-copy-regex:
 			globalDefaultCommonResources: true,
 			want: []*config.Library{
 				{
-					Name:    "SecretManager",
+					Name:    "secretmanager",
 					Version: "2.3.0",
 					PHP: &config.PHPPackage{
 						ComponentName: "SecretManager",
@@ -497,6 +497,47 @@ deep-copy-regex:
 						},
 						{
 							Path: "google/cloud/multipygapic",
+							PHP: &config.PHPAPI{
+								CommonResources: new(false),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nested API path deriving lowercase hyphenated library name",
+			setupLib: func(t *testing.T, dir string) {
+				libDir := filepath.Join(dir, "SecurityPrivateCa")
+				if err := os.Mkdir(libDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				owlbotContent := `
+deep-copy-regex:
+  - source: /google/cloud/security/privateca/(v1)/.*-php/(.*)
+    dest: /owl-bot-staging/SecurityPrivateCa/$1/$2
+`
+				if err := os.WriteFile(filepath.Join(libDir, ".OwlBot.yaml"), []byte(owlbotContent), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			globalDefaultCommonResources: true,
+			want: []*config.Library{
+				{
+					Name:    "security-privateca",
+					Version: "1.0.0",
+					PHP: &config.PHPPackage{
+						ComponentName: "SecurityPrivateCa",
+					},
+					APIs: []*config.API{
+						{
+							Path: "google/cloud/security/privateca/v1",
 							PHP: &config.PHPAPI{
 								CommonResources: new(false),
 							},


### PR DESCRIPTION
Update php.DefaultLibraryName to derive lowercase hyphenated library names from API paths (e.g. google/cloud/security/privateca/v1 -> security-privateca).
    
Update migrate tool to use php.DefaultLibraryName(apis[0].Path) for library.Name instead of the repository folder name.
    
Fixes https://github.com/googleapis/librarian/issues/7024