### PR TITLE
feat(internal/librarian/php): initialize new component before generation

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -86,6 +86,19 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err != nil {
 		return err
 	}
+	if _, err := os.Stat(componentName); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		params, err := newInitParams(googleapisDir, library.APIs[0])
+		if err != nil {
+			return err
+		}
+		params.componentName = componentName
+		if err := initComponent(ctx, params); err != nil {
+			return err
+		}
+	}
 	stagingDir := filepath.Join(owlBotStagingDir, componentName)
 	if err := os.RemoveAll(stagingDir); err != nil {
 		return err

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -84,6 +84,8 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
+// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
+// once the install steps for the dev tool are ready.
 func TestGenerate_NewLibrary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow integration test")
@@ -143,6 +145,8 @@ cp %s SecretManager/owlbot.py
 	}
 }
 
+// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
+// once the install steps for the dev tool are ready.
 func TestGenerate_InitComponentError(t *testing.T) {
 	requirePHPGenerator(t)
 	googleapisDir := "../../testdata/googleapis"

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -16,6 +16,7 @@ package php
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +45,7 @@ func TestGenerate(t *testing.T) {
 	}
 	repoRoot := t.TempDir()
 	t.Chdir(repoRoot)
-	destDir := filepath.Join(repoRoot, "output")
+	destDir := filepath.Join(repoRoot, "SecretManager")
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -80,6 +81,157 @@ func TestGenerate(t *testing.T) {
 		if stat, err := os.Stat(p); err != nil || !stat.IsDir() {
 			t.Errorf("expected directory %s to exist and be a directory", p)
 		}
+	}
+}
+
+func TestGenerate_NewLibrary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow integration test")
+	}
+	requirePHPGenerator(t)
+	googleapisDir := "../../testdata/googleapis"
+	absGoogleapis, err := filepath.Abs(googleapisDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absOwlbotCopy, err := filepath.Abs(filepath.Join("testdata", "owlbot_copy.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	devDir := filepath.Join(repoRoot, "dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mockDevScript := filepath.Join(devDir, "google-cloud")
+	scriptContent := fmt.Sprintf(`#!/bin/sh
+mkdir -p SecretManager
+cp %s SecretManager/owlbot.py
+`, absOwlbotCopy)
+	if err := os.WriteFile(mockDevScript, []byte(scriptContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	destDir := filepath.Join(repoRoot, "SecretManager")
+	library := &config.Library{
+		Name:   "secretmanager",
+		Output: destDir,
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					CommonResources: new(true),
+					StagingSubdir:   "v1",
+				},
+			},
+		},
+	}
+	cfg := &config.Config{
+		Language: config.LanguagePhp,
+	}
+	err = Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: absGoogleapis})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify output
+	outputDirs := []string{"src", "tests", "samples", "fragments"}
+	for _, dir := range outputDirs {
+		p := filepath.Join(library.Output, dir)
+		if stat, err := os.Stat(p); err != nil || !stat.IsDir() {
+			t.Errorf("expected directory %s to exist and be a directory", p)
+		}
+	}
+}
+
+func TestGenerate_InitComponentError(t *testing.T) {
+	requirePHPGenerator(t)
+	googleapisDir := "../../testdata/googleapis"
+	absGoogleapis, err := filepath.Abs(googleapisDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	devDir := filepath.Join(repoRoot, "dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mockDevScript := filepath.Join(devDir, "google-cloud")
+	scriptContent := `#!/bin/sh
+exit 1
+`
+	if err := os.WriteFile(mockDevScript, []byte(scriptContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	destDir := filepath.Join(repoRoot, "SecretManager")
+	library := &config.Library{
+		Name:   "secretmanager",
+		Output: destDir,
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					CommonResources: new(true),
+					StagingSubdir:   "v1",
+				},
+			},
+		},
+	}
+	cfg := &config.Config{
+		Language: config.LanguagePhp,
+	}
+	err = Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: absGoogleapis})
+	if err == nil {
+		t.Fatal("Generate() expected error, got nil")
+	}
+}
+
+func TestGenerate_StatError(t *testing.T) {
+	requirePHPGenerator(t)
+	googleapisDir := "../../testdata/googleapis"
+	absGoogleapis, err := filepath.Abs(googleapisDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	// Create an inaccessible component directory to trigger a permission error on Stat
+	componentDir := filepath.Join(repoRoot, "SecretManager")
+	if err := os.MkdirAll(componentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nestedDir := filepath.Join(componentDir, "nested")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(componentDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(componentDir, 0o755)
+	})
+	library := &config.Library{
+		Name:   "secretmanager",
+		Output: componentDir,
+		PHP: &config.PHPPackage{
+			ComponentName: "SecretManager/nested",
+		},
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					CommonResources: new(true),
+					StagingSubdir:   "v1",
+				},
+			},
+		},
+	}
+	cfg := &config.Config{
+		Language: config.LanguagePhp,
+	}
+	err = Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: absGoogleapis})
+	if !errors.Is(err, os.ErrPermission) {
+		t.Errorf("Generate() error = %v, want wrap of %v", err, os.ErrPermission)
 	}
 }
 

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -256,6 +256,12 @@ func requirePHPGenerator(t *testing.T) {
 
 func TestGenerate_Error(t *testing.T) {
 	requirePHPGenerator(t)
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	// Pre-create component directory so Generate skips component initialization and tests config validation.
+	if err := os.MkdirAll(filepath.Join(repoRoot, "SecretManager"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	for _, test := range []struct {
 		name    string
 		lib     *config.Library

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -58,6 +58,8 @@ func newInitParams(googleapisDir string, api *config.API) (*initParams, error) {
 		return nil, err
 	}
 	apiVersion := serviceconfig.ExtractVersion(api.Path)
+	// TODO(https://github.com/googleapis/librarian/issues/7226):
+	// Refactor namespace resolution to avoid stripping and re-appending the version suffix.
 	phpNS := ns
 	if apiVersion != "" {
 		phpNS = ns + `\` + strings.ToUpper(apiVersion[:1]) + apiVersion[1:]

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -16,6 +16,7 @@ package php
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/repometadata"
 	"github.com/googleapis/librarian/internal/serviceconfig"
@@ -34,12 +36,16 @@ var (
 	versionSuffixRe = regexp.MustCompile(`\\V\d+.*$`)
 )
 
+const devTool = "dev/google-cloud"
+
 type initParams struct {
+	componentName   string
+	phpNamespace    string
+	protoPackage    string
 	apiShortName    string
+	apiVersion      string
 	productDocs     string
 	productHomepage string
-	protoPackage    string
-	apiVersion      string
 }
 
 func newInitParams(googleapisDir string, api *config.API) (*initParams, error) {
@@ -47,13 +53,41 @@ func newInitParams(googleapisDir string, api *config.API) (*initParams, error) {
 	if err != nil {
 		return nil, err
 	}
+	ns, err := namespace(googleapisDir, api.Path)
+	if err != nil {
+		return nil, err
+	}
+	apiVersion := serviceconfig.ExtractVersion(api.Path)
+	phpNS := ns
+	if apiVersion != "" {
+		phpNS = ns + `\` + strings.ToUpper(apiVersion[:1]) + apiVersion[1:]
+	}
 	return &initParams{
+		phpNamespace:    phpNS,
+		protoPackage:    protoPackage(api),
 		apiShortName:    svcAPI.ShortName,
+		apiVersion:      apiVersion,
 		productDocs:     svcAPI.DocumentationURI,
 		productHomepage: repometadata.ExtractBaseProductURL(svcAPI.DocumentationURI),
-		protoPackage:    protoPackage(api),
-		apiVersion:      serviceconfig.ExtractVersion(api.Path),
 	}, nil
+}
+
+func initComponent(ctx context.Context, params *initParams) error {
+	args := []string{
+		"component:new",
+		"--no-update",
+		"--component-name=" + params.componentName,
+		"--php-namespace=" + params.phpNamespace,
+		"--proto-package=" + params.protoPackage,
+		"--api-short-name=" + params.apiShortName,
+		"--api-version=" + params.apiVersion,
+		"--product-docs=" + params.productDocs,
+		"--product-homepage=" + params.productHomepage,
+	}
+	if err := command.Run(ctx, devTool, args...); err != nil {
+		return fmt.Errorf("failed to init new PHP component %s: %w", params.componentName, err)
+	}
+	return nil
 }
 
 // ComponentNameForLibrary resolves the component name for a PHP library.

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -19,6 +19,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -176,6 +177,7 @@ func TestNewInitParams(t *testing.T) {
 				Path: "google/cloud/secretmanager/v1",
 			},
 			want: &initParams{
+				phpNamespace:    `Google\Cloud\SecretManager\V1`,
 				apiShortName:    "secretmanager",
 				productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
 				productHomepage: "https://cloud.google.com/secret-manager/",
@@ -192,6 +194,7 @@ func TestNewInitParams(t *testing.T) {
 				},
 			},
 			want: &initParams{
+				phpNamespace:    `Google\Cloud\SecretManager\V1`,
 				apiShortName:    "secretmanager",
 				productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
 				productHomepage: "https://cloud.google.com/secret-manager/",
@@ -210,6 +213,67 @@ func TestNewInitParams(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestInitComponent(t *testing.T) {
+	ctx := t.Context()
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	devDir := filepath.Join(repoRoot, "dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mockScript := filepath.Join(devDir, "google-cloud")
+	scriptContent := `#!/bin/sh
+echo "$@" > dev_output.txt
+`
+	if err := os.WriteFile(mockScript, []byte(scriptContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	params := &initParams{
+		componentName:   "Speech",
+		phpNamespace:    `Google\Cloud\Speech\V2`,
+		protoPackage:    "google.cloud.speech.v2",
+		apiShortName:    "speech",
+		apiVersion:      "v2",
+		productDocs:     "https://cloud.google.com/speech-to-text/docs",
+		productHomepage: "https://cloud.google.com/speech-to-text",
+	}
+	if err := initComponent(ctx, params); err != nil {
+		t.Fatal(err)
+	}
+	gotBytes, err := os.ReadFile(filepath.Join(repoRoot, "dev_output.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(string(gotBytes))
+	want := `component:new --no-update --component-name=Speech --php-namespace=Google\Cloud\Speech\V2 --proto-package=google.cloud.speech.v2 --api-short-name=speech --api-version=v2 --product-docs=https://cloud.google.com/speech-to-text/docs --product-homepage=https://cloud.google.com/speech-to-text`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestInitComponent_Error(t *testing.T) {
+	ctx := t.Context()
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	devDir := filepath.Join(repoRoot, "dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mockScript := filepath.Join(devDir, "google-cloud")
+	scriptContent := `#!/bin/sh
+exit 1
+`
+	if err := os.WriteFile(mockScript, []byte(scriptContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	params := &initParams{
+		componentName: "Speech",
+	}
+	if err := initComponent(ctx, params); err == nil {
+		t.Fatal("initComponent() expected error, got nil")
 	}
 }
 
@@ -303,8 +367,8 @@ func TestComponentNameForLibrary(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != test.want {
-				t.Errorf("ComponentNameForLibrary() = %q, want %q", got, test.want)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -216,6 +216,8 @@ func TestNewInitParams(t *testing.T) {
 	}
 }
 
+// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
+// once the install steps for the dev tool are ready.
 func TestInitComponent(t *testing.T) {
 	ctx := t.Context()
 	repoRoot := t.TempDir()
@@ -254,6 +256,8 @@ echo "$@" > dev_output.txt
 	}
 }
 
+// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
+// once the install steps for the dev tool are ready.
 func TestInitComponent_Error(t *testing.T) {
 	ctx := t.Context()
 	repoRoot := t.TempDir()


### PR DESCRIPTION
When generating a new PHP library (component directory does not yet exist in google-cloud-php), Librarian invokes the repository development tool (dev/google-cloud component:new) with required component options to scaffold the component skeleton prior to GAPIC generation.

  
For https://github.com/googleapis/librarian/issues/7153