### PR TITLE
fix(internal/librarian/php): remove version suffix from init namespace

### DIFF
--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -58,14 +58,8 @@ func newInitParams(googleapisDir string, api *config.API) (*initParams, error) {
 		return nil, err
 	}
 	apiVersion := serviceconfig.ExtractVersion(api.Path)
-	// TODO(https://github.com/googleapis/librarian/issues/7226):
-	// Refactor namespace resolution to avoid stripping and re-appending the version suffix.
-	phpNS := ns
-	if apiVersion != "" {
-		phpNS = ns + `\` + strings.ToUpper(apiVersion[:1]) + apiVersion[1:]
-	}
 	return &initParams{
-		phpNamespace:    phpNS,
+		phpNamespace:    ns,
 		protoPackage:    protoPackage(api),
 		apiShortName:    svcAPI.ShortName,
 		apiVersion:      apiVersion,

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -177,7 +177,7 @@ func TestNewInitParams(t *testing.T) {
 				Path: "google/cloud/secretmanager/v1",
 			},
 			want: &initParams{
-				phpNamespace:    `Google\Cloud\SecretManager\V1`,
+				phpNamespace:    `Google\Cloud\SecretManager`,
 				apiShortName:    "secretmanager",
 				productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
 				productHomepage: "https://cloud.google.com/secret-manager/",
@@ -194,7 +194,7 @@ func TestNewInitParams(t *testing.T) {
 				},
 			},
 			want: &initParams{
-				phpNamespace:    `Google\Cloud\SecretManager\V1`,
+				phpNamespace:    `Google\Cloud\SecretManager`,
 				apiShortName:    "secretmanager",
 				productDocs:     "https://cloud.google.com/secret-manager/docs/overview",
 				productHomepage: "https://cloud.google.com/secret-manager/",


### PR DESCRIPTION
The PHP component initialization parameters previously re-appended the version suffix to the base namespace. The dev tool expects the root component namespace without the API version suffix.

This updates newInitParams to use the unversioned namespace directly.

Fixes https://github.com/googleapis/librarian/issues/7226
