### PR TITLE
Revert "refactor(internal/librarian/python): remove deprecated internal librarian.yaml config"

### DIFF
--- a/internal/librarian/python/install.go
+++ b/internal/librarian/python/install.go
@@ -16,15 +16,28 @@ package python
 
 import (
 	"context"
+	_ "embed"
+	"fmt"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/tool/pip"
+	"github.com/googleapis/librarian/internal/yaml"
 )
+
+//go:embed librarian.yaml
+var librarianYAML []byte
 
 // Install installs Python pip tool dependencies.
 func Install(ctx context.Context, tools *config.Tools) error {
-	if tools == nil || len(tools.Pip) == 0 {
+	if tools != nil && len(tools.Pip) > 0 {
+		return pip.Install(ctx, tools.Pip)
+	}
+	cfg, err := yaml.Unmarshal[config.Config](librarianYAML)
+	if err != nil {
+		return fmt.Errorf("parsing embedded librarian.yaml: %w", err)
+	}
+	if len(cfg.Tools.Pip) == 0 {
 		return nil
 	}
-	return pip.Install(ctx, tools.Pip)
+	return pip.Install(ctx, cfg.Tools.Pip)
 }

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -36,7 +36,7 @@ func TestInstall(t *testing.T) {
 		tools *config.Tools
 	}{
 		{
-			name:  "nil tools",
+			name:  "fallback to embedded librarian.yaml",
 			tools: nil,
 		},
 		{

--- a/internal/librarian/python/librarian.yaml
+++ b/internal/librarian/python/librarian.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# TODO(https://github.com/googleapis/librarian/issues/4848): move this file to
+# github.com/googleapis/google-cloud-python after the repository has migrated to
+# librarian.
+language: python
+tools:
+  pip:
+    - name: gapic-generator
+      version: "1.37.1"
+    - name: nox
+      version: "2025.11.12"
+    - name: ruff
+      version: "0.14.14"
+    - name: isort
+      version: "5.11.0"
+    - name: black
+      version: "23.7.0"
+      package: "black[jupyter]==23.7.0"
+    - name: synthtool
+      version: "e643ce8e20f8fe237a31a1754524ba987de72875"
+      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875"


### PR DESCRIPTION
Reverts googleapis/librarian#7157

Unblock python team using docker command since librarian (python) hasn't been updated to use protoc version defined in librarian.yaml.