### PR TITLE
fix(sidekick/swift): correct doc links for services

### DIFF
--- a/internal/sidekick/swift/doc_link.go
+++ b/internal/sidekick/swift/doc_link.go
@@ -141,9 +141,11 @@ func (c *codec) methodDocLink(m *api.Method) (string, error) {
 	if s == nil {
 		return "", nil
 	}
-	return c.docLink(s.Package, fmt.Sprintf("%s/%s(request:)", pascalCase(s.Name), camelCase(m.Name))), nil
+	name := fmt.Sprintf("%sClient/%s(request:)", pascalCaseNoMangling(s.Name), camelCase(m.Name))
+	return c.docLink(s.Package, name), nil
 }
 
 func (c *codec) serviceDocLink(s *api.Service) string {
-	return c.docLink(s.Package, pascalCase(s.Name))
+	name := fmt.Sprintf("%sClient", pascalCaseNoMangling(s.Name))
+	return c.docLink(s.Package, name)
 }

--- a/internal/sidekick/swift/doc_link_test.go
+++ b/internal/sidekick/swift/doc_link_test.go
@@ -124,13 +124,13 @@ func TestDocLink(t *testing.T) {
 			name:   "method link",
 			link:   "SomeService.CreateFoo",
 			scopes: []string{"test.v1"},
-			want:   "<doc:SomeService/createFoo(request:)>",
+			want:   "<doc:SomeServiceClient/createFoo(request:)>",
 		},
 		{
 			name:   "service link",
 			link:   "SomeService",
 			scopes: []string{"test.v1"},
-			want:   "<doc:SomeService>",
+			want:   "<doc:SomeServiceClient>",
 		},
 		{
 			name:   "fully qualified message link",


### PR DESCRIPTION
The name of the main service type changed from `Foo` to `FooClient` in #6566, I neglected to change the `doc:` links at the time.

Fixes https://github.com/googleapis/google-cloud-swift/issues/301

Generated output in https://github.com/googleapis/google-cloud-swift/pull/307 