### PR TITLE
feat(sidekick/impl): use `GoogleCloudGax._HTTPClient`

### DIFF
--- a/internal/sidekick/swift/generate_service_telemetry_test.go
+++ b/internal/sidekick/swift/generate_service_telemetry_test.go
@@ -93,8 +93,8 @@ func checkStubContents(t *testing.T, outDir string) {
 		t.Fatal(err)
 	}
 	contentStr := string(content)
-	got := extractBlock(t, contentStr, "req.setValue(Clients.clientHeader,", "\n")
-	want := "req.setValue(Clients.clientHeader, forHTTPHeaderField: \"X-Goog-Api-Client\")\n"
+	got := extractBlock(t, contentStr, "req.addHeader(name: ", "value: Clients.clientHeader)")
+	want := `req.addHeader(name: "X-Goog-Api-Client", value: Clients.clientHeader)`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -100,14 +100,15 @@ func TestGenerateStub_Structure(t *testing.T) {
 
 	got = extractBlock(t, transportContentStr, `  class ProtocolTransport: `, `HTTPClient`)
 	want = `  class ProtocolTransport: ProtocolStub {
-    let inner: GoogleCloudGax.HTTPClient`
+    let inner: GoogleCloudGax._HTTPClient`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	got = extractBlock(t, transportContentStr, `return try GoogleCloudWkt._ProtoJSONDecoder()`, ", from: data)\n    }")
-	want = `return try GoogleCloudWkt._ProtoJSONDecoder().decode(
-        SomeTestPackage.Response.self, from: data)
+	got = extractBlock(t, transportContentStr, `return try await req.rpc(`, ".get()\n    }")
+	want = `return try await req.rpc(
+        SomeTestPackage.Response.self, timeout: options.attemptTimeout
+      ).get()
     }`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/swift/templates/http/transport.swift.mustache
+++ b/internal/sidekick/swift/templates/http/transport.swift.mustache
@@ -31,14 +31,17 @@ import Foundation
 {{#Codec.ServiceImports}}
 import {{.}}
 {{/Codec.ServiceImports}}
-import GoogleCloudGax
+@_spi(GoogleCloudInternal) import GoogleCloudGax
 
 extension Clients {
   class {{Codec.StubPrefix}}Transport: {{Codec.StubPrefix}}Stub {
-    let inner: GoogleCloudGax.HTTPClient
+    let inner: GoogleCloudGax._HTTPClient
 
     public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {
-      self.inner = try GoogleCloudGax.HTTPClient(from: options, withDefaultEndpoint: "https://{{DefaultHost}}")
+      self.inner = try GoogleCloudGax._HTTPClient(
+        from: options,
+        withDefaultEndpoint: "https://{{DefaultHost}}",
+      )
     }
     {{#Codec.RestMethods}}
 
@@ -84,28 +87,28 @@ extension Clients {
       query.append(contentsOf: try encoder.encode(request.{{Codec.Name}}, prefix: "{{JSONName}}"))
       {{/IsOneOf}}
       {{/Codec.QueryParams}}
-      var req = try await self.inner.Request(path: path, query: query)
-      req.httpMethod = "{{Codec.HTTPMethod}}"
-      req.setValue(Clients.clientHeader, forHTTPHeaderField: "X-Goog-Api-Client")
+      var req = try await self.inner.newRequest(path: path, query: query)
+      req.setMethod(.{{Codec.HTTPMethod}})
+      req.addHeader(name: "X-Goog-Api-Client", value: Clients.clientHeader)
       {{#Codec.HasBody}}
       {{#Codec.IsBodyWildcard}}
-      req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-      req.httpBody = try JSONEncoder().encode(request)
+      req.setBody(data: try JSONEncoder().encode(request), ofContentType: "application/json")
       {{/Codec.IsBodyWildcard}}
       {{^Codec.IsBodyWildcard}}
       if let body = request.{{Codec.BodyField}} {
-        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try JSONEncoder().encode(body)
+        req.setBody(data: try JSONEncoder().encode(body), ofContentType: "application/json")
       }
       {{/Codec.IsBodyWildcard}}
       {{/Codec.HasBody}}
       {{^ReturnsEmpty}}
-      let (data, _) = try await self.inner.rpc(for: req).get()
-      return try {{InputType.Codec.Model.WktPackage}}._ProtoJSONDecoder().decode(
-        {{Codec.ReturnType}}.self, from: data)
+      return try await req.rpc(
+        {{Codec.ReturnType}}.self, timeout: options.attemptTimeout
+      ).get()
       {{/ReturnsEmpty}}
       {{#ReturnsEmpty}}
-      _ = try await self.inner.rpc(for: req).get()
+      _ = try await req.rpc(
+        {{Codec.ReturnType}}.self, timeout: options.attemptTimeout
+      ).get()
       {{/ReturnsEmpty}}
     }
     {{/Codec.RestMethods}}


### PR DESCRIPTION
The new HTTP client in `GoogleCloudGax` is based on the `AsyncHTTPClient` library, which is more suitable for server-side applications. It also makes the code easier to generate, and uses the attempt timeout, if any is set.

Fixes https://github.com/googleapis/google-cloud-swift/issues/303 

Generated output: https://github.com/googleapis/google-cloud-swift/pull/305