### PR TITLE
impl(internal/sidekick/rust): use unimplemented_bidi_stub in stub

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -144,7 +144,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			name:     "stub: method signature and default body",
 			file:     "src/stub.rs",
 			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
-			endStr:   "        }\n    }",
+			endStr:   "    }",
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
@@ -154,10 +154,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
     )>> + Send {
-        async {
-            let _ = gaxi::unimplemented::unimplemented_stub::<()>().await;
-            unreachable!() // satisfies the type checker; the stub above always panics.
-        }
+        gaxi::unimplemented::unimplemented_bidi_stub()
     }`,
 		},
 		{

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -63,11 +63,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
     )>> + Send {
-        {{! TODO(#6835) - create a streaming unimplemented stub in gaxi }}
-        async {
-            let _ = gaxi::unimplemented::unimplemented_stub::<()>().await;
-            unreachable!() // satisfies the type checker; the stub above always panics.
-        }
+        gaxi::unimplemented::unimplemented_bidi_stub()
     }
     {{/Codec.IsBidiStreaming}}
     {{^Codec.IsBidiStreaming}}


### PR DESCRIPTION
Update the stub trait template to use gaxi::unimplemented::unimplemented_bidi_stub() as the default implementation for bidirectional streaming methods.

For #6835 