### PR TITLE
feat(internal/librarian/php): call dev tool from librarian generate on first generation

### DIFF
--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -70,9 +70,8 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 	if err := initComponent(ctx, params); err != nil {
 		return "", err
 	}
-	// The dev tool hardcodes the scaffold output strictly to params.componentName.
-	// If a custom library.Output is requested, we must manually move the scaffolded
-	// directory to the correct target location.
+	// The dev tool always scaffolds to params.componentName.
+	// Move it manually if a custom output directory is requested.
 	if targetDir != params.componentName {
 		if err := os.MkdirAll(filepath.Dir(targetDir), 0o755); err != nil {
 			return "", fmt.Errorf("mkdir %q: %w", filepath.Dir(targetDir), err)

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -58,24 +58,21 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 	if err != nil {
 		return "", err
 	}
-	targetDir := params.componentName
-	if library.Output != "" {
-		targetDir = library.Output
+	targetDir := library.Output
+	if targetDir == "" {
+		targetDir = params.componentName
 	}
-	_, err = os.Stat(targetDir)
-	if err == nil {
-		// Component exists, return the component name.
-		return params.componentName, nil
-	}
-	if !errors.Is(err, fs.ErrNotExist) {
+
+	if _, err := os.Stat(targetDir); err == nil {
+		return params.componentName, nil // Component already exists
+	} else if !errors.Is(err, fs.ErrNotExist) {
 		return "", err
 	}
+
 	if err := initComponent(ctx, params); err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(params.componentName); err != nil {
-		return "", fmt.Errorf("missing component %q: %w", params.componentName, err)
-	}
+
 	if targetDir != params.componentName {
 		if err := os.MkdirAll(filepath.Dir(targetDir), 0o755); err != nil {
 			return "", fmt.Errorf("mkdir %q: %w", filepath.Dir(targetDir), err)
@@ -83,7 +80,10 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 		if err := os.Rename(params.componentName, targetDir); err != nil {
 			return "", fmt.Errorf("rename %q to %q: %w", params.componentName, targetDir, err)
 		}
+	} else if _, err := os.Stat(params.componentName); err != nil {
+		return "", fmt.Errorf("missing component %q: %w", params.componentName, err)
 	}
+
 	return params.componentName, nil
 }
 

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -58,7 +58,11 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 	if err != nil {
 		return "", err
 	}
-	_, err = os.Stat(params.componentName)
+	targetDir := params.componentName
+	if library.Output != "" {
+		targetDir = library.Output
+	}
+	_, err = os.Stat(targetDir)
 	if err == nil {
 		// Component exists, return the component name.
 		return params.componentName, nil
@@ -68,6 +72,17 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 	}
 	if err := initComponent(ctx, params); err != nil {
 		return "", err
+	}
+	if _, err := os.Stat(params.componentName); err != nil {
+		return "", fmt.Errorf("missing component %q: %w", params.componentName, err)
+	}
+	if targetDir != params.componentName {
+		if err := os.MkdirAll(filepath.Dir(targetDir), 0o755); err != nil {
+			return "", fmt.Errorf("mkdir %q: %w", filepath.Dir(targetDir), err)
+		}
+		if err := os.Rename(params.componentName, targetDir); err != nil {
+			return "", fmt.Errorf("rename %q to %q: %w", params.componentName, targetDir, err)
+		}
 	}
 	return params.componentName, nil
 }

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -73,6 +73,9 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 		return "", err
 	}
 
+	// The dev tool hardcodes the scaffold output strictly to params.componentName.
+	// If a custom library.Output is requested, we must manually move the scaffolded
+	// directory to the correct target location.
 	if targetDir != params.componentName {
 		if err := os.MkdirAll(filepath.Dir(targetDir), 0o755); err != nil {
 			return "", fmt.Errorf("mkdir %q: %w", filepath.Dir(targetDir), err)

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -62,17 +62,14 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 	if targetDir == "" {
 		targetDir = params.componentName
 	}
-
 	if _, err := os.Stat(targetDir); err == nil {
 		return params.componentName, nil // Component already exists
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return "", err
 	}
-
 	if err := initComponent(ctx, params); err != nil {
 		return "", err
 	}
-
 	// The dev tool hardcodes the scaffold output strictly to params.componentName.
 	// If a custom library.Output is requested, we must manually move the scaffolded
 	// directory to the correct target location.
@@ -86,7 +83,6 @@ func initComponentIfMissing(ctx context.Context, library *config.Library, google
 	} else if _, err := os.Stat(params.componentName); err != nil {
 		return "", fmt.Errorf("missing component %q: %w", params.componentName, err)
 	}
-
 	return params.componentName, nil
 }
 

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -354,8 +354,10 @@ func TestInitComponentIfMissing(t *testing.T) {
 				t.Errorf("wasInitialized = %v, wantInit = %v", wasInitialized, test.wantInit)
 			}
 			if test.library.Output != "" {
-				if _, err := os.Stat(filepath.Join(repoRoot, test.library.Output)); err != nil {
-					t.Error(err)
+				_, statErr := os.Stat(filepath.Join(repoRoot, test.library.Output))
+				wasMoved := statErr == nil
+				if !wasMoved {
+					t.Errorf("wasMoved = %v, wantMoved = true", wasMoved)
 				}
 			}
 		})

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -278,7 +278,7 @@ func TestInitComponentIfMissing(t *testing.T) {
 					t.Fatal(err)
 				}
 				mockScript := filepath.Join(devDir, "google-cloud")
-				scriptContent := "#!/bin/sh\ntouch initialized.txt\n"
+				scriptContent := "#!/bin/sh\nmkdir SecretManager\ntouch initialized.txt\n"
 				if err := os.WriteFile(mockScript, []byte(scriptContent), 0o755); err != nil {
 					t.Fatal(err)
 				}
@@ -303,12 +303,35 @@ func TestInitComponentIfMissing(t *testing.T) {
 					t.Fatal(err)
 				}
 				mockScript := filepath.Join(devDir, "google-cloud")
-				scriptContent := "#!/bin/sh\ntouch initialized.txt\n"
+				scriptContent := "#!/bin/sh\nmkdir CustomSecretManager\ntouch initialized.txt\n"
 				if err := os.WriteFile(mockScript, []byte(scriptContent), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			},
 			wantComponent: "CustomSecretManager",
+			wantInit:      true,
+		},
+		{
+			name: "new component initialized with library.Output",
+			library: &config.Library{
+				Name: "secretmanager",
+				Output: "custom/output/path",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			setup: func(t *testing.T, repoRoot string) {
+				devDir := filepath.Join(repoRoot, "dev")
+				if err := os.MkdirAll(devDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				mockScript := filepath.Join(devDir, "google-cloud")
+				scriptContent := "#!/bin/sh\nmkdir SecretManager\ntouch initialized.txt\n"
+				if err := os.WriteFile(mockScript, []byte(scriptContent), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantComponent: "SecretManager",
 			wantInit:      true,
 		},
 	} {
@@ -329,6 +352,11 @@ func TestInitComponentIfMissing(t *testing.T) {
 			wasInitialized := statErr == nil
 			if wasInitialized != test.wantInit {
 				t.Errorf("wasInitialized = %v, wantInit = %v", wasInitialized, test.wantInit)
+			}
+			if test.library.Output != "" {
+				if _, err := os.Stat(filepath.Join(repoRoot, test.library.Output)); err != nil {
+					t.Error(err)
+				}
 			}
 		})
 	}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -314,7 +314,7 @@ func TestInitComponentIfMissing(t *testing.T) {
 		{
 			name: "new component initialized with library.Output",
 			library: &config.Library{
-				Name: "secretmanager",
+				Name:   "secretmanager",
 				Output: "custom/output/path",
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},


### PR DESCRIPTION
This change allows us to generate initial files if the library is brand new by using the newly installed dev tool (#7122). The upstream `dev/google-cloud component:new` tool hardcodes its scaffolding output to a directory named after the component and does not natively support an output directory override. To fix this, `initComponentIfMissing` now checks for the existence of `library.Output` instead of `componentName`. If missing, it allows the dev tool to scaffold the default directory, then manually moves the result to the configured `library.Output` destination. 

Fixes https://github.com/googleapis/librarian/issues/7153