### PR TITLE
fix(internal/librarian): preserve skip_generate on mixed libraries in tidy

### DIFF
--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -108,11 +108,6 @@ func tidyLibrary(cfg *config.Config, lib *config.Library) (*config.Library, erro
 	if lib.Output != "" && len(lib.APIs) == 1 && isDerivableOutput(cfg, lib) {
 		lib.Output = ""
 	}
-	if isMixedLibrary(cfg.Language, lib) {
-		// Mixed libraries with handwritten code or those that are fully handwritten
-		// are never generated, so ensure that skip_generate is false.
-		lib.SkipGenerate = false
-	}
 	if len(lib.Roots) == 1 && lib.Roots[0] == "googleapis" {
 		lib.Roots = nil
 	}

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -902,7 +902,7 @@ func TestTidy_MissingGoogleApisSource(t *testing.T) {
 	}
 }
 
-func TestTidy_VeneerSkipGenerate(t *testing.T) {
+func TestTidy_SkipGenerate(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := &config.Config{
 		Language: config.LanguageRust,
@@ -930,7 +930,7 @@ func TestTidy_VeneerSkipGenerate(t *testing.T) {
 	if len(cfg.Libraries) != 1 {
 		t.Fatalf("expected 1 library, got %d", len(cfg.Libraries))
 	}
-	if cfg.Libraries[0].SkipGenerate {
-		t.Errorf("expected skip_generate to be false for veneer library, got true")
+	if !cfg.Libraries[0].SkipGenerate {
+		t.Errorf("expected skip_generate to be true for mixed library, got true")
 	}
 }

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -931,6 +931,6 @@ func TestTidy_SkipGenerate(t *testing.T) {
 		t.Fatalf("expected 1 library, got %d", len(cfg.Libraries))
 	}
 	if !cfg.Libraries[0].SkipGenerate {
-		t.Errorf("expected skip_generate to be true for mixed library, got true")
+		t.Errorf("expected skip_generate to be true for mixed library, got false")
 	}
 }


### PR DESCRIPTION
The tidy command previously forced `skip_generate` to false for mixed libraries. This prevented configurations from explicitly setting `skip_generate` to true on mixed libraries to skip generation.

The override in tidyLibrary is removed so that `skip_generate` values are preserved as configured.

Fixes https://github.com/googleapis/librarian/issues/7257
