### PR TITLE
feat(internal/sidekick/rust): make request on BidiStreamBuilder optional

### DIFF
--- a/internal/sidekick/api/method.go
+++ b/internal/sidekick/api/method.go
@@ -199,6 +199,11 @@ func (m *Method) HasAutoPopulatedFields() bool {
 	return len(m.AutoPopulated) != 0
 }
 
+// IsBidiStreaming returns true if the method is a bidirectional streaming RPC.
+func (m *Method) IsBidiStreaming() bool {
+	return m.ClientSideStreaming && m.ServerSideStreaming
+}
+
 // SampleInfo contains sample generation information for a single method,
 // usually if it is an AIP conforming method.
 type SampleInfo struct {

--- a/internal/sidekick/api/mustache_helpers_test.go
+++ b/internal/sidekick/api/mustache_helpers_test.go
@@ -38,3 +38,38 @@ func TestHasMessages(t *testing.T) {
 		t.Errorf("expected HasMessages() == false for: %v", model)
 	}
 }
+
+func TestMethodIsBidiStreaming(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method *Method
+		want   bool
+	}{
+		{
+			name:   "unary method",
+			method: &Method{},
+			want:   false,
+		},
+		{
+			name:   "client streaming only",
+			method: &Method{ClientSideStreaming: true},
+			want:   false,
+		},
+		{
+			name:   "server streaming only",
+			method: &Method{ServerSideStreaming: true},
+			want:   false,
+		},
+		{
+			name:   "bidi streaming",
+			method: &Method{ClientSideStreaming: true, ServerSideStreaming: true},
+			want:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.method.IsBidiStreaming(); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -139,7 +139,18 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			endStr:   "        }",
 			want: `        /// Sets the full request, replacing any prior values.
         pub fn with_request<V: Into<crate::model::Request>>(mut self, v: V) -> Self {
-            self.0.request = v.into();
+            self.0.request = std::option::Option::Some(v.into());
+            self
+        }`,
+		},
+		{
+			name:     "builder: field setter",
+			file:     "src/builder.rs",
+			startStr: "        /// Sets the value of [query]",
+			endStr:   "        }",
+			want: `        /// Sets the value of [query][crate::model::Request::query].
+        pub fn set_query<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.get_or_insert_with(std::default::Default::default).query = v.into();
             self
         }`,
 		},
@@ -151,7 +162,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
-        _req: crate::model::Request,
+        _req: std::option::Option<crate::model::Request>,
         _options: crate::BidiStreamOptions,
     ) -> impl std::future::Future<Output = crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
@@ -168,7 +179,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
-        req: crate::model::Request,
+        req: std::option::Option<crate::model::Request>,
         options: crate::BidiStreamOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
@@ -184,7 +195,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
-        req: crate::model::Request,
+        req: std::option::Option<crate::model::Request>,
         options: crate::BidiStreamOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
@@ -201,7 +212,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
-        req: crate::model::Request,
+        req: std::option::Option<crate::model::Request>,
         options: crate::BidiStreamOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
@@ -218,7 +229,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
-        req: crate::model::Request,
+        req: std::option::Option<crate::model::Request>,
         options: crate::BidiStreamOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -84,7 +84,7 @@ pub mod {{Codec.ModuleName}} {
     #[derive(Clone, Debug)]
     pub(crate) struct BidiStreamBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
-        request: R,
+        request: Option<R>,
         options: crate::BidiStreamOptions,
     }
 
@@ -94,7 +94,7 @@ pub mod {{Codec.ModuleName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>) -> Self {
             Self {
                 stub,
-                request: R::default(),
+                request: None,
                 options: crate::BidiStreamOptions::default(),
             }
         }
@@ -179,7 +179,12 @@ pub mod {{Codec.ModuleName}} {
 
         /// Sets the full request, replacing any prior values.
         pub fn with_request<V: Into<{{InputType.Codec.QualifiedName}}>>(mut self, v: V) -> Self {
+            {{#Codec.IsBidiStreaming}}
+            self.0.request = std::option::Option::Some(v.into());
+            {{/Codec.IsBidiStreaming}}
+            {{^Codec.IsBidiStreaming}}
             self.0.request = v.into();
+            {{/Codec.IsBidiStreaming}}
             self
         }
 
@@ -525,7 +530,12 @@ pub mod {{Codec.ModuleName}} {
         {{#Singular}}
         {{^Optional}}
         pub fn set_{{Codec.SetterName}}<T: Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into();
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.into();
+            {{/IsBidiStreaming}}
             self
         }
         {{/Optional}}
@@ -534,7 +544,12 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_{{Codec.SetterName}}<T>(mut self, v: T) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = std::option::Option::Some(v.into());
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = std::option::Option::Some(v.into());
+            {{/IsBidiStreaming}}
             self
         }
 
@@ -549,7 +564,12 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_or_clear_{{Codec.SetterName}}<T>(mut self, v: std::option::Option<T>) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.map(|x| x.into());
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.map(|x| x.into());
+            {{/IsBidiStreaming}}
             self
         }
         {{/Codec.IsBoxed}}
@@ -557,7 +577,12 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_{{Codec.SetterName}}<T>(mut self, v: T) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = std::option::Option::Some(std::boxed::Box::new(v.into()));
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = std::option::Option::Some(std::boxed::Box::new(v.into()));
+            {{/IsBidiStreaming}}
             self
         }
 
@@ -572,7 +597,12 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_or_clear_{{Codec.SetterName}}<T>(mut self, v: std::option::Option<T>) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.map(|x| std::boxed::Box::new(x.into()));
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.map(|x| std::boxed::Box::new(x.into()));
+            {{/IsBidiStreaming}}
             self
         }
         {{/Codec.IsBoxed}}
@@ -585,7 +615,12 @@ pub mod {{Codec.ModuleName}} {
             V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
             use std::iter::Iterator;
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
+            {{/IsBidiStreaming}}
             self
         }
         {{/Repeated}}
@@ -596,7 +631,13 @@ pub mod {{Codec.ModuleName}} {
             K: std::convert::Into<{{{Codec.KeyType}}}>,
             V: std::convert::Into<{{{Codec.ValueType}}}>,
         {
+            use std::iter::Iterator;
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            {{/IsBidiStreaming}}
             self
         }
         {{/Map}}
@@ -608,7 +649,12 @@ pub mod {{Codec.ModuleName}} {
         /// Note that all the setters affecting `{{Codec.FieldName}}` are
         /// mutually exclusive.
         pub fn set_{{Codec.SetterName}}<T: Into<Option<{{{Codec.FieldType}}}>>>(mut self, v: T) ->Self {
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into();
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.into();
+            {{/IsBidiStreaming}}
             self
         }
         {{#Fields}}
@@ -623,7 +669,13 @@ pub mod {{Codec.ModuleName}} {
         {{/Deprecated}}
         {{#Singular}}
         pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
+            {{#IsBidiStreaming}}
+            let req = self.0.request.get_or_insert_with(std::default::Default::default);
+            *req = std::mem::take(req).set_{{Codec.SetterName}}(v);
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
             self.0.request = self.0.request.set_{{Codec.SetterName}}(v);
+            {{/IsBidiStreaming}}
             self
         }
         {{/Singular}}
@@ -634,11 +686,20 @@ pub mod {{Codec.ModuleName}} {
             V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
             use std::iter::Iterator;
-            self.{{Group.Codec.FieldName}} = std::option::Option::Some(
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Group.Codec.FieldName}} = std::option::Option::Some(
                 {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
                     v.into_iter().map(|i| i.into()).collect()
                 )
             );
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
+            self.0.request.{{Group.Codec.FieldName}} = std::option::Option::Some(
+                {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
+                    v.into_iter().map(|i| i.into()).collect()
+                )
+            );
+            {{/IsBidiStreaming}}
             self
         }
         {{/Repeated}}
@@ -650,11 +711,20 @@ pub mod {{Codec.ModuleName}} {
             V: std::convert::Into<{{{Codec.ValueType}}}>,
         {
             use std::iter::Iterator;
-            self.{{Group.Codec.FieldName}} = std::option::Option::Some(
+            {{#IsBidiStreaming}}
+            self.0.request.get_or_insert_with(std::default::Default::default).{{Group.Codec.FieldName}} = std::option::Option::Some(
                 {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
                     v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
                 )
             );
+            {{/IsBidiStreaming}}
+            {{^IsBidiStreaming}}
+            self.0.request.{{Group.Codec.FieldName}} = std::option::Option::Some(
+                {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
+                    v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
+                )
+            );
+            {{/IsBidiStreaming}}
             self
         }
         {{/Map}}

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -631,7 +631,6 @@ pub mod {{Codec.ModuleName}} {
             K: std::convert::Into<{{{Codec.KeyType}}}>,
             V: std::convert::Into<{{{Codec.ValueType}}}>,
         {
-            use std::iter::Iterator;
             {{#IsBidiStreaming}}
             self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             {{/IsBidiStreaming}}
@@ -670,8 +669,8 @@ pub mod {{Codec.ModuleName}} {
         {{#Singular}}
         pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
             {{#IsBidiStreaming}}
-            let req = self.0.request.get_or_insert_with(std::default::Default::default);
-            *req = std::mem::take(req).set_{{Codec.SetterName}}(v);
+            let req = self.0.request.take().unwrap_or_default().set_{{Codec.SetterName}}(v);
+            self.0.request = std::option::Option::Some(req);
             {{/IsBidiStreaming}}
             {{^IsBidiStreaming}}
             self.0.request = self.0.request.set_{{Codec.SetterName}}(v);

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -57,7 +57,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
-        _req: {{InputType.Codec.QualifiedName}},
+        _req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         _options: crate::BidiStreamOptions,
     ) -> impl std::future::Future<Output = crate::Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -30,7 +30,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
-        req: {{InputType.Codec.QualifiedName}},
+        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::BidiStreamOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
@@ -79,7 +79,7 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
-        req: {{InputType.Codec.QualifiedName}},
+        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::BidiStreamOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -68,7 +68,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
-        req: {{InputType.Codec.QualifiedName}},
+        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::BidiStreamOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -131,7 +131,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
-        req: {{InputType.Codec.QualifiedName}},
+        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::BidiStreamOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
@@ -139,6 +139,13 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     )> {
         use gaxi::prost::{FromProto, ToProto};
         use futures::stream::StreamExt as _;
+
+        let req = req.ok_or_else(|| {
+            {{! TODO(#6835) - determine appropriate error type for missing initial request }}
+            google_cloud_gax::error::Error::binding(
+                "a request is required"
+            )
+        })?;
 
         let first_req = req
             .to_proto()


### PR DESCRIPTION
Change the request field on BidiStreamBuilder to Option<R> defaulting to None, lazily initializing the request struct when field setters are called.

Update stub traits, dynamic stubs, tracing wrappers, and transport layers for bidirectional streaming to accept Option<Request>, with the transport layer returning a binding error when an initial request is missing.

For #6835