### PR TITLE
fix(sidekick/swift): mangling for `Type

### DIFF
--- a/internal/sidekick/swift/convert_proto_names.go
+++ b/internal/sidekick/swift/convert_proto_names.go
@@ -48,7 +48,7 @@ func (c *codec) protoMessageTypeName(m *api.Message) string {
 func (c *codec) protoEnumTypeName(e *api.Enum) string {
 	mangled := pascalCase(e.Name)
 	if mangled == "Type_" {
-		//Protobuf uses `TypeEnum` in this case.
+		// Protobuf uses `TypeEnum` in this case.
 		mangled = "TypeEnum"
 	}
 	if e.Parent == nil {

--- a/internal/sidekick/swift/convert_proto_names.go
+++ b/internal/sidekick/swift/convert_proto_names.go
@@ -46,14 +46,19 @@ func (c *codec) protoMessageTypeName(m *api.Message) string {
 // for a given api.Enum. For top-level enums, it formats the package prefix and enum name.
 // For nested enums, it resolves the parent message's proto type name and appends the PascalCase enum name.
 func (c *codec) protoEnumTypeName(e *api.Enum) string {
+	mangled := pascalCase(e.Name)
+	if mangled == "Type_" {
+		//Protobuf uses `TypeEnum` in this case.
+		mangled = "TypeEnum"
+	}
 	if e.Parent == nil {
-		fullName := fmt.Sprintf("%s%s", ProtoPackagePrefix(e.Package), pascalCase(e.Name))
+		fullName := fmt.Sprintf("%s%s", ProtoPackagePrefix(e.Package), mangled)
 		if c.ModulePath != "" {
 			return fmt.Sprintf("%s.%s", c.ModulePath, fullName)
 		}
 		return fullName
 	}
-	return fmt.Sprintf("%s.%s", c.protoMessageTypeName(e.Parent), pascalCase(e.Name))
+	return fmt.Sprintf("%s.%s", c.protoMessageTypeName(e.Parent), mangled)
 }
 
 func (c *codec) messageFileName(m *api.Message) string {

--- a/internal/sidekick/swift/convert_proto_names_test.go
+++ b/internal/sidekick/swift/convert_proto_names_test.go
@@ -44,8 +44,14 @@ func TestProtoMessageAndEnumTypeName(t *testing.T) {
 		Package: "test",
 		Parent:  parentMsg,
 	}
+	typeEnum := &api.Enum{
+		Name:    "Type",
+		ID:      ".test.OuterMessage.Type",
+		Package: "test",
+		Parent:  parentMsg,
+	}
 
-	model := api.NewTestAPI([]*api.Message{parentMsg, nestedMsg}, []*api.Enum{topEnum, nestedEnum}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{parentMsg, nestedMsg}, []*api.Enum{topEnum, nestedEnum, typeEnum}, []*api.Service{})
 	model.PackageName = "test"
 
 	t.Run("with empty ModulePath", func(t *testing.T) {
@@ -72,6 +78,12 @@ func TestProtoMessageAndEnumTypeName(t *testing.T) {
 		gotNestedEnum := codec.protoEnumTypeName(nestedEnum)
 		wantNestedEnum := "Test_OuterMessage.NestedEnum"
 		if gotNestedEnum != wantNestedEnum {
+			t.Errorf("protoEnumTypeName(nestedEnum) = %q, want %q", gotNestedEnum, wantNestedEnum)
+		}
+
+		gotTypeEnum := codec.protoEnumTypeName(typeEnum)
+		wantTypeEnum := "Test_OuterMessage.TypeEnum"
+		if gotTypeEnum != wantTypeEnum {
 			t.Errorf("protoEnumTypeName(nestedEnum) = %q, want %q", gotNestedEnum, wantNestedEnum)
 		}
 	})

--- a/internal/sidekick/swift/convert_proto_names_test.go
+++ b/internal/sidekick/swift/convert_proto_names_test.go
@@ -84,7 +84,7 @@ func TestProtoMessageAndEnumTypeName(t *testing.T) {
 		gotTypeEnum := codec.protoEnumTypeName(typeEnum)
 		wantTypeEnum := "Test_OuterMessage.TypeEnum"
 		if gotTypeEnum != wantTypeEnum {
-			t.Errorf("protoEnumTypeName(nestedEnum) = %q, want %q", gotNestedEnum, wantNestedEnum)
+			t.Errorf("protoEnumTypeName(typeEnum) = %q, want %q", gotNestedEnum, wantNestedEnum)
 		}
 	})
 


### PR DESCRIPTION
Protobuf uses different mangling than sidekick for enums named `Type`.

Fixers #7261 

See https://github.com/googleapis/google-cloud-swift/pull/420 for the generated output
