### PR TITLE
fix(tool/cmd/migrate/php): programmatically set explicit Output during PHP migration

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -265,6 +265,7 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 			Name:    libraryName,
 			Version: version,
 			APIs:    apis,
+			Output:  name,
 		}
 		derivedComp, err := php.ComponentNameForLibrary(googleapisDir, lib)
 		if err != nil {

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -110,6 +110,7 @@ deep-copy-regex:
 			{
 				Name:    "secretmanager",
 				Version: "2.3.0",
+				Output:  "SecretManager",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -496,6 +497,7 @@ deep-copy-regex:
 				{
 					Name:    "secretmanager",
 					Version: "2.3.0",
+					Output:  "SecretManager",
 					APIs: []*config.API{
 						{
 							Path: "google/cloud/secretmanager/v1",
@@ -538,6 +540,7 @@ deep-copy-regex:
 				{
 					Name:    "security-privateca",
 					Version: "1.0.0",
+					Output:  "SecurityPrivateCa",
 					PHP: &config.PHPPackage{
 						ComponentName: "SecurityPrivateCa",
 					},
@@ -579,6 +582,7 @@ deep-copy-regex:
 				{
 					Name:    "identity-accesscontextmanager",
 					Version: "1.0.0",
+					Output:  "AccessContextManager",
 					PHP: &config.PHPPackage{
 						ComponentName: "AccessContextManager",
 					},
@@ -645,6 +649,7 @@ deep-copy-regex:
 				{
 					Name:    "secretmanager",
 					Version: "2.3.0",
+					Output:  "secretmanager",
 					PHP: &config.PHPPackage{
 						ComponentName: "secretmanager",
 					},


### PR DESCRIPTION
This fixes an issue where PHP library configurations generated by the migrate tool did not explicitly set the Output field in the librarian.yaml. Because PHP's CamelCase convention cannot be algorithmically derived from a lowercase string, the migration tool now relies on the parsed ComponentName to set the Output explicitly.

Fixes #7262