### PR TITLE
fix(internal/librarian/php): skip post-processor if staging directory does not exist

### DIFF
--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -47,14 +47,34 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 		return err
 	}
 
-	if err := command.RunInDir(ctx, componentName, "python3", "owlbot.py"); err != nil {
-		return fmt.Errorf("failed to run owlbot.py: %w", err)
-	}
 	bin, err := binDir()
 	if err != nil {
 		return fmt.Errorf("failed to get bin dir: %w", err)
 	}
 	postProcessor := filepath.Join(bin, "php-post-processor")
+
+	// Run post-processor in API staging directories before owlbot.py moves them.
+	for _, api := range library.APIs {
+		if api.PHP == nil {
+			continue
+		}
+		apiStagingDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
+		if _, err := os.Stat(apiStagingDir); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("failed to stat staging dir for %s: %w", api.Path, err)
+		}
+		if err := command.RunInDir(ctx, apiStagingDir, postProcessor, "--input", "."); err != nil {
+			return fmt.Errorf("failed to run php-post-processor on %s: %w", api.Path, err)
+		}
+	}
+
+	if err := command.RunInDir(ctx, componentName, "python3", "owlbot.py"); err != nil {
+		return fmt.Errorf("failed to run owlbot.py: %w", err)
+	}
+
+	// Legacy behavior: run post-processor on componentName after owlbot.py
 	if err := command.RunInDir(ctx, componentName, postProcessor, "--input", "."); err != nil {
 		return fmt.Errorf("failed to run php-post-processor: %w", err)
 	}

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -52,7 +52,6 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 		return fmt.Errorf("failed to get bin dir: %w", err)
 	}
 	postProcessor := filepath.Join(bin, "php-post-processor")
-
 	// Run post-processor in API staging directories before owlbot.py moves them.
 	for _, api := range library.APIs {
 		if api.PHP == nil {
@@ -69,11 +68,9 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 			return fmt.Errorf("failed to run php-post-processor on %s: %w", api.Path, err)
 		}
 	}
-
 	if err := command.RunInDir(ctx, componentName, "python3", "owlbot.py"); err != nil {
 		return fmt.Errorf("failed to run owlbot.py: %w", err)
 	}
-
 	// Legacy behavior: run post-processor on componentName after owlbot.py
 	if err := command.RunInDir(ctx, componentName, postProcessor, "--input", "."); err != nil {
 		return fmt.Errorf("failed to run php-post-processor: %w", err)

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
@@ -288,14 +289,9 @@ func TestPostProcess_PHPPostProcessor_WithAPIs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 runs, got %d", len(lines))
-	}
-	if lines[0] != stagingDir {
-		t.Errorf("expected post-processor to run first in %q, got %q", stagingDir, lines[0])
-	}
-	if lines[1] != destDir {
-		t.Errorf("expected post-processor to run second in %q, got %q", destDir, lines[1])
+	got := strings.Split(strings.TrimSpace(string(content)), "\n")
+	want := []string{stagingDir, destDir}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -199,6 +199,10 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	stagingDir := filepath.Join(repoRoot, owlBotStagingDir, "SecretManager", "v1")
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	setupMockPHPPostProcessor(t, "#!/bin/sh\ntouch php_post_processor_ran.txt\n")
 	owlbotPy := filepath.Join(destDir, "owlbot.py")
 	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(0)"), 0o755); err != nil {
@@ -207,6 +211,12 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
+		APIs: []*config.API{{
+			Path: "my/api/v1",
+			PHP: &config.PHPAPI{
+				StagingSubdir: "v1",
+			},
+		}},
 		PHP: &config.PHPPackage{
 			ComponentName: "SecretManager",
 		},
@@ -214,7 +224,7 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	if err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName); err != nil {
 		t.Fatal(err)
 	}
-	expectedFile := filepath.Join(destDir, "php_post_processor_ran.txt")
+	expectedFile := filepath.Join(stagingDir, "php_post_processor_ran.txt")
 	if _, err := os.Stat(expectedFile); err != nil {
 		t.Error(err)
 	}

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -16,9 +16,11 @@ package php
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -199,10 +201,6 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	stagingDir := filepath.Join(repoRoot, owlBotStagingDir, "SecretManager", "v1")
-	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
 	setupMockPHPPostProcessor(t, "#!/bin/sh\ntouch php_post_processor_ran.txt\n")
 	owlbotPy := filepath.Join(destDir, "owlbot.py")
 	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(0)"), 0o755); err != nil {
@@ -211,12 +209,6 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
-		APIs: []*config.API{{
-			Path: "my/api/v1",
-			PHP: &config.PHPAPI{
-				StagingSubdir: "v1",
-			},
-		}},
 		PHP: &config.PHPPackage{
 			ComponentName: "SecretManager",
 		},
@@ -224,7 +216,7 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	if err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName); err != nil {
 		t.Fatal(err)
 	}
-	expectedFile := filepath.Join(stagingDir, "php_post_processor_ran.txt")
+	expectedFile := filepath.Join(destDir, "php_post_processor_ran.txt")
 	if _, err := os.Stat(expectedFile); err != nil {
 		t.Error(err)
 	}
@@ -254,5 +246,56 @@ func TestPostProcess_PHPPostProcessorError(t *testing.T) {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("expected exit error, got: %v", err)
+	}
+}
+
+func TestPostProcess_PHPPostProcessor_WithAPIs(t *testing.T) {
+	ctx := t.Context()
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	destDir := filepath.Join(repoRoot, "SecretManager")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stagingDir := filepath.Join(repoRoot, owlBotStagingDir, "SecretManager", "v1")
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mockScript := fmt.Sprintf("#!/bin/sh\npwd >> %s/php_post_processor_ran.txt\n", destDir)
+	setupMockPHPPostProcessor(t, mockScript)
+	owlbotPy := filepath.Join(destDir, "owlbot.py")
+	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(0)"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lib := &config.Library{
+		Name:   "SecretManager",
+		Output: destDir,
+		APIs: []*config.API{{
+			Path: "my/api/v1",
+			PHP: &config.PHPAPI{
+				StagingSubdir: "v1",
+			},
+		}},
+		PHP: &config.PHPPackage{
+			ComponentName: "SecretManager",
+		},
+	}
+	if err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName); err != nil {
+		t.Fatal(err)
+	}
+	expectedFile := filepath.Join(destDir, "php_post_processor_ran.txt")
+	content, err := os.ReadFile(expectedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(lines))
+	}
+	if lines[0] != stagingDir {
+		t.Errorf("expected post-processor to run first in %q, got %q", stagingDir, lines[0])
+	}
+	if lines[1] != destDir {
+		t.Errorf("expected post-processor to run second in %q, got %q", destDir, lines[1])
 	}
 }


### PR DESCRIPTION
When generating APIs partially, some API staging subdirectories might not be created. Previously, the PHP post-processor would attempt to run in these missing directories and crash. This change adds an `os.Stat` check to verify that the `apiStagingDir` exists before running the post-processor. If it doesn't exist, we handle `fs.ErrNotExist` by safely continuing to the next API, preventing the crash.

Fixes https://github.com/googleapis/librarian/issues/7259