### PR TITLE
fix(internal/librarian/php): run post-processor in API staging directories before owlbot

### DIFF
--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -37,7 +37,7 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 			err = errors.Join(err, cleanupErr)
 		}
 	}()
-
+	
 	// TODO(https://github.com/googleapis/librarian/issues/7153): We need to use component name as library output to maintain backward compatibility. Change this to library.Output when ready.
 	owlbotPy := filepath.Join(componentName, "owlbot.py")
 	if _, err := os.Stat(owlbotPy); err != nil {
@@ -47,16 +47,28 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 		return err
 	}
 
-	if err := command.RunInDir(ctx, componentName, "python3", "owlbot.py"); err != nil {
-		return fmt.Errorf("failed to run owlbot.py: %w", err)
-	}
 	bin, err := binDir()
 	if err != nil {
 		return fmt.Errorf("failed to get bin dir: %w", err)
 	}
 	postProcessor := filepath.Join(bin, "php-post-processor")
-	if err := command.RunInDir(ctx, componentName, postProcessor, "--input", "."); err != nil {
-		return fmt.Errorf("failed to run php-post-processor: %w", err)
+	// Run post-processor in API staging directories before owlbot.py moves them.
+	for _, api := range library.APIs {
+		if api.PHP == nil {
+			continue
+		}
+		apiStagingDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
+		if _, err := os.Stat(apiStagingDir); err == nil {
+			if err := command.RunInDir(ctx, apiStagingDir, postProcessor, "--input", "."); err != nil {
+				return fmt.Errorf("failed to run php-post-processor on %s: %w", api.Path, err)
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to stat staging dir for %s: %w", api.Path, err)
+		}
 	}
+	if err := command.RunInDir(ctx, componentName, "python3", "owlbot.py"); err != nil {
+		return fmt.Errorf("failed to run owlbot.py: %w", err)
+	}
+
 	return nil
 }

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -52,7 +52,17 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 		return fmt.Errorf("failed to get bin dir: %w", err)
 	}
 	postProcessor := filepath.Join(bin, "php-post-processor")
-	// Run post-processor in API staging directories before owlbot.py moves them.
+	if err := runPostProcessors(ctx, library, stagingDir, postProcessor); err != nil {
+		return err
+	}
+	if err := command.RunInDir(ctx, componentName, "python3", "owlbot.py"); err != nil {
+		return fmt.Errorf("failed to run owlbot.py: %w", err)
+	}
+
+	return nil
+}
+
+func runPostProcessors(ctx context.Context, library *config.Library, stagingDir, postProcessor string) error {
 	for _, api := range library.APIs {
 		if api.PHP == nil {
 			continue
@@ -66,9 +76,5 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 			return fmt.Errorf("failed to stat staging dir for %s: %w", api.Path, err)
 		}
 	}
-	if err := command.RunInDir(ctx, componentName, "python3", "owlbot.py"); err != nil {
-		return fmt.Errorf("failed to run owlbot.py: %w", err)
-	}
-
 	return nil
 }

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -64,9 +64,6 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 
 func runPostProcessors(ctx context.Context, library *config.Library, stagingDir, postProcessor string) error {
 	for _, api := range library.APIs {
-		if api.PHP == nil {
-			continue
-		}
 		apiStagingDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
 		if err := command.RunInDir(ctx, apiStagingDir, postProcessor, "--input", "."); err != nil {
 			return fmt.Errorf("failed to run php-post-processor on %s: %w", api.Path, err)

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -37,7 +37,7 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 			err = errors.Join(err, cleanupErr)
 		}
 	}()
-	
+
 	// TODO(https://github.com/googleapis/librarian/issues/7153): We need to use component name as library output to maintain backward compatibility. Change this to library.Output when ready.
 	owlbotPy := filepath.Join(componentName, "owlbot.py")
 	if _, err := os.Stat(owlbotPy); err != nil {

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -68,12 +68,8 @@ func runPostProcessors(ctx context.Context, library *config.Library, stagingDir,
 			continue
 		}
 		apiStagingDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
-		if _, err := os.Stat(apiStagingDir); err == nil {
-			if err := command.RunInDir(ctx, apiStagingDir, postProcessor, "--input", "."); err != nil {
-				return fmt.Errorf("failed to run php-post-processor on %s: %w", api.Path, err)
-			}
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to stat staging dir for %s: %w", api.Path, err)
+		if err := command.RunInDir(ctx, apiStagingDir, postProcessor, "--input", "."); err != nil {
+			return fmt.Errorf("failed to run php-post-processor on %s: %w", api.Path, err)
 		}
 	}
 	return nil

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -16,10 +16,13 @@ package php
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/testhelper"
@@ -199,7 +202,8 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	setupMockPHPPostProcessor(t, "#!/bin/sh\ntouch php_post_processor_ran.txt\n")
+	expectedFile := filepath.Join(repoRoot, "php_post_processor_pwd.txt")
+	setupMockPHPPostProcessor(t, fmt.Sprintf("#!/bin/sh\npwd > %s\n", expectedFile))
 	owlbotPy := filepath.Join(destDir, "owlbot.py")
 	if err := os.WriteFile(owlbotPy, []byte("import sys; sys.exit(0)"), 0o755); err != nil {
 		t.Fatal(err)
@@ -207,16 +211,33 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					StagingSubdir: "SecretManager/v1",
+				},
+			},
+		},
 		PHP: &config.PHPPackage{
 			ComponentName: "SecretManager",
 		},
 	}
+	stagingSubdir := filepath.Join(repoRoot, owlBotStagingDir, lib.PHP.ComponentName, "SecretManager/v1")
+	if err := os.MkdirAll(stagingSubdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName); err != nil {
 		t.Fatal(err)
 	}
-	expectedFile := filepath.Join(destDir, "php_post_processor_ran.txt")
-	if _, err := os.Stat(expectedFile); err != nil {
-		t.Error(err)
+	out, err := os.ReadFile(expectedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := stagingSubdir + "\n"
+	if got := string(out); got != want {
+		t.Errorf("php-post-processor ran in wrong directory (-want +got):\n%s", cmp.Diff(want, got))
 	}
 }
 
@@ -236,9 +257,21 @@ func TestPostProcess_PHPPostProcessorError(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					StagingSubdir: "SecretManager/v1",
+				},
+			},
+		},
 		PHP: &config.PHPPackage{
 			ComponentName: "SecretManager",
 		},
+	}
+	stagingSubdir := filepath.Join(repoRoot, owlBotStagingDir, lib.PHP.ComponentName, "SecretManager/v1")
+	if err := os.MkdirAll(stagingSubdir, 0o755); err != nil {
+		t.Fatal(err)
 	}
 	err := postProcessLibrary(ctx, lib, lib.PHP.ComponentName)
 	var exitErr *exec.ExitError

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -236,8 +236,9 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := stagingSubdir + "\n"
-	if got := string(out); got != want {
-		t.Errorf("php-post-processor ran in wrong directory (-want +got):\n%s", cmp.Diff(want, got))
+	got := string(out)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
The PHP post-processor is now executed inside the API staging directories before owlbot.py is run. This ensures that the post-processor modifies the newly generated API files prior to any file movement or cleanup performed by owlbot.py.

Fixes https://github.com/googleapis/librarian/issues/7269