### PR TITLE
fix(sidekick/rust): discovery LROs and features

### DIFF
--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -30,7 +30,20 @@ import (
 // errQuickstartServiceNotFound is returned when the requested quickstart service override is not found.
 var errQuickstartServiceNotFound = errors.New("quickstart_service_override not found")
 
-const gaxiPackageName = "gaxi"
+const (
+	gaxiPackageName = "gaxi"
+	// An internal-only feature to enable the discovery-based LRO code, which is
+	// usually hand-crafted.
+	//
+	// Large APIs (such as compute) use feature-per-service. That is, the
+	// application can decide what services, if any, are enabled. In these
+	// services we also write a small amount of hand-crafted code to support LROs. This
+	// hand-crafted code must be enabled **ONLY** when any of the services that have LROs are enabled.
+	//
+	// We create a secret feature (with this name) that is enabled when any of the
+	// services with LROs is enabled.
+	lroOperationFeature = "__enable-discovery-LRO"
+)
 
 type modelAnnotations struct {
 	PackageName                string
@@ -66,6 +79,11 @@ type modelAnnotations struct {
 	// The set of default features, only applicable if `PerServiceFeatures` is
 	// true.
 	DefaultFeatures []string
+	// Additional features in this crate.
+	//
+	// At the moment this is used to define `__enableDiscoverLRO` but may grow to
+	// include other features beyond the feature-per-service stuff.
+	ExtraFeatures []string
 	// A list of additional modules loaded by the `lib.rs` file.
 	ExtraModules []string
 	// If true, at lease one service has a method we cannot wrap (yet).
@@ -179,10 +197,14 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		}
 	}
 	hasLROs := false
+	hasDiscoveryLROs := false
 	for _, s := range model.Services {
 		for _, m := range s.Methods {
 			if m.OperationInfo != nil || m.DiscoveryLro != nil || m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob" {
 				hasLROs = true
+			}
+			if m.DiscoveryLro != nil {
+				hasDiscoveryLROs = true
 			}
 			if !codec.generateMethod(m) {
 				continue
@@ -271,6 +293,12 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		includeRpcStatusConversion = true
 	}
 
+	perServiceFeatures := codec.perServiceFeatures && len(servicesSubset) > 0
+	var extraFeatures []string
+	if hasDiscoveryLROs && perServiceFeatures {
+		extraFeatures = []string{lroOperationFeature}
+	}
+
 	ann := &modelAnnotations{
 		PackageName:                codec.packageName(model),
 		PackageNamespace:           codec.rootModuleName(model),
@@ -293,7 +321,8 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		NotForPublication:       codec.doNotPublish,
 		DisabledRustdocWarnings: codec.disabledRustdocWarnings,
 		DisabledClippyWarnings:  codec.disabledClippyWarnings,
-		PerServiceFeatures:      codec.perServiceFeatures && len(servicesSubset) > 0,
+		PerServiceFeatures:      perServiceFeatures,
+		ExtraFeatures:           extraFeatures,
 		ExtraModules:            codec.extraModules,
 		Incomplete: slices.ContainsFunc(model.Services, func(s *api.Service) bool {
 			return slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !codec.generateMethod(m) })

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -200,14 +200,14 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	hasDiscoveryLROs := false
 	for _, s := range model.Services {
 		for _, m := range s.Methods {
+			if !codec.generateMethod(m) {
+				continue
+			}
 			if m.OperationInfo != nil || m.DiscoveryLro != nil || m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob" {
 				hasLROs = true
 			}
 			if m.DiscoveryLro != nil {
 				hasDiscoveryLROs = true
-			}
-			if !codec.generateMethod(m) {
-				continue
 			}
 			if _, err := codec.annotateMethod(m); err != nil {
 				return nil, err

--- a/internal/sidekick/rust/annotate_service.go
+++ b/internal/sidekick/rust/annotate_service.go
@@ -91,6 +91,16 @@ func (a *serviceAnnotations) FeatureName() string {
 	return strcase.ToKebab(a.ModuleName)
 }
 
+// EnabledFeatures returns the other features enabled by the service.
+func (a *serviceAnnotations) EnabledFeatures() []string {
+	for _, m := range a.Methods {
+		if m.DiscoveryLro != nil {
+			return []string{lroOperationFeature}
+		}
+	}
+	return []string{}
+}
+
 func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 	// Check if the service has bidirectional streaming RPCs in its API definition
 	// before methods are filtered by generateMethod. We check this before filtering

--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -26,7 +26,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	libconfig "github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
 	"github.com/googleapis/librarian/internal/sources"
 )
@@ -179,6 +181,73 @@ func TestRustFromDiscovery(t *testing.T) {
 	}
 	importsModelModules(t, path.Join(outDir, "src", "model.rs"))
 	checkApiVersionComments(t, outDir)
+}
+
+func TestRustFromDiscoveryWitLro(t *testing.T) {
+	outDir := t.TempDir()
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: libconfig.SpecDiscovery,
+		ServiceConfig:       path.Join(testdataDir, "googleapis/google/cloud/compute/v1/compute_v1.yaml"),
+		SpecificationSource: path.Join(testdataDir, "discovery/compute.v1.json"),
+		Codec: map[string]string{
+			"package:wkt":          "source=google.protobuf,package=google-cloud-wkt",
+			"per-service-features": "true",
+		},
+		Discovery: &api.Discovery{
+			OperationID: ".google.cloud.compute.v1.Operation",
+			Pollers: []*api.Poller{
+				{
+					Prefix:   "compute/v1/projects/{project}/zones/{zone}",
+					MethodID: ".google.cloud.compute.v1.zoneOperations.get",
+				},
+				{
+					Prefix:   "compute/v1/projects/{project}/regions/{region}",
+					MethodID: ".google.cloud.compute.v1.regionOperations.get",
+				},
+				{
+					Prefix:   "compute/v1/projects/{project}",
+					MethodID: ".google.cloud.compute.v1.globalOperations.get",
+				},
+				{
+					Prefix:   "compute/v1/",
+					MethodID: ".google.cloud.compute.v1.globalOrganizationOperations.get",
+				},
+			},
+		},
+	}
+	model, err := parser.CreateModel(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range expectedInCrate {
+		filename := path.Join(outDir, expected)
+		stat, err := os.Stat(filename)
+		if errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("missing %s: %s", filename, err)
+		}
+		if stat.Mode().Perm()|0o666 != 0o666 {
+			t.Errorf("generated files should not be executable %s: %o", filename, stat.Mode())
+		}
+	}
+	contentBytes, err := os.ReadFile(path.Join(outDir, "Cargo.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(contentBytes)
+	got := extractBlock(t, contents, fmt.Sprintf("\n%s", lroOperationFeature), " = []\n")
+	want := fmt.Sprintf("\n%s = []\n", lroOperationFeature)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s\n====\n%s", diff, contents)
+	}
+	got = extractBlock(t, contents, "\ninstances = ", "]\n")
+	want = fmt.Sprintf("\ninstances = [\"%s\", ]\n", lroOperationFeature)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s\n====\n%s", diff, contents)
+	}
 }
 
 func TestRustFromProtobuf(t *testing.T) {

--- a/internal/sidekick/rust/generate_test.go
+++ b/internal/sidekick/rust/generate_test.go
@@ -183,7 +183,7 @@ func TestRustFromDiscovery(t *testing.T) {
 	checkApiVersionComments(t, outDir)
 }
 
-func TestRustFromDiscoveryWitLro(t *testing.T) {
+func TestRustFromDiscoveryWithLro(t *testing.T) {
 	outDir := t.TempDir()
 
 	cfg := &parser.ModelConfig{

--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -54,8 +54,11 @@ default-rustls-provider = ["gaxi/_default-rustls-provider"]
 {{#Codec.PerServiceFeatures}}
 {{#Codec.Services}}
 # Enables `client::{{Codec.Name}}` and all the types it depends on.
-{{Codec.FeatureName}} = []
+{{Codec.FeatureName}} = [{{#Codec.EnabledFeatures}}"{{{.}}}", {{/Codec.EnabledFeatures}}]
 {{/Codec.Services}}
+{{#Codec.ExtraFeatures}}
+{{{.}}} = []
+{{/Codec.ExtraFeatures}}
 {{/Codec.PerServiceFeatures}}
 
 {{! We want docs for all features, not just the default features. }}


### PR DESCRIPTION
When using per-service-features the hand-crafted code to support LROs should **only** be enabled if a service with LROs is enabled. Otherwise the types involved may not exist.

This PR introduces a new internal-only feature (starting with `__`) that is enabled when a service with LROs is enabled. The hand-crafted code can use that feature to gate itself.

We can change our mind about this approach because removing the internal-only feature is not breaking.

Towards https://github.com/googleapis/google-cloud-rust/issues/6220 

See https://github.com/googleapis/google-cloud-rust/pull/6384 for the generated output.