### PR TITLE
feat(librarian): support SHA256-by-OS for protoc

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -117,7 +117,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `version` | string | Is the version to install. |
-| `sha256` | string | Is the default SHA256 checksum of the package (used for linux-x86_64 if not specified in SHA256ByPlatform). |
+| `sha256` | string | Is the default SHA256 checksum of the package (used for linux-x86_64 if not specified in sha256_by_platform). |
 | `sha256_by_platform` | map[string]string | Defines SHA256 checksums indexed by the release platform name (e.g., "linux-x86_64", "osx-aarch_64", "osx-x86_64", "win64", "win32"). |
 
 ## Default Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -117,7 +117,8 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `version` | string | Is the version to install. |
-| `sha256` | string | Is the SHA256 checksum of the tarball. |
+| `sha256` | string | Is the default SHA256 checksum of the package (used for linux-x86_64 if not specified in SHA256ByPlatform). |
+| `sha256_by_platform` | map[string]string | Defines SHA256 checksums indexed by the release platform name (e.g., "linux-x86_64", "osx-aarch_64", "osx-x86_64", "win64", "win32"). |
 
 ## Default Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,7 +244,7 @@ type Protoc struct {
 	// Version is the version to install.
 	Version string `yaml:"version,omitempty"`
 
-	// SHA256 is the default SHA256 checksum of the package (used for linux-x86_64 if not specified in SHA256ByPlatform).
+	// SHA256 is the default SHA256 checksum of the package (used for linux-x86_64 if not specified in sha256_by_platform).
 	SHA256 string `yaml:"sha256,omitempty"`
 
 	// SHA256ByPlatform defines SHA256 checksums indexed by the release platform name

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,8 +244,12 @@ type Protoc struct {
 	// Version is the version to install.
 	Version string `yaml:"version,omitempty"`
 
-	// SHA256 is the SHA256 checksum of the tarball.
+	// SHA256 is the default SHA256 checksum of the package (used for linux-x86_64 if not specified in SHA256ByPlatform).
 	SHA256 string `yaml:"sha256,omitempty"`
+
+	// SHA256ByPlatform defines SHA256 checksums indexed by the release platform name
+	// (e.g., "linux-x86_64", "osx-aarch_64", "osx-x86_64", "win64", "win32").
+	SHA256ByPlatform map[string]string `yaml:"sha256_by_platform,omitempty"`
 }
 
 // Default contains default settings for all libraries.

--- a/internal/tool/protoc/protoc.go
+++ b/internal/tool/protoc/protoc.go
@@ -57,12 +57,19 @@ func Install(ctx context.Context, protoc *config.Protoc) error {
 	if _, err := os.Stat(binaryPath); err == nil {
 		return nil
 	}
-	url := downloadURL(protoc.Version, runtime.GOOS, runtime.GOARCH)
+	url, err := downloadURL(protoc.Version, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+	sha256, err := sha256ForPlatform(protoc, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
 	dir, err := InstallDir(protoc.Version)
 	if err != nil {
 		return err
 	}
-	return downloadAndExtract(ctx, url, dir, protoc.SHA256)
+	return downloadAndExtract(ctx, url, dir, sha256)
 }
 
 // BinaryPath returns the absolute path to the protoc binary for the given version.
@@ -128,16 +135,49 @@ func downloadAndExtract(ctx context.Context, url, dir, sha256 string) error {
 }
 
 // downloadURL returns the download URL for the protoc binary for the given version, OS, and arch.
-func downloadURL(version, os, arch string) string {
-	suffix := platformSuffix(os, arch)
-	return fmt.Sprintf("%s/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s.zip", githubURLBase, version, version, suffix)
+func downloadURL(version, os, arch string) (string, error) {
+	suffix, err := platformSuffix(os, arch)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s.zip", githubURLBase, version, version, suffix), nil
 }
 
 // platformSuffix returns the platform suffix for the given OS and architecture.
-func platformSuffix(os, arch string) string {
+func platformSuffix(os, arch string) (string, error) {
 	if os == osWindows {
-		return "win64"
+		if arch == "386" {
+			return "win32", nil
+		}
+		if arch == "amd64" || arch == "arm64" {
+			return "win64", nil
+		}
+		return "", fmt.Errorf("unsupported windows architecture for protoc: %s", arch)
 	}
 
-	return osMap[os] + "-" + archMap[arch]
+	osName, ok := osMap[os]
+	if !ok {
+		return "", fmt.Errorf("unsupported OS for protoc: %s", os)
+	}
+	archName, ok := archMap[arch]
+	if !ok {
+		return "", fmt.Errorf("unsupported architecture for protoc: %s", arch)
+	}
+	return osName + "-" + archName, nil
+}
+
+func sha256ForPlatform(pc *config.Protoc, goos, goarch string) (string, error) {
+	platform, err := platformSuffix(goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	if pc.SHA256ByPlatform != nil {
+		if hash, ok := pc.SHA256ByPlatform[platform]; ok && hash != "" {
+			return hash, nil
+		}
+	}
+	if platform == "linux-x86_64" && pc.SHA256 != "" {
+		return pc.SHA256, nil
+	}
+	return "", fmt.Errorf("missing sha256 checksum for protoc on platform %q", platform)
 }

--- a/internal/tool/protoc/protoc_test.go
+++ b/internal/tool/protoc/protoc_test.go
@@ -231,24 +231,229 @@ func TestDownloadURL(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "simple version",
+			name:    "macos arm64",
 			version: "25.1",
 			os:      "darwin",
 			arch:    "arm64",
 			want:    "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-osx-aarch_64.zip",
 		},
 		{
-			name:    "release candidate",
+			name:    "macos amd64",
+			version: "25.1",
+			os:      "darwin",
+			arch:    "amd64",
+			want:    "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-osx-x86_64.zip",
+		},
+		{
+			name:    "linux amd64",
 			version: "26.0-rc1",
 			os:      "linux",
 			arch:    "amd64",
 			want:    "https://github.com/protocolbuffers/protobuf/releases/download/v26.0-rc1/protoc-26.0-rc1-linux-x86_64.zip",
 		},
+		{
+			name:    "linux arm64",
+			version: "29.3",
+			os:      "linux",
+			arch:    "arm64",
+			want:    "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-linux-aarch_64.zip",
+		},
+		{
+			name:    "windows amd64",
+			version: "29.3",
+			os:      "windows",
+			arch:    "amd64",
+			want:    "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-win64.zip",
+		},
+		{
+			name:    "windows 386",
+			version: "29.3",
+			os:      "windows",
+			arch:    "386",
+			want:    "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-win32.zip",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := downloadURL(test.version, test.os, test.arch)
+			got, err := downloadURL(test.version, test.os, test.arch)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDownloadURL_Error(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		version string
+		os      string
+		arch    string
+	}{
+		{
+			name:    "unsupported os",
+			version: "29.3",
+			os:      "freebsd",
+			arch:    "amd64",
+		},
+		{
+			name:    "unsupported arch",
+			version: "29.3",
+			os:      "linux",
+			arch:    "mips",
+		},
+		{
+			name:    "unsupported windows arch",
+			version: "29.3",
+			os:      "windows",
+			arch:    "mips",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := downloadURL(test.version, test.os, test.arch); err == nil {
+				t.Errorf("downloadURL(%q, %q, %q) expected error, got nil", test.version, test.os, test.arch)
+			}
+		})
+	}
+}
+
+func TestPlatformSuffix(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		os   string
+		arch string
+		want string
+	}{
+		{name: "darwin arm64", os: "darwin", arch: "arm64", want: "osx-aarch_64"},
+		{name: "darwin amd64", os: "darwin", arch: "amd64", want: "osx-x86_64"},
+		{name: "linux amd64", os: "linux", arch: "amd64", want: "linux-x86_64"},
+		{name: "linux arm64", os: "linux", arch: "arm64", want: "linux-aarch_64"},
+		{name: "windows amd64", os: "windows", arch: "amd64", want: "win64"},
+		{name: "windows arm64", os: "windows", arch: "arm64", want: "win64"},
+		{name: "windows 386", os: "windows", arch: "386", want: "win32"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := platformSuffix(test.os, test.arch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSha256ForPlatform(t *testing.T) {
+	pcWithMap := &config.Protoc{
+		Version: "29.3",
+		SHA256:  "legacy-fallback-sha",
+		SHA256ByPlatform: map[string]string{
+			"osx-aarch_64": "osx-arm-sha",
+			"osx-x86_64":   "osx-intel-sha",
+			"linux-x86_64": "linux-x86-sha",
+			"win64":        "win64-sha",
+		},
+	}
+
+	pcLegacyOnly := &config.Protoc{
+		Version: "29.3",
+		SHA256:  "legacy-fallback-sha",
+	}
+
+	for _, test := range []struct {
+		name   string
+		pc     *config.Protoc
+		goos   string
+		goarch string
+		want   string
+	}{
+		{
+			name:   "explicit map for osx-aarch_64",
+			pc:     pcWithMap,
+			goos:   "darwin",
+			goarch: "arm64",
+			want:   "osx-arm-sha",
+		},
+		{
+			name:   "explicit map for osx-x86_64",
+			pc:     pcWithMap,
+			goos:   "darwin",
+			goarch: "amd64",
+			want:   "osx-intel-sha",
+		},
+		{
+			name:   "explicit map for linux-x86_64",
+			pc:     pcWithMap,
+			goos:   "linux",
+			goarch: "amd64",
+			want:   "linux-x86-sha",
+		},
+		{
+			name:   "explicit map for win64",
+			pc:     pcWithMap,
+			goos:   "windows",
+			goarch: "amd64",
+			want:   "win64-sha",
+		},
+		{
+			name:   "legacy fallback for linux-x86_64",
+			pc:     pcLegacyOnly,
+			goos:   "linux",
+			goarch: "amd64",
+			want:   "legacy-fallback-sha",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := sha256ForPlatform(test.pc, test.goos, test.goarch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSha256ForPlatform_Error(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		pc     *config.Protoc
+		goos   string
+		goarch string
+	}{
+		{
+			name: "missing macos checksum with legacy linux only",
+			pc: &config.Protoc{
+				Version: "29.3",
+				SHA256:  "linux-only-sha",
+			},
+			goos:   "darwin",
+			goarch: "arm64",
+		},
+		{
+			name: "missing windows checksum with empty config",
+			pc: &config.Protoc{
+				Version: "29.3",
+			},
+			goos:   "windows",
+			goarch: "amd64",
+		},
+		{
+			name: "unsupported os",
+			pc: &config.Protoc{
+				Version: "29.3",
+			},
+			goos:   "plan9",
+			goarch: "amd64",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := sha256ForPlatform(test.pc, test.goos, test.goarch); err == nil {
+				t.Errorf("sha256ForPlatform(%+v, %q, %q) expected error, got nil", test.pc, test.goos, test.goarch)
 			}
 		})
 	}
@@ -283,6 +488,32 @@ func TestDownloadAndExtract(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "protoc.zip")); err == nil {
 		t.Errorf("zip file was not cleaned up")
+	}
+}
+
+func TestInstall_AlreadyInstalled(t *testing.T) {
+	binaryName := protocBinaryName()
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
+	version := "29.3"
+	protocDir := filepath.Join(binDir, "protoc", "v"+version, "bin")
+	if err := os.MkdirAll(protocDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testhelper.WriteExecutable(t, filepath.Join(protocDir, binaryName), "#!/bin/sh\nexit 0\n")
+
+	pc := &config.Protoc{Version: version}
+	if err := Install(t.Context(), pc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInstall_MissingSHA256Error(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("LIBRARIAN_BIN", binDir)
+	pc := &config.Protoc{Version: "29.3-test-missing-sha"}
+	if err := Install(t.Context(), pc); err == nil {
+		t.Fatal("Install expected error for missing sha256, got nil")
 	}
 }
 


### PR DESCRIPTION
When using `librarian install` to download and install `protoc` the SHA256 depends on the platform. This PR introduces a new configuration dictionary to define the SHA256s, and changes the code to use this configuration.

Fixes #7281 