### PR TITLE
feat(sidekick): install protoc via librarian

### DIFF
--- a/internal/librarian/dart/codec.go
+++ b/internal/librarian/dart/codec.go
@@ -28,7 +28,7 @@ import (
 
 var errInvalidSpecificationFormat = errors.New("dart generation requires protobuf specification format")
 
-func toModelConfig(library *config.Library, ch *config.API, srcs *sources.Sources) (*parser.ModelConfig, error) {
+func toModelConfig(library *config.Library, ch *config.API, srcs *sources.Sources, pc *config.Protoc) (*parser.ModelConfig, error) {
 	if library.SpecificationFormat != "" && library.SpecificationFormat != config.SpecProtobuf {
 		return nil, fmt.Errorf("%w, got %q", errInvalidSpecificationFormat, library.SpecificationFormat)
 	}
@@ -58,10 +58,12 @@ func toModelConfig(library *config.Library, ch *config.API, srcs *sources.Source
 	}
 
 	modelConfig := &parser.ModelConfig{
+		Language:            config.LanguageDart,
 		SpecificationFormat: config.SpecProtobuf,
 		ServiceConfig:       svcConfig.ServiceConfig,
 		SpecificationSource: ch.Path,
 		Source:              src,
+		Protoc:              pc,
 		Codec:               buildCodec(library),
 		Override: api.ModelOverride{
 			Name:        name,

--- a/internal/librarian/dart/codec_test.go
+++ b/internal/librarian/dart/codec_test.go
@@ -310,11 +310,35 @@ func TestToModelConfig(t *testing.T) {
 		name          string
 		library       *config.Library
 		channel       *config.API
+		pc            *config.Protoc
 		googleapisDir string
 		showcaseDir   string
 		want          *parser.ModelConfig
 		wantErr       error
 	}{
+		{
+			name:    "with protoc",
+			library: &config.Library{},
+			channel: &config.API{
+				Path: "google/cloud/functions/v2",
+			},
+			pc:            &config.Protoc{Version: "29.3"},
+			googleapisDir: googleapisDir,
+			want: &parser.ModelConfig{
+				Language:            config.LanguageDart,
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "google/cloud/functions/v2",
+				Protoc:              &config.Protoc{Version: "29.3"},
+				Source: &sources.SourceConfig{
+					Sources: &sources.Sources{
+						Googleapis: googleapisDir,
+					},
+					ActiveRoots: []string{"googleapis"},
+				},
+				Codec:    map[string]string{},
+				Override: api.ModelOverride{},
+			},
+		},
 		{
 			name:    "empty library",
 			library: &config.Library{},
@@ -536,7 +560,10 @@ func TestToModelConfig(t *testing.T) {
 			if test.showcaseDir != "" {
 				sources.Showcase = test.showcaseDir
 			}
-			got, err := toModelConfig(test.library, test.channel, sources)
+			if test.want != nil && test.want.Language == "" {
+				test.want.Language = config.LanguageDart
+			}
+			got, err := toModelConfig(test.library, test.channel, sources, test.pc)
 			if test.wantErr != nil {
 				if !errors.Is(err, test.wantErr) {
 					t.Errorf("toModelConfig() error: %v, wantErr: %v", err, test.wantErr)

--- a/internal/librarian/dart/generate.go
+++ b/internal/librarian/dart/generate.go
@@ -29,8 +29,12 @@ import (
 )
 
 // Generate generates a Dart client library.
-func Generate(ctx context.Context, library *config.Library, sources *sources.Sources) error {
-	modelConfig, err := toModelConfig(library, library.APIs[0], sources)
+func Generate(ctx context.Context, cfg *config.Config, library *config.Library, sources *sources.Sources) error {
+	var pc *config.Protoc
+	if cfg != nil && cfg.Tools != nil {
+		pc = cfg.Tools.Protoc
+	}
+	modelConfig, err := toModelConfig(library, library.APIs[0], sources, pc)
 	if err != nil {
 		return err
 	}

--- a/internal/librarian/dart/generate_test.go
+++ b/internal/librarian/dart/generate_test.go
@@ -71,7 +71,7 @@ func TestGenerate(t *testing.T) {
 		Googleapis: googleapisDir,
 	}
 	for _, library := range libraries {
-		if err := Generate(t.Context(), library, sources); err != nil {
+		if err := Generate(t.Context(), &config.Config{Language: "dart"}, library, sources); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -105,10 +105,37 @@ func TestGenerate_Error(t *testing.T) {
 	sources := &sources.Sources{
 		Googleapis: googleapisDir,
 	}
-	gotErr := Generate(t.Context(), libraries[0], sources)
+	gotErr := Generate(t.Context(), &config.Config{Language: "dart"}, libraries[0], sources)
 	wantErr := errInvalidSpecificationFormat
 	if !errors.Is(gotErr, wantErr) {
 		t.Errorf("Generate error = %v, wantErr %v", gotErr, wantErr)
+	}
+}
+
+func TestGenerate_WithProtocConfigError(t *testing.T) {
+	testhelper.RequireCommand(t, "dart")
+
+	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outDir := t.TempDir()
+	library := &config.Library{
+		Name:   "google_cloud_rpc",
+		APIs:   []*config.API{{Path: "google/rpc"}},
+		Output: filepath.Join(outDir, "google_cloud_rpc"),
+	}
+	sources := &sources.Sources{
+		Googleapis: googleapisDir,
+	}
+	cfg := &config.Config{
+		Language: "dart",
+		Tools: &config.Tools{
+			Protoc: &config.Protoc{Version: "0.0.0-nonexistent"},
+		},
+	}
+	if err := Generate(t.Context(), cfg, library, sources); err == nil {
+		t.Fatal("Generate with nonexistent protoc expected error, got nil")
 	}
 }
 
@@ -152,7 +179,7 @@ func TestGenerateLibrary(t *testing.T) {
 	sources := &sources.Sources{
 		Googleapis: googleapisDir,
 	}
-	if err := Generate(t.Context(), library, sources); err != nil {
+	if err := Generate(t.Context(), &config.Config{Language: "dart"}, library, sources); err != nil {
 		t.Fatal(err)
 	}
 	if err := Format(t.Context(), library); err != nil {

--- a/internal/librarian/dart/install.go
+++ b/internal/librarian/dart/install.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dart
+
+import (
+	"context"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// Install installs the tools required for Dart library generation.
+func Install(ctx context.Context, tools *config.Tools) error {
+	// This is currently used to bootstrap the command and just install `protoc`.
+	return nil
+}

--- a/internal/librarian/dart/install.go
+++ b/internal/librarian/dart/install.go
@@ -22,6 +22,5 @@ import (
 
 // Install installs the tools required for Dart library generation.
 func Install(ctx context.Context, tools *config.Tools) error {
-	// This is currently used to bootstrap the command and just install `protoc`.
 	return nil
 }

--- a/internal/librarian/dart/install_test.go
+++ b/internal/librarian/dart/install_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dart
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestInstall(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		tools *config.Tools
+	}{
+		{
+			name:  "nil tools",
+			tools: nil,
+		},
+		{
+			name:  "empty tools",
+			tools: &config.Tools{},
+		},
+		{
+			name: "with protoc",
+			tools: &config.Tools{
+				Protoc: &config.Protoc{Version: "29.3"},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Install(t.Context(), test.tools); err != nil {
+				t.Fatalf("Install() unexpected error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/librarian/generate.go
+++ b/internal/librarian/generate.go
@@ -195,7 +195,7 @@ func generateLibraries(ctx context.Context, cfg *config.Config, libraries []*con
 		g.SetLimit(runtime.NumCPU())
 		for _, library := range libraries {
 			g.Go(func() error {
-				if err := dart.Generate(gctx, library, src); err != nil {
+				if err := dart.Generate(gctx, cfg, library, src); err != nil {
 					return fmt.Errorf("generate library %q (%s): %w", library.Name, cfg.Language, err)
 				}
 				if err := dart.Format(gctx, library); err != nil {

--- a/internal/librarian/install_test.go
+++ b/internal/librarian/install_test.go
@@ -27,23 +27,31 @@ import (
 )
 
 func TestInstallCommand_WithLanguage(t *testing.T) {
-	t.Chdir(t.TempDir())
-	if err := Run(t.Context(), "librarian", "install", "fake"); err != nil {
-		t.Fatal(err)
+	for _, lang := range []string{"dart", "fake", "rust", "swift"} {
+		t.Run(lang, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			if err := Run(t.Context(), "librarian", "install", lang); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
 func TestInstallCommand_FromConfig(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Chdir(tmpDir)
-	cfg := &config.Config{
-		Language: config.LanguageFake,
-	}
-	if err := yaml.Write(filepath.Join(tmpDir, config.LibrarianYAML), cfg); err != nil {
-		t.Fatal(err)
-	}
-	if err := Run(t.Context(), "librarian", "install"); err != nil {
-		t.Fatal(err)
+	for _, lang := range []string{config.LanguageDart, config.LanguageFake, config.LanguageRust, config.LanguageSwift} {
+		t.Run(lang, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Chdir(tmpDir)
+			cfg := &config.Config{
+				Language: lang,
+			}
+			if err := yaml.Write(filepath.Join(tmpDir, config.LibrarianYAML), cfg); err != nil {
+				t.Fatal(err)
+			}
+			if err := Run(t.Context(), "librarian", "install"); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/internal/librarian/librarian.go
+++ b/internal/librarian/librarian.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/librarian/dart"
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
@@ -32,6 +33,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/ruby"
 	"github.com/googleapis/librarian/internal/librarian/rust"
+	"github.com/googleapis/librarian/internal/librarian/swift"
 	"github.com/googleapis/librarian/internal/tool/protoc"
 	"github.com/googleapis/librarian/internal/yaml"
 	"github.com/urfave/cli/v3"
@@ -112,6 +114,8 @@ Examples:
 				}
 			}
 			switch lang {
+			case config.LanguageDart:
+				return dart.Install(ctx, tools)
 			case config.LanguageFake:
 				return nil
 			case config.LanguageGo:
@@ -128,6 +132,8 @@ Examples:
 				return ruby.Install(ctx, tools)
 			case config.LanguageRust:
 				return rust.Install(ctx, tools)
+			case config.LanguageSwift:
+				return swift.Install(ctx, tools)
 			default:
 				return fmt.Errorf("language %q does not support install", lang)
 			}

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -25,7 +25,7 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
-func libraryToModelConfig(library *config.Library, ch *config.API, srcs *sources.Sources) (*parser.ModelConfig, error) {
+func libraryToModelConfig(library *config.Library, ch *config.API, srcs *sources.Sources, pc *config.Protoc) (*parser.ModelConfig, error) {
 	specFormat := config.SpecProtobuf
 	if library.SpecificationFormat != "" {
 		specFormat = library.SpecificationFormat
@@ -56,6 +56,7 @@ func libraryToModelConfig(library *config.Library, ch *config.API, srcs *sources
 		SpecificationFormat: specFormat,
 		SpecificationSource: specSource,
 		Source:              src,
+		Protoc:              pc,
 		ServiceConfig:       svcConfig.ServiceConfig,
 		Codec:               buildCodec(library, svcConfig.ReleaseLevel(config.LanguageRust, library.Version)),
 		Override: api.ModelOverride{
@@ -228,7 +229,7 @@ func formatPackageDependency(dep *config.RustPackageDependency) string {
 	return strings.Join(parts, ",")
 }
 
-func moduleToModelConfig(library *config.Library, module *config.RustModule, srcs *sources.Sources) (*parser.ModelConfig, error) {
+func moduleToModelConfig(library *config.Library, module *config.RustModule, srcs *sources.Sources, pc *config.Protoc) (*parser.ModelConfig, error) {
 	src := sources.NewSourceConfig(srcs, library.Roots)
 	var title string
 	if module.APIPath != "" && len(src.ActiveRoots) == 1 && src.ActiveRoots[0] == "googleapis" {
@@ -263,6 +264,7 @@ func moduleToModelConfig(library *config.Library, module *config.RustModule, src
 		ServiceConfig:       module.ServiceConfig,
 		SpecificationSource: module.APIPath,
 		Source:              src,
+		Protoc:              pc,
 		Codec:               buildModuleCodec(library, module),
 		Override: api.ModelOverride{
 			Title:       title,

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -49,9 +49,34 @@ func TestLibraryToModelConfig(t *testing.T) {
 		name             string
 		library          *config.Library
 		api              *config.API
+		pc               *config.Protoc
 		wantReleaseLevel string
 		want             *parser.ModelConfig
 	}{
+		{
+			name: "minimal config with protoc",
+			library: &config.Library{
+				Name: "google-cloud-secretmanager",
+			},
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+			},
+			pc: &config.Protoc{Version: "29.3"},
+			want: &parser.ModelConfig{
+				Language:            config.LanguageRust,
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "google/cloud/secretmanager/v1",
+				ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				Protoc:              &config.Protoc{Version: "29.3"},
+				Source: &sources.SourceConfig{
+					ActiveRoots: []string{"googleapis"},
+				},
+				Override: api.ModelOverride{
+					Title:       "Secret Manager API",
+					Description: "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
+				},
+			},
+		},
 		{
 			name: "minimal config",
 			library: &config.Library{
@@ -584,7 +609,7 @@ func TestLibraryToModelConfig(t *testing.T) {
 			if test.want.Source.Sources == nil {
 				test.want.Source.Sources = srcs
 			}
-			got, err := libraryToModelConfig(test.library, test.api, srcs)
+			got, err := libraryToModelConfig(test.library, test.api, srcs, test.pc)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -606,8 +631,29 @@ func TestModuleToModelConfig(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		library *config.Library
+		pc      *config.Protoc
 		want    *parser.ModelConfig
 	}{
+		{
+			name: "with protoc config",
+			library: &config.Library{
+				Rust: &config.RustCrate{
+					Modules: []*config.RustModule{
+						{
+							APIPath: "google/cloud/secretmanager/v1",
+							Output:  "src/generated",
+						},
+					},
+				},
+			},
+			pc: &config.Protoc{Version: "29.3"},
+			want: &parser.ModelConfig{
+				Protoc: &config.Protoc{Version: "29.3"},
+				Source: &sources.SourceConfig{
+					ActiveRoots: []string{"googleapis"},
+				},
+			},
+		},
 		{
 			name: "with ResourceNameHeuristic false",
 			library: &config.Library{
@@ -887,12 +933,17 @@ func TestModuleToModelConfig(t *testing.T) {
 				if test.want.Source.Sources == nil {
 					test.want.Source.Sources = srcs
 				}
-				got, err := moduleToModelConfig(test.library, module, srcs)
+				got, err := moduleToModelConfig(test.library, module, srcs, test.pc)
 				if err != nil {
 					t.Fatal(err)
 				}
 				if diff := cmp.Diff(test.want.Source, got.Source); diff != "" {
 					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+				if test.want.Protoc != nil {
+					if diff := cmp.Diff(test.want.Protoc, got.Protoc); diff != "" {
+						t.Errorf("mismatch (-want +got):\n%s", diff)
+					}
 				}
 				commentOverrides = append(commentOverrides, got.CommentOverrides...)
 				if diff := cmp.Diff(test.want.PaginationOverrides, got.PaginationOverrides); diff != "" {

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -55,14 +55,18 @@ func IsMixedLibrary(lib *config.Library) bool {
 
 // Generate generates a Rust client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, sources *sources.Sources) error {
+	var pc *config.Protoc
+	if cfg != nil && cfg.Tools != nil {
+		pc = cfg.Tools.Protoc
+	}
 	if IsMixedLibrary(library) {
-		return generateVeneer(ctx, library, sources)
+		return generateVeneer(ctx, pc, library, sources)
 	}
 	if len(library.APIs) != 1 {
 		return fmt.Errorf("the Rust generator only supports a single api per library")
 	}
 
-	modelConfig, err := libraryToModelConfig(library, library.APIs[0], sources)
+	modelConfig, err := libraryToModelConfig(library, library.APIs[0], sources, pc)
 	if err != nil {
 		return err
 	}
@@ -122,18 +126,18 @@ func Format(ctx context.Context, library *config.Library) error {
 	return nil
 }
 
-func generateVeneer(ctx context.Context, library *config.Library, sources *sources.Sources) error {
+func generateVeneer(ctx context.Context, pc *config.Protoc, library *config.Library, sources *sources.Sources) error {
 	if library.Rust == nil || len(library.Rust.Modules) == 0 {
 		return nil
 	}
 	for _, module := range library.Rust.Modules {
 		if module.Template == "storage" {
-			return generateRustStorage(ctx, library, module.Output, sources)
+			return generateRustStorage(ctx, pc, library, module.Output, sources)
 		}
 		if module.Template == "bigquery" {
-			return generateRustBigQuery(ctx, library, module.Output, sources)
+			return generateRustBigQuery(ctx, pc, library, module.Output, sources)
 		}
-		modelConfig, err := moduleToModelConfig(library, module, sources)
+		modelConfig, err := moduleToModelConfig(library, module, sources, pc)
 		if err != nil {
 			return fmt.Errorf("moduleToModelConfig %q: %w", module.Output, err)
 		}
@@ -211,13 +215,13 @@ func DefaultOutput(api, defaultOutput string) string {
 //
 // The StorageControl client depends on multiple specification sources.
 // We load them both here, and pass them along to `rust.GenerateStorage` which will merge them appropriately.
-func generateRustStorage(ctx context.Context, library *config.Library, moduleOutput string, sources *sources.Sources) error {
+func generateRustStorage(ctx context.Context, pc *config.Protoc, library *config.Library, moduleOutput string, sources *sources.Sources) error {
 	output := "src/storage/src/generated/gapic"
 	storageModule := findModuleByOutput(library, output)
 	if storageModule == nil {
 		return fmt.Errorf("module %q not found in library %q", output, library.Name)
 	}
-	storageConfig, err := moduleToModelConfig(library, storageModule, sources)
+	storageConfig, err := moduleToModelConfig(library, storageModule, sources, pc)
 	if err != nil {
 		return fmt.Errorf("failed to create storage model config: %w", err)
 	}
@@ -231,7 +235,7 @@ func generateRustStorage(ctx context.Context, library *config.Library, moduleOut
 	if controlModule == nil {
 		return fmt.Errorf("module %q not found in library %q", output, library.Name)
 	}
-	controlConfig, err := moduleToModelConfig(library, controlModule, sources)
+	controlConfig, err := moduleToModelConfig(library, controlModule, sources, pc)
 	if err != nil {
 		return fmt.Errorf("failed to create control model config: %w", err)
 	}
@@ -244,7 +248,7 @@ func generateRustStorage(ctx context.Context, library *config.Library, moduleOut
 }
 
 // generateRustBigQuery generates rust BigQuery query builder.
-func generateRustBigQuery(ctx context.Context, library *config.Library, moduleOutput string, sources *sources.Sources) error {
+func generateRustBigQuery(ctx context.Context, pc *config.Protoc, library *config.Library, moduleOutput string, sources *sources.Sources) error {
 	var bqModule *config.RustModule
 	for _, module := range library.Rust.Modules {
 		if module.Template == "bigquery" {
@@ -256,7 +260,7 @@ func generateRustBigQuery(ctx context.Context, library *config.Library, moduleOu
 		return fmt.Errorf("module with template 'bigquery' not found in library %q", library.Name)
 	}
 
-	modelConfig, err := moduleToModelConfig(library, bqModule, sources)
+	modelConfig, err := moduleToModelConfig(library, bqModule, sources, pc)
 	if err != nil {
 		return fmt.Errorf("failed to create bigquery model config: %w", err)
 	}

--- a/internal/librarian/rust/resolve.go
+++ b/internal/librarian/rust/resolve.go
@@ -31,7 +31,11 @@ func ResolveDependencies(ctx context.Context, cfg *config.Config, lib *config.Li
 	if len(lib.APIs) == 0 {
 		return cfg, nil
 	}
-	externalPackages, err := findExternalPackages(lib, sources)
+	var pc *config.Protoc
+	if cfg != nil && cfg.Tools != nil {
+		pc = cfg.Tools.Protoc
+	}
+	externalPackages, err := findExternalPackages(lib, sources, pc)
 	if err != nil {
 		return nil, err
 	}
@@ -41,10 +45,10 @@ func ResolveDependencies(ctx context.Context, cfg *config.Config, lib *config.Li
 // findExternalPackages identifies Protobuf packages that are used by the library
 // but not defined within it. It parses the library's APIs into a model,
 // finds all transitive dependencies, and returns the set of external Protobuf packages.
-func findExternalPackages(lib *config.Library, sources *sources.Sources) (map[string]bool, error) {
+func findExternalPackages(lib *config.Library, sources *sources.Sources, pc *config.Protoc) (map[string]bool, error) {
 	// Only resolve dependencies for the first API in the library.
 	// This is consistent with how the Rust generator works.
-	modelConfig, err := libraryToModelConfig(lib, lib.APIs[0], sources)
+	modelConfig, err := libraryToModelConfig(lib, lib.APIs[0], sources, pc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create model config: %w", err)
 	}

--- a/internal/librarian/swift/compile_protobufs.go
+++ b/internal/librarian/swift/compile_protobufs.go
@@ -21,12 +21,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sources"
+	"github.com/googleapis/librarian/internal/tool/protoc"
 )
 
-func compileProtobufs(ctx context.Context, library *config.Library, module *config.SwiftModule, src *sources.Sources) error {
+func compileProtobufs(ctx context.Context, pc *config.Protoc, library *config.Library, module *config.SwiftModule, src *sources.Sources) error {
 	if err := os.MkdirAll(module.Output, 0o755); err != nil {
 		return err
 	}
@@ -76,5 +76,5 @@ func compileProtobufs(ctx context.Context, library *config.Library, module *conf
 	args = append(args, protoImports...)
 	args = append(args, protoFiles...)
 
-	return command.Run(ctx, "protoc", args...)
+	return protoc.RunOrSystem(ctx, nil, pc, args...)
 }

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -32,12 +32,16 @@ import (
 // Generate generates a Swift client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
 	if IsMixedLibrary(library) {
-		return generateModule(ctx, library, src)
+		return generateModule(ctx, cfg, library, src)
 	}
 	if len(library.APIs) != 1 {
 		return fmt.Errorf("the Swift generator only supports a single api per library")
 	}
-	modelConfig, err := libraryToModelConfig(library, library.APIs[0], src)
+	var pc *config.Protoc
+	if cfg != nil && cfg.Tools != nil {
+		pc = cfg.Tools.Protoc
+	}
+	modelConfig, err := libraryToModelConfig(library, library.APIs[0], src, pc)
 	if err != nil {
 		return err
 	}
@@ -96,7 +100,7 @@ func DefaultLibraryName(api string) string {
 	return strings.ReplaceAll(api, "/", "-")
 }
 
-func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sources.Sources) (*parser.ModelConfig, error) {
+func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sources.Sources, pc *config.Protoc) (*parser.ModelConfig, error) {
 	svcConfig, err := serviceconfig.Find(src.Googleapis, apiCfg.Path, config.LanguageSwift)
 	if err != nil {
 		return nil, err
@@ -122,6 +126,7 @@ func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sour
 		ServiceConfig:       svcConfig.ServiceConfig,
 		SpecificationSource: apiCfg.Path,
 		Source:              sourceConfig,
+		Protoc:              pc,
 		Override: api.ModelOverride{
 			SkippedIDs: skippedIDs,
 		},

--- a/internal/librarian/swift/generate_module.go
+++ b/internal/librarian/swift/generate_module.go
@@ -25,7 +25,11 @@ import (
 	"github.com/googleapis/librarian/internal/sources"
 )
 
-func generateModule(ctx context.Context, library *config.Library, src *sources.Sources) error {
+func generateModule(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
+	var pc *config.Protoc
+	if cfg != nil && cfg.Tools != nil {
+		pc = cfg.Tools.Protoc
+	}
 	for _, module := range library.Swift.Modules {
 		switch module.ModuleType {
 		case "package-version":
@@ -33,11 +37,11 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 				return err
 			}
 		case "swift-protobuf":
-			if err := compileProtobufs(ctx, library, module, src); err != nil {
+			if err := compileProtobufs(ctx, pc, library, module, src); err != nil {
 				return err
 			}
 		case "convert-swift":
-			modelConfig := moduleToModelConfig(library, module, src)
+			modelConfig := moduleToModelConfig(library, module, src, pc)
 			model, err := parser.CreateModel(modelConfig)
 			if err != nil {
 				return err
@@ -46,7 +50,7 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 				return err
 			}
 		case "", "default", "grpc-client":
-			modelConfig := moduleToModelConfig(library, module, src)
+			modelConfig := moduleToModelConfig(library, module, src, pc)
 			model, err := parser.CreateModel(modelConfig)
 			if err != nil {
 				return err
@@ -61,7 +65,7 @@ func generateModule(ctx context.Context, library *config.Library, src *sources.S
 	return nil
 }
 
-func moduleToModelConfig(library *config.Library, module *config.SwiftModule, src *sources.Sources) *parser.ModelConfig {
+func moduleToModelConfig(library *config.Library, module *config.SwiftModule, src *sources.Sources, pc *config.Protoc) *parser.ModelConfig {
 	sourceConfig := sources.NewSourceConfig(src, library.Roots)
 	// Prefer the module-specific include list if configured, allowing per-module filtering
 	// (e.g., selecting only specific dependency `.proto` files for conversion generation).
@@ -89,6 +93,7 @@ func moduleToModelConfig(library *config.Library, module *config.SwiftModule, sr
 		SpecificationSource: module.APIPath,
 		ServiceConfig:       module.ServiceConfig,
 		Source:              sourceConfig,
+		Protoc:              pc,
 		Override: api.ModelOverride{
 			SkippedIDs: skippedIDs,
 		},

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -114,8 +114,26 @@ func TestModuleToModelConfig(t *testing.T) {
 		name   string
 		lib    *config.Library
 		module *config.SwiftModule
+		pc     *config.Protoc
 		want   *parser.ModelConfig
 	}{
+		{
+			name: "with protoc config",
+			lib: &config.Library{
+				Swift: &config.SwiftPackage{},
+			},
+			module: &config.SwiftModule{APIPath: "foo"},
+			pc:     &config.Protoc{Version: "29.3"},
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "foo",
+				Protoc:              &config.Protoc{Version: "29.3"},
+				Source: &sources.SourceConfig{
+					Sources:     &sources.Sources{},
+					ActiveRoots: []string{"googleapis"},
+				},
+			},
+		},
 		{
 			name: "no include list",
 			lib: &config.Library{
@@ -242,7 +260,7 @@ func TestModuleToModelConfig(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := moduleToModelConfig(test.lib, test.module, src)
+			got := moduleToModelConfig(test.lib, test.module, src, test.pc)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -322,7 +340,7 @@ func TestModuleToModelConfig_SkippedIds(t *testing.T) {
 			APIPath:    "google/type",
 			SkippedIds: []string{".google.type.Money"},
 		}
-		modelCfg := moduleToModelConfig(library, module, src)
+		modelCfg := moduleToModelConfig(library, module, src, nil)
 		expected := []string{".google.type.Money"}
 		if diff := cmp.Diff(expected, modelCfg.Override.SkippedIDs); diff != "" {
 			t.Errorf("moduleToModelConfig() mismatch (-want +got):\n%s", diff)
@@ -338,7 +356,7 @@ func TestModuleToModelConfig_SkippedIds(t *testing.T) {
 		module := &config.SwiftModule{
 			APIPath: "google/type",
 		}
-		modelCfg := moduleToModelConfig(library, module, src)
+		modelCfg := moduleToModelConfig(library, module, src, nil)
 		expected := []string{".google.type.Color"}
 		if diff := cmp.Diff(expected, modelCfg.Override.SkippedIDs); diff != "" {
 			t.Errorf("moduleToModelConfig() mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -211,8 +211,30 @@ func TestLibraryToModelConfig(t *testing.T) {
 		name    string
 		library *config.Library
 		api     *config.API
+		pc      *config.Protoc
 		want    *parser.ModelConfig
 	}{
+		{
+			name: "minimal config with protoc",
+			library: &config.Library{
+				Name:    "google-cloud-secretmanager",
+				Version: "1.2.3",
+			},
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+			},
+			pc: &config.Protoc{Version: "29.3"},
+			want: &parser.ModelConfig{
+				Language:            config.LanguageSwift,
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "google/cloud/secretmanager/v1",
+				ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				Protoc:              &config.Protoc{Version: "29.3"},
+				Source: &sources.SourceConfig{
+					ActiveRoots: []string{"googleapis"},
+				},
+			},
+		},
 		{
 			name: "minimal config",
 			library: &config.Library{
@@ -345,7 +367,7 @@ func TestLibraryToModelConfig(t *testing.T) {
 			// Avoid typing this in every input
 			test.want.Source.Sources = srcs
 
-			got, err := libraryToModelConfig(test.library, test.api, srcs)
+			got, err := libraryToModelConfig(test.library, test.api, srcs, test.pc)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/swift/install.go
+++ b/internal/librarian/swift/install.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"context"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// Install installs the tools required for Swift library generation.
+func Install(ctx context.Context, tools *config.Tools) error {
+	// TODO(https://github.com/googleapis/librarian/issues/6745): Install Swift plugins (e.g. protoc-gen-swift, protoc-gen-grpc-swift).
+	// This is currently used to bootstrap the command and just install `protoc`.
+	return nil
+}

--- a/internal/librarian/swift/install.go
+++ b/internal/librarian/swift/install.go
@@ -23,6 +23,5 @@ import (
 // Install installs the tools required for Swift library generation.
 func Install(ctx context.Context, tools *config.Tools) error {
 	// TODO(https://github.com/googleapis/librarian/issues/6745): Install Swift plugins (e.g. protoc-gen-swift, protoc-gen-grpc-swift).
-	// This is currently used to bootstrap the command and just install `protoc`.
 	return nil
 }

--- a/internal/librarian/swift/install_test.go
+++ b/internal/librarian/swift/install_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestInstall(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		tools *config.Tools
+	}{
+		{
+			name:  "nil tools",
+			tools: nil,
+		},
+		{
+			name:  "empty tools",
+			tools: &config.Tools{},
+		},
+		{
+			name: "with protoc",
+			tools: &config.Tools{
+				Protoc: &config.Protoc{Version: "29.3"},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Install(t.Context(), test.tools); err != nil {
+				t.Fatalf("Install() unexpected error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/sidekick/parser/parser.go
+++ b/internal/sidekick/parser/parser.go
@@ -37,6 +37,12 @@ type ModelConfig struct {
 	SpecificationSource string
 	Source              *sources.SourceConfig
 
+	// Protoc configuration
+	//
+	// This is initialized in the tools configuration for `librarian.yaml`, we want to avoid passing the full
+	// librarian configuration to the parsers.
+	Protoc *config.Protoc
+
 	// File paths to descriptor files
 	DescriptorFilesToGenerate string
 	DescriptorFiles           string

--- a/internal/sidekick/parser/protobuf.go
+++ b/internal/sidekick/parser/protobuf.go
@@ -24,12 +24,14 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser/httprule"
 	"github.com/googleapis/librarian/internal/sidekick/parser/svcconfig"
 	"github.com/googleapis/librarian/internal/sidekick/protobuf"
 	"github.com/googleapis/librarian/internal/sources"
+	"github.com/googleapis/librarian/internal/tool/protoc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
@@ -51,7 +53,7 @@ func ParseProtobuf(cfg *ModelConfig) (*api.API, error) {
 		}
 	} else {
 		source := cfg.SpecificationSource
-		request, err = codeGeneratorRequestFromSource(source, cfg.Source)
+		request, err = codeGeneratorRequestFromSource(source, cfg.Source, cfg.Protoc)
 		if err != nil {
 			return nil, err
 		}
@@ -85,13 +87,13 @@ func codeGeneratorRequestFromDescriptors(descriptorFiles, generateFiles string) 
 }
 
 // Create a temporary files to store `protoc`'s output.
-func codeGeneratorRequestFromSource(source string, sourceCfg *sources.SourceConfig) (*pluginpb.CodeGeneratorRequest, error) {
+func codeGeneratorRequestFromSource(source string, sourceCfg *sources.SourceConfig, pc *config.Protoc) (*pluginpb.CodeGeneratorRequest, error) {
 	files, err := protobuf.DetermineInputFiles(source, sourceCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	contents, err := runProtoc(files, sourceCfg)
+	contents, err := runProtoc(files, sourceCfg, pc)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +158,7 @@ func filterTargetDescriptors(allFiles []*descriptorpb.FileDescriptorProto, gener
 	return target, nil
 }
 
-func runProtoc(files []string, sourceCfg *sources.SourceConfig) ([]byte, error) {
+func runProtoc(files []string, sourceCfg *sources.SourceConfig, pc *config.Protoc) ([]byte, error) {
 	tempFile, err := os.CreateTemp("", "protoc-out-")
 	if err != nil {
 		return nil, err
@@ -183,8 +185,13 @@ func runProtoc(files []string, sourceCfg *sources.SourceConfig) ([]byte, error) 
 
 	args = append(args, files...)
 
+	protocPath, err := protoc.BinaryPathOrSystem(pc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find protoc: %w", err)
+	}
+
 	var stderr, stdout bytes.Buffer
-	cmd := exec.Command("protoc", args...)
+	cmd := exec.Command(protocPath, args...)
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {

--- a/internal/sidekick/parser/protobuf_test.go
+++ b/internal/sidekick/parser/protobuf_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sample"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sidekick/api"
@@ -2169,7 +2170,7 @@ func newTestCodeGeneratorRequest(t *testing.T, filename ...string) *pluginpb.Cod
 		ActiveRoots: []string{"googleapis", "protobuf-src"},
 		IncludeList: append([]string{}, filename...),
 	}
-	request, err := codeGeneratorRequestFromSource("testdata", src)
+	request, err := codeGeneratorRequestFromSource("testdata", src, nil)
 	if err != nil {
 		t.Fatalf("Failed to make API for Protobuf %v", err)
 	}
@@ -2232,6 +2233,25 @@ func TestParseProtobuf_Descriptors(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatalf("ParseProtobuf returned nil model")
+	}
+}
+
+func TestParseProtobuf_ProtocConfig(t *testing.T) {
+	cfg := &ModelConfig{
+		SpecificationSource: "testdata",
+		ServiceConfig:       secretManagerYamlFullPath,
+		Protoc:              &config.Protoc{Version: "0.0.0-nonexistent"},
+		Source: &sources.SourceConfig{
+			Sources: &sources.Sources{
+				Googleapis:  "../../testdata/googleapis",
+				ProtobufSrc: "testdata",
+			},
+			ActiveRoots: []string{"googleapis", "protobuf-src"},
+			IncludeList: []string{"scalar.proto"},
+		},
+	}
+	if _, err := ParseProtobuf(cfg); err == nil {
+		t.Fatal("ParseProtobuf with nonexistent protoc binary expected error, got nil")
 	}
 }
 

--- a/internal/sidekick/rust_prost/generate.go
+++ b/internal/sidekick/rust_prost/generate.go
@@ -25,9 +25,9 @@ import (
 	"github.com/googleapis/librarian/internal/command"
 	libconfig "github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
-	"github.com/googleapis/librarian/internal/sidekick/parser"
-
 	"github.com/googleapis/librarian/internal/sidekick/language"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+	"github.com/googleapis/librarian/internal/tool/protoc"
 )
 
 //go:embed all:templates
@@ -41,7 +41,7 @@ func Generate(ctx context.Context, model *api.API, outdir string, template strin
 	if err := command.Run(ctx, command.Cargo, "--version"); err != nil {
 		return fmt.Errorf("got an error trying to run `cargo --version`, the instructions on https://www.rust-lang.org/learn/get-started may solve this problem: %w", err)
 	}
-	if err := command.Run(ctx, "protoc", "--version"); err != nil {
+	if err := protoc.RunOrSystem(ctx, nil, cfg.Protoc, "--version"); err != nil {
 		return fmt.Errorf("got an error trying to run `protoc --version`, the instructions on https://grpc.io/docs/protoc-installation/ may solve this problem: %w", err)
 	}
 
@@ -76,7 +76,7 @@ func Generate(ctx context.Context, model *api.API, outdir string, template strin
 			}
 		}
 	}
-	return buildRS(ctx, rootPaths, tmpDir, outdir)
+	return buildRS(ctx, cfg.Protoc, rootPaths, tmpDir, outdir)
 }
 
 func templatesProvider() language.TemplateProvider {
@@ -89,7 +89,7 @@ func templatesProvider() language.TemplateProvider {
 	}
 }
 
-func buildRS(ctx context.Context, rootPaths []string, tmpDir, outDir string) error {
+func buildRS(ctx context.Context, pc *libconfig.Protoc, rootPaths []string, tmpDir, outDir string) error {
 	var absRoots []string
 	for _, r := range rootPaths {
 		absRoot, err := filepath.Abs(r)
@@ -109,5 +109,10 @@ func buildRS(ctx context.Context, rootPaths []string, tmpDir, outDir string) err
 		"SOURCE_ROOT": strings.Join(absRoots, string(os.PathListSeparator)),
 		"DEST":        absOutDir,
 	}
+	protocPath, err := protoc.BinaryPathOrSystem(pc)
+	if err != nil {
+		return fmt.Errorf("failed to find protoc: %w", err)
+	}
+	env["PROTOC"] = protocPath
 	return command.RunInDirWithEnv(ctx, tmpDir, env, command.Cargo, "build", "--features", "_generate-protos")
 }

--- a/internal/sidekick/rust_prost/generate_test.go
+++ b/internal/sidekick/rust_prost/generate_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust_prost
+
+import (
+	"testing"
+
+	libconfig "github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerate_ProtocConfigError(t *testing.T) {
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: libconfig.SpecProtobuf,
+		Protoc:              &libconfig.Protoc{Version: "0.0.0-nonexistent"},
+	}
+	if err := Generate(t.Context(), model, t.TempDir(), "prost", cfg); err == nil {
+		t.Fatal("Generate with nonexistent protoc binary expected error, got nil")
+	}
+}


### PR DESCRIPTION
Change Dart, Rust, and Swift to use the `protoc` version installed via librarian. That simplifies the operation of `librarian` for these languages, but will require updates to several howtos and the `librarian.yaml` configuration.

Fixes #7280 