### PR TITLE
feat(internal/sidekick/rust): wrap stream closed errors in BrokenPipe io error

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -260,7 +260,10 @@ func TestGenerateBidiStreaming(t *testing.T) {
                         .send(prost_item)
                         .await
                         .map_err(|_| {
-                            google_cloud_gax::error::Error::io("cannot send request: stream is closed")
+                            google_cloud_gax::error::Error::io(std::io::Error::new(
+                                std::io::ErrorKind::BrokenPipe,
+                                "cannot send request: stream is closed",
+                            ))
                         })
                 }
             },

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -189,8 +189,10 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                         .send(prost_item)
                         .await
                         .map_err(|_| {
-                            {{! TODO(#6835) - use a custom error kind for stream closed errors }}
-                            google_cloud_gax::error::Error::io("cannot send request: stream is closed")
+                            google_cloud_gax::error::Error::io(std::io::Error::new(
+                                std::io::ErrorKind::BrokenPipe,
+                                "cannot send request: stream is closed",
+                            ))
                         })
                 }
             },


### PR DESCRIPTION
Update the bidirectional streaming transport template to construct a std::io::Error with std::io::ErrorKind::BrokenPipe when sending over a closed request channel fails.

This provides standard I/O broken pipe semantics to callers while preserving the error kind and message.

For #6835 