### PR TITLE
feat(sidekick/rust): skip convert for Any fields

### DIFF
--- a/internal/sidekick/api/field.go
+++ b/internal/sidekick/api/field.go
@@ -186,6 +186,14 @@ func (f *Field) IsObject() bool {
 	return f.Typez == TypezMessage
 }
 
+// IsWktAny returns true if the field is of type ".google.protobuf.Any"
+//
+// This is a well-known type that requires special treatment in some
+// sidekick gencode <-> Protobuf gencode conversions.
+func (f *Field) IsWktAny() bool {
+	return f.TypezID == WktAnyID
+}
+
 // IsResourceReference returns true if the field is annotated with google.api.resource_reference.
 func (f *Field) IsResourceReference() bool {
 	return f.ResourceReference != nil

--- a/internal/sidekick/api/well_known_types.go
+++ b/internal/sidekick/api/well_known_types.go
@@ -15,39 +15,39 @@
 package api
 
 const (
-	// WktAnyID is the well-known type ID for google.protobuf.Any
+	// WktAnyID is the well-known type ID for google.protobuf.Any.
 	WktAnyID = ".google.protobuf.Any"
-	// WktStructID is the well-known type ID for google.protobuf.Struct
+	// WktStructID is the well-known type ID for google.protobuf.Struct.
 	WktStructID = ".google.protobuf.Struct"
-	// WktValueID is the well-known type ID for google.protobuf.Value
+	// WktValueID is the well-known type ID for google.protobuf.Value.
 	WktValueID = ".google.protobuf.Value"
-	// WktListValueID is the well-known type ID for google.protobuf.ListValue
+	// WktListValueID is the well-known type ID for google.protobuf.ListValue.
 	WktListValueID = ".google.protobuf.ListValue"
-	// WktEmptyID is the well-known type ID for google.protobuf.Empty
+	// WktEmptyID is the well-known type ID for google.protobuf.Empty.
 	WktEmptyID = ".google.protobuf.Empty"
-	// WktFieldMaskID is the well-known type ID for google.protobuf.FieldMask
+	// WktFieldMaskID is the well-known type ID for google.protobuf.FieldMask.
 	WktFieldMaskID = ".google.protobuf.FieldMask"
-	// WktDurationID is the well-known type ID for google.protobuf.Duration
+	// WktDurationID is the well-known type ID for google.protobuf.Duration.
 	WktDurationID = ".google.protobuf.Duration"
-	// WktTimestampID is the well-known type ID for google.protobuf.Timestamp
+	// WktTimestampID is the well-known type ID for google.protobuf.Timestamp.
 	WktTimestampID = ".google.protobuf.Timestamp"
-	// WktNullValueID is the well-known type ID for google.protobuf.NullValue
+	// WktNullValueID is the well-known type ID for google.protobuf.NullValue.
 	WktNullValueID = ".google.protobuf.NullValue"
-	// WktBytesValueID is the well-known type ID for google.protobuf.BytesValue
+	// WktBytesValueID is the well-known type ID for google.protobuf.BytesValue.
 	WktBytesValueID = ".google.protobuf.BytesValue"
-	// WktUInt64ValueID is the well-known type ID for google.protobuf.UInt64Value
+	// WktUInt64ValueID is the well-known type ID for google.protobuf.UInt64Value.
 	WktUInt64ValueID = ".google.protobuf.UInt64Value"
-	// WktInt64ValueID is the well-known type ID for google.protobuf.Int64Value
+	// WktInt64ValueID is the well-known type ID for google.protobuf.Int64Value.
 	WktInt64ValueID = ".google.protobuf.Int64Value"
-	// WktUInt32ValueID is the well-known type ID for google.protobuf.UInt32Value
+	// WktUInt32ValueID is the well-known type ID for google.protobuf.UInt32Value.
 	WktUInt32ValueID = ".google.protobuf.UInt32Value"
-	// WktInt32ValueID is the well-known type ID for google.protobuf.Int32Value
+	// WktInt32ValueID is the well-known type ID for google.protobuf.Int32Value.
 	WktInt32ValueID = ".google.protobuf.Int32Value"
-	// WktFloatValueID is the well-known type ID for google.protobuf.FloatValue
+	// WktFloatValueID is the well-known type ID for google.protobuf.FloatValue.
 	WktFloatValueID = ".google.protobuf.FloatValue"
-	// WktDoubleValueID is the well-known type ID for google.protobuf.DoubleValue
+	// WktDoubleValueID is the well-known type ID for google.protobuf.DoubleValue.
 	WktDoubleValueID = ".google.protobuf.DoubleValue"
-	// WktBoolValueID is the well-known type ID for google.protobuf.BoolValue
+	// WktBoolValueID is the well-known type ID for google.protobuf.BoolValue.
 	WktBoolValueID = ".google.protobuf.BoolValue"
 )
 

--- a/internal/sidekick/api/well_known_types.go
+++ b/internal/sidekick/api/well_known_types.go
@@ -14,6 +14,26 @@
 
 package api
 
+const (
+	WktAnyID         = ".google.protobuf.Any"
+	WktStructID      = ".google.protobuf.Struct"
+	WktValueID       = ".google.protobuf.Value"
+	WktListValueID   = ".google.protobuf.ListValue"
+	WktEmptyID       = ".google.protobuf.Empty"
+	WktFieldMaskID   = ".google.protobuf.FieldMask"
+	WktDurationID    = ".google.protobuf.Duration"
+	WktTimestampID   = ".google.protobuf.Timestamp"
+	WktNullValueID   = ".google.protobuf.NullValue"
+	WktBytesValueID  = ".google.protobuf.BytesValue"
+	WktUInt64ValueID = ".google.protobuf.UInt64Value"
+	WktInt64ValueID  = ".google.protobuf.Int64Value"
+	WktUInt32ValueID = ".google.protobuf.UInt32Value"
+	WktInt32ValueID  = ".google.protobuf.Int32Value"
+	WktFloatValueID  = ".google.protobuf.FloatValue"
+	WktDoubleValueID = ".google.protobuf.DoubleValue"
+	WktBoolValueID   = ".google.protobuf.BoolValue"
+)
+
 // LoadWellKnownTypes adds well-known types to `state`.
 //
 // Some source specification formats (Discovery, OpenAPI) must manually add the
@@ -24,40 +44,40 @@ func (model *API) LoadWellKnownTypes() {
 		model.AddMessage(message)
 	}
 	model.AddEnum(&Enum{
+		ID:      WktNullValueID,
 		Name:    "NullValue",
 		Package: "google.protobuf",
-		ID:      ".google.protobuf.NullValue",
 	})
 }
 
 var wellKnownMessages = []*Message{
 	{
-		ID:      ".google.protobuf.Any",
+		ID:      WktAnyID,
 		Name:    "Any",
 		Package: "google.protobuf",
 	},
 	{
-		ID:      ".google.protobuf.Struct",
+		ID:      WktStructID,
 		Name:    "Struct",
 		Package: "google.protobuf",
 	},
 	{
-		ID:      ".google.protobuf.Value",
+		ID:      WktValueID,
 		Name:    "Value",
 		Package: "google.protobuf",
 	},
 	{
-		ID:      ".google.protobuf.ListValue",
+		ID:      WktListValueID,
 		Name:    "ListValue",
 		Package: "google.protobuf",
 	},
 	{
-		ID:      ".google.protobuf.Empty",
+		ID:      WktEmptyID,
 		Name:    "Empty",
 		Package: "google.protobuf",
 	},
 	{
-		ID:      ".google.protobuf.FieldMask",
+		ID:      WktFieldMaskID,
 		Name:    "FieldMask",
 		Package: "google.protobuf",
 		Fields: []*Field{
@@ -70,21 +90,21 @@ var wellKnownMessages = []*Message{
 		},
 	},
 	{
-		ID:      ".google.protobuf.Duration",
+		ID:      WktDurationID,
 		Name:    "Duration",
 		Package: "google.protobuf",
 	},
 	{
-		ID:      ".google.protobuf.Timestamp",
+		ID:      WktTimestampID,
 		Name:    "Timestamp",
 		Package: "google.protobuf",
 	},
-	{ID: ".google.protobuf.BytesValue", Name: "BytesValue", Package: "google.protobuf"},
-	{ID: ".google.protobuf.UInt64Value", Name: "UInt64Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.Int64Value", Name: "Int64Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.UInt32Value", Name: "UInt32Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.Int32Value", Name: "Int32Value", Package: "google.protobuf"},
-	{ID: ".google.protobuf.FloatValue", Name: "FloatValue", Package: "google.protobuf"},
-	{ID: ".google.protobuf.DoubleValue", Name: "DoubleValue", Package: "google.protobuf"},
-	{ID: ".google.protobuf.BoolValue", Name: "BoolValue", Package: "google.protobuf"},
+	{ID: WktBytesValueID, Name: "BytesValue", Package: "google.protobuf"},
+	{ID: WktUInt64ValueID, Name: "UInt64Value", Package: "google.protobuf"},
+	{ID: WktInt64ValueID, Name: "Int64Value", Package: "google.protobuf"},
+	{ID: WktUInt32ValueID, Name: "UInt32Value", Package: "google.protobuf"},
+	{ID: WktInt32ValueID, Name: "Int32Value", Package: "google.protobuf"},
+	{ID: WktFloatValueID, Name: "FloatValue", Package: "google.protobuf"},
+	{ID: WktDoubleValueID, Name: "DoubleValue", Package: "google.protobuf"},
+	{ID: WktBoolValueID, Name: "BoolValue", Package: "google.protobuf"},
 }

--- a/internal/sidekick/api/well_known_types.go
+++ b/internal/sidekick/api/well_known_types.go
@@ -15,23 +15,40 @@
 package api
 
 const (
-	WktAnyID         = ".google.protobuf.Any"
-	WktStructID      = ".google.protobuf.Struct"
-	WktValueID       = ".google.protobuf.Value"
-	WktListValueID   = ".google.protobuf.ListValue"
-	WktEmptyID       = ".google.protobuf.Empty"
-	WktFieldMaskID   = ".google.protobuf.FieldMask"
-	WktDurationID    = ".google.protobuf.Duration"
-	WktTimestampID   = ".google.protobuf.Timestamp"
-	WktNullValueID   = ".google.protobuf.NullValue"
-	WktBytesValueID  = ".google.protobuf.BytesValue"
+	// WktAnyID is the well-known type ID for google.protobuf.Any
+	WktAnyID = ".google.protobuf.Any"
+	// WktStructID is the well-known type ID for google.protobuf.Struct
+	WktStructID = ".google.protobuf.Struct"
+	// WktValueID is the well-known type ID for google.protobuf.Value
+	WktValueID = ".google.protobuf.Value"
+	// WktListValueID is the well-known type ID for google.protobuf.ListValue
+	WktListValueID = ".google.protobuf.ListValue"
+	// WktEmptyID is the well-known type ID for google.protobuf.Empty
+	WktEmptyID = ".google.protobuf.Empty"
+	// WktFieldMaskID is the well-known type ID for google.protobuf.FieldMask
+	WktFieldMaskID = ".google.protobuf.FieldMask"
+	// WktDurationID is the well-known type ID for google.protobuf.Duration
+	WktDurationID = ".google.protobuf.Duration"
+	// WktTimestampID is the well-known type ID for google.protobuf.Timestamp
+	WktTimestampID = ".google.protobuf.Timestamp"
+	// WktNullValueID is the well-known type ID for google.protobuf.NullValue
+	WktNullValueID = ".google.protobuf.NullValue"
+	// WktBytesValueID is the well-known type ID for google.protobuf.BytesValue
+	WktBytesValueID = ".google.protobuf.BytesValue"
+	// WktUInt64ValueID is the well-known type ID for google.protobuf.UInt64Value
 	WktUInt64ValueID = ".google.protobuf.UInt64Value"
-	WktInt64ValueID  = ".google.protobuf.Int64Value"
+	// WktInt64ValueID is the well-known type ID for google.protobuf.Int64Value
+	WktInt64ValueID = ".google.protobuf.Int64Value"
+	// WktUInt32ValueID is the well-known type ID for google.protobuf.UInt32Value
 	WktUInt32ValueID = ".google.protobuf.UInt32Value"
-	WktInt32ValueID  = ".google.protobuf.Int32Value"
-	WktFloatValueID  = ".google.protobuf.FloatValue"
+	// WktInt32ValueID is the well-known type ID for google.protobuf.Int32Value
+	WktInt32ValueID = ".google.protobuf.Int32Value"
+	// WktFloatValueID is the well-known type ID for google.protobuf.FloatValue
+	WktFloatValueID = ".google.protobuf.FloatValue"
+	// WktDoubleValueID is the well-known type ID for google.protobuf.DoubleValue
 	WktDoubleValueID = ".google.protobuf.DoubleValue"
-	WktBoolValueID   = ".google.protobuf.BoolValue"
+	// WktBoolValueID is the well-known type ID for google.protobuf.BoolValue
+	WktBoolValueID = ".google.protobuf.BoolValue"
 )
 
 // LoadWellKnownTypes adds well-known types to `state`.

--- a/internal/sidekick/rust/annotate_field.go
+++ b/internal/sidekick/rust/annotate_field.go
@@ -22,6 +22,17 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/language"
 )
 
+var (
+	// The annotations print a warning when generating code that converts between sidekick-gencode
+	// and Prost-gencode **and** has a field of type Any. The warning is supressed for some
+	//  well-known cases where we decided it was fine.
+	suppressProstConvertAndAnyWarnings = map[string]struct{}{
+		".google.rpc.Status":                           {},
+		".google.longrunning.Operation":                {},
+		".google.storage.control.v2.ObjectFullContext": {},
+	}
+)
+
 type fieldAnnotations struct {
 	// In Rust, message fields are fields inside a struct. These must be
 	// `snake_case`. Possibly mangled with `r#` if the name is a Rust reserved
@@ -194,6 +205,11 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 	primitiveFieldType, err := c.fieldType(field, model, true, model.PackageName)
 	if err != nil {
 		return nil, err
+	}
+	if field.TypezID == api.WktAnyID && c.templateOverride == templateConvertProst {
+		if _, ok := suppressProstConvertAndAnyWarnings[message.ID]; !ok {
+			fmt.Printf("WARNING: unknown field of type wkt::Any, conversion skipped, consider ad-hoc code, message: %s\n", message.ID)
+		}
 	}
 	ann := &fieldAnnotations{
 		FieldName:          toSnake(field.Name),

--- a/internal/sidekick/rust/annotate_field.go
+++ b/internal/sidekick/rust/annotate_field.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// The annotations print a warning when generating code that converts between sidekick-gencode
-	// and Prost-gencode **and** has a field of type Any. The warning is supressed for some
+	// and Prost-gencode **and** has a field of type Any. The warning is suppressed for some
 	//  well-known cases where we decided it was fine.
 	suppressProstConvertAndAnyWarnings = map[string]struct{}{
 		".google.rpc.Status":                           {},

--- a/internal/sidekick/rust/generate.go
+++ b/internal/sidekick/rust/generate.go
@@ -27,6 +27,10 @@ import (
 //go:embed all:templates
 var templates embed.FS
 
+const (
+	templateConvertProst = "templates/convert-prost"
+)
+
 // Generate generates Rust code from the model.
 func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.ModelConfig) error {
 	c, err := newCodec(cfg.SpecificationFormat, cfg.Codec)

--- a/internal/sidekick/rust/templates/convert-prost/message.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/message.mustache
@@ -31,6 +31,10 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
         Ok(Self::Output {
             {{#Codec.BasicFields}}
             {{#Singular}}
+            {{#IsWktAny}}
+            {{Codec.FieldName}}: None,
+            {{/IsWktAny}}
+            {{^IsWktAny}}
             {{^Optional}}
             {{Codec.FieldName}}: self.{{Codec.FieldName}}.to_proto()?,
             {{/Optional}}
@@ -42,7 +46,9 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
             {{Codec.FieldName}}: self.{{Codec.FieldName}}.map(|v| v.to_proto().map(std::boxed::Box::new)).transpose()?,
             {{/Codec.MapToBoxed}}
             {{/Optional}}
+            {{/IsWktAny}}
             {{/Singular}}
+            {{! A sequence or map with `google.protobuf.Any` is unlikely. If it ever happens, we see a break and fix it with more understanding }}
             {{#Repeated}}
             {{Codec.FieldName}}: self.{{Codec.FieldName}}
                 .into_iter()
@@ -71,13 +77,16 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
             {{Codec.QualifiedName}}::new()
                 {{#Codec.BasicFields}}
                 {{#Singular}}
+                {{^IsWktAny}}
                 {{^Optional}}
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}})
                 {{/Optional}}
                 {{#Optional}}
                 .set_or_clear_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()).transpose()?)
                 {{/Optional}}
+                {{/IsWktAny}}
                 {{/Singular}}
+                {{! A sequence or map with `google.protobuf.Any` is unlikely. If it ever happens, we see a break and fix it with more understanding }}
                 {{#Repeated}}
                 {{^IsEnum}}
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|v| v.cnv())


### PR DESCRIPTION
The convert-prost template skips fields of type `wkt::Any`, as these cannot be converted.

Towards https://github.com/googleapis/google-cloud-rust/issues/6353 

To see the generated code look at: https://github.com/googleapis/google-cloud-rust/pull/6408/changes

In particular the second diff:

https://github.com/googleapis/google-cloud-rust/pull/6408/changes/74efd51a7a7f71de5926d0f4d30b3967788e6011

