### PR TITLE
feat(sidekick): support fields in skipped_ids

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -267,6 +267,7 @@ This document describes the schema for the librarian.yaml.
 | `readme_after_title_text` | string | Is text to insert in the README after the title. |
 | `readme_quickstart_text` | string | Is text to use for the quickstart section in the README. |
 | `repository_url` | string | Is the URL to the repository for this package. |
+| `skipped_ids` | list of string | Is a list of proto IDs to skip in generation. |
 | `supports_sse` | bool | Indicates whether the target API supports Server-Sent Events (SSE) for methods where `ServerSideStreaming` is `true`. |
 | `title_override` | string | Overrides the API title. |
 | `version` | string | Is the version of the dart package. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -453,6 +453,9 @@ type DartPackage struct {
 	// RepositoryURL is the URL to the repository for this package.
 	RepositoryURL string `yaml:"repository_url,omitempty"`
 
+	// SkippedIds is a list of proto IDs to skip in generation.
+	SkippedIds []string `yaml:"skipped_ids,omitempty"`
+
 	// SupportsSSE indicates whether the target API supports Server-Sent Events (SSE) for methods
 	// where `ServerSideStreaming` is `true`.
 	SupportsSSE bool `yaml:"supports_sse,omitempty"`

--- a/internal/librarian/dart/codec.go
+++ b/internal/librarian/dart/codec.go
@@ -50,11 +50,13 @@ func toModelConfig(library *config.Library, ch *config.API, srcs *sources.Source
 
 	title := svcConfig.Title
 	var name string
+	var skippedIDs []string
 	if library.Dart != nil {
 		name = library.Dart.NameOverride
 		if library.Dart.TitleOverride != "" {
 			title = library.Dart.TitleOverride
 		}
+		skippedIDs = library.Dart.SkippedIds
 	}
 
 	modelConfig := &parser.ModelConfig{
@@ -69,6 +71,7 @@ func toModelConfig(library *config.Library, ch *config.API, srcs *sources.Source
 			Name:        name,
 			Description: svcConfig.Description,
 			Title:       title,
+			SkippedIDs:  skippedIDs,
 		},
 	}
 	return modelConfig, nil

--- a/internal/librarian/dart/codec_test.go
+++ b/internal/librarian/dart/codec_test.go
@@ -542,6 +542,32 @@ func TestToModelConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "with skipped ids",
+			library: &config.Library{
+				Dart: &config.DartPackage{
+					SkippedIds: []string{".google.cloud.secretmanager.v1.Secret.name"},
+				},
+			},
+			channel: &config.API{
+				Path: "google/cloud/functions/v2",
+			},
+			googleapisDir: googleapisDir,
+			want: &parser.ModelConfig{
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "google/cloud/functions/v2",
+				Source: &sources.SourceConfig{
+					Sources: &sources.Sources{
+						Googleapis: googleapisDir,
+					},
+					ActiveRoots: []string{"googleapis"},
+				},
+				Codec: map[string]string{},
+				Override: api.ModelOverride{
+					SkippedIDs: []string{".google.cloud.secretmanager.v1.Secret.name"},
+				},
+			},
+		},
+		{
 			name: "unsupported specification format",
 			library: &config.Library{
 				SpecificationFormat: "openapi",

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -258,6 +258,11 @@ func moduleToModelConfig(library *config.Library, module *config.RustModule, src
 		resourceNameHeuristic = *module.ResourceNameHeuristic
 	}
 
+	skippedIDs := module.SkippedIds
+	if len(skippedIDs) == 0 && library.Rust != nil && len(library.Rust.SkippedIds) > 0 {
+		skippedIDs = library.Rust.SkippedIds
+	}
+
 	modelCfg := &parser.ModelConfig{
 		Language:            config.LanguageRust,
 		SpecificationFormat: specificationFormat,
@@ -269,7 +274,7 @@ func moduleToModelConfig(library *config.Library, module *config.RustModule, src
 		Override: api.ModelOverride{
 			Title:       title,
 			IncludedIDs: module.IncludedIds,
-			SkippedIDs:  module.SkippedIds,
+			SkippedIDs:  skippedIDs,
 		},
 		ResourceNameHeuristic: resourceNameHeuristic,
 	}

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -377,6 +377,33 @@ func TestLibraryToModelConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "with skipped ids",
+			library: &config.Library{
+				Name:  "google-cloud-secretmanager",
+				Roots: []string{"googleapis"},
+				Rust: &config.RustCrate{
+					SkippedIds: []string{".google.cloud.secretmanager.v1.Secret.name"},
+				},
+			},
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+			},
+			want: &parser.ModelConfig{
+				Language:            config.LanguageRust,
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "google/cloud/secretmanager/v1",
+				ServiceConfig:       "google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+				Source: &sources.SourceConfig{
+					ActiveRoots: []string{"googleapis"},
+				},
+				Override: api.ModelOverride{
+					Title:       "Secret Manager API",
+					Description: "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
+					SkippedIDs:  []string{".google.cloud.secretmanager.v1.Secret.name"},
+				},
+			},
+		},
+		{
 			name: "with openapi format",
 			library: &config.Library{
 				Name:                "secretmanager-openapi-v1",
@@ -1460,4 +1487,51 @@ func TestBuildCodec(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestModuleToModelConfig_SkippedIds(t *testing.T) {
+	srcs := &sources.Sources{
+		Googleapis: absPath(t, googleapisRoot),
+	}
+
+	t.Run("module level skipped_ids", func(t *testing.T) {
+		library := &config.Library{
+			Name: "google-cloud-secretmanager",
+			Rust: &config.RustCrate{
+				SkippedIds: []string{".google.cloud.secretmanager.v1.Secret.name"},
+			},
+		}
+		module := &config.RustModule{
+			APIPath:    "google/cloud/secretmanager/v1",
+			SkippedIds: []string{".google.cloud.secretmanager.v1.Secret.labels"},
+		}
+		modelCfg, err := moduleToModelConfig(library, module, srcs, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := []string{".google.cloud.secretmanager.v1.Secret.labels"}
+		if diff := cmp.Diff(expected, modelCfg.Override.SkippedIDs); diff != "" {
+			t.Errorf("moduleToModelConfig() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("library level fallback skipped_ids", func(t *testing.T) {
+		library := &config.Library{
+			Name: "google-cloud-secretmanager",
+			Rust: &config.RustCrate{
+				SkippedIds: []string{".google.cloud.secretmanager.v1.Secret.name"},
+			},
+		}
+		module := &config.RustModule{
+			APIPath: "google/cloud/secretmanager/v1",
+		}
+		modelCfg, err := moduleToModelConfig(library, module, srcs, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := []string{".google.cloud.secretmanager.v1.Secret.name"}
+		if diff := cmp.Diff(expected, modelCfg.Override.SkippedIDs); diff != "" {
+			t.Errorf("moduleToModelConfig() mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/sample/api.go
+++ b/internal/sample/api.go
@@ -357,6 +357,7 @@ func Automatic() *api.Message {
 		Fields: []*api.Field{
 			{
 				Name:          "customerManagedEncryption",
+				ID:            "..Automatic.customerManagedEncryption",
 				JSONName:      "customerManagedEncryption",
 				Documentation: "Optional. The customer-managed encryption configuration of the Secret.",
 				Typez:         api.TypezMessage,
@@ -385,6 +386,7 @@ func SecretPayload() *api.Message {
 		Fields: []*api.Field{
 			{
 				Name:          "data",
+				ID:            "..SecretPayload.data",
 				JSONName:      "data",
 				Documentation: "The secret data. Must be no larger than 64KiB.",
 				Typez:         api.TypezBytes,
@@ -393,6 +395,7 @@ func SecretPayload() *api.Message {
 			},
 			{
 				Name:          "dataCrc32c",
+				ID:            "..SecretPayload.dataCrc32c",
 				JSONName:      "dataCrc32c",
 				Documentation: "Optional. If specified, SecretManagerService will verify the integrity of the\nreceived data on SecretManagerService.AddSecretVersion calls using\nthe crc32c checksum and store it to include in future\nSecretManagerService.AccessSecretVersion responses. If a checksum is\nnot provided in the SecretManagerService.AddSecretVersion request, the\nSecretManagerService will generate and store one for you.\n\nThe CRC32C value is encoded as a Int64 for compatibility, and can be\nsafely downconverted to uint32 in languages that support this type.\nhttps://cloud.google.com/apis/design/design_patterns#integer_types",
 				Typez:         api.TypezInt64,

--- a/internal/sidekick/api/field.go
+++ b/internal/sidekick/api/field.go
@@ -186,14 +186,6 @@ func (f *Field) IsObject() bool {
 	return f.Typez == TypezMessage
 }
 
-// IsWktAny returns true if the field is of type ".google.protobuf.Any"
-//
-// This is a well-known type that requires special treatment in some
-// sidekick gencode <-> Protobuf gencode conversions.
-func (f *Field) IsWktAny() bool {
-	return f.TypezID == WktAnyID
-}
-
 // IsResourceReference returns true if the field is annotated with google.api.resource_reference.
 func (f *Field) IsResourceReference() bool {
 	return f.ResourceReference != nil

--- a/internal/sidekick/api/message.go
+++ b/internal/sidekick/api/message.go
@@ -32,6 +32,11 @@ type Message struct {
 	// OpenAPI specifications. The query and request parameters for each method
 	// are grouped into a synthetic message.
 	SyntheticRequest bool
+	// If true, some of the fields were removed.
+	//
+	// When generating Sidekick-gencode <-> Protobuf-gencode converters this is useful to know because
+	// the emitted code for the protos may need additional initializers.
+	SkippedFields []*Field
 	// If true, this message is a placeholder / doppelganger for a `api.Service`.
 	//
 	// These messages are created by sidekick when parsing Discovery docs and
@@ -69,4 +74,9 @@ type Message struct {
 // HasFields returns true if the message has fields.
 func (m *Message) HasFields() bool {
 	return len(m.Fields) != 0
+}
+
+// HasSkippedFields returns true if the message has fields affected by the `skipped_ids` configuration.
+func (m *Message) HasSkippedFields() bool {
+	return len(m.SkippedFields) != 0
 }

--- a/internal/sidekick/api/skip.go
+++ b/internal/sidekick/api/skip.go
@@ -105,7 +105,7 @@ func skipMessageElements(message *Message, skip func(id string) bool, skipField 
 		}
 		return false
 	}
-	message.Fields = slices.DeleteFunc(slices.Clone(message.Fields), skipped)
+	message.Fields = slices.DeleteFunc(message.Fields, skipped)
 	message.SkippedFields = slices.DeleteFunc(previous, func(x *Field) bool { return !skipped(x) })
 	for _, oneof := range message.OneOfs {
 		oneof.Fields = slices.DeleteFunc(oneof.Fields, func(x *Field) bool {

--- a/internal/sidekick/api/skip.go
+++ b/internal/sidekick/api/skip.go
@@ -41,7 +41,10 @@ func SkipModelElements(model *API, overrides ModelOverride) error {
 			return err
 		}
 		skip := func(id string) bool { return !includedIds[id] }
-		skipModelElementsImpl(model, skip)
+		skipField := func(id string) bool { return false }
+		if err := skipModelElementsImpl(model, skip, skipField); err != nil {
+			return err
+		}
 	}
 
 	if len(overrides.SkippedIDs) > 0 {
@@ -50,27 +53,69 @@ func SkipModelElements(model *API, overrides ModelOverride) error {
 			skippedIDs[id] = true
 		}
 		skip := func(id string) bool { return skippedIDs[id] }
-		skipModelElementsImpl(model, skip)
+		skipField := func(id string) bool { return skippedIDs[id] }
+		if err := skipModelElementsImpl(model, skip, skipField); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func skipModelElementsImpl(model *API, skip func(id string) bool) {
+func skipModelElementsImpl(model *API, skip func(id string) bool, skipField func(id string) bool) error {
 	for _, m := range model.Messages {
-		skipMessageElements(m, skip)
+		skipMessageElements(m, skip, skipField)
 	}
 	model.Enums = slices.DeleteFunc(model.Enums, func(x *Enum) bool { return skip(x.ID) })
 	model.Messages = slices.DeleteFunc(model.Messages, func(x *Message) bool { return skip(x.ID) })
 	model.Services = slices.DeleteFunc(model.Services, func(x *Service) bool { return skip(x.ID) })
+
 	for service := range model.AllServices() {
 		service.Methods = slices.DeleteFunc(service.Methods, func(x *Method) bool { return skip(x.ID) })
+		for _, method := range service.Methods {
+			if method.Pagination != nil && skipField(method.Pagination.ID) {
+				return fmt.Errorf("unsupported: skipping field %s which enables pagination", method.Pagination.ID)
+			}
+			idx := slices.IndexFunc(method.Signatures, func(s *MethodSignature) bool {
+				return slices.ContainsFunc(s.Fields, func(f *Field) bool { return skipField(f.ID) })
+			})
+			if idx != -1 {
+				return fmt.Errorf("unsupported: skipping field that is in one of the method signatures for method: %s", method.ID)
+			}
+		}
 	}
+	if model.QuickstartService != nil && !slices.Contains(model.Services, model.QuickstartService) {
+		model.QuickstartService = findQuickstartService(model)
+	}
+	return nil
 }
 
-func skipMessageElements(message *Message, skip func(id string) bool) {
+func skipMessageElements(message *Message, skip func(id string) bool, skipField func(id string) bool) {
 	for _, m := range message.Messages {
-		skipMessageElements(m, skip)
+		skipMessageElements(m, skip, skipField)
 	}
 	message.Messages = slices.DeleteFunc(message.Messages, func(x *Message) bool { return skip(x.ID) })
 	message.Enums = slices.DeleteFunc(message.Enums, func(x *Enum) bool { return skip(x.ID) })
+	previous := slices.Clone(message.Fields)
+	skipped := func(x *Field) bool {
+		if skipField(x.ID) {
+			return true
+		}
+		if x.Group != nil && skipField(x.Group.ID) {
+			return true
+		}
+		return false
+	}
+	message.Fields = slices.DeleteFunc(slices.Clone(message.Fields), skipped)
+	message.SkippedFields = slices.DeleteFunc(previous, func(x *Field) bool { return !skipped(x) })
+	for _, oneof := range message.OneOfs {
+		oneof.Fields = slices.DeleteFunc(oneof.Fields, func(x *Field) bool {
+			return skipField(x.ID)
+		})
+		if len(oneof.Fields) > 0 {
+			oneof.ExampleField = slices.MaxFunc(oneof.Fields, sortOneOfFieldForExamples)
+		}
+	}
+	message.OneOfs = slices.DeleteFunc(message.OneOfs, func(x *OneOf) bool {
+		return skipField(x.ID) || len(x.Fields) == 0
+	})
 }

--- a/internal/sidekick/api/skip_test.go
+++ b/internal/sidekick/api/skip_test.go
@@ -390,3 +390,286 @@ func TestIncludeMethods(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestSkipMessageFields(t *testing.T) {
+	f0 := &Field{Name: "field0", ID: ".test.Message0.field0", Typez: TypezString}
+	f1 := &Field{Name: "field1", ID: ".test.Message0.field1", Typez: TypezString}
+	f2 := &Field{Name: "field2", ID: ".test.Message0.field2", Typez: TypezInt32}
+	m0 := &Message{
+		Name:    "Message0",
+		Package: "test",
+		ID:      ".test.Message0",
+		Fields:  []*Field{f0, f1, f2},
+	}
+	model := NewTestAPI([]*Message{m0}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, ModelOverride{
+		SkippedIDs: []string{".test.Message0.field1"},
+	})
+	want := []*Field{f0, f2}
+	if diff := cmp.Diff(want, m0.Fields, cmpopts.IgnoreFields(Field{}, "Parent")); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSkipNestedMessageFields(t *testing.T) {
+	f0 := &Field{Name: "field0", ID: ".test.Outer.Inner.field0", Typez: TypezString}
+	f1 := &Field{Name: "field1", ID: ".test.Outer.Inner.field1", Typez: TypezString}
+	inner := &Message{
+		Name:    "Inner",
+		Package: "test",
+		ID:      ".test.Outer.Inner",
+		Fields:  []*Field{f0, f1},
+	}
+	outer := &Message{
+		Name:     "Outer",
+		Package:  "test",
+		ID:       ".test.Outer",
+		Messages: []*Message{inner},
+	}
+	model := NewTestAPI([]*Message{outer, inner}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, ModelOverride{
+		SkippedIDs: []string{".test.Outer.Inner.field1"},
+	})
+	want := []*Field{f0}
+	if diff := cmp.Diff(want, inner.Fields, cmpopts.IgnoreFields(Field{}, "Parent")); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSkipOneOfField(t *testing.T) {
+	f0 := &Field{Name: "field0", ID: ".test.Message.field0", Typez: TypezString}
+	f1 := &Field{Name: "field1", ID: ".test.Message.field1", Typez: TypezString, IsOneOf: true}
+	f2 := &Field{Name: "field2", ID: ".test.Message.field2", Typez: TypezInt32, IsOneOf: true}
+	oneof := &OneOf{
+		Name:   "choice",
+		ID:     ".test.Message.choice",
+		Fields: []*Field{f1, f2},
+	}
+	m := &Message{
+		Name:    "Message",
+		Package: "test",
+		ID:      ".test.Message",
+		Fields:  []*Field{f0, f1, f2},
+		OneOfs:  []*OneOf{oneof},
+	}
+	model := NewTestAPI([]*Message{m}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, ModelOverride{
+		SkippedIDs: []string{".test.Message.field1"},
+	})
+	wantFields := []*Field{f0, f2}
+	if diff := cmp.Diff(wantFields, m.Fields, cmpopts.IgnoreFields(Field{}, "Parent", "Group")); diff != "" {
+		t.Errorf("mismatch in fields (-want +got):\n%s", diff)
+	}
+	wantOneOfFields := []*Field{f2}
+	if diff := cmp.Diff(wantOneOfFields, oneof.Fields, cmpopts.IgnoreFields(Field{}, "Parent", "Group")); diff != "" {
+		t.Errorf("mismatch in oneof fields (-want +got):\n%s", diff)
+	}
+	if oneof.ExampleField != f2 {
+		t.Errorf("expected ExampleField to be %v, got %v", f2, oneof.ExampleField)
+	}
+}
+
+func TestSkipAllOneOfFields(t *testing.T) {
+	f1 := &Field{Name: "field1", ID: ".test.Message.field1", Typez: TypezString, IsOneOf: true}
+	f2 := &Field{Name: "field2", ID: ".test.Message.field2", Typez: TypezInt32, IsOneOf: true}
+	oneof := &OneOf{
+		Name:   "choice",
+		ID:     ".test.Message.choice",
+		Fields: []*Field{f1, f2},
+	}
+	m := &Message{
+		Name:    "Message",
+		Package: "test",
+		ID:      ".test.Message",
+		Fields:  []*Field{f1, f2},
+		OneOfs:  []*OneOf{oneof},
+	}
+	model := NewTestAPI([]*Message{m}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, ModelOverride{
+		SkippedIDs: []string{".test.Message.field1", ".test.Message.field2"},
+	})
+	if len(m.Fields) != 0 {
+		t.Errorf("expected no fields, got %v", m.Fields)
+	}
+	if len(m.OneOfs) != 0 {
+		t.Errorf("expected empty oneof to be pruned, got %v", m.OneOfs)
+	}
+}
+
+func TestSkipOneOfDirectly(t *testing.T) {
+	f0 := &Field{Name: "field0", ID: ".test.Message.field0", Typez: TypezString}
+	f1 := &Field{Name: "field1", ID: ".test.Message.field1", Typez: TypezString, IsOneOf: true}
+	f2 := &Field{Name: "field2", ID: ".test.Message.field2", Typez: TypezInt32, IsOneOf: true}
+	oneof := &OneOf{
+		Name:   "choice",
+		ID:     ".test.Message.choice",
+		Fields: []*Field{f1, f2},
+	}
+	m := &Message{
+		Name:    "Message",
+		Package: "test",
+		ID:      ".test.Message",
+		Fields:  []*Field{f0, f1, f2},
+		OneOfs:  []*OneOf{oneof},
+	}
+	model := NewTestAPI([]*Message{m}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, ModelOverride{
+		SkippedIDs: []string{".test.Message.choice"},
+	})
+	wantFields := []*Field{f0}
+	if diff := cmp.Diff(wantFields, m.Fields, cmpopts.IgnoreFields(Field{}, "Parent", "Group")); diff != "" {
+		t.Errorf("mismatch in fields (-want +got):\n%s", diff)
+	}
+	if len(m.OneOfs) != 0 {
+		t.Errorf("expected oneof to be removed, got %v", m.OneOfs)
+	}
+}
+
+func TestSkipFieldAffectsMethodSignature(t *testing.T) {
+	fName := &Field{Name: "name", ID: ".test.Req.name", Typez: TypezString}
+	fTarget := &Field{Name: "target", ID: ".test.Req.target", Typez: TypezString}
+	fSkip := &Field{Name: "skip_me", ID: ".test.Req.skip_me", Typez: TypezString}
+	req := &Message{
+		Name:    "Req",
+		Package: "test",
+		ID:      ".test.Req",
+		Fields:  []*Field{fName, fTarget, fSkip},
+	}
+	resp := &Message{
+		Name:    "Resp",
+		Package: "test",
+		ID:      ".test.Resp",
+	}
+	sigKeep := &MethodSignature{
+		Names:  []string{"name", "target"},
+		Fields: []*Field{fName, fTarget},
+	}
+	sigDrop := &MethodSignature{
+		Names:  []string{"name", "skip_me"},
+		Fields: []*Field{fName, fSkip},
+	}
+	method := &Method{
+		Name:         "DoWork",
+		ID:           ".test.Service.DoWork",
+		InputTypeID:  req.ID,
+		OutputTypeID: resp.ID,
+		Signatures:   []*MethodSignature{sigKeep, sigDrop},
+	}
+	service := &Service{
+		Name:    "Service",
+		Package: "test",
+		ID:      ".test.Service",
+		Methods: []*Method{method},
+	}
+	model := NewTestAPI([]*Message{req, resp}, []*Enum{}, []*Service{service})
+	CrossReference(model)
+	err := SkipModelElements(model, ModelOverride{SkippedIDs: []string{".test.Req.skip_me"}})
+	if err == nil {
+		t.Errorf("removing a signature should result in an error, got %+v", method)
+	}
+}
+
+func TestSkipFieldAffectsPagination(t *testing.T) {
+	pageSizeField := &Field{Name: "page_size", JSONName: "pageSize", ID: ".test.ListReq.page_size", Typez: TypezInt32}
+	pageTokenField := &Field{Name: "page_token", JSONName: "pageToken", ID: ".test.ListReq.page_token", Typez: TypezString}
+	nextPageTokenField := &Field{Name: "next_page_token", JSONName: "nextPageToken", ID: ".test.ListResp.next_page_token", Typez: TypezString}
+	itemsField := &Field{Name: "items", JSONName: "items", ID: ".test.ListResp.items", Typez: TypezMessage, TypezID: ".test.Item", Repeated: true}
+
+	req := &Message{
+		Name:    "ListReq",
+		Package: "test",
+		ID:      ".test.ListReq",
+		Fields:  []*Field{pageSizeField, pageTokenField},
+	}
+	resp := &Message{
+		Name:    "ListResp",
+		Package: "test",
+		ID:      ".test.ListResp",
+		Fields:  []*Field{nextPageTokenField, itemsField},
+	}
+	item := &Message{
+		Name:    "Item",
+		Package: "test",
+		ID:      ".test.Item",
+	}
+	method := &Method{
+		Name:         "ListItems",
+		ID:           ".test.Service.ListItems",
+		InputTypeID:  req.ID,
+		OutputTypeID: resp.ID,
+	}
+	service := &Service{
+		Name:    "Service",
+		Package: "test",
+		ID:      ".test.Service",
+		Methods: []*Method{method},
+	}
+	model := NewTestAPI([]*Message{req, resp, item}, []*Enum{}, []*Service{service})
+	UpdateMethodPagination(nil, model)
+	CrossReference(model)
+	if method.Pagination == nil || resp.Pagination == nil {
+		t.Fatalf("expected pagination to be set before skip")
+	}
+
+	err := SkipModelElements(model, ModelOverride{
+		SkippedIDs: []string{".test.ListReq.page_token"},
+	})
+	if err == nil {
+		t.Errorf("removing a pagination field should result in errors: got = %+v", method)
+	}
+}
+
+func TestIncludeKeepsAllMessageFields(t *testing.T) {
+	f0 := &Field{Name: "field0", ID: ".test.Message0.field0", Typez: TypezString}
+	f1 := &Field{Name: "field1", ID: ".test.Message0.field1", Typez: TypezString}
+	m0 := &Message{
+		Name:    "Message0",
+		Package: "test",
+		ID:      ".test.Message0",
+		Fields:  []*Field{f0, f1},
+	}
+	model := NewTestAPI([]*Message{m0}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, ModelOverride{
+		IncludedIDs: []string{".test.Message0"},
+	})
+	want := []*Field{f0, f1}
+	if diff := cmp.Diff(want, m0.Fields, cmpopts.IgnoreFields(Field{}, "Parent")); diff != "" {
+		t.Errorf("mismatch in fields (-want +got):\n%s", diff)
+	}
+}
+
+func TestSkipPreservesExternalAndDependencyMessagesInSymbolTable(t *testing.T) {
+	timestamp := &Message{
+		Name:    "Timestamp",
+		Package: "google.protobuf",
+		ID:      ".google.protobuf.Timestamp",
+	}
+	m0 := &Message{
+		Name:    "Message0",
+		Package: "test",
+		ID:      ".test.Message0",
+		Fields: []*Field{
+			{Name: "field0", ID: ".test.Message0.field0", Typez: TypezString},
+			{Name: "field1", ID: ".test.Message0.field1", Typez: TypezString},
+		},
+	}
+	model := NewTestAPI([]*Message{m0}, []*Enum{}, []*Service{})
+	model.AddMessage(timestamp)
+	CrossReference(model)
+
+	if err := SkipModelElements(model, ModelOverride{
+		SkippedIDs: []string{".test.Message0.field1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := model.Message(".google.protobuf.Timestamp"); got == nil {
+		t.Errorf("expected .google.protobuf.Timestamp to remain in symbol table after skipping an unrelated field")
+	}
+}

--- a/internal/sidekick/parser/openapi.go
+++ b/internal/sidekick/parser/openapi.go
@@ -276,6 +276,7 @@ func makeRequestMessage(a *api.API, parent *api.Message, operation *v3.Operation
 		}
 		field := &api.Field{
 			Name:          p.Name,
+			ID:            fmt.Sprintf("%s.%s", message.ID, p.Name),
 			JSONName:      p.Name, // OpenAPI fields are already camelCase
 			Documentation: documentation,
 			Deprecated:    p.Deprecated,
@@ -306,6 +307,7 @@ func makeRequestMessage(a *api.API, parent *api.Message, operation *v3.Operation
 		bodyFieldPath = name
 		field := &api.Field{
 			Name:          name,
+			ID:            fmt.Sprintf("%s.%s", message.ID, name),
 			JSONName:      name,
 			Documentation: "The request body.",
 			Typez:         api.TypezMessage,
@@ -405,7 +407,7 @@ func makeField(model *api.API, packageName, messageName, name string, optional b
 	}
 	switch field.Type[0] {
 	case "boolean", "integer", "number", "string":
-		return makeScalarField(messageName, name, field, optional, field)
+		return makeScalarField(packageName, messageName, name, field, optional, field)
 	case "object":
 		return makeObjectField(model, packageName, messageName, name, field)
 	case "array":
@@ -415,13 +417,14 @@ func makeField(model *api.API, packageName, messageName, name string, optional b
 	}
 }
 
-func makeScalarField(messageName, name string, schema *base.Schema, optional bool, field *base.Schema) (*api.Field, error) {
+func makeScalarField(packageName, messageName, name string, schema *base.Schema, optional bool, field *base.Schema) (*api.Field, error) {
 	typez, typezID, err := scalarType(messageName, name, schema)
 	if err != nil {
 		return nil, err
 	}
 	return &api.Field{
 		Name:          name,
+		ID:            fmt.Sprintf(".%s.%s.%s", packageName, messageName, name),
 		JSONName:      name, // OpenAPI field names are always camelCase
 		Documentation: field.Description,
 		Typez:         typez,
@@ -447,6 +450,7 @@ func makeObjectField(model *api.API, packageName, messageName, name string, fiel
 			// Untyped message fields are .google.protobuf.Any
 			return &api.Field{
 				Name:          name,
+				ID:            fmt.Sprintf(".%s.%s.%s", packageName, messageName, name),
 				JSONName:      name, // OpenAPI field names are always camelCase
 				Documentation: field.Description,
 				Deprecated:    field.Deprecated != nil && *field.Deprecated,
@@ -461,6 +465,7 @@ func makeObjectField(model *api.API, packageName, messageName, name string, fiel
 		}
 		return &api.Field{
 			Name:          name,
+			ID:            fmt.Sprintf(".%s.%s.%s", packageName, messageName, name),
 			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
 			Deprecated:    field.Deprecated != nil && *field.Deprecated,
@@ -476,6 +481,7 @@ func makeObjectField(model *api.API, packageName, messageName, name string, fiel
 		typezID := fmt.Sprintf(".%s.%s", packageName, strings.TrimPrefix(proxy.GetReference(), "#/components/schemas/"))
 		return &api.Field{
 			Name:          name,
+			ID:            fmt.Sprintf(".%s.%s.%s", packageName, messageName, name),
 			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
 			Deprecated:    field.Deprecated != nil && *field.Deprecated,
@@ -502,12 +508,13 @@ func makeArrayField(model *api.API, packageName, messageName, name string, field
 	var result *api.Field
 	switch schema.Type[0] {
 	case "boolean", "integer", "number", "string":
-		result, err = makeScalarField(messageName, name, schema, false, field)
+		result, err = makeScalarField(packageName, messageName, name, schema, false, field)
 	case "object":
 		typezID := fmt.Sprintf(".%s.%s", packageName, strings.TrimPrefix(reference, "#/components/schemas/"))
 		if len(typezID) > 0 {
 			new := &api.Field{
 				Name:          name,
+				ID:            fmt.Sprintf(".%s.%s.%s", packageName, messageName, name),
 				JSONName:      name, // OpenAPI field names are always camelCase
 				Documentation: field.Description,
 				Deprecated:    field.Deprecated != nil && *field.Deprecated,
@@ -535,6 +542,7 @@ func makeObjectFieldAllOf(packageName, messageName, name string, field *base.Sch
 		typezID := fmt.Sprintf(".%s.%s", packageName, strings.TrimPrefix(proxy.GetReference(), "#/components/schemas/"))
 		return &api.Field{
 			Name:          name,
+			ID:            fmt.Sprintf(".%s.%s.%s", packageName, messageName, name),
 			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
 			Deprecated:    field.Deprecated != nil && *field.Deprecated,

--- a/internal/sidekick/parser/openapi_test.go
+++ b/internal/sidekick/parser/openapi_test.go
@@ -131,66 +131,78 @@ func TestOpenAPI_BasicTypes(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:     "fBool",
+				ID:       "..Fake.fBool",
 				JSONName: "fBool",
 				Typez:    api.TypezBool,
 				TypezID:  "bool",
 			},
 			{
 				Name:     "fInt64",
+				ID:       "..Fake.fInt64",
 				JSONName: "fInt64",
 				Typez:    api.TypezInt64,
 				TypezID:  "int64",
 			},
 			{
 				Name:     "fInt32",
+				ID:       "..Fake.fInt32",
 				JSONName: "fInt32",
 				Typez:    api.TypezInt32,
 				TypezID:  "int32",
 			},
 			{
 				Name:     "fUInt32",
+				ID:       "..Fake.fUInt32",
 				JSONName: "fUInt32",
 				Typez:    api.TypezUint32,
 				TypezID:  "uint32",
 			},
 			{
 				Name:     "fFloat",
+				ID:       "..Fake.fFloat",
 				JSONName: "fFloat",
 				Typez:    api.TypezFloat,
 				TypezID:  "float",
 			},
 			{
 				Name:     "fDouble",
+				ID:       "..Fake.fDouble",
 				JSONName: "fDouble",
 				Typez:    api.TypezDouble,
 				TypezID:  "double",
 			},
 			{
 				Name:     "fString",
+				ID:       "..Fake.fString",
 				JSONName: "fString",
 				Typez:    api.TypezString,
 				TypezID:  "string",
 			},
 			{
 				Name:     "fOptional",
+				ID:       "..Fake.fOptional",
 				JSONName: "fOptional",
 				Typez:    api.TypezString,
 				TypezID:  "string",
-				Optional: true},
+				Optional: true,
+			},
 			{
 				Name:     "fSInt64",
+				ID:       "..Fake.fSInt64",
 				JSONName: "fSInt64",
 				Typez:    api.TypezInt64,
 				TypezID:  "int64",
 			},
 			{
 				Name:     "fSUInt64",
+				ID:       "..Fake.fSUInt64",
 				JSONName: "fSUInt64",
 				Typez:    api.TypezUint64,
 				TypezID:  "uint64",
 			},
 			{
 				Name:     "fDuration",
+				ID:       "..Fake.fDuration",
 				JSONName: "fDuration",
 				Typez:    api.TypezMessage,
 				TypezID:  ".google.protobuf.Duration",
@@ -198,6 +210,7 @@ func TestOpenAPI_BasicTypes(t *testing.T) {
 			},
 			{
 				Name:     "fTimestamp",
+				ID:       "..Fake.fTimestamp",
 				JSONName: "fTimestamp",
 				Typez:    api.TypezMessage,
 				TypezID:  ".google.protobuf.Timestamp",
@@ -205,6 +218,7 @@ func TestOpenAPI_BasicTypes(t *testing.T) {
 			},
 			{
 				Name:     "fFieldMask",
+				ID:       "..Fake.fFieldMask",
 				JSONName: "fFieldMask",
 				Typez:    api.TypezMessage,
 				TypezID:  ".google.protobuf.FieldMask",
@@ -212,6 +226,7 @@ func TestOpenAPI_BasicTypes(t *testing.T) {
 			},
 			{
 				Name:     "fBytes",
+				ID:       "..Fake.fBytes",
 				JSONName: "fBytes",
 				Typez:    api.TypezBytes,
 				TypezID:  "bytes",
@@ -264,48 +279,56 @@ func TestOpenAPI_ArrayTypes(t *testing.T) {
 			{
 				Repeated: true,
 				Name:     "fBool",
+				ID:       "..Fake.fBool",
 				JSONName: "fBool",
 				Typez:    api.TypezBool,
 				TypezID:  "bool"},
 			{
 				Repeated: true,
 				Name:     "fInt64",
+				ID:       "..Fake.fInt64",
 				JSONName: "fInt64",
 				Typez:    api.TypezInt64,
 				TypezID:  "int64"},
 			{
 				Repeated: true,
 				Name:     "fInt32",
+				ID:       "..Fake.fInt32",
 				JSONName: "fInt32",
 				Typez:    api.TypezInt32,
 				TypezID:  "int32"},
 			{
 				Repeated: true,
 				Name:     "fUInt32",
+				ID:       "..Fake.fUInt32",
 				JSONName: "fUInt32",
 				Typez:    api.TypezUint32,
 				TypezID:  "uint32"},
 			{
 				Repeated: true,
 				Name:     "fString",
+				ID:       "..Fake.fString",
 				JSONName: "fString",
 				Typez:    api.TypezString,
 				TypezID:  "string"},
 			{
 				Repeated: true,
 				Name:     "fSInt64",
+				ID:       "..Fake.fSInt64",
 				JSONName: "fSInt64",
 				Typez:    api.TypezInt64,
 				TypezID:  "int64"},
 			{
 				Repeated: true,
 				Name:     "fSUInt64",
+				ID:       "..Fake.fSUInt64",
 				JSONName: "fSUInt64",
 				Typez:    api.TypezUint64,
 				TypezID:  "uint64"},
 			{
 				Repeated: true,
 				Name:     "fDuration",
+				ID:       "..Fake.fDuration",
 				JSONName: "fDuration",
 				Typez:    api.TypezMessage,
 				TypezID:  ".google.protobuf.Duration",
@@ -313,6 +336,7 @@ func TestOpenAPI_ArrayTypes(t *testing.T) {
 			{
 				Repeated: true,
 				Name:     "fTimestamp",
+				ID:       "..Fake.fTimestamp",
 				JSONName: "fTimestamp",
 				Typez:    api.TypezMessage,
 				TypezID:  ".google.protobuf.Timestamp",
@@ -320,6 +344,7 @@ func TestOpenAPI_ArrayTypes(t *testing.T) {
 			{
 				Repeated: true,
 				Name:     "fFieldMask",
+				ID:       "..Fake.fFieldMask",
 				JSONName: "fFieldMask",
 				Typez:    api.TypezMessage,
 				TypezID:  ".google.protobuf.FieldMask",
@@ -327,6 +352,7 @@ func TestOpenAPI_ArrayTypes(t *testing.T) {
 			{
 				Repeated: true,
 				Name:     "fBytes",
+				ID:       "..Fake.fBytes",
 				JSONName: "fBytes",
 				Typez:    api.TypezBytes,
 				TypezID:  "bytes",
@@ -373,6 +399,7 @@ func TestOpenAPI_SimpleObject(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "fObject",
+				ID:            "..Fake.fObject",
 				JSONName:      "fObject",
 				Typez:         api.TypezMessage,
 				TypezID:       "..Foo",
@@ -381,6 +408,7 @@ func TestOpenAPI_SimpleObject(t *testing.T) {
 			},
 			{
 				Name:          "fObjectArray",
+				ID:            "..Fake.fObjectArray",
 				JSONName:      "fObjectArray",
 				Typez:         api.TypezMessage,
 				TypezID:       "..Bar",
@@ -418,7 +446,7 @@ func TestOpenAPI_Any(t *testing.T) {
 		ID:            "..Fake",
 		Documentation: "A test message.",
 		Fields: []*api.Field{
-			{Name: "fMap", JSONName: "fMap", Typez: api.TypezMessage, TypezID: ".google.protobuf.Any", Optional: true},
+			{Name: "fMap", ID: "..Fake.fMap", JSONName: "fMap", Typez: api.TypezMessage, TypezID: ".google.protobuf.Any", Optional: true},
 		},
 	})
 }
@@ -453,6 +481,7 @@ func TestOpenAPI_MapString(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:     "fMap",
+				ID:       "..Fake.fMap",
 				JSONName: "fMap",
 				Typez:    api.TypezMessage,
 				TypezID:  "$map<string, string>",
@@ -460,6 +489,7 @@ func TestOpenAPI_MapString(t *testing.T) {
 			},
 			{
 				Name:     "fMapS32",
+				ID:       "..Fake.fMapS32",
 				JSONName: "fMapS32",
 				Typez:    api.TypezMessage,
 				TypezID:  "$map<string, int32>",
@@ -467,6 +497,7 @@ func TestOpenAPI_MapString(t *testing.T) {
 			},
 			{
 				Name:     "fMapS64",
+				ID:       "..Fake.fMapS64",
 				JSONName: "fMapS64",
 				Typez:    api.TypezMessage,
 				TypezID:  "$map<string, int64>",
@@ -505,6 +536,7 @@ func TestOpenAPI_MapInteger(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:     "fMapI32",
+				ID:       "..Fake.fMapI32",
 				JSONName: "fMapI32",
 				Typez:    api.TypezMessage,
 				TypezID:  "$map<string, int32>",
@@ -513,6 +545,7 @@ func TestOpenAPI_MapInteger(t *testing.T) {
 			},
 			{
 				Name:     "fMapI64",
+				ID:       "..Fake.fMapI64",
 				JSONName: "fMapI64",
 				Typez:    api.TypezMessage,
 				TypezID:  "$map<string, int64>",
@@ -556,6 +589,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "name",
+				ID:            "..Location.name",
 				JSONName:      "name",
 				Documentation: "Resource name for the location, which may vary between implementations." + "\nFor example: `\"projects/example-project/locations/us-east1\"`",
 				Typez:         api.TypezString,
@@ -564,6 +598,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "locationId",
+				ID:            "..Location.locationId",
 				JSONName:      "locationId",
 				Documentation: "The canonical id for this location. For example: `\"us-east1\"`.",
 				Typez:         api.TypezString,
@@ -572,6 +607,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "displayName",
+				ID:            "..Location.displayName",
 				JSONName:      "displayName",
 				Documentation: `The friendly name for this location, typically a nearby city name.` + "\n" + `For example, "Tokyo".`,
 				Typez:         api.TypezString,
@@ -580,6 +616,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "labels",
+				ID:            "..Location.labels",
 				JSONName:      "labels",
 				Documentation: "Cross-service attributes for the location. For example\n\n    {\"cloud.googleapis.com/region\": \"us-east1\"}",
 				Typez:         api.TypezMessage,
@@ -589,6 +626,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "metadata",
+				ID:            "..Location.metadata",
 				JSONName:      "metadata",
 				Documentation: `Service-specific metadata. For example the available capacity at the given` + "\n" + `location.`,
 				Typez:         api.TypezMessage,
@@ -610,6 +648,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "locations",
+				ID:            "..ListLocationsResponse.locations",
 				JSONName:      "locations",
 				Documentation: "A list of locations that matches the specified filter in the request.",
 				Typez:         api.TypezMessage,
@@ -618,6 +657,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "nextPageToken",
+				ID:            "..ListLocationsResponse.nextPageToken",
 				JSONName:      "nextPageToken",
 				Documentation: "The standard List next-page token.",
 				Typez:         api.TypezString,
@@ -628,6 +668,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		Pagination: &api.PaginationInfo{
 			NextPageToken: &api.Field{
 				Name:          "nextPageToken",
+				ID:            "..ListLocationsResponse.nextPageToken",
 				JSONName:      "nextPageToken",
 				Documentation: "The standard List next-page token.",
 				Typez:         api.TypezString,
@@ -636,6 +677,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			PageableItem: &api.Field{
 				Name:          "locations",
+				ID:            "..ListLocationsResponse.locations",
 				JSONName:      "locations",
 				Documentation: "A list of locations that matches the specified filter in the request.",
 				Typez:         api.TypezMessage,
@@ -655,6 +697,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "project",
+				ID:            "..Service.ListLocationsRequest.project",
 				JSONName:      "project",
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations`.",
 				Typez:         api.TypezString,
@@ -663,6 +706,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:     "filter",
+				ID:       "..Service.ListLocationsRequest.filter",
 				JSONName: "filter",
 				Documentation: "A filter to narrow down results to a preferred subset." +
 					"\nThe filtering language accepts strings like `\"displayName=tokyo" +
@@ -674,6 +718,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "pageSize",
+				ID:            "..Service.ListLocationsRequest.pageSize",
 				JSONName:      "pageSize",
 				Documentation: "The maximum number of results to return.\nIf not set, the service selects a default.",
 				Typez:         api.TypezInt32,
@@ -682,6 +727,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "pageToken",
+				ID:            "..Service.ListLocationsRequest.pageToken",
 				JSONName:      "pageToken",
 				Documentation: "A page token received from the `next_page_token` field in the response.\nSend that page token to receive the subsequent page.",
 				Typez:         api.TypezString,
@@ -745,6 +791,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		},
 		Pagination: &api.Field{
 			Name:          "pageToken",
+			ID:            "..Service.ListLocationsRequest.pageToken",
 			JSONName:      "pageToken",
 			Documentation: "A page token received from the `next_page_token` field in the response.\nSend that page token to receive the subsequent page.",
 			Typez:         api.TypezString,
@@ -856,6 +903,7 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "project",
+				ID:            "..Service.SetIamPolicyByProjectAndLocationAndSecretRequest.project",
 				JSONName:      "project",
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.TypezString,
@@ -864,6 +912,7 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 			},
 			{
 				Name:          "location",
+				ID:            "..Service.SetIamPolicyByProjectAndLocationAndSecretRequest.location",
 				JSONName:      "location",
 				Documentation: "The `{location}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.TypezString,
@@ -872,6 +921,7 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 			},
 			{
 				Name:          "secret",
+				ID:            "..Service.SetIamPolicyByProjectAndLocationAndSecretRequest.secret",
 				JSONName:      "secret",
 				Documentation: "The `{secret}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.TypezString,
@@ -880,6 +930,7 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 			},
 			{
 				Name:          "body",
+				ID:            "..Service.SetIamPolicyByProjectAndLocationAndSecretRequest.body",
 				JSONName:      "body",
 				Documentation: "The request body.",
 				Typez:         api.TypezMessage,
@@ -903,6 +954,7 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "project",
+				ID:            "..Service.SetIamPolicyRequest.project",
 				JSONName:      "project",
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.TypezString,
@@ -911,6 +963,7 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 			},
 			{
 				Name:          "secret",
+				ID:            "..Service.SetIamPolicyRequest.secret",
 				JSONName:      "secret",
 				Documentation: "The `{secret}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/secrets/{secret}:setIamPolicy`.",
 				Typez:         api.TypezString,
@@ -919,6 +972,7 @@ func TestOpenAPI_SyntheticMessageWithExistingBody(t *testing.T) {
 			},
 			{
 				Name:          "body",
+				ID:            "..Service.SetIamPolicyRequest.body",
 				JSONName:      "body",
 				Documentation: "The request body.",
 				Typez:         api.TypezMessage,
@@ -979,6 +1033,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 				},
 				Pagination: &api.Field{
 					Name:          "pageToken",
+					ID:            "..Service.ListFoosRequest.pageToken",
 					JSONName:      "pageToken",
 					Documentation: "The `{pageToken}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/foos`.",
 					Typez:         api.TypezString,
@@ -999,6 +1054,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:     "nextPageToken",
+				ID:       "..ListFoosResponse.nextPageToken",
 				Typez:    9,
 				TypezID:  "string",
 				JSONName: "nextPageToken",
@@ -1006,6 +1062,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 			},
 			{
 				Name:     "secrets",
+				ID:       "..ListFoosResponse.secrets",
 				Typez:    api.TypezMessage,
 				TypezID:  "..Foo",
 				JSONName: "secrets",
@@ -1015,6 +1072,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 		Pagination: &api.PaginationInfo{
 			NextPageToken: &api.Field{
 				Name:     "nextPageToken",
+				ID:       "..ListFoosResponse.nextPageToken",
 				Typez:    9,
 				TypezID:  "string",
 				JSONName: "nextPageToken",
@@ -1022,6 +1080,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 			},
 			PageableItem: &api.Field{
 				Name:     "secrets",
+				ID:       "..ListFoosResponse.secrets",
 				Typez:    api.TypezMessage,
 				TypezID:  "..Foo",
 				JSONName: "secrets",
@@ -1074,6 +1133,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 
 	request_id := &api.Field{
 		Name:          "requestId",
+		ID:            ".test.TestService.CreateFooRequest.requestId",
 		JSONName:      "requestId",
 		Documentation: "Test-only Description",
 		Typez:         api.TypezString,
@@ -1083,6 +1143,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 	}
 	request_id_explicit := &api.Field{
 		Name:          "requestIdExplicitlyNotRequired",
+		ID:            ".test.TestService.CreateFooRequest.requestIdExplicitlyNotRequired",
 		JSONName:      "requestIdExplicitlyNotRequired",
 		Documentation: "Test-only Description",
 		Typez:         api.TypezString,
@@ -1099,6 +1160,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:          "project",
+				ID:            ".test.TestService.CreateFooRequest.project",
 				JSONName:      "project",
 				Documentation: "The `{project}` component of the target path.\n\nThe full target path will be in the form `/v1/projects/{project}/foos`.",
 				Typez:         api.TypezString,
@@ -1107,6 +1169,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 			},
 			{
 				Name:          "fooId",
+				ID:            ".test.TestService.CreateFooRequest.fooId",
 				JSONName:      "fooId",
 				Documentation: "Test-only Description",
 				Typez:         api.TypezString,
@@ -1117,6 +1180,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 			request_id_explicit,
 			{
 				Name:          "notRequestIdRequired",
+				ID:            ".test.TestService.CreateFooRequest.notRequestIdRequired",
 				Documentation: "Test-only Description",
 				Typez:         api.TypezString,
 				TypezID:       "string",
@@ -1125,6 +1189,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 			},
 			{
 				Name:          "notRequestIdMissingFormat",
+				ID:            ".test.TestService.CreateFooRequest.notRequestIdMissingFormat",
 				Documentation: "Test-only Description",
 				Typez:         api.TypezString,
 				TypezID:       "string",
@@ -1133,6 +1198,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 			},
 			{
 				Name:          "notRequestIdMissingServiceConfig",
+				ID:            ".test.TestService.CreateFooRequest.notRequestIdMissingServiceConfig",
 				Documentation: "Test-only Description",
 				Typez:         api.TypezString,
 				TypezID:       "string",
@@ -1233,6 +1299,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:     "name",
+				ID:       "..Response.name",
 				Typez:    api.TypezString,
 				TypezID:  "string",
 				JSONName: "name",
@@ -1240,6 +1307,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 			},
 			{
 				Name:       "other",
+				ID:         "..Response.other",
 				Typez:      api.TypezString,
 				TypezID:    "string",
 				JSONName:   "other",
@@ -1261,6 +1329,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		Fields: []*api.Field{
 			{
 				Name:     "name",
+				ID:       "..DeprecatedMessage.name",
 				Typez:    api.TypezString,
 				TypezID:  "string",
 				JSONName: "name",

--- a/internal/sidekick/rust/annotate_field.go
+++ b/internal/sidekick/rust/annotate_field.go
@@ -22,17 +22,6 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/language"
 )
 
-var (
-	// The annotations print a warning when generating code that converts between sidekick-gencode
-	// and Prost-gencode **and** has a field of type Any. The warning is suppressed for some
-	//  well-known cases where we decided it was fine.
-	suppressProstConvertAndAnyWarnings = map[string]struct{}{
-		".google.rpc.Status":                           {},
-		".google.longrunning.Operation":                {},
-		".google.storage.control.v2.ObjectFullContext": {},
-	}
-)
-
 type fieldAnnotations struct {
 	// In Rust, message fields are fields inside a struct. These must be
 	// `snake_case`. Possibly mangled with `r#` if the name is a Rust reserved
@@ -205,11 +194,6 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 	primitiveFieldType, err := c.fieldType(field, model, true, model.PackageName)
 	if err != nil {
 		return nil, err
-	}
-	if field.TypezID == api.WktAnyID && c.templateOverride == templateConvertProst {
-		if _, ok := suppressProstConvertAndAnyWarnings[message.ID]; !ok {
-			fmt.Printf("WARNING: unknown field of type wkt::Any, conversion skipped, consider ad-hoc code, message: %s\n", message.ID)
-		}
 	}
 	ann := &fieldAnnotations{
 		FieldName:          toSnake(field.Name),

--- a/internal/sidekick/rust/generate.go
+++ b/internal/sidekick/rust/generate.go
@@ -27,10 +27,6 @@ import (
 //go:embed all:templates
 var templates embed.FS
 
-const (
-	templateConvertProst = "templates/convert-prost"
-)
-
 // Generate generates Rust code from the model.
 func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.ModelConfig) error {
 	c, err := newCodec(cfg.SpecificationFormat, cfg.Codec)

--- a/internal/sidekick/rust/generate_convert_test.go
+++ b/internal/sidekick/rust/generate_convert_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	libconfig "github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerateConvert(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		message    *api.Message
+		skippedIDs []string
+		want       string
+	}{
+		{
+			name: "simple message with two string fields",
+			message: &api.Message{
+				Name:    "SimpleMessage",
+				Package: "test.v1",
+				ID:      ".test.v1.SimpleMessage",
+				Fields: []*api.Field{
+					{
+						Name:     "field1",
+						JSONName: "field1",
+						ID:       ".test.v1.SimpleMessage.field1",
+						Typez:    api.TypezString,
+					},
+					{
+						Name:     "field2",
+						JSONName: "field2",
+						ID:       ".test.v1.SimpleMessage.field2",
+						Typez:    api.TypezString,
+					},
+				},
+			},
+			want: `impl gaxi::prost::ToProto<SimpleMessage> for crate::model::SimpleMessage {
+    type Output = SimpleMessage;
+    fn to_proto(self) -> std::result::Result<SimpleMessage, gaxi::prost::ConvertError> {
+        Ok(Self::Output {
+            field1: self.field1.to_proto()?,
+            field2: self.field2.to_proto()?,
+        })
+    }
+}
+
+impl gaxi::prost::FromProto<crate::model::SimpleMessage> for SimpleMessage {
+    fn cnv(self) -> std::result::Result<crate::model::SimpleMessage, gaxi::prost::ConvertError> {
+        Ok(
+            crate::model::SimpleMessage::new()
+                .set_field1(self.field1)
+                .set_field2(self.field2)
+        )
+    }
+}`,
+		},
+		{
+			name: "message with two singular string fields and one skipped",
+			message: &api.Message{
+				Name:    "MessageWithSkippedString",
+				Package: "test.v1",
+				ID:      ".test.v1.MessageWithSkippedString",
+				Fields: []*api.Field{
+					{
+						Name:     "field1",
+						JSONName: "field1",
+						ID:       ".test.v1.MessageWithSkippedString.field1",
+						Typez:    api.TypezString,
+					},
+					{
+						Name:     "field2",
+						JSONName: "field2",
+						ID:       ".test.v1.MessageWithSkippedString.field2",
+						Typez:    api.TypezString,
+					},
+				},
+			},
+			skippedIDs: []string{".test.v1.MessageWithSkippedString.field2"},
+			want: `impl gaxi::prost::ToProto<MessageWithSkippedString> for crate::model::MessageWithSkippedString {
+    type Output = MessageWithSkippedString;
+    fn to_proto(self) -> std::result::Result<MessageWithSkippedString, gaxi::prost::ConvertError> {
+        Ok(Self::Output {
+            field1: self.field1.to_proto()?,
+            ..Self::Output::default()
+        })
+    }
+}
+
+impl gaxi::prost::FromProto<crate::model::MessageWithSkippedString> for MessageWithSkippedString {
+    fn cnv(self) -> std::result::Result<crate::model::MessageWithSkippedString, gaxi::prost::ConvertError> {
+        Ok(
+            crate::model::MessageWithSkippedString::new()
+                .set_field1(self.field1)
+        )
+    }
+}`,
+		},
+		{
+			name: "message with skipped any field",
+			message: &api.Message{
+				Name:    "MessageWithSkippedAny",
+				Package: "test.v1",
+				ID:      ".test.v1.MessageWithSkippedAny",
+				Fields: []*api.Field{
+					{
+						Name:     "field1",
+						JSONName: "field1",
+						ID:       ".test.v1.MessageWithSkippedAny.field1",
+						Typez:    api.TypezString,
+					},
+					{
+						Name:     "field2",
+						JSONName: "field2",
+						ID:       ".test.v1.MessageWithSkippedAny.field2",
+						Typez:    api.TypezMessage,
+						TypezID:  api.WktAnyID,
+					},
+				},
+			},
+			skippedIDs: []string{".test.v1.MessageWithSkippedAny.field2"},
+			want: `impl gaxi::prost::ToProto<MessageWithSkippedAny> for crate::model::MessageWithSkippedAny {
+    type Output = MessageWithSkippedAny;
+    fn to_proto(self) -> std::result::Result<MessageWithSkippedAny, gaxi::prost::ConvertError> {
+        Ok(Self::Output {
+            field1: self.field1.to_proto()?,
+            ..Self::Output::default()
+        })
+    }
+}
+
+impl gaxi::prost::FromProto<crate::model::MessageWithSkippedAny> for MessageWithSkippedAny {
+    fn cnv(self) -> std::result::Result<crate::model::MessageWithSkippedAny, gaxi::prost::ConvertError> {
+        Ok(
+            crate::model::MessageWithSkippedAny::new()
+                .set_field1(self.field1)
+        )
+    }
+}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			model := api.NewTestAPI([]*api.Message{test.message}, []*api.Enum{}, []*api.Service{})
+			model.PackageName = "test.v1"
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
+			if len(test.skippedIDs) > 0 {
+				if err := api.SkipModelElements(model, api.ModelOverride{SkippedIDs: test.skippedIDs}); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cfg := &parser.ModelConfig{
+				SpecificationFormat: libconfig.SpecProtobuf,
+				Codec: map[string]string{
+					"package:wkt":       "source=google.protobuf,package=google-cloud-wkt",
+					"template-override": "templates/convert-prost",
+				},
+			}
+			if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+				t.Fatal(err)
+			}
+
+			contents, err := os.ReadFile(filepath.Join(outDir, "convert.rs"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := extractBlock(t, string(contents), "impl gaxi::prost::ToProto<"+test.message.Name+">", "\n        )\n    }\n}")
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/templates/convert-prost/message.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/message.mustache
@@ -31,10 +31,6 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
         Ok(Self::Output {
             {{#Codec.BasicFields}}
             {{#Singular}}
-            {{#IsWktAny}}
-            {{Codec.FieldName}}: None,
-            {{/IsWktAny}}
-            {{^IsWktAny}}
             {{^Optional}}
             {{Codec.FieldName}}: self.{{Codec.FieldName}}.to_proto()?,
             {{/Optional}}
@@ -46,7 +42,6 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
             {{Codec.FieldName}}: self.{{Codec.FieldName}}.map(|v| v.to_proto().map(std::boxed::Box::new)).transpose()?,
             {{/Codec.MapToBoxed}}
             {{/Optional}}
-            {{/IsWktAny}}
             {{/Singular}}
             {{! A sequence or map with `google.protobuf.Any` is unlikely. If it ever happens, we see a break and fix it with more understanding }}
             {{#Repeated}}
@@ -66,6 +61,9 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
             {{#OneOfs}}
             {{Codec.FieldName}}: self.{{Codec.FieldName}}.map(|v| v.to_proto()).transpose()?,
             {{/OneOfs}}
+            {{#HasSkippedFields}}
+            ..Self::Output::default()
+            {{/HasSkippedFields}}
         })
     }
 }
@@ -77,14 +75,12 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} 
             {{Codec.QualifiedName}}::new()
                 {{#Codec.BasicFields}}
                 {{#Singular}}
-                {{^IsWktAny}}
                 {{^Optional}}
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}})
                 {{/Optional}}
                 {{#Optional}}
                 .set_or_clear_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()).transpose()?)
                 {{/Optional}}
-                {{/IsWktAny}}
                 {{/Singular}}
                 {{! A sequence or map with `google.protobuf.Any` is unlikely. If it ever happens, we see a break and fix it with more understanding }}
                 {{#Repeated}}


### PR DESCRIPTION
Sometimes we just need to skip one field, this adds support to do so. When we do remove a field, the data model preserves the removed fields. This is useful to generate slightly different code in the Sidekick-codegen <-> Prost-codegen functions.

Fixes #7252 and towards https://github.com/googleapis/google-cloud-rust/issues/6353 to see the effect on Rust: https://github.com/googleapis/google-cloud-rust/pull/6415 