### PR TITLE
fix(sidekick/rust): lints in generated code

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -265,7 +265,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
                 req_stream,
                 options.into(),
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
-                &x_goog_request_params,
+                x_goog_request_params,
             )
             .await?;`,
 		},

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -189,7 +189,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 req_stream,
                 options.into(),
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
-                &x_goog_request_params,
+                x_goog_request_params,
             )
             .await?;
 


### PR DESCRIPTION
This change fixes lints in the generated code, specifically:

```
error: this expression creates a reference which is immediately
dereferenced by the compiler
--> src/generated/showcase/src/transport.rs:1832:17
     |
1832 |                 &x_goog_request_params,
     |                 ^^^^^^^^^^^^^^^^^^^^^^ help: change this to:
`x_goog_request_params`
     |
     = help: for further information visit
https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#needless_borrow
     = note: `-D clippy::needless-borrow` implied by `-D warnings`
```