### PR TITLE
feat(sidekick/rust): add samples for bidi streaming methods and builders

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -71,6 +71,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		Codec: map[string]string{
 			"package:wkt":                    "source=google.protobuf,package=google-cloud-wkt",
 			"include-bidi-streaming-methods": "true",
+			"generate-rpc-samples":           "true",
 		},
 	}
 	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
@@ -97,6 +98,75 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		endStr   string
 		want     string
 	}{
+		{
+			name:     "client: method docstring and example",
+			file:     "src/client.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    ///\n    /// # Example",
+			endStr:   "        super::builder::protocol::Chat::new(self.inner.clone())\n    }",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    ///
+    /// # Example
+    /// ` + "```" + `
+    /// # use google_cloud_test_v1::client::Protocol;
+    /// # use google_cloud_test_v1::model::Request;
+    /// use google_cloud_test_v1::Result;
+    /// async fn sample(
+    ///    client: &Protocol
+    /// ) -> Result<()> {
+    ///     let (sender, mut receiver) = client.chat()
+    ///         .with_request(Request::default())
+    ///         .send()
+    ///         .await?;
+    ///
+    ///     sender.send(Request::default()).await?;
+    ///     drop(sender); // Half-close the stream
+    ///
+    ///     while let Some(response) = receiver.recv().await {
+    ///         let response = response?;
+    ///         println!("response {:?}", response);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ` + "```" + `
+    pub fn chat(&self) -> super::builder::protocol::Chat
+    {
+        super::builder::protocol::Chat::new(self.inner.clone())
+    }`,
+		},
+		{
+			name:     "builder: struct docstring and example",
+			file:     "src/builder.rs",
+			startStr: "    /// The request builder for [Protocol::chat][crate::client::Protocol::chat] calls.\n    ///\n    /// # Example",
+			endStr:   "    #[cfg(google_cloud_unstable_gapic_streaming)]",
+			want: `    /// The request builder for [Protocol::chat][crate::client::Protocol::chat] calls.
+    ///
+    /// # Example
+    /// ` + "```" + `
+    /// # use google_cloud_test_v1::builder::protocol::Chat;
+    /// # use google_cloud_test_v1::model::Request;
+    /// # async fn sample() -> google_cloud_test_v1::Result<()> {
+    /// let builder = prepare_request_builder();
+    /// let (sender, mut receiver) = builder
+    ///     .with_request(Request::default())
+    ///     .send()
+    ///     .await?;
+    ///
+    /// sender.send(Request::default()).await?;
+    /// drop(sender); // Half-close the stream
+    ///
+    /// while let Some(response) = receiver.recv().await {
+    ///     let response = response?;
+    ///     println!("response {:?}", response);
+    /// }
+    /// # Ok(()) }
+    ///
+    /// fn prepare_request_builder() -> Chat {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ` + "```" + `
+    #[cfg(google_cloud_unstable_gapic_streaming)]`,
+		},
 		{
 			name:     "builder: struct definition",
 			file:     "src/builder.rs",

--- a/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
@@ -29,4 +29,19 @@ limitations under the License.
 /// }
 /// ```
 {{/IsStreaming}}
+{{#Codec.IsBidiStreaming}}
+///
+/// # Example
+/// ```
+/// # use {{Service.Model.Codec.PackageNamespace}}::client::{{Service.Codec.Name}};
+{{> /templates/common/client_method_samples/use_statements}}
+/// use {{Service.Model.Codec.PackageNamespace}}::Result;
+/// async fn sample(
+{{> /templates/common/client_method_samples/parameters}}
+/// ) -> Result<()> {
+{{> /templates/common/client_method_samples/method_call}}
+///     Ok(())
+/// }
+/// ```
+{{/Codec.IsBidiStreaming}}
 {{/ModelCodec.GenerateRpcSamples}}

--- a/internal/sidekick/rust/templates/common/client_method_samples/method_call.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/method_call.mustache
@@ -13,6 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+{{#Codec.IsBidiStreaming}}
+///     let (sender, mut receiver) = client.{{Codec.Name}}()
+///         .with_request({{InputType.Codec.Name}}::default())
+///         .send()
+///         .await?;
+///
+///     sender.send({{InputType.Codec.Name}}::default()).await?;
+///     drop(sender); // Half-close the stream
+///
+///     while let Some(response) = receiver.recv().await {
+///         let response = response?;
+///         println!("response {:?}", response);
+///     }
+{{/Codec.IsBidiStreaming}}
 {{#IsSimple}}
 {{#ReturnsEmpty}}
 ///     client.{{Codec.Name}}()

--- a/internal/sidekick/rust/templates/common/client_method_samples/use_statements.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/use_statements.mustache
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+{{#Codec.IsBidiStreaming}}
+/// # use {{InputType.Codec.NameInExamples}};
+{{/Codec.IsBidiStreaming}}
 {{#IsLRO}}
 /// use google_cloud_lro::Poller;
 {{/IsLRO}}

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -108,10 +108,24 @@ pub mod {{Codec.ModuleName}} {
     /// # Example
     /// ```
     /// # use {{Model.Codec.PackageNamespace}}::builder::{{Service.Codec.ModuleName}}::{{Codec.BuilderName}};
+    {{#Codec.IsBidiStreaming}}
+    /// # use {{InputType.Codec.NameInExamples}};
+    {{/Codec.IsBidiStreaming}}
     /// # async fn sample() -> {{Model.Codec.PackageNamespace}}::Result<()> {
     {{#Codec.IsBidiStreaming}}
     /// let builder = prepare_request_builder();
-    /// let (sender, mut receiver) = builder.send().await?;
+    /// let (sender, mut receiver) = builder
+    ///     .with_request({{InputType.Codec.Name}}::default())
+    ///     .send()
+    ///     .await?;
+    ///
+    /// sender.send({{InputType.Codec.Name}}::default()).await?;
+    /// drop(sender); // Half-close the stream
+    ///
+    /// while let Some(response) = receiver.recv().await {
+    ///     let response = response?;
+    ///     println!("response {:?}", response);
+    /// }
     {{/Codec.IsBidiStreaming}}
     {{^Codec.IsBidiStreaming}}
     {{#OperationInfo}}


### PR DESCRIPTION
Add examples demonstrate setting the initial request on the builder, stream initiation, sending streaming requests, half-closing the stream, and receiving streaming responses.

For #6835 