### PR TITLE
feat(internal/librarian): allow specifying library name in add command

### DIFF
--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -75,7 +75,7 @@ The <api> is a path within the configured googleapis source, such as
 "google/cloud/secretmanager/v1". The library name and other defaults are
 derived from the first API path using language-specific rules.
 
-When adding a Ruby library, the --library-name flag can be used to explicitly
+When adding a Ruby library, the --name flag can be used to explicitly
 specify the library name.
 
 If the API path should naturally be included in an existing library, and if the
@@ -92,7 +92,7 @@ To add a preview client of an existing library, prefix the API path with
 Examples:
 
 	librarian add google/cloud/secretmanager/v1
-	librarian add google/cloud/secretmanager/v1 --library-name google-cloud-secret_manager-v1
+	librarian add google/cloud/secretmanager/v1 --name google-cloud-secret_manager-v1
 	librarian add preview/google/cloud/secretmanager/v1beta
 
 A typical librarian workflow for adding a new client library is:
@@ -102,7 +102,7 @@ A typical librarian workflow for adding a new client library is:
 
 Flags:
 
-	--library-name string  explicitly specified library name; only applicable for Ruby
+	--name string  explicitly specified library name; only applicable for Ruby
 
 # Generate a client library
 

--- a/cmd/librarian/doc.go
+++ b/cmd/librarian/doc.go
@@ -75,6 +75,9 @@ The <api> is a path within the configured googleapis source, such as
 "google/cloud/secretmanager/v1". The library name and other defaults are
 derived from the first API path using language-specific rules.
 
+When adding a Ruby library, the --library-name flag can be used to explicitly
+specify the library name.
+
 If the API path should naturally be included in an existing library, and if the
 language supports doing so, that library is modified. Otherwise, a new library
 is created.
@@ -89,12 +92,17 @@ To add a preview client of an existing library, prefix the API path with
 Examples:
 
 	librarian add google/cloud/secretmanager/v1
+	librarian add google/cloud/secretmanager/v1 --library-name google-cloud-secret_manager-v1
 	librarian add preview/google/cloud/secretmanager/v1beta
 
 A typical librarian workflow for adding a new client library is:
 
 	librarian add <api>            # onboard a new API into librarian.yaml
 	librarian generate <library>   # generate the client library
+
+Flags:
+
+	--library-name string  explicitly specified library name; only applicable for Ruby
 
 # Generate a client library
 

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -95,21 +95,21 @@ A typical librarian workflow for adding a new client library is:
 			if len(apis) != 1 {
 				return errWrongAPICount
 			}
-			libraryName := c.String("library-name")
+			explicitLibraryName := c.String("library-name")
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}
-			return runAdd(ctx, cfg, apis[0], libraryName)
+			return runAdd(ctx, cfg, apis[0], explicitLibraryName)
 		},
 	}
 }
 
-func runAdd(ctx context.Context, cfg *config.Config, api, libraryName string) error {
-	if libraryName != "" && cfg.Language != config.LanguageRuby {
+func runAdd(ctx context.Context, cfg *config.Config, api, explicitLibraryName string) error {
+	if explicitLibraryName != "" && cfg.Language != config.LanguageRuby {
 		return errLibraryNameOnlyForRuby
 	}
-	name, cfg, err := addLibrary(cfg, api, libraryName)
+	name, cfg, err := addLibrary(cfg, api, explicitLibraryName)
 	if err != nil {
 		return err
 	}
@@ -183,8 +183,6 @@ func deriveLibraryName(language string, api string) string {
 		return nodejs.DefaultLibraryName(api)
 	case config.LanguagePython:
 		return python.DefaultLibraryName(api)
-	case config.LanguageRuby:
-		return ruby.DefaultLibraryName(api)
 	case config.LanguageRust:
 		return rust.DefaultLibraryName(api)
 	case config.LanguageSwift:
@@ -200,10 +198,10 @@ func deriveLibraryName(language string, api string) string {
 // It returns the name of the new or updated library, the updated config, and an
 // error if the API cannot be added (e.g. because it already exists, or the new
 // API is a preview and there is no corresponding stable library).
-func addLibrary(cfg *config.Config, apiPath, libraryName string) (string, *config.Config, error) {
+func addLibrary(cfg *config.Config, apiPath, explicitLibraryName string) (string, *config.Config, error) {
 	stablePath, isPreview := strings.CutPrefix(apiPath, "preview/")
 	api := &config.API{Path: stablePath}
-	existingLib := findExistingLibraryForAPI(cfg, stablePath, libraryName)
+	existingLib := findExistingLibraryForAPI(cfg, stablePath, explicitLibraryName)
 	if isPreview {
 		if existingLib == nil {
 			return "", nil, fmt.Errorf("%w: API path %s", errPreviewRequiresLibrary, apiPath)
@@ -213,7 +211,7 @@ func addLibrary(cfg *config.Config, apiPath, libraryName string) (string, *confi
 	if existingLib != nil {
 		return updateExistingLibrary(cfg, existingLib, api)
 	}
-	return addNewLibrary(cfg, api, libraryName)
+	return addNewLibrary(cfg, api, explicitLibraryName)
 }
 
 // findExistingLibraryForAPI determines if an existing library in cfg is
@@ -222,14 +220,14 @@ func addLibrary(cfg *config.Config, apiPath, libraryName string) (string, *confi
 // by deriving the library name from the API path and seeing if that library
 // already exists. In Python the mapping from API path to library name isn't
 // always as simple for historical reasons.
-func findExistingLibraryForAPI(cfg *config.Config, apiPath, libraryName string) *config.Library {
+func findExistingLibraryForAPI(cfg *config.Config, apiPath, explicitLibraryName string) *config.Library {
 	switch cfg.Language {
 	case config.LanguageNodejs:
 		return nodejs.FindExistingLibraryForNewAPI(cfg.Libraries, apiPath)
 	case config.LanguagePython:
 		return python.FindExistingLibraryForNewAPI(cfg.Libraries, apiPath)
 	default:
-		name := libraryName
+		name := explicitLibraryName
 		if name == "" {
 			name = deriveLibraryName(cfg.Language, apiPath)
 		}
@@ -265,8 +263,8 @@ func addPreviewLibrary(cfg *config.Config, lib *config.Library, api *config.API)
 }
 
 // addNewLibrary adds a new library to the config.
-func addNewLibrary(cfg *config.Config, api *config.API, libraryName string) (string, *config.Config, error) {
-	name := libraryName
+func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName string) (string, *config.Config, error) {
+	name := explicitLibraryName
 	if name == "" {
 		name = deriveLibraryName(cfg.Language, api.Path)
 	}

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -43,6 +43,7 @@ import (
 var (
 	errAPIAlreadyExists       = errors.New("api already exists in library")
 	errLibraryAlreadyExists   = errors.New("library already exists in config")
+	errLibraryNameOnlyForRuby = errors.New("--library-name is only applicable for Ruby")
 	errPreviewAlreadyExists   = errors.New("preview library config already exists")
 	errPreviewRequiresLibrary = errors.New("only APIs with an existing Library can have a Preview")
 	errWrongAPICount          = errors.New("must provide exactly one API path")
@@ -59,6 +60,9 @@ The <api> is a path within the configured googleapis source, such as
 "google/cloud/secretmanager/v1". The library name and other defaults are
 derived from the first API path using language-specific rules.
 
+When adding a Ruby library, the --library-name flag can be used to explicitly
+specify the library name.
+
 If the API path should naturally be included in an existing library, and if the
 language supports doing so, that library is modified. Otherwise, a new library
 is created.
@@ -73,28 +77,39 @@ To add a preview client of an existing library, prefix the API path with
 Examples:
 
 	librarian add google/cloud/secretmanager/v1
+	librarian add google/cloud/secretmanager/v1 --library-name google-cloud-secret_manager-v1
 	librarian add preview/google/cloud/secretmanager/v1beta
 
 A typical librarian workflow for adding a new client library is:
 
 	librarian add <api>            # onboard a new API into librarian.yaml
 	librarian generate <library>   # generate the client library`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "library-name",
+				Usage: "explicitly specified library name; only applicable for Ruby",
+			},
+		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			apis := c.Args().Slice()
 			if len(apis) != 1 {
 				return errWrongAPICount
 			}
+			libraryName := c.String("library-name")
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
 			}
-			return runAdd(ctx, cfg, apis[0])
+			return runAdd(ctx, cfg, apis[0], libraryName)
 		},
 	}
 }
 
-func runAdd(ctx context.Context, cfg *config.Config, api string) error {
-	name, cfg, err := addLibrary(cfg, api)
+func runAdd(ctx context.Context, cfg *config.Config, api, libraryName string) error {
+	if libraryName != "" && cfg.Language != config.LanguageRuby {
+		return errLibraryNameOnlyForRuby
+	}
+	name, cfg, err := addLibrary(cfg, api, libraryName)
 	if err != nil {
 		return err
 	}
@@ -168,6 +183,8 @@ func deriveLibraryName(language string, api string) string {
 		return nodejs.DefaultLibraryName(api)
 	case config.LanguagePython:
 		return python.DefaultLibraryName(api)
+	case config.LanguageRuby:
+		return ruby.DefaultLibraryName(api)
 	case config.LanguageRust:
 		return rust.DefaultLibraryName(api)
 	case config.LanguageSwift:
@@ -183,10 +200,10 @@ func deriveLibraryName(language string, api string) string {
 // It returns the name of the new or updated library, the updated config, and an
 // error if the API cannot be added (e.g. because it already exists, or the new
 // API is a preview and there is no corresponding stable library).
-func addLibrary(cfg *config.Config, apiPath string) (string, *config.Config, error) {
+func addLibrary(cfg *config.Config, apiPath, libraryName string) (string, *config.Config, error) {
 	stablePath, isPreview := strings.CutPrefix(apiPath, "preview/")
 	api := &config.API{Path: stablePath}
-	existingLib := findExistingLibraryForAPI(cfg, stablePath)
+	existingLib := findExistingLibraryForAPI(cfg, stablePath, libraryName)
 	if isPreview {
 		if existingLib == nil {
 			return "", nil, fmt.Errorf("%w: API path %s", errPreviewRequiresLibrary, apiPath)
@@ -196,7 +213,7 @@ func addLibrary(cfg *config.Config, apiPath string) (string, *config.Config, err
 	if existingLib != nil {
 		return updateExistingLibrary(cfg, existingLib, api)
 	}
-	return addNewLibrary(cfg, api)
+	return addNewLibrary(cfg, api, libraryName)
 }
 
 // findExistingLibraryForAPI determines if an existing library in cfg is
@@ -205,14 +222,17 @@ func addLibrary(cfg *config.Config, apiPath string) (string, *config.Config, err
 // by deriving the library name from the API path and seeing if that library
 // already exists. In Python the mapping from API path to library name isn't
 // always as simple for historical reasons.
-func findExistingLibraryForAPI(cfg *config.Config, apiPath string) *config.Library {
+func findExistingLibraryForAPI(cfg *config.Config, apiPath, libraryName string) *config.Library {
 	switch cfg.Language {
 	case config.LanguageNodejs:
 		return nodejs.FindExistingLibraryForNewAPI(cfg.Libraries, apiPath)
 	case config.LanguagePython:
 		return python.FindExistingLibraryForNewAPI(cfg.Libraries, apiPath)
 	default:
-		name := deriveLibraryName(cfg.Language, apiPath)
+		name := libraryName
+		if name == "" {
+			name = deriveLibraryName(cfg.Language, apiPath)
+		}
 		// Not using FindLibrary as the error handling becomes awkward.
 		for _, library := range cfg.Libraries {
 			if library.Name == name {
@@ -245,8 +265,11 @@ func addPreviewLibrary(cfg *config.Config, lib *config.Library, api *config.API)
 }
 
 // addNewLibrary adds a new library to the config.
-func addNewLibrary(cfg *config.Config, api *config.API) (string, *config.Config, error) {
-	name := deriveLibraryName(cfg.Language, api.Path)
+func addNewLibrary(cfg *config.Config, api *config.API, libraryName string) (string, *config.Config, error) {
+	name := libraryName
+	if name == "" {
+		name = deriveLibraryName(cfg.Language, api.Path)
+	}
 	lib := &config.Library{
 		Name:          name,
 		CopyrightYear: strconv.Itoa(time.Now().Year()),

--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -43,7 +43,7 @@ import (
 var (
 	errAPIAlreadyExists       = errors.New("api already exists in library")
 	errLibraryAlreadyExists   = errors.New("library already exists in config")
-	errLibraryNameOnlyForRuby = errors.New("--library-name is only applicable for Ruby")
+	errNameOnlyForRuby        = errors.New("--name is only applicable for Ruby")
 	errPreviewAlreadyExists   = errors.New("preview library config already exists")
 	errPreviewRequiresLibrary = errors.New("only APIs with an existing Library can have a Preview")
 	errWrongAPICount          = errors.New("must provide exactly one API path")
@@ -60,7 +60,7 @@ The <api> is a path within the configured googleapis source, such as
 "google/cloud/secretmanager/v1". The library name and other defaults are
 derived from the first API path using language-specific rules.
 
-When adding a Ruby library, the --library-name flag can be used to explicitly
+When adding a Ruby library, the --name flag can be used to explicitly
 specify the library name.
 
 If the API path should naturally be included in an existing library, and if the
@@ -77,7 +77,7 @@ To add a preview client of an existing library, prefix the API path with
 Examples:
 
 	librarian add google/cloud/secretmanager/v1
-	librarian add google/cloud/secretmanager/v1 --library-name google-cloud-secret_manager-v1
+	librarian add google/cloud/secretmanager/v1 --name google-cloud-secret_manager-v1
 	librarian add preview/google/cloud/secretmanager/v1beta
 
 A typical librarian workflow for adding a new client library is:
@@ -86,7 +86,7 @@ A typical librarian workflow for adding a new client library is:
 	librarian generate <library>   # generate the client library`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "library-name",
+				Name:  "name",
 				Usage: "explicitly specified library name; only applicable for Ruby",
 			},
 		},
@@ -95,7 +95,7 @@ A typical librarian workflow for adding a new client library is:
 			if len(apis) != 1 {
 				return errWrongAPICount
 			}
-			explicitLibraryName := c.String("library-name")
+			explicitLibraryName := c.String("name")
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				return err
@@ -107,7 +107,7 @@ A typical librarian workflow for adding a new client library is:
 
 func runAdd(ctx context.Context, cfg *config.Config, api, explicitLibraryName string) error {
 	if explicitLibraryName != "" && cfg.Language != config.LanguageRuby {
-		return errLibraryNameOnlyForRuby
+		return errNameOnlyForRuby
 	}
 	name, cfg, err := addLibrary(cfg, api, explicitLibraryName)
 	if err != nil {

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -106,7 +106,7 @@ func TestAddLibraryCommand(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
-			err = runAdd(t.Context(), cfg, test.apiPath)
+			err = runAdd(t.Context(), cfg, test.apiPath, "")
 			if test.wantError != nil {
 				if !errors.Is(err, test.wantError) {
 					t.Errorf("expected error %v, got %v", test.wantError, err)
@@ -239,7 +239,7 @@ func TestAddLibrary(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
-			gotName, cfg, err := addLibrary(cfg, test.apiPath)
+			gotName, cfg, err := addLibrary(cfg, test.apiPath, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -418,7 +418,7 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
 				t.Fatal(err)
 			}
-			gotName, gotCfg, err := addLibrary(test.cfg, test.apiPath)
+			gotName, gotCfg, err := addLibrary(test.cfg, test.apiPath, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -467,7 +467,7 @@ func TestAddLibrary_ExistingLibrary_Error(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
 				t.Fatal(err)
 			}
-			_, _, err := addLibrary(test.cfg, test.apiPath)
+			_, _, err := addLibrary(test.cfg, test.apiPath, "")
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}
@@ -503,7 +503,7 @@ func TestAddLibrary_Preview(t *testing.T) {
 				Language:  config.LanguageGo,
 				Libraries: test.initialLibraries,
 			}
-			gotName, gotCfg, err := addLibrary(cfg, test.apiPath)
+			gotName, gotCfg, err := addLibrary(cfg, test.apiPath, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -557,7 +557,7 @@ func TestAddLibrary_Preview_Error(t *testing.T) {
 				Language:  config.LanguageGo,
 				Libraries: test.initialLibraries,
 			}
-			_, _, err := addLibrary(cfg, test.apiPath)
+			_, _, err := addLibrary(cfg, test.apiPath, "")
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}
@@ -594,6 +594,7 @@ func TestDeriveLibraryName(t *testing.T) {
 		{config.LanguagePhp, "google/cloud/secretmanager/v1", "secretmanager"},
 		{config.LanguagePhp, "google/cloud/security/privateca/v1", "security-privateca"},
 		{config.LanguagePhp, "google/pubsub/v1", "pubsub"},
+		{config.LanguageRuby, "google/cloud/secretmanager/v1", "google-cloud-secretmanager-v1"},
 	} {
 		t.Run(test.language+"/"+test.apiPath, func(t *testing.T) {
 			got := deriveLibraryName(test.language, test.apiPath)
@@ -624,7 +625,7 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 		t.Fatal(err)
 	}
 	// developerconnect has Locations mixin in its service.yaml
-	err = runAdd(t.Context(), cfg, "google/cloud/developerconnect/v1")
+	err = runAdd(t.Context(), cfg, "google/cloud/developerconnect/v1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -677,7 +678,7 @@ func TestAddLibraryCommand_Php(t *testing.T) {
 		t.Fatal(err)
 	}
 	// developerconnect has Locations mixin in its service.yaml
-	err = runAdd(t.Context(), cfg, "google/cloud/developerconnect/v1")
+	err = runAdd(t.Context(), cfg, "google/cloud/developerconnect/v1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -761,7 +762,7 @@ func TestAddLibrary_Swift(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
-			err = runAdd(t.Context(), cfg, "google/cloud/secretmanager/v1")
+			err = runAdd(t.Context(), cfg, "google/cloud/secretmanager/v1", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -777,4 +778,180 @@ func TestAddLibrary_Swift(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddLibraryCommand_Ruby(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("explicit library name for versioned and wrapper gems with release please", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+		if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-manifest.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "release-please-config.json"), []byte(`{"packages":{}}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := sample.Config()
+		cfg.Language = config.LanguageRuby
+		cfg.Default.Output = "output"
+		cfg.Libraries = nil
+		cfg.Sources.Googleapis.Dir = googleapisDir
+		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+			t.Fatal(err)
+		}
+
+		// 1. Add versioned gem with custom name
+		if err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"); err != nil {
+			t.Fatal(err)
+		}
+
+		// 2. Add wrapper gem with custom name
+		if err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager", "--library-name", "google-cloud-secret_manager"); err != nil {
+			t.Fatal(err)
+		}
+
+		gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantLibraries := []*config.Library{
+			{
+				Name:          "google-cloud-secret_manager",
+				CopyrightYear: strconv.Itoa(time.Now().Year()),
+				Version:       "0.0.1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v1:0.0"},
+				},
+			},
+			{
+				Name:          "google-cloud-secret_manager-v1",
+				CopyrightYear: strconv.Itoa(time.Now().Year()),
+				Version:       "0.0.1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+		}
+		sort.Slice(gotCfg.Libraries, func(i, j int) bool {
+			return gotCfg.Libraries[i].Name < gotCfg.Libraries[j].Name
+		})
+		if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
+			t.Errorf("libraries mismatch (-want +got):\n%s", diff)
+		}
+
+		// Check Release Please manifest
+		manifest, err := readJSONFile[map[string]string](filepath.Join(tmpDir, ".release-please-manifest.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantManifest := map[string]string{
+			"google-cloud-secret_manager":           "0.0.1",
+			"google-cloud-secret_manager+FILLER":    "0.0.0",
+			"google-cloud-secret_manager-v1":        "0.0.1",
+			"google-cloud-secret_manager-v1+FILLER": "0.0.0",
+		}
+		if diff := cmp.Diff(wantManifest, manifest); diff != "" {
+			t.Errorf("manifest mismatch (-want +got):\n%s", diff)
+		}
+
+		// Check Release Please config
+		rpConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-config.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantRPConfig := map[string]any{
+			"packages": map[string]any{
+				"google-cloud-secret_manager": map[string]any{
+					"component":    "google-cloud-secret_manager",
+					"version_file": "lib/google/cloud/secret_manager/version.rb",
+				},
+				"google-cloud-secret_manager-v1": map[string]any{
+					"component":    "google-cloud-secret_manager-v1",
+					"version_file": "lib/google/cloud/secret_manager/v1/version.rb",
+				},
+			},
+		}
+		if diff := cmp.Diff(wantRPConfig, rpConfig); diff != "" {
+			t.Errorf("release please config mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("default library name without flag", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		cfg := sample.Config()
+		cfg.Language = config.LanguageRuby
+		cfg.Default.Output = "output"
+		cfg.Libraries = nil
+		cfg.Sources.Googleapis.Dir = googleapisDir
+		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1"); err != nil {
+			t.Fatal(err)
+		}
+
+		gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(gotCfg.Libraries) != 1 || gotCfg.Libraries[0].Name != "google-cloud-secretmanager-v1" {
+			t.Errorf("got libraries = %v, want 1 library named google-cloud-secretmanager-v1", gotCfg.Libraries)
+		}
+	})
+
+	t.Run("error when library-name specified for non-ruby language", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		cfg := sample.Config()
+		cfg.Language = config.LanguageGo
+		cfg.Default.Output = "output"
+		cfg.Libraries = nil
+		cfg.Sources.Googleapis.Dir = googleapisDir
+		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+			t.Fatal(err)
+		}
+
+		err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1", "--library-name", "custom-name")
+		if !errors.Is(err, errLibraryNameOnlyForRuby) {
+			t.Fatalf("expected error %v, got %v", errLibraryNameOnlyForRuby, err)
+		}
+	})
+
+	t.Run("error when adding duplicate library name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		cfg := sample.Config()
+		cfg.Language = config.LanguageRuby
+		cfg.Default.Output = "output"
+		cfg.Libraries = []*config.Library{
+			{
+				Name: "google-cloud-secret_manager-v1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+		}
+		cfg.Sources.Googleapis.Dir = googleapisDir
+		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+			t.Fatal(err)
+		}
+
+		err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1")
+		if !errors.Is(err, errAPIAlreadyExists) {
+			t.Fatalf("expected error %v, got %v", errAPIAlreadyExists, err)
+		}
+	})
 }

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -909,7 +909,6 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-
 			manifest := test.initialManifest
 			if manifest == nil {
 				manifest = map[string]string{}
@@ -921,7 +920,6 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-manifest.json"), manifestBytes, 0o644); err != nil {
 				t.Fatal(err)
 			}
-
 			packages := test.initialPackages
 			if packages == nil {
 				packages = map[string]any{}
@@ -933,7 +931,6 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(tmpDir, "release-please-config.json"), rpConfigBytes, 0o644); err != nil {
 				t.Fatal(err)
 			}
-
 			cfg := sample.Config()
 			cfg.Language = config.LanguageRuby
 			cfg.Default.Output = "output"
@@ -942,12 +939,10 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
-
 			args := append([]string{"librarian", "add"}, test.args...)
 			if err := Run(t.Context(), args...); err != nil {
 				t.Fatal(err)
 			}
-
 			gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
 			if err != nil {
 				t.Fatal(err)
@@ -958,7 +953,6 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			if diff := cmp.Diff(test.wantFinalLibraries, gotCfg.Libraries); diff != "" {
 				t.Errorf("libraries mismatch (-want +got):\n%s", diff)
 			}
-
 			gotManifest, err := readJSONFile[map[string]string](filepath.Join(tmpDir, ".release-please-manifest.json"))
 			if err != nil {
 				t.Fatal(err)
@@ -966,7 +960,6 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			if diff := cmp.Diff(test.wantManifest, gotManifest); diff != "" {
 				t.Errorf("manifest mismatch (-want +got):\n%s", diff)
 			}
-
 			gotRPConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-config.json"))
 			if err != nil {
 				t.Fatal(err)
@@ -1029,7 +1022,6 @@ func TestAddLibraryCommand_Ruby_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
-
 			cfg := sample.Config()
 			cfg.Language = test.language
 			cfg.Default.Output = "output"
@@ -1038,7 +1030,6 @@ func TestAddLibraryCommand_Ruby_Error(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
-
 			args := append([]string{"librarian", "add"}, test.args...)
 			err := Run(t.Context(), args...)
 			if !errors.Is(err, test.wantErr) {

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -15,6 +15,7 @@
 package librarian
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -786,89 +787,91 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("explicit library name for versioned and wrapper gems with release please", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Chdir(tmpDir)
-		if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-manifest.json"), []byte("{}"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "release-please-config.json"), []byte(`{"packages":{}}`), 0o644); err != nil {
-			t.Fatal(err)
-		}
-
-		cfg := sample.Config()
-		cfg.Language = config.LanguageRuby
-		cfg.Default.Output = "output"
-		cfg.Libraries = nil
-		cfg.Sources.Googleapis.Dir = googleapisDir
-		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
-			t.Fatal(err)
-		}
-
-		// 1. Add versioned gem with custom name
-		if err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"); err != nil {
-			t.Fatal(err)
-		}
-
-		// 2. Add wrapper gem with custom name
-		if err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager", "--library-name", "google-cloud-secret_manager"); err != nil {
-			t.Fatal(err)
-		}
-
-		gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
-		if err != nil {
-			t.Fatal(err)
-		}
-		wantLibraries := []*config.Library{
-			{
-				Name:          "google-cloud-secret_manager",
-				CopyrightYear: strconv.Itoa(time.Now().Year()),
-				Version:       "0.0.1",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-				Ruby: &config.RubyPackage{
-					WrapperOf: []string{"v1:0.0"},
+	for _, test := range []struct {
+		name               string
+		initialLibraries   []*config.Library
+		initialManifest    map[string]string
+		initialPackages    map[string]any
+		args               []string
+		wantFinalLibraries []*config.Library
+		wantManifest       map[string]string
+		wantPackages       map[string]any
+	}{
+		{
+			name: "explicit library name for versioned gem with release please",
+			args: []string{"google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"},
+			wantFinalLibraries: []*config.Library{
+				{
+					Name:          "google-cloud-secret_manager-v1",
+					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					Version:       "0.0.1",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+					},
 				},
 			},
-			{
-				Name:          "google-cloud-secret_manager-v1",
-				CopyrightYear: strconv.Itoa(time.Now().Year()),
-				Version:       "0.0.1",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
+			wantManifest: map[string]string{
+				"google-cloud-secret_manager-v1":        "0.0.1",
+				"google-cloud-secret_manager-v1+FILLER": "0.0.0",
+			},
+			wantPackages: map[string]any{
+				"google-cloud-secret_manager-v1": map[string]any{
+					"component":    "google-cloud-secret_manager-v1",
+					"version_file": "lib/google/cloud/secret_manager/v1/version.rb",
 				},
 			},
-		}
-		sort.Slice(gotCfg.Libraries, func(i, j int) bool {
-			return gotCfg.Libraries[i].Name < gotCfg.Libraries[j].Name
-		})
-		if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
-			t.Errorf("libraries mismatch (-want +got):\n%s", diff)
-		}
-
-		// Check Release Please manifest
-		manifest, err := readJSONFile[map[string]string](filepath.Join(tmpDir, ".release-please-manifest.json"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		wantManifest := map[string]string{
-			"google-cloud-secret_manager":           "0.0.1",
-			"google-cloud-secret_manager+FILLER":    "0.0.0",
-			"google-cloud-secret_manager-v1":        "0.0.1",
-			"google-cloud-secret_manager-v1+FILLER": "0.0.0",
-		}
-		if diff := cmp.Diff(wantManifest, manifest); diff != "" {
-			t.Errorf("manifest mismatch (-want +got):\n%s", diff)
-		}
-
-		// Check Release Please config
-		rpConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-config.json"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		wantRPConfig := map[string]any{
-			"packages": map[string]any{
+		},
+		{
+			name: "explicit library name for wrapper gem with release please",
+			initialLibraries: []*config.Library{
+				{
+					Name:          "google-cloud-secret_manager-v1",
+					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					Version:       "0.0.1",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+					},
+				},
+			},
+			initialManifest: map[string]string{
+				"google-cloud-secret_manager-v1":        "0.0.1",
+				"google-cloud-secret_manager-v1+FILLER": "0.0.0",
+			},
+			initialPackages: map[string]any{
+				"google-cloud-secret_manager-v1": map[string]any{
+					"component":    "google-cloud-secret_manager-v1",
+					"version_file": "lib/google/cloud/secret_manager/v1/version.rb",
+				},
+			},
+			args: []string{"google/cloud/secretmanager", "--library-name", "google-cloud-secret_manager"},
+			wantFinalLibraries: []*config.Library{
+				{
+					Name:          "google-cloud-secret_manager",
+					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					Version:       "0.0.1",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+					},
+					Ruby: &config.RubyPackage{
+						WrapperOf: []string{"v1:0.0"},
+					},
+				},
+				{
+					Name:          "google-cloud-secret_manager-v1",
+					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					Version:       "0.0.1",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+					},
+				},
+			},
+			wantManifest: map[string]string{
+				"google-cloud-secret_manager":           "0.0.1",
+				"google-cloud-secret_manager+FILLER":    "0.0.0",
+				"google-cloud-secret_manager-v1":        "0.0.1",
+				"google-cloud-secret_manager-v1+FILLER": "0.0.0",
+			},
+			wantPackages: map[string]any{
 				"google-cloud-secret_manager": map[string]any{
 					"component":    "google-cloud-secret_manager",
 					"version_file": "lib/google/cloud/secret_manager/version.rb",
@@ -878,80 +881,171 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 					"version_file": "lib/google/cloud/secret_manager/v1/version.rb",
 				},
 			},
-		}
-		if diff := cmp.Diff(wantRPConfig, rpConfig); diff != "" {
-			t.Errorf("release please config mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("default library name without flag", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Chdir(tmpDir)
-
-		cfg := sample.Config()
-		cfg.Language = config.LanguageRuby
-		cfg.Default.Output = "output"
-		cfg.Libraries = nil
-		cfg.Sources.Googleapis.Dir = googleapisDir
-		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1"); err != nil {
-			t.Fatal(err)
-		}
-
-		gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(gotCfg.Libraries) != 1 || gotCfg.Libraries[0].Name != "google-cloud-secretmanager-v1" {
-			t.Errorf("got libraries = %v, want 1 library named google-cloud-secretmanager-v1", gotCfg.Libraries)
-		}
-	})
-
-	t.Run("error when library-name specified for non-ruby language", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Chdir(tmpDir)
-
-		cfg := sample.Config()
-		cfg.Language = config.LanguageGo
-		cfg.Default.Output = "output"
-		cfg.Libraries = nil
-		cfg.Sources.Googleapis.Dir = googleapisDir
-		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
-			t.Fatal(err)
-		}
-
-		err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1", "--library-name", "custom-name")
-		if !errors.Is(err, errLibraryNameOnlyForRuby) {
-			t.Fatalf("expected error %v, got %v", errLibraryNameOnlyForRuby, err)
-		}
-	})
-
-	t.Run("error when adding duplicate library name", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Chdir(tmpDir)
-
-		cfg := sample.Config()
-		cfg.Language = config.LanguageRuby
-		cfg.Default.Output = "output"
-		cfg.Libraries = []*config.Library{
-			{
-				Name: "google-cloud-secret_manager-v1",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
+		},
+		{
+			name: "default library name without flag",
+			args: []string{"google/cloud/secretmanager/v1"},
+			wantFinalLibraries: []*config.Library{
+				{
+					Name:          "google-cloud-secretmanager-v1",
+					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					Version:       "0.0.1",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+					},
 				},
 			},
-		}
-		cfg.Sources.Googleapis.Dir = googleapisDir
-		if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
-			t.Fatal(err)
-		}
+			wantManifest: map[string]string{
+				"google-cloud-secretmanager-v1":        "0.0.1",
+				"google-cloud-secretmanager-v1+FILLER": "0.0.0",
+			},
+			wantPackages: map[string]any{
+				"google-cloud-secretmanager-v1": map[string]any{
+					"component":    "google-cloud-secretmanager-v1",
+					"version_file": "lib/google/cloud/secretmanager/v1/version.rb",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Chdir(tmpDir)
 
-		err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1")
-		if !errors.Is(err, errAPIAlreadyExists) {
-			t.Fatalf("expected error %v, got %v", errAPIAlreadyExists, err)
-		}
-	})
+			manifest := test.initialManifest
+			if manifest == nil {
+				manifest = map[string]string{}
+			}
+			manifestBytes, err := json.Marshal(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-manifest.json"), manifestBytes, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			packages := test.initialPackages
+			if packages == nil {
+				packages = map[string]any{}
+			}
+			rpConfigBytes, err := json.Marshal(map[string]any{"packages": packages})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(tmpDir, "release-please-config.json"), rpConfigBytes, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg := sample.Config()
+			cfg.Language = config.LanguageRuby
+			cfg.Default.Output = "output"
+			cfg.Libraries = test.initialLibraries
+			cfg.Sources.Googleapis.Dir = googleapisDir
+			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+				t.Fatal(err)
+			}
+
+			args := append([]string{"librarian", "add"}, test.args...)
+			if err := Run(t.Context(), args...); err != nil {
+				t.Fatal(err)
+			}
+
+			gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sort.Slice(gotCfg.Libraries, func(i, j int) bool {
+				return gotCfg.Libraries[i].Name < gotCfg.Libraries[j].Name
+			})
+			if diff := cmp.Diff(test.wantFinalLibraries, gotCfg.Libraries); diff != "" {
+				t.Errorf("libraries mismatch (-want +got):\n%s", diff)
+			}
+
+			gotManifest, err := readJSONFile[map[string]string](filepath.Join(tmpDir, ".release-please-manifest.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.wantManifest, gotManifest); diff != "" {
+				t.Errorf("manifest mismatch (-want +got):\n%s", diff)
+			}
+
+			gotRPConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-config.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRPConfig := map[string]any{"packages": test.wantPackages}
+			if diff := cmp.Diff(wantRPConfig, gotRPConfig); diff != "" {
+				t.Errorf("release please config mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddLibraryCommand_Ruby_Error(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name             string
+		language         string
+		initialLibraries []*config.Library
+		args             []string
+		wantErr          error
+	}{
+		{
+			name:     "library-name flag specified for non-ruby language",
+			language: config.LanguageGo,
+			args:     []string{"google/cloud/secretmanager/v1", "--library-name", "custom-name"},
+			wantErr:  errLibraryNameOnlyForRuby,
+		},
+		{
+			name:     "duplicate API path",
+			language: config.LanguageRuby,
+			initialLibraries: []*config.Library{
+				{
+					Name: "google-cloud-secret_manager-v1",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+					},
+				},
+			},
+			args:    []string{"google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"},
+			wantErr: errAPIAlreadyExists,
+		},
+		{
+			name:     "duplicate library name with different API",
+			language: config.LanguageRuby,
+			initialLibraries: []*config.Library{
+				{
+					Name: "google-cloud-secret_manager-v1",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v2"},
+					},
+				},
+			},
+			args:    []string{"google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"},
+			wantErr: errLibraryAlreadyExists,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Chdir(tmpDir)
+
+			cfg := sample.Config()
+			cfg.Language = test.language
+			cfg.Default.Output = "output"
+			cfg.Libraries = test.initialLibraries
+			cfg.Sources.Googleapis.Dir = googleapisDir
+			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+				t.Fatal(err)
+			}
+
+			args := append([]string{"librarian", "add"}, test.args...)
+			err := Run(t.Context(), args...)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("expected error %v, got %v", test.wantErr, err)
+			}
+		})
+	}
 }

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -786,7 +786,6 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	for _, test := range []struct {
 		name               string
 		initialLibraries   []*config.Library
@@ -799,7 +798,7 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 	}{
 		{
 			name: "explicit library name for versioned gem with release please",
-			args: []string{"google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"},
+			args: []string{"google/cloud/secretmanager/v1", "--name", "google-cloud-secret_manager-v1"},
 			wantFinalLibraries: []*config.Library{
 				{
 					Name:          "google-cloud-secret_manager-v1",
@@ -843,7 +842,7 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 					"version_file": "lib/google/cloud/secret_manager/v1/version.rb",
 				},
 			},
-			args: []string{"google/cloud/secretmanager", "--library-name", "google-cloud-secret_manager"},
+			args: []string{"google/cloud/secretmanager", "--name", "google-cloud-secret_manager"},
 			wantFinalLibraries: []*config.Library{
 				{
 					Name:          "google-cloud-secret_manager",
@@ -985,7 +984,6 @@ func TestAddLibraryCommand_Ruby_Error(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	for _, test := range []struct {
 		name             string
 		language         string
@@ -994,10 +992,10 @@ func TestAddLibraryCommand_Ruby_Error(t *testing.T) {
 		wantErr          error
 	}{
 		{
-			name:     "library-name flag specified for non-ruby language",
+			name:     "name flag specified for non-ruby language",
 			language: config.LanguageGo,
-			args:     []string{"google/cloud/secretmanager/v1", "--library-name", "custom-name"},
-			wantErr:  errLibraryNameOnlyForRuby,
+			args:     []string{"google/cloud/secretmanager/v1", "--name", "custom-name"},
+			wantErr:  errNameOnlyForRuby,
 		},
 		{
 			name:     "duplicate API path",
@@ -1010,7 +1008,7 @@ func TestAddLibraryCommand_Ruby_Error(t *testing.T) {
 					},
 				},
 			},
-			args:    []string{"google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"},
+			args:    []string{"google/cloud/secretmanager/v1", "--name", "google-cloud-secret_manager-v1"},
 			wantErr: errAPIAlreadyExists,
 		},
 		{
@@ -1024,7 +1022,7 @@ func TestAddLibraryCommand_Ruby_Error(t *testing.T) {
 					},
 				},
 			},
-			args:    []string{"google/cloud/secretmanager/v1", "--library-name", "google-cloud-secret_manager-v1"},
+			args:    []string{"google/cloud/secretmanager/v1", "--name", "google-cloud-secret_manager-v1"},
 			wantErr: errLibraryAlreadyExists,
 		},
 	} {

--- a/internal/librarian/config.go
+++ b/internal/librarian/config.go
@@ -115,7 +115,7 @@ func runConfigSet(path, value string) error {
 }
 
 func libraryName(cfg *config.Config, apiPath string) (string, error) {
-	if library := findExistingLibraryForAPI(cfg, apiPath); library != nil {
+	if library := findExistingLibraryForAPI(cfg, apiPath, ""); library != nil {
 		return library.Name, nil
 	}
 	return "", fmt.Errorf("%w for API: %s", ErrLibraryNotFound, apiPath)

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -31,11 +31,6 @@ var (
 	errNoVersionedAPI = errors.New("no versioned API found")
 )
 
-// DefaultLibraryName derives the default library name from an API path.
-func DefaultLibraryName(api string) string {
-	return strings.ReplaceAll(api, "/", "-")
-}
-
 // Add initializes a new Ruby library configuration.
 func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	lib.Version = defaultVersion

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -31,6 +31,11 @@ var (
 	errNoVersionedAPI = errors.New("no versioned API found")
 )
 
+// DefaultLibraryName derives the default library name from an API path.
+func DefaultLibraryName(api string) string {
+	return strings.ReplaceAll(api, "/", "-")
+}
+
 // Add initializes a new Ruby library configuration.
 func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	lib.Version = defaultVersion

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -22,26 +22,71 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
+func TestDefaultLibraryName(t *testing.T) {
+	for _, test := range []struct {
+		apiPath string
+		want    string
+	}{
+		{"google/cloud/secretmanager/v1", "google-cloud-secretmanager-v1"},
+		{"google/cloud/secretmanager", "google-cloud-secretmanager"},
+	} {
+		t.Run(test.apiPath, func(t *testing.T) {
+			got := DefaultLibraryName(test.apiPath)
+			if got != test.want {
+				t.Errorf("DefaultLibraryName(%q) = %q, want %q", test.apiPath, got, test.want)
+			}
+		})
+	}
+}
+
 func TestAdd(t *testing.T) {
-	in := &config.Library{
-		Name: "google-cloud-secretmanager-v1",
-		APIs: []*config.API{
-			{Path: "google/cloud/secretmanager/v1"},
+	for _, test := range []struct {
+		name string
+		in   *config.Library
+		want *config.Library
+	}{
+		{
+			name: "default library name",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager-v1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-cloud-secretmanager-v1",
+				Version: "0.0.1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
 		},
-	}
-	want := &config.Library{
-		Name:    "google-cloud-secretmanager-v1",
-		Version: "0.0.1",
-		APIs: []*config.API{
-			{Path: "google/cloud/secretmanager/v1"},
+		{
+			name: "custom library name",
+			in: &config.Library{
+				Name: "google-cloud-secret_manager-v1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-cloud-secret_manager-v1",
+				Version: "0.0.1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
 		},
-	}
-	got, err := Add(&config.Config{}, in)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Add(&config.Config{}, test.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -22,23 +22,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 )
 
-func TestDefaultLibraryName(t *testing.T) {
-	for _, test := range []struct {
-		apiPath string
-		want    string
-	}{
-		{"google/cloud/secretmanager/v1", "google-cloud-secretmanager-v1"},
-		{"google/cloud/secretmanager", "google-cloud-secretmanager"},
-	} {
-		t.Run(test.apiPath, func(t *testing.T) {
-			got := DefaultLibraryName(test.apiPath)
-			if got != test.want {
-				t.Errorf("DefaultLibraryName(%q) = %q, want %q", test.apiPath, got, test.want)
-			}
-		})
-	}
-}
-
 func TestAdd(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
Add `--library-name` flag to the `librarian add` command to allow explicitly specifying the library name, which is applicable for Ruby client libraries. The doc notes that this is only applicable for Ruby.

When the Ruby team specifies a Gem name for a new library, the Platform team rotation person would pass the name to the option. Example: `librarian add google/cloud/secretmanager/v1 --library-name google-cloud-secret_manager-v1`

Fixes https://github.com/googleapis/librarian/issues/7303