### PR TITLE
fix(sidekick/swift): doc links for `oneofs`

### DIFF
--- a/internal/sidekick/swift/annotate_oneof.go
+++ b/internal/sidekick/swift/annotate_oneof.go
@@ -31,7 +31,7 @@ func (c *codec) annotateOneOf(oneof *api.OneOf) error {
 		return err
 	}
 	annotations := &oneOfAnnotations{
-		Name:         "OneOf_" + pascalCase(oneof.Name),
+		Name:         OneOfName(oneof.Name),
 		PropertyName: camelCase(oneof.Name),
 		Checker:      camelCase(oneof.Name + "CheckAndSet"),
 		DocLines:     docLines,

--- a/internal/sidekick/swift/doc_link.go
+++ b/internal/sidekick/swift/doc_link.go
@@ -93,12 +93,12 @@ func (c *codec) tryFieldDocLink(id string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			fieldName := camelCase(f.Name)
+			swiftName := camelCase(f.Name)
 			if f.Group == nil {
-				return c.docLink(m.Package, fmt.Sprintf("%s/%s", messageName, fieldName)), nil
+				return c.docLink(m.Package, fmt.Sprintf("%s/%s", messageName, swiftName)), nil
 			}
 			groupName := OneOfName(f.Group.Name)
-			return c.docLink(m.Package, fmt.Sprintf("%s/%s/%s(_:)", messageName, groupName, fieldName)), nil
+			return c.docLink(m.Package, fmt.Sprintf("%s/%s/%s(_:)", messageName, groupName, swiftName)), nil
 		}
 	}
 	for _, o := range m.OneOfs {

--- a/internal/sidekick/swift/doc_link.go
+++ b/internal/sidekick/swift/doc_link.go
@@ -89,11 +89,16 @@ func (c *codec) tryFieldDocLink(id string) (string, error) {
 	}
 	for _, f := range m.Fields {
 		if f.Name == fieldName {
-			p, err := c.messageTypeName(m)
+			messageName, err := c.messageTypeName(m)
 			if err != nil {
 				return "", err
 			}
-			return c.docLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(f.Name))), nil
+			fieldName := camelCase(f.Name)
+			if f.Group == nil {
+				return c.docLink(m.Package, fmt.Sprintf("%s/%s", messageName, fieldName)), nil
+			}
+			groupName := OneOfName(f.Group.Name)
+			return c.docLink(m.Package, fmt.Sprintf("%s/%s/%s(_:)", messageName, groupName, fieldName)), nil
 		}
 	}
 	for _, o := range m.OneOfs {
@@ -102,7 +107,7 @@ func (c *codec) tryFieldDocLink(id string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return c.docLink(m.Package, fmt.Sprintf("%s/%s", p, camelCase(o.Name))), nil
+			return c.docLink(m.Package, fmt.Sprintf("%s/%s", p, OneOfName(o.Name))), nil
 		}
 	}
 	return "", nil

--- a/internal/sidekick/swift/doc_link_test.go
+++ b/internal/sidekick/swift/doc_link_test.go
@@ -108,13 +108,13 @@ func TestDocLink(t *testing.T) {
 			name:   "oneof field link (1)",
 			link:   "SomeMessage.error",
 			scopes: []string{"test.v1"},
-			want:   "<doc:SomeMessage/OneOf_Result/error>",
+			want:   "<doc:SomeMessage/OneOf_Result/error(_:)>",
 		},
 		{
 			name:   "oneof field link (2)",
 			link:   "SomeMessage.response",
 			scopes: []string{"test.v1"},
-			want:   "<doc:SomeMessage/OneOf_Result/response>",
+			want:   "<doc:SomeMessage/OneOf_Result/response(_:)>",
 		},
 		{
 			name:   "enum value link",

--- a/internal/sidekick/swift/doc_link_test.go
+++ b/internal/sidekick/swift/doc_link_test.go
@@ -43,26 +43,16 @@ func TestDocLink(t *testing.T) {
 		ID:      ".test.v1.SomeMessage.error",
 		IsOneOf: true,
 	}
-	typez := &api.Field{
-		Name: "type",
-		ID:   ".test.v1.SomeMessage.type",
-	}
-	someMessage := &api.Message{
-		Name:    "SomeMessage",
-		ID:      ".test.v1.SomeMessage",
-		Package: "test.v1",
-		Enums:   []*api.Enum{someEnum},
-		Fields: []*api.Field{
-			{Name: "unused"}, {Name: "field"}, response, errorz, typez,
-		},
-		OneOfs: []*api.OneOf{
-			{
-				Name:   "result",
-				ID:     ".test.v1.SomeMessage.result",
-				Fields: []*api.Field{response, errorz},
-			},
-		},
-	}
+	result := api.NewTestOneOf("result").WithFields(response, errorz)
+	someMessage := api.NewTestMessage("SomeMessage").
+		WithPackage("test.v1").
+		WithFields(
+			api.NewTestField("unused"),
+			api.NewTestField("field"),
+			api.NewTestField("typez"),
+		).
+		WithOneOfs(result)
+	someMessage.Enums = append(someMessage.Enums, someEnum)
 	otherMessage := &api.Message{
 		Name:    "OtherMessage",
 		ID:      ".other.v1.OtherMessage",
@@ -90,7 +80,7 @@ func TestDocLink(t *testing.T) {
 		{Name: "OtherPrefix", ApiPackage: "other.v1"},
 	})
 
-	tests := []struct {
+	for _, test := range []struct {
 		name   string
 		link   string
 		scopes []string
@@ -113,6 +103,18 @@ func TestDocLink(t *testing.T) {
 			link:   "SomeMessage.field",
 			scopes: []string{"test.v1"},
 			want:   "<doc:SomeMessage/field>",
+		},
+		{
+			name:   "oneof field link (1)",
+			link:   "SomeMessage.error",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeMessage/OneOf_Result/error>",
+		},
+		{
+			name:   "oneof field link (2)",
+			link:   "SomeMessage.response",
+			scopes: []string{"test.v1"},
+			want:   "<doc:SomeMessage/OneOf_Result/response>",
 		},
 		{
 			name:   "enum value link",
@@ -144,16 +146,14 @@ func TestDocLink(t *testing.T) {
 			scopes: []string{},
 			want:   "https://www.google.com/search?q=Swift+other.v1+OtherPrefix.OtherMessage",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.linkDefinition(tt.link, tt.scopes)
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := c.linkDefinition(test.link, test.scopes)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != tt.want {
-				t.Errorf("docLink() = %q, want %q", got, tt.want)
+			if got != test.want {
+				t.Errorf("docLink() = %q, want %q", got, test.want)
 			}
 		})
 	}

--- a/internal/sidekick/swift/names.go
+++ b/internal/sidekick/swift/names.go
@@ -217,3 +217,13 @@ func ProtoPackagePrefix(packageName string) string {
 	}
 	return strings.Join(camelParts, "_") + "_"
 }
+
+// OneOfName returns the name for a `oneof`.
+//
+// In Swift, each `oneof` group is implemented by an `enum` (a sum type) in the
+// message that contains it. This function computes the (unqualified) name. By
+// convention, `oneof` names are `snake_case`, while Swift types are
+// `PascalCase`.
+func OneOfName(oneOfName string) string {
+	return "OneOf_" + pascalCaseNoMangling(oneOfName)
+}

--- a/internal/sidekick/swift/names_test.go
+++ b/internal/sidekick/swift/names_test.go
@@ -237,3 +237,22 @@ func TestProtoPackagePrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestOneOfName(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "branches", want: "OneOf_Branches"},
+		{input: "several_things", want: "OneOf_SeveralThings"},
+		{input: "type", want: "OneOf_Type"},
+		{input: "self", want: "OneOf_Self"},
+	} {
+		t.Run(test.input, func(t *testing.T) {
+			got := OneOfName(test.input)
+			if got != test.want {
+				t.Errorf("OneOfName(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes the doc links for `oneofs` and fields within a oneof group. A bit of refactoring to compute / define the oneof names in a single place.

Towards https://github.com/googleapis/google-cloud-swift/issues/353 

The generated code goes in https://github.com/googleapis/google-cloud-swift/pull/460