### PR TITLE
fix(internal/filesystem): skip unzip execution for empty archives

### DIFF
--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -148,7 +148,9 @@ func Unzip(ctx context.Context, src, dest string) error {
 	empty := len(r.File) == 0
 	// Do not use defer because we want to close the file before running unzip to avoid
 	// file contention.
-	r.Close()
+	if err := r.Close(); err != nil {
+		return err
+	}
 	if empty {
 		return nil
 	}

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -145,8 +145,11 @@ func Unzip(ctx context.Context, src, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
-	if len(r.File) == 0 {
+	empty := len(r.File) == 0
+	// Do not use defer because we want to close the file before running unzip to avoid
+	// file contention.
+	r.Close()
+	if empty {
 		return nil
 	}
 	return command.Run(ctx, "unzip", "-q", "-o", src, "-d", dest)

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -146,8 +146,7 @@ func Unzip(ctx context.Context, src, dest string) error {
 		return err
 	}
 	empty := len(r.File) == 0
-	// Do not use defer because we want to close the file before running unzip to avoid
-	// file contention.
+	// Avoid file contention with potential unzip call by force closing the reader.
 	if err := r.Close(); err != nil {
 		return err
 	}

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -16,6 +16,7 @@
 package filesystem
 
 import (
+	"archive/zip"
 	"context"
 	"errors"
 	"fmt"
@@ -138,7 +139,16 @@ func CopyFile(src, dest string) error {
 }
 
 // Unzip unzips the src archive into dest directory using the system unzip command.
+// If the archive contains 0 files, it returns nil without invoking unzip.
 func Unzip(ctx context.Context, src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	if len(r.File) == 0 {
+		return nil
+	}
 	return command.Run(ctx, "unzip", "-q", "-o", src, "-d", dest)
 }
 

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -356,6 +356,17 @@ func TestUnzip_Permissions(t *testing.T) {
 	}
 }
 
+func TestUnzip_Empty(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	zipPath := filepath.Join(tmp, "empty.zip")
+	destDir := filepath.Join(tmp, "dest")
+	createZip(t, zipPath, nil, nil)
+	if err := Unzip(t.Context(), zipPath, destDir); err != nil {
+		t.Fatalf("Unzip() error = %v", err)
+	}
+}
+
 func createZip(t *testing.T, path string, files map[string]string, modes map[string]os.FileMode) {
 	t.Helper()
 	f, err := os.Create(path)

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -363,7 +363,7 @@ func TestUnzip_Empty(t *testing.T) {
 	destDir := filepath.Join(tmp, "dest")
 	createZip(t, zipPath, nil, nil)
 	if err := Unzip(t.Context(), zipPath, destDir); err != nil {
-		t.Fatalf("Unzip() error = %v", err)
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Unzip is updated to inspect the zip archive contents using archive/zip before invoking the system unzip binary, immediately returning nil if the archive contains zero files. The archive reader is closed before running the external unzip process to prevent holding open a file handle during command execution.

This prevents errors when unzipping empty archives and avoids unnecessary subprocess calls.

Fixes #7308
