### PR TITLE
feat(internal/sidekick/rust): use RequestOptions for bidi streaming

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -102,7 +102,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			file:     "src/builder.rs",
 			startStr: "    #[derive(Clone, Debug)]\n    pub struct Chat(",
 			endStr:   ");",
-			want:     "    #[derive(Clone, Debug)]\n    pub struct Chat(BidiStreamBuilder<crate::model::Request>);",
+			want:     "    #[derive(Clone, Debug)]\n    pub struct Chat(RequestBuilder<std::option::Option<crate::model::Request>>);",
 		},
 		{
 			name:     "builder: send method",
@@ -120,18 +120,17 @@ func TestGenerateBidiStreaming(t *testing.T) {
         }`,
 		},
 		{
-			name:     "builder: with_request_channel_capacity method",
+			name:     "builder: request builder impl",
 			file:     "src/builder.rs",
-			startStr: "        /// Sets the buffer capacity of internal request channel.\n",
-			endStr:   "        }",
-			want: `        /// Sets the buffer capacity of internal request channel.
-        ///
-        /// Valid values must be between ` + "`1`" + ` and ` + "`google_cloud_gax::options::MAX_REQUEST_CHANNEL_CAPACITY`." + `
-        /// The default capacity is ` + "`16`." + `
-        pub fn with_request_channel_capacity(mut self, capacity: usize) -> Self {
-            self.0.options.set_request_channel_capacity(capacity);
-            self
-        }`,
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[doc(hidden)]\n    impl crate::RequestBuilder for Chat",
+			endStr:   "\n    }",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[doc(hidden)]
+    impl crate::RequestBuilder for Chat {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }`,
 		},
 		{
 			name:     "builder: with_request method",
@@ -164,7 +163,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     fn chat(
         &self,
         _req: std::option::Option<crate::model::Request>,
-        _options: crate::BidiStreamOptions,
+        _options: crate::RequestOptions,
     ) -> impl std::future::Future<Output = crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
@@ -181,7 +180,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     async fn chat(
         &self,
         req: std::option::Option<crate::model::Request>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
@@ -197,7 +196,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     async fn chat(
         &self,
         req: std::option::Option<crate::model::Request>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
@@ -214,7 +213,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     async fn chat(
         &self,
         req: std::option::Option<crate::model::Request>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
@@ -231,7 +230,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     async fn chat(
         &self,
         req: std::option::Option<crate::model::Request>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
@@ -263,7 +262,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
                 extensions,
                 path,
                 req_stream,
-                options.into(),
+                options,
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
                 x_goog_request_params,
             )

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -78,28 +78,6 @@ pub mod {{Codec.ModuleName}} {
         }
     }
 
-    {{#Codec.HasBidiStreaming}}
-    /// Common implementation for [crate::client::{{Codec.Name}}] bidi stream builders.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    #[derive(Clone, Debug)]
-    pub(crate) struct BidiStreamBuilder<R: std::default::Default> {
-        stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
-        request: Option<R>,
-        options: crate::BidiStreamOptions,
-    }
-
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    impl<R> BidiStreamBuilder<R>
-    where R: std::default::Default {
-        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>) -> Self {
-            Self {
-                stub,
-                request: None,
-                options: crate::BidiStreamOptions::default(),
-            }
-        }
-    }
-    {{/Codec.HasBidiStreaming}}
 
     {{#Codec.Methods}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}] calls.
@@ -149,12 +127,7 @@ pub mod {{Codec.ModuleName}} {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     {{/Codec.IsBidiStreaming}}
     #[derive(Clone, Debug)]
-    {{#Codec.IsBidiStreaming}}
-    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(BidiStreamBuilder<{{InputType.Codec.QualifiedName}}>);
-    {{/Codec.IsBidiStreaming}}
-    {{^Codec.IsBidiStreaming}}
-    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
-    {{/Codec.IsBidiStreaming}}
+    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{#Codec.IsBidiStreaming}}std::option::Option<{{InputType.Codec.QualifiedName}}>{{/Codec.IsBidiStreaming}}{{^Codec.IsBidiStreaming}}{{InputType.Codec.QualifiedName}}{{/Codec.IsBidiStreaming}}>);
 
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
@@ -162,20 +135,9 @@ pub mod {{Codec.ModuleName}} {
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {
             Self(
-                {{#Codec.IsBidiStreaming}}BidiStreamBuilder{{/Codec.IsBidiStreaming}}{{^Codec.IsBidiStreaming}}RequestBuilder{{/Codec.IsBidiStreaming}}::new(stub)
+                RequestBuilder::new(stub)
             )
         }
-
-        {{#Codec.IsBidiStreaming}}
-        /// Sets the buffer capacity of internal request channel.
-        ///
-        /// Valid values must be between `1` and `google_cloud_gax::options::MAX_REQUEST_CHANNEL_CAPACITY`.
-        /// The default capacity is `16`.
-        pub fn with_request_channel_capacity(mut self, capacity: usize) -> Self {
-            self.0.options.set_request_channel_capacity(capacity);
-            self
-        }
-        {{/Codec.IsBidiStreaming}}
 
         /// Sets the full request, replacing any prior values.
         pub fn with_request<V: Into<{{InputType.Codec.QualifiedName}}>>(mut self, v: V) -> Self {
@@ -189,7 +151,7 @@ pub mod {{Codec.ModuleName}} {
         }
 
         /// Sets all the options, replacing any prior values.
-        pub fn with_options<V: Into<{{#Codec.IsBidiStreaming}}crate::BidiStreamOptions{{/Codec.IsBidiStreaming}}{{^Codec.IsBidiStreaming}}crate::RequestOptions{{/Codec.IsBidiStreaming}}>>(mut self, v: V) -> Self {
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
             self.0.options = v.into();
             self
         }
@@ -731,22 +693,15 @@ pub mod {{Codec.ModuleName}} {
         {{/InputType.OneOfs}}
     }
 
-    #[doc(hidden)]
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    impl crate::RequestBuilder for {{Codec.BuilderName}} {
-        fn request_options(&mut self) -> &mut crate::RequestOptions {
-            self.0.options.request_options_mut()
-        }
-    }
     {{/Codec.IsBidiStreaming}}
-    {{^Codec.IsBidiStreaming}}
+    #[doc(hidden)]
     impl crate::RequestBuilder for {{Codec.BuilderName}} {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
             &mut self.0.options
         }
     }
-    {{/Codec.IsBidiStreaming}}
 
     {{/Codec.Methods}}
 }

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -173,10 +173,6 @@ pub(crate) use google_cloud_gax::client_builder::Result as ClientBuilderResult;
 pub(crate) use google_cloud_gax::client_builder::internal::ClientFactory;
 pub(crate) use google_cloud_gax::client_builder::internal::new_builder as new_client_builder;
 pub(crate) use google_cloud_gax::options::RequestOptions;
-{{#Codec.HasBidiStreaming}}
-#[cfg(google_cloud_unstable_gapic_streaming)]
-pub(crate) use google_cloud_gax::options::BidiStreamOptions;
-{{/Codec.HasBidiStreaming}}
 pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 {{/Codec.HasServices}}

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -58,7 +58,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     fn {{Codec.Name}}(
         &self,
         _req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
-        _options: crate::BidiStreamOptions,
+        _options: crate::RequestOptions,
     ) -> impl std::future::Future<Output = crate::Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -31,7 +31,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     async fn {{Codec.Name}}(
         &self,
         req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
@@ -80,7 +80,7 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
     async fn {{Codec.Name}}(
         &self,
         req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -69,7 +69,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     async fn {{Codec.Name}}(
         &self,
         req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -162,7 +162,11 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             .to_proto()
             .map_err(google_cloud_gax::error::Error::ser)?;
 
-        let (req_tx, req_rx) = tokio::sync::mpsc::channel(options.request_stream_channel_capacity());
+        let (req_tx, req_rx) = tokio::sync::mpsc::channel(
+            options
+                .request_stream_channel_capacity()
+                .unwrap_or(google_cloud_gax::options::internal::DEFAULT_REQUEST_CHANNEL_CAPACITY),
+        );
 
         let req_stream = futures::stream::once(async move { first_req })
             .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx));

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -132,7 +132,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     async fn {{Codec.Name}}(
         &self,
         req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
-        options: crate::BidiStreamOptions,
+        options: crate::RequestOptions,
     ) -> Result<(
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
@@ -162,7 +162,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             .to_proto()
             .map_err(google_cloud_gax::error::Error::ser)?;
 
-        let (req_tx, req_rx) = tokio::sync::mpsc::channel(options.request_channel_capacity());
+        let (req_tx, req_rx) = tokio::sync::mpsc::channel(options.request_stream_channel_capacity());
 
         let req_stream = futures::stream::once(async move { first_req })
             .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx));
@@ -187,7 +187,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 extensions,
                 path,
                 req_stream,
-                options.into(),
+                options,
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
                 x_goog_request_params,
             )


### PR DESCRIPTION
Update Rust client generator templates to use standard RequestOptions for bidirectional streaming RPCs, removing BidiStreamBuilder and specialized option types.

Generated bidi RPC builders now use standard RequestBuilder and implement RequestBuilder directly, unifying request option handling across unary and streaming RPCs.

For #6835 