### PR TITLE
fix(java): add uses cfg.Default.Java group ids

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -278,7 +278,7 @@ func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName stri
 		lib = golang.Add(lib)
 	case config.LanguageJava:
 		var err error
-		lib, err = java.Add(lib, nil)
+		lib, err = java.Add(cfg, lib, nil)
 		if err != nil {
 			return "", nil, err
 		}
@@ -330,7 +330,7 @@ func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api 
 	case config.LanguageJava:
 		existingLib.APIs = append(existingLib.APIs, api)
 		var err error
-		existingLib, err = java.Add(existingLib, api)
+		existingLib, err = java.Add(cfg, existingLib, api)
 		if err != nil {
 			return "", nil, err
 		}

--- a/internal/librarian/java/add.go
+++ b/internal/librarian/java/add.go
@@ -46,7 +46,7 @@ const (
 // Add initializes a new Java library with default values, or extends an
 // existing library with a new API path, and registers the appropriate
 // modules in versions.txt.
-func Add(lib *config.Library, addedAPI *config.API) (*config.Library, error) {
+func Add(cfg *config.Config, lib *config.Library, addedAPI *config.API) (*config.Library, error) {
 	if lib.Version == "" {
 		lib.Version = defaultVersion
 	}
@@ -61,24 +61,22 @@ func Add(lib *config.Library, addedAPI *config.API) (*config.Library, error) {
 		lib.Java.ReleasedVersion = defaultReleasedVersion
 	}
 
-	// We use the first API to infer the group ID.
-	// It is unrealistic for a single library to mix cloud and non-cloud APIs.
+	var d *config.Default
+	if cfg != nil {
+		d = cfg.Default
+	}
+	lib = FillDefaultJava(lib, d)
+
 	apiPath := lib.APIs[0].Path
-	switch {
-	case strings.HasPrefix(apiPath, "google/shopping/"):
-		lib = setNonCloudMavenDefaults(lib, "com.google.shopping")
-	case strings.HasPrefix(apiPath, "google/maps/"):
-		lib = setNonCloudMavenDefaults(lib, "com.google.maps")
-	case strings.HasPrefix(apiPath, "google/ads/"):
-		lib = setNonCloudMavenDefaults(lib, "com.google.api-ads")
-	default:
-		if !strings.HasPrefix(apiPath, "google/cloud/") {
+	if !strings.HasPrefix(apiPath, "google/cloud/") {
+		lib.Java.ArtifactID = "google-" + lib.Name
+		if lib.Java.GroupID == "" {
 			log.Printf(
 				"WARNING: unrecognized non-cloud API path %q. Setting fake GroupID %q. "+
 					"Please manually configure java.group_id and java.distribution_name_override in librarian.yaml.",
 				apiPath, fakeGroupID,
 			)
-			lib = setNonCloudMavenDefaults(lib, fakeGroupID)
+			lib.Java.GroupID = fakeGroupID
 		}
 	}
 
@@ -252,12 +250,6 @@ func appendLines(path string, lines []string) error {
 		buf.WriteByte('\n')
 	}
 	return os.WriteFile(path, buf.Bytes(), 0o644)
-}
-
-func setNonCloudMavenDefaults(lib *config.Library, groupID string) *config.Library {
-	lib.Java.ArtifactID = "google-" + lib.Name
-	lib.Java.GroupID = groupID
-	return lib
 }
 
 // DefaultLibraryName derives a default library name from an API path by stripping

--- a/internal/librarian/java/add_test.go
+++ b/internal/librarian/java/add_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sample"
 )
 
 func TestAdd(t *testing.T) {
@@ -137,7 +138,7 @@ func TestAdd(t *testing.T) {
 			if err := os.WriteFile(versionsFileName, nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
-			got, err := Add(test.lib, nil)
+			got, err := Add(sample.Config(), test.lib, nil)
 			if err != nil {
 				t.Fatalf("Add() error = %v", err)
 			}
@@ -240,7 +241,7 @@ func TestAdd_VersionsTxt(t *testing.T) {
 			if err := os.WriteFile(versionsFileName, nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
-			_, err := Add(test.lib, nil)
+			_, err := Add(sample.Config(), test.lib, nil)
 			if err != nil {
 				t.Fatalf("Add() error = %v", err)
 			}
@@ -287,7 +288,7 @@ func TestAdd_ExistingLibrary(t *testing.T) {
 	}
 	addedAPI := &config.API{Path: "google/cloud/secretmanager/v1beta1"}
 
-	got, err := Add(lib, addedAPI)
+	got, err := Add(nil, lib, addedAPI)
 	if err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}

--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -101,7 +101,7 @@ func FillDefaultJava(lib *config.Library, d *config.Default) *config.Library {
 // It matches the library's API paths against the custom group ID prefixes in default
 // and assigns the first matching group ID.
 func fillGroupIDIfEmpty(lib *config.Library, d *config.Default) {
-	if lib.Java.GroupID != "" || d.Java == nil || d.Java.CustomGroupIDs == nil {
+	if lib.Java.GroupID != "" || d == nil || d.Java == nil || d.Java.CustomGroupIDs == nil {
 		return
 	}
 	for _, api := range lib.APIs {

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -87,6 +87,11 @@ func Config() *config.Config {
 			TagFormat: "{name}/v{version}",
 			Java: &config.JavaDefault{
 				LibrariesBOMVersion: "1.0.0",
+				CustomGroupIDs: map[string]string{
+					"google/shopping": "com.google.shopping",
+					"google/maps":     "com.google.maps",
+					"google/ads":      "com.google.api-ads",
+				},
 			},
 		},
 		Sources: &config.Sources{


### PR DESCRIPTION
Pass `*config.Config` into `java.Add` so that it can access the allowed group ID mappings. Eliminates the hardcoded `switch` statement for `java.Add` and some of the supporting code. Adds a similar group ID mapping to the `sample.Config()` defaults so that `java.Add` tests have a canonical example to use as input.

Fixes #6755