### PR TITLE
feat(internal/sidekick/rust): refactor bidi streaming templates

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -17,7 +17,6 @@ package rust
 import (
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -114,9 +113,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     ///    client: &Protocol
     /// ) -> Result<()> {
     ///     let (sender, mut receiver) = client.chat()
-    ///         .with_request(Request::default())
-    ///         .send()
-    ///         .await?;
+    ///         .build();
     ///
     ///     sender.send(Request::default()).await?;
     ///     drop(sender); // Half-close the stream
@@ -146,10 +143,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     /// # use google_cloud_test_v1::model::Request;
     /// # async fn sample() -> google_cloud_test_v1::Result<()> {
     /// let builder = prepare_request_builder();
-    /// let (sender, mut receiver) = builder
-    ///     .with_request(Request::default())
-    ///     .send()
-    ///     .await?;
+    /// let (sender, mut receiver) = builder.build();
     ///
     /// sender.send(Request::default()).await?;
     /// drop(sender); // Half-close the stream
@@ -172,21 +166,21 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			file:     "src/builder.rs",
 			startStr: "    #[derive(Clone, Debug)]\n    pub struct Chat(",
 			endStr:   ");",
-			want:     "    #[derive(Clone, Debug)]\n    pub struct Chat(RequestBuilder<std::option::Option<crate::model::Request>>);",
+			want:     "    #[derive(Clone, Debug)]\n    pub struct Chat(BidiStreamBuilder);",
 		},
 		{
-			name:     "builder: send method",
+			name:     "builder: build method",
 			file:     "src/builder.rs",
-			startStr: "        /// Initiates the bidirectional stream.\n        pub async fn send(",
-			endStr:   "        }",
+			startStr: "        /// Initiates the bidirectional stream.\n        pub fn build(",
+			endStr:   "            (*self.0.stub).chat(self.0.options)\n        }",
 			want: `        /// Initiates the bidirectional stream.
-        pub async fn send(
+        pub fn build(
             self,
-        ) -> Result<(
+        ) -> (
             google_cloud_gax::streaming::RequestSender<crate::model::Request>,
             google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
-        )> {
-            (*self.0.stub).chat(self.0.request, self.0.options).await
+        ) {
+            (*self.0.stub).chat(self.0.options)
         }`,
 		},
 		{
@@ -203,28 +197,6 @@ func TestGenerateBidiStreaming(t *testing.T) {
     }`,
 		},
 		{
-			name:     "builder: with_request method",
-			file:     "src/builder.rs",
-			startStr: "        /// Sets the full request, replacing any prior values.\n        pub fn with_request<",
-			endStr:   "        }",
-			want: `        /// Sets the full request, replacing any prior values.
-        pub fn with_request<V: Into<crate::model::Request>>(mut self, v: V) -> Self {
-            self.0.request = std::option::Option::Some(v.into());
-            self
-        }`,
-		},
-		{
-			name:     "builder: field setter",
-			file:     "src/builder.rs",
-			startStr: "        /// Sets the value of [query]",
-			endStr:   "        }",
-			want: `        /// Sets the value of [query][crate::model::Request::query].
-        pub fn set_query<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.get_or_insert_with(std::default::Default::default).query = v.into();
-            self
-        }`,
-		},
-		{
 			name:     "stub: method signature and default body",
 			file:     "src/stub.rs",
 			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
@@ -232,117 +204,123 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
-        _req: std::option::Option<crate::model::Request>,
         _options: crate::RequestOptions,
-    ) -> impl std::future::Future<Output = crate::Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
-    )>> + Send {
+    ) {
         gaxi::unimplemented::unimplemented_bidi_stub()
     }`,
 		},
 		{
 			name:     "stub dynamic: trait method",
 			file:     "src/stub/dynamic.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn chat(",
-			endStr:   ")>;",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
+			endStr:   ");",
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn chat(
+    fn chat(
         &self,
-        req: std::option::Option<crate::model::Request>,
         options: crate::RequestOptions,
-    ) -> crate::Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
-    )>;`,
+    );`,
 		},
 		{
 			name:     "stub dynamic: blanket forwarding impl",
 			file:     "src/stub/dynamic.rs",
-			startStr: "    /// Forwards the call to the implementation provided by `T`.\n    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn chat(",
+			startStr: "    /// Forwards the call to the implementation provided by `T`.\n    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
 			endStr:   "    }",
 			want: `    /// Forwards the call to the implementation provided by ` + "`T`." + `
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn chat(
+    fn chat(
         &self,
-        req: std::option::Option<crate::model::Request>,
         options: crate::RequestOptions,
-    ) -> crate::Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
-    )> {
-        T::chat(self, req, options).await
+    ) {
+        T::chat(self, options)
     }`,
 		},
 		{
 			name:     "tracing: method wrapper",
 			file:     "src/tracing.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn chat(",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
 			endStr:   "    }",
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn chat(
+    fn chat(
         &self,
-        req: std::option::Option<crate::model::Request>,
         options: crate::RequestOptions,
-    ) -> Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
-    )> {
-        self.inner.chat(req, options).await
+    ) {
+        self.inner.chat(options)
     }`,
 		},
 		{
 			name:     "transport: method signature",
 			file:     "src/transport.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn chat(",
-			endStr:   ")> {",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
+			endStr:   ") -> (",
 			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn chat(
+    fn chat(
         &self,
-        req: std::option::Option<crate::model::Request>,
         options: crate::RequestOptions,
-    ) -> Result<(
-        google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
-    )> {`,
+    ) -> (`,
 		},
 		{
-			name:     "transport: request params without routing",
+			name:     "transport: request stream assembly and future call",
 			file:     "src/transport.rs",
-			startStr: "        let req = req.ok_or_else(|| {\n",
-			endStr:   "        let x_goog_request_params = \"\";",
-			want: `        let req = req.ok_or_else(|| {
-            google_cloud_gax::error::Error::binding(
-                "a request is required"
-            )
-        })?;
+			startStr: "        let (req_tx, req_rx) = tokio::sync::mpsc::channel",
+			endStr:   "        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(",
+			want: `        let (req_tx, req_rx) = tokio::sync::mpsc::channel(
+            options
+                .request_stream_channel_capacity()
+                .unwrap_or(google_cloud_gax::options::internal::DEFAULT_REQUEST_CHANNEL_CAPACITY),
+        );
+        let req_stream = tokio_stream::wrappers::ReceiverStream::new(req_rx);
 
-        let x_goog_request_params = "";`,
-		},
-		{
-			name:     "transport: eager bidi_stream call",
-			file:     "src/transport.rs",
-			startStr: "        let result = self.grpc_inner\n            .bidi_stream::<",
-			endStr:   ".await?;",
-			want: `        let result = self.grpc_inner
-            .bidi_stream::<
-                crate::prost::test::v1::Request,
-                crate::prost::test::v1::Response,
-            >(
-                extensions,
-                path,
-                req_stream,
-                options,
-                &crate::info::X_GOOG_API_CLIENT_HEADER,
-                x_goog_request_params,
-            )
-            .await?;`,
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "test.v1.Protocol",
+                "Chat",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/test.v1.Protocol/Chat"
+        );
+
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+
+        let grpc_inner = self.grpc_inner.clone();
+        tokio::spawn(async move {
+            let result = grpc_inner
+                .bidi_stream::<
+                    crate::prost::test::v1::Request,
+                    crate::prost::test::v1::Response,
+                >(
+                    extensions,
+                    path,
+                    req_stream,
+                    options,
+                    &crate::info::X_GOOG_API_CLIENT_HEADER,
+                    x_goog_request_params,
+                )
+                .await;
+            let _ = resp_tx.send(result);
+        });
+
+        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(`,
 		},
 		{
 			name:     "transport: request sender and response receiver",
 			file:     "src/transport.rs",
 			startStr: "        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(",
-			endStr:   "        Ok((request_sender, response_receiver))\n    }",
+			endStr:   "        (request_sender, response_receiver)\n    }",
 			want: `        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(
             move |item: crate::model::Request| {
                 let req_tx = req_tx.clone();
@@ -353,23 +331,24 @@ func TestGenerateBidiStreaming(t *testing.T) {
                     req_tx
                         .send(prost_item)
                         .await
-                        .map_err(|_| {
-                            google_cloud_gax::error::Error::io(std::io::Error::new(
-                                std::io::ErrorKind::BrokenPipe,
-                                "cannot send request: stream is closed",
-                            ))
-                        })
+                        .map_err(|_| google_cloud_gax::streaming::SendError::StreamClosed)
                 }
             },
         );
-        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_stream(
-            result.into_inner().map(|res| {
+        let future = resp_rx.map(|res| match res {
+            Ok(Ok(response)) => Ok(response.into_inner().map(|res| {
                 res.map_err(gaxi::grpc::from_status::to_gax_error)
                     .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
-            }),
-        );
+            })),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(google_cloud_gax::error::Error::io(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "stream initialization task cancelled",
+            ))),
+        });
+        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_future(future);
 
-        Ok((request_sender, response_receiver))
+        (request_sender, response_receiver)
     }`,
 		},
 	} {
@@ -378,109 +357,6 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			got := extractBlock(t, content, test.startStr, test.endStr)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGenerateBidiStreamingWithRouting(t *testing.T) {
-	for _, test := range []struct {
-		name            string
-		routingRequired bool
-		wantSubstrings  []string
-		wantAbsent      []string
-	}{
-		{
-			name:            "without routing required",
-			routingRequired: false,
-			wantSubstrings: []string{
-				"let x_goog_request_params = {",
-				"gaxi::routing_parameter::format(&[",
-				`.map(|v| ("table_name", v))`,
-			},
-			wantAbsent: []string{
-				"BindingError",
-				"PathMismatchBuilder",
-			},
-		},
-		{
-			name:            "with routing required",
-			routingRequired: true,
-			wantSubstrings: []string{
-				"let x_goog_request_params = {",
-				"if x_goog_request_params.is_empty() {",
-				"use google_cloud_gax::error::binding::BindingError;",
-				"use gaxi::path_parameter::PathMismatchBuilder;",
-				"let builder = PathMismatchBuilder::default();",
-				`"projects/*/datasets/*/tables/*"`,
-				"return Err(google_cloud_gax::error::Error::binding(BindingError { paths }))",
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			outDir := t.TempDir()
-
-			request := api.NewTestMessage("Request").WithPackage("test.v1")
-			request.Fields = []*api.Field{
-				{
-					Name:     "table_name",
-					JSONName: "tableName",
-					ID:       ".test.v1.Request.table_name",
-					Typez:    api.TypezString,
-				},
-			}
-			response := api.NewTestMessage("Response").WithPackage("test.v1")
-
-			bidiMethod := api.NewTestMethod("AppendRows").WithInput(request).WithOutput(response).WithBidiStreaming()
-			bidiMethod.PathInfo = &api.PathInfo{
-				Bindings: []*api.PathBinding{{Verb: "GET", PathTemplate: &api.PathTemplate{}}},
-			}
-			bidiMethod.Routing = []*api.RoutingInfo{
-				{
-					Name: "table_name",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "datasets", "*", "tables", "*"}},
-						},
-					},
-				},
-			}
-			service := api.NewTestService("WriteStream").WithPackage("test.v1").WithMethods(bidiMethod)
-
-			model := api.NewTestAPI([]*api.Message{request, response}, []*api.Enum{}, []*api.Service{service})
-			model.PackageName = "test.v1"
-			if err := api.CrossReference(model); err != nil {
-				t.Fatal(err)
-			}
-
-			cfg := &parser.ModelConfig{
-				SpecificationFormat: libconfig.SpecProtobuf,
-				Codec: map[string]string{
-					"package:wkt":                    "source=google.protobuf,package=google-cloud-wkt",
-					"include-bidi-streaming-methods": "true",
-					"routing-required":               strconv.FormatBool(test.routingRequired),
-				},
-			}
-			if err := Generate(t.Context(), model, outDir, cfg); err != nil {
-				t.Fatal(err)
-			}
-
-			transportContent, err := os.ReadFile(filepath.Join(outDir, "src/transport.rs"))
-			if err != nil {
-				t.Fatal(err)
-			}
-			content := string(transportContent)
-
-			for _, sub := range test.wantSubstrings {
-				if !strings.Contains(content, sub) {
-					t.Errorf("missing expected substring %q in generated transport.rs", sub)
-				}
-			}
-			for _, absent := range test.wantAbsent {
-				if strings.Contains(content, absent) {
-					t.Errorf("unexpected substring %q found in generated transport.rs", absent)
-				}
 			}
 		})
 	}

--- a/internal/sidekick/rust/templates/common/client_method_samples/method_call.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/method_call.mustache
@@ -15,9 +15,7 @@ limitations under the License.
 }}
 {{#Codec.IsBidiStreaming}}
 ///     let (sender, mut receiver) = client.{{Codec.Name}}()
-///         .with_request({{InputType.Codec.Name}}::default())
-///         .send()
-///         .await?;
+///         .build();
 ///
 ///     sender.send({{InputType.Codec.Name}}::default()).await?;
 ///     drop(sender); // Half-close the stream

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -77,7 +77,26 @@ pub mod {{Codec.ModuleName}} {
             }
         }
     }
+    {{#Codec.HasBidiStreaming}}
 
+    /// Common implementation for [crate::client::{{Codec.Name}}] bidi stream builders.
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug)]
+    pub(crate) struct BidiStreamBuilder {
+        stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
+        options: crate::RequestOptions,
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl BidiStreamBuilder {
+        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>) -> Self {
+            Self {
+                stub,
+                options: crate::RequestOptions::default(),
+            }
+        }
+    }
+    {{/Codec.HasBidiStreaming}}
 
     {{#Codec.Methods}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}] calls.
@@ -92,10 +111,7 @@ pub mod {{Codec.ModuleName}} {
     /// # async fn sample() -> {{Model.Codec.PackageNamespace}}::Result<()> {
     {{#Codec.IsBidiStreaming}}
     /// let builder = prepare_request_builder();
-    /// let (sender, mut receiver) = builder
-    ///     .with_request({{InputType.Codec.Name}}::default())
-    ///     .send()
-    ///     .await?;
+    /// let (sender, mut receiver) = builder.build();
     ///
     /// sender.send({{InputType.Codec.Name}}::default()).await?;
     /// drop(sender); // Half-close the stream
@@ -139,9 +155,13 @@ pub mod {{Codec.ModuleName}} {
     {{/Codec.InternalBuilders}}
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsBidiStreaming}}
     #[derive(Clone, Debug)]
-    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{#Codec.IsBidiStreaming}}std::option::Option<{{InputType.Codec.QualifiedName}}>{{/Codec.IsBidiStreaming}}{{^Codec.IsBidiStreaming}}{{InputType.Codec.QualifiedName}}{{/Codec.IsBidiStreaming}}>);
+    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(BidiStreamBuilder);
+    {{/Codec.IsBidiStreaming}}
+    {{^Codec.IsBidiStreaming}}
+    #[derive(Clone, Debug)]
+    {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
+    {{/Codec.IsBidiStreaming}}
 
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
@@ -149,20 +169,17 @@ pub mod {{Codec.ModuleName}} {
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {
             Self(
-                RequestBuilder::new(stub)
+                {{#Codec.IsBidiStreaming}}BidiStreamBuilder{{/Codec.IsBidiStreaming}}{{^Codec.IsBidiStreaming}}RequestBuilder{{/Codec.IsBidiStreaming}}::new(stub)
             )
         }
 
+        {{^Codec.IsBidiStreaming}}
         /// Sets the full request, replacing any prior values.
         pub fn with_request<V: Into<{{InputType.Codec.QualifiedName}}>>(mut self, v: V) -> Self {
-            {{#Codec.IsBidiStreaming}}
-            self.0.request = std::option::Option::Some(v.into());
-            {{/Codec.IsBidiStreaming}}
-            {{^Codec.IsBidiStreaming}}
             self.0.request = v.into();
-            {{/Codec.IsBidiStreaming}}
             self
         }
+        {{/Codec.IsBidiStreaming}}
 
         /// Sets all the options, replacing any prior values.
         pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
@@ -171,14 +188,15 @@ pub mod {{Codec.ModuleName}} {
         }
 
         {{#Codec.IsBidiStreaming}}
+        {{! TODO(#6835) - support explicit routing parameters for bidirectional streaming RPCs }}
         /// Initiates the bidirectional stream.
-        pub async fn send(
+        pub fn build(
             self,
-        ) -> Result<(
+        ) -> (
             google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
             google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
-        )> {
-            (*self.0.stub).{{Codec.Name}}(self.0.request, self.0.options).await
+        ) {
+            (*self.0.stub).{{Codec.Name}}(self.0.options)
         }
         {{/Codec.IsBidiStreaming}}
         {{^Codec.IsBidiStreaming}}
@@ -492,7 +510,6 @@ pub mod {{Codec.ModuleName}} {
             req
         }
         {{/HasAutoPopulatedFields}}
-        {{/Codec.IsBidiStreaming}}
         {{#InputType.Codec.BasicFields}}
 
         /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
@@ -506,12 +523,7 @@ pub mod {{Codec.ModuleName}} {
         {{#Singular}}
         {{^Optional}}
         pub fn set_{{Codec.SetterName}}<T: Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into();
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.into();
-            {{/IsBidiStreaming}}
             self
         }
         {{/Optional}}
@@ -520,12 +532,7 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_{{Codec.SetterName}}<T>(mut self, v: T) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = std::option::Option::Some(v.into());
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = std::option::Option::Some(v.into());
-            {{/IsBidiStreaming}}
             self
         }
 
@@ -540,12 +547,7 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_or_clear_{{Codec.SetterName}}<T>(mut self, v: std::option::Option<T>) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.map(|x| x.into());
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.map(|x| x.into());
-            {{/IsBidiStreaming}}
             self
         }
         {{/Codec.IsBoxed}}
@@ -553,12 +555,7 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_{{Codec.SetterName}}<T>(mut self, v: T) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = std::option::Option::Some(std::boxed::Box::new(v.into()));
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = std::option::Option::Some(std::boxed::Box::new(v.into()));
-            {{/IsBidiStreaming}}
             self
         }
 
@@ -573,12 +570,7 @@ pub mod {{Codec.ModuleName}} {
         pub fn set_or_clear_{{Codec.SetterName}}<T>(mut self, v: std::option::Option<T>) -> Self
         where T: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.map(|x| std::boxed::Box::new(x.into()));
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.map(|x| std::boxed::Box::new(x.into()));
-            {{/IsBidiStreaming}}
             self
         }
         {{/Codec.IsBoxed}}
@@ -591,12 +583,7 @@ pub mod {{Codec.ModuleName}} {
             V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
             use std::iter::Iterator;
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
-            {{/IsBidiStreaming}}
             self
         }
         {{/Repeated}}
@@ -607,12 +594,8 @@ pub mod {{Codec.ModuleName}} {
             K: std::convert::Into<{{{Codec.KeyType}}}>,
             V: std::convert::Into<{{{Codec.ValueType}}}>,
         {
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
+            use std::iter::Iterator;
             self.0.request.{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-            {{/IsBidiStreaming}}
             self
         }
         {{/Map}}
@@ -624,12 +607,7 @@ pub mod {{Codec.ModuleName}} {
         /// Note that all the setters affecting `{{Codec.FieldName}}` are
         /// mutually exclusive.
         pub fn set_{{Codec.SetterName}}<T: Into<Option<{{{Codec.FieldType}}}>>>(mut self, v: T) ->Self {
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Codec.FieldName}} = v.into();
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Codec.FieldName}} = v.into();
-            {{/IsBidiStreaming}}
             self
         }
         {{#Fields}}
@@ -644,13 +622,7 @@ pub mod {{Codec.ModuleName}} {
         {{/Deprecated}}
         {{#Singular}}
         pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
-            {{#IsBidiStreaming}}
-            let req = self.0.request.take().unwrap_or_default().set_{{Codec.SetterName}}(v);
-            self.0.request = std::option::Option::Some(req);
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request = self.0.request.set_{{Codec.SetterName}}(v);
-            {{/IsBidiStreaming}}
             self
         }
         {{/Singular}}
@@ -661,20 +633,11 @@ pub mod {{Codec.ModuleName}} {
             V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
         {
             use std::iter::Iterator;
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Group.Codec.FieldName}} = std::option::Option::Some(
-                {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                    v.into_iter().map(|i| i.into()).collect()
-                )
-            );
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Group.Codec.FieldName}} = std::option::Option::Some(
                 {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
                     v.into_iter().map(|i| i.into()).collect()
                 )
             );
-            {{/IsBidiStreaming}}
             self
         }
         {{/Repeated}}
@@ -686,25 +649,17 @@ pub mod {{Codec.ModuleName}} {
             V: std::convert::Into<{{{Codec.ValueType}}}>,
         {
             use std::iter::Iterator;
-            {{#IsBidiStreaming}}
-            self.0.request.get_or_insert_with(std::default::Default::default).{{Group.Codec.FieldName}} = std::option::Option::Some(
-                {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                    v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
-                )
-            );
-            {{/IsBidiStreaming}}
-            {{^IsBidiStreaming}}
             self.0.request.{{Group.Codec.FieldName}} = std::option::Option::Some(
                 {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
                     v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
                 )
             );
-            {{/IsBidiStreaming}}
             self
         }
         {{/Map}}
         {{/Fields}}
         {{/InputType.OneOfs}}
+        {{/Codec.IsBidiStreaming}}
     }
 
     {{#Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -57,12 +57,11 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
-        _req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         _options: crate::RequestOptions,
-    ) -> impl std::future::Future<Output = crate::Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
-    )>> + Send {
+    ) {
         gaxi::unimplemented::unimplemented_bidi_stub()
     }
     {{/Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -28,14 +28,13 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     {{#Codec.Methods}}
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn {{Codec.Name}}(
+    fn {{Codec.Name}}(
         &self,
-        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::RequestOptions,
-    ) -> crate::Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
-    )>;
+    );
 
     {{/Codec.IsBidiStreaming}}
     {{^Codec.IsBidiStreaming}}
@@ -77,15 +76,14 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
     /// Forwards the call to the implementation provided by `T`.
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn {{Codec.Name}}(
+    fn {{Codec.Name}}(
         &self,
-        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::RequestOptions,
-    ) -> crate::Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
-    )> {
-        T::{{Codec.Name}}(self, req, options).await
+    ) {
+        T::{{Codec.Name}}(self, options)
     }
 
     {{/Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -66,15 +66,14 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     {{#Codec.IsBidiStreaming}}
     {{! TODO(#6835) - add tracing for bidi streaming methods }}
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn {{Codec.Name}}(
+    fn {{Codec.Name}}(
         &self,
-        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::RequestOptions,
-    ) -> Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
-    )> {
-        self.inner.{{Codec.Name}}(req, options).await
+    ) {
+        self.inner.{{Codec.Name}}(options)
     }
     {{/Codec.IsBidiStreaming}}
     {{^Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -129,47 +129,26 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     {{#Codec.Methods}}
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn {{Codec.Name}}(
+    fn {{Codec.Name}}(
         &self,
-        req: std::option::Option<{{InputType.Codec.QualifiedName}}>,
         options: crate::RequestOptions,
-    ) -> Result<(
+    ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
-    )> {
+    ) {
         use gaxi::prost::{FromProto, ToProto};
         use futures::stream::StreamExt as _;
+        use futures::FutureExt as _;
 
-        let req = req.ok_or_else(|| {
-            {{! TODO(#6835) - determine appropriate error type for missing initial request }}
-            google_cloud_gax::error::Error::binding(
-                "a request is required"
-            )
-        })?;
-
-        {{!
-        Per AIP-4222, fallback to HTTP path templates only applies to unary RPCs.
-        Streaming RPCs only extract routing parameters if explicitly annotated.
-        }}
-        {{#HasRouting}}
-        {{> /templates/grpc-client/routinginfo}}
-        {{/HasRouting}}
-        {{^HasRouting}}
+        {{! TODO(#6835) - support explicit routing parameters for bidirectional streaming RPCs }}
         let x_goog_request_params = "";
-        {{/HasRouting}}
-
-        let first_req = req
-            .to_proto()
-            .map_err(google_cloud_gax::error::Error::ser)?;
 
         let (req_tx, req_rx) = tokio::sync::mpsc::channel(
             options
                 .request_stream_channel_capacity()
                 .unwrap_or(google_cloud_gax::options::internal::DEFAULT_REQUEST_CHANNEL_CAPACITY),
         );
-
-        let req_stream = futures::stream::once(async move { first_req })
-            .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx));
+        let req_stream = tokio_stream::wrappers::ReceiverStream::new(req_rx);
 
         let extensions = {
             let mut e = gaxi::grpc::tonic::Extensions::new();
@@ -183,19 +162,25 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}"
         );
 
-        let result = self.grpc_inner
-            .bidi_stream::<
-                crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
-                crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
-            >(
-                extensions,
-                path,
-                req_stream,
-                options,
-                &crate::info::X_GOOG_API_CLIENT_HEADER,
-                x_goog_request_params,
-            )
-            .await?;
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+
+        let grpc_inner = self.grpc_inner.clone();
+        tokio::spawn(async move {
+            let result = grpc_inner
+                .bidi_stream::<
+                    crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
+                    crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
+                >(
+                    extensions,
+                    path,
+                    req_stream,
+                    options,
+                    &crate::info::X_GOOG_API_CLIENT_HEADER,
+                    x_goog_request_params,
+                )
+                .await;
+            let _ = resp_tx.send(result);
+        });
 
         let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(
             move |item: {{InputType.Codec.QualifiedName}}| {
@@ -207,23 +192,24 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                     req_tx
                         .send(prost_item)
                         .await
-                        .map_err(|_| {
-                            google_cloud_gax::error::Error::io(std::io::Error::new(
-                                std::io::ErrorKind::BrokenPipe,
-                                "cannot send request: stream is closed",
-                            ))
-                        })
+                        .map_err(|_| google_cloud_gax::streaming::SendError::StreamClosed)
                 }
             },
         );
-        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_stream(
-            result.into_inner().map(|res| {
+        let future = resp_rx.map(|res| match res {
+            Ok(Ok(response)) => Ok(response.into_inner().map(|res| {
                 res.map_err(gaxi::grpc::from_status::to_gax_error)
                     .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
-            }),
-        );
+            })),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(google_cloud_gax::error::Error::io(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "stream initialization task cancelled",
+            ))),
+        });
+        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_future(future);
 
-        Ok((request_sender, response_receiver))
+        (request_sender, response_receiver)
     }
 
     {{/Codec.IsBidiStreaming}}


### PR DESCRIPTION
Refactor bidirectional streaming templates in Rust sidekick to lazily initialize the transport and stub synchronously. Bidirectional streaming builders now wrap BidiStreamBuilder without storing an initial request or generating request field setters. All requests are sent asynchronously through RequestSender.

The existing implementation was broken because services may not send RepsonseHeaders until multiple requests were sent, causing a deadlock that could not be worked around.

For #6835 