### PR TITLE
fix(internal/librarian/php): ignore unmatched patterns in prettier

### DIFF
--- a/internal/librarian/php/format.go
+++ b/internal/librarian/php/format.go
@@ -36,9 +36,10 @@ func Format(ctx context.Context, library *config.Library) error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
-	// Run prettier '**/Client/*' --write --parser=php --single-quote --print-width=120 --plugin=<pluginPath>
+	// Run prettier '**/Client/*' --no-error-on-unmatched-pattern --write --parser=php --single-quote --print-width=120 --plugin=<pluginPath>
 	return command.RunInDirWithEnv(ctx, outdir, prettierEnv(prettierPath), prettierPath,
 		"**/Client/*",
+		"--no-error-on-unmatched-pattern",
 		"--write",
 		"--parser=php",
 		"--single-quote",

--- a/internal/librarian/php/format_test.go
+++ b/internal/librarian/php/format_test.go
@@ -74,6 +74,18 @@ class Foo
 	}
 }
 
+func TestFormat_NoMatchingFiles(t *testing.T) {
+	requirePrettier(t)
+	tmpDir := t.TempDir()
+	library := &config.Library{
+		Name:   "test-library",
+		Output: tmpDir,
+	}
+	if err := Format(t.Context(), library); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFormat_ErrorPrettierMissing(t *testing.T) {
 	t.Setenv("LIBRARIAN_BIN", t.TempDir())
 	library := &config.Library{


### PR DESCRIPTION
The `--no-error-on-unmatched-pattern` flag is added to the Prettier invocation in the PHP formatter to prevent Prettier from returning an error when no files match the **/Client/* glob pattern.

This ensures that libraries without matching client files do not fail code formatting during generation.

Fixes #7314
