### PR TITLE
refactor(internal/librarian/php): adopt proto.Gather helper

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -23,11 +23,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/filesystem"
+	"github.com/googleapis/librarian/internal/proto"
 	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/tool/protoc"
@@ -259,8 +259,7 @@ func extractOutput(ctx context.Context, zipPath, outDir string) error {
 }
 
 func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
-	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
-	protos, err := gatherProtos(apiDir)
+	protos, err := proto.Gather(googleapisDir, apiPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("%w for API %s: %w", errNoProtos, apiPath, err)
@@ -270,29 +269,6 @@ func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
 	if len(protos) == 0 {
 		return nil, fmt.Errorf("%w for API %s", errNoProtos, apiPath)
 	}
-	return protos, nil
-}
-
-// gatherProtos walks the directory tree recursively from root and returns
-// a sorted list of absolute paths for all found proto files.
-func gatherProtos(root string) ([]string, error) {
-	var protos []string
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		if d.Type().IsRegular() && filepath.Ext(path) == ".proto" {
-			protos = append(protos, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	slices.Sort(protos)
 	return protos, nil
 }
 

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -259,7 +259,8 @@ func extractOutput(ctx context.Context, zipPath, outDir string) error {
 }
 
 func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
-	protos, err := proto.Gather(googleapisDir, apiPath)
+	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
+	protos, err := proto.Gather(apiDir, apiPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("%w for API %s: %w", errNoProtos, apiPath, err)

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -325,40 +325,6 @@ func TestGenerate_Error(t *testing.T) {
 	}
 }
 
-func TestGatherProtos(t *testing.T) {
-	tmp := t.TempDir()
-	files := []struct {
-		path    string
-		isProto bool
-	}{
-		{"a.proto", true},
-		{"sub/b.proto", true},
-		{"c.txt", false},
-		{"sub/d.proto", true},
-	}
-	for _, f := range files {
-		p := filepath.Join(tmp, f.path)
-		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	got, err := gatherProtos(tmp)
-	if err != nil {
-		t.Fatalf("gatherProtos failed: %v", err)
-	}
-	want := []string{
-		filepath.Join(tmp, "a.proto"),
-		filepath.Join(tmp, "sub/b.proto"),
-		filepath.Join(tmp, "sub/d.proto"),
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func TestGapicOpts(t *testing.T) {
 	for _, test := range []struct {
 		name               string


### PR DESCRIPTION
The custom `gatherProtos` directory walker in the PHP generator is removed and replaced with the centralized `proto.Gather` helper function.

This consolidates proto gathering logic across language generators and removes redundant file traversal helper functions and unit tests.

Fixes https://github.com/googleapis/librarian/issues/7317
