### PR TITLE
feat(sidekick/swift): use `@_spi` for some imports

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -634,6 +634,7 @@ This document describes the schema for the librarian.yaml.
 | `version` | string | Configures the minimum version for external package definitions.<br><br>For example, if the `swift-protobuf` package used `1.36.1`, then the codec would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf", from: "1.36.1") ``` |
 | `required_by_services` | bool | Is true if this dependency is required by packages with services.<br><br>This will be set for the `gax` library and the `auth` library. Maybe more if we split the HTTP and gRPC clients into separate libraries. |
 | `api_package` | string | Is the name of the API package provided by this library.<br><br>In Swift a package contains at most one channel for one API. For packages that implement an API, this field contains the name of the package in the specification language of that API. At the moment this is only used by Protobuf-based APIs, as OpenAPI and discovery doc APIs are self-contained.<br><br>Note that some packages, for example `auth` and `gax`, do not implement APIs. This field is empty for such libraries.<br><br>Examples:<br>- The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.<br>- The `GoogleCloudLocation` package will set this to `google.cloud.location`. |
+| `spi` | string | If set, the dependency requires an `@_spi(...)` attribute. |
 
 ## SwiftModule Configuration
 

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -137,6 +137,8 @@ type SwiftDependency struct {
 	// - The `GoogleCloudWkt` package will set this to `google.cloud.protobuf`.
 	// - The `GoogleCloudLocation` package will set this to `google.cloud.location`.
 	ApiPackage string `yaml:"api_package,omitempty"`
+	// SpiAttribute if set, the dependency requires an `@_spi(...)` attribute.
+	SpiAttribute string `yaml:"spi,omitempty"`
 }
 
 // SwiftModule defines a generation target within a larger crate. Typically a veneer, but sometimes also test targets.

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -99,12 +99,20 @@ func (ann *messageAnnotations) ConvertImports() []string {
 }
 
 // MessageImports returns the list of dependencies for this message.
-func (ann *messageAnnotations) MessageImports() []string {
-	result := make([]string, 0, len(ann.DependsOn))
-	for _, dep := range ann.DependsOn {
-		result = append(result, dep.Name)
+func (ann *messageAnnotations) MessageImports() []*dependencyImport {
+	result := make([]*dependencyImport, 0, len(ann.DependsOn))
+	for _, d := range ann.DependsOn {
+		dep := &dependencyImport{
+			Module: d.Name,
+		}
+		if d.SpiAttribute != "" {
+			dep.Attributes = append(dep.Attributes, fmt.Sprintf("@_spi(%s)", d.SpiAttribute))
+		}
+		result = append(result, dep)
 	}
-	slices.Sort(result)
+	slices.SortFunc(result, func(a, b *dependencyImport) int {
+		return strings.Compare(a.Module, b.Module)
+	})
 	return result
 }
 

--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -15,6 +15,7 @@
 package swift
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"strings"
@@ -111,7 +112,7 @@ func (ann *messageAnnotations) MessageImports() []*dependencyImport {
 		result = append(result, dep)
 	}
 	slices.SortFunc(result, func(a, b *dependencyImport) int {
-		return strings.Compare(a.Module, b.Module)
+		return cmp.Compare(a.Module, b.Module)
 	})
 	return result
 }

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -29,7 +29,7 @@ func TestAnnotateMessage(t *testing.T) {
 		name        string
 		message     *api.Message
 		want        *messageAnnotations
-		wantImports []string
+		wantImports []*dependencyImport
 	}{
 		{
 			name: "simple",
@@ -52,7 +52,7 @@ func TestAnnotateMessage(t *testing.T) {
 				ProtoTypeName:       "Test_Secret",
 				ModulePath:          "",
 			},
-			wantImports: []string{"GoogleCloudWkt"},
+			wantImports: []*dependencyImport{{Module: "GoogleCloudWkt"}},
 		},
 		{
 			name: "escaped name",
@@ -72,7 +72,7 @@ func TestAnnotateMessage(t *testing.T) {
 				ProtoTypeName:       "Test_Protocol_",
 				ModulePath:          "",
 			},
-			wantImports: []string{"GoogleCloudWkt"},
+			wantImports: []*dependencyImport{{Module: "GoogleCloudWkt"}},
 		},
 		{
 			name: "with oneof",
@@ -91,7 +91,7 @@ func TestAnnotateMessage(t *testing.T) {
 				ProtoTypeName:       "Test_WithOneof",
 				ModulePath:          "",
 			},
-			wantImports: []string{"GoogleCloudWkt"},
+			wantImports: []*dependencyImport{{Module: "GoogleCloudWkt"}},
 		},
 		{
 			name: "with custom json name",
@@ -112,7 +112,7 @@ func TestAnnotateMessage(t *testing.T) {
 				ProtoTypeName:       "Test_WithCustomJSON",
 				ModulePath:          "",
 			},
-			wantImports: []string{"GoogleCloudWkt"},
+			wantImports: []*dependencyImport{{Module: "GoogleCloudWkt"}},
 		},
 		{
 			name: "with pagination",
@@ -140,7 +140,7 @@ func TestAnnotateMessage(t *testing.T) {
 				ProtoTypeName:       "Test_WithPagination",
 				ModulePath:          "",
 			},
-			wantImports: []string{"GoogleCloudGax", "GoogleCloudWkt"},
+			wantImports: []*dependencyImport{{Module: "GoogleCloudGax"}, {Module: "GoogleCloudWkt"}},
 		},
 		{
 			name: "service placeholder",
@@ -160,7 +160,7 @@ func TestAnnotateMessage(t *testing.T) {
 				ProtoTypeName:       "Test_Service",
 				ModulePath:          "",
 			},
-			wantImports: []string{"GoogleCloudWkt"},
+			wantImports: []*dependencyImport{{Module: "GoogleCloudWkt"}},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -174,6 +174,84 @@ func TestAnnotateMessage(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantImports, test.message.Codec.(*messageAnnotations).MessageImports()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAnnotateMessage_ImportAttributes(t *testing.T) {
+	noSpiConfig := &config.Library{
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{Name: wellKnownSwiftPackage, ApiPackage: wellKnownProtobufPackage},
+					{Name: paginationSwiftPackage, RequiredByServices: true},
+				},
+			},
+		},
+	}
+	withSpiConfig := &config.Library{
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{Name: wellKnownSwiftPackage, ApiPackage: wellKnownProtobufPackage, SpiAttribute: "Test001"},
+					{Name: paginationSwiftPackage, RequiredByServices: true, SpiAttribute: "Test002"},
+				},
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name        string
+		message     *api.Message
+		config      *config.Library
+		wantImports []*dependencyImport
+	}{
+		{
+			name:        "simple",
+			message:     api.NewTestMessage("Secret"),
+			config:      noSpiConfig,
+			wantImports: []*dependencyImport{{Module: "GoogleCloudWkt"}},
+		},
+		{
+			name:        "with spi attribute",
+			message:     api.NewTestMessage("Secret"),
+			config:      withSpiConfig,
+			wantImports: []*dependencyImport{{Module: "GoogleCloudWkt", Attributes: []string{"@_spi(Test001)"}}},
+		},
+		{
+			name: "with pagination",
+			message: api.NewTestMessage("WithPagination").WithPagination(
+				api.NewTestField("next_page_token").WithType(api.TypezString),
+				api.NewTestField("pageable_item").WithType(api.TypezString).WithRepeated(),
+			),
+			config:      noSpiConfig,
+			wantImports: []*dependencyImport{{Module: "GoogleCloudGax"}, {Module: "GoogleCloudWkt"}},
+		},
+		{
+			name: "with pagination and attributes",
+			message: api.NewTestMessage("WithPagination").WithPagination(
+				api.NewTestField("next_page_token").WithType(api.TypezString),
+				api.NewTestField("pageable_item").WithType(api.TypezString).WithRepeated(),
+			),
+			config: withSpiConfig,
+			wantImports: []*dependencyImport{
+				{Module: "GoogleCloudGax", Attributes: []string{"@_spi(Test002)"}},
+				{Module: "GoogleCloudWkt", Attributes: []string{"@_spi(Test001)"}},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, f := range test.message.Fields {
+				f.Parent = test.message
+			}
+			model := api.NewTestAPI([]*api.Message{test.message}, []*api.Enum{}, []*api.Service{})
+			codec := newTestCodec(t, model, test.config)
+			if err := codec.annotateModel(); err != nil {
+				t.Fatal(err)
 			}
 			if diff := cmp.Diff(test.wantImports, test.message.Codec.(*messageAnnotations).MessageImports()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -459,7 +537,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
-	wantRequestImports := []string{"GoogleCloudWkt"}
+	wantRequestImports := []*dependencyImport{{Module: "GoogleCloudWkt"}}
 	if diff := cmp.Diff(wantRequestImports, gotRequest.MessageImports()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -480,7 +558,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
-	wantResponseImports := []string{"GoogleCloudGax", "GoogleCloudWkt"}
+	wantResponseImports := []*dependencyImport{{Module: "GoogleCloudGax"}, {Module: "GoogleCloudWkt"}}
 	if diff := cmp.Diff(wantResponseImports, gotResponse.MessageImports()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -536,7 +614,7 @@ func TestAnnotateMessage_RecursiveNested(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	wantImports := []string{"GoogleCloudGax", "GoogleCloudWkt"}
+	wantImports := []*dependencyImport{{Module: "GoogleCloudGax"}, {Module: "GoogleCloudWkt"}}
 	if diff := cmp.Diff(wantImports, gotOuter.MessageImports()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -368,7 +368,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath", "HasConvertedFields")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
-	wantRequestImports := []string{"GoogleCloudWkt"}
+	wantRequestImports := []*dependencyImport{{Module: "GoogleCloudWkt"}}
 	if diff := cmp.Diff(wantRequestImports, gotRequest.MessageImports()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
@@ -388,7 +388,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	// Response type is a paginated response which depends on gax
-	wantResponseImports := []string{"GoogleCloudGax", "GoogleCloudWkt"}
+	wantResponseImports := []*dependencyImport{{Module: "GoogleCloudGax"}, {Module: "GoogleCloudWkt"}}
 	if diff := cmp.Diff(wantResponseImports, gotResponse.MessageImports()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/dependency_import.go
+++ b/internal/sidekick/swift/dependency_import.go
@@ -17,6 +17,9 @@ package swift
 // dependencyImport defines how a dependency should be imported.
 type dependencyImport struct {
 	// The name of the module to import
-	Module     string
+	Module string
+	// Any number of attributes that predece the import.
+	//
+	// At the moment this is only used for the `@_spi(...)` attribute.
 	Attributes []string
 }

--- a/internal/sidekick/swift/dependency_import.go
+++ b/internal/sidekick/swift/dependency_import.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+// dependencyImport defines how a dependency should be imported.
+type dependencyImport struct {
+	// The name of the module to import
+	Module     string
+	Attributes []string
+}

--- a/internal/sidekick/swift/templates/common/message_file.swift.mustache
+++ b/internal/sidekick/swift/templates/common/message_file.swift.mustache
@@ -25,7 +25,10 @@ limitations under the License.
 {{/Codec.IsGated}}
 import Foundation
 {{#Codec.MessageImports}}
-import {{.}}
+{{#Attributes}}
+{{{.}}}
+{{/Attributes}}
+import {{Module}}
 {{/Codec.MessageImports}}
 
 {{> /templates/common/message}}

--- a/internal/sidekick/swift/templates/common/placeholder_file.swift.mustache
+++ b/internal/sidekick/swift/templates/common/placeholder_file.swift.mustache
@@ -25,7 +25,10 @@ limitations under the License.
 {{/Codec.IsGated}}
 import Foundation
 {{#Codec.MessageImports}}
-import {{.}}
+{{#Attributes}}
+{{{.}}}
+{{/Attributes}}
+import {{Module}}
 {{/Codec.MessageImports}}
 
 {{> /templates/common/placeholder}}


### PR DESCRIPTION
This will allow us to use `@_spi(GoogleCloudInternal` when importing `GoogleCloudWkt` and `GoogleCloudGax`. This provides an extra layer of protection against customers accidentally using "internal-only" types or functions in their code.

Fixes https://github.com/googleapis/google-cloud-swift/issues/448 and towards https://github.com/googleapis/google-cloud-swift/issues/13 

See https://github.com/googleapis/google-cloud-swift/pull/470 for the effect of these changes.