### PR TITLE
fix(internal/proto): enable recursive proto gathering for google/rpc

### DIFF
--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -26,7 +26,6 @@ var (
 	nonRecursivePaths = map[string]bool{
 		"google/api":   true,
 		"google/cloud": true,
-		"google/rpc":   true,
 	}
 )
 

--- a/internal/proto/proto_test.go
+++ b/internal/proto/proto_test.go
@@ -76,17 +76,6 @@ func TestGather(t *testing.T) {
 			},
 		},
 		{
-			name:    "non-recursive for google/rpc",
-			relPath: "google/rpc",
-			files: []string{
-				"status.proto",
-				"context/attribute_context.proto",
-			},
-			wantFiles: []string{
-				"status.proto",
-			},
-		},
-		{
 			name:    "non-recursive with OS-native path separators",
 			relPath: filepath.FromSlash("google/cloud"),
 			files: []string{


### PR DESCRIPTION
The `google/rpc` base path is removed from the non-recursive path exclusions in internal/proto, enabling recursive protobuf file discovery across its subdirectories.

This is not a breaking change to google-cloud-java, however, `google/rpc/context` is redundant after this change. Therefore, we will update the librarian version and remove API `google/rpc/context` from librarian.yaml in google-cloud-java.

Fixes #7321
