### PR TITLE
fix(dart): use `@docImport` for service exceptions

### DIFF
--- a/internal/sidekick/dart/annotate.go
+++ b/internal/sidekick/dart/annotate.go
@@ -483,7 +483,6 @@ func (annotate *annotateModel) annotateModel(options map[string]string) error {
 	// Add the import for ServiceClient and related functionality.
 	if len(model.Services) > 0 {
 		annotate.imports[serviceClientImport] = true
-		annotate.imports[serviceExceptionImport] = true
 	}
 
 	// `protobuf.dart` defines `JsonEncodable`, which is needed by any API that defines an `enum` or `message`.

--- a/internal/sidekick/dart/dart.go
+++ b/internal/sidekick/dart/dart.go
@@ -28,11 +28,10 @@ import (
 )
 
 const (
-	httpImport             = "package:http/http.dart as http"
-	serviceClientImport    = "package:google_cloud_rpc/service_client.dart"
-	serviceExceptionImport = "package:google_cloud_rpc/exceptions.dart"
-	encodingImport         = "package:google_cloud_protobuf/src/encoding.dart"
-	protobufImport         = "package:google_cloud_protobuf/protobuf.dart"
+	httpImport          = "package:http/http.dart as http"
+	serviceClientImport = "package:google_cloud_rpc/service_client.dart"
+	encodingImport      = "package:google_cloud_protobuf/src/encoding.dart"
+	protobufImport      = "package:google_cloud_protobuf/protobuf.dart"
 )
 
 var needsCtorValidation = map[string]string{

--- a/internal/sidekick/dart/templates/lib/src/api.g.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/src/api.g.dart.mustache
@@ -25,6 +25,10 @@ limitations under the License.
 {{{.}}}
 {{/Codec.DocLines}}
 {{/Codec.HasDocLines}}
+{{#Codec.HasServices}}
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
+{{/Codec.HasServices}}
 library;
 
 // ignore_for_file: camel_case_types {{! Nested messages have the parent/child separated by an underscore }}


### PR DESCRIPTION
Uses `@docImport` rather than a regular import for `package:google_cloud_rpc/exceptions.dart`. Some methods document throwing exceptions from this package but these exception are never used directly. For example:

```diff
/// The Google Cloud client for the Generative Language API.
///
/// The Gemini API allows developers to build generative AI applications using
/// Gemini models. Gemini is our most capable model, built from the ground up
/// to be multimodal. It can generalize and seamlessly understand, operate
/// across, and combine different types of information including language,
/// images, audio, video, and code. You can use the Gemini API for use cases
/// like reasoning across text and images, content generation, dialogue
/// agents, summarization and classification systems, and more.
///
///
+ /// @docImport 'package:google_cloud_rpc/exceptions.dart';
library;

// ignore_for_file: camel_case_types
// ignore_for_file: comment_references
// ignore_for_file: constant_identifier_names
// ignore_for_file: implementation_imports
// ignore_for_file: lines_longer_than_80_chars
// ignore_for_file: non_constant_identifier_names
// ignore_for_file: unintended_html_in_doc_comment

import 'package:google_cloud_longrunning/longrunning.dart';
import 'package:google_cloud_protobuf/protobuf.dart';
import 'package:google_cloud_protobuf/src/encoding.dart';
- import 'package:google_cloud_rpc/exceptions.dart';
import 'package:google_cloud_rpc/exceptions.dart';
import 'package:google_cloud_rpc/rpc.dart';
import 'package:google_cloud_rpc/service_client.dart';
import 'package:google_cloud_type/type.dart';

...

  /// Creates a `CacheService` that does authentication through an API key.
  ///
  /// Throws [ConfigurationException] if called without arguments and none of
  /// the above environment variables are set. On the web,
  /// always throws [ConfigurationException] if called without arguments.
  ///
  /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
  factory CacheService.fromApiKey([String? apiKey]) =>
      CacheService(client: httpClientFromApiKey(apiKey, _apiKeys));
```

