### PR TITLE
refactor(internal/librarian/php): split generateAPI into helper functions

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -148,10 +148,6 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 		}
 	}()
 	googleapisDir := params.srcCfg.Root("googleapis")
-	mainProtos, err := gatherMainProtos(googleapisDir, params.api.Path)
-	if err != nil {
-		return err
-	}
 	var pc *config.Protoc
 	if params.cfg.Tools != nil {
 		pc = params.cfg.Tools.Protoc
@@ -161,11 +157,7 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 		return err
 	}
 	// Run 2: Proto Message Generation
-	protoArgs := buildProtoProtocArgs(params, protoZipPath, mainProtos)
-	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protoArgs...); err != nil {
-		return fmt.Errorf("failed to generate PHP Proto API %s: %w", params.api.Path, err)
-	}
-	return extractOutput(ctx, protoZipPath, params.protoDestDir)
+	return generateProto(ctx, params, pc, googleapisDir, protoZipPath)
 }
 
 func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, gapicZipPath string) error {
@@ -200,10 +192,19 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, gapicArgs...); err != nil {
 		return fmt.Errorf("failed to generate PHP GAPIC API %s: %w", params.api.Path, err)
 	}
-	if err := extractOutput(ctx, gapicZipPath, params.gapicDestDir); err != nil {
+	return extractOutput(ctx, gapicZipPath, params.gapicDestDir)
+}
+
+func generateProto(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, protoZipPath string) error {
+	mainProtos, err := gatherMainProtos(googleapisDir, params.api.Path)
+	if err != nil {
 		return err
 	}
-	return nil
+	protoArgs := buildProtoProtocArgs(params, protoZipPath, mainProtos)
+	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protoArgs...); err != nil {
+		return fmt.Errorf("failed to generate PHP Proto API %s: %w", params.api.Path, err)
+	}
+	return extractOutput(ctx, protoZipPath, params.protoDestDir)
 }
 
 // gatherGAPICProtos collects all proto files inside the target API directory,

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -139,7 +139,6 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 	sanitizedPath := strings.ReplaceAll(params.api.Path, "/", "_")
 	gapicZipPath := filepath.Join(params.tempDir, sanitizedPath+"-gapic.zip")
 	protoZipPath := filepath.Join(params.tempDir, sanitizedPath+"-proto.zip")
-
 	defer func() {
 		if cleanupErr := os.Remove(gapicZipPath); cleanupErr != nil && !errors.Is(cleanupErr, fs.ErrNotExist) {
 			retErr = errors.Join(retErr, fmt.Errorf("failed to remove gapic zip: %w", cleanupErr))
@@ -149,7 +148,27 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 		}
 	}()
 	googleapisDir := params.srcCfg.Root("googleapis")
-	// Resolve service config files
+	mainProtos, err := gatherMainProtos(googleapisDir, params.api.Path)
+	if err != nil {
+		return err
+	}
+	var pc *config.Protoc
+	if params.cfg.Tools != nil {
+		pc = params.cfg.Tools.Protoc
+	}
+	// Run 1: GAPIC Client Generation
+	if err := generateGAPIC(ctx, params, pc, googleapisDir, gapicZipPath); err != nil {
+		return err
+	}
+	// Run 2: Proto Message Generation
+	protoArgs := buildProtoProtocArgs(params, protoZipPath, mainProtos)
+	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protoArgs...); err != nil {
+		return fmt.Errorf("failed to generate PHP Proto API %s: %w", params.api.Path, err)
+	}
+	return extractOutput(ctx, protoZipPath, params.protoDestDir)
+}
+
+func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, gapicZipPath string) error {
 	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, params.api.Path)
 	if err != nil {
 		return err
@@ -177,16 +196,6 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 	if err != nil {
 		return err
 	}
-	mainProtos, err := gatherMainProtos(googleapisDir, params.api.Path)
-	if err != nil {
-		return err
-	}
-
-	var pc *config.Protoc
-	if params.cfg.Tools != nil {
-		pc = params.cfg.Tools.Protoc
-	}
-	// Run 1: GAPIC Client Generation
 	gapicArgs := buildGapicProtocArgs(params, gapicZipPath, opts, gapicProtos)
 	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, gapicArgs...); err != nil {
 		return fmt.Errorf("failed to generate PHP GAPIC API %s: %w", params.api.Path, err)
@@ -194,12 +203,7 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 	if err := extractOutput(ctx, gapicZipPath, params.gapicDestDir); err != nil {
 		return err
 	}
-	// Run 2: Proto Message Generation
-	protoArgs := buildProtoProtocArgs(params, protoZipPath, mainProtos)
-	if err := protoc.RunOrSystem(ctx, map[string]string{"GOOGLEAPIS_DIR": googleapisDir}, pc, protoArgs...); err != nil {
-		return fmt.Errorf("failed to generate PHP Proto API %s: %w", params.api.Path, err)
-	}
-	return extractOutput(ctx, protoZipPath, params.protoDestDir)
+	return nil
 }
 
 // gatherGAPICProtos collects all proto files inside the target API directory,


### PR DESCRIPTION
The PHP API generation logic in generateAPI is refactored by extracting the GAPIC client generation and protobuf message generation steps into distinct helper functions, `generateGAPIC` and `generateProto`. No function change.

This change enables features like skipping GAPIC generation for common protos in PHP.
