### PR TITLE
feat(migrate/php): extract oldest copyright year for PHP libraries

### DIFF
--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -18,6 +18,7 @@ package license
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 )
 
 // HasHeader returns true if the content contains the Apache 2.0 license header.
@@ -49,4 +50,21 @@ func HeaderBulk() []string {
 		" See the License for the specific language governing permissions and",
 		" limitations under the License.",
 	}
+}
+
+var copyrightYearRegexp = regexp.MustCompile(`Copyright (\d{4})`)
+
+// OldestYear returns the oldest copyright year found in the content.
+// It returns an empty string if no copyright year is found.
+func OldestYear(content []byte) string {
+	var oldest string
+	for _, match := range copyrightYearRegexp.FindAllSubmatch(content, -1) {
+		if len(match) > 1 {
+			year := string(match[1])
+			if oldest == "" || year < oldest {
+				oldest = year
+			}
+		}
+	}
+	return oldest
 }

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -54,17 +54,13 @@ func HeaderBulk() []string {
 
 var copyrightYearRegexp = regexp.MustCompile(`Copyright (\d{4})`)
 
-// OldestYear returns the oldest copyright year found in the content.
+// Year returns the first copyright year found in the content.
 // It returns an empty string if no copyright year is found.
-func OldestYear(content []byte) string {
-	var oldest string
-	for _, match := range copyrightYearRegexp.FindAllSubmatch(content, -1) {
+func Year(content []byte) string {
+	if match := copyrightYearRegexp.FindSubmatch(content); match != nil {
 		if len(match) > 1 {
-			year := string(match[1])
-			if oldest == "" || year < oldest {
-				oldest = year
-			}
+			return string(match[1])
 		}
 	}
-	return oldest
+	return ""
 }

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -389,7 +389,7 @@ func extractOldestCopyrightYear(libraryDir string) (string, error) {
 			return nil
 		}
 
-		year, err := getOldestYearInFile(path, buffer)
+		year, err := getYearInFile(path, buffer)
 		if err != nil {
 			return err
 		}
@@ -402,7 +402,7 @@ func extractOldestCopyrightYear(libraryDir string) (string, error) {
 	return oldest, err
 }
 
-func getOldestYearInFile(path string, buffer []byte) (string, error) {
+func getYearInFile(path string, buffer []byte) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -414,5 +414,5 @@ func getOldestYearInFile(path string, buffer []byte) (string, error) {
 		return "", err
 	}
 
-	return license.OldestYear(buffer[:bytesRead]), nil
+	return license.Year(buffer[:bytesRead]), nil
 }

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -32,6 +32,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
 	"github.com/googleapis/librarian/internal/librarian/php"
+	"github.com/googleapis/librarian/internal/license"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -102,7 +103,6 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 var (
 	owlbotSourceWithVersionRegexp    = regexp.MustCompile(`^/([a-zA-Z0-9_/]+)/\((v[0-9a-zA-Z|]+)\)/.*-php/.*$`)
 	owlbotSourceWithoutVersionRegexp = regexp.MustCompile(`^/([a-zA-Z0-9_/]+)/.*-php/.*$`)
-	copyrightYearRegexp              = regexp.MustCompile(`Copyright (\d{4})`)
 )
 
 type owlBotConfig struct {
@@ -414,14 +414,5 @@ func getOldestYearInFile(path string, buffer []byte) (string, error) {
 		return "", err
 	}
 
-	var oldest string
-	for _, match := range copyrightYearRegexp.FindAllSubmatch(buffer[:bytesRead], -1) {
-		if len(match) > 1 {
-			year := string(match[1])
-			if oldest == "" || year < oldest {
-				oldest = year
-			}
-		}
-	}
-	return oldest, nil
+	return license.OldestYear(buffer[:bytesRead]), nil
 }

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -19,6 +19,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -101,6 +102,7 @@ func runPHPMigration(ctx context.Context, repoPath string) error {
 var (
 	owlbotSourceWithVersionRegexp    = regexp.MustCompile(`^/([a-zA-Z0-9_/]+)/\((v[0-9a-zA-Z|]+)\)/.*-php/.*$`)
 	owlbotSourceWithoutVersionRegexp = regexp.MustCompile(`^/([a-zA-Z0-9_/]+)/.*-php/.*$`)
+	copyrightYearRegexp              = regexp.MustCompile(`Copyright (\d{4})`)
 )
 
 type owlBotConfig struct {
@@ -261,11 +263,16 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 			continue
 		}
 		libraryName := php.DefaultLibraryName(apis[0].Path)
+		copyrightYear, err := extractOldestCopyrightYear(filepath.Join(repoPath, name))
+		if err != nil {
+			return nil, err
+		}
 		lib := &config.Library{
-			Name:    libraryName,
-			Version: version,
-			APIs:    apis,
-			Output:  name,
+			Name:          libraryName,
+			Version:       version,
+			APIs:          apis,
+			Output:        name,
+			CopyrightYear: copyrightYear,
 		}
 		derivedComp, err := php.ComponentNameForLibrary(googleapisDir, lib)
 		if err != nil {
@@ -369,4 +376,48 @@ func normalizeStagingSubdir(apiPath, stagingDir string) string {
 		return ""
 	}
 	return stagingDir
+}
+
+func extractOldestCopyrightYear(libraryDir string) (string, error) {
+	var oldest string
+	buffer := make([]byte, 4096)
+	err := filepath.WalkDir(libraryDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".php") {
+			return nil
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		defer file.Close()
+
+		bytesRead, err := file.Read(buffer)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if bytesRead == 0 {
+			return nil
+		}
+
+		matches := copyrightYearRegexp.FindAllSubmatch(buffer[:bytesRead], -1)
+		for _, match := range matches {
+			if len(match) > 1 {
+				year := string(match[1])
+				if oldest == "" || year < oldest {
+					oldest = year
+				}
+			}
+		}
+		return nil
+	})
+	return oldest, err
 }

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -378,18 +378,11 @@ func normalizeStagingSubdir(apiPath, stagingDir string) string {
 	return stagingDir
 }
 
-func ignoreNotExist(err error) error {
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil
-	}
-	return err
-}
-
 func extractOldestCopyrightYear(libraryDir string) (string, error) {
 	var oldest string
 	buffer := make([]byte, 4096)
 	err := filepath.WalkDir(libraryDir, func(path string, entry fs.DirEntry, err error) error {
-		if err = ignoreNotExist(err); err != nil {
+		if err != nil {
 			return err
 		}
 		if entry.IsDir() || !strings.HasSuffix(path, ".php") {
@@ -397,7 +390,7 @@ func extractOldestCopyrightYear(libraryDir string) (string, error) {
 		}
 
 		year, err := getOldestYearInFile(path, buffer)
-		if err = ignoreNotExist(err); err != nil {
+		if err != nil {
 			return err
 		}
 

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -378,46 +378,57 @@ func normalizeStagingSubdir(apiPath, stagingDir string) string {
 	return stagingDir
 }
 
+func ignoreNotExist(err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
 func extractOldestCopyrightYear(libraryDir string) (string, error) {
 	var oldest string
 	buffer := make([]byte, 4096)
 	err := filepath.WalkDir(libraryDir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
+		if err = ignoreNotExist(err); err != nil {
 			return err
 		}
 		if entry.IsDir() || !strings.HasSuffix(path, ".php") {
 			return nil
 		}
-		file, err := os.Open(path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
+
+		year, err := getOldestYearInFile(path, buffer)
+		if err = ignoreNotExist(err); err != nil {
 			return err
 		}
-		defer file.Close()
 
-		bytesRead, err := file.Read(buffer)
-		if err != nil && err != io.EOF {
-			return err
-		}
-		if bytesRead == 0 {
-			return nil
-		}
-
-		matches := copyrightYearRegexp.FindAllSubmatch(buffer[:bytesRead], -1)
-		for _, match := range matches {
-			if len(match) > 1 {
-				year := string(match[1])
-				if oldest == "" || year < oldest {
-					oldest = year
-				}
-			}
+		if year != "" && (oldest == "" || year < oldest) {
+			oldest = year
 		}
 		return nil
 	})
 	return oldest, err
+}
+
+func getOldestYearInFile(path string, buffer []byte) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	bytesRead, err := file.Read(buffer)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	var oldest string
+	for _, match := range copyrightYearRegexp.FindAllSubmatch(buffer[:bytesRead], -1) {
+		if len(match) > 1 {
+			year := string(match[1])
+			if oldest == "" || year < oldest {
+				oldest = year
+			}
+		}
+	}
+	return oldest, nil
 }

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -662,6 +662,62 @@ deep-copy-regex:
 				},
 			},
 		},
+		{
+			name: "extracts oldest copyright year from .php files",
+			setupLib: func(t *testing.T, dir string) {
+				libDir := filepath.Join(dir, "SecretManagerTest")
+				if err := os.Mkdir(libDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "composer.json"), []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				owlbotContent := `
+deep-copy-regex:
+  - source: /google/cloud/secretmanager/(v1)/.*-php/(.*)
+    dest: /owl-bot-staging/SecretManagerTest/$1/$2
+`
+				if err := os.WriteFile(filepath.Join(libDir, ".OwlBot.yaml"), []byte(owlbotContent), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				// Create PHP files with different copyright years
+				srcDir := filepath.Join(libDir, "src")
+				if err := os.Mkdir(srcDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(srcDir, "a.php"), []byte("<?php\n/*\n * Copyright 2023 Google LLC\n */\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(srcDir, "b.php"), []byte("<?php\n/*\n * Copyright 2020 Google LLC\n */\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				// Also create a file without copyright year
+				if err := os.WriteFile(filepath.Join(srcDir, "c.php"), []byte("<?php\n// No copyright\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			globalDefaultCommonResources: true,
+			want: []*config.Library{
+				{
+					Name:          "secretmanager",
+					Version:       "1.0.0",
+					Output:        "SecretManagerTest",
+					CopyrightYear: "2020",
+					PHP: &config.PHPPackage{
+						ComponentName: "SecretManagerTest",
+					},
+					APIs: []*config.API{
+						{
+							Path: "google/cloud/secretmanager/v1",
+							PHP:  &config.PHPAPI{},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()


### PR DESCRIPTION
Librarian's clean step deletes the target directory before generation to remove stale files, which breaks the legacy synthtool/owlbot.py copyright year preservation logic and leads to yearly copyright churn. To fix this, we've introduced the `copyright_year` field in `librarian.yaml` to explicitly set copyright years during post-processing. This decision is made in accordance with the doc "[Migrating PHP to Librarian](https://docs.google.com/document/d/1kxoL0p8JBqwTXoz4mQJH3bj3jHIOPJrSrsvoUZBgyUk/edit?tab=t.0#heading=h.6aw374b79k8s)".

Fixes #6795 