### PR TITLE
cleanup(internal/sidekick/rust): use SendError constructors in transport

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -327,11 +327,11 @@ func TestGenerateBidiStreaming(t *testing.T) {
                 async move {
                     let prost_item = item
                         .to_proto()
-                        .map_err(google_cloud_gax::error::Error::ser)?;
+                        .map_err(google_cloud_gax::streaming::SendError::ser)?;
                     req_tx
                         .send(prost_item)
                         .await
-                        .map_err(|_| google_cloud_gax::streaming::SendError::StreamClosed)
+                        .map_err(|_| google_cloud_gax::streaming::SendError::stream_closed())
                 }
             },
         );

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -188,11 +188,11 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 async move {
                     let prost_item = item
                         .to_proto()
-                        .map_err(google_cloud_gax::error::Error::ser)?;
+                        .map_err(google_cloud_gax::streaming::SendError::ser)?;
                     req_tx
                         .send(prost_item)
                         .await
-                        .map_err(|_| google_cloud_gax::streaming::SendError::StreamClosed)
+                        .map_err(|_| google_cloud_gax::streaming::SendError::stream_closed())
                 }
             },
         );


### PR DESCRIPTION
Update the bidirectional streaming transport template to use the new SendError::ser and SendError::stream_closed constructor methods rather than constructing variants directly.