### PR TITLE
impl(internal/sidekick/rust): use bidi_streaming helper in transport

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -271,84 +271,23 @@ func TestGenerateBidiStreaming(t *testing.T) {
     ) -> (`,
 		},
 		{
-			name:     "transport: request stream assembly and future call",
+			name:     "transport: bidi_streaming call",
 			file:     "src/transport.rs",
-			startStr: "        let (req_tx, req_rx) = tokio::sync::mpsc::channel",
-			endStr:   "        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(",
-			want: `        let (req_tx, req_rx) = tokio::sync::mpsc::channel(
-            options
-                .request_stream_channel_capacity()
-                .unwrap_or(google_cloud_gax::options::internal::DEFAULT_REQUEST_CHANNEL_CAPACITY),
-        );
-        let req_stream = tokio_stream::wrappers::ReceiverStream::new(req_rx);
-
-        let extensions = {
-            let mut e = gaxi::grpc::tonic::Extensions::new();
-            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
-                "test.v1.Protocol",
-                "Chat",
-            ));
-            e
-        };
-        let path = http::uri::PathAndQuery::from_static(
-            "/test.v1.Protocol/Chat"
-        );
-
-        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-
-        let grpc_inner = self.grpc_inner.clone();
-        tokio::spawn(async move {
-            let result = grpc_inner
-                .bidi_stream::<
-                    crate::prost::test::v1::Request,
-                    crate::prost::test::v1::Response,
-                >(
-                    extensions,
-                    path,
-                    req_stream,
-                    options,
-                    &crate::info::X_GOOG_API_CLIENT_HEADER,
-                    x_goog_request_params,
-                )
-                .await;
-            let _ = resp_tx.send(result);
-        });
-
-        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(`,
-		},
-		{
-			name:     "transport: request sender and response receiver",
-			file:     "src/transport.rs",
-			startStr: "        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(",
-			endStr:   "        (request_sender, response_receiver)\n    }",
-			want: `        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(
-            move |item: crate::model::Request| {
-                let req_tx = req_tx.clone();
-                async move {
-                    let prost_item = item
-                        .to_proto()
-                        .map_err(google_cloud_gax::streaming::SendError::ser)?;
-                    req_tx
-                        .send(prost_item)
-                        .await
-                        .map_err(|_| google_cloud_gax::streaming::SendError::stream_closed())
-                }
-            },
-        );
-        let future = resp_rx.map(|res| match res {
-            Ok(Ok(response)) => Ok(response.into_inner().map(|res| {
-                res.map_err(gaxi::grpc::from_status::to_gax_error)
-                    .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
-            })),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(google_cloud_gax::error::Error::io(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "stream initialization task cancelled",
-            ))),
-        });
-        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_future(future);
-
-        (request_sender, response_receiver)
+			startStr: "        self.grpc_inner\n            .bidi_streaming::<",
+			endStr:   "x_goog_request_params,\n            )\n    }",
+			want: `        self.grpc_inner
+            .bidi_streaming::<
+                crate::model::Request,
+                crate::model::Response,
+                crate::prost::test::v1::Request,
+                crate::prost::test::v1::Response,
+            >(
+                extensions,
+                path,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                x_goog_request_params,
+            )
     }`,
 		},
 	} {

--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -271,12 +271,12 @@ func TestGenerateBidiStreaming(t *testing.T) {
     ) -> (`,
 		},
 		{
-			name:     "transport: bidi_streaming call",
+			name:     "transport: execute_bidi_streaming call",
 			file:     "src/transport.rs",
-			startStr: "        self.grpc_inner\n            .bidi_streaming::<",
+			startStr: "        self.grpc_inner\n            .execute_bidi_streaming::<",
 			endStr:   "x_goog_request_params,\n            )\n    }",
 			want: `        self.grpc_inner
-            .bidi_streaming::<
+            .execute_bidi_streaming::<
                 crate::model::Request,
                 crate::model::Response,
                 crate::prost::test::v1::Request,

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -136,19 +136,8 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
     ) {
-        use gaxi::prost::{FromProto, ToProto};
-        use futures::stream::StreamExt as _;
-        use futures::FutureExt as _;
-
         {{! TODO(#6835) - support explicit routing parameters for bidirectional streaming RPCs }}
         let x_goog_request_params = "";
-
-        let (req_tx, req_rx) = tokio::sync::mpsc::channel(
-            options
-                .request_stream_channel_capacity()
-                .unwrap_or(google_cloud_gax::options::internal::DEFAULT_REQUEST_CHANNEL_CAPACITY),
-        );
-        let req_stream = tokio_stream::wrappers::ReceiverStream::new(req_rx);
 
         let extensions = {
             let mut e = gaxi::grpc::tonic::Extensions::new();
@@ -162,54 +151,19 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}"
         );
 
-        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-
-        let grpc_inner = self.grpc_inner.clone();
-        tokio::spawn(async move {
-            let result = grpc_inner
-                .bidi_stream::<
-                    crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
-                    crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
-                >(
-                    extensions,
-                    path,
-                    req_stream,
-                    options,
-                    &crate::info::X_GOOG_API_CLIENT_HEADER,
-                    x_goog_request_params,
-                )
-                .await;
-            let _ = resp_tx.send(result);
-        });
-
-        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(
-            move |item: {{InputType.Codec.QualifiedName}}| {
-                let req_tx = req_tx.clone();
-                async move {
-                    let prost_item = item
-                        .to_proto()
-                        .map_err(google_cloud_gax::streaming::SendError::ser)?;
-                    req_tx
-                        .send(prost_item)
-                        .await
-                        .map_err(|_| google_cloud_gax::streaming::SendError::stream_closed())
-                }
-            },
-        );
-        let future = resp_rx.map(|res| match res {
-            Ok(Ok(response)) => Ok(response.into_inner().map(|res| {
-                res.map_err(gaxi::grpc::from_status::to_gax_error)
-                    .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
-            })),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(google_cloud_gax::error::Error::io(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "stream initialization task cancelled",
-            ))),
-        });
-        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_future(future);
-
-        (request_sender, response_receiver)
+        self.grpc_inner
+            .bidi_streaming::<
+                {{InputType.Codec.QualifiedName}},
+                {{OutputType.Codec.QualifiedName}},
+                crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
+                crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
+            >(
+                extensions,
+                path,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                x_goog_request_params,
+            )
     }
 
     {{/Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -152,7 +152,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
 
         self.grpc_inner
-            .bidi_streaming::<
+            .execute_bidi_streaming::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},


### PR DESCRIPTION
Update the Rust transport template for bidirectional streaming RPCs to delegate to the new bidi_streaming helper method on gaxi::grpc::Client instead of emitting inline channel and conversion boilerplate.

For #6835 