### PR TITLE
feat(internal/librarian/php): allow skipping GAPIC client generation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -454,6 +454,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
+| `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -839,6 +839,10 @@ type PHPAPI struct {
 	// Must be configured either globally or per-API.
 	CommonResources *bool `yaml:"common_resources,omitempty"`
 
+	// GenerateGAPIC indicates whether to generate the GAPIC client surface.
+	// Defaults to true.
+	GenerateGAPIC *bool `yaml:"generate_gapic,omitempty"`
+
 	// ProtoPackage overrides the derived proto package for the API.
 	ProtoPackage string `yaml:"proto_package,omitempty"`
 

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -160,7 +160,11 @@ func generateAPI(ctx context.Context, params *generateAPIParams) (retErr error) 
 	return generateProto(ctx, params, pc, googleapisDir, protoZipPath)
 }
 
+// generateGAPIC generates the GAPIC client surface.
 func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, gapicZipPath string) error {
+	if !shouldGenerateGAPIC(params.api) {
+		return nil
+	}
 	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, params.api.Path)
 	if err != nil {
 		return err
@@ -193,6 +197,14 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 		return fmt.Errorf("failed to generate PHP GAPIC API %s: %w", params.api.Path, err)
 	}
 	return extractOutput(ctx, gapicZipPath, params.gapicDestDir)
+}
+
+// shouldGenerateGAPIC checks if GAPIC client generation should proceed.
+func shouldGenerateGAPIC(api *config.API) bool {
+	if api.PHP.GenerateGAPIC != nil {
+		return *api.PHP.GenerateGAPIC
+	}
+	return true
 }
 
 func generateProto(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, protoZipPath string) error {

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -136,7 +136,7 @@ func TestGenerate_GenerateGAPICFalse(t *testing.T) {
 	if stat, err := os.Stat(protoDir); err != nil || !stat.IsDir() {
 		t.Errorf("expected directory %s to exist and be a directory", protoDir)
 	}
-	for _, dir := range []string{"tests", "samples", "fragments"} {
+	for _, dir := range []string{"src", "tests", "samples"} {
 		p := filepath.Join(library.Output, dir)
 		if _, err := os.Stat(p); !errors.Is(err, fs.ErrNotExist) {
 			t.Errorf("expected directory %s to not exist", p)

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -17,6 +17,7 @@ package php
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -80,6 +81,64 @@ func TestGenerate(t *testing.T) {
 		p := filepath.Join(library.Output, dir)
 		if stat, err := os.Stat(p); err != nil || !stat.IsDir() {
 			t.Errorf("expected directory %s to exist and be a directory", p)
+		}
+	}
+}
+
+func TestGenerate_GenerateGAPICFalse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow integration test")
+	}
+	requirePHPGenerator(t)
+	googleapisDir := "../../testdata/googleapis"
+	absGoogleapis, err := filepath.Abs(googleapisDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absOwlbotCopy, err := filepath.Abs(filepath.Join("testdata", "owlbot_copy.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+	destDir := filepath.Join(repoRoot, "SecretManager")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink mock owlbot.py. Tests use a simplified copy-only stub to
+	// avoid Node.js/prettier dependencies.
+	if err := os.Symlink(absOwlbotCopy, filepath.Join(destDir, "owlbot.py")); err != nil {
+		t.Fatal(err)
+	}
+	library := &config.Library{
+		Name:   "secretmanager",
+		Output: destDir,
+		APIs: []*config.API{
+			{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					GenerateGAPIC: new(false),
+					StagingSubdir: "v1",
+				},
+			},
+		},
+	}
+	cfg := &config.Config{
+		Language: config.LanguagePhp,
+	}
+	err = Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: absGoogleapis})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify output: proto directory exists, but GAPIC output directories do not.
+	protoDir := filepath.Join(library.Output, "proto")
+	if stat, err := os.Stat(protoDir); err != nil || !stat.IsDir() {
+		t.Errorf("expected directory %s to exist and be a directory", protoDir)
+	}
+	for _, dir := range []string{"tests", "samples", "fragments"} {
+		p := filepath.Join(library.Output, dir)
+		if _, err := os.Stat(p); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("expected directory %s to not exist", p)
 		}
 	}
 }

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -548,3 +548,44 @@ func TestBuildProtoProtocArgs(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestShouldGenerateGAPIC(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		api  *config.API
+		want bool
+	}{
+		{
+			name: "unset defaults to true",
+			api: &config.API{
+				PHP: &config.PHPAPI{},
+			},
+			want: true,
+		},
+		{
+			name: "explicitly true",
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					GenerateGAPIC: new(true),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "explicitly false",
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					GenerateGAPIC: new(false),
+				},
+			},
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := shouldGenerateGAPIC(test.api)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -117,8 +117,9 @@ func TestGenerate_GenerateGAPICFalse(t *testing.T) {
 			{
 				Path: "google/cloud/secretmanager/v1",
 				PHP: &config.PHPAPI{
-					GenerateGAPIC: new(false),
-					StagingSubdir: "v1",
+					GenerateGAPIC:   new(false),
+					CommonResources: new(false),
+					StagingSubdir:   "v1",
 				},
 			},
 		},


### PR DESCRIPTION
A `generate_gapic` configuration option is added to the PHP API configuration, allowing APIs to selectively skip GAPIC client generation while continuing to generate protobuf messages.

When `generate_gapic` is set to false, generateGAPIC skips service configuration lookup and protoc execution for the GAPIC plugin. The option defaults to `true` when omitted to preserve standard generation behavior.

Fixes https://github.com/googleapis/librarian/issues/7333
