### PR TITLE
feat(sidekick/swift): generate smaller LROs

### DIFF
--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -197,7 +197,7 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 		}
 		responseIsEmpty := respMsg.ID == ".google.protobuf.Empty"
 		if responseIsEmpty {
-			respTypeName = "Void"
+			respTypeName = "Swift.Void"
 		}
 		lro = &lroAnnotations{
 			ReturnType:      respTypeName,

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -528,7 +528,7 @@ func TestAnnotateMethod_LRO_Empty(t *testing.T) {
 		PathExpression: "/",
 		HTTPMethod:     "POST",
 		LRO: &lroAnnotations{
-			ReturnType:      "Void",
+			ReturnType:      "Swift.Void",
 			MetadataType:    "LroMetadata",
 			ResponseIsEmpty: true,
 		},

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -872,8 +872,8 @@ func TestGenerateService_LRO_Empty(t *testing.T) {
 	contentStr := string(content)
 
 	wantContains := []string{
-		"public func deleteWorkflow(withPolling: DeleteWorkflowRequest) async throws -> any GoogleCloudGax.PollableOperation<Void>",
-		"GoogleCloudGax._PollableOperationImpl<Void>",
+		"public func deleteWorkflow(withPolling: DeleteWorkflowRequest) async throws -> any GoogleCloudGax.PollableOperation<Swift.Void>",
+		"GoogleCloudGax._PollableOperationImpl<Swift.Void>",
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(contentStr, want) {

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -105,36 +105,12 @@ public class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol {
   {{/Deprecated}}
   public func {{> /templates/common/method_signature/lro_options}} {
     let extractStatus = { (op: {{Codec.ReturnType}}) throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
-      guard op.done else {
-        return .init(done: false, result: nil)
-      }
-
-      switch op.result {
       {{#Codec.LRO.ResponseIsEmpty}}
-      case .response:
-        return .init(done: true, result: .success(()))
+      return try op._extractStatusEmpty()
       {{/Codec.LRO.ResponseIsEmpty}}
       {{^Codec.LRO.ResponseIsEmpty}}
-      case .response(let anyValue):
-        guard let anyValueUnwrapped = anyValue else {
-          return .init(done: true, result: .failure(GoogleCloudGax.RequestError.binding("Operation completed but response value was missing")))
-        }
-        let response = try {{Codec.LRO.ReturnType}}(fromAny: anyValueUnwrapped)
-        return .init(done: true, result: .success(response))
+      return try op._extractStatus({{Codec.LRO.ReturnType}}.self)
       {{/Codec.LRO.ResponseIsEmpty}}
-      case .error(let status):
-        guard let statusUnwrapped = status else {
-          return .init(done: true, result: .failure(GoogleCloudGax.RequestError.binding("Operation completed but error value was missing")))
-        }
-        let error = GoogleCloudGax.RequestError.service(
-          GoogleCloudGax.ServiceError(code: GoogleRpc.Code(intValue: Int(statusUnwrapped.code)), message: statusUnwrapped.message))
-        return .init(done: true, result: .failure(error))
-      case .none:
-        return .init(
-          done: true,
-          result: .failure(
-            GoogleCloudGax.RequestError.binding("Operation completed but result was missing")))
-      }
     }
     let rawOp = try await self.{{Codec.Name}}(request: withPolling, options: options)
     let initialState = try extractStatus(rawOp)


### PR DESCRIPTION
Reduce the size of the generated code by using a (new) helper method in the `GoogleLongRunnning.Operation` type.

Towards https://github.com/googleapis/google-cloud-swift/issues/70 

Look at https://github.com/googleapis/google-cloud-swift/pull/477 for the output.