### PR TITLE
feat(internal/librarian/php): support excluding protos from generation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -454,6 +454,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
+| `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -839,6 +839,11 @@ type PHPAPI struct {
 	// Must be configured either globally or per-API.
 	CommonResources *bool `yaml:"common_resources,omitempty"`
 
+	// ExcludedProtos is a list of proto files to exclude from generation.
+	// It expects the full path starting from the root of the googleapis
+	// directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto").
+	ExcludedProtos []string `yaml:"excluded_protos,omitempty"`
+
 	// GenerateGAPIC indicates whether to generate the GAPIC client surface.
 	// Defaults to true.
 	GenerateGAPIC *bool `yaml:"generate_gapic,omitempty"`

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -188,7 +189,7 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 	opts := gapicOpts(apiMetadata, grpcConfigAbsPath, serviceYamlAbsPath)
 	additionalProtos := params.api.PHP.AdditionalProtos
 	includeCommonResources := *params.api.PHP.CommonResources
-	gapicProtos, err := gatherGAPICProtos(googleapisDir, params.api.Path, additionalProtos, includeCommonResources)
+	gapicProtos, err := gatherGAPICProtos(googleapisDir, params.api.Path, additionalProtos, params.api.PHP.ExcludedProtos, includeCommonResources)
 	if err != nil {
 		return err
 	}
@@ -208,7 +209,7 @@ func shouldGenerateGAPIC(api *config.API) bool {
 }
 
 func generateProto(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, protoZipPath string) error {
-	mainProtos, err := gatherMainProtos(googleapisDir, params.api.Path)
+	mainProtos, err := gatherMainProtos(googleapisDir, params.api.Path, params.api.PHP.ExcludedProtos)
 	if err != nil {
 		return err
 	}
@@ -221,8 +222,8 @@ func generateProto(ctx context.Context, params *generateAPIParams, pc *config.Pr
 
 // gatherGAPICProtos collects all proto files inside the target API directory,
 // appends common resources, and appends any configured additional protos.
-func gatherGAPICProtos(googleapisDir, apiPath string, additionalProtos []string, includeCommonResources bool) ([]string, error) {
-	targetProtos, err := gatherMainProtos(googleapisDir, apiPath)
+func gatherGAPICProtos(googleapisDir, apiPath string, additionalProtos, excludeProtos []string, includeCommonResources bool) ([]string, error) {
+	targetProtos, err := gatherMainProtos(googleapisDir, apiPath, excludeProtos)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +276,7 @@ func extractOutput(ctx context.Context, zipPath, outDir string) error {
 	return nil
 }
 
-func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
+func gatherMainProtos(googleapisDir, apiPath string, excludeProtos []string) ([]string, error) {
 	apiDir := filepath.Join(googleapisDir, filepath.FromSlash(apiPath))
 	protos, err := proto.Gather(apiDir, apiPath)
 	if err != nil {
@@ -284,10 +285,21 @@ func gatherMainProtos(googleapisDir, apiPath string) ([]string, error) {
 		}
 		return nil, err
 	}
+	protos = filterProtos(googleapisDir, protos, excludeProtos)
 	if len(protos) == 0 {
 		return nil, fmt.Errorf("%w for API %s", errNoProtos, apiPath)
 	}
 	return protos, nil
+}
+
+func filterProtos(googleapisDir string, protos, excludeProtos []string) []string {
+	for _, exclude := range excludeProtos {
+		fullPath := filepath.Join(googleapisDir, exclude)
+		slices.DeleteFunc(protos, func(p string) bool {
+			return p == fullPath
+		})
+	}
+	return protos
 }
 
 func absConfigPath(baseDir, configPath string) (string, error) {

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -294,8 +294,8 @@ func gatherMainProtos(googleapisDir, apiPath string, excludeProtos []string) ([]
 
 func filterProtos(googleapisDir string, protos, excludeProtos []string) []string {
 	for _, exclude := range excludeProtos {
-		fullPath := filepath.Join(googleapisDir, exclude)
-		slices.DeleteFunc(protos, func(p string) bool {
+		fullPath := filepath.Join(googleapisDir, filepath.FromSlash(exclude))
+		protos = slices.DeleteFunc(protos, func(p string) bool {
 			return p == fullPath
 		})
 	}

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -445,6 +445,7 @@ func TestGatherGAPICProtos(t *testing.T) {
 		setupFiles             []string
 		apiPath                string
 		additionalProtos       []string
+		excludeProtos          []string
 		includeCommonResources bool
 		wantProtos             []string
 	}{
@@ -494,6 +495,20 @@ func TestGatherGAPICProtos(t *testing.T) {
 				"google/cloud/location/locations.proto",
 			},
 		},
+		{
+			name: "excluded protos removed",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+				"google/cloud/secretmanager/v1/resources.proto",
+			},
+			apiPath: "google/cloud/secretmanager/v1",
+			excludeProtos: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
+			},
+			wantProtos: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -506,7 +521,7 @@ func TestGatherGAPICProtos(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			got, err := gatherGAPICProtos(tempDir, test.apiPath, test.additionalProtos, test.includeCommonResources)
+			got, err := gatherGAPICProtos(tempDir, test.apiPath, test.additionalProtos, test.excludeProtos, test.includeCommonResources)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -523,10 +538,11 @@ func TestGatherGAPICProtos(t *testing.T) {
 
 func TestGatherGAPICProtos_Error(t *testing.T) {
 	for _, test := range []struct {
-		name       string
-		setupFiles []string
-		apiPath    string
-		wantErr    error
+		name          string
+		setupFiles    []string
+		apiPath       string
+		excludeProtos []string
+		wantErr       error
 	}{
 		{
 			name:       "directory not found",
@@ -540,6 +556,17 @@ func TestGatherGAPICProtos_Error(t *testing.T) {
 			apiPath:    "google/cloud/secretmanager/v1",
 			wantErr:    errNoProtos,
 		},
+		{
+			name: "all protos excluded",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+			apiPath: "google/cloud/secretmanager/v1",
+			excludeProtos: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+			wantErr: errNoProtos,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -552,9 +579,48 @@ func TestGatherGAPICProtos_Error(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			_, err := gatherGAPICProtos(tempDir, test.apiPath, nil, true)
+			_, err := gatherGAPICProtos(tempDir, test.apiPath, nil, test.excludeProtos, true)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("gatherGAPICProtos() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestFilterProtos(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		protos        []string
+		excludeProtos []string
+		want          []string
+	}{
+		{
+			name: "exclude matches",
+			protos: []string{
+				"/path/to/google/cloud/secretmanager/v1/service.proto",
+				"/path/to/google/cloud/secretmanager/v1/resources.proto",
+			},
+			excludeProtos: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
+			},
+			want: []string{
+				"/path/to/google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+		{
+			name: "no exclude",
+			protos: []string{
+				"/path/to/google/cloud/secretmanager/v1/service.proto",
+			},
+			want: []string{
+				"/path/to/google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := filterProtos("/path/to", test.protos, test.excludeProtos)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
An `excluded_protos` configuration option is added to the PHP API configuration, allowing APIs to exclude specific proto files from generation.

During GAPIC and protobuf generation, Librarian filters out any proto files matching the configured excluded paths before invoking protoc. If all protos for an API are excluded, generation returns an error indicating no protos were found.

Fixes https://github.com/googleapis/librarian/issues/7336
