### PR TITLE
fix(librarian/swift): support showcase generation

### DIFF
--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -34,6 +34,7 @@ func libraryToModelConfig(library *config.Library, ch *config.API, srcs *sources
 	src := sources.NewSourceConfig(srcs, library.Roots)
 	root := srcs.Googleapis
 	if ch.Path == "schema/google/showcase/v1beta1" {
+		// TODO(https://github.com/googleapis/librarian/issues/7337) - clean this up
 		root = srcs.Showcase
 	}
 	svcConfig, err := serviceconfig.Find(root, ch.Path, config.LanguageRust)

--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -105,12 +105,16 @@ func DefaultLibraryName(api string) string {
 }
 
 func libraryToModelConfig(library *config.Library, apiCfg *config.API, src *sources.Sources, pc *config.Protoc) (*parser.ModelConfig, error) {
-	svcConfig, err := serviceconfig.Find(src.Googleapis, apiCfg.Path, config.LanguageSwift)
+	sourceConfig := sources.NewSourceConfig(src, library.Roots)
+	root := src.Googleapis
+	if apiCfg.Path == "schema/google/showcase/v1beta1" {
+		// TODO(https://github.com/googleapis/librarian/issues/7337) - clean this up
+		root = src.Showcase
+	}
+	svcConfig, err := serviceconfig.Find(root, apiCfg.Path, config.LanguageSwift)
 	if err != nil {
 		return nil, err
 	}
-
-	sourceConfig := sources.NewSourceConfig(src, library.Roots)
 	if library.Swift != nil && len(library.Swift.IncludeList) > 0 {
 		sourceConfig.IncludeList = library.Swift.IncludeList
 	}

--- a/internal/librarian/swift/generate_test.go
+++ b/internal/librarian/swift/generate_test.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	googleapisRoot = "../../../internal/testdata/googleapis"
+	showcaseRoot   = "../../../internal/testdata/gapic-showcase"
 	discoveryRoot  = "fake/path/to/testdata/discovery"
 )
 
@@ -236,6 +237,27 @@ func TestLibraryToModelConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "showcase",
+			library: &config.Library{
+				Name:  "google-cloud-showcase",
+				Roots: []string{"showcase", "googleapis"},
+			},
+			api: &config.API{
+				Path: "schema/google/showcase/v1beta1",
+			},
+			pc: &config.Protoc{Version: "29.3"},
+			want: &parser.ModelConfig{
+				Language:            config.LanguageSwift,
+				SpecificationFormat: config.SpecProtobuf,
+				SpecificationSource: "schema/google/showcase/v1beta1",
+				ServiceConfig:       "schema/google/showcase/v1beta1/showcase_v1beta1.yaml",
+				Protoc:              &config.Protoc{Version: "29.3"},
+				Source: &sources.SourceConfig{
+					ActiveRoots: []string{"showcase", "googleapis"},
+				},
+			},
+		},
+		{
 			name: "minimal config",
 			library: &config.Library{
 				Name:    "google-cloud-secretmanager",
@@ -386,6 +408,7 @@ func TestLibraryToModelConfig(t *testing.T) {
 			srcs := &sources.Sources{
 				Discovery:  absPath(t, discoveryRoot),
 				Googleapis: absPath(t, googleapisRoot),
+				Showcase:   absPath(t, showcaseRoot),
 			}
 			if test.want.Source == nil {
 				t.Fatal("bad test expectation: test.want.Sources should not be nil")


### PR DESCRIPTION
Showcase uses a different root for the service config file, and evidently the service config module cannot handle more than one root.

Towards https://github.com/googleapis/google-cloud-swift/issues/454 