### PR TITLE
refactor(yaml): use supported go.yaml.in/yaml/v3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Before submitting changes, run the full test suite:
 - `internal/config`: **Pure data types only.** Structs and constants here are a direct 1:1 mapping with `librarian.yaml`. Do not add functions or methods to this package.
 - `internal/serviceconfig/sdk.yaml`: **Contains exceptions to default behavior.** Governed by principles in `@doc/sdk-yaml-principles.md`.
 - `internal/testhelper`: **ALWAYS** check here for existing utilities before creating new test tools.
-- `internal/yaml`: **ALWAYS** use this package instead of `gopkg.in/yaml.v3`.
+- `internal/yaml`: **ALWAYS** use this package instead of `go.yaml.in/yaml/v3`.
 - `internal/sidekick/parser`: **ALWAYS** check `protobuf_imports_oss.go` for existing bridged types. If they exist, do not import the corresponding protobuf packages (like `"google.golang.org/genproto/googleapis/api/annotations"` or `"cloud.google.com/go/iam/apiv1/iampb"`) directly. Use the centralized aliases in `protobuf_imports_oss.go` and `protobuf_imports_google3.go` to ensure compatibility across environments.
 
 ## Additional Context

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/urfave/cli/v3 v3.6.2
 	github.com/yuin/goldmark v1.7.16
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/mod v0.37.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/tools v0.47.0
@@ -22,7 +23,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -228,7 +228,6 @@ require (
 	go.augendre.info/fatcontext v0.9.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/net v0.56.0 // indirect
@@ -239,6 +238,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect

--- a/internal/yaml/ref.go
+++ b/internal/yaml/ref.go
@@ -17,7 +17,7 @@ package yaml
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // RefString is a string that is a reference to another resource.

--- a/internal/yaml/ref_test.go
+++ b/internal/yaml/ref_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type refConfig struct {

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/yamlfmt/formatters/basic"
 	"github.com/googleapis/librarian/internal/license"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // StringSlice is a custom slice of strings that allows for fine-grained control


### PR DESCRIPTION
Refactors use of `gopkg.in/yaml/v3`, which has been archived, to the officially supported go.yaml.in/yaml/v3.

Note: They are shipping a v4 soonish. Hopefully it's a drop-in replacement.

Fixes #6617