### PR TITLE
feat(migrate/php): strip PA namespace during migration for non-generic APIs

### DIFF
--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -26,11 +26,22 @@ import (
 // E.g., "google/cloud/speech/v2" -> "speech"
 // E.g., "google/cloud/security/privateca/v1" -> "security-privateca".
 func DefaultLibraryName(apiPath string) string {
-	apiPath = strings.TrimPrefix(apiPath, "google/cloud/")
-	apiPath = strings.TrimPrefix(apiPath, "google/")
 	if serviceconfig.ExtractVersion(apiPath) != "" {
 		apiPath = path.Dir(apiPath)
 	}
+
+	parts := strings.Split(apiPath, "/")
+	if len(parts) >= 3 && parts[0] == "google" {
+		serviceName := parts[len(parts)-1]
+		if serviceName == "admin" || serviceName == "type" {
+			apiPath = strings.TrimPrefix(apiPath, "google/")
+		} else {
+			apiPath = strings.TrimPrefix(apiPath, "google/"+parts[1]+"/")
+		}
+	} else {
+		apiPath = strings.TrimPrefix(apiPath, "google/")
+	}
+
 	apiPath = strings.ReplaceAll(apiPath, "/", "-")
 	return strings.ToLower(apiPath)
 }

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -23,8 +23,10 @@ import (
 )
 
 // DefaultLibraryName derives the library name for PHP purely from the API path.
+// It strips the Product Area namespace from the library name, unless the remaining name is generic.
 // E.g., "google/cloud/speech/v2" -> "speech"
-// E.g., "google/cloud/security/privateca/v1" -> "security-privateca".
+// E.g., "google/identity/accesscontextmanager/v1" -> "accesscontextmanager"
+// E.g., "google/datastore/admin/v1" -> "datastore-admin"
 func DefaultLibraryName(apiPath string) string {
 	if serviceconfig.ExtractVersion(apiPath) != "" {
 		apiPath = path.Dir(apiPath)
@@ -34,8 +36,14 @@ func DefaultLibraryName(apiPath string) string {
 	if len(parts) >= 3 && parts[0] == "google" {
 		serviceName := parts[len(parts)-1]
 		if serviceName == "admin" || serviceName == "type" {
+			// Do not strip the Product Area (PA) for generic services to prevent collisions.
+			// E.g., "google/datastore/admin" -> "datastore/admin"
+			// E.g., "google/geo/type" -> "geo/type"
 			apiPath = strings.TrimPrefix(apiPath, "google/")
 		} else {
+			// Strip the PA segment unconditionally (e.g., cloud, identity) by removing parts[1].
+			// E.g., "google/cloud/speech" -> "speech"
+			// E.g., "google/identity/accesscontextmanager" -> "accesscontextmanager"
 			apiPath = strings.TrimPrefix(apiPath, "google/"+parts[1]+"/")
 		}
 	} else {

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -24,9 +24,9 @@ import (
 
 // DefaultLibraryName derives the library name for PHP purely from the API path.
 // It strips the Product Area namespace from the library name, unless the remaining name is generic.
-// E.g., "google/cloud/speech/v2" -> "speech"
-// E.g., "google/identity/accesscontextmanager/v1" -> "accesscontextmanager"
-// E.g., "google/datastore/admin/v1" -> "datastore-admin"
+// E.g., "google/cloud/speech/v2" -> "speech".
+// E.g., "google/identity/accesscontextmanager/v1" -> "accesscontextmanager".
+// E.g., "google/datastore/admin/v1" -> "datastore-admin".
 func DefaultLibraryName(apiPath string) string {
 	if serviceconfig.ExtractVersion(apiPath) != "" {
 		apiPath = path.Dir(apiPath)
@@ -37,13 +37,13 @@ func DefaultLibraryName(apiPath string) string {
 		serviceName := parts[len(parts)-1]
 		if serviceName == "admin" || serviceName == "type" {
 			// Do not strip the Product Area (PA) for generic services to prevent collisions.
-			// E.g., "google/datastore/admin" -> "datastore/admin"
-			// E.g., "google/geo/type" -> "geo/type"
+			// E.g., "google/datastore/admin" -> "datastore/admin".
+			// E.g., "google/geo/type" -> "geo/type".
 			apiPath = strings.TrimPrefix(apiPath, "google/")
 		} else {
 			// Strip the PA segment unconditionally (e.g., cloud, identity) by removing parts[1].
-			// E.g., "google/cloud/speech" -> "speech"
-			// E.g., "google/identity/accesscontextmanager" -> "accesscontextmanager"
+			// E.g., "google/cloud/speech" -> "speech".
+			// E.g., "google/identity/accesscontextmanager" -> "accesscontextmanager".
 			apiPath = strings.TrimPrefix(apiPath, "google/"+parts[1]+"/")
 		}
 	} else {

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -22,7 +22,6 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -32,7 +31,6 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
 	"github.com/googleapis/librarian/internal/librarian/php"
-	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -262,7 +260,7 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 		if len(apis) == 0 {
 			continue
 		}
-		libraryName := deriveMigratedLibraryName(apis[0].Path)
+		libraryName := php.DefaultLibraryName(apis[0].Path)
 		lib := &config.Library{
 			Name:    libraryName,
 			Version: version,
@@ -371,25 +369,4 @@ func normalizeStagingSubdir(apiPath, stagingDir string) string {
 		return ""
 	}
 	return stagingDir
-}
-
-// deriveMigratedLibraryName derives the library name from the API path for migration.
-// It strips the PA segment (e.g. cloud, identity, geo) to conform to the new naming scheme.
-func deriveMigratedLibraryName(apiPath string) string {
-	if serviceconfig.ExtractVersion(apiPath) != "" {
-		apiPath = path.Dir(apiPath)
-	}
-	parts := strings.Split(apiPath, "/")
-	if len(parts) >= 3 && parts[0] == "google" {
-		serviceName := parts[len(parts)-1]
-		if serviceName == "admin" || serviceName == "type" {
-			apiPath = strings.TrimPrefix(apiPath, "google/")
-		} else {
-			apiPath = strings.TrimPrefix(apiPath, "google/"+parts[1]+"/")
-		}
-	} else {
-		apiPath = strings.TrimPrefix(apiPath, "google/")
-	}
-	apiPath = strings.ReplaceAll(apiPath, "/", "-")
-	return strings.ToLower(apiPath)
 }

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -379,7 +379,6 @@ func deriveMigratedLibraryName(apiPath string) string {
 	if serviceconfig.ExtractVersion(apiPath) != "" {
 		apiPath = path.Dir(apiPath)
 	}
-
 	parts := strings.Split(apiPath, "/")
 	if len(parts) >= 3 && parts[0] == "google" {
 		serviceName := parts[len(parts)-1]

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -31,6 +32,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian"
 	"github.com/googleapis/librarian/internal/librarian/php"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -260,7 +262,7 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 		if len(apis) == 0 {
 			continue
 		}
-		libraryName := php.DefaultLibraryName(apis[0].Path)
+		libraryName := deriveMigratedLibraryName(apis[0].Path)
 		lib := &config.Library{
 			Name:    libraryName,
 			Version: version,
@@ -369,4 +371,27 @@ func normalizeStagingSubdir(apiPath, stagingDir string) string {
 		return ""
 	}
 	return stagingDir
+}
+
+// deriveMigratedLibraryName derives the library name from the API path for migration.
+// It strips the PA segment (e.g. cloud, identity, geo) to conform to the new naming scheme.
+func deriveMigratedLibraryName(apiPath string) string {
+	if serviceconfig.ExtractVersion(apiPath) != "" {
+		apiPath = path.Dir(apiPath)
+	}
+
+	parts := strings.Split(apiPath, "/")
+	if len(parts) >= 3 && parts[0] == "google" {
+		serviceName := parts[len(parts)-1]
+		if serviceName == "admin" || serviceName == "type" {
+			apiPath = strings.TrimPrefix(apiPath, "google/")
+		} else {
+			apiPath = strings.TrimPrefix(apiPath, "google/"+parts[1]+"/")
+		}
+	} else {
+		apiPath = strings.TrimPrefix(apiPath, "google/")
+	}
+
+	apiPath = strings.ReplaceAll(apiPath, "/", "-")
+	return strings.ToLower(apiPath)
 }

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -390,7 +390,6 @@ func deriveMigratedLibraryName(apiPath string) string {
 	} else {
 		apiPath = strings.TrimPrefix(apiPath, "google/")
 	}
-
 	apiPath = strings.ReplaceAll(apiPath, "/", "-")
 	return strings.ToLower(apiPath)
 }

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -580,7 +580,7 @@ deep-copy-regex:
 			globalDefaultCommonResources: true,
 			want: []*config.Library{
 				{
-					Name:    "identity-accesscontextmanager",
+					Name:    "accesscontextmanager",
 					Version: "1.0.0",
 					Output:  "AccessContextManager",
 					PHP: &config.PHPPackage{


### PR DESCRIPTION
This PR modifies the PHP migration tool to strip the Product Area (PA) namespace from the generated library name. 
Previously, the PA was only stripped for `cloud` APIs. This updates the tool to strip the PA for any `google/` namespace (e.g., `google/identity/accesscontextmanager/v1` -> `accesscontextmanager`), ensuring consistent library naming across all Product Areas. I manually ran migration and this script will cover all current libraries in google-cloud-php

Fixes  https://github.com/googleapis/librarian/issues/7330