### PR TITLE
refactor(internal/librarian/php): remove obsolete migration-mode option

### DIFF
--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -315,9 +315,6 @@ func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbs
 		transport = apiMetadata.Transport(config.LanguagePhp)
 	}
 	opts := []string{"metadata", "transport=" + string(transport)}
-	// TODO(https://github.com/googleapis/gapic-generator-php/pull/834):
-	// remove when generator change is done
-	opts = append(opts, "migration-mode=NEW_SURFACE_ONLY")
 	if apiMetadata != nil && apiMetadata.HasRESTNumericEnums(config.LanguagePhp) {
 		opts = append(opts, "rest-numeric-enums")
 	}

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -395,7 +395,7 @@ func TestGapicOpts(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			want: []string{"metadata", "transport=grpc+rest", "migration-mode=NEW_SURFACE_ONLY", "generate-snippets"},
+			want: []string{"metadata", "transport=grpc+rest", "generate-snippets"},
 		},
 		{
 			name: "with grpc config and service yaml",
@@ -405,7 +405,7 @@ func TestGapicOpts(t *testing.T) {
 			grpcConfigAbsPath:  "/absolute/path/to/googleapis/grpc_config.json",
 			serviceYamlAbsPath: "/absolute/path/to/googleapis/service.yaml",
 			want: []string{
-				"metadata", "transport=grpc+rest", "migration-mode=NEW_SURFACE_ONLY",
+				"metadata", "transport=grpc+rest",
 				"rest-numeric-enums", "generate-snippets",
 				"grpc_service_config=/absolute/path/to/googleapis/grpc_config.json",
 				"service_yaml=/absolute/path/to/googleapis/service.yaml",
@@ -416,7 +416,7 @@ func TestGapicOpts(t *testing.T) {
 			apiMetadata: &serviceconfig.API{
 				SkipRESTNumericEnums: []string{"php"},
 			},
-			want: []string{"metadata", "transport=grpc+rest", "migration-mode=NEW_SURFACE_ONLY",
+			want: []string{"metadata", "transport=grpc+rest",
 				"generate-snippets"},
 		},
 		{
@@ -426,7 +426,7 @@ func TestGapicOpts(t *testing.T) {
 					"php": serviceconfig.Transport("rest"),
 				},
 			},
-			want: []string{"metadata", "transport=rest", "migration-mode=NEW_SURFACE_ONLY",
+			want: []string{"metadata", "transport=rest",
 				"rest-numeric-enums", "generate-snippets"},
 		},
 	} {


### PR DESCRIPTION
The temporary `migration-mode=NEW_SURFACE_ONLY` GAPIC generator option is removed from PHP generator arguments.

This option was previously required while upstream generator changes were in progress in gapic-generator-php, and is no longer needed.
