### PR TITLE
feat(internal/sidekick/rust): support used_if streaming package deps

### DIFF
--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -145,7 +145,7 @@ func (m *modelAnnotations) ReleaseLevelIsGA() bool {
 func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	codec.hasServices = len(model.Services) > 0
 
-	resolveUsedPackages(model, codec.extraPackages)
+	resolveUsedPackages(model, codec.extraPackages, codec.hasBidiStreaming(model))
 	// Annotate enums and messages that we intend to generate. In the
 	// process we discover the external dependencies and trim the list of
 	// packages used by this API.
@@ -279,7 +279,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 			bidiStreamingServices = append(bidiStreamingServices, s)
 		}
 	}
-	hasBidiStreaming := codec.templateOverride == "" && codec.includeBidiStreamingMethods && slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
+	hasBidiStreaming := codec.hasBidiStreaming(model)
 	if hasBidiStreaming {
 		for _, pkg := range codec.extraPackages {
 			if pkg.name == gaxiPackageName && !slices.Contains(pkg.features, "_internal-grpc-client") {

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -659,11 +659,9 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 					t.Errorf("mismatch (-want +got):\n%s", diff)
 				}
 			}
-			if len(test.wantRequiredPackages) > 0 {
-				less := func(a, b string) bool { return a < b }
-				if diff := cmp.Diff(test.wantRequiredPackages, got.RequiredPackages, cmpopts.SortSlices(less)); diff != "" {
-					t.Errorf("RequiredPackages mismatch (-want +got):\n%s", diff)
-				}
+			less := func(a, b string) bool { return a < b }
+			if diff := cmp.Diff(test.wantRequiredPackages, got.RequiredPackages, cmpopts.SortSlices(less), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -551,13 +551,31 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			},
 		},
 	}
+	serverStreamingService := &api.Service{
+		Name:    "ServerStreamingService",
+		ID:      ".test.v1.ServerStreamingService",
+		Package: "test.v1",
+		Methods: []*api.Method{
+			{
+				Name:                "List",
+				ID:                  ".test.v1.ServerStreamingService.List",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ServerSideStreaming: true,
+				PathInfo:            &api.PathInfo{},
+			},
+		},
+	}
 
 	for _, test := range []struct {
-		name             string
-		service          *api.Service
-		options          map[string]string
-		want             bool
-		wantGaxiFeatures []string
+		name                 string
+		service              *api.Service
+		options              map[string]string
+		want                 bool
+		wantGaxiFeatures     []string
+		wantRequiredPackages []string
 	}{
 		{
 			name:    "bidi streaming enabled with bidi method",
@@ -565,9 +583,11 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			options: map[string]string{
 				"include-bidi-streaming-methods": "true",
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
+				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want:             true,
-			wantGaxiFeatures: []string{"_internal-grpc-client"},
+			want:                 true,
+			wantGaxiFeatures:     []string{"_internal-grpc-client"},
+			wantRequiredPackages: []string{`gaxi                 = { workspace = true, features = ["_internal-grpc-client"] }`, "prost.workspace      = true"},
 		},
 		{
 			name:    "bidi streaming disabled with bidi method",
@@ -575,8 +595,10 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			options: map[string]string{
 				"include-bidi-streaming-methods": "false",
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
+				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want: false,
+			want:                 false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
 		{
 			name:    "bidi streaming enabled with unary method",
@@ -584,8 +606,21 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			options: map[string]string{
 				"include-bidi-streaming-methods": "true",
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
+				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want: false,
+			want:                 false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
+		},
+		{
+			name:    "bidi streaming enabled with server streaming method",
+			service: serverStreamingService,
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
+				"package:prost":                  "package=prost,used-if=streaming",
+			},
+			want:                 false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
 		{
 			name:    "template override with bidi method",
@@ -594,8 +629,10 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				"include-bidi-streaming-methods": "true",
 				"template-override":              "templates/tonic",
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
+				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want: false,
+			want:                 false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -620,6 +657,12 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				}
 				if diff := cmp.Diff(test.wantGaxiFeatures, codec.extraPackages[idx].features); diff != "" {
 					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+			}
+			if len(test.wantRequiredPackages) > 0 {
+				less := func(a, b string) bool { return a < b }
+				if diff := cmp.Diff(test.wantRequiredPackages, got.RequiredPackages, cmpopts.SortSlices(less)); diff != "" {
+					t.Errorf("RequiredPackages mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -391,7 +391,7 @@ type packagez struct {
 	usedIf []string
 }
 
-func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
+func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasBidiStreaming bool) {
 	hasServices := len(model.Services) > 0
 	hasLROs := false
 	hasAutoPopulation := false
@@ -423,6 +423,10 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez) {
 				break
 			}
 			if namedFeature == "autopopulated" && hasAutoPopulation {
+				pkg.used = true
+				break
+			}
+			if namedFeature == "streaming" && hasBidiStreaming {
 				pkg.used = true
 				break
 			}
@@ -1554,6 +1558,13 @@ func (c *codec) generateMethod(m *api.Method) bool {
 		return false
 	}
 	return m.PathInfo.Bindings[0].PathTemplate != nil
+}
+
+func (c *codec) hasBidiStreaming(model *api.API) bool {
+	if c.templateOverride != "" || !c.includeBidiStreamingMethods {
+		return false
+	}
+	return slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
 }
 
 // escapeKeyword is the list of Rust keywords and reserved words can be found

--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -69,6 +69,8 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		SpecificationFormat: libconfig.SpecProtobuf,
 		Codec: map[string]string{
 			"package:wkt":                    "source=google.protobuf,package=google-cloud-wkt",
+			"package:prost":                  "package=prost,used-if=streaming",
+			"package:prost-types":            "package=prost-types,used-if=streaming",
 			"include-bidi-streaming-methods": "true",
 			"generate-rpc-samples":           "true",
 		},
@@ -289,6 +291,16 @@ func TestGenerateBidiStreaming(t *testing.T) {
                 x_goog_request_params,
             )
     }`,
+		},
+		{
+			name:     "cargo.toml: dependencies block",
+			file:     "Cargo.toml",
+			startStr: "[dependencies]\n",
+			endStr:   "prost.workspace      = true\n",
+			want: `[dependencies]
+prost-types.workspace = true
+prost.workspace      = true
+`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/sidekick/rust/templates/common/Cargo.toml.mustache
+++ b/internal/sidekick/rust/templates/common/Cargo.toml.mustache
@@ -67,15 +67,6 @@ all-features = true
 {{/Codec.HasServices}}
 
 [dependencies]
-{{#Codec.HasBidiStreaming}}
-{{! TODO(#6835) - Make prost and prost-types optional dependencies gated by the streaming feature flag. }}
-prost.workspace = true
-prost-types.workspace = true
-futures.workspace = true
-http.workspace = true
-tokio.workspace = true
-tokio-stream.workspace = true
-{{/Codec.HasBidiStreaming}}
 {{#Codec.RequiredPackages}}
 {{{.}}}
 {{/Codec.RequiredPackages}}

--- a/internal/sidekick/rust/used_by_test.go
+++ b/internal/sidekick/rust/used_by_test.go
@@ -36,7 +36,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
 	want := []*packagez{
 		{
 			name:        "location",
@@ -64,7 +64,7 @@ func TestUsedByServicesNoServices(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
 	want := []*packagez{
 		{
 			name:        "location",
@@ -73,6 +73,7 @@ func TestUsedByServicesNoServices(t *testing.T) {
 		{
 			name:        "tracing",
 			packageName: "tracing",
+			used:        false,
 			usedIf:      []string{"services"},
 		},
 	}
@@ -100,7 +101,7 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
 	want := []*packagez{
 		{
 			name:        "location",
@@ -136,7 +137,7 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
 	want := []*packagez{
 		{
 			name:        "location",
@@ -176,7 +177,7 @@ func TestUsedByUuidWithAutoPopulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
 	want := []*packagez{
 		{
 			name:        "location",
@@ -213,7 +214,7 @@ func TestUsedByUuidWithoutAutoPopulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolveUsedPackages(model, c.extraPackages)
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
 	want := []*packagez{
 		{
 			name:        "location",
@@ -225,6 +226,160 @@ func TestUsedByUuidWithoutAutoPopulation(t *testing.T) {
 			used:        false,
 			usedIf:      []string{"autopopulated"},
 			features:    []string{"v4"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUsedByStreamingWithStreaming(t *testing.T) {
+	method := &api.Method{
+		Name:                "Chat",
+		ClientSideStreaming: true,
+		ServerSideStreaming: true,
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
+		"include-bidi-streaming-methods": "true",
+		"package:location":               "package=gcp-sdk-location,source=google.cloud.location",
+		"package:prost":                  "used-if=streaming,package=prost",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "prost",
+			packageName: "prost",
+			used:        true,
+			usedIf:      []string{"streaming"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUsedByStreamingWithoutStreaming(t *testing.T) {
+	method := &api.Method{
+		Name: "CreateResource",
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
+		"include-bidi-streaming-methods": "true",
+		"package:location":               "package=gcp-sdk-location,source=google.cloud.location",
+		"package:prost":                  "used-if=streaming,package=prost",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "prost",
+			packageName: "prost",
+			used:        false,
+			usedIf:      []string{"streaming"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUsedByStreamingServerStreamingOnly(t *testing.T) {
+	method := &api.Method{
+		Name:                "ServerStream",
+		ClientSideStreaming: false,
+		ServerSideStreaming: true,
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
+		"include-bidi-streaming-methods": "true",
+		"package:location":               "package=gcp-sdk-location,source=google.cloud.location",
+		"package:prost":                  "used-if=streaming,package=prost",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "prost",
+			packageName: "prost",
+			used:        false,
+			usedIf:      []string{"streaming"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUsedByStreamingBidiDisabled(t *testing.T) {
+	method := &api.Method{
+		Name:                "Chat",
+		ClientSideStreaming: true,
+		ServerSideStreaming: true,
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
+		"include-bidi-streaming-methods": "false",
+		"package:location":               "package=gcp-sdk-location,source=google.cloud.location",
+		"package:prost":                  "used-if=streaming,package=prost",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveUsedPackages(model, c.extraPackages, c.hasBidiStreaming(model))
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "prost",
+			packageName: "prost",
+			used:        false,
+			usedIf:      []string{"streaming"},
 		},
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }


### PR DESCRIPTION
Add support for resolving package dependencies marked with used-if=streaming when bidirectional streaming is enabled and present in the service model.

Previously, gRPC and streaming dependencies were hardcoded directly in Cargo.toml.mustache behind HasBidiStreaming. With this change, these dependencies can be dynamically specified in librarian.yaml via package_dependencies and conditionally included only when streaming methods are generated.

For #6835 