### PR TITLE
feat(swift): support gRPC routing parameter extraction

### DIFF
--- a/internal/sidekick/swift/annotate_method.go
+++ b/internal/sidekick/swift/annotate_method.go
@@ -25,6 +25,7 @@ type methodAnnotations struct {
 	Name           string
 	DocLines       []string
 	PathVariables  []*pathVariable
+	RoutingParams  []*routingParam
 	PathExpression string
 	HTTPMethod     string
 	HasBody        bool
@@ -103,6 +104,11 @@ func (ann *methodAnnotations) HasPathVariables() bool {
 	return len(ann.PathVariables) != 0
 }
 
+// HasRoutingParams returns true if the method has routing parameters for gRPC x-goog-request-params header.
+func (ann *methodAnnotations) HasRoutingParams() bool {
+	return len(ann.RoutingParams) != 0
+}
+
 // PlainRPC returns true if the method is not a pagination or LRO.
 func (ann *methodAnnotations) PlainRPC() bool {
 	return ann.LRO == nil && ann.Pagination == nil && ann.DiscoveryLRO == nil
@@ -131,16 +137,26 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 	}
 	var pathExpressionStr string
 	var pathVariables []*pathVariable
+	var routingParams []*routingParam
 	var httpMethod string
 	var hasBody bool
 	var isBodyWildcard bool
 	var bodyField string
 	var queryParams []*api.Field
 
+	// Extract routing parameters for gRPC per AIP-4222:
+	// - Prefer explicit google.api.routing annotations if present.
+	// - Fall back to extracting path parameters from the google.api.http path template.
+	if method.HasRouting() {
+		routingParams = c.routingParamsFromRouting(method.Routing)
+	} else if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 {
+		routingParams = c.routingParamsFromPathTemplate(method.PathInfo.Bindings[0].PathTemplate)
+	}
+
 	// In Protobuf APIs (such as Storage Control or pure gRPC services), some RPC
 	// methods do not define google.api.http annotations.
-	// - HTTP/REST methods: Continue to extract httpMethod, pathExpressionStr,
-	//   bodyField, queryParams, and pathVariables as before.
+	// - HTTP/REST methods: Extract httpMethod, pathExpressionStr, bodyField,
+	//   queryParams, and pathVariables as before.
 	// - Pure gRPC methods (without HTTP annotations): Safely bypass the HTTP
 	//   extraction without crashing, leaving those fields as their default zero values.
 	if method.PathInfo != nil && len(method.PathInfo.Bindings) > 0 {
@@ -220,6 +236,7 @@ func (c *codec) annotateMethod(method *api.Method, modelAnn *modelAnnotations) e
 		DocLines:         docLines,
 		PathExpression:   pathExpressionStr,
 		PathVariables:    pathVariables,
+		RoutingParams:    routingParams,
 		HTTPMethod:       httpMethod,
 		HasBody:          hasBody,
 		IsBodyWildcard:   isBodyWildcard,

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -118,3 +118,131 @@ func (*codec) fieldPathParameterExpression(optional bool, field *api.Field) (str
 	}
 	return fmt.Sprintf(".%s as %s?", fieldCodec.Name, fieldCodec.FieldType), nil
 }
+
+// routingParam describes a parameter used for gRPC x-goog-request-params routing metadata.
+type routingParam struct {
+	RoutingKey string
+	Variants   []*routingParamVariant
+}
+
+type routingParamVariant struct {
+	FieldAccessor    string
+	PrefixSegments   []string
+	MatchingSegments []string
+	SuffixSegments   []string
+	Last             bool
+}
+
+func formatFieldAccessor(fieldPath []string) string {
+	if len(fieldPath) == 0 {
+		return "request.name"
+	}
+	var parts []string
+	for _, p := range fieldPath {
+		parts = append(parts, camelCase(p))
+	}
+	return "request." + strings.Join(parts, "?.")
+}
+
+func annotateSegments(segments []string, isPrefix bool, isSuffix bool) []string {
+	if len(segments) == 0 {
+		return nil
+	}
+	var ann []string
+	literalBuffer := ""
+	flushBuffer := func() {
+		if literalBuffer != "" {
+			ann = append(ann, fmt.Sprintf(`.literal(%q)`, literalBuffer))
+		}
+		literalBuffer = ""
+	}
+	for index, segment := range segments {
+		switch segment {
+		case api.MultiSegmentWildcard:
+			flushBuffer()
+			if len(segments) == 1 && !isSuffix {
+				ann = append(ann, ".multiWildcard")
+			} else if len(segments) != index+1 {
+				ann = append(ann, ".multiWildcard")
+			} else {
+				ann = append(ann, ".trailingMultiWildcard")
+			}
+		case api.SingleSegmentWildcard:
+			if index != 0 || isSuffix {
+				literalBuffer += "/"
+			}
+			flushBuffer()
+			ann = append(ann, ".singleWildcard")
+		default:
+			if index != 0 || isSuffix {
+				literalBuffer += "/"
+			}
+			literalBuffer += segment
+		}
+	}
+	if isPrefix && len(segments) > 0 && segments[len(segments)-1] == api.SingleSegmentWildcard {
+		literalBuffer += "/"
+	}
+	flushBuffer()
+	return ann
+}
+
+func (c *codec) routingParamsFromRouting(routingInfos []*api.RoutingInfo) []*routingParam {
+	var params []*routingParam
+	for _, info := range routingInfos {
+		if info.Name == "" && len(info.Variants) > 0 && len(info.Variants[0].FieldPath) == 0 {
+			// Explicit empty routing annotation disables routing headers per AIP-4222.
+			continue
+		}
+		routingKey := info.Name
+
+		var variants []*routingParamVariant
+		for _, variant := range info.Variants {
+			if len(variant.FieldPath) == 0 {
+				continue
+			}
+			if routingKey == "" {
+				routingKey = strings.Join(variant.FieldPath, ".")
+			}
+			variants = append(variants, &routingParamVariant{
+				FieldAccessor:    formatFieldAccessor(variant.FieldPath),
+				PrefixSegments:   annotateSegments(variant.Prefix.Segments, true, false),
+				MatchingSegments: annotateSegments(variant.Matching.Segments, false, false),
+				SuffixSegments:   annotateSegments(variant.Suffix.Segments, false, true),
+			})
+		}
+
+		if len(variants) > 0 {
+			for i, v := range variants {
+				v.Last = (i == len(variants)-1)
+			}
+			params = append(params, &routingParam{
+				RoutingKey: routingKey,
+				Variants:   variants,
+			})
+		}
+	}
+	return params
+}
+
+func (c *codec) routingParamsFromPathTemplate(t *api.PathTemplate) []*routingParam {
+	var params []*routingParam
+	for _, segment := range t.Segments {
+		if segment.Variable != nil {
+			fieldPath := segment.Variable.FieldPath
+			params = append(params, &routingParam{
+				RoutingKey: strings.Join(fieldPath, "."),
+				Variants: []*routingParamVariant{
+					{
+						FieldAccessor:    formatFieldAccessor(fieldPath),
+						PrefixSegments:   nil,
+						MatchingSegments: []string{".multiWildcard"},
+						SuffixSegments:   nil,
+						Last:             true,
+					},
+				},
+			})
+		}
+	}
+	return params
+}

--- a/internal/sidekick/swift/format_path.go
+++ b/internal/sidekick/swift/format_path.go
@@ -119,12 +119,14 @@ func (*codec) fieldPathParameterExpression(optional bool, field *api.Field) (str
 	return fmt.Sprintf(".%s as %s?", fieldCodec.Name, fieldCodec.FieldType), nil
 }
 
-// routingParam describes a parameter used for gRPC x-goog-request-params routing metadata.
+// Describes a parameter used for gRPC x-goog-request-params routing metadata.
 type routingParam struct {
 	RoutingKey string
 	Variants   []*routingParamVariant
 }
 
+// Represents a single candidate field path and pattern rule for extracting a routing
+// parameter value.
 type routingParamVariant struct {
 	FieldAccessor    string
 	PrefixSegments   []string
@@ -133,9 +135,14 @@ type routingParamVariant struct {
 	Last             bool
 }
 
+// Builds a Swift field access expression with optional chaining from a field path slice
+// (e.g., ["table", "parent"] -> "request.table?.parent").
+//
+// Returns an empty string if fieldPath is empty; callers are expected to filter out
+// empty field paths as AIP-4222 routing parameters must extract from a specific field.
 func formatFieldAccessor(fieldPath []string) string {
 	if len(fieldPath) == 0 {
-		return "request.name"
+		return ""
 	}
 	var parts []string
 	for _, p := range fieldPath {
@@ -144,6 +151,11 @@ func formatFieldAccessor(fieldPath []string) string {
 	return "request." + strings.Join(parts, "?.")
 }
 
+// Converts a list of path segments into Swift _RoutingMatcher token expressions
+// (e.g. .literal("projects/"), .singleWildcard, .multiWildcard).
+//
+// isPrefix ensures a trailing slash delimiter is appended before the matching segment.
+// isSuffix ensures leading/inter-segment slashes are preserved after the matching segment.
 func annotateSegments(segments []string, isPrefix bool, isSuffix bool) []string {
 	if len(segments) == 0 {
 		return nil
@@ -180,13 +192,14 @@ func annotateSegments(segments []string, isPrefix bool, isSuffix bool) []string 
 			literalBuffer += segment
 		}
 	}
-	if isPrefix && len(segments) > 0 && segments[len(segments)-1] == api.SingleSegmentWildcard {
+	if isPrefix && len(segments) > 0 {
 		literalBuffer += "/"
 	}
 	flushBuffer()
 	return ann
 }
 
+// Extracts routing parameters from explicit google.api.routing annotations per AIP-4222.
 func (c *codec) routingParamsFromRouting(routingInfos []*api.RoutingInfo) []*routingParam {
 	var params []*routingParam
 	for _, info := range routingInfos {
@@ -225,11 +238,16 @@ func (c *codec) routingParamsFromRouting(routingInfos []*api.RoutingInfo) []*rou
 	return params
 }
 
+// Extracts fallback routing parameters from a google.api.http path template when explicit
+// google.api.routing annotations are absent per AIP-4222.
 func (c *codec) routingParamsFromPathTemplate(t *api.PathTemplate) []*routingParam {
 	var params []*routingParam
 	for _, segment := range t.Segments {
 		if segment.Variable != nil {
 			fieldPath := segment.Variable.FieldPath
+			if len(fieldPath) == 0 {
+				continue
+			}
 			params = append(params, &routingParam{
 				RoutingKey: strings.Join(fieldPath, "."),
 				Variants: []*routingParamVariant{

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -323,3 +323,217 @@ func TestNewPathVariable(t *testing.T) {
 		})
 	}
 }
+
+func TestRoutingParams(t *testing.T) {
+	requestMessage := &api.Message{
+		Name:    "GetBucketRequest",
+		Package: "google.storage.v2",
+		ID:      ".google.storage.v2.GetBucketRequest",
+		Fields: []*api.Field{
+			{
+				Name:  "name",
+				Typez: api.TypezString,
+			},
+			{
+				Name:  "parent",
+				Typez: api.TypezString,
+			},
+		},
+	}
+
+	model := api.NewTestAPI([]*api.Message{requestMessage}, nil, []*api.Service{})
+	model.AddMessage(requestMessage)
+	codec := newTestCodec(t, model, nil)
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name         string
+		routingInfos []*api.RoutingInfo
+		want         []*routingParam
+	}{
+		{
+			name: "explicit routing info with custom name",
+			routingInfos: []*api.RoutingInfo{
+				{
+					Name: "bucket",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"name"},
+						},
+					},
+				},
+			},
+			want: []*routingParam{
+				{
+					RoutingKey: "bucket",
+					Variants: []*routingParamVariant{
+						{
+							FieldAccessor: "request.name",
+							Last:          true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "explicit routing info without custom name",
+			routingInfos: []*api.RoutingInfo{
+				{
+					Name: "",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"parent"},
+						},
+					},
+				},
+			},
+			want: []*routingParam{
+				{
+					RoutingKey: "parent",
+					Variants: []*routingParamVariant{
+						{
+							FieldAccessor: "request.parent",
+							Last:          true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "routing info with pattern and suffix",
+			routingInfos: []*api.RoutingInfo{
+				{
+					Name: "bucket",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"name"},
+							Matching: api.RoutingPathSpec{
+								Segments: []string{"projects", "*", "buckets", "*"},
+							},
+							Suffix: api.RoutingPathSpec{
+								Segments: []string{"**"},
+							},
+						},
+					},
+				},
+			},
+			want: []*routingParam{
+				{
+					RoutingKey: "bucket",
+					Variants: []*routingParamVariant{
+						{
+							FieldAccessor:    "request.name",
+							MatchingSegments: []string{`.literal("projects/")`, `.singleWildcard`, `.literal("/buckets/")`, `.singleWildcard`},
+							SuffixSegments:   []string{`.trailingMultiWildcard`},
+							Last:             true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "routing info with multiple fallback variants across different fields",
+			routingInfos: []*api.RoutingInfo{
+				{
+					Name: "routing_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"name"},
+							Matching: api.RoutingPathSpec{
+								Segments: []string{"projects", "*"},
+							},
+						},
+						{
+							FieldPath: []string{"parent"},
+							Matching: api.RoutingPathSpec{
+								Segments: []string{"**"},
+							},
+						},
+					},
+				},
+			},
+			want: []*routingParam{
+				{
+					RoutingKey: "routing_id",
+					Variants: []*routingParamVariant{
+						{
+							FieldAccessor:    "request.name",
+							MatchingSegments: []string{`.literal("projects/")`, `.singleWildcard`},
+							Last:             false,
+						},
+						{
+							FieldAccessor:    "request.parent",
+							MatchingSegments: []string{`.multiWildcard`},
+							Last:             true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty routing annotation disables routing",
+			routingInfos: []*api.RoutingInfo{
+				{
+					Name: "",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := codec.routingParamsFromRouting(test.routingInfos)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRoutingParamsFromPathTemplate(t *testing.T) {
+	requestMessage := &api.Message{
+		Name:    "GetBucketRequest",
+		Package: "google.storage.v2",
+		ID:      ".google.storage.v2.GetBucketRequest",
+		Fields: []*api.Field{
+			{
+				Name:  "name",
+				Typez: api.TypezString,
+			},
+		},
+	}
+	model := api.NewTestAPI([]*api.Message{requestMessage}, nil, []*api.Service{})
+	model.AddMessage(requestMessage)
+	codec := newTestCodec(t, model, nil)
+	if err := codec.annotateModel(); err != nil {
+		t.Fatal(err)
+	}
+
+	template := (&api.PathTemplate{}).
+		WithLiteral("v2").
+		WithVariableNamed("name")
+
+	got := codec.routingParamsFromPathTemplate(template)
+
+	want := []*routingParam{
+		{
+			RoutingKey: "name",
+			Variants: []*routingParamVariant{
+				{
+					FieldAccessor:    "request.name",
+					MatchingSegments: []string{".multiWildcard"},
+					Last:             true,
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/swift/format_path_test.go
+++ b/internal/sidekick/swift/format_path_test.go
@@ -473,6 +473,74 @@ func TestRoutingParams(t *testing.T) {
 			},
 		},
 		{
+			name: "routing info with literal prefix and nested field path",
+			routingInfos: []*api.RoutingInfo{
+				{
+					Name: "table",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table", "parent"},
+							Prefix: api.RoutingPathSpec{
+								Segments: []string{"projects"},
+							},
+							Matching: api.RoutingPathSpec{
+								Segments: []string{"*"},
+							},
+							Suffix: api.RoutingPathSpec{
+								Segments: []string{"tables", "*"},
+							},
+						},
+					},
+				},
+			},
+			want: []*routingParam{
+				{
+					RoutingKey: "table",
+					Variants: []*routingParamVariant{
+						{
+							FieldAccessor:    "request.table?.parent",
+							PrefixSegments:   []string{`.literal("projects/")`},
+							MatchingSegments: []string{`.singleWildcard`},
+							SuffixSegments:   []string{`.literal("/tables/")`, `.singleWildcard`},
+							Last:             true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "routing info with wildcard prefix",
+			routingInfos: []*api.RoutingInfo{
+				{
+					Name: "location",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"name"},
+							Prefix: api.RoutingPathSpec{
+								Segments: []string{"projects", "*"},
+							},
+							Matching: api.RoutingPathSpec{
+								Segments: []string{"locations", "*"},
+							},
+						},
+					},
+				},
+			},
+			want: []*routingParam{
+				{
+					RoutingKey: "location",
+					Variants: []*routingParamVariant{
+						{
+							FieldAccessor:    "request.name",
+							PrefixSegments:   []string{`.literal("projects/")`, `.singleWildcard`, `.literal("/")`},
+							MatchingSegments: []string{`.literal("locations/")`, `.singleWildcard`},
+							Last:             true,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "empty routing annotation disables routing",
 			routingInfos: []*api.RoutingInfo{
 				{

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -352,11 +352,15 @@ func TestGenerateStub_Grpc(t *testing.T) {
 				OutputTypeID: empty.ID,
 				OutputType:   empty,
 				ReturnsEmpty: true,
-				PathInfo: &api.PathInfo{
-					Bindings: []*api.PathBinding{{
-						Verb:         "DELETE",
-						PathTemplate: (&api.PathTemplate{}).WithLiteral("v2").WithLiteral("projects").WithVariableNamed("name"),
-					}},
+				Routing: []*api.RoutingInfo{
+					{
+						Name: "bucket",
+						Variants: []*api.RoutingInfoVariant{
+							{
+								FieldPath: []string{"name"},
+							},
+						},
+					},
 				},
 			},
 			{
@@ -450,8 +454,8 @@ func TestGenerateStub_Grpc(t *testing.T) {
 	if !strings.Contains(transportStr, "let protoRequest = try request.toProto()") {
 		t.Errorf("transport missing request.toProto() call:\n%s", transportStr)
 	}
-	if !strings.Contains(transportStr, "pathVariable0.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)") {
-		t.Errorf("transport missing addingPercentEncoding for routing params:\n%s", transportStr)
+	if !strings.Contains(transportStr, "GoogleCloudGaxGRPC._RoutingMatcher.value(") {
+		t.Errorf("transport missing GoogleCloudGaxGRPC._RoutingMatcher.value for routing params:\n%s", transportStr)
 	}
 	if !strings.Contains(transportStr, `path: "/google.storage.control.v2.StorageControl/CreateFolder"`) {
 		t.Errorf("transport missing CreateFolder gRPC path in execute:\n%s", transportStr)
@@ -466,7 +470,10 @@ func TestGenerateStub_Grpc(t *testing.T) {
 	if !strings.Contains(transportStr, `path: "/google.longrunning.Operations/GetOperation"`) {
 		t.Errorf("transport missing operations GetOperation gRPC path in execute:\n%s", transportStr)
 	}
-	if !strings.Contains(transportStr, `routingParams.append("parent=\(encoded)")`) {
-		t.Errorf("transport missing routing parameter extraction in method body:\n%s", transportStr)
+	if !strings.Contains(transportStr, `("parent",`) {
+		t.Errorf("transport missing parent routing parameter extraction in method body:\n%s", transportStr)
+	}
+	if !strings.Contains(transportStr, `("bucket",`) {
+		t.Errorf("transport missing bucket routing parameter extraction in method body:\n%s", transportStr)
 	}
 }

--- a/internal/sidekick/swift/templates/grpc/transport.swift.mustache
+++ b/internal/sidekick/swift/templates/grpc/transport.swift.mustache
@@ -30,7 +30,6 @@ import GoogleCloudAuth
 {{#Codec.ServiceImports}}
 import {{.}}
 {{/Codec.ServiceImports}}
-
 {{#Codec.ModulePath}}
 internal import {{.}}
 {{/Codec.ModulePath}}
@@ -51,18 +50,26 @@ extension Clients {
     public init(_ inner: GoogleCloudGaxGRPC._GRPCClient) {
       self.inner = inner
     }
+
     {{#Codec.Methods}}
 
     public func {{> /templates/common/method_signature/request_options}} {
-      {{#Codec.HasPathVariables}}
-      var routingParams: [String] = []
-      {{#Codec.PathVariables}}
-      if let {{Name}} = request{{Expression}}{{#Test}}, {{{.}}}{{/Test}} {
-        let encoded = {{Name}}.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? {{Name}}
-        routingParams.append("{{FieldPath}}=\(encoded)")
-      }
-      {{/Codec.PathVariables}}
-      {{/Codec.HasPathVariables}}
+      {{#Codec.HasRoutingParams}}
+      let routingParams = GoogleCloudGaxGRPC._RoutingMatcher.format([
+        {{#Codec.RoutingParams}}
+        ("{{RoutingKey}}",
+          {{#Variants}}
+          GoogleCloudGaxGRPC._RoutingMatcher.value(
+            {{{FieldAccessor}}},
+            prefix: [{{#PrefixSegments}}{{{.}}}, {{/PrefixSegments}}],
+            matching: [{{#MatchingSegments}}{{{.}}}, {{/MatchingSegments}}],
+            suffix: [{{#SuffixSegments}}{{{.}}}, {{/SuffixSegments}}]
+          ){{^Last}} ?? {{/Last}}
+          {{/Variants}}
+        ),
+        {{/Codec.RoutingParams}}
+      ])
+      {{/Codec.HasRoutingParams}}
 
       let protoRequest = try request.toProto()
       {{^ReturnsEmpty}}
@@ -70,8 +77,8 @@ extension Clients {
         path: "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}",
         request: protoRequest,
         options: options,
-        clientHeader: Clients.clientHeader{{#Codec.HasPathVariables}},
-        routingParams: routingParams{{/Codec.HasPathVariables}}
+        clientHeader: Clients.clientHeader{{#Codec.HasRoutingParams}},
+        routingParams: routingParams{{/Codec.HasRoutingParams}}
       )
       return try {{Codec.ReturnType}}(proto: protoResponse)
       {{/ReturnsEmpty}}
@@ -80,8 +87,8 @@ extension Clients {
         path: "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}",
         request: protoRequest,
         options: options,
-        clientHeader: Clients.clientHeader{{#Codec.HasPathVariables}},
-        routingParams: routingParams{{/Codec.HasPathVariables}}
+        clientHeader: Clients.clientHeader{{#Codec.HasRoutingParams}},
+        routingParams: routingParams{{/Codec.HasRoutingParams}}
       )
       {{/ReturnsEmpty}}
     }


### PR DESCRIPTION
Adds support for [AIP-4222](https://google.aip.dev/4222) routing parameter extraction in the Swift code generator. Generated gRPC client transports now extract routing parameters from `google.api.routing` annotations (and fall back to `google.api.http` URI path templates) and format them into the `x-goog-request-params` request metadata header.


for https://github.com/googleapis/google-cloud-swift/issues/479

generates https://github.com/googleapis/google-cloud-swift/pull/481 

