### PR TITLE
feat(internal/librarian/php): allow skipping sample generation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -457,7 +457,7 @@ This document describes the schema for the librarian.yaml.
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
-| `no_samples` | bool | Indicates whether to skip generating samples. This is typically false. |
+| `samples` | bool (optional) | Determines whether to generate samples for the API, default is true when omitted. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -457,7 +457,7 @@ This document describes the schema for the librarian.yaml.
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
-| `samples` | bool (optional) | Determines whether to generate samples for the API, default is true when omitted. |
+| `samples` | bool (optional) | Determines whether to generate samples for the API. Default to true when omitted. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -457,6 +457,7 @@ This document describes the schema for the librarian.yaml.
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
+| `no_samples` | bool | Indicates whether to skip generating samples. This is typically false. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -851,9 +851,9 @@ type PHPAPI struct {
 	// ProtoPackage overrides the derived proto package for the API.
 	ProtoPackage string `yaml:"proto_package,omitempty"`
 
-	// NoSamples indicates whether to skip generating samples.
-	// This is typically false.
-	NoSamples bool `yaml:"no_samples,omitempty"`
+	// Samples determines whether to generate samples for the API,
+	// default is true when omitted.
+	Samples *bool `yaml:"samples,omitempty"`
 
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.
 	StagingSubdir string `yaml:"staging_subdir,omitempty"`

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -851,6 +851,10 @@ type PHPAPI struct {
 	// ProtoPackage overrides the derived proto package for the API.
 	ProtoPackage string `yaml:"proto_package,omitempty"`
 
+	// NoSamples indicates whether to skip generating samples.
+	// This is typically false.
+	NoSamples bool `yaml:"no_samples,omitempty"`
+
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.
 	StagingSubdir string `yaml:"staging_subdir,omitempty"`
 }

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -851,8 +851,8 @@ type PHPAPI struct {
 	// ProtoPackage overrides the derived proto package for the API.
 	ProtoPackage string `yaml:"proto_package,omitempty"`
 
-	// Samples determines whether to generate samples for the API,
-	// default is true when omitted.
+	// Samples determines whether to generate samples for the API.
+	// Default to true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
 
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -186,7 +186,7 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 	if err != nil {
 		return err
 	}
-	opts := gapicOpts(apiMetadata, grpcConfigAbsPath, serviceYamlAbsPath)
+	opts := gapicOpts(params.api, apiMetadata, grpcConfigAbsPath, serviceYamlAbsPath)
 	additionalProtos := params.api.PHP.AdditionalProtos
 	includeCommonResources := *params.api.PHP.CommonResources
 	gapicProtos, err := gatherGAPICProtos(googleapisDir, params.api.Path, additionalProtos, params.api.PHP.ExcludedProtos, includeCommonResources)
@@ -309,7 +309,7 @@ func absConfigPath(baseDir, configPath string) (string, error) {
 	return filepath.Abs(filepath.Join(baseDir, configPath))
 }
 
-func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbsPath string, samples bool) []string {
+func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbsPath string) []string {
 	transport := serviceconfig.GRPCRest
 	if apiMetadata != nil {
 		transport = apiMetadata.Transport(config.LanguagePhp)
@@ -318,7 +318,7 @@ func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbs
 	if apiMetadata != nil && apiMetadata.HasRESTNumericEnums(config.LanguagePhp) {
 		opts = append(opts, "rest-numeric-enums")
 	}
-	if samples {
+	if shouldGenerateSamples(api) {
 		opts = append(opts, "generate-snippets")
 	}
 
@@ -329,4 +329,11 @@ func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbs
 		opts = append(opts, "service_yaml="+serviceYamlAbsPath)
 	}
 	return opts
+}
+
+func shouldGenerateSamples(api *config.API) bool {
+	if api.PHP.Samples != nil {
+		return *api.PHP.Samples
+	}
+	return true
 }

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -309,7 +309,7 @@ func absConfigPath(baseDir, configPath string) (string, error) {
 	return filepath.Abs(filepath.Join(baseDir, configPath))
 }
 
-func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbsPath string) []string {
+func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbsPath string, samples bool) []string {
 	transport := serviceconfig.GRPCRest
 	if apiMetadata != nil {
 		transport = apiMetadata.Transport(config.LanguagePhp)
@@ -318,7 +318,10 @@ func gapicOpts(apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbs
 	if apiMetadata != nil && apiMetadata.HasRESTNumericEnums(config.LanguagePhp) {
 		opts = append(opts, "rest-numeric-enums")
 	}
-	opts = append(opts, "generate-snippets")
+	if samples {
+		opts = append(opts, "generate-snippets")
+	}
+
 	if grpcConfigAbsPath != "" {
 		opts = append(opts, "grpc_service_config="+grpcConfigAbsPath)
 	}

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -332,7 +332,7 @@ func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPat
 }
 
 func shouldGenerateSamples(api *config.API) bool {
-	if api != nil && api.PHP != nil && api.PHP.Samples != nil {
+	if api.PHP.Samples != nil {
 		return *api.PHP.Samples
 	}
 	return true

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -332,7 +332,7 @@ func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPat
 }
 
 func shouldGenerateSamples(api *config.API) bool {
-	if api.PHP.Samples != nil {
+	if api != nil && api.PHP != nil && api.PHP.Samples != nil {
 		return *api.PHP.Samples
 	}
 	return true

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -396,12 +396,12 @@ func TestGapicOpts(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			api: &config.API{PHP: &config.PHPAPI{}},
+			api:  &config.API{PHP: &config.PHPAPI{}},
 			want: []string{"metadata", "transport=grpc+rest", "generate-snippets"},
 		},
 		{
 			name: "with grpc config and service yaml",
-			api: &config.API{PHP: &config.PHPAPI{}},
+			api:  &config.API{PHP: &config.PHPAPI{}},
 			apiMetadata: &serviceconfig.API{
 				ServiceConfig: "service.yaml", // The API struct might just hold it for transport, though we pass it below
 			},
@@ -416,7 +416,7 @@ func TestGapicOpts(t *testing.T) {
 		},
 		{
 			name: "skip rest numeric enums",
-			api: &config.API{PHP: &config.PHPAPI{}},
+			api:  &config.API{PHP: &config.PHPAPI{}},
 			apiMetadata: &serviceconfig.API{
 				SkipRESTNumericEnums: []string{"php"},
 			},
@@ -425,7 +425,7 @@ func TestGapicOpts(t *testing.T) {
 		},
 		{
 			name: "custom transport",
-			api: &config.API{PHP: &config.PHPAPI{}},
+			api:  &config.API{PHP: &config.PHPAPI{}},
 			apiMetadata: &serviceconfig.API{
 				Transports: map[string]serviceconfig.Transport{
 					"php": serviceconfig.Transport("rest"),

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -396,10 +396,12 @@ func TestGapicOpts(t *testing.T) {
 	}{
 		{
 			name: "defaults",
+			api: &config.API{PHP: &config.PHPAPI{}},
 			want: []string{"metadata", "transport=grpc+rest", "generate-snippets"},
 		},
 		{
 			name: "with grpc config and service yaml",
+			api: &config.API{PHP: &config.PHPAPI{}},
 			apiMetadata: &serviceconfig.API{
 				ServiceConfig: "service.yaml", // The API struct might just hold it for transport, though we pass it below
 			},
@@ -414,6 +416,7 @@ func TestGapicOpts(t *testing.T) {
 		},
 		{
 			name: "skip rest numeric enums",
+			api: &config.API{PHP: &config.PHPAPI{}},
 			apiMetadata: &serviceconfig.API{
 				SkipRESTNumericEnums: []string{"php"},
 			},
@@ -422,6 +425,7 @@ func TestGapicOpts(t *testing.T) {
 		},
 		{
 			name: "custom transport",
+			api: &config.API{PHP: &config.PHPAPI{}},
 			apiMetadata: &serviceconfig.API{
 				Transports: map[string]serviceconfig.Transport{
 					"php": serviceconfig.Transport("rest"),

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -388,6 +388,7 @@ func TestGenerate_Error(t *testing.T) {
 func TestGapicOpts(t *testing.T) {
 	for _, test := range []struct {
 		name               string
+		api                *config.API
 		apiMetadata        *serviceconfig.API
 		grpcConfigAbsPath  string
 		serviceYamlAbsPath string
@@ -429,9 +430,18 @@ func TestGapicOpts(t *testing.T) {
 			want: []string{"metadata", "transport=rest",
 				"rest-numeric-enums", "generate-snippets"},
 		},
+		{
+			name: "skip samples",
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					Samples: new(false),
+				},
+			},
+			want: []string{"metadata", "transport=grpc+rest"},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := gapicOpts(test.apiMetadata, test.grpcConfigAbsPath, test.serviceYamlAbsPath)
+			got := gapicOpts(test.api, test.apiMetadata, test.grpcConfigAbsPath, test.serviceYamlAbsPath)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -709,6 +719,47 @@ func TestShouldGenerateGAPIC(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := shouldGenerateGAPIC(test.api)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestShouldGenerateSamples(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		api  *config.API
+		want bool
+	}{
+		{
+			name: "unset defaults to true",
+			api: &config.API{
+				PHP: &config.PHPAPI{},
+			},
+			want: true,
+		},
+		{
+			name: "explicitly true",
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					Samples: new(true),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "explicitly false",
+			api: &config.API{
+				PHP: &config.PHPAPI{
+					Samples: new(false),
+				},
+			},
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := shouldGenerateSamples(test.api)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
A `samples` configuration option is added to the PHP API configuration, allowing APIs to selectively skip generating samples and code snippets.

When `samples` is set to false, gapicOpts omits the `generate-snippets` argument during GAPIC client generation. The option defaults to `true` when omitted to preserve standard generation behavior.

Fixes https://github.com/googleapis/librarian/issues/7349
