### PR TITLE
feat(go): add control for the protobuf code generation level

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -347,6 +347,7 @@ This document describes the schema for the librarian.yaml.
 | `nested_protos` | list of string | Is a list of nested proto files. |
 | `no_metadata` | bool | Indicates whether to skip generating gapic_metadata.json. This is typically false. |
 | `no_snippets` | bool | Indicates whether to skip generating snippets. This is typically false. |
+| `proto_api_level` | string | Allows direct control of protobuf plugin's code generation level. Values allowed are API_OPEN, API_HYBRID, and API_OPAQUE. The default is unset, which relies on proto file annotations. More info: https://protobuf.dev/reference/go/opaque-migration/ |
 | `proto_only` | bool | Determines whether to generate a Proto-only client. A proto-only client does not define a service in the proto files. |
 | `proto_package` | string | Is the proto package name. |
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -89,6 +89,11 @@ type GoAPI struct {
 	ProtoOnly bool `yaml:"proto_only,omitempty"`
 	// ProtoPackage is the proto package name.
 	ProtoPackage string `yaml:"proto_package,omitempty"`
+	// ProtoAPILevel allows direct control of protobuf plugin's code generation
+	// level. Values allowed are API_OPEN, API_HYBRID, and API_OPAQUE.
+	// The default is unset, which relies on proto file annotations.
+	// More info: https://protobuf.dev/reference/go/opaque-migration/
+	ProtoAPILevel string `yaml:proto_api_level,omitempty"`
 }
 
 // RustDefault contains Rust-specific default configuration.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -84,16 +84,16 @@ type GoAPI struct {
 	// NoSnippets indicates whether to skip generating snippets.
 	// This is typically false.
 	NoSnippets bool `yaml:"no_snippets,omitempty"`
-	// ProtoOnly determines whether to generate a Proto-only client.
-	// A proto-only client does not define a service in the proto files.
-	ProtoOnly bool `yaml:"proto_only,omitempty"`
-	// ProtoPackage is the proto package name.
-	ProtoPackage string `yaml:"proto_package,omitempty"`
 	// ProtoAPILevel allows direct control of protobuf plugin's code generation
 	// level. Values allowed are API_OPEN, API_HYBRID, and API_OPAQUE.
 	// The default is unset, which relies on proto file annotations.
 	// More info: https://protobuf.dev/reference/go/opaque-migration/
 	ProtoAPILevel string `yaml:"proto_api_level,omitempty"`
+	// ProtoOnly determines whether to generate a Proto-only client.
+	// A proto-only client does not define a service in the proto files.
+	ProtoOnly bool `yaml:"proto_only,omitempty"`
+	// ProtoPackage is the proto package name.
+	ProtoPackage string `yaml:"proto_package,omitempty"`
 }
 
 // RustDefault contains Rust-specific default configuration.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -93,7 +93,7 @@ type GoAPI struct {
 	// level. Values allowed are API_OPEN, API_HYBRID, and API_OPAQUE.
 	// The default is unset, which relies on proto file annotations.
 	// More info: https://protobuf.dev/reference/go/opaque-migration/
-	ProtoAPILevel string `yaml:proto_api_level,omitempty"`
+	ProtoAPILevel string `yaml:"proto_api_level,omitempty"`
 }
 
 // RustDefault contains Rust-specific default configuration.

--- a/internal/librarian/golang/generate.go
+++ b/internal/librarian/golang/generate.go
@@ -151,6 +151,9 @@ func generateAPI(ctx context.Context, apiPath string, goAPI *config.GoAPI, pc *c
 		"--go-grpc_out=" + outDir,
 		"--go-grpc_opt=require_unimplemented_servers=false",
 	}
+	if goAPI.ProtoAPILevel != "" {
+		args = append(args, "--go_opt=default_api_level="+goAPI.ProtoAPILevel)
+	}
 	if !goAPI.ProtoOnly {
 		gapicOpts, err := buildGAPICOpts(apiPath, goAPI, version, googleapisDir)
 		if err != nil {

--- a/internal/librarian/golang/generate_test.go
+++ b/internal/librarian/golang/generate_test.go
@@ -309,6 +309,28 @@ func TestGenerateLibrary(t *testing.T) {
 			},
 		},
 		{
+			name: "proto only with hybrid proto level",
+			library: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{{
+					Path: "google/cloud/secretmanager/v1",
+					Go: &config.GoAPI{
+						ClientPackage: "secretmanager",
+						ProtoOnly:     true,
+						ImportPath:    "secretmanager/apiv1",
+						ProtoAPILevel: "API_HYBRID",
+					},
+				}},
+			},
+			want: []string{
+				"secretmanager/apiv1/secretmanagerpb/service.pb.go",
+				"secretmanager/apiv1/secretmanagerpb/service_protoopaque.pb.go",
+			},
+			removed: []string{
+				"secretmanager/apiv1/secret_manager_client.go",
+			},
+		},
+		{
 			name: "nested protos",
 			library: &config.Library{
 				Name: "containeranalysis",


### PR DESCRIPTION
This PR adds a new entry for Go language config, which enables us to configure specific packages to use newer code generation levels (namely, API_HYBRID).  It plumbs this option through to the protoc invocation and augments the testing to validate that the passed option emits the new protobuf artifacts

Related: b/549762318