### PR TITLE
fix(tool/cmd/migrate/php): parse and extract gapic_yaml from BUILD.bazel

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -456,6 +456,7 @@ This document describes the schema for the librarian.yaml.
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
 | `excluded_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
+| `gapic_yaml` | string | Is the GAPIC YAML configuration file, if provided. It expects the path relative to the config root or the googleapis directory (e.g., "google/cloud/aiplatform/v1/aiplatform_gapic.yaml"). |
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `samples` | bool (optional) | Determines whether to generate samples for the API. Default to true when omitted. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -849,6 +849,11 @@ type PHPAPI struct {
 	// directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto").
 	ExcludedProtos []string `yaml:"excluded_protos,omitempty"`
 
+	// GapicYAML is the GAPIC YAML configuration file, if provided.
+	// It expects the path relative to the config root or the googleapis directory
+	// (e.g., "google/cloud/aiplatform/v1/aiplatform_gapic.yaml").
+	GapicYAML string `yaml:"gapic_yaml,omitempty"`
+
 	// GenerateGAPIC indicates whether to generate the GAPIC client surface.
 	// Defaults to true.
 	GenerateGAPIC *bool `yaml:"generate_gapic,omitempty"`

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -186,7 +186,11 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 	if err != nil {
 		return err
 	}
-	opts := gapicOpts(params.api, apiMetadata, grpcConfigAbsPath, serviceYamlAbsPath)
+	gapicYamlAbsPath, err := absConfigPath(googleapisDir, params.api.PHP.GapicYAML)
+	if err != nil {
+		return err
+	}
+	opts := gapicOpts(params.api, apiMetadata, grpcConfigAbsPath, serviceYamlAbsPath, gapicYamlAbsPath)
 	additionalProtos := params.api.PHP.AdditionalProtos
 	includeCommonResources := *params.api.PHP.CommonResources
 	gapicProtos, err := gatherGAPICProtos(googleapisDir, params.api.Path, additionalProtos, params.api.PHP.ExcludedProtos, includeCommonResources)
@@ -309,7 +313,7 @@ func absConfigPath(baseDir, configPath string) (string, error) {
 	return filepath.Abs(filepath.Join(baseDir, configPath))
 }
 
-func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbsPath string) []string {
+func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbsPath, gapicYamlAbsPath string) []string {
 	transport := serviceconfig.GRPCRest
 	if apiMetadata != nil {
 		transport = apiMetadata.Transport(config.LanguagePhp)
@@ -327,6 +331,9 @@ func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPat
 	}
 	if serviceYamlAbsPath != "" {
 		opts = append(opts, "service_yaml="+serviceYamlAbsPath)
+	}
+	if gapicYamlAbsPath != "" {
+		opts = append(opts, "gapic_yaml="+gapicYamlAbsPath)
 	}
 	return opts
 }

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -392,6 +392,7 @@ func TestGapicOpts(t *testing.T) {
 		apiMetadata        *serviceconfig.API
 		grpcConfigAbsPath  string
 		serviceYamlAbsPath string
+		gapicYamlAbsPath   string
 		want               []string
 	}{
 		{
@@ -412,6 +413,16 @@ func TestGapicOpts(t *testing.T) {
 				"rest-numeric-enums", "generate-snippets",
 				"grpc_service_config=/absolute/path/to/googleapis/grpc_config.json",
 				"service_yaml=/absolute/path/to/googleapis/service.yaml",
+			},
+		},
+		{
+			name:             "with gapic yaml",
+			api:              &config.API{PHP: &config.PHPAPI{GapicYAML: "foo_gapic.yaml"}},
+			gapicYamlAbsPath: "/absolute/path/to/googleapis/foo_gapic.yaml",
+			want: []string{
+				"metadata", "transport=grpc+rest",
+				"generate-snippets",
+				"gapic_yaml=/absolute/path/to/googleapis/foo_gapic.yaml",
 			},
 		},
 		{
@@ -445,7 +456,7 @@ func TestGapicOpts(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := gapicOpts(test.api, test.apiMetadata, test.grpcConfigAbsPath, test.serviceYamlAbsPath)
+			got := gapicOpts(test.api, test.apiMetadata, test.grpcConfigAbsPath, test.serviceYamlAbsPath, test.gapicYamlAbsPath)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -238,12 +238,12 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 		}
 
 		for _, api := range apis {
-			additionalProtos, hasCommonResources, err := parsePHPBazel(googleapisDir, api.Path)
+			additionalProtos, hasCommonResources, gapicYAML, err := parsePHPBazel(googleapisDir, api.Path)
 			if err != nil {
 				log.Printf("Warning: failed to parse BUILD.bazel for %s: %v", api.Path, err)
 				continue
 			}
-			if len(additionalProtos) > 0 || hasCommonResources != globalDefaultCommonResources {
+			if len(additionalProtos) > 0 || hasCommonResources != globalDefaultCommonResources || gapicYAML != "" {
 				if api.PHP == nil {
 					api.PHP = &config.PHPAPI{}
 				}
@@ -253,6 +253,9 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 			}
 			if hasCommonResources != globalDefaultCommonResources {
 				api.PHP.CommonResources = &hasCommonResources
+			}
+			if gapicYAML != "" {
+				api.PHP.GapicYAML = gapicYAML
 			}
 		}
 
@@ -287,16 +290,29 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 	return libs, nil
 }
 
-func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, error) {
+func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, string, error) {
 	file, err := parseBazel(googleapisDir, apiPath)
 	if err != nil {
-		return nil, false, err
+		return nil, false, "", err
 	}
 	if file == nil {
-		return nil, false, nil
+		return nil, false, "", nil
 	}
 	var additionalProtos []string
 	var hasCommonResources bool
+	var gapicYAML string
+	if rules := file.Rules("php_gapic_library"); len(rules) > 0 {
+		rule := rules[0]
+		if attr := rule.Attr("gapic_yaml"); attr != nil {
+			if s, ok := attr.(*build.StringExpr); ok && s.Value != "" {
+				val := s.Value
+				if _, after, found := strings.Cut(val, ":"); found {
+					val = after
+				}
+				gapicYAML = filepath.ToSlash(filepath.Join(apiPath, val))
+			}
+		}
+	}
 	if rules := file.Rules("proto_library_with_info"); len(rules) > 0 {
 		rule := rules[0]
 		if attr := rule.Attr("deps"); attr != nil {
@@ -326,7 +342,7 @@ func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, error) {
 			}
 		}
 	}
-	return additionalProtos, hasCommonResources, nil
+	return additionalProtos, hasCommonResources, gapicYAML, nil
 }
 
 func parseBazel(googleapisDir, dir string) (*build.File, error) {

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -379,6 +379,7 @@ func TestParsePHPBazel(t *testing.T) {
 		bazelRules          string
 		want                []string
 		wantCommonResources bool
+		wantGapicYAML       string
 	}{
 		{
 			name:                "no BUILD.bazel",
@@ -433,6 +434,44 @@ proto_library_with_info(
 			want:                nil,
 			wantCommonResources: false,
 		},
+		{
+			name: "valid BUILD.bazel with gapic_yaml",
+			bazelRules: `
+php_gapic_library(
+    name = "ces_php_gapic",
+    srcs = [":ces_proto_with_info"],
+    gapic_yaml = ":ces_gapic.yaml",
+)
+proto_library_with_info(
+    name = "ces_proto_with_info",
+    deps = [
+        ":ces_proto",
+    ],
+)
+`,
+			want:                nil,
+			wantCommonResources: false,
+			wantGapicYAML:       "google/cloud/ces/v1/ces_gapic.yaml",
+		},
+		{
+			name: "valid BUILD.bazel with empty gapic_yaml",
+			bazelRules: `
+php_gapic_library(
+    name = "ces_php_gapic",
+    srcs = [":ces_proto_with_info"],
+    gapic_yaml = "",
+)
+proto_library_with_info(
+    name = "ces_proto_with_info",
+    deps = [
+        ":ces_proto",
+    ],
+)
+`,
+			want:                nil,
+			wantCommonResources: false,
+			wantGapicYAML:       "",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -445,7 +484,7 @@ proto_library_with_info(
 					t.Fatal(err)
 				}
 			}
-			got, gotCommonResources, err := parsePHPBazel(tempDir, "google/cloud/ces/v1")
+			got, gotCommonResources, gotGapicYAML, err := parsePHPBazel(tempDir, "google/cloud/ces/v1")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -454,6 +493,9 @@ proto_library_with_info(
 			}
 			if gotCommonResources != test.wantCommonResources {
 				t.Errorf("mismatch common resources flag: want %t, got %t", test.wantCommonResources, gotCommonResources)
+			}
+			if gotGapicYAML != test.wantGapicYAML {
+				t.Errorf("mismatch gapic_yaml: want %q, got %q", test.wantGapicYAML, gotGapicYAML)
 			}
 		})
 	}


### PR DESCRIPTION
The `migrate` tool previously ignored the `gapic_yaml` attribute when parsing `php_gapic_library` rules in Bazel, resulting in missing configuration for the PHP microgenerator. This updates the tool to extract the path, serialize it to `librarian.yaml`, and pass the `--gapic_yaml` flag during generation to ensure custom LRO configurations are applied.

Fixes https://github.com/googleapis/librarian/issues/7354