### PR TITLE
feat(sidekick/swift): use `_QueryParameterEncoder`

### DIFF
--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -219,6 +219,16 @@ func TestGenerateStub_QueryParameters(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
+
+	got = extractBlock(t, contentStr, `var query = [`, `query.append(`)
+	want = `var query = [
+        URLQueryItem(name: "$alt", value: "json;enum-encoding=int"),
+      ]
+      let encoder = GoogleCloudGax._QueryParameterEncoder()
+      query.append(`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestGenerateStub_Discovery(t *testing.T) {

--- a/internal/sidekick/swift/templates/http/transport.swift.mustache
+++ b/internal/sidekick/swift/templates/http/transport.swift.mustache
@@ -61,7 +61,7 @@ extension Clients {
         URLQueryItem(name: "$apiVersion", value: "{{.}}"),
         {{/APIVersion}}
       ]
-      let encoder = GoogleCloudGax.QueryParameterEncoder()
+      let encoder = GoogleCloudGax._QueryParameterEncoder()
       {{/Codec.HasQueryParams}}
       {{^Codec.HasQueryParams}}
       let query = [


### PR DESCRIPTION
Change the template to use `_QueryParameterEncoder`, this new name signals to customers that they should not be using the type themselves.

Towards https://github.com/googleapis/google-cloud-swift/issues/497 