### PR TITLE
feat(sidekick/swift): use `@_spi` in retry stub

### DIFF
--- a/internal/sidekick/swift/templates/common/retry.swift.mustache
+++ b/internal/sidekick/swift/templates/common/retry.swift.mustache
@@ -31,7 +31,7 @@ import Foundation
 {{#Codec.ServiceImports}}
 import {{.}}
 {{/Codec.ServiceImports}}
-import GoogleCloudGax
+@_spi(GoogleCloudInternal) import GoogleCloudGax
 
 extension Clients {
   final class {{Codec.StubPrefix}}Retry: {{Codec.StubPrefix}}Stub {


### PR DESCRIPTION
Add the attribute in the import for `GoogleCloudGax`, this will let us mark the type as `@_spi(GoogleCloudInternal)`.

Towards https://github.com/googleapis/google-cloud-swift/issues/501 
