### PR TITLE
chore(internal/serviceconfig): skip rest numeric enums for php storage control

### DIFF
--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1343,8 +1343,8 @@
     go: grpc
     java: grpc
 - path: google/storage/control/v2
-  transports:
-    php: grpc
+  skip_rest_numeric_enums:
+    - php
 - path: google/storage/v2
   new_issue_uri: https://issuetracker.google.com/issues/new?component=187243&template=1162869
   transports:

--- a/internal/serviceconfig/sdk.yaml
+++ b/internal/serviceconfig/sdk.yaml
@@ -1342,6 +1342,9 @@
   transports:
     go: grpc
     java: grpc
+- path: google/storage/control/v2
+  transports:
+    php: grpc
 - path: google/storage/v2
   new_issue_uri: https://issuetracker.google.com/issues/new?component=187243&template=1162869
   transports:


### PR DESCRIPTION
The Google Cloud Storage Control API (google/storage/control/v2) is configured to skip rest_numeric_enums for PHP.

This prevents passing the rest-numeric-enums option during PHP client generation for google/storage/control/v2 to match expected serialization behavior.
