### PR TITLE
fix(internal/librarian/ruby): forward all ruby cloud opts to generator

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -186,14 +186,29 @@ func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir stri
 		if api.Ruby.RubyCloudOpts.ExtraDependencies != "" {
 			opts = append(opts, "ruby-cloud-extra-dependencies="+api.Ruby.RubyCloudOpts.ExtraDependencies)
 		}
+		if api.Ruby.RubyCloudOpts.FactoryMethodSuffix != "" {
+			opts = append(opts, "ruby-cloud-factory-method-suffix="+api.Ruby.RubyCloudOpts.FactoryMethodSuffix)
+		}
 		if api.Ruby.RubyCloudOpts.GemNamespace != "" {
 			opts = append(opts, "ruby-cloud-gem-namespace="+api.Ruby.RubyCloudOpts.GemNamespace)
 		}
 		if api.Ruby.RubyCloudOpts.MigrationVersion != "" {
 			opts = append(opts, "ruby-cloud-migration-version="+api.Ruby.RubyCloudOpts.MigrationVersion)
 		}
+		if api.Ruby.RubyCloudOpts.NamespaceOverride != "" {
+			opts = append(opts, "ruby-cloud-namespace-override="+api.Ruby.RubyCloudOpts.NamespaceOverride)
+		}
+		if api.Ruby.RubyCloudOpts.PathOverride != "" {
+			opts = append(opts, "ruby-cloud-path-override="+api.Ruby.RubyCloudOpts.PathOverride)
+		}
 		if api.Ruby.RubyCloudOpts.ServiceOverride != "" {
 			opts = append(opts, "ruby-cloud-service-override="+api.Ruby.RubyCloudOpts.ServiceOverride)
+		}
+		if api.Ruby.RubyCloudOpts.WrapperGemOverride != "" {
+			opts = append(opts, "ruby-cloud-wrapper-gem-override="+api.Ruby.RubyCloudOpts.WrapperGemOverride)
+		}
+		if api.Ruby.RubyCloudOpts.YardStrict != "" {
+			opts = append(opts, "ruby-cloud-yard-strict="+api.Ruby.RubyCloudOpts.YardStrict)
 		}
 	}
 	if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -152,6 +152,48 @@ func TestBuildGAPICOpts(t *testing.T) {
 			},
 		},
 		{
+			name: "ruby cloud opts with all options",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Ruby: &config.RubyAPI{
+					RubyCloudOpts: &config.RubyCloudOpts{
+						EnvPrefix:           "SECRET_MANAGER",
+						ExtraDependencies:   "google-cloud-core=~>1.6",
+						FactoryMethodSuffix: "service",
+						GemNamespace:        "Google::Cloud::SecretManager::V1",
+						MigrationVersion:    "1.0",
+						NamespaceOverride:   "SecretManager=Secretmanager",
+						PathOverride:        "secret_manager=secretmanager",
+						ServiceOverride:     "SecretManager=secretmanager",
+						WrapperGemOverride:  "google-cloud-secret_manager",
+						YardStrict:          "false",
+					},
+				},
+			},
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+			},
+			want: []string{
+				"ruby-cloud-gem-name=google-cloud-secret_manager",
+				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
+				"ruby-cloud-generate-transports=grpc;rest",
+				"ruby-cloud-rest-numeric-enums=true",
+				"ruby-cloud-env-prefix=SECRET_MANAGER",
+				"ruby-cloud-extra-dependencies=google-cloud-core=~>1.6",
+				"ruby-cloud-factory-method-suffix=service",
+				"ruby-cloud-gem-namespace=Google::Cloud::SecretManager::V1",
+				"ruby-cloud-migration-version=1.0",
+				"ruby-cloud-namespace-override=SecretManager=Secretmanager",
+				"ruby-cloud-path-override=secret_manager=secretmanager",
+				"ruby-cloud-service-override=SecretManager=secretmanager",
+				"ruby-cloud-wrapper-gem-override=google-cloud-secret_manager",
+				"ruby-cloud-yard-strict=false",
+			},
+		},
+		{
 			name: "wrapper library with wrapper_of option",
 			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",


### PR DESCRIPTION
Forward the remaining RubyCloudOpts fields (FactoryMethodSuffix, NamespaceOverride, PathOverride, WrapperGemOverride, and YardStrict) to the gapic generator in buildGAPICOpts.

This is currently blocking Batch #5 of the google-cloud-ruby Librarian onboarding migration (see go/sdk-librarian-ruby-tracker).

### Examples of blocked Batch #5 gems:
1. **google-cloud-backupdr-v1 & google-cloud-backupdr**:
   `librarian.yaml` specifies:
   ```yaml
   ruby_cloud_opts:
     ruby-cloud-namespace-override: Backupdr=BackupDR
     ruby-cloud-path-override: backup_dr=backupdr
   ```
   Without `ruby-cloud-path-override` and `ruby-cloud-namespace-override` forwarded, files are generated under `lib/google/cloud/backup_dr/` instead of `lib/google/cloud/backupdr/`, causing bundler gemspec constant resolution errors (`uninitialized constant Google::Cloud::Backupdr`).

2. **google-cloud-automl**:
   `librarian.yaml` specifies `ruby-cloud-path-override: auto_ml=automl` and `ruby-cloud-namespace-override: AutoMl=AutoML`. Without forwarding, files are generated under `lib/google/cloud/auto_ml/` and the version resets to `0.0.1`.

3. **google-cloud-beyond_corp-* gems** (e.g. `google-cloud-beyond_corp-app_connections-v1`):
   `librarian.yaml` specifies `ruby-cloud-wrapper-gem-override: google-cloud-beyond_corp`. Without forwarding, the gemspec description and wrapper dependency reference non-existent gem names like `google-cloud-beyond_corp-app_connections`.

Fixes https://github.com/googleapis/librarian/issues/7359