### PR TITLE
refactor(swift): remove protoc-gen-grpc-swift plugin invocation

### DIFF
--- a/internal/librarian/swift/compile_protobufs.go
+++ b/internal/librarian/swift/compile_protobufs.go
@@ -71,7 +71,6 @@ func compileProtobufs(ctx context.Context, pc *config.Protoc, library *config.Li
 
 	args := []string{
 		"--swift_out=Visibility=Public:" + module.Output,
-		"--grpc-swift_out=Visibility=Public:" + module.Output,
 	}
 	args = append(args, protoImports...)
 	args = append(args, protoFiles...)

--- a/internal/librarian/swift/generate_module_test.go
+++ b/internal/librarian/swift/generate_module_test.go
@@ -74,7 +74,6 @@ func TestGenerateModule(t *testing.T) {
 func TestGenerateModule_SwiftProtobuf(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "protoc-gen-swift")
-	testhelper.RequireCommand(t, "protoc-gen-grpc-swift")
 
 	googleapisDir, err := filepath.Abs("../../testdata/googleapis")
 	if err != nil {


### PR DESCRIPTION
linked with https://github.com/googleapis/google-cloud-swift/pull/504 