### PR TITLE
fix(dart): restore package description position

### DIFF
--- a/internal/sidekick/dart/templates/README.md.mustache
+++ b/internal/sidekick/dart/templates/README.md.mustache
@@ -40,6 +40,8 @@ The Google Cloud client library for the {{{Title}}}.
 ## What's this?
 
 The Google Cloud client library for the {{{Title}}}.
+
+{{Description}}
 {{#Codec.HasSkills}}
 
 ## Agent Skills
@@ -55,8 +57,6 @@ dart pub get
 dart run skills@ get
 ```
 {{/Codec.HasSkills}}
-
-{{Description}}
 {{#Codec.ReadMeQuickstartText}}
 
 {{{Codec.ReadMeQuickstartText}}}


### PR DESCRIPTION
Moves the package description in `README.md` to the **What's this?** section, rather than the **Agent Skills** section.