### PR TITLE
feat(tool/cmd/migrate/php): set copyright_year to 2026 for PHP libraries

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -265,10 +265,11 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 		}
 		libraryName := php.DefaultLibraryName(apis[0].Path)
 		lib := &config.Library{
-			Name:    libraryName,
-			Version: version,
-			APIs:    apis,
-			Output:  name,
+			CopyrightYear: "2026",
+			Name:          libraryName,
+			Version:       version,
+			APIs:          apis,
+			Output:        name,
 		}
 		derivedComp, err := php.ComponentNameForLibrary(googleapisDir, lib)
 		if err != nil {

--- a/tool/cmd/migrate/php_test.go
+++ b/tool/cmd/migrate/php_test.go
@@ -108,9 +108,10 @@ deep-copy-regex:
 		},
 		Libraries: []*config.Library{
 			{
-				Name:    "secretmanager",
-				Version: "2.3.0",
-				Output:  "SecretManager",
+				CopyrightYear: "2026",
+				Name:          "secretmanager",
+				Version:       "2.3.0",
+				Output:        "SecretManager",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",
@@ -537,9 +538,10 @@ deep-copy-regex:
 			globalDefaultCommonResources: true,
 			want: []*config.Library{
 				{
-					Name:    "secretmanager",
-					Version: "2.3.0",
-					Output:  "SecretManager",
+					CopyrightYear: "2026",
+					Name:          "secretmanager",
+					Version:       "2.3.0",
+					Output:        "SecretManager",
 					APIs: []*config.API{
 						{
 							Path: "google/cloud/secretmanager/v1",
@@ -580,9 +582,10 @@ deep-copy-regex:
 			globalDefaultCommonResources: true,
 			want: []*config.Library{
 				{
-					Name:    "security-privateca",
-					Version: "1.0.0",
-					Output:  "SecurityPrivateCa",
+					CopyrightYear: "2026",
+					Name:          "security-privateca",
+					Version:       "1.0.0",
+					Output:        "SecurityPrivateCa",
 					PHP: &config.PHPPackage{
 						ComponentName: "SecurityPrivateCa",
 					},
@@ -622,9 +625,10 @@ deep-copy-regex:
 			globalDefaultCommonResources: true,
 			want: []*config.Library{
 				{
-					Name:    "identity-accesscontextmanager",
-					Version: "1.0.0",
-					Output:  "AccessContextManager",
+					CopyrightYear: "2026",
+					Name:          "identity-accesscontextmanager",
+					Version:       "1.0.0",
+					Output:        "AccessContextManager",
 					PHP: &config.PHPPackage{
 						ComponentName: "AccessContextManager",
 					},
@@ -689,9 +693,10 @@ deep-copy-regex:
 			globalDefaultCommonResources: true,
 			want: []*config.Library{
 				{
-					Name:    "secretmanager",
-					Version: "2.3.0",
-					Output:  "secretmanager",
+					CopyrightYear: "2026",
+					Name:          "secretmanager",
+					Version:       "2.3.0",
+					Output:        "secretmanager",
 					PHP: &config.PHPPackage{
 						ComponentName: "secretmanager",
 					},


### PR DESCRIPTION
This PR updates the migrate tool to explicitly set `copyright_year: "2026"` for PHP libraries, so that code generated by librarian correctly bumps the copyright year during migration. Small cleanup PR to actually set the copyright year.

For https://github.com/googleapis/librarian/issues/6795