### PR TITLE
feat(internal/sidekick/rust): support server-side streaming in gapics

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -545,6 +545,7 @@ This document describes the schema for the librarian.yaml.
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
 | `include_bidi_streaming_methods` | bool | Indicates whether to include gRPC bi-directional streaming methods. |
+| `include_server_streaming_methods` | bool | Indicates whether to include gRPC server-side streaming methods. |
 | `post_process_protos` | string | Indicates whether to post-process protos. |
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |
 | `pagination_overrides` | list of [RustPaginationOverride](#rustpaginationoverride-configuration) | Contains overrides for pagination configuration. |
@@ -589,6 +590,7 @@ This document describes the schema for the librarian.yaml.
 | `include_list` | yaml.StringSlice | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
 | `include_bidi_streaming_methods` | bool | Indicates whether to include gRPC bi-directional streaming methods. |
+| `include_server_streaming_methods` | bool | Indicates whether to include gRPC server-side streaming methods. |
 | `internal_builders` | bool | Indicates whether generated builders should be internal to the crate. |
 | `module_path` | string | Is the Rust module path for converters (e.g., "crate::generated::gapic::model"). |
 | `module_roots` | map[string]string |  |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -171,6 +171,10 @@ type RustModule struct {
 	// methods.
 	IncludeBidiStreamingMethods bool `yaml:"include_bidi_streaming_methods,omitempty"`
 
+	// IncludeServerStreamingMethods indicates whether to include gRPC server-side streaming
+	// methods.
+	IncludeServerStreamingMethods bool `yaml:"include_server_streaming_methods,omitempty"`
+
 	// InternalBuilders indicates whether generated builders should be internal to the crate.
 	InternalBuilders bool `yaml:"internal_builders,omitempty"`
 
@@ -273,6 +277,10 @@ type RustCrate struct {
 	// IncludeBidiStreamingMethods indicates whether to include gRPC bi-directional streaming
 	// methods.
 	IncludeBidiStreamingMethods bool `yaml:"include_bidi_streaming_methods,omitempty"`
+
+	// IncludeServerStreamingMethods indicates whether to include gRPC server-side streaming
+	// methods.
+	IncludeServerStreamingMethods bool `yaml:"include_server_streaming_methods,omitempty"`
 
 	// PostProcessProtos indicates whether to post-process protos.
 	PostProcessProtos string `yaml:"post_process_protos,omitempty"`

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -138,6 +138,9 @@ func buildCodec(library *config.Library, releaseLevel string) map[string]string 
 	if rust.IncludeBidiStreamingMethods {
 		codec["include-bidi-streaming-methods"] = "true"
 	}
+	if rust.IncludeServerStreamingMethods {
+		codec["include-server-streaming-methods"] = "true"
+	}
 	if rust.PerServiceFeatures {
 		codec["per-service-features"] = "true"
 	}
@@ -320,6 +323,9 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	}
 	if module.IncludeBidiStreamingMethods {
 		codec["include-bidi-streaming-methods"] = "true"
+	}
+	if module.IncludeServerStreamingMethods {
+		codec["include-server-streaming-methods"] = "true"
 	}
 	detailedTracingAttributes := library.Rust != nil && library.Rust.DetailedTracingAttributes != nil && *library.Rust.DetailedTracingAttributes
 	if module.DetailedTracingAttributes != nil {

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -32,15 +32,22 @@ import (
 )
 
 func generateProstHybrid(ctx context.Context, model *api.API, library *config.Library, outdir string, modelConfig *parser.ModelConfig) error {
-	if library.Rust == nil || !library.Rust.IncludeBidiStreamingMethods || library.Rust.TemplateOverride != "" {
+	if library.Rust == nil || library.Rust.TemplateOverride != "" {
 		return nil
 	}
-	hasBidiStreaming := slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
-	if !hasBidiStreaming {
+	includeBidi := library.Rust.IncludeBidiStreamingMethods
+	includeServer := library.Rust.IncludeServerStreamingMethods
+	if !includeBidi && !includeServer {
+		return nil
+	}
+	hasStreaming := slices.ContainsFunc(model.Services, func(s *api.Service) bool {
+		return (includeBidi && s.HasBidiStreaming()) || (includeServer && s.HasServerSideStreaming())
+	})
+	if !hasStreaming {
 		return nil
 	}
 
-	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToStreaming(model)
+	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToStreaming(model, includeBidi, includeServer)
 	if err != nil {
 		return err
 	}
@@ -73,11 +80,11 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 }
 
 // filterModelToStreaming constructs a hybrid api.API model containing only
-// bidirectional streaming RPC types for prost conversion generation. It also returns
+// enabled bidirectional and server-side streaming RPC types for prost conversion generation. It also returns
 // a sorted slice of all non-WKT unused type IDs to exclude via prost_build extern_path,
 // and a boolean indicating whether google.rpc.Status is referenced in the streaming path.
 // Errors if Any is encountered in the streaming reachability path.
-func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
+func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool) (*api.API, []string, bool, error) {
 	type streamingTypeItem struct {
 		id       string
 		rpc      string
@@ -89,10 +96,12 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 	streamingEnums := make(map[string]bool)
 	var queue []streamingTypeItem
 
-	// Collect initial input/output message types from all bidirectional streaming RPCs.
+	// Collect initial input/output message types from all enabled bidirectional and server-side streaming RPCs.
 	for _, s := range model.Services {
 		for _, m := range s.Methods {
-			if m.ClientSideStreaming && m.ServerSideStreaming {
+			isBidi := m.ClientSideStreaming && m.ServerSideStreaming && includeBidi
+			isServer := !m.ClientSideStreaming && m.ServerSideStreaming && includeServer
+			if isBidi || isServer {
 				rpcName := s.Name + "." + m.Name
 				if m.InputTypeID != "" {
 					queue = append(queue, streamingTypeItem{
@@ -267,7 +276,9 @@ func filterModelToStreaming(model *api.API) (*api.API, []string, bool, error) {
 		// Services, Messages, and Enums slices are filtered to only streaming types so convert.rs
 		// only contains conversion implementations for streaming RPCs.
 		// Filtering model.Messages and model.Enums preserves their original deterministic file order.
-		Services:            language.FilterSlice(model.Services, (*api.Service).HasBidiStreaming),
+		Services: language.FilterSlice(model.Services, func(s *api.Service) bool {
+			return (includeBidi && s.HasBidiStreaming()) || (includeServer && s.HasServerSideStreaming())
+		}),
 		Messages:            language.FilterSlice(model.Messages, func(m *api.Message) bool { return streamingMsgs[m.ID] }),
 		ExternalMessages:    externalMessages,
 		Enums:               language.FilterSlice(model.Enums, func(e *api.Enum) bool { return streamingEnums[e.ID] }),

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -51,8 +51,7 @@ func TestGenerateProstHybrid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expandMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg)
-	expandMethod.ServerSideStreaming = true
+	expandMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg).WithServerSideStreaming()
 	serverService := api.NewTestService("ServerService").WithPackage("google.cloud.test.v1").WithMethods(expandMethod)
 	serverStreamingModel := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{serverService})
 	if err := api.CrossReference(serverStreamingModel); err != nil {
@@ -379,8 +378,7 @@ func TestFilterModelToStreamingServerStreaming(t *testing.T) {
 	respMsg := api.NewTestMessage("EchoResponse").WithPackage("google.test.v1")
 	unusedMsg := api.NewTestMessage("UnusedMsg").WithPackage("google.test.v1")
 
-	expandMethod := api.NewTestMethod("Expand").WithInput(reqMsg).WithOutput(respMsg)
-	expandMethod.ServerSideStreaming = true
+	expandMethod := api.NewTestMethod("Expand").WithInput(reqMsg).WithOutput(respMsg).WithServerSideStreaming()
 
 	serverService := api.NewTestService("EchoService").WithPackage("google.test.v1").WithMethods(expandMethod)
 	model := api.NewTestAPI([]*api.Message{reqMsg, respMsg, unusedMsg}, []*api.Enum{}, []*api.Service{serverService})
@@ -407,8 +405,7 @@ func TestFilterModelToStreamingIsolation(t *testing.T) {
 	serverResp := api.NewTestMessage("ServerResp").WithPackage("google.test.v1")
 
 	bidiMethod := api.NewTestMethod("Chat").WithInput(bidiMsg).WithOutput(bidiMsg).WithBidiStreaming()
-	serverMethod := api.NewTestMethod("Expand").WithInput(serverReq).WithOutput(serverResp)
-	serverMethod.ServerSideStreaming = true
+	serverMethod := api.NewTestMethod("Expand").WithInput(serverReq).WithOutput(serverResp).WithServerSideStreaming()
 
 	service := api.NewTestService("MixedService").WithPackage("google.test.v1").WithMethods(bidiMethod, serverMethod)
 	model := api.NewTestAPI([]*api.Message{bidiMsg, serverReq, serverResp}, []*api.Enum{}, []*api.Service{service})

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
@@ -49,12 +51,21 @@ func TestGenerateProstHybrid(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	expandMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg)
+	expandMethod.ServerSideStreaming = true
+	serverService := api.NewTestService("ServerService").WithPackage("google.cloud.test.v1").WithMethods(expandMethod)
+	serverStreamingModel := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{serverService})
+	if err := api.CrossReference(serverStreamingModel); err != nil {
+		t.Fatal(err)
+	}
+
 	for _, test := range []struct {
-		name                        string
-		model                       *api.API
-		includeBidiStreamingMethods bool
-		templateOverride            string
-		wantProstDir                bool
+		name                          string
+		model                         *api.API
+		includeBidiStreamingMethods   bool
+		includeServerStreamingMethods bool
+		templateOverride              string
+		wantProstDir                  bool
 	}{
 		{
 			name:                        "feature disabled does not create prost dir",
@@ -81,14 +92,21 @@ func TestGenerateProstHybrid(t *testing.T) {
 			includeBidiStreamingMethods: true,
 			wantProstDir:                true,
 		},
+		{
+			name:                          "server streaming enabled creates prost dir",
+			model:                         serverStreamingModel,
+			includeServerStreamingMethods: true,
+			wantProstDir:                  true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
 			lib := &config.Library{
 				Name: "test-package",
 				Rust: &config.RustCrate{
-					IncludeBidiStreamingMethods: test.includeBidiStreamingMethods,
-					TemplateOverride:            test.templateOverride,
+					IncludeBidiStreamingMethods:   test.includeBidiStreamingMethods,
+					IncludeServerStreamingMethods: test.includeServerStreamingMethods,
+					TemplateOverride:              test.templateOverride,
 				},
 			}
 			absSpecSource, err := filepath.Abs("../../testdata/googleapis/google/type")
@@ -136,7 +154,7 @@ func TestFilterModelToStreaming(t *testing.T) {
 	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
 	model := api.NewTestAPI([]*api.Message{streamingMsg, unusedMsg}, []*api.Enum{}, []*api.Service{bidiService})
 
-	filtered, unused, _, err := filterModelToStreaming(model)
+	filtered, unused, _, err := filterModelToStreaming(model, true, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +190,7 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{streamMsg, unaryReq, childData}, []*api.Enum{}, []*api.Service{bidiService, unaryService})
 
-	filtered, _, _, err := filterModelToStreaming(model)
+	filtered, _, _, err := filterModelToStreaming(model, true, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,7 +237,7 @@ func TestFilterModelToStreamingExternalTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	filtered, _, _, err := filterModelToStreaming(model)
+	filtered, _, _, err := filterModelToStreaming(model, true, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -249,7 +267,7 @@ func TestFilterModelToStreamingAnyError(t *testing.T) {
 
 	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
 
-	_, _, _, err := filterModelToStreaming(anyModel)
+	_, _, _, err := filterModelToStreaming(anyModel, true, true)
 	if err == nil {
 		t.Fatal("expected error for google.protobuf.Any, got nil")
 	}
@@ -291,7 +309,7 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 	statusModel := api.NewTestAPI([]*api.Message{reqMsg}, []*api.Enum{}, []*api.Service{statusService})
 	statusModel.AddMessage(statusMsg)
 
-	filtered, unused, hasStatus, err := filterModelToStreaming(statusModel)
+	filtered, unused, hasStatus, err := filterModelToStreaming(statusModel, true, true)
 	if err != nil {
 		t.Fatalf("unexpected error for google.rpc.Status: %v", err)
 	}
@@ -338,7 +356,7 @@ func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{parent, child, sibling, streamReq}, []*api.Enum{}, []*api.Service{bidiService})
 
-	_, unusedTypes, _, err := filterModelToStreaming(model)
+	_, unusedTypes, _, err := filterModelToStreaming(model, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -353,5 +371,93 @@ func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
 		if unused == sibling.ID {
 			t.Errorf("sibling field message %q of parent should not be in unusedTypes", sibling.ID)
 		}
+	}
+}
+
+func TestFilterModelToStreamingServerStreaming(t *testing.T) {
+	reqMsg := api.NewTestMessage("ExpandRequest").WithPackage("google.test.v1")
+	respMsg := api.NewTestMessage("EchoResponse").WithPackage("google.test.v1")
+	unusedMsg := api.NewTestMessage("UnusedMsg").WithPackage("google.test.v1")
+
+	expandMethod := api.NewTestMethod("Expand").WithInput(reqMsg).WithOutput(respMsg)
+	expandMethod.ServerSideStreaming = true
+
+	serverService := api.NewTestService("EchoService").WithPackage("google.test.v1").WithMethods(expandMethod)
+	model := api.NewTestAPI([]*api.Message{reqMsg, respMsg, unusedMsg}, []*api.Enum{}, []*api.Service{serverService})
+
+	filtered, unused, _, err := filterModelToStreaming(model, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(filtered.Services) != 1 || filtered.Services[0].ID != serverService.ID {
+		t.Errorf("got services %v, want [%s]", filtered.Services, serverService.ID)
+	}
+	if len(filtered.Messages) != 2 {
+		t.Errorf("got messages %v, want [%s, %s]", filtered.Messages, reqMsg.ID, respMsg.ID)
+	}
+	if len(unused) != 1 || unused[0] != unusedMsg.ID {
+		t.Errorf("got unused %v, want [%s]", unused, unusedMsg.ID)
+	}
+}
+
+func TestFilterModelToStreamingIsolation(t *testing.T) {
+	bidiMsg := api.NewTestMessage("BidiMsg").WithPackage("google.test.v1")
+	serverReq := api.NewTestMessage("ServerReq").WithPackage("google.test.v1")
+	serverResp := api.NewTestMessage("ServerResp").WithPackage("google.test.v1")
+
+	bidiMethod := api.NewTestMethod("Chat").WithInput(bidiMsg).WithOutput(bidiMsg).WithBidiStreaming()
+	serverMethod := api.NewTestMethod("Expand").WithInput(serverReq).WithOutput(serverResp)
+	serverMethod.ServerSideStreaming = true
+
+	service := api.NewTestService("MixedService").WithPackage("google.test.v1").WithMethods(bidiMethod, serverMethod)
+	model := api.NewTestAPI([]*api.Message{bidiMsg, serverReq, serverResp}, []*api.Enum{}, []*api.Service{service})
+
+	for _, test := range []struct {
+		name          string
+		includeBidi   bool
+		includeServer bool
+		wantMessages  []string
+		wantUnused    []string
+	}{
+		{
+			name:          "server streaming only ignores bidi types",
+			includeBidi:   false,
+			includeServer: true,
+			wantMessages:  []string{serverReq.ID, serverResp.ID},
+			wantUnused:    []string{bidiMsg.ID},
+		},
+		{
+			name:          "bidi streaming only ignores server streaming types",
+			includeBidi:   true,
+			includeServer: false,
+			wantMessages:  []string{bidiMsg.ID},
+			wantUnused:    []string{serverReq.ID, serverResp.ID},
+		},
+		{
+			name:          "both streaming types enabled includes all types",
+			includeBidi:   true,
+			includeServer: true,
+			wantMessages:  []string{bidiMsg.ID, serverReq.ID, serverResp.ID},
+			wantUnused:    nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			filtered, unused, _, err := filterModelToStreaming(model, test.includeBidi, test.includeServer)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var gotMessages []string
+			for _, m := range filtered.Messages {
+				gotMessages = append(gotMessages, m.ID)
+			}
+			less := func(a, b string) bool { return a < b }
+			if diff := cmp.Diff(test.wantMessages, gotMessages, cmpopts.SortSlices(less), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch in filtered messages (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantUnused, unused, cmpopts.SortSlices(less), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch in unused messages (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/sidekick/api/model_test.go
+++ b/internal/sidekick/api/model_test.go
@@ -324,3 +324,101 @@ func TestService_HasClientSideStreaming(t *testing.T) {
 		})
 	}
 }
+
+func TestService_HasBidiStreaming(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		methods []*Method
+		want    bool
+	}{
+		{
+			name: "no methods",
+			want: false,
+		},
+		{
+			name: "unary only",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: false, ServerSideStreaming: false},
+			},
+			want: false,
+		},
+		{
+			name: "server only streaming",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: false, ServerSideStreaming: true},
+			},
+			want: false,
+		},
+		{
+			name: "client only streaming",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: true, ServerSideStreaming: false},
+			},
+			want: false,
+		},
+		{
+			name: "bidi streaming",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: true, ServerSideStreaming: true},
+			},
+			want: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := &Service{Methods: test.methods}
+			got := s.HasBidiStreaming()
+			if got != test.want {
+				t.Errorf("got %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestService_HasServerSideStreaming(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		methods []*Method
+		want    bool
+	}{
+		{
+			name: "no methods",
+			want: false,
+		},
+		{
+			name: "unary only",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: false, ServerSideStreaming: false},
+			},
+			want: false,
+		},
+		{
+			name: "bidi streaming (not server-only)",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: true, ServerSideStreaming: true},
+			},
+			want: false,
+		},
+		{
+			name: "client only streaming",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: true, ServerSideStreaming: false},
+			},
+			want: false,
+		},
+		{
+			name: "server-side streaming",
+			methods: []*Method{
+				{Name: "m1", ClientSideStreaming: false, ServerSideStreaming: true},
+			},
+			want: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := &Service{Methods: test.methods}
+			got := s.HasServerSideStreaming()
+			if got != test.want {
+				t.Errorf("got %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/sidekick/api/service.go
+++ b/internal/sidekick/api/service.go
@@ -62,7 +62,7 @@ func (s *Service) HasBidiStreaming() bool {
 }
 
 // HasServerSideStreaming returns true if the service contains any methods
-// that support server-side streaming.
+// that support server-side streaming and are not bidirectional.
 func (s *Service) HasServerSideStreaming() bool {
 	return slices.ContainsFunc(s.Methods, func(m *Method) bool {
 		return !m.ClientSideStreaming && m.ServerSideStreaming

--- a/internal/sidekick/api/service.go
+++ b/internal/sidekick/api/service.go
@@ -60,3 +60,11 @@ func (s *Service) HasBidiStreaming() bool {
 		return m.ClientSideStreaming && m.ServerSideStreaming
 	})
 }
+
+// HasServerSideStreaming returns true if the service contains any methods
+// that support server-side streaming.
+func (s *Service) HasServerSideStreaming() bool {
+	return slices.ContainsFunc(s.Methods, func(m *Method) bool {
+		return !m.ClientSideStreaming && m.ServerSideStreaming
+	})
+}

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -283,6 +283,22 @@ func (m *Method) WithBidiStreaming() *Method {
 	return m
 }
 
+// WithServerSideStreaming sets the method as a server-side streaming
+// method. This method will not have client side streaming.
+func (m *Method) WithServerSideStreaming() *Method {
+	m.ClientSideStreaming = false
+	m.ServerSideStreaming = true
+	return m
+}
+
+// WithClientSideStreaming sets the method as a client-side streaming
+// method. This method will not have server-side streaming.
+func (m *Method) WithClientSideStreaming() *Method {
+	m.ClientSideStreaming = true
+	m.ServerSideStreaming = false
+	return m
+}
+
 // WithDiscoveryLro sets the discovery LRO information.
 func (m *Method) WithDiscoveryLro(info *DiscoveryLro) *Method {
 	m.DiscoveryLro = info

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -56,7 +56,8 @@ func (m *methodAnnotation) IsBidiStreaming() bool {
 	return m.ClientSideStreaming && m.ServerSideStreaming
 }
 
-// IsServerStreaming returns true if the method is a server-side streaming RPC.
+// IsServerStreaming returns true if the method is a server-side streaming RPC
+// and is not bidirectional.
 func (m *methodAnnotation) IsServerStreaming() bool {
 	return !m.ClientSideStreaming && m.ServerSideStreaming
 }

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -56,6 +56,11 @@ func (m *methodAnnotation) IsBidiStreaming() bool {
 	return m.ClientSideStreaming && m.ServerSideStreaming
 }
 
+// IsServerStreaming returns true if the method is a server-side streaming RPC.
+func (m *methodAnnotation) IsServerStreaming() bool {
+	return !m.ClientSideStreaming && m.ServerSideStreaming
+}
+
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
 func (m *methodAnnotation) HasGrpcResourceNameArgs() bool {
 	return len(m.GrpcResourceNameArgs) > 0

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -590,3 +590,24 @@ func TestIsBidiStreaming(t *testing.T) {
 		})
 	}
 }
+
+func TestIsServerStreaming(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		client bool
+		server bool
+		want   bool
+	}{
+		{"bidi streaming", true, true, false},
+		{"client-only streaming", true, false, false},
+		{"server-only streaming", false, true, true},
+		{"unary", false, false, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ann := &methodAnnotation{ClientSideStreaming: test.client, ServerSideStreaming: test.server}
+			if got := ann.IsServerStreaming(); got != test.want {
+				t.Errorf("methodAnnotation.IsServerStreaming() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -54,8 +54,12 @@ type modelAnnotations struct {
 	ExternPackages             []string
 	HasLROs                    bool
 	HasBidiStreaming           bool
+	HasServerStreaming         bool
+	HasStreaming               bool
 	IncludeRpcStatusConversion bool
 	BidiStreamingServices      []*api.Service
+	ServerStreamingServices    []*api.Service
+	StreamingServices          []*api.Service
 	CopyrightYear              string
 	BoilerPlate                []string
 	DefaultHost                string
@@ -145,7 +149,7 @@ func (m *modelAnnotations) ReleaseLevelIsGA() bool {
 func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	codec.hasServices = len(model.Services) > 0
 
-	resolveUsedPackages(model, codec.extraPackages, codec.hasBidiStreaming(model))
+	resolveUsedPackages(model, codec.extraPackages, codec.hasStreaming(model))
 	// Annotate enums and messages that we intend to generate. In the
 	// process we discover the external dependencies and trim the list of
 	// packages used by this API.
@@ -274,16 +278,30 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	}
 
 	var bidiStreamingServices []*api.Service
+	var serverStreamingServices []*api.Service
+	var streamingServices []*api.Service
 	for _, s := range servicesSubset {
-		if s.HasBidiStreaming() {
+		isBidi := codec.includeBidiStreamingMethods && s.HasBidiStreaming()
+		isServer := codec.includeServerStreamingMethods && s.HasServerSideStreaming()
+		if isBidi {
 			bidiStreamingServices = append(bidiStreamingServices, s)
 		}
+		if isServer {
+			serverStreamingServices = append(serverStreamingServices, s)
+		}
+		if isBidi || isServer {
+			streamingServices = append(streamingServices, s)
+		}
 	}
-	hasBidiStreaming := codec.hasBidiStreaming(model)
-	if hasBidiStreaming {
+	hasBidiStreaming := codec.templateOverride == "" && len(bidiStreamingServices) > 0
+	hasServerStreaming := codec.templateOverride == "" && len(serverStreamingServices) > 0
+	hasStreaming := hasBidiStreaming || hasServerStreaming
+	if hasStreaming {
 		for _, pkg := range codec.extraPackages {
-			if pkg.name == gaxiPackageName && !slices.Contains(pkg.features, "_internal-grpc-client") {
-				pkg.features = append(pkg.features, "_internal-grpc-client")
+			if pkg.name == gaxiPackageName {
+				if !slices.Contains(pkg.features, "_internal-grpc-client") {
+					pkg.features = append(pkg.features, "_internal-grpc-client")
+				}
 			}
 		}
 	}
@@ -308,8 +326,12 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		ExternPackages:             externPackages(codec.extraPackages),
 		HasLROs:                    hasLROs,
 		HasBidiStreaming:           hasBidiStreaming,
+		HasServerStreaming:         hasServerStreaming,
+		HasStreaming:               hasStreaming,
 		IncludeRpcStatusConversion: includeRpcStatusConversion,
 		BidiStreamingServices:      bidiStreamingServices,
+		ServerStreamingServices:    serverStreamingServices,
+		StreamingServices:          streamingServices,
 		CopyrightYear:              codec.generationYear,
 		BoilerPlate: append(license.HeaderBulk(),
 			"",

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -802,8 +802,7 @@ func TestModelAnnotationsStreamingServices(t *testing.T) {
 	bidiMethod.PathInfo = &api.PathInfo{}
 	bidiService := api.NewTestService("BidiService").WithPackage("test.v1").WithMethods(bidiMethod)
 
-	serverMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg)
-	serverMethod.ServerSideStreaming = true
+	serverMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg).WithServerSideStreaming()
 	serverMethod.PathInfo = &api.PathInfo{}
 	serverService := api.NewTestService("ServerService").WithPackage("test.v1").WithMethods(serverMethod)
 

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -511,7 +511,7 @@ func TestGenerateSetterSamples(t *testing.T) {
 	}
 }
 
-func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
+func TestModelAnnotationsHasStreaming(t *testing.T) {
 	msg := &api.Message{
 		Name:    "Request",
 		ID:      ".test.v1.Request",
@@ -557,8 +557,36 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 		Package: "test.v1",
 		Methods: []*api.Method{
 			{
-				Name:                "List",
-				ID:                  ".test.v1.ServerStreamingService.List",
+				Name:                "Expand",
+				ID:                  ".test.v1.ServerStreamingService.Expand",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ServerSideStreaming: true,
+				PathInfo:            &api.PathInfo{},
+			},
+		},
+	}
+	mixedService := &api.Service{
+		Name:    "MixedService",
+		ID:      ".test.v1.MixedService",
+		Package: "test.v1",
+		Methods: []*api.Method{
+			{
+				Name:                "Chat",
+				ID:                  ".test.v1.MixedService.Chat",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ClientSideStreaming: true,
+				ServerSideStreaming: true,
+				PathInfo:            &api.PathInfo{},
+			},
+			{
+				Name:                "Expand",
+				ID:                  ".test.v1.MixedService.Expand",
 				InputTypeID:         msg.ID,
 				OutputTypeID:        msg.ID,
 				InputType:           msg,
@@ -573,7 +601,9 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 		name                 string
 		service              *api.Service
 		options              map[string]string
-		want                 bool
+		wantBidi             bool
+		wantServer           bool
+		wantStreaming        bool
 		wantGaxiFeatures     []string
 		wantRequiredPackages []string
 	}{
@@ -585,7 +615,38 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want:                 true,
+			wantBidi:             true,
+			wantServer:           false,
+			wantStreaming:        true,
+			wantGaxiFeatures:     []string{"_internal-grpc-client"},
+			wantRequiredPackages: []string{`gaxi                 = { workspace = true, features = ["_internal-grpc-client"] }`, "prost.workspace      = true"},
+		},
+		{
+			name:    "server streaming enabled with server streaming method",
+			service: serverStreamingService,
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+				"package:gaxi":                     "package=google-cloud-gax,used-if=services",
+				"package:prost":                    "package=prost,used-if=streaming",
+			},
+			wantBidi:             false,
+			wantServer:           true,
+			wantStreaming:        true,
+			wantGaxiFeatures:     []string{"_internal-grpc-client"},
+			wantRequiredPackages: []string{`gaxi                 = { workspace = true, features = ["_internal-grpc-client"] }`, "prost.workspace      = true"},
+		},
+		{
+			name:    "both streaming enabled with mixed service",
+			service: mixedService,
+			options: map[string]string{
+				"include-bidi-streaming-methods":   "true",
+				"include-server-streaming-methods": "true",
+				"package:gaxi":                     "package=google-cloud-gax,used-if=services",
+				"package:prost":                    "package=prost,used-if=streaming",
+			},
+			wantBidi:             true,
+			wantServer:           true,
+			wantStreaming:        true,
 			wantGaxiFeatures:     []string{"_internal-grpc-client"},
 			wantRequiredPackages: []string{`gaxi                 = { workspace = true, features = ["_internal-grpc-client"] }`, "prost.workspace      = true"},
 		},
@@ -597,7 +658,22 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want:                 false,
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
+		},
+		{
+			name:    "server streaming disabled with server streaming method",
+			service: serverStreamingService,
+			options: map[string]string{
+				"include-server-streaming-methods": "false",
+				"package:gaxi":                     "package=google-cloud-gax,used-if=services",
+				"package:prost":                    "package=prost,used-if=streaming",
+			},
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
 			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
 		{
@@ -608,7 +684,22 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want:                 false,
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
+		},
+		{
+			name:    "server streaming enabled with unary method",
+			service: unaryService,
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+				"package:gaxi":                     "package=google-cloud-gax,used-if=services",
+				"package:prost":                    "package=prost,used-if=streaming",
+			},
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
 			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
 		{
@@ -619,7 +710,22 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want:                 false,
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
+		},
+		{
+			name:    "server streaming enabled with bidi streaming method",
+			service: bidiService,
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+				"package:gaxi":                     "package=google-cloud-gax,used-if=services",
+				"package:prost":                    "package=prost,used-if=streaming",
+			},
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
 			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
 		{
@@ -631,7 +737,23 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 				"package:gaxi":                   "package=google-cloud-gax,used-if=services",
 				"package:prost":                  "package=prost,used-if=streaming",
 			},
-			want:                 false,
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
+			wantRequiredPackages: []string{"gaxi.workspace       = true"},
+		},
+		{
+			name:    "template override with server streaming method",
+			service: serverStreamingService,
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+				"template-override":                "templates/tonic",
+				"package:gaxi":                     "package=google-cloud-gax,used-if=services",
+				"package:prost":                    "package=prost,used-if=streaming",
+			},
+			wantBidi:             false,
+			wantServer:           false,
+			wantStreaming:        false,
 			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
 	} {
@@ -645,8 +767,14 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got.HasBidiStreaming != test.want {
-				t.Errorf("HasBidiStreaming = %v, want %v", got.HasBidiStreaming, test.want)
+			if got.HasBidiStreaming != test.wantBidi {
+				t.Errorf("HasBidiStreaming = %v, want %v", got.HasBidiStreaming, test.wantBidi)
+			}
+			if got.HasServerStreaming != test.wantServer {
+				t.Errorf("HasServerStreaming = %v, want %v", got.HasServerStreaming, test.wantServer)
+			}
+			if got.HasStreaming != test.wantStreaming {
+				t.Errorf("HasStreaming = %v, want %v", got.HasStreaming, test.wantStreaming)
 			}
 			if len(test.wantGaxiFeatures) > 0 {
 				idx := slices.IndexFunc(codec.extraPackages, func(pkg *packagez) bool {
@@ -667,25 +795,31 @@ func TestModelAnnotationsHasBidiStreaming(t *testing.T) {
 	}
 }
 
-func TestModelAnnotationsBidiStreamingServices(t *testing.T) {
+func TestModelAnnotationsStreamingServices(t *testing.T) {
 	msg := api.NewTestMessage("Request").WithPackage("test.v1")
 
 	bidiMethod := api.NewTestMethod("Chat").WithInput(msg).WithOutput(msg).WithBidiStreaming()
 	bidiMethod.PathInfo = &api.PathInfo{}
 	bidiService := api.NewTestService("BidiService").WithPackage("test.v1").WithMethods(bidiMethod)
 
+	serverMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg)
+	serverMethod.ServerSideStreaming = true
+	serverMethod.PathInfo = &api.PathInfo{}
+	serverService := api.NewTestService("ServerService").WithPackage("test.v1").WithMethods(serverMethod)
+
 	unaryMethod := api.NewTestMethod("Get").WithInput(msg).WithOutput(msg)
 	unaryMethod.PathInfo = &api.PathInfo{}
 	unaryService := api.NewTestService("UnaryService").WithPackage("test.v1").WithMethods(unaryMethod)
 
-	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{bidiService, unaryService})
+	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{bidiService, serverService, unaryService})
 	if err := api.CrossReference(model); err != nil {
 		t.Fatal(err)
 	}
 
 	codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{
-		"include-bidi-streaming-methods": "true",
-		"per-service-features":           "true",
+		"include-bidi-streaming-methods":   "true",
+		"include-server-streaming-methods": "true",
+		"per-service-features":             "true",
 	})
 	got, err := annotateModel(model, codec)
 	if err != nil {
@@ -697,6 +831,15 @@ func TestModelAnnotationsBidiStreamingServices(t *testing.T) {
 	}
 	if got.BidiStreamingServices[0].Name != "BidiService" {
 		t.Errorf("expected BidiStreamingServices[0].Name == %q, got %q", "BidiService", got.BidiStreamingServices[0].Name)
+	}
+	if len(got.ServerStreamingServices) != 1 {
+		t.Fatalf("expected 1 ServerStreamingService, got %d", len(got.ServerStreamingServices))
+	}
+	if got.ServerStreamingServices[0].Name != "ServerService" {
+		t.Errorf("expected ServerStreamingServices[0].Name == %q, got %q", "ServerService", got.ServerStreamingServices[0].Name)
+	}
+	if len(got.StreamingServices) != 2 {
+		t.Fatalf("expected 2 StreamingServices, got %d", len(got.StreamingServices))
 	}
 }
 

--- a/internal/sidekick/rust/annotate_service.go
+++ b/internal/sidekick/rust/annotate_service.go
@@ -58,6 +58,10 @@ type serviceAnnotations struct {
 	InternalBuilders bool
 	// If true, the service has at least one bidirectional streaming RPC in the API definition.
 	HasBidiStreaming bool
+	// If true, the service has at least one server-side streaming RPC in the API definition.
+	HasServerStreaming bool
+	// If true, the service has at least one streaming RPC (bidirectional or server-side) in the API definition.
+	HasStreaming bool
 }
 
 // BuilderVisibility returns the visibility for client and request builders.
@@ -102,14 +106,14 @@ func (a *serviceAnnotations) EnabledFeatures() []string {
 }
 
 func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
-	// Check if the service has bidirectional streaming RPCs in its API definition
+	// Check if the service has bidirectional or server-side streaming RPCs in its API definition
 	// before methods are filtered by generateMethod. We check this before filtering
-	// because we are incrementally adding bidi-streaming support (initializing transport
+	// because we are incrementally adding streaming support (initializing transport
 	// stubs like grpc_inner first before generating streaming method implementations in
 	// subsequent steps).
-	hasBidiStreaming := c.includeBidiStreamingMethods && slices.ContainsFunc(s.Methods, func(m *api.Method) bool {
-		return m.ClientSideStreaming && m.ServerSideStreaming
-	})
+	hasBidiStreaming := c.includeBidiStreamingMethods && s.HasBidiStreaming()
+	hasServerStreaming := c.includeServerStreamingMethods && s.HasServerSideStreaming()
+	hasStreaming := hasBidiStreaming || hasServerStreaming
 
 	// Some codecs skip some methods.
 	methods := language.FilterSlice(s.Methods, func(m *api.Method) bool {
@@ -152,6 +156,8 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
 		HasBidiStreaming:          hasBidiStreaming,
+		HasServerStreaming:        hasServerStreaming,
+		HasStreaming:              hasStreaming,
 	}
 	s.Codec = ann
 	return ann, nil

--- a/internal/sidekick/rust/annotate_service_test.go
+++ b/internal/sidekick/rust/annotate_service_test.go
@@ -362,84 +362,184 @@ func TestServiceAnnotations(t *testing.T) {
 	}
 }
 
-func TestServiceAnnotationsHasBidiStreaming(t *testing.T) {
-	createModel := func() (*api.API, *api.Service) {
-		msg := &api.Message{
-			Name:    "Request",
-			ID:      ".test.v1.Request",
-			Package: "test.v1",
-		}
-		service := &api.Service{
-			Name:    "BidiService",
-			ID:      ".test.v1.BidiService",
-			Package: "test.v1",
-			Methods: []*api.Method{
-				{
-					Name:                "Chat",
-					ID:                  ".test.v1.BidiService.Chat",
-					InputTypeID:         msg.ID,
-					OutputTypeID:        msg.ID,
-					InputType:           msg,
-					OutputType:          msg,
-					ClientSideStreaming: true,
-					ServerSideStreaming: true,
-					PathInfo:            &api.PathInfo{},
-				},
-				{
-					Name:                "Unary",
-					ID:                  ".test.v1.BidiService.Unary",
-					InputTypeID:         msg.ID,
-					OutputTypeID:        msg.ID,
-					InputType:           msg,
-					OutputType:          msg,
-					ClientSideStreaming: false,
-					ServerSideStreaming: false,
-					PathInfo:            &api.PathInfo{},
-				},
+func TestServiceAnnotationsStreaming(t *testing.T) {
+	msg := &api.Message{
+		Name:    "Request",
+		ID:      ".test.v1.Request",
+		Package: "test.v1",
+	}
+	bidiService := &api.Service{
+		Name:    "BidiService",
+		ID:      ".test.v1.BidiService",
+		Package: "test.v1",
+		Methods: []*api.Method{
+			{
+				Name:                "Chat",
+				ID:                  ".test.v1.BidiService.Chat",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ClientSideStreaming: true,
+				ServerSideStreaming: true,
+				PathInfo:            &api.PathInfo{},
 			},
-		}
-		model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{service})
-		if err := api.CrossReference(model); err != nil {
-			t.Fatal(err)
-		}
-		return model, service
+			{
+				Name:                "Unary",
+				ID:                  ".test.v1.BidiService.Unary",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ClientSideStreaming: false,
+				ServerSideStreaming: false,
+				PathInfo:            &api.PathInfo{},
+			},
+		},
+	}
+	serverService := &api.Service{
+		Name:    "ServerService",
+		ID:      ".test.v1.ServerService",
+		Package: "test.v1",
+		Methods: []*api.Method{
+			{
+				Name:                "Expand",
+				ID:                  ".test.v1.ServerService.Expand",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ClientSideStreaming: false,
+				ServerSideStreaming: true,
+				PathInfo:            &api.PathInfo{},
+			},
+			{
+				Name:                "Unary",
+				ID:                  ".test.v1.ServerService.Unary",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ClientSideStreaming: false,
+				ServerSideStreaming: false,
+				PathInfo:            &api.PathInfo{},
+			},
+		},
+	}
+	unaryService := &api.Service{
+		Name:    "UnaryService",
+		ID:      ".test.v1.UnaryService",
+		Package: "test.v1",
+		Methods: []*api.Method{
+			{
+				Name:                "Get",
+				ID:                  ".test.v1.UnaryService.Get",
+				InputTypeID:         msg.ID,
+				OutputTypeID:        msg.ID,
+				InputType:           msg,
+				OutputType:          msg,
+				ClientSideStreaming: false,
+				ServerSideStreaming: false,
+				PathInfo:            &api.PathInfo{},
+			},
+		},
 	}
 
-	t.Run("bidi service with option enabled", func(t *testing.T) {
-		model, service := createModel()
-		codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{
-			"include-bidi-streaming-methods": "true",
+	for _, test := range []struct {
+		name          string
+		service       *api.Service
+		options       map[string]string
+		wantBidi      bool
+		wantServer    bool
+		wantStreaming bool
+	}{
+		{
+			name:    "bidi service with option enabled",
+			service: bidiService,
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			wantBidi:      true,
+			wantServer:    false,
+			wantStreaming: true,
+		},
+		{
+			name:          "bidi service with option omitted",
+			service:       bidiService,
+			options:       map[string]string{},
+			wantBidi:      false,
+			wantServer:    false,
+			wantStreaming: false,
+		},
+		{
+			name:    "server streaming service with option enabled",
+			service: serverService,
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+			},
+			wantBidi:      false,
+			wantServer:    true,
+			wantStreaming: true,
+		},
+		{
+			name:          "server streaming service with option omitted",
+			service:       serverService,
+			options:       map[string]string{},
+			wantBidi:      false,
+			wantServer:    false,
+			wantStreaming: false,
+		},
+		{
+			name:    "non-streaming service with options enabled",
+			service: unaryService,
+			options: map[string]string{
+				"include-bidi-streaming-methods":   "true",
+				"include-server-streaming-methods": "true",
+			},
+			wantBidi:      false,
+			wantServer:    false,
+			wantStreaming: false,
+		},
+		{
+			name:    "both options enabled with bidi service",
+			service: bidiService,
+			options: map[string]string{
+				"include-bidi-streaming-methods":   "true",
+				"include-server-streaming-methods": "true",
+			},
+			wantBidi:      true,
+			wantServer:    false,
+			wantStreaming: true,
+		},
+		{
+			name:    "both options enabled with server streaming service",
+			service: serverService,
+			options: map[string]string{
+				"include-bidi-streaming-methods":   "true",
+				"include-server-streaming-methods": "true",
+			},
+			wantBidi:      false,
+			wantServer:    true,
+			wantStreaming: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{test.service})
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
+			codec := newTestCodec(t, libconfig.SpecProtobuf, "", test.options)
+			annotateModel(model, codec)
+			serviceAnn := test.service.Codec.(*serviceAnnotations)
+			if got := serviceAnn.HasBidiStreaming; got != test.wantBidi {
+				t.Errorf("serviceAnnotations.HasBidiStreaming = %v, want %v", got, test.wantBidi)
+			}
+			if got := serviceAnn.HasServerStreaming; got != test.wantServer {
+				t.Errorf("serviceAnnotations.HasServerStreaming = %v, want %v", got, test.wantServer)
+			}
+			if got := serviceAnn.HasStreaming; got != test.wantStreaming {
+				t.Errorf("serviceAnnotations.HasStreaming = %v, want %v", got, test.wantStreaming)
+			}
 		})
-		annotateModel(model, codec)
-		serviceAnn := service.Codec.(*serviceAnnotations)
-		if !serviceAnn.HasBidiStreaming {
-			t.Errorf("serviceAnnotations.HasBidiStreaming = false, want true")
-		}
-	})
-
-	t.Run("bidi service with option omitted", func(t *testing.T) {
-		model, service := createModel()
-		codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{})
-		annotateModel(model, codec)
-		serviceAnn := service.Codec.(*serviceAnnotations)
-		if serviceAnn.HasBidiStreaming {
-			t.Errorf("serviceAnnotations.HasBidiStreaming = true, want false")
-		}
-	})
-
-	t.Run("non-streaming service with option enabled", func(t *testing.T) {
-		model := serviceAnnotationsModel()
-		service := model.Service(".test.v1.ResourceService")
-		if service == nil {
-			t.Fatal("cannot find .test.v1.ResourceService")
-		}
-		codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{
-			"include-bidi-streaming-methods": "true",
-		})
-		annotateModel(model, codec)
-		serviceAnn := service.Codec.(*serviceAnnotations)
-		if serviceAnn.HasBidiStreaming {
-			t.Errorf("serviceAnnotations.HasBidiStreaming = true, want false")
-		}
-	})
+	}
 }

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -138,6 +138,12 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `include-bidi-streaming-methods` value %q to boolean: %w", definition, err)
 			}
 			codec.includeBidiStreamingMethods = value
+		case key == "include-server-streaming-methods":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `include-server-streaming-methods` value %q to boolean: %w", definition, err)
+			}
+			codec.includeServerStreamingMethods = value
 		case key == "per-service-features":
 			value, err := strconv.ParseBool(definition)
 			if err != nil {
@@ -320,6 +326,8 @@ type codec struct {
 	includeStreamingMethods bool
 	// If true, this includes gRPC bi-directional streaming methods.
 	includeBidiStreamingMethods bool
+	// If true, this includes gRPC server-side streaming methods.
+	includeServerStreamingMethods bool
 	// If true, google.rpc.Status conversion is generated in convert.rs.
 	includeRpcStatusConversion bool
 	// If true, the generator will produce per-client features.
@@ -391,7 +399,7 @@ type packagez struct {
 	usedIf []string
 }
 
-func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasBidiStreaming bool) {
+func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasStreaming bool) {
 	hasServices := len(model.Services) > 0
 	hasLROs := false
 	hasAutoPopulation := false
@@ -426,7 +434,7 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasBidiStrea
 				pkg.used = true
 				break
 			}
-			if namedFeature == "streaming" && hasBidiStreaming {
+			if namedFeature == "streaming" && hasStreaming {
 				pkg.used = true
 				break
 			}
@@ -1549,6 +1557,9 @@ func (c *codec) generateMethod(m *api.Method) bool {
 		if m.ClientSideStreaming && m.ServerSideStreaming && c.includeBidiStreamingMethods {
 			return true
 		}
+		if !m.ClientSideStreaming && m.ServerSideStreaming && c.includeServerStreamingMethods {
+			return true
+		}
 		return c.includeStreamingMethods
 	}
 	if c.includeGrpcOnlyMethods {
@@ -1565,6 +1576,17 @@ func (c *codec) hasBidiStreaming(model *api.API) bool {
 		return false
 	}
 	return slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
+}
+
+func (c *codec) hasServerStreaming(model *api.API) bool {
+	if c.templateOverride != "" || !c.includeServerStreamingMethods {
+		return false
+	}
+	return slices.ContainsFunc(model.Services, (*api.Service).HasServerSideStreaming)
+}
+
+func (c *codec) hasStreaming(model *api.API) bool {
+	return c.hasBidiStreaming(model) || c.hasServerStreaming(model)
 }
 
 // escapeKeyword is the list of Rust keywords and reserved words can be found

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -237,6 +237,15 @@ func TestParseOptions(t *testing.T) {
 		{
 			Format: libconfig.SpecProtobuf,
 			Options: map[string]string{
+				"include-server-streaming-methods": "true",
+			},
+			Update: func(c *codec) {
+				c.includeServerStreamingMethods = true
+			},
+		},
+		{
+			Format: libconfig.SpecProtobuf,
+			Options: map[string]string{
 				"per-service-features": "true",
 			},
 			Update: func(c *codec) {
@@ -394,6 +403,7 @@ func TestParseOptionsErrors(t *testing.T) {
 		{Options: map[string]string{"include-grpc-only-methods": ""}},
 		{Options: map[string]string{"include-streaming-methods": ""}},
 		{Options: map[string]string{"include-bidi-streaming-methods": ""}},
+		{Options: map[string]string{"include-server-streaming-methods": ""}},
 		{Options: map[string]string{"per-service-features": ""}},
 		{Options: map[string]string{"detailed-tracing-attributes": ""}},
 		{Options: map[string]string{"lro-stub-options": ""}},
@@ -2318,11 +2328,12 @@ func TestParseOptionsGenerateRpcSamples(t *testing.T) {
 
 func TestGenerateMethod_Streaming(t *testing.T) {
 	for _, test := range []struct {
-		name                        string
-		includeStreamingMethods     bool
-		includeBidiStreamingMethods bool
-		method                      *api.Method
-		want                        bool
+		name                          string
+		includeStreamingMethods       bool
+		includeBidiStreamingMethods   bool
+		includeServerStreamingMethods bool
+		method                        *api.Method
+		want                          bool
 	}{
 		{
 			name:                    "skips client-side streaming by default",
@@ -2381,6 +2392,43 @@ func TestGenerateMethod_Streaming(t *testing.T) {
 			want: true,
 		},
 		{
+			name:                        "skips server-side streaming method implementations when only includeBidiStreamingMethods is enabled",
+			includeBidiStreamingMethods: true,
+			method: &api.Method{
+				Name:                "ServerStreaming",
+				ServerSideStreaming: true,
+			},
+			want: false,
+		},
+		{
+			name:                          "generates server-side streaming method implementations when includeServerStreamingMethods is enabled",
+			includeServerStreamingMethods: true,
+			method: &api.Method{
+				Name:                "ServerStreaming",
+				ServerSideStreaming: true,
+			},
+			want: true,
+		},
+		{
+			name:                          "skips bidirectional streaming method implementations when only includeServerStreamingMethods is enabled",
+			includeServerStreamingMethods: true,
+			method: &api.Method{
+				Name:                "BidiStreaming",
+				ClientSideStreaming: true,
+				ServerSideStreaming: true,
+			},
+			want: false,
+		},
+		{
+			name:                          "skips client-only streaming when includeServerStreamingMethods is enabled",
+			includeServerStreamingMethods: true,
+			method: &api.Method{
+				Name:                "ClientStreaming",
+				ClientSideStreaming: true,
+			},
+			want: false,
+		},
+		{
 			name:                        "skips client-only streaming when includeBidiStreamingMethods is enabled",
 			includeBidiStreamingMethods: true,
 			method: &api.Method{
@@ -2392,8 +2440,9 @@ func TestGenerateMethod_Streaming(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			c := &codec{
-				includeStreamingMethods:     test.includeStreamingMethods,
-				includeBidiStreamingMethods: test.includeBidiStreamingMethods,
+				includeStreamingMethods:       test.includeStreamingMethods,
+				includeBidiStreamingMethods:   test.includeBidiStreamingMethods,
+				includeServerStreamingMethods: test.includeServerStreamingMethods,
 			}
 			if got := c.generateMethod(test.method); got != test.want {
 				t.Errorf("generateMethod() = %v, want %v", got, test.want)

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -48,8 +48,7 @@ func TestGenerateServerStreaming(t *testing.T) {
 	}
 	response := api.NewTestMessage("EchoResponse").WithPackage("test.v1")
 
-	serverMethod := api.NewTestMethod("Expand").WithInput(request).WithOutput(response)
-	serverMethod.ServerSideStreaming = true
+	serverMethod := api.NewTestMethod("Expand").WithInput(request).WithOutput(response).WithServerSideStreaming()
 	serverMethod.AutoPopulated = []*api.Field{requestId}
 	serverMethod.PathInfo = &api.PathInfo{
 		Bindings: []*api.PathBinding{{Verb: "POST", PathTemplate: &api.PathTemplate{}}},

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	libconfig "github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/sidekick/api"
+	"github.com/googleapis/librarian/internal/sidekick/parser"
+)
+
+func TestGenerateServerStreaming(t *testing.T) {
+	outDir := t.TempDir()
+
+	request := api.NewTestMessage("ExpandRequest").WithPackage("test.v1")
+	request.Fields = []*api.Field{
+		{
+			Name:     "content",
+			JSONName: "content",
+			ID:       ".test.v1.ExpandRequest.content",
+			Typez:    api.TypezString,
+		},
+	}
+	response := api.NewTestMessage("EchoResponse").WithPackage("test.v1")
+
+	serverMethod := api.NewTestMethod("Expand").WithInput(request).WithOutput(response)
+	serverMethod.ServerSideStreaming = true
+	serverMethod.PathInfo = &api.PathInfo{
+		Bindings: []*api.PathBinding{{Verb: "POST", PathTemplate: &api.PathTemplate{}}},
+	}
+	service := api.NewTestService("Echo").WithPackage("test.v1").WithMethods(serverMethod)
+
+	model := api.NewTestAPI([]*api.Message{request, response}, []*api.Enum{}, []*api.Service{service})
+	model.PackageName = "test.v1"
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: libconfig.SpecProtobuf,
+		Codec: map[string]string{
+			"package:wkt":                      "source=google.protobuf,package=google-cloud-wkt",
+			"package:prost":                    "package=prost,used-if=streaming",
+			"package:prost-types":              "package=prost-types,used-if=streaming",
+			"include-server-streaming-methods": "true",
+		},
+	}
+	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	files := make(map[string]string)
+	readFile := func(relPath string) string {
+		if content, ok := files[relPath]; ok {
+			return content
+		}
+		b, err := os.ReadFile(filepath.Join(outDir, relPath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[relPath] = string(b)
+		return files[relPath]
+	}
+
+	for _, test := range []struct {
+		name     string
+		file     string
+		startStr string
+		endStr   string
+		want     string
+	}{
+		{
+			name:     "client: method definition",
+			file:     "src/client.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    pub fn expand(&self) -> super::builder::echo::Expand",
+			endStr:   "    }",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    pub fn expand(&self) -> super::builder::echo::Expand
+    {
+        super::builder::echo::Expand::new(self.inner.clone())
+    }`,
+		},
+		{
+			name:     "builder: struct definition",
+			file:     "src/builder.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[derive(Clone, Debug)]\n    pub struct Expand(",
+			endStr:   ");",
+			want:     "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[derive(Clone, Debug)]\n    pub struct Expand(RequestBuilder<crate::model::ExpandRequest>);",
+		},
+		{
+			name:     "builder: send method",
+			file:     "src/builder.rs",
+			startStr: "        /// Initiates the server stream.\n        pub async fn send(",
+			endStr:   "        }",
+			want: `        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+            (*self.0.stub).expand(self.0.request, self.0.options).await
+        }`,
+		},
+		{
+			name:     "builder: RequestBuilder trait impl",
+			file:     "src/builder.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[doc(hidden)]\n    impl crate::RequestBuilder for Expand {",
+			endStr:   "        }\n    }",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[doc(hidden)]
+    impl crate::RequestBuilder for Expand {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }`,
+		},
+		{
+			name:     "stub: method signature",
+			file:     "src/stub.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn expand(",
+			endStr:   "    }",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    fn expand(
+        &self,
+        _req: crate::model::ExpandRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<Output = crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
+    >> + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
+    }`,
+		},
+		{
+			name:     "stub/dynamic: trait method",
+			file:     "src/stub/dynamic.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			endStr:   ">;",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
+    >;`,
+		},
+		{
+			name:     "stub dynamic: blanket forwarding impl",
+			file:     "src/stub/dynamic.rs",
+			startStr: "    /// Forwards the call to the implementation provided by `T`.\n    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			endStr:   "    }",
+			want: `    /// Forwards the call to the implementation provided by ` + "`T`." + `
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
+    > {
+        T::expand(self, req, options).await
+    }`,
+		},
+		{
+			name:     "tracing: forwarder method",
+			file:     "src/tracing.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			endStr:   "    }",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+        self.inner.expand(req, options).await
+    }`,
+		},
+		{
+			name:     "transport: method implementation",
+			file:     "src/transport.rs",
+			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			endStr:   "            .await\n    }",
+			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+        let x_goog_request_params = [
+            None::<String>; 0
+        ]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "test.v1.Echo",
+                "Expand",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/test.v1.Echo/Expand"
+        );
+
+        self.grpc_inner
+            .execute_server_streaming::<
+                crate::model::ExpandRequest,
+                crate::model::EchoResponse,
+                crate::prost::test::v1::ExpandRequest,
+                crate::prost::test::v1::EchoResponse,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }`,
+		},
+		{
+			name:     "cargo.toml: dependencies block",
+			file:     "Cargo.toml",
+			startStr: "[dependencies]\n",
+			endStr:   "prost.workspace      = true\n",
+			want: `[dependencies]
+prost-types.workspace = true
+prost.workspace      = true
+`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			content := readFile(test.file)
+			got := extractBlock(t, content, test.startStr, test.endStr)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -17,6 +17,7 @@ package rust
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,6 +30,13 @@ func TestGenerateServerStreaming(t *testing.T) {
 	outDir := t.TempDir()
 
 	request := api.NewTestMessage("ExpandRequest").WithPackage("test.v1")
+	requestId := &api.Field{
+		Name:          "request_id",
+		JSONName:      "requestId",
+		ID:            ".test.v1.ExpandRequest.request_id",
+		Typez:         api.TypezString,
+		AutoPopulated: true,
+	}
 	request.Fields = []*api.Field{
 		{
 			Name:     "content",
@@ -36,11 +44,13 @@ func TestGenerateServerStreaming(t *testing.T) {
 			ID:       ".test.v1.ExpandRequest.content",
 			Typez:    api.TypezString,
 		},
+		requestId,
 	}
 	response := api.NewTestMessage("EchoResponse").WithPackage("test.v1")
 
 	serverMethod := api.NewTestMethod("Expand").WithInput(request).WithOutput(response)
 	serverMethod.ServerSideStreaming = true
+	serverMethod.AutoPopulated = []*api.Field{requestId}
 	serverMethod.PathInfo = &api.PathInfo{
 		Bindings: []*api.PathBinding{{Verb: "POST", PathTemplate: &api.PathTemplate{}}},
 	}
@@ -237,6 +247,17 @@ func TestGenerateServerStreaming(t *testing.T) {
     }`,
 		},
 		{
+			name:     "builder: field setter",
+			file:     "src/builder.rs",
+			startStr: "        /// Sets the value of [request_id][crate::model::ExpandRequest::request_id].\n        pub fn set_request_id<T: Into<std::string::String>>(mut self, v: T) -> Self {",
+			endStr:   "        }",
+			want: `        /// Sets the value of [request_id][crate::model::ExpandRequest::request_id].
+        pub fn set_request_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.request_id = v.into();
+            self
+        }`,
+		},
+		{
 			name:     "cargo.toml: dependencies block",
 			file:     "Cargo.toml",
 			startStr: "[dependencies]\n",
@@ -255,4 +276,11 @@ prost.workspace      = true
 			}
 		})
 	}
+
+	t.Run("builder: does not generate auto_populate for server streaming", func(t *testing.T) {
+		builderContent := readFile("src/builder.rs")
+		if strings.Contains(builderContent, "auto_populate") {
+			t.Errorf("expected builder.rs not to contain auto_populate helper for server streaming method")
+		}
+	})
 }

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -518,7 +518,6 @@ pub mod {{Codec.ModuleName}} {
             {{/Model.Codec.LroStubOptions}}
         }
         {{/OperationInfo}}
-        {{/Codec.IsServerStreaming}}
         {{#HasAutoPopulatedFields}}
 
         fn auto_populate(mut req: {{InputType.Codec.QualifiedName}}, force: bool) -> {{InputType.Codec.QualifiedName}} {
@@ -535,6 +534,7 @@ pub mod {{Codec.ModuleName}} {
             req
         }
         {{/HasAutoPopulatedFields}}
+        {{/Codec.IsServerStreaming}}
         {{#InputType.Codec.BasicFields}}
 
         /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -124,7 +124,12 @@ pub mod {{Codec.ModuleName}} {
     ///     println!("response {:?}", response);
     /// }
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    /// let builder = prepare_request_builder();
+    /// let mut receiver = builder.send().await?;
+    {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}
+    {{^Codec.IsServerStreaming}}
     {{#OperationInfo}}
     /// use google_cloud_lro::Poller;
     ///
@@ -147,6 +152,7 @@ pub mod {{Codec.ModuleName}} {
     /// let response = builder.send().await?;
     {{/Pagination}}
     {{/OperationInfo}}
+    {{/Codec.IsServerStreaming}}
     {{/Codec.IsBidiStreaming}}
     /// # Ok(()) }
     ///
@@ -162,6 +168,9 @@ pub mod {{Codec.ModuleName}} {
     {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(BidiStreamBuilder);
     {{/Codec.IsBidiStreaming}}
     {{^Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    {{/Codec.IsServerStreaming}}
     #[derive(Clone, Debug)]
     {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
     {{/Codec.IsBidiStreaming}}
@@ -169,6 +178,9 @@ pub mod {{Codec.ModuleName}} {
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    {{/Codec.IsServerStreaming}}
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {
             Self(
@@ -202,7 +214,16 @@ pub mod {{Codec.ModuleName}} {
             (*self.0.stub).{{Codec.Name}}(self.0.options)
         }
         {{/Codec.IsBidiStreaming}}
+        {{#Codec.IsServerStreaming}}
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+            (*self.0.stub).{{Codec.Name}}(self.0.request, self.0.options).await
+        }
+        {{/Codec.IsServerStreaming}}
         {{^Codec.IsBidiStreaming}}
+        {{^Codec.IsServerStreaming}}
         /// Sends the request.
         {{#OperationInfo}}
         ///
@@ -497,6 +518,7 @@ pub mod {{Codec.ModuleName}} {
             {{/Model.Codec.LroStubOptions}}
         }
         {{/OperationInfo}}
+        {{/Codec.IsServerStreaming}}
         {{#HasAutoPopulatedFields}}
 
         fn auto_populate(mut req: {{InputType.Codec.QualifiedName}}, force: bool) -> {{InputType.Codec.QualifiedName}} {
@@ -667,6 +689,9 @@ pub mod {{Codec.ModuleName}} {
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    {{/Codec.IsServerStreaming}}
     #[doc(hidden)]
     impl crate::RequestBuilder for {{Codec.BuilderName}} {
         fn request_options(&mut self) -> &mut crate::RequestOptions {

--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -131,6 +131,9 @@ impl {{Codec.Name}} {
     {{#Codec.IsBidiStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    {{/Codec.IsServerStreaming}}
     {{> /templates/common/client_method_preamble}}
     {{Codec.BuilderVisibility}} fn {{Codec.Name}}(&self) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
     {

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -125,13 +125,13 @@ pub(crate) mod tracing;
 #[doc(hidden)]
 pub(crate) mod transport;
 
-{{#Codec.HasBidiStreaming}}
+{{#Codec.HasStreaming}}
 #[cfg(google_cloud_unstable_gapic_streaming)]
 {{#Codec.PerServiceFeatures}}
 #[cfg(any(
-{{#Codec.BidiStreamingServices}}
+{{#Codec.StreamingServices}}
     feature = "{{Codec.FeatureName}}",
-{{/Codec.BidiStreamingServices}}
+{{/Codec.StreamingServices}}
 ))]
 {{/Codec.PerServiceFeatures}}
 #[doc(hidden)]
@@ -142,7 +142,7 @@ pub(crate) mod transport;
 pub(crate) mod prost {
     include!("prost/includes.rs");
 }
-{{/Codec.HasBidiStreaming}}
+{{/Codec.HasStreaming}}
 
 /// The default host used by the service.
 {{#Codec.PerServiceFeatures}}

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -65,7 +65,20 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         gaxi::unimplemented::unimplemented_bidi_stub()
     }
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    fn {{Codec.Name}}(
+        &self,
+        _req: {{InputType.Codec.QualifiedName}},
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<Output = crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+    >> + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
+    }
+    {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}
+    {{^Codec.IsServerStreaming}}
     fn {{Codec.Name}}(
         &self,
         _req: {{InputType.Codec.QualifiedName}},
@@ -73,6 +86,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     ) -> impl std::future::Future<Output = crate::Result<crate::Response<{{Codec.ReturnType}}>>> + Send {
         gaxi::unimplemented::unimplemented_stub()
     }
+    {{/Codec.IsServerStreaming}}
     {{/Codec.IsBidiStreaming}}
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -37,13 +37,26 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     );
 
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn {{Codec.Name}}(
+        &self,
+        req: {{InputType.Codec.QualifiedName}},
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+    >;
+
+    {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}
+    {{^Codec.IsServerStreaming}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<{{Codec.ReturnType}}>>;
 
+    {{/Codec.IsServerStreaming}}
     {{/Codec.IsBidiStreaming}}
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}
@@ -87,7 +100,21 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
     }
 
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn {{Codec.Name}}(
+        &self,
+        req: {{InputType.Codec.QualifiedName}},
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+    > {
+        T::{{Codec.Name}}(self, req, options).await
+    }
+
+    {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}
+    {{^Codec.IsServerStreaming}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -96,6 +123,7 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
         T::{{Codec.Name}}(self, req, options).await
     }
 
+    {{/Codec.IsServerStreaming}}
     {{/Codec.IsBidiStreaming}}
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -76,7 +76,19 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         self.inner.{{Codec.Name}}(options)
     }
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    {{! TODO(#6835) - add tracing for server streaming methods }}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn {{Codec.Name}}(
+        &self,
+        req: {{InputType.Codec.QualifiedName}},
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+        self.inner.{{Codec.Name}}(req, options).await
+    }
+    {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}
+    {{^Codec.IsServerStreaming}}
     {{#Codec.DetailedTracingAttributes}}
     #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     {{/Codec.DetailedTracingAttributes}}
@@ -139,6 +151,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         self.inner.{{Codec.Name}}(req, options).await
         {{/Codec.DetailedTracingAttributes}}
     }
+    {{/Codec.IsServerStreaming}}
     {{/Codec.IsBidiStreaming}}
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -35,10 +35,10 @@ use crate::Error;
 #[derive(Clone)]
 pub struct {{Codec.Name}} {
     inner: gaxi::http::ReqwestClient,
-    {{#Codec.HasBidiStreaming}}
+    {{#Codec.HasStreaming}}
     #[cfg(google_cloud_unstable_gapic_streaming)]
     grpc_inner: gaxi::grpc::Client,
-    {{/Codec.HasBidiStreaming}}
+    {{/Codec.HasStreaming}}
 }
 
 {{#Codec.PerServiceFeatures}}
@@ -46,18 +46,18 @@ pub struct {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl std::fmt::Debug for {{Codec.Name}} {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        {{^Codec.HasBidiStreaming}}
+        {{^Codec.HasStreaming}}
         f.debug_struct("{{Codec.Name}}")
             .field("inner", &self.inner)
             .finish()
-        {{/Codec.HasBidiStreaming}}
-        {{#Codec.HasBidiStreaming}}
+        {{/Codec.HasStreaming}}
+        {{#Codec.HasStreaming}}
         let mut builder = f.debug_struct("{{Codec.Name}}");
         builder.field("inner", &self.inner);
         #[cfg(google_cloud_unstable_gapic_streaming)]
         builder.field("grpc_inner", &self.grpc_inner);
         builder.finish()
-        {{/Codec.HasBidiStreaming}}
+        {{/Codec.HasStreaming}}
     }
 }
 
@@ -66,7 +66,7 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
-        {{^Codec.HasBidiStreaming}}
+        {{^Codec.HasStreaming}}
         {{#Codec.DetailedTracingAttributes}}
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
@@ -81,8 +81,8 @@ impl {{Codec.Name}} {
         let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
         {{/Codec.DetailedTracingAttributes}}
-        {{/Codec.HasBidiStreaming}}
-        {{#Codec.HasBidiStreaming}}
+        {{/Codec.HasStreaming}}
+        {{#Codec.HasStreaming}}
         {{#Codec.DetailedTracingAttributes}}
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
         let inner = gaxi::http::ReqwestClient::new(config.clone(), crate::DEFAULT_HOST).await?;
@@ -118,7 +118,7 @@ impl {{Codec.Name}} {
             grpc_inner,
         })
         {{/Codec.DetailedTracingAttributes}}
-        {{/Codec.HasBidiStreaming}}
+        {{/Codec.HasStreaming}}
     }
 }
 
@@ -167,7 +167,72 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     }
 
     {{/Codec.IsBidiStreaming}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn {{Codec.Name}}(
+        &self,
+        req: {{InputType.Codec.QualifiedName}},
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+        {{!
+        AIP-4222 says:
+
+            For any given RPC, if the explicit routing headers annotation is
+            present, the code generators **must** use it and **ignore** any
+            routing headers that might be implicitly specified in the
+            google.api.http annotation.
+
+        So we only need to generate one of the two code paths.
+        }}
+        {{#HasRouting}}
+        {{> /templates/grpc-client/routinginfo}}
+        {{/HasRouting}}
+        {{^HasRouting}}
+        let x_goog_request_params = [
+            {{#PathInfo.Codec.UniqueParameters}}
+                {{{FieldAccessor}}}.map(|v| format!("{{FieldName}}={v}")),
+            {{/PathInfo.Codec.UniqueParameters}}
+            {{^PathInfo.Codec.UniqueParameters}}
+            None::<String>; 0
+            {{/PathInfo.Codec.UniqueParameters}}
+        ]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+        {{/HasRouting}}
+
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "{{SourceService.Package}}.{{SourceService.Name}}",
+                "{{Name}}",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}"
+        );
+
+        self.grpc_inner
+            .execute_server_streaming::<
+                {{InputType.Codec.QualifiedName}},
+                {{OutputType.Codec.QualifiedName}},
+                crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
+                crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }
+
+    {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}
+    {{^Codec.IsServerStreaming}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -327,6 +392,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{/ReturnsEmpty}}
         {{/Codec.HasBindings}}
     }
+    {{/Codec.IsServerStreaming}}
     {{/Codec.IsBidiStreaming}}
 
     {{/Codec.Methods}}


### PR DESCRIPTION
Add code generation support for server-side streaming RPC methods in Rust GAPIC clients, request builders, stubs, and transport layers. Generated code invokes the execute_server_streaming helper on the gRPC transport client.

Add the include_server_streaming_methods configuration option to allow generating server-side streaming methods independently from bidirectional streaming methods.

For #7373