### PR TITLE
fix(sidekick/rust): redundant body fields

### DIFF
--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -150,6 +150,12 @@ type routingVariantAnnotations struct {
 	SuffixSegments   []string
 }
 
+// PathExtraction represents the actions to extract path parameters from a request body.
+type PathExtraction struct {
+	// Rust code to take the leaf field.
+	FieldTake string
+}
+
 type bindingSubstitution struct {
 	// Rust code to access the leaf field, given a `req`
 	//
@@ -164,8 +170,8 @@ type bindingSubstitution struct {
 	// - assume context i.e. use the try operator: `?`
 	FieldAccessor string
 
-	// Rust code to safely take/clear the leaf field given a mutable `req`
-	FieldClear string
+	// Rust code to extract this field from the request body, if necessary.
+	PathExtraction *PathExtraction
 
 	// The field name
 	//
@@ -500,21 +506,26 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method) (*bindingSubsti
 	for _, n := range v.FieldPath {
 		rustNames = append(rustNames, toSnakeNoMangling(n))
 	}
-	clears, err := makeClearAccessors(v.FieldPath, m)
-	if err != nil {
-		return nil, err
-	}
-	var fieldClear strings.Builder
-	fieldClear.WriteString("Some(&mut req)")
-	for _, c := range clears {
-		fieldClear.WriteString(c)
+	var pathExtraction *PathExtraction
+	full_body := m.PathInfo != nil && m.PathInfo.BodyFieldPath == "*"
+	if full_body {
+		clears, err := makeClearAccessors(v.FieldPath, m)
+		if err != nil {
+			return nil, err
+		}
+		var fieldClear strings.Builder
+		fieldClear.WriteString("Some(&mut req)")
+		for _, c := range clears {
+			fieldClear.WriteString(c)
+		}
+		pathExtraction = &PathExtraction{FieldTake: fieldClear.String()}
 	}
 	binding := &bindingSubstitution{
-		FieldAccessor: fieldAccessor.String(),
-		FieldName:     strings.Join(rustNames, "."),
-		FieldClear:    fieldClear.String(),
-		Template:      v.Segments,
-		fullBody:      m.PathInfo != nil && m.PathInfo.BodyFieldPath == "*",
+		FieldAccessor:  fieldAccessor.String(),
+		FieldName:      strings.Join(rustNames, "."),
+		PathExtraction: pathExtraction,
+		Template:       v.Segments,
+		fullBody:       full_body,
 	}
 	return binding, nil
 }
@@ -536,12 +547,13 @@ func makeClearAccessors(fields []string, m *api.Method) ([]string, error) {
 		if field == nil {
 			return nil, fmt.Errorf("invalid routing/path field (%q) for request message %s", rustFieldName, message.ID)
 		}
+		if field.IsOneOf {
+			return nil, fmt.Errorf("taking from a one-of is unsupported (%q) for request message %s", rustFieldName, message.ID)
+		}
 		if field.Typez != api.TypezMessage {
 			clears = append(clears, fmt.Sprintf(".map(|m| std::mem::take(&mut m.%s))", rustFieldName))
 		} else {
-			if field.IsOneOf {
-				clears = append(clears, fmt.Sprintf(".and_then(|m| m.%s_mut())", rustFieldName))
-			} else if field.Optional {
+			if field.Optional {
 				clears = append(clears, fmt.Sprintf(".and_then(|m| m.%s.as_mut())", rustFieldName))
 			} else {
 				clears = append(clears, fmt.Sprintf(".map(|m| &mut m.%s)", rustFieldName))

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -184,14 +184,6 @@ type bindingSubstitution struct {
 	//
 	// e.g. ["projects", "*"]
 	Template []string
-
-	// Whether the HTTP body is configured as "*"
-	fullBody bool
-}
-
-// FullBody returns true if the HTTP body is configured as "*".
-func (s *bindingSubstitution) FullBody() bool {
-	return s.fullBody
 }
 
 // TemplateAsArray returns Rust code that yields an array of path segments.
@@ -507,8 +499,8 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method) (*bindingSubsti
 		rustNames = append(rustNames, toSnakeNoMangling(n))
 	}
 	var pathExtraction *PathExtraction
-	full_body := m.PathInfo != nil && m.PathInfo.BodyFieldPath == "*"
-	if full_body {
+	fullBody := m.PathInfo != nil && m.PathInfo.BodyFieldPath == "*"
+	if fullBody {
 		clears, err := makeClearAccessors(v.FieldPath, m)
 		if err != nil {
 			return nil, err
@@ -525,7 +517,6 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method) (*bindingSubsti
 		FieldName:      strings.Join(rustNames, "."),
 		PathExtraction: pathExtraction,
 		Template:       v.Segments,
-		fullBody:       full_body,
 	}
 	return binding, nil
 }

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -56,6 +56,11 @@ func (m *methodAnnotation) IsBidiStreaming() bool {
 	return m.ClientSideStreaming && m.ServerSideStreaming
 }
 
+// FullBody returns true if the HTTP body is configured as "*".
+func (m *methodAnnotation) FullBody() bool {
+	return m.PathInfo != nil && m.PathInfo.BodyFieldPath == "*"
+}
+
 // IsServerStreaming returns true if the method is a server-side streaming RPC
 // and is not bidirectional.
 func (m *methodAnnotation) IsServerStreaming() bool {
@@ -159,6 +164,9 @@ type bindingSubstitution struct {
 	// - assume context i.e. use the try operator: `?`
 	FieldAccessor string
 
+	// Rust code to safely take/clear the leaf field given a mutable `req`
+	FieldClear string
+
 	// The field name
 	//
 	// Nested fields are '.'-separated.
@@ -170,6 +178,14 @@ type bindingSubstitution struct {
 	//
 	// e.g. ["projects", "*"]
 	Template []string
+
+	// Whether the HTTP body is configured as "*"
+	fullBody bool
+}
+
+// FullBody returns true if the HTTP body is configured as "*".
+func (s *bindingSubstitution) FullBody() bool {
+	return s.fullBody
 }
 
 // TemplateAsArray returns Rust code that yields an array of path segments.
@@ -484,12 +500,60 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method) (*bindingSubsti
 	for _, n := range v.FieldPath {
 		rustNames = append(rustNames, toSnakeNoMangling(n))
 	}
+	clears, err := makeClearAccessors(v.FieldPath, m)
+	if err != nil {
+		return nil, err
+	}
+	var fieldClear strings.Builder
+	fieldClear.WriteString("Some(&mut req)")
+	for _, c := range clears {
+		fieldClear.WriteString(c)
+	}
 	binding := &bindingSubstitution{
 		FieldAccessor: fieldAccessor.String(),
 		FieldName:     strings.Join(rustNames, "."),
+		FieldClear:    fieldClear.String(),
 		Template:      v.Segments,
+		fullBody:      m.PathInfo != nil && m.PathInfo.BodyFieldPath == "*",
 	}
 	return binding, nil
+}
+
+func makeClearAccessors(fields []string, m *api.Method) ([]string, error) {
+	findField := func(name string, message *api.Message) *api.Field {
+		for _, f := range message.Fields {
+			if f.Name == name {
+				return f
+			}
+		}
+		return nil
+	}
+	var clears []string
+	message := m.InputType
+	for _, name := range fields {
+		field := findField(name, message)
+		rustFieldName := toSnake(name)
+		if field == nil {
+			return nil, fmt.Errorf("invalid routing/path field (%q) for request message %s", rustFieldName, message.ID)
+		}
+		if field.Typez != api.TypezMessage {
+			clears = append(clears, fmt.Sprintf(".map(|m| std::mem::take(&mut m.%s))", rustFieldName))
+		} else {
+			if field.IsOneOf {
+				clears = append(clears, fmt.Sprintf(".and_then(|m| m.%s_mut())", rustFieldName))
+			} else if field.Optional {
+				clears = append(clears, fmt.Sprintf(".and_then(|m| m.%s.as_mut())", rustFieldName))
+			} else {
+				clears = append(clears, fmt.Sprintf(".map(|m| &mut m.%s)", rustFieldName))
+			}
+		}
+		if field.Typez == api.TypezMessage {
+			if fieldMessage := m.Model.Message(field.TypezID); fieldMessage != nil {
+				message = fieldMessage
+			}
+		}
+	}
+	return clears, nil
 }
 
 func (c *codec) annotatePathBinding(b *api.PathBinding, m *api.Method) (*pathBindingAnnotation, error) {

--- a/internal/sidekick/rust/annotate_path_info_test.go
+++ b/internal/sidekick/rust/annotate_path_info_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	libconfig "github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 )
@@ -273,6 +274,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 		Substitutions: []*bindingSubstitution{
 			{
 				FieldAccessor: "Some(&req).map(|m| &m.name).map(|s| s.as_str())",
+				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.name))",
 				FieldName:     "name",
 				Template:      []string{"projects", "*", "locations", "*"},
 			},
@@ -296,16 +298,19 @@ func TestPathBindingAnnotations(t *testing.T) {
 		Substitutions: []*bindingSubstitution{
 			{
 				FieldAccessor: "Some(&req).map(|m| &m.project).map(|s| s.as_str())",
+				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.project))",
 				FieldName:     "project",
 				Template:      []string{"*"},
 			},
 			{
 				FieldAccessor: "Some(&req).map(|m| &m.location).map(|s| s.as_str())",
+				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.location))",
 				FieldName:     "location",
 				Template:      []string{"*"},
 			},
 			{
 				FieldAccessor: "Some(&req).map(|m| &m.id)",
+				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.id))",
 				FieldName:     "id",
 				Template:      []string{"*"},
 			},
@@ -328,16 +333,19 @@ func TestPathBindingAnnotations(t *testing.T) {
 		Substitutions: []*bindingSubstitution{
 			{
 				FieldAccessor: "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.project).map(|s| s.as_str())",
+				FieldClear:    "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.project))",
 				FieldName:     "child.project",
 				Template:      []string{"*"},
 			},
 			{
 				FieldAccessor: "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.location).map(|s| s.as_str())",
+				FieldClear:    "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.location))",
 				FieldName:     "child.location",
 				Template:      []string{"*"},
 			},
 			{
 				FieldAccessor: "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.id)",
+				FieldClear:    "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.id))",
 				FieldName:     "child.id",
 				Template:      []string{"*"},
 			},
@@ -371,6 +379,7 @@ func TestPathBindingAnnotations(t *testing.T) {
 		Substitutions: []*bindingSubstitution{
 			{
 				FieldAccessor: "Some(&req).and_then(|m| m.oneof_field()).map(|s| s.as_str())",
+				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.oneof_field))",
 				FieldName:     "oneof_field",
 				Template:      []string{"*"},
 			},
@@ -383,7 +392,8 @@ func TestPathBindingAnnotations(t *testing.T) {
 		InputTypeID:  ".test.Request",
 		OutputTypeID: ".test.Response",
 		PathInfo: &api.PathInfo{
-			Bindings: []*api.PathBinding{b0, b1, b2, b3, b4},
+			Bindings:      []*api.PathBinding{b0, b1, b2, b3, b4},
+			BodyFieldPath: "*",
 		},
 	}
 	service := &api.Service{
@@ -401,21 +411,21 @@ func TestPathBindingAnnotations(t *testing.T) {
 	codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{})
 	annotateModel(model, codec)
 
-	if diff := cmp.Diff(want_b0, b0.Codec); diff != "" {
+	if diff := cmp.Diff(want_b0, b0.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(want_b1, b1.Codec); diff != "" {
+	if diff := cmp.Diff(want_b1, b1.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(want_b2, b2.Codec); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-
-	if diff := cmp.Diff(want_b3, b3.Codec); diff != "" {
+	if diff := cmp.Diff(want_b2, b2.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff(want_b4, b4.Codec); diff != "" {
+	if diff := cmp.Diff(want_b3, b3.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(want_b4, b4.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -484,11 +494,12 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 		FieldName     string
 		WantFieldName string
 		WantAccessor  string
+		WantClear     string
 	}{
-		{"machine", "machine", "Some(&req).map(|m| &m.machine).map(|s| s.as_str())"},
-		{"machineType", "machine_type", "Some(&req).map(|m| &m.machine_type).map(|s| s.as_str())"},
-		{"machine_type", "machine_type", "Some(&req).map(|m| &m.machine_type).map(|s| s.as_str())"},
-		{"type", "type", "Some(&req).map(|m| &m.r#type).map(|s| s.as_str())"},
+		{"machine", "machine", "Some(&req).map(|m| &m.machine).map(|s| s.as_str())", "Some(&mut req).map(|m| std::mem::take(&mut m.machine))"},
+		{"machineType", "machine_type", "Some(&req).map(|m| &m.machine_type).map(|s| s.as_str())", "Some(&mut req).map(|m| std::mem::take(&mut m.machine_type))"},
+		{"machine_type", "machine_type", "Some(&req).map(|m| &m.machine_type).map(|s| s.as_str())", "Some(&mut req).map(|m| std::mem::take(&mut m.machine_type))"},
+		{"type", "type", "Some(&req).map(|m| &m.r#type).map(|s| s.as_str())", "Some(&mut req).map(|m| std::mem::take(&mut m.r#type))"},
 	} {
 		field := &api.Field{
 			Name:     test.FieldName,
@@ -523,6 +534,7 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 				{
 					FieldAccessor: test.WantAccessor,
 					FieldName:     test.WantFieldName,
+					FieldClear:    test.WantClear,
 					Template:      []string{"*"},
 				},
 			},
@@ -550,7 +562,7 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 		api.CrossReference(model)
 		codec := newTestCodec(t, libconfig.SpecProtobuf, "", map[string]string{})
 		annotateModel(model, codec)
-		if diff := cmp.Diff(wantBinding, binding.Codec); diff != "" {
+		if diff := cmp.Diff(wantBinding, binding.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 

--- a/internal/sidekick/rust/annotate_path_info_test.go
+++ b/internal/sidekick/rust/annotate_path_info_test.go
@@ -273,10 +273,10 @@ func TestPathBindingAnnotations(t *testing.T) {
 		QueryParams: []*api.Field{f_id},
 		Substitutions: []*bindingSubstitution{
 			{
-				FieldAccessor: "Some(&req).map(|m| &m.name).map(|s| s.as_str())",
-				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.name))",
-				FieldName:     "name",
-				Template:      []string{"projects", "*", "locations", "*"},
+				FieldAccessor:  "Some(&req).map(|m| &m.name).map(|s| s.as_str())",
+				PathExtraction: &PathExtraction{FieldTake: "Some(&mut req).map(|m| std::mem::take(&mut m.name))"},
+				FieldName:      "name",
+				Template:       []string{"projects", "*", "locations", "*"},
 			},
 		},
 	}
@@ -297,22 +297,22 @@ func TestPathBindingAnnotations(t *testing.T) {
 		PathFmt: "/v1/projects/{}/locations/{}/ids/{}:action",
 		Substitutions: []*bindingSubstitution{
 			{
-				FieldAccessor: "Some(&req).map(|m| &m.project).map(|s| s.as_str())",
-				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.project))",
-				FieldName:     "project",
-				Template:      []string{"*"},
+				FieldAccessor:  "Some(&req).map(|m| &m.project).map(|s| s.as_str())",
+				PathExtraction: &PathExtraction{FieldTake: "Some(&mut req).map(|m| std::mem::take(&mut m.project))"},
+				FieldName:      "project",
+				Template:       []string{"*"},
 			},
 			{
-				FieldAccessor: "Some(&req).map(|m| &m.location).map(|s| s.as_str())",
-				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.location))",
-				FieldName:     "location",
-				Template:      []string{"*"},
+				FieldAccessor:  "Some(&req).map(|m| &m.location).map(|s| s.as_str())",
+				PathExtraction: &PathExtraction{FieldTake: "Some(&mut req).map(|m| std::mem::take(&mut m.location))"},
+				FieldName:      "location",
+				Template:       []string{"*"},
 			},
 			{
-				FieldAccessor: "Some(&req).map(|m| &m.id)",
-				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.id))",
-				FieldName:     "id",
-				Template:      []string{"*"},
+				FieldAccessor:  "Some(&req).map(|m| &m.id)",
+				PathExtraction: &PathExtraction{FieldTake: "Some(&mut req).map(|m| std::mem::take(&mut m.id))"},
+				FieldName:      "id",
+				Template:       []string{"*"},
 			},
 		},
 	}
@@ -332,22 +332,22 @@ func TestPathBindingAnnotations(t *testing.T) {
 		PathFmt: "/v1/projects/{}/locations/{}/ids/{}:actionOnChild",
 		Substitutions: []*bindingSubstitution{
 			{
-				FieldAccessor: "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.project).map(|s| s.as_str())",
-				FieldClear:    "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.project))",
-				FieldName:     "child.project",
-				Template:      []string{"*"},
+				FieldAccessor:  "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.project).map(|s| s.as_str())",
+				PathExtraction: &PathExtraction{FieldTake: "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.project))"},
+				FieldName:      "child.project",
+				Template:       []string{"*"},
 			},
 			{
-				FieldAccessor: "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.location).map(|s| s.as_str())",
-				FieldClear:    "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.location))",
-				FieldName:     "child.location",
-				Template:      []string{"*"},
+				FieldAccessor:  "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.location).map(|s| s.as_str())",
+				PathExtraction: &PathExtraction{FieldTake: "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.location))"},
+				FieldName:      "child.location",
+				Template:       []string{"*"},
 			},
 			{
-				FieldAccessor: "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.id)",
-				FieldClear:    "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.id))",
-				FieldName:     "child.id",
-				Template:      []string{"*"},
+				FieldAccessor:  "Some(&req).and_then(|m| m.child.as_ref()).map(|m| &m.id)",
+				PathExtraction: &PathExtraction{FieldTake: "Some(&mut req).and_then(|m| m.child.as_mut()).map(|m| std::mem::take(&mut m.id))"},
+				FieldName:      "child.id",
+				Template:       []string{"*"},
 			},
 		},
 	}
@@ -379,7 +379,6 @@ func TestPathBindingAnnotations(t *testing.T) {
 		Substitutions: []*bindingSubstitution{
 			{
 				FieldAccessor: "Some(&req).and_then(|m| m.oneof_field()).map(|s| s.as_str())",
-				FieldClear:    "Some(&mut req).map(|m| std::mem::take(&mut m.oneof_field))",
 				FieldName:     "oneof_field",
 				Template:      []string{"*"},
 			},
@@ -392,15 +391,26 @@ func TestPathBindingAnnotations(t *testing.T) {
 		InputTypeID:  ".test.Request",
 		OutputTypeID: ".test.Response",
 		PathInfo: &api.PathInfo{
-			Bindings:      []*api.PathBinding{b0, b1, b2, b3, b4},
+			Bindings:      []*api.PathBinding{b0, b1, b2, b3},
 			BodyFieldPath: "*",
+		},
+	}
+	methodBar := &api.Method{
+		Name:         "DoBar",
+		ID:           ".test.Service.DoBar",
+		InputType:    request,
+		InputTypeID:  ".test.Request",
+		OutputTypeID: ".test.Response",
+		PathInfo: &api.PathInfo{
+			Bindings:      []*api.PathBinding{b4},
+			BodyFieldPath: "",
 		},
 	}
 	service := &api.Service{
 		Name:    "FooService",
 		ID:      ".test.FooService",
 		Package: "test",
-		Methods: []*api.Method{method},
+		Methods: []*api.Method{method, methodBar},
 	}
 
 	model := api.NewTestAPI(
@@ -532,10 +542,10 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 			PathFmt: "/v1/machines/{}:create",
 			Substitutions: []*bindingSubstitution{
 				{
-					FieldAccessor: test.WantAccessor,
-					FieldName:     test.WantFieldName,
-					FieldClear:    test.WantClear,
-					Template:      []string{"*"},
+					FieldAccessor:  test.WantAccessor,
+					FieldName:      test.WantFieldName,
+					PathExtraction: &PathExtraction{FieldTake: test.WantClear},
+					Template:       []string{"*"},
 				},
 			},
 		}
@@ -546,7 +556,8 @@ func TestPathBindingAnnotationsStyle(t *testing.T) {
 			InputTypeID:  ".test.Request",
 			OutputTypeID: ".test.Response",
 			PathInfo: &api.PathInfo{
-				Bindings: []*api.PathBinding{binding},
+				Bindings:      []*api.PathBinding{binding},
+				BodyFieldPath: "*",
 			},
 		}
 		service := &api.Service{

--- a/internal/sidekick/rust/annotate_service_test.go
+++ b/internal/sidekick/rust/annotate_service_test.go
@@ -321,7 +321,7 @@ func TestServiceAnnotations(t *testing.T) {
 	// Codec.
 	serviceAnn := service.Codec.(*serviceAnnotations)
 	wantMethodList := []*api.Method{method, emptyMethod}
-	if diff := cmp.Diff(wantMethodList, serviceAnn.Methods, cmpopts.IgnoreFields(api.Method{}, "Model", "Service", "SourceService")); diff != "" {
+	if diff := cmp.Diff(wantMethodList, serviceAnn.Methods, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{}), cmpopts.IgnoreFields(api.Method{}, "Model", "Service", "SourceService")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
@@ -339,7 +339,7 @@ func TestServiceAnnotations(t *testing.T) {
 		ServiceNameToSnake:  "resource_service",
 		ReturnType:          "crate::model::Response",
 	}
-	if diff := cmp.Diff(wantMethod, method.Codec); diff != "" {
+	if diff := cmp.Diff(wantMethod, method.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
@@ -357,7 +357,7 @@ func TestServiceAnnotations(t *testing.T) {
 		ServiceNameToSnake:  "resource_service",
 		ReturnType:          "()",
 	}
-	if diff := cmp.Diff(wantMethod, emptyMethod.Codec); diff != "" {
+	if diff := cmp.Diff(wantMethod, emptyMethod.Codec, cmpopts.IgnoreUnexported(pathBindingAnnotation{}, bindingSubstitution{})); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -250,6 +250,9 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{#Codec.HasBindingSubstitutions}}
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
+        {{#Codec.FullBody}}
+        let mut req = req;
+        {{/Codec.FullBody}}
         {{/Codec.HasBindingSubstitutions}}
         {{#HasAutoPopulatedFields}}
         let options = google_cloud_gax::options::internal::set_default_idempotency(
@@ -306,6 +309,11 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             let resource_name = String::new();
             {{/Codec.ResourceNameTemplate}}
             {{/Codec.HasResourceNameGeneration}}
+            {{#Codec.Substitutions}}
+            {{#FullBody}}
+            let _ = {{{FieldClear}}};
+            {{/FullBody}}
+            {{/Codec.Substitutions}}
             let builder = self.inner.builder(Method::{{Verb}}, path);
             {{#Codec.QueryParamsCanFail}}
             let builder = (|| {

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -310,9 +310,9 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{/Codec.ResourceNameTemplate}}
             {{/Codec.HasResourceNameGeneration}}
             {{#Codec.Substitutions}}
-            {{#FullBody}}
-            let _ = {{{FieldClear}}};
-            {{/FullBody}}
+            {{#PathExtraction}}
+            let _ = {{{FieldTake}}};
+            {{/PathExtraction}}
             {{/Codec.Substitutions}}
             let builder = self.inner.builder(Method::{{Verb}}, path);
             {{#Codec.QueryParamsCanFail}}


### PR DESCRIPTION
We extract path variables from the request for our HTTP-based RPCs.

If they have an `api.http.body: *` annotation, we also include these path variables in the body. As far as we knew, this was not a problem to repeat fields with the same value. Turns out one service rejects the duplicated field (IMO erroneously, but whatever).

Still, we can extract the path variables from these requests and at least send fewer bytes over the network. That is a bit of a win.

Generated changes in: https://github.com/googleapis/google-cloud-rust/pull/6518

Towards: https://github.com/googleapis/google-cloud-rust/issues/6515