### PR TITLE
feat(internal/librarian/php): initialize default library version on add

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -690,7 +690,7 @@ func TestAddLibraryCommand_Php(t *testing.T) {
 	wantLibraries := []*config.Library{
 		{
 			Name:          "developerconnect",
-			Version: "0.0.0",
+			Version:       "0.0.0",
 			CopyrightYear: strconv.Itoa(time.Now().Year()),
 			APIs: []*config.API{
 				{

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -690,6 +690,7 @@ func TestAddLibraryCommand_Php(t *testing.T) {
 	wantLibraries := []*config.Library{
 		{
 			Name:          "developerconnect",
+			Version: "0.0.0",
 			CopyrightYear: strconv.Itoa(time.Now().Year()),
 			APIs: []*config.API{
 				{

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -39,19 +39,10 @@ func DefaultLibraryName(apiPath string) string {
 
 // Add populates PHP-specific default configuration for all APIs in the library.
 func Add(lib *config.Library) *config.Library {
-	initVersion(lib)
-	initAPIs(lib.APIs)
-	return lib
-}
-
-func initVersion(lib *config.Library) {
 	if lib.Version == "" {
 		lib.Version = defaultVersion
 	}
-}
-
-func initAPIs(apis []*config.API) {
-	for _, api := range apis {
+	for _, api := range lib.APIs {
 		if api.PHP == nil {
 			api.PHP = &config.PHPAPI{}
 		}
@@ -59,4 +50,5 @@ func initAPIs(apis []*config.API) {
 			api.PHP.StagingSubdir = serviceconfig.ExtractVersion(api.Path)
 		}
 	}
+	return lib
 }

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -40,11 +40,11 @@ func DefaultLibraryName(apiPath string) string {
 // Add populates PHP-specific default configuration for all APIs in the library.
 func Add(lib *config.Library) *config.Library {
 	lib.Version = defaultVersion
-	initAPI(lib.APIs)
+	initAPIs(lib.APIs)
 	return lib
 }
 
-func initAPI(apis []*config.API) {
+func initAPIs(apis []*config.API) {
 	for _, api := range apis {
 		if api.PHP == nil {
 			api.PHP = &config.PHPAPI{}

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -22,6 +22,8 @@ import (
 	"github.com/googleapis/librarian/internal/serviceconfig"
 )
 
+const defaultVersion = "0.0.0"
+
 // DefaultLibraryName derives the library name for PHP purely from the API path.
 // E.g., "google/cloud/speech/v2" -> "speech"
 // E.g., "google/cloud/security/privateca/v1" -> "security-privateca".
@@ -37,7 +39,13 @@ func DefaultLibraryName(apiPath string) string {
 
 // Add populates PHP-specific default configuration for all APIs in the library.
 func Add(lib *config.Library) *config.Library {
-	for _, api := range lib.APIs {
+	lib.Version = defaultVersion
+	addPHPAPI(lib.APIs)
+	return lib
+}
+
+func addPHPAPI(apis []*config.API) {
+	for _, api := range apis {
 		if api.PHP == nil {
 			api.PHP = &config.PHPAPI{}
 		}
@@ -45,5 +53,4 @@ func Add(lib *config.Library) *config.Library {
 			api.PHP.StagingSubdir = serviceconfig.ExtractVersion(api.Path)
 		}
 	}
-	return lib
 }

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -39,9 +39,15 @@ func DefaultLibraryName(apiPath string) string {
 
 // Add populates PHP-specific default configuration for all APIs in the library.
 func Add(lib *config.Library) *config.Library {
-	lib.Version = defaultVersion
+	initVersion(lib)
 	initAPIs(lib.APIs)
 	return lib
+}
+
+func initVersion(lib *config.Library) {
+	if lib.Version == "" {
+		lib.Version = defaultVersion
+	}
 }
 
 func initAPIs(apis []*config.API) {

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -40,11 +40,11 @@ func DefaultLibraryName(apiPath string) string {
 // Add populates PHP-specific default configuration for all APIs in the library.
 func Add(lib *config.Library) *config.Library {
 	lib.Version = defaultVersion
-	addPHPAPI(lib.APIs)
+	initAPI(lib.APIs)
 	return lib
 }
 
-func addPHPAPI(apis []*config.API) {
+func initAPI(apis []*config.API) {
 	for _, api := range apis {
 		if api.PHP == nil {
 			api.PHP = &config.PHPAPI{}

--- a/internal/librarian/php/add_test.go
+++ b/internal/librarian/php/add_test.go
@@ -78,6 +78,7 @@ func TestAdd(t *testing.T) {
 				},
 			},
 			want: &config.Library{
+				Version: "0.0.0",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/speech/v2",
@@ -101,6 +102,7 @@ func TestAdd(t *testing.T) {
 				},
 			},
 			want: &config.Library{
+				Version: "0.0.0",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/speech/v2",
@@ -120,6 +122,7 @@ func TestAdd(t *testing.T) {
 				},
 			},
 			want: &config.Library{
+				Version: "0.0.0",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/speech/v2",

--- a/internal/librarian/php/add_test.go
+++ b/internal/librarian/php/add_test.go
@@ -114,6 +114,26 @@ func TestAdd(t *testing.T) {
 			},
 		},
 		{
+			name: "existing version",
+			lib: &config.Library{
+				Version: "1.2.3",
+				APIs: []*config.API{
+					{Path: "google/cloud/speech/v2"},
+				},
+			},
+			want: &config.Library{
+				Version: "1.2.3",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/speech/v2",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v2",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multiple APIs",
 			lib: &config.Library{
 				APIs: []*config.API{


### PR DESCRIPTION
A default version (0.0.0) is initialized on newly added PHP libraries when the version field is not already populated.

This ensures newly onboarded PHP libraries in librarian.yaml start with an initial semantic version, matching the onboarding behavior across other languages in Librarian.

Fixes #7382
