### PR TITLE
fix(internal/librarian/php): run post processor only on root staging dirs

### DIFF
--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -101,7 +101,7 @@ func rootStagingDirs(library *config.Library) []string {
 			if parent == dir {
 				break
 			}
-			dir = filepath.Dir(dir)
+			dir = parent
 		}
 		if !found {
 			res = append(res, originalDir)

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -70,7 +70,7 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 }
 
 func runPostProcessors(ctx context.Context, library *config.Library, stagingDirBase, postProcessor string) error {
-	stagingDirs := removePrefixDirectories(library)
+	stagingDirs := rootStagingDirs(library)
 	for _, stagingDir := range stagingDirs {
 		apiStagingDir := filepath.Join(stagingDirBase, stagingDir)
 		if err := command.RunInDir(ctx, apiStagingDir, postProcessor, "--input", "."); err != nil {
@@ -80,10 +80,11 @@ func runPostProcessors(ctx context.Context, library *config.Library, stagingDirB
 	return nil
 }
 
-func removePrefixDirectories(library *config.Library) []string {
+// rootStagingDirs returns a list of unique root directories from the library's staging directories.
+func rootStagingDirs(library *config.Library) []string {
 	stagingDirs := make([]string, 0, len(library.APIs))
 	for _, api := range library.APIs {
-		stagingDirs = append(stagingDirs, filepath.FromSlash(api.PHP.StagingSubdir))
+		stagingDirs = append(stagingDirs, filepath.Clean(filepath.FromSlash(api.PHP.StagingSubdir)))
 	}
 	var res []string
 	prefixes := make(map[string]bool)
@@ -91,7 +92,7 @@ func removePrefixDirectories(library *config.Library) []string {
 	for _, dir := range stagingDirs {
 		originalDir := dir
 		found := false
-		for dir != "/" {
+		for dir != "." {
 			if prefixes[dir] {
 				found = true
 				break

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/command"
@@ -68,14 +69,41 @@ func postProcessLibrary(ctx context.Context, library *config.Library, componentN
 	return nil
 }
 
-func runPostProcessors(ctx context.Context, library *config.Library, stagingDir, postProcessor string) error {
-	for _, api := range library.APIs {
-		apiStagingDir := filepath.Join(stagingDir, api.PHP.StagingSubdir)
+func runPostProcessors(ctx context.Context, library *config.Library, stagingDirBase, postProcessor string) error {
+	stagingDirs := removePrefixDirectories(library)
+	for _, stagingDir := range stagingDirs {
+		apiStagingDir := filepath.Join(stagingDirBase, stagingDir)
 		if err := command.RunInDir(ctx, apiStagingDir, postProcessor, "--input", "."); err != nil {
-			return fmt.Errorf("failed to run php-post-processor on %s: %w", api.Path, err)
+			return fmt.Errorf("failed to run php-post-processor on %s: %w", apiStagingDir, err)
 		}
 	}
 	return nil
+}
+
+func removePrefixDirectories(library *config.Library) []string {
+	stagingDirs := make([]string, 0, len(library.APIs))
+	for _, api := range library.APIs {
+		stagingDirs = append(stagingDirs, filepath.FromSlash(api.PHP.StagingSubdir))
+	}
+	var res []string
+	prefixes := make(map[string]bool)
+	slices.Sort(stagingDirs)
+	for _, dir := range stagingDirs {
+		originalDir := dir
+		found := false
+		for dir != "/" {
+			if prefixes[dir] {
+				found = true
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+		if !found {
+			res = append(res, originalDir)
+			prefixes[originalDir] = true
+		}
+	}
+	return res
 }
 
 // restoreCopyrightYear replaces the copyright year in generated source files.
@@ -104,7 +132,7 @@ func updateCopyrightYearInFile(path, year string, re *regexp.Regexp) error {
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", path, err)
 	}
-	replacement := []byte(fmt.Sprintf("Copyright %s Google", year))
+	replacement := fmt.Appendf(nil, "Copyright %s Google", year)
 	updated := re.ReplaceAll(content, replacement)
 	if bytes.Equal(content, updated) {
 		return nil

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -92,9 +92,13 @@ func rootStagingDirs(library *config.Library) []string {
 	for _, dir := range stagingDirs {
 		originalDir := dir
 		found := false
-		for dir != "." && dir != "/" {
+		for {
 			if prefixes[dir] {
 				found = true
+				break
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
 				break
 			}
 			dir = filepath.Dir(dir)

--- a/internal/librarian/php/postprocess.go
+++ b/internal/librarian/php/postprocess.go
@@ -92,7 +92,7 @@ func rootStagingDirs(library *config.Library) []string {
 	for _, dir := range stagingDirs {
 		originalDir := dir
 		found := false
-		for dir != "." {
+		for dir != "." && dir != "/" {
 			if prefixes[dir] {
 				found = true
 				break

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -321,3 +321,127 @@ func TestRestoreCopyrightYear(t *testing.T) {
 		})
 	}
 }
+
+func TestRootStagingDirs(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		want    []string
+	}{
+		{
+			name: "single API",
+			library: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+				},
+			},
+			want: []string{"v1"},
+		},
+		{
+			name: "distinct APIs",
+			library: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v2",
+						},
+					},
+				},
+			},
+			want: []string{"v1", "v2"},
+		},
+		{
+			name: "nested subdirectories excluded",
+			library: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1/Admin",
+						},
+					},
+				},
+			},
+			want: []string{"v1"},
+		},
+		{
+			name: "deeply nested subdirectories",
+			library: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "a/b/c",
+						},
+					},
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "a/b",
+						},
+					},
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "a/b/c/d",
+						},
+					},
+				},
+			},
+			want: []string{"a/b"},
+		},
+		{
+			name: "duplicate staging subdirs",
+			library: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+				},
+			},
+			want: []string{"v1"},
+		},
+		{
+			name: "trailing slash and unnormalized paths",
+			library: &config.Library{
+				APIs: []*config.API{
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1/sub/",
+						},
+					},
+					{
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1/sub/nested",
+						},
+					},
+				},
+			},
+			want: []string{"v1/sub"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := rootStagingDirs(test.library)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The PHP post-processor execution is updated to target only unique root staging directories instead of every API staging subdirectory.

A `rootStagingDirs` helper identifies the top-level staging directories for a library by sorting paths and pruning nested descendant subdirectories. This prevents running the post-processor redundantly on subdirectories already processed as part of their parent directory.
