### PR TITLE
feat(swift): add librarian publish command

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -127,6 +127,25 @@ func OutputWithEnv(ctx context.Context, env map[string]string, command string, a
 	return runCmd(ctx, "", env, command, arg...)
 }
 
+// OutputWithStdin executes a program (with arguments) and stdin input and returns stdout.
+func OutputWithStdin(ctx context.Context, stdin io.Reader, command string, arg ...string) (string, error) {
+	return OutputWithStdinAndEnv(ctx, stdin, nil, command, arg...)
+}
+
+// OutputWithStdinAndEnv executes a program with stdin and optional environment variables and returns stdout.
+func OutputWithStdinAndEnv(ctx context.Context, stdin io.Reader, env map[string]string, command string, arg ...string) (string, error) {
+	cmd := buildCmd(ctx, "", env, command, arg...)
+	cmd.Stdin = stdin
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			return "", fmt.Errorf("%s: %s: %w", cmd, exitErr.Stderr, err)
+		}
+		return "", fmt.Errorf("%s: %w", cmd, err)
+	}
+	return string(output), nil
+}
+
 func buildCmd(ctx context.Context, dir string, env map[string]string, command string, arg ...string) *exec.Cmd {
 	// Merge system PATH env with the provided environment variables.
 	pathEnv := os.Getenv(envPath)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -337,3 +337,26 @@ func TestLookPath_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputWithStdin(t *testing.T) {
+	input := "hello world\n"
+	got, err := OutputWithStdin(t.Context(), strings.NewReader(input), "cat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != input {
+		t.Errorf("OutputWithStdin() = %q, want %q", got, input)
+	}
+}
+
+func TestOutputWithStdinAndEnv(t *testing.T) {
+	input := "input data\n"
+	got, err := OutputWithStdinAndEnv(t.Context(), strings.NewReader(input), map[string]string{"FOO": "bar"}, "sh", "-c", "echo $FOO && cat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "bar\ninput data\n"
+	if got != want {
+		t.Errorf("OutputWithStdinAndEnv() = %q, want %q", got, want)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -206,3 +206,61 @@ func HasChangesIn(dir, exclusion string, filesChanged []string) bool {
 	}
 	return false
 }
+
+// RemoteTagExists checks if a tag exists on the remote repository.
+func RemoteTagExists(ctx context.Context, gitExe, remote, tag string) (bool, error) {
+	output, err := command.Output(ctx, gitExe, "ls-remote", "--tags", remote, "refs/tags/"+tag, "refs/tags/"+tag+"^{}")
+	if err != nil {
+		return false, fmt.Errorf("failed to check remote tags for %s: %w", remote, err)
+	}
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, "refs/tags/"+tag) || strings.HasSuffix(line, "refs/tags/"+tag+"^{}") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// SubtreeSplit runs git subtree split for the given prefix and origin commit.
+func SubtreeSplit(ctx context.Context, gitExe, prefix, origin string) (string, error) {
+	output, err := command.Output(ctx, gitExe, "-c", "commit.gpgsign=false", "subtree", "split", "--prefix="+prefix, "-q", origin)
+	if err != nil {
+		return "", fmt.Errorf("failed to split subtree %s: %w", prefix, err)
+	}
+	splitSHA := strings.TrimSpace(output)
+	if len(splitSHA) != 40 {
+		return "", fmt.Errorf("unexpected git subtree split output for prefix %s: %q", prefix, output)
+	}
+	return splitSHA, nil
+}
+
+// PushBranch pushes a local ref to a branch on the remote repository.
+func PushBranch(ctx context.Context, gitExe, remote, localRef, remoteBranch string, force bool) error {
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, remote, fmt.Sprintf("%s:refs/heads/%s", localRef, remoteBranch))
+	return command.Run(ctx, gitExe, args...)
+}
+
+// PushTag pushes a tag to the remote repository.
+func PushTag(ctx context.Context, gitExe, remote, tag string, force bool) error {
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, remote, "refs/tags/"+tag)
+	return command.Run(ctx, gitExe, args...)
+}
+
+// PushRefToTag pushes a specific commit hash to a tag on the remote repository.
+func PushRefToTag(ctx context.Context, gitExe, remote, localRef, tag string, force bool) error {
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, remote, fmt.Sprintf("%s:refs/tags/%s", localRef, tag))
+	return command.Run(ctx, gitExe, args...)
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -229,7 +229,7 @@ func SubtreeSplit(ctx context.Context, gitExe, prefix, origin string) (string, e
 		return "", fmt.Errorf("failed to split subtree %s: %w", prefix, err)
 	}
 	splitSHA := strings.TrimSpace(output)
-	if len(splitSHA) != 40 {
+	if len(splitSHA) != 40 && len(splitSHA) != 64 {
 		return "", fmt.Errorf("unexpected git subtree split output for prefix %s: %q", prefix, output)
 	}
 	return splitSHA, nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -700,3 +700,64 @@ func TestGitConfigIgnoreGlobalSigning(t *testing.T) {
 
 	testhelper.SetupRepo(t)
 }
+
+func TestRemoteTagExists(t *testing.T) {
+	remoteDir := testhelper.SetupRepo(t)
+	testhelper.RunGit(t, "tag", "1.0.0")
+
+	got, err := RemoteTagExists(t.Context(), command.Git, remoteDir, "1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Errorf("RemoteTagExists() = false; want true for existing tag")
+	}
+
+	gotNonExistent, err := RemoteTagExists(t.Context(), command.Git, remoteDir, "2.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotNonExistent {
+		t.Errorf("RemoteTagExists() = true; want false for nonexistent tag")
+	}
+}
+
+func TestSubtreeSplit(t *testing.T) {
+	testhelper.SetupForVersionBump(t, "dummy-tag")
+	sha, err := SubtreeSplit(t.Context(), command.Git, "src/storage", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sha) != 40 {
+		t.Errorf("SubtreeSplit() = %q; want 40 character SHA", sha)
+	}
+}
+
+func TestPushBranchAndPushTag(t *testing.T) {
+	remoteDir := testhelper.SetupRepo(t)
+	cloneDir := t.TempDir()
+	t.Chdir(cloneDir)
+	testhelper.RunGit(t, "clone", remoteDir, ".")
+	testhelper.ConfigNewGitRepository(t)
+
+	head, err := GetCommitHash(t.Context(), command.Git, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PushBranch(t.Context(), command.Git, remoteDir, head, "feature-branch", false); err != nil {
+		t.Fatalf("PushBranch() = %v", err)
+	}
+
+	if err := PushRefToTag(t.Context(), command.Git, remoteDir, head, "v2.0.0", false); err != nil {
+		t.Fatalf("PushRefToTag() = %v", err)
+	}
+
+	exists, err := RemoteTagExists(t.Context(), command.Git, remoteDir, "v2.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Errorf("RemoteTagExists(v2.0.0) = false; want true after PushRefToTag")
+	}
+}

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -131,6 +131,7 @@ func swiftPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) err
 	command.Verbose = verbose
 	return swift.Publish(ctx, swift.PublishParams{
 		Config:           cfg,
+		Libraries:        cmd.Args().Slice(),
 		DryRun:           dryRun,
 		DryRunKeepGoing:  dryRunKeepGoing,
 		SkipSemverChecks: skipSemverChecks,

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/librarian/dart"
 	"github.com/googleapis/librarian/internal/librarian/rust"
+	"github.com/googleapis/librarian/internal/librarian/swift"
 	"github.com/googleapis/librarian/internal/yaml"
 	"github.com/urfave/cli/v3"
 )
@@ -35,7 +36,7 @@ func publishCommand() *cli.Command {
 		Description: `publish releases the libraries that were updated in a release commit
 prepared by librarian bump.
 
-Only Dart and Rust are supported.`,
+Only Dart, Rust, and Swift are supported.`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "dry-run",
@@ -54,6 +55,20 @@ Only Dart and Rust are supported.`,
 				Aliases: []string{"v"},
 				Usage:   "streams output of publishing commands executed",
 			},
+			&cli.StringFlag{
+				Name:  "remote-url-format",
+				Usage: "template for remote repository URLs (e.g. 'git@github.com:googleapis/{name}.git')",
+			},
+			&cli.StringFlag{
+				Name:  "origin",
+				Value: "HEAD",
+				Usage: "source commit or branch to split from",
+			},
+			&cli.StringFlag{
+				Name:  "remote-branch",
+				Value: "main",
+				Usage: "branch name on the remote repository",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
@@ -65,6 +80,9 @@ Only Dart and Rust are supported.`,
 			}
 			if cfg.Language == config.LanguageDart {
 				return dartPublish(ctx, cfg, cmd)
+			}
+			if cfg.Language == config.LanguageSwift {
+				return swiftPublish(ctx, cfg, cmd)
 			}
 			return fmt.Errorf("publish is not supported for %q", cfg.Language)
 		},
@@ -99,5 +117,26 @@ func rustPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) erro
 		SkipSemverChecks: skipSemverChecks,
 		Verbose:          verbose,
 		IgnoredChanges:   IgnoredChanges,
+	})
+}
+
+func swiftPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) error {
+	dryRun := cmd.Bool("dry-run")
+	skipSemverChecks := cmd.Bool("skip-semver-checks")
+	dryRunKeepGoing := cmd.Bool("dry-run-keep-going")
+	verbose := cmd.Bool("verbose")
+	remoteURLFormat := cmd.String("remote-url-format")
+	origin := cmd.String("origin")
+	remoteBranch := cmd.String("remote-branch")
+	command.Verbose = verbose
+	return swift.Publish(ctx, swift.PublishParams{
+		Config:           cfg,
+		DryRun:           dryRun,
+		DryRunKeepGoing:  dryRunKeepGoing,
+		SkipSemverChecks: skipSemverChecks,
+		Verbose:          verbose,
+		RemoteURLFormat:  remoteURLFormat,
+		Origin:           origin,
+		RemoteBranch:     remoteBranch,
 	})
 }

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -69,6 +69,11 @@ Only Dart, Rust, and Swift are supported.`,
 				Value: "main",
 				Usage: "branch name on the remote repository",
 			},
+			&cli.StringFlag{
+				Name:  "upstream",
+				Value: config.RemoteUpstream,
+				Usage: "name of the upstream git remote",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			cfg, err := yaml.Read[config.Config](config.LibrarianYAML)
@@ -128,6 +133,7 @@ func swiftPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) err
 	remoteURLFormat := cmd.String("remote-url-format")
 	origin := cmd.String("origin")
 	remoteBranch := cmd.String("remote-branch")
+	upstream := cmd.String("upstream")
 	command.Verbose = verbose
 	return swift.Publish(ctx, swift.PublishParams{
 		Config:           cfg,
@@ -139,5 +145,6 @@ func swiftPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) err
 		RemoteURLFormat:  remoteURLFormat,
 		Origin:           origin,
 		RemoteBranch:     remoteBranch,
+		Upstream:         upstream,
 	})
 }

--- a/internal/librarian/publish.go
+++ b/internal/librarian/publish.go
@@ -100,6 +100,7 @@ func dartPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) erro
 	dryRunKeepGoing := cmd.Bool("dry-run-keep-going")
 	verbose := cmd.Bool("verbose")
 	command.Verbose = verbose
+	setupLogger(verbose)
 	return dart.Publish(ctx, dart.PublishParams{
 		Config:           cfg,
 		DryRun:           dryRun,
@@ -115,6 +116,7 @@ func rustPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) erro
 	dryRunKeepGoing := cmd.Bool("dry-run-keep-going")
 	verbose := cmd.Bool("verbose")
 	command.Verbose = verbose
+	setupLogger(verbose)
 	return rust.Publish(ctx, rust.PublishParams{
 		Config:           cfg,
 		DryRun:           dryRun,
@@ -135,6 +137,7 @@ func swiftPublish(ctx context.Context, cfg *config.Config, cmd *cli.Command) err
 	remoteBranch := cmd.String("remote-branch")
 	upstream := cmd.String("upstream")
 	command.Verbose = verbose
+	setupLogger(verbose)
 	return swift.Publish(ctx, swift.PublishParams{
 		Config:           cfg,
 		Libraries:        cmd.Args().Slice(),

--- a/internal/librarian/publish_test.go
+++ b/internal/librarian/publish_test.go
@@ -74,7 +74,7 @@ func TestPublishCommand_Swift(t *testing.T) {
 	testhelper.RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
 	testhelper.ConfigNewGitRepository(t)
 
-	splitBareRepo := filepath.Join(t.TempDir(), "google-cloud-auth.git")
+	splitBareRepo := filepath.Join(t.TempDir(), "swift-auth.git")
 	splitRemote := t.TempDir()
 	testhelper.ContinueInNewGitRepository(t, splitRemote)
 	if err := os.WriteFile("README.md", []byte("# Auth"), 0o644); err != nil {

--- a/internal/librarian/publish_test.go
+++ b/internal/librarian/publish_test.go
@@ -95,4 +95,9 @@ func TestPublishCommand_Swift(t *testing.T) {
 	if err != nil {
 		t.Fatalf("librarian publish --dry-run failed: %v", err)
 	}
+
+	err = Run(t.Context(), "librarian", "publish", "--dry-run", "--remote-url-format", filepath.Dir(splitBareRepo)+"/{name}.git", "google-cloud-auth")
+	if err != nil {
+		t.Fatalf("librarian publish specific library failed: %v", err)
+	}
 }

--- a/internal/librarian/publish_test.go
+++ b/internal/librarian/publish_test.go
@@ -85,7 +85,7 @@ func TestPublishCommand_Swift(t *testing.T) {
 	testhelper.RunGit(t, "clone", "--bare", splitRemote, splitBareRepo)
 
 	t.Chdir(cloneDir)
-	err = Run(t.Context(), "librarian", "publish", "--dry-run", "--remote-url-format", filepath.Dir(splitBareRepo)+"/{name}.git")
+	err := Run(t.Context(), "librarian", "publish", "--dry-run", "--remote-url-format", filepath.Dir(splitBareRepo)+"/{name}.git")
 	if err != nil {
 		t.Fatalf("librarian publish --dry-run failed: %v", err)
 	}

--- a/internal/librarian/publish_test.go
+++ b/internal/librarian/publish_test.go
@@ -45,12 +45,6 @@ func TestPublishCommand_Swift(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 
 	remoteDir := t.TempDir()
-	curDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chdir(curDir) }()
-
 	testhelper.ContinueInNewGitRepository(t, remoteDir)
 	if err := os.WriteFile("LICENSE", []byte("license"), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/librarian/publish_test.go
+++ b/internal/librarian/publish_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package librarian
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/testhelper"
+	"github.com/googleapis/librarian/internal/yaml"
+)
+
+func TestPublishCommand_UnsupportedLanguage(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	cfg := &config.Config{
+		Language: "python",
+	}
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Run(t.Context(), "librarian", "publish")
+	if err == nil {
+		t.Fatal("expected error for unsupported language, got nil")
+	}
+}
+
+func TestPublishCommand_Swift(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+
+	remoteDir := t.TempDir()
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(curDir) }()
+
+	testhelper.ContinueInNewGitRepository(t, remoteDir)
+	if err := os.WriteFile("LICENSE", []byte("license"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	authDir := filepath.Join("packages", "auth")
+	testhelper.AddSwiftPackage(t, authDir, "GoogleCloudAuth")
+	cfg := &config.Config{
+		Language: config.LanguageSwift,
+		Repo:     "googleapis/google-cloud-swift",
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-auth",
+				Version: "1.0.0",
+				Output:  "packages/auth",
+			},
+		},
+	}
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+		t.Fatal(err)
+	}
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "initial commit")
+
+	cloneDir := t.TempDir()
+	t.Chdir(cloneDir)
+	testhelper.RunGit(t, "clone", remoteDir, ".")
+	testhelper.RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
+	testhelper.ConfigNewGitRepository(t)
+
+	splitBareRepo := filepath.Join(t.TempDir(), "google-cloud-auth.git")
+	splitRemote := t.TempDir()
+	testhelper.ContinueInNewGitRepository(t, splitRemote)
+	if err := os.WriteFile("README.md", []byte("# Auth"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "init auth remote")
+	testhelper.RunGit(t, "clone", "--bare", splitRemote, splitBareRepo)
+
+	t.Chdir(cloneDir)
+	err = Run(t.Context(), "librarian", "publish", "--dry-run", "--remote-url-format", filepath.Dir(splitBareRepo)+"/{name}.git")
+	if err != nil {
+		t.Fatalf("librarian publish --dry-run failed: %v", err)
+	}
+}

--- a/internal/librarian/publish_test.go
+++ b/internal/librarian/publish_test.go
@@ -94,4 +94,9 @@ func TestPublishCommand_Swift(t *testing.T) {
 	if err != nil {
 		t.Fatalf("librarian publish specific library failed: %v", err)
 	}
+
+	err = Run(t.Context(), "librarian", "publish", "--dry-run", "--upstream", config.RemoteUpstream, "--remote-url-format", filepath.Dir(splitBareRepo)+"/{name}.git", "google-cloud-auth")
+	if err != nil {
+		t.Fatalf("librarian publish with --upstream failed: %v", err)
+	}
 }

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -66,7 +66,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 
 	if err := git.MatchesBranchPoint(ctx, gitExe, config.RemoteUpstream, config.BranchMain); err != nil {
 		if params.DryRunKeepGoing {
-			slog.Warn("Branch point check failed, but continuing due to --keep-going", "error", err)
+			slog.Error("Branch point check failed, but continuing due to --keep-going", "error", err)
 		} else {
 			return err
 		}
@@ -104,7 +104,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 
 		if _, err := os.Stat(libDir); err != nil {
 			if params.DryRunKeepGoing {
-				slog.Warn("library directory not found, but continuing due to --keep-going", "library", lib.Name, "path", libDir, "error", err)
+				slog.Error("library directory not found, but continuing due to --keep-going", "library", lib.Name, "path", libDir, "error", err)
 				continue
 			}
 			return fmt.Errorf("library directory %s does not exist: %w", libDir, err)
@@ -116,7 +116,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 		tagExists, err := git.RemoteTagExists(ctx, gitExe, remoteURL, tag)
 		if err != nil {
 			if params.DryRunKeepGoing {
-				slog.Warn("failed to check remote tags, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
+				slog.Error("failed to check remote tags, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
 				continue
 			}
 			return fmt.Errorf("failed to check remote tags for %s on %s: %w", lib.Name, remoteURL, err)
@@ -137,7 +137,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 		})
 		if err != nil {
 			if params.DryRunKeepGoing {
-				slog.Warn("failed to split library, but continuing due to --keep-going", "library", lib.Name, "error", err)
+				slog.Error("failed to split library, but continuing due to --keep-going", "library", lib.Name, "error", err)
 				continue
 			}
 			return fmt.Errorf("failed to split %s: %w", lib.Name, err)
@@ -150,7 +150,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 
 		if err := git.PushBranch(ctx, gitExe, remoteURL, splitSHA, remoteBranch, true); err != nil {
 			if params.DryRunKeepGoing {
-				slog.Warn("failed to push branch, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
+				slog.Error("failed to push branch, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
 				continue
 			}
 			return fmt.Errorf("failed to push branch for %s to %s: %w", lib.Name, remoteURL, err)
@@ -158,7 +158,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 
 		if err := git.PushRefToTag(ctx, gitExe, remoteURL, splitSHA, tag, true); err != nil {
 			if params.DryRunKeepGoing {
-				slog.Warn("failed to push tag, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
+				slog.Error("failed to push tag, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
 				continue
 			}
 			return fmt.Errorf("failed to push tag %s for %s to %s: %w", tag, lib.Name, remoteURL, err)

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -99,6 +99,14 @@ func Publish(ctx context.Context, params PublishParams) error {
 			continue
 		}
 
+		if libDir == "" {
+			if params.DryRunKeepGoing {
+				slog.Error("library directory is empty, skipping", "library", lib.Name)
+				continue
+			}
+			return fmt.Errorf("library %s has no output directory configured", lib.Name)
+		}
+
 		if _, err := os.Stat(libDir); err != nil {
 			if params.DryRunKeepGoing {
 				slog.Error("library directory not found, but continuing due to --keep-going", "library", lib.Name, "path", libDir, "error", err)

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -122,7 +122,8 @@ func Publish(ctx context.Context, params PublishParams) error {
 			return fmt.Errorf("library directory %s does not exist: %w", libDir, err)
 		}
 
-		remoteURL := FormatRemoteURL(params.RemoteURLFormat, params.Config.Repo, lib.Name)
+		repoName := SplitRepoName(libDir)
+		remoteURL := FormatRemoteURL(params.RemoteURLFormat, params.Config.Repo, repoName)
 		tag := lib.Version
 
 		tagExists, err := git.RemoteTagExists(ctx, gitExe, remoteURL, tag)
@@ -234,12 +235,29 @@ func packageDirectory(lib *config.Library, defaults *config.Default) string {
 	return dir
 }
 
+// SplitRepoName derives the split repository name for a library directory.
+// For example, packages/wkt -> swift-wkt, generated/google-rpc -> swift-google-rpc.
+func SplitRepoName(libDir string) string {
+	if libDir == "" {
+		return ""
+	}
+	base := filepath.Base(libDir)
+	if base == "." || base == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(base, "swift-") {
+		return "swift-" + base
+	}
+	return base
+}
+
 func matchLibrary(targets []string, lib *config.Library, pkgDir string) bool {
 	cleanDir := filepath.Clean(pkgDir)
 	baseDir := filepath.Base(cleanDir)
+	repoName := SplitRepoName(pkgDir)
 	for _, target := range targets {
 		cleanTarget := filepath.Clean(target)
-		if target == lib.Name || cleanTarget == cleanDir || cleanTarget == baseDir || target == pkgDir || target == lib.Output {
+		if target == lib.Name || cleanTarget == cleanDir || cleanTarget == baseDir || target == pkgDir || target == lib.Output || target == repoName {
 			return true
 		}
 		if lib.Swift != nil && (target == lib.Swift.LibraryNameOverride || target == lib.Swift.PackageNameOverride) {

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/git"
+)
+
+// PublishParams holds parameters for running the Swift Publish function.
+type PublishParams struct {
+	// Config is the repository configuration.
+	Config *config.Config
+	// DryRun indicates whether to run publish without pushing.
+	DryRun bool
+	// DryRunKeepGoing indicates whether to run in dry-run mode without stopping on errors.
+	DryRunKeepGoing bool
+	// SkipSemverChecks indicates whether to skip semantic versioning checks.
+	SkipSemverChecks bool
+	// Verbose indicates whether to stream the output of executed commands.
+	Verbose bool
+	// IgnoredChanges is a list of file paths/patterns to ignore when detecting changed libraries.
+	IgnoredChanges []string
+	// RemoteURLFormat is an optional template for remote repository URLs (e.g. 'git@github.com:googleapis/{name}.git').
+	RemoteURLFormat string
+	// Origin is the source commit or branch to split from (default: HEAD).
+	Origin string
+	// RemoteBranch is the target branch on the remote repository (default: main).
+	RemoteBranch string
+	// RootFiles is the list of root files to preserve (default: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md).
+	RootFiles []string
+	// GitExe is the path to the git binary (default: command.Git).
+	GitExe string
+}
+
+// Publish iterates through every library in librarian.yaml, checks if the version
+// has already been published to the target split repository, and performs a repo split
+// and push if needed.
+func Publish(ctx context.Context, params PublishParams) error {
+	gitExe := params.GitExe
+	if gitExe == "" {
+		gitExe = command.Git
+	}
+
+	if err := git.MatchesBranchPoint(ctx, gitExe, config.RemoteUpstream, config.BranchMain); err != nil {
+		if params.DryRunKeepGoing {
+			slog.Warn("Branch point check failed, but continuing due to --keep-going", "error", err)
+		} else {
+			return err
+		}
+	}
+
+	if params.Config == nil {
+		return nil
+	}
+
+	origin := params.Origin
+	if origin == "" {
+		origin = "HEAD"
+	}
+	remoteBranch := params.RemoteBranch
+	if remoteBranch == "" {
+		remoteBranch = config.BranchMain
+	}
+	rootFiles := params.RootFiles
+	if len(rootFiles) == 0 {
+		rootFiles = DefaultRootFiles
+	}
+
+	for _, lib := range params.Config.Libraries {
+		if lib.SkipRelease || lib.Version == "" {
+			continue
+		}
+
+		libDir := libraryOutput(lib, params.Config.Default)
+		if libDir == "" {
+			return fmt.Errorf("library %s has no output directory", lib.Name)
+		}
+
+		if _, err := os.Stat(libDir); err != nil {
+			if params.DryRunKeepGoing {
+				slog.Warn("library directory not found, but continuing due to --keep-going", "library", lib.Name, "path", libDir, "error", err)
+				continue
+			}
+			return fmt.Errorf("library directory %s does not exist: %w", libDir, err)
+		}
+
+		remoteURL := FormatRemoteURL(params.RemoteURLFormat, params.Config.Repo, lib.Name)
+		tag := lib.Version
+
+		tagExists, err := git.RemoteTagExists(ctx, gitExe, remoteURL, tag)
+		if err != nil {
+			if params.DryRunKeepGoing {
+				slog.Warn("failed to check remote tags, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
+				continue
+			}
+			return fmt.Errorf("failed to check remote tags for %s on %s: %w", lib.Name, remoteURL, err)
+		}
+
+		if tagExists {
+			slog.Info("version already tagged on remote repository, skipping", "library", lib.Name, "version", tag, "remote", remoteURL)
+			continue
+		}
+
+		slog.Info("splitting repository for library", "library", lib.Name, "path", libDir, "version", tag, "remote", remoteURL)
+
+		splitSHA, err := Split(ctx, SplitParams{
+			TargetDir: libDir,
+			Origin:    origin,
+			RootFiles: rootFiles,
+			GitExe:    gitExe,
+		})
+		if err != nil {
+			if params.DryRunKeepGoing {
+				slog.Warn("failed to split library, but continuing due to --keep-going", "library", lib.Name, "error", err)
+				continue
+			}
+			return fmt.Errorf("failed to split %s: %w", lib.Name, err)
+		}
+
+		if params.DryRun {
+			slog.Info("[DRY-RUN] Would push to remote", "library", lib.Name, "remote", remoteURL, "branch", remoteBranch, "sha", splitSHA, "tag", tag)
+			continue
+		}
+
+		if err := git.PushBranch(ctx, gitExe, remoteURL, splitSHA, remoteBranch, true); err != nil {
+			if params.DryRunKeepGoing {
+				slog.Warn("failed to push branch, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
+				continue
+			}
+			return fmt.Errorf("failed to push branch for %s to %s: %w", lib.Name, remoteURL, err)
+		}
+
+		if err := git.PushRefToTag(ctx, gitExe, remoteURL, splitSHA, tag, true); err != nil {
+			if params.DryRunKeepGoing {
+				slog.Warn("failed to push tag, but continuing due to --keep-going", "library", lib.Name, "remote", remoteURL, "error", err)
+				continue
+			}
+			return fmt.Errorf("failed to push tag %s for %s to %s: %w", tag, lib.Name, remoteURL, err)
+		}
+
+		slog.Info("successfully published library", "library", lib.Name, "version", tag, "remote", remoteURL)
+	}
+
+	return nil
+}
+
+// FormatRemoteURL constructs the remote repository URL for a library.
+func FormatRemoteURL(format, repo, name string) string {
+	if format != "" {
+		return strings.ReplaceAll(format, "{name}", name)
+	}
+	org := "googleapis"
+	if repo != "" {
+		parts := strings.Split(repo, "/")
+		if len(parts) > 0 && parts[0] != "" {
+			org = parts[0]
+		}
+	}
+	return fmt.Sprintf("git@github.com:%s/%s.git", org, name)
+}
+
+func libraryOutput(lib *config.Library, defaults *config.Default) string {
+	if lib.Output != "" {
+		return lib.Output
+	}
+	if IsMixedLibrary(lib) {
+		return ""
+	}
+	apiPath := ""
+	if len(lib.APIs) > 0 && lib.APIs[0].Path != "" {
+		apiPath = lib.APIs[0].Path
+	}
+	defaultOut := ""
+	if defaults != nil {
+		defaultOut = defaults.Output
+	}
+	return DefaultOutput(apiPath, defaultOut)
+}

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -49,6 +49,8 @@ type PublishParams struct {
 	Origin string
 	// RemoteBranch is the target branch on the remote repository (default: main).
 	RemoteBranch string
+	// Upstream is the name of the upstream git remote (default: upstream).
+	Upstream string
 	// RootFiles is the list of root files to preserve (default: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md).
 	RootFiles []string
 	// GitExe is the path to the git binary (default: command.Git).
@@ -64,7 +66,12 @@ func Publish(ctx context.Context, params PublishParams) error {
 		gitExe = command.Git
 	}
 
-	if err := git.MatchesBranchPoint(ctx, gitExe, config.RemoteUpstream, config.BranchMain); err != nil {
+	upstream := params.Upstream
+	if upstream == "" {
+		upstream = config.RemoteUpstream
+	}
+
+	if err := git.MatchesBranchPoint(ctx, gitExe, upstream, config.BranchMain); err != nil {
 		if params.DryRunKeepGoing {
 			slog.Error("Branch point check failed, but continuing due to --keep-going", "error", err)
 		} else {

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"slices"
+	"path/filepath"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/command"
@@ -102,7 +102,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 		}
 
 		libDir := libraryOutput(lib, params.Config.Default)
-		if len(params.Libraries) > 0 && !slices.Contains(params.Libraries, lib.Name) && !slices.Contains(params.Libraries, libDir) {
+		if len(params.Libraries) > 0 && !matchLibrary(params.Libraries, lib.Name, libDir) {
 			continue
 		}
 
@@ -213,4 +213,16 @@ func libraryOutput(lib *config.Library, defaults *config.Default) string {
 		defaultOut = defaults.Output
 	}
 	return DefaultOutput(apiPath, defaultOut)
+}
+
+func matchLibrary(targets []string, name, dir string) bool {
+	cleanDir := filepath.Clean(dir)
+	baseDir := filepath.Base(cleanDir)
+	for _, target := range targets {
+		cleanTarget := filepath.Clean(target)
+		if target == name || cleanTarget == cleanDir || cleanTarget == baseDir || target == dir {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/command"
@@ -30,6 +31,8 @@ import (
 type PublishParams struct {
 	// Config is the repository configuration.
 	Config *config.Config
+	// Libraries is an optional list of library names or paths to publish.
+	Libraries []string
 	// DryRun indicates whether to run publish without pushing.
 	DryRun bool
 	// DryRunKeepGoing indicates whether to run in dry-run mode without stopping on errors.
@@ -87,6 +90,9 @@ func Publish(ctx context.Context, params PublishParams) error {
 	}
 
 	for _, lib := range params.Config.Libraries {
+		if len(params.Libraries) > 0 && !slices.Contains(params.Libraries, lib.Name) && !slices.Contains(params.Libraries, lib.Output) {
+			continue
+		}
 		if lib.SkipRelease || lib.Version == "" {
 			continue
 		}

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -101,8 +101,8 @@ func Publish(ctx context.Context, params PublishParams) error {
 			continue
 		}
 
-		libDir := libraryOutput(lib, params.Config.Default)
-		if len(params.Libraries) > 0 && !matchLibrary(params.Libraries, lib.Name, libDir) {
+		libDir := packageDirectory(lib, params.Config.Default)
+		if len(params.Libraries) > 0 && !matchLibrary(params.Libraries, lib, libDir) {
 			continue
 		}
 
@@ -155,7 +155,7 @@ func Publish(ctx context.Context, params PublishParams) error {
 			return fmt.Errorf("failed to split %s: %w", lib.Name, err)
 		}
 
-		if params.DryRun {
+		if params.DryRun || params.DryRunKeepGoing {
 			slog.Info("[DRY-RUN] Would push to remote", "library", lib.Name, "remote", remoteURL, "branch", remoteBranch, "sha", splitSHA, "tag", tag)
 			continue
 		}
@@ -215,12 +215,34 @@ func libraryOutput(lib *config.Library, defaults *config.Default) string {
 	return DefaultOutput(apiPath, defaultOut)
 }
 
-func matchLibrary(targets []string, name, dir string) bool {
-	cleanDir := filepath.Clean(dir)
+func packageDirectory(lib *config.Library, defaults *config.Default) string {
+	dir := libraryOutput(lib, defaults)
+	if dir == "" {
+		return ""
+	}
+	current := dir
+	for current != "." && current != "/" && current != "" {
+		if _, err := os.Stat(filepath.Join(current, "Package.swift")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return dir
+}
+
+func matchLibrary(targets []string, lib *config.Library, pkgDir string) bool {
+	cleanDir := filepath.Clean(pkgDir)
 	baseDir := filepath.Base(cleanDir)
 	for _, target := range targets {
 		cleanTarget := filepath.Clean(target)
-		if target == name || cleanTarget == cleanDir || cleanTarget == baseDir || target == dir {
+		if target == lib.Name || cleanTarget == cleanDir || cleanTarget == baseDir || target == pkgDir || target == lib.Output {
+			return true
+		}
+		if lib.Swift != nil && (target == lib.Swift.LibraryNameOverride || target == lib.Swift.PackageNameOverride) {
 			return true
 		}
 	}

--- a/internal/librarian/swift/publish.go
+++ b/internal/librarian/swift/publish.go
@@ -90,16 +90,13 @@ func Publish(ctx context.Context, params PublishParams) error {
 	}
 
 	for _, lib := range params.Config.Libraries {
-		if len(params.Libraries) > 0 && !slices.Contains(params.Libraries, lib.Name) && !slices.Contains(params.Libraries, lib.Output) {
-			continue
-		}
 		if lib.SkipRelease || lib.Version == "" {
 			continue
 		}
 
 		libDir := libraryOutput(lib, params.Config.Default)
-		if libDir == "" {
-			return fmt.Errorf("library %s has no output directory", lib.Name)
+		if len(params.Libraries) > 0 && !slices.Contains(params.Libraries, lib.Name) && !slices.Contains(params.Libraries, libDir) {
+			continue
 		}
 
 		if _, err := os.Stat(libDir); err != nil {

--- a/internal/librarian/swift/publish_test.go
+++ b/internal/librarian/swift/publish_test.go
@@ -37,35 +37,81 @@ func TestFormatRemoteURL(t *testing.T) {
 			name:    "default googleapis",
 			format:  "",
 			repo:    "googleapis/google-cloud-swift",
-			libName: "google-cloud-auth",
-			wantURL: "git@github.com:googleapis/google-cloud-auth.git",
+			libName: "swift-auth",
+			wantURL: "git@github.com:googleapis/swift-auth.git",
 		},
 		{
 			name:    "custom format",
 			format:  "git@github.com:test-org/{name}.git",
 			repo:    "googleapis/google-cloud-swift",
-			libName: "google-cloud-auth",
-			wantURL: "git@github.com:test-org/google-cloud-auth.git",
+			libName: "swift-auth",
+			wantURL: "git@github.com:test-org/swift-auth.git",
 		},
 		{
 			name:    "custom https format",
 			format:  "https://github.com/test-org/{name}.git",
 			repo:    "googleapis/google-cloud-swift",
-			libName: "google-rpc",
-			wantURL: "https://github.com/test-org/google-rpc.git",
+			libName: "swift-google-rpc",
+			wantURL: "https://github.com/test-org/swift-google-rpc.git",
 		},
 		{
 			name:    "empty repo fallback",
 			format:  "",
 			repo:    "",
-			libName: "google-cloud-auth",
-			wantURL: "git@github.com:googleapis/google-cloud-auth.git",
+			libName: "swift-auth",
+			wantURL: "git@github.com:googleapis/swift-auth.git",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := FormatRemoteURL(tc.format, tc.repo, tc.libName)
 			if got != tc.wantURL {
 				t.Errorf("FormatRemoteURL(%q, %q, %q) = %q, want %q", tc.format, tc.repo, tc.libName, got, tc.wantURL)
+			}
+		})
+	}
+}
+
+func TestSplitRepoName(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		libDir string
+		want   string
+	}{
+		{
+			name:   "packages wkt",
+			libDir: "packages/wkt",
+			want:   "swift-wkt",
+		},
+		{
+			name:   "generated google-rpc",
+			libDir: "generated/google-rpc",
+			want:   "swift-google-rpc",
+		},
+		{
+			name:   "packages auth",
+			libDir: "packages/auth",
+			want:   "swift-auth",
+		},
+		{
+			name:   "already prefixed with swift-",
+			libDir: "packages/swift-auth",
+			want:   "swift-auth",
+		},
+		{
+			name:   "empty",
+			libDir: "",
+			want:   "",
+		},
+		{
+			name:   "dot",
+			libDir: ".",
+			want:   "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SplitRepoName(tc.libDir)
+			if got != tc.want {
+				t.Errorf("SplitRepoName(%q) = %q, want %q", tc.libDir, got, tc.want)
 			}
 		})
 	}
@@ -101,8 +147,8 @@ func TestPublishSuccess(t *testing.T) {
 	testhelper.RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
 	testhelper.ConfigNewGitRepository(t)
 	remotesMap := map[string]string{
-		"google-cloud-auth":    authRemote,
-		"google-cloud-storage": storageRemote,
+		"swift-auth":    authRemote,
+		"swift-storage": storageRemote,
 	}
 
 	cfg := &config.Config{
@@ -153,7 +199,7 @@ func TestPublishSuccess(t *testing.T) {
 	}
 
 	// Verify that storage remote now has tag 1.1.0
-	storageBareRepo := filepath.Join(tempDir, "google-cloud-storage.git")
+	storageBareRepo := filepath.Join(tempDir, "swift-storage.git")
 	hasTag, err := git.RemoteTagExists(t.Context(), command.Git, storageBareRepo, "1.1.0")
 	if err != nil {
 		t.Fatal(err)
@@ -176,7 +222,7 @@ func TestPublishDryRun(t *testing.T) {
 	testhelper.ConfigNewGitRepository(t)
 
 	tempDir := t.TempDir()
-	storageBareRepo := filepath.Join(tempDir, "google-cloud-storage.git")
+	storageBareRepo := filepath.Join(tempDir, "swift-auth.git")
 	testhelper.RunGit(t, "clone", "--bare", storageRemote, storageBareRepo)
 
 	cfg := &config.Config{

--- a/internal/librarian/swift/publish_test.go
+++ b/internal/librarian/swift/publish_test.go
@@ -209,3 +209,44 @@ func TestPublishDryRun(t *testing.T) {
 		t.Errorf("tag 1.0.0 was pushed during dry-run; want not pushed")
 	}
 }
+
+func TestPublishEmptyOutputDir(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+
+	monorepoRemote := setupMonorepoWithRootFiles(t)
+	cloneDir := t.TempDir()
+	t.Chdir(cloneDir)
+	testhelper.RunGit(t, "clone", monorepoRemote, ".")
+	testhelper.RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
+	testhelper.ConfigNewGitRepository(t)
+
+	cfg := &config.Config{
+		Language: config.LanguageSwift,
+		Repo:     "googleapis/google-cloud-swift",
+		Libraries: []*config.Library{
+			{
+				Name:    "mixed-lib",
+				Version: "1.0.0",
+				Swift: &config.SwiftPackage{
+					Modules: []*config.SwiftModule{{Output: "Tests/generated", APIPath: "google/storage/v2"}},
+				},
+			},
+		},
+	}
+
+	err := Publish(t.Context(), PublishParams{
+		Config: cfg,
+	})
+	if err == nil {
+		t.Fatal("expected error for library without output directory, got nil")
+	}
+
+	// With DryRunKeepGoing, it should log and continue without error
+	err = Publish(t.Context(), PublishParams{
+		Config:          cfg,
+		DryRunKeepGoing: true,
+	})
+	if err != nil {
+		t.Fatalf("Publish() with DryRunKeepGoing failed: %v", err)
+	}
+}

--- a/internal/librarian/swift/publish_test.go
+++ b/internal/librarian/swift/publish_test.go
@@ -255,57 +255,75 @@ func TestMatchLibrary(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		targets []string
-		libName string
-		libDir  string
+		lib     *config.Library
+		pkgDir  string
 		want    bool
 	}{
 		{
 			name:    "match by name",
 			targets: []string{"google-cloud-wkt"},
-			libName: "google-cloud-wkt",
-			libDir:  "packages/wkt",
+			lib:     &config.Library{Name: "google-cloud-wkt", Output: "packages/wkt/Sources/GoogleCloudWkt/generated"},
+			pkgDir:  "packages/wkt",
 			want:    true,
 		},
 		{
 			name:    "match by relative path",
 			targets: []string{"packages/wkt"},
-			libName: "google-cloud-wkt",
-			libDir:  "packages/wkt",
+			lib:     &config.Library{Name: "google-cloud-wkt", Output: "packages/wkt/Sources/GoogleCloudWkt/generated"},
+			pkgDir:  "packages/wkt",
 			want:    true,
+		},
+		{
+			name:    "match by raw output",
+			targets: []string{"packages/wkt/Sources/GoogleCloudWkt/generated"},
+			lib:     &config.Library{Name: "google-cloud-wkt", Output: "packages/wkt/Sources/GoogleCloudWkt/generated"},
+			pkgDir:  "packages/wkt",
+			want:    true,
+		},
+		{
+			name:    "match by swift override name",
+			targets: []string{"GoogleCloudWkt"},
+			lib: &config.Library{
+				Name:   "google-cloud-wkt",
+				Output: "packages/wkt/Sources/GoogleCloudWkt/generated",
+				Swift:  &config.SwiftPackage{LibraryNameOverride: "GoogleCloudWkt"},
+			},
+			pkgDir: "packages/wkt",
+			want:   true,
 		},
 		{
 			name:    "match by path with trailing slash",
 			targets: []string{"packages/wkt/"},
-			libName: "google-cloud-wkt",
-			libDir:  "packages/wkt",
+			lib:     &config.Library{Name: "google-cloud-wkt", Output: "packages/wkt/Sources/GoogleCloudWkt/generated"},
+			pkgDir:  "packages/wkt",
 			want:    true,
 		},
 		{
 			name:    "match by path with leading dot-slash",
 			targets: []string{"./packages/wkt"},
-			libName: "google-cloud-wkt",
-			libDir:  "packages/wkt",
+			lib:     &config.Library{Name: "google-cloud-wkt", Output: "packages/wkt/Sources/GoogleCloudWkt/generated"},
+			pkgDir:  "packages/wkt",
 			want:    true,
 		},
 		{
 			name:    "match by base directory name",
 			targets: []string{"wkt"},
-			libName: "google-cloud-wkt",
-			libDir:  "packages/wkt",
+			lib:     &config.Library{Name: "google-cloud-wkt", Output: "packages/wkt/Sources/GoogleCloudWkt/generated"},
+			pkgDir:  "packages/wkt",
 			want:    true,
 		},
 		{
 			name:    "no match",
 			targets: []string{"packages/auth"},
-			libName: "google-cloud-wkt",
-			libDir:  "packages/wkt",
+			lib:     &config.Library{Name: "google-cloud-wkt", Output: "packages/wkt/Sources/GoogleCloudWkt/generated"},
+			pkgDir:  "packages/wkt",
 			want:    false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := matchLibrary(tc.targets, tc.libName, tc.libDir)
+			got := matchLibrary(tc.targets, tc.lib, tc.pkgDir)
 			if got != tc.want {
-				t.Errorf("matchLibrary(%v, %q, %q) = %v, want %v", tc.targets, tc.libName, tc.libDir, got, tc.want)
+				t.Errorf("matchLibrary(%v, %v, %q) = %v, want %v", tc.targets, tc.lib.Name, tc.pkgDir, got, tc.want)
 			}
 		})
 	}

--- a/internal/librarian/swift/publish_test.go
+++ b/internal/librarian/swift/publish_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/git"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+func TestFormatRemoteURL(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		format  string
+		repo    string
+		libName string
+		wantURL string
+	}{
+		{
+			name:    "default googleapis",
+			format:  "",
+			repo:    "googleapis/google-cloud-swift",
+			libName: "google-cloud-auth",
+			wantURL: "git@github.com:googleapis/google-cloud-auth.git",
+		},
+		{
+			name:    "custom format",
+			format:  "git@github.com:test-org/{name}.git",
+			repo:    "googleapis/google-cloud-swift",
+			libName: "google-cloud-auth",
+			wantURL: "git@github.com:test-org/google-cloud-auth.git",
+		},
+		{
+			name:    "custom https format",
+			format:  "https://github.com/test-org/{name}.git",
+			repo:    "googleapis/google-cloud-swift",
+			libName: "google-rpc",
+			wantURL: "https://github.com/test-org/google-rpc.git",
+		},
+		{
+			name:    "empty repo fallback",
+			format:  "",
+			repo:    "",
+			libName: "google-cloud-auth",
+			wantURL: "git@github.com:googleapis/google-cloud-auth.git",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatRemoteURL(tc.format, tc.repo, tc.libName)
+			if got != tc.wantURL {
+				t.Errorf("FormatRemoteURL(%q, %q, %q) = %q, want %q", tc.format, tc.repo, tc.libName, got, tc.wantURL)
+			}
+		})
+	}
+}
+
+func setupSplitRemoteRepo(t *testing.T) string {
+	t.Helper()
+	remoteDir := t.TempDir()
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(curDir) }()
+
+	testhelper.ContinueInNewGitRepository(t, remoteDir)
+	if err := os.WriteFile("README.md", []byte("# Remote Repo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "initial remote commit")
+	return remoteDir
+}
+
+func TestPublishSuccess(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+
+	// Create remote split repos for two libraries: auth and storage
+	authRemote := setupSplitRemoteRepo(t)
+	storageRemote := setupSplitRemoteRepo(t)
+
+	// Pre-tag auth on its remote so auth is considered already published
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chdir(authRemote)
+	testhelper.RunGit(t, "tag", "1.0.0")
+	_ = os.Chdir(curDir)
+
+	// Set up monorepo
+	monorepoRemote := setupMonorepoWithRootFiles(t)
+	cloneDir := t.TempDir()
+	t.Chdir(cloneDir)
+	testhelper.RunGit(t, "clone", monorepoRemote, ".")
+	testhelper.RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
+	testhelper.ConfigNewGitRepository(t)
+	remotesMap := map[string]string{
+		"google-cloud-auth":    authRemote,
+		"google-cloud-storage": storageRemote,
+	}
+
+	cfg := &config.Config{
+		Language: config.LanguageSwift,
+		Repo:     "googleapis/google-cloud-swift",
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-auth",
+				Version: "1.0.0",
+				Output:  "packages/auth",
+			},
+			{
+				Name:    "google-cloud-storage",
+				Version: "1.1.0",
+				Output:  "packages/storage",
+			},
+			{
+				Name:        "skipped-lib",
+				Version:     "1.0.0",
+				Output:      "packages/auth",
+				SkipRelease: true,
+			},
+			{
+				Name:    "unversioned-lib",
+				Version: "",
+				Output:  "packages/auth",
+			},
+		},
+	}
+
+	// Publish with dynamic remote format using template
+	// We can use a custom remote URL format using local paths:
+	// For testing, we point FormatRemoteURL to remotesMap entries
+	tempDir := t.TempDir()
+	for name, remotePath := range remotesMap {
+		linkPath := filepath.Join(tempDir, name+".git")
+		testhelper.RunGit(t, "clone", "--bare", remotePath, linkPath)
+	}
+
+	err = Publish(t.Context(), PublishParams{
+		Config:          cfg,
+		RemoteURLFormat: filepath.Join(tempDir, "{name}.git"),
+		Origin:          "HEAD",
+		RemoteBranch:    config.BranchMain,
+	})
+	if err != nil {
+		t.Fatalf("Publish() failed: %v", err)
+	}
+
+	// Verify that storage remote now has tag 1.1.0
+	storageBareRepo := filepath.Join(tempDir, "google-cloud-storage.git")
+	hasTag, err := git.RemoteTagExists(t.Context(), command.Git, storageBareRepo, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasTag {
+		t.Errorf("tag 1.1.0 was not pushed to storage remote")
+	}
+}
+
+func TestPublishDryRun(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+
+	storageRemote := setupSplitRemoteRepo(t)
+
+	monorepoRemote := setupMonorepoWithRootFiles(t)
+	cloneDir := t.TempDir()
+	t.Chdir(cloneDir)
+	testhelper.RunGit(t, "clone", monorepoRemote, ".")
+	testhelper.RunGit(t, "remote", "rename", "origin", config.RemoteUpstream)
+	testhelper.ConfigNewGitRepository(t)
+
+	tempDir := t.TempDir()
+	storageBareRepo := filepath.Join(tempDir, "google-cloud-storage.git")
+	testhelper.RunGit(t, "clone", "--bare", storageRemote, storageBareRepo)
+
+	cfg := &config.Config{
+		Language: config.LanguageSwift,
+		Repo:     "googleapis/google-cloud-swift",
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-storage",
+				Version: "1.0.0",
+				Output:  "packages/auth",
+			},
+		},
+	}
+
+	err := Publish(t.Context(), PublishParams{
+		Config:          cfg,
+		RemoteURLFormat: filepath.Join(tempDir, "{name}.git"),
+		DryRun:          true,
+	})
+	if err != nil {
+		t.Fatalf("Publish() with DryRun failed: %v", err)
+	}
+
+	// Verify tag was NOT pushed
+	hasTag, err := git.RemoteTagExists(t.Context(), command.Git, storageBareRepo, "1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasTag {
+		t.Errorf("tag 1.0.0 was pushed during dry-run; want not pushed")
+	}
+}

--- a/internal/librarian/swift/publish_test.go
+++ b/internal/librarian/swift/publish_test.go
@@ -250,3 +250,63 @@ func TestPublishEmptyOutputDir(t *testing.T) {
 		t.Fatalf("Publish() with DryRunKeepGoing failed: %v", err)
 	}
 }
+
+func TestMatchLibrary(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		targets []string
+		libName string
+		libDir  string
+		want    bool
+	}{
+		{
+			name:    "match by name",
+			targets: []string{"google-cloud-wkt"},
+			libName: "google-cloud-wkt",
+			libDir:  "packages/wkt",
+			want:    true,
+		},
+		{
+			name:    "match by relative path",
+			targets: []string{"packages/wkt"},
+			libName: "google-cloud-wkt",
+			libDir:  "packages/wkt",
+			want:    true,
+		},
+		{
+			name:    "match by path with trailing slash",
+			targets: []string{"packages/wkt/"},
+			libName: "google-cloud-wkt",
+			libDir:  "packages/wkt",
+			want:    true,
+		},
+		{
+			name:    "match by path with leading dot-slash",
+			targets: []string{"./packages/wkt"},
+			libName: "google-cloud-wkt",
+			libDir:  "packages/wkt",
+			want:    true,
+		},
+		{
+			name:    "match by base directory name",
+			targets: []string{"wkt"},
+			libName: "google-cloud-wkt",
+			libDir:  "packages/wkt",
+			want:    true,
+		},
+		{
+			name:    "no match",
+			targets: []string{"packages/auth"},
+			libName: "google-cloud-wkt",
+			libDir:  "packages/wkt",
+			want:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchLibrary(tc.targets, tc.libName, tc.libDir)
+			if got != tc.want {
+				t.Errorf("matchLibrary(%v, %q, %q) = %v, want %v", tc.targets, tc.libName, tc.libDir, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/swift/publish_test.go
+++ b/internal/librarian/swift/publish_test.go
@@ -142,7 +142,7 @@ func TestPublishSuccess(t *testing.T) {
 		testhelper.RunGit(t, "clone", "--bare", remotePath, linkPath)
 	}
 
-	err = Publish(t.Context(), PublishParams{
+	err := Publish(t.Context(), PublishParams{
 		Config:          cfg,
 		RemoteURLFormat: filepath.Join(tempDir, "{name}.git"),
 		Origin:          "HEAD",

--- a/internal/librarian/swift/publish_test.go
+++ b/internal/librarian/swift/publish_test.go
@@ -71,21 +71,18 @@ func TestFormatRemoteURL(t *testing.T) {
 	}
 }
 
-func setupSplitRemoteRepo(t *testing.T) string {
+func setupSplitRemoteRepo(t *testing.T, tag string) string {
 	t.Helper()
 	remoteDir := t.TempDir()
-	curDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chdir(curDir) }()
-
 	testhelper.ContinueInNewGitRepository(t, remoteDir)
 	if err := os.WriteFile("README.md", []byte("# Remote Repo"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	testhelper.RunGit(t, "add", ".")
 	testhelper.RunGit(t, "commit", "-m", "initial remote commit")
+	if tag != "" {
+		testhelper.RunGit(t, "tag", tag)
+	}
 	return remoteDir
 }
 
@@ -93,17 +90,8 @@ func TestPublishSuccess(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 
 	// Create remote split repos for two libraries: auth and storage
-	authRemote := setupSplitRemoteRepo(t)
-	storageRemote := setupSplitRemoteRepo(t)
-
-	// Pre-tag auth on its remote so auth is considered already published
-	curDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = os.Chdir(authRemote)
-	testhelper.RunGit(t, "tag", "1.0.0")
-	_ = os.Chdir(curDir)
+	authRemote := setupSplitRemoteRepo(t, "1.0.0")
+	storageRemote := setupSplitRemoteRepo(t, "")
 
 	// Set up monorepo
 	monorepoRemote := setupMonorepoWithRootFiles(t)
@@ -178,7 +166,7 @@ func TestPublishSuccess(t *testing.T) {
 func TestPublishDryRun(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
 
-	storageRemote := setupSplitRemoteRepo(t)
+	storageRemote := setupSplitRemoteRepo(t, "")
 
 	monorepoRemote := setupMonorepoWithRootFiles(t)
 	cloneDir := t.TempDir()

--- a/internal/librarian/swift/split.go
+++ b/internal/librarian/swift/split.go
@@ -76,7 +76,10 @@ func Split(ctx context.Context, params SplitParams) (string, error) {
 }
 
 func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin string, rootFiles []string) (string, error) {
-	rootEntries := getRootEntries(ctx, gitExe, origin, rootFiles)
+	rootEntries, err := getRootEntries(ctx, gitExe, origin, rootFiles)
+	if err != nil {
+		return "", err
+	}
 	if len(rootEntries) == 0 {
 		return rawSHA, nil
 	}
@@ -191,12 +194,12 @@ func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin str
 	return lastNewCommit, nil
 }
 
-func getRootEntries(ctx context.Context, gitExe, origin string, rootFiles []string) []string {
+func getRootEntries(ctx context.Context, gitExe, origin string, rootFiles []string) ([]string, error) {
 	var entries []string
 	for _, f := range rootFiles {
 		out, err := command.Output(ctx, gitExe, "ls-tree", origin, "--", f)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to ls-tree for %s at %s: %w", f, origin, err)
 		}
 		for line := range strings.SplitSeq(out, "\n") {
 			line = strings.TrimSpace(line)
@@ -205,5 +208,5 @@ func getRootEntries(ctx context.Context, gitExe, origin string, rootFiles []stri
 			}
 		}
 	}
-	return entries
+	return entries, nil
 }

--- a/internal/librarian/swift/split.go
+++ b/internal/librarian/swift/split.go
@@ -76,10 +76,7 @@ func Split(ctx context.Context, params SplitParams) (string, error) {
 }
 
 func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin string, rootFiles []string) (string, error) {
-	rootEntries, err := getRootEntries(ctx, gitExe, origin, rootFiles)
-	if err != nil {
-		return "", err
-	}
+	rootEntries := getRootEntries(ctx, gitExe, origin, rootFiles)
 	if len(rootEntries) == 0 {
 		return rawSHA, nil
 	}
@@ -132,7 +129,7 @@ func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin str
 			return "", fmt.Errorf("failed to get parents for %s: %w", c, err)
 		}
 		var parentArgs []string
-		for _, p := range strings.Fields(parentsOut) {
+		for p := range strings.FieldsSeq(parentsOut) {
 			mappedP := p
 			if mapped, ok := commitMap[p]; ok {
 				mappedP = mapped
@@ -192,7 +189,7 @@ func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin str
 	return lastNewCommit, nil
 }
 
-func getRootEntries(ctx context.Context, gitExe, origin string, rootFiles []string) ([]string, error) {
+func getRootEntries(ctx context.Context, gitExe, origin string, rootFiles []string) []string {
 	var entries []string
 	for _, f := range rootFiles {
 		out, err := command.Output(ctx, gitExe, "ls-tree", origin, "--", f)
@@ -206,5 +203,5 @@ func getRootEntries(ctx context.Context, gitExe, origin string, rootFiles []stri
 			}
 		}
 	}
-	return entries, nil
+	return entries
 }

--- a/internal/librarian/swift/split.go
+++ b/internal/librarian/swift/split.go
@@ -137,34 +137,17 @@ func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin str
 			parentArgs = append(parentArgs, "-p", mappedP)
 		}
 
-		authorName, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%an", c)
+		metaOut, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%an%x00%ae%x00%ad%x00%cn%x00%ce%x00%cd%x00%B", c)
 		if err != nil {
 			return "", err
 		}
-		authorEmail, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%ae", c)
-		if err != nil {
-			return "", err
+		parts := strings.SplitN(metaOut, "\x00", 7)
+		if len(parts) < 7 {
+			return "", fmt.Errorf("failed to parse metadata for commit %s", c)
 		}
-		authorDate, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%ad", c)
-		if err != nil {
-			return "", err
-		}
-		committerName, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%cn", c)
-		if err != nil {
-			return "", err
-		}
-		committerEmail, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%ce", c)
-		if err != nil {
-			return "", err
-		}
-		committerDate, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%cd", c)
-		if err != nil {
-			return "", err
-		}
-		commitMsg, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%B", c)
-		if err != nil {
-			return "", err
-		}
+		authorName, authorEmail, authorDate := parts[0], parts[1], parts[2]
+		committerName, committerEmail, committerDate := parts[3], parts[4], parts[5]
+		commitMsg := parts[6]
 
 		env := map[string]string{
 			"GIT_AUTHOR_NAME":     authorName,

--- a/internal/librarian/swift/split.go
+++ b/internal/librarian/swift/split.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/git"
+)
+
+var (
+	// DefaultRootFiles are the root files preserved on every commit in the split repository.
+	DefaultRootFiles = []string{"LICENSE", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md"}
+)
+
+// SplitParams holds parameters for splitting a subdirectory out of the monorepo.
+type SplitParams struct {
+	// TargetDir is the directory path relative to the monorepo root (e.g. packages/auth, generated/google-rpc).
+	TargetDir string
+	// Origin is the source commit or branch to split from (default: HEAD).
+	Origin string
+	// RootFiles is the list of root files to preserve across every commit.
+	RootFiles []string
+	// GitExe is the path to the git binary (default: command.Git).
+	GitExe string
+}
+
+// Split splits a subdirectory from the repository into a standalone commit history,
+// placing the subtree contents at the root and preserving specified root files on every commit.
+// It returns the resulting 40-character commit hash.
+func Split(ctx context.Context, params SplitParams) (string, error) {
+	gitExe := params.GitExe
+	if gitExe == "" {
+		gitExe = command.Git
+	}
+	origin := params.Origin
+	if origin == "" {
+		origin = "HEAD"
+	}
+	targetDir := strings.Trim(params.TargetDir, "/")
+	if targetDir == "" {
+		return "", errors.New("target directory cannot be empty")
+	}
+
+	rawSHA, err := git.SubtreeSplit(ctx, gitExe, targetDir, origin)
+	if err != nil {
+		return "", err
+	}
+
+	rootFiles := params.RootFiles
+	if rootFiles == nil {
+		rootFiles = DefaultRootFiles
+	}
+	if len(rootFiles) == 0 {
+		return rawSHA, nil
+	}
+
+	return rewriteHistoryWithRootFiles(ctx, gitExe, rawSHA, origin, rootFiles)
+}
+
+func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin string, rootFiles []string) (string, error) {
+	rootEntries, err := getRootEntries(ctx, gitExe, origin, rootFiles)
+	if err != nil {
+		return "", err
+	}
+	if len(rootEntries) == 0 {
+		return rawSHA, nil
+	}
+
+	revOutput, err := command.Output(ctx, gitExe, "rev-list", "--reverse", "--topo-order", rawSHA)
+	if err != nil {
+		return "", fmt.Errorf("failed to get commit list for %s: %w", rawSHA, err)
+	}
+	commits := strings.Fields(revOutput)
+	if len(commits) == 0 {
+		return rawSHA, nil
+	}
+
+	commitMap := make(map[string]string, len(commits))
+	lastNewCommit := rawSHA
+
+	for _, c := range commits {
+		treeOut, err := command.Output(ctx, gitExe, "ls-tree", c)
+		if err != nil {
+			return "", fmt.Errorf("failed to ls-tree for %s: %w", c, err)
+		}
+
+		var currentEntries []string
+		for line := range strings.SplitSeq(treeOut, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			parts := strings.Split(line, "\t")
+			if len(parts) >= 2 {
+				filename := parts[len(parts)-1]
+				if slices.Contains(rootFiles, filename) {
+					continue
+				}
+			}
+			currentEntries = append(currentEntries, line)
+		}
+
+		combined := append(currentEntries, rootEntries...)
+		mktreeInput := strings.Join(combined, "\n") + "\n"
+
+		newTree, err := command.OutputWithStdin(ctx, strings.NewReader(mktreeInput), gitExe, "mktree")
+		if err != nil {
+			return "", fmt.Errorf("git mktree failed for %s: %w", c, err)
+		}
+		newTree = strings.TrimSpace(newTree)
+
+		parentsOut, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=%P", c)
+		if err != nil {
+			return "", fmt.Errorf("failed to get parents for %s: %w", c, err)
+		}
+		var parentArgs []string
+		for _, p := range strings.Fields(parentsOut) {
+			mappedP := p
+			if mapped, ok := commitMap[p]; ok {
+				mappedP = mapped
+			}
+			parentArgs = append(parentArgs, "-p", mappedP)
+		}
+
+		authorName, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%an", c)
+		if err != nil {
+			return "", err
+		}
+		authorEmail, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%ae", c)
+		if err != nil {
+			return "", err
+		}
+		authorDate, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%ad", c)
+		if err != nil {
+			return "", err
+		}
+		committerName, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%cn", c)
+		if err != nil {
+			return "", err
+		}
+		committerEmail, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%ce", c)
+		if err != nil {
+			return "", err
+		}
+		committerDate, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%cd", c)
+		if err != nil {
+			return "", err
+		}
+		commitMsg, err := command.Output(ctx, gitExe, "log", "-n", "1", "--pretty=format:%B", c)
+		if err != nil {
+			return "", err
+		}
+
+		env := map[string]string{
+			"GIT_AUTHOR_NAME":     authorName,
+			"GIT_AUTHOR_EMAIL":    authorEmail,
+			"GIT_AUTHOR_DATE":     authorDate,
+			"GIT_COMMITTER_NAME":  committerName,
+			"GIT_COMMITTER_EMAIL": committerEmail,
+			"GIT_COMMITTER_DATE":  committerDate,
+		}
+		args := []string{"-c", "commit.gpgsign=false", "commit-tree", newTree}
+		args = append(args, parentArgs...)
+
+		newCommit, err := command.OutputWithStdinAndEnv(ctx, strings.NewReader(commitMsg), env, gitExe, args...)
+		if err != nil {
+			return "", fmt.Errorf("git commit-tree failed for %s: %w", c, err)
+		}
+		newCommit = strings.TrimSpace(newCommit)
+		commitMap[c] = newCommit
+		lastNewCommit = newCommit
+	}
+
+	return lastNewCommit, nil
+}
+
+func getRootEntries(ctx context.Context, gitExe, origin string, rootFiles []string) ([]string, error) {
+	var entries []string
+	for _, f := range rootFiles {
+		out, err := command.Output(ctx, gitExe, "ls-tree", origin, "--", f)
+		if err != nil {
+			continue
+		}
+		for line := range strings.SplitSeq(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				entries = append(entries, line)
+			}
+		}
+	}
+	return entries, nil
+}

--- a/internal/librarian/swift/split.go
+++ b/internal/librarian/swift/split.go
@@ -115,7 +115,26 @@ func rewriteHistoryWithRootFiles(ctx context.Context, gitExe, rawSHA, origin str
 			currentEntries = append(currentEntries, line)
 		}
 
+		// Git tree objects require entries to be sorted alphabetically, with tree
+		// objects sorted as if they have a trailing slash. Unsorted entries cause git fsck to fail.
 		combined := append(currentEntries, rootEntries...)
+		slices.SortFunc(combined, func(a, b string) int {
+			partsA := strings.SplitN(a, "\t", 2)
+			partsB := strings.SplitN(b, "\t", 2)
+			if len(partsA) < 2 || len(partsB) < 2 {
+				return strings.Compare(a, b)
+			}
+			nameA, nameB := partsA[1], partsB[1]
+			isTreeA := strings.Contains(partsA[0], " tree ")
+			isTreeB := strings.Contains(partsB[0], " tree ")
+			if isTreeA {
+				nameA += "/"
+			}
+			if isTreeB {
+				nameB += "/"
+			}
+			return strings.Compare(nameA, nameB)
+		})
 		mktreeInput := strings.Join(combined, "\n") + "\n"
 
 		newTree, err := command.OutputWithStdin(ctx, strings.NewReader(mktreeInput), gitExe, "mktree")

--- a/internal/librarian/swift/split_test.go
+++ b/internal/librarian/swift/split_test.go
@@ -104,6 +104,8 @@ func TestSplitSuccess(t *testing.T) {
 			}
 		}
 	}
+
+	testhelper.RunGit(t, "fsck", "--full")
 }
 
 func TestSplitNoRootFiles(t *testing.T) {

--- a/internal/librarian/swift/split_test.go
+++ b/internal/librarian/swift/split_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/command"
+	"github.com/googleapis/librarian/internal/testhelper"
+)
+
+func setupMonorepoWithRootFiles(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	testhelper.ContinueInNewGitRepository(t, repoDir)
+
+	for _, f := range DefaultRootFiles {
+		if err := os.WriteFile(f, []byte("contents of "+f), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	authDir := filepath.Join("packages", "auth")
+	testhelper.AddSwiftPackage(t, authDir, "GoogleCloudAuth")
+	storageDir := filepath.Join("packages", "storage")
+	testhelper.AddSwiftPackage(t, storageDir, "GoogleCloudStorage")
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "feat: initial commit with auth and storage")
+
+	// Add a second commit to the package
+	authFile := filepath.Join(authDir, "Sources", "GoogleCloudAuth", "Auth.swift")
+	if err := os.WriteFile(authFile, []byte("// new auth code"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "feat: update auth logic")
+
+	return repoDir
+}
+
+func TestSplitSuccess(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+	setupMonorepoWithRootFiles(t)
+
+	splitSHA, err := Split(t.Context(), SplitParams{
+		TargetDir: "packages/auth",
+		Origin:    "HEAD",
+	})
+	if err != nil {
+		t.Fatalf("Split() failed: %v", err)
+	}
+	if len(splitSHA) != 40 {
+		t.Fatalf("Split() = %q, want 40-character SHA", splitSHA)
+	}
+
+	// Verify root files exist in the split commit
+	lsOut, err := command.Output(t.Context(), command.Git, "ls-tree", "--name-only", splitSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := strings.Fields(lsOut)
+	for _, expectedFile := range []string{"LICENSE", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md", "Package.swift", "Sources"} {
+		found := false
+		for _, f := range files {
+			if f == expectedFile {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected file %q in split tree, got files: %v", expectedFile, files)
+		}
+	}
+
+	// Verify all commits in history contain root files
+	revListOut, err := command.Output(t.Context(), command.Git, "rev-list", splitSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commits := strings.Fields(revListOut)
+	if len(commits) < 2 {
+		t.Errorf("expected at least 2 commits in split history, got %d", len(commits))
+	}
+	for _, c := range commits {
+		tree, err := command.Output(t.Context(), command.Git, "ls-tree", "--name-only", c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cFiles := strings.Fields(tree)
+		for _, rf := range DefaultRootFiles {
+			found := false
+			for _, f := range cFiles {
+				if f == rf {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("commit %s missing root file %s; found: %v", c, rf, cFiles)
+			}
+		}
+	}
+}
+
+func TestSplitNoRootFiles(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+	setupMonorepoWithRootFiles(t)
+
+	splitSHA, err := Split(t.Context(), SplitParams{
+		TargetDir: "packages/auth",
+		Origin:    "HEAD",
+		RootFiles: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Split() failed: %v", err)
+	}
+
+	lsOut, err := command.Output(t.Context(), command.Git, "ls-tree", "--name-only", splitSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := strings.Fields(lsOut)
+	for _, unexpectedFile := range DefaultRootFiles {
+		for _, f := range files {
+			if f == unexpectedFile {
+				t.Errorf("unexpected file %q in split tree when RootFiles is empty", unexpectedFile)
+			}
+		}
+	}
+}
+
+func TestSplitEmptyTargetDir(t *testing.T) {
+	testhelper.RequireCommand(t, "git")
+	setupMonorepoWithRootFiles(t)
+
+	_, err := Split(t.Context(), SplitParams{
+		TargetDir: "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty target dir, got nil")
+	}
+}

--- a/internal/librarian/swift/split_test.go
+++ b/internal/librarian/swift/split_test.go
@@ -17,6 +17,7 @@ package swift
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -75,13 +76,7 @@ func TestSplitSuccess(t *testing.T) {
 	}
 	files := strings.Fields(lsOut)
 	for _, expectedFile := range []string{"LICENSE", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md", "Package.swift", "Sources"} {
-		found := false
-		for _, f := range files {
-			if f == expectedFile {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(files, expectedFile)
 		if !found {
 			t.Errorf("expected file %q in split tree, got files: %v", expectedFile, files)
 		}
@@ -103,13 +98,7 @@ func TestSplitSuccess(t *testing.T) {
 		}
 		cFiles := strings.Fields(tree)
 		for _, rf := range DefaultRootFiles {
-			found := false
-			for _, f := range cFiles {
-				if f == rf {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(cFiles, rf)
 			if !found {
 				t.Errorf("commit %s missing root file %s; found: %v", c, rf, cFiles)
 			}


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-swift/issues/450

Implements `librarian publish` for Swift to support publishing individual client libraries from the monorepo to standalone split repositories, following [go/cloud-swift:split-repo-publishing](http://goto.google.com/cloud-swift:split-repo-publishing)

Example repo publish:
* https://github.com/chingor13/swift-wkt
* https://github.com/chingor13/swift-auth

### Usage

```bash
# Preview what will be split, tagged, and pushed without modifying remotes (Dry Run)
librarian publish --dry-run

# Publish all packages (checks remote tags and only splits/pushes unreleased versions)
librarian publish

# Dry run a single library
librarian publish --dry-run google-cloud-auth

# Publish a single library to its remote repository
librarian publish google-cloud-auth

# You can also use the output path directly:
librarian publish --dry-run packages/auth

# Dry run publishing a single subrepo to a personal/staging GitHub org
librarian publish --dry-run \
  --remote-url-format="git@github.com:my-staging-org/{name}.git" \
  google-cloud-auth

# Publish all packages to a staging org
librarian publish \
  --remote-url-format="git@github.com:my-staging-org/{name}.git"

# Using HTTPS URLs (e.g. in CI with access tokens)
librarian publish \
  --remote-url-format="https://github.com/my-staging-org/{name}.git" \
  google-cloud-auth

# Split from a specific release commit/tag and push to a custom branch
librarian publish \
  --origin=release-2026-08-24 \
  --remote-branch=main \
  google-cloud-auth

# Stream verbose git execution logs
librarian publish -v --dry-run

# Continue running across all libraries even if one encounters an error (useful for multi-package CI validation)
librarian publish --dry-run-keep-going
```



### Changes

- **Subtree Splitting & History Rewriting (`internal/librarian/swift/split.go`)**:
  - Implements `swift.Split` to run `git subtree split` for a specified library output directory.
  - Rewrites the extracted commit history using Git plumbing (`git ls-tree`, `git mktree`, `git commit-tree`) to preserve root repository files (`LICENSE`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`) across every commit in the split history.
  - Preserves commit parent relationships, commit messages, author metadata, and committer timestamps without requiring interactive GPG signing.

- **Swift Publish Workflow (`internal/librarian/swift/publish.go`)**:
  - Implements `swift.Publish` to iterate through `cfg.Libraries` in `librarian.yaml`, skipping unversioned or `SkipRelease: true` packages.
  - Resolves target split repository URLs using `--remote-url-format` or defaults based on `cfg.Repo` (`git@github.com:<org>/<name>.git`).
  - Performs idempotency checks via `git ls-remote --tags` against the remote repository for `refs/tags/<version>`, skipping libraries that have already been tagged.
  - Pushes the rewritten branch (`refs/heads/<remoteBranch>`) and release tag (`refs/tags/<version>`) to the split repository.
  - Supports `--dry-run` and `--dry-run-keep-going` modes.

- **CLI Integration (`internal/librarian/publish.go`)**:
  - Registers Swift publish support in `publishCommand()`.
  - Adds `--remote-url-format`, `--origin`, and `--remote-branch` flags.

- **Plumbing Helpers (`internal/command`, `internal/git`)**:
  - Adds `command.OutputWithStdin` and `command.OutputWithStdinAndEnv`.
  - Adds `git.RemoteTagExists`, `git.SubtreeSplit`, `git.PushBranch`, `git.PushTag`, and `git.PushRefToTag`.

- **Testing**:
  - Adds unit and integration tests in `internal/librarian/swift/split_test.go`, `internal/librarian/swift/publish_test.go`, and `internal/librarian/publish_test.go` covering history rewriting, root file preservation, remote tag checks, dry-run simulation, and CLI routing.