### PR TITLE
feat(sidekick/swift): clients are `Sendable`

### DIFF
--- a/internal/sidekick/swift/generate_deprecated_service_test.go
+++ b/internal/sidekick/swift/generate_deprecated_service_test.go
@@ -34,14 +34,14 @@ func TestGenerateService_Deprecated(t *testing.T) {
 		{
 			name:         "deprecated",
 			deprecated:   true,
-			wantClient:   "/// @Snippet(path: \"DeprecatedServiceQuickstart\")\n@available(*, deprecated)\npublic class DeprecatedServiceClient",
-			wantProtocol: "/// and pass a mock implementation in your tests.\n  @available(*, deprecated)\n  public protocol DeprecatedServiceProtocol",
+			wantClient:   "/// @Snippet(path: \"DeprecatedServiceQuickstart\")\n@available(*, deprecated)\npublic final class DeprecatedServiceClient: ",
+			wantProtocol: "/// and pass a mock implementation in your tests.\n  @available(*, deprecated)\n  public protocol DeprecatedServiceProtocol ",
 		},
 		{
 			name:         "not-deprecated",
 			deprecated:   false,
-			wantClient:   "/// @Snippet(path: \"DeprecatedServiceQuickstart\")\npublic class DeprecatedServiceClient",
-			wantProtocol: "/// and pass a mock implementation in your tests.\n  public protocol DeprecatedServiceProtocol",
+			wantClient:   "/// @Snippet(path: \"DeprecatedServiceQuickstart\")\npublic final class DeprecatedServiceClient: ",
+			wantProtocol: "/// and pass a mock implementation in your tests.\n  public protocol DeprecatedServiceProtocol ",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -70,11 +70,11 @@ func TestGenerateService_Deprecated(t *testing.T) {
 			}
 			contentStr := string(content)
 
-			got := extractBlock(t, contentStr, `/// @Snippet(path: "DeprecatedServiceQuickstart")`, "public class DeprecatedServiceClient")
+			got := extractBlock(t, contentStr, `/// @Snippet(path: "DeprecatedServiceQuickstart")`, "public final class DeprecatedServiceClient: ")
 			if diff := cmp.Diff(test.wantClient, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
-			got = extractBlock(t, contentStr, `/// and pass a mock implementation in your tests.`, "public protocol DeprecatedServiceProtocol")
+			got = extractBlock(t, contentStr, `/// and pass a mock implementation in your tests.`, "public protocol DeprecatedServiceProtocol ")
 			if diff := cmp.Diff(test.wantProtocol, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/sidekick/swift/generate_service_comments_test.go
+++ b/internal/sidekick/swift/generate_service_comments_test.go
@@ -96,8 +96,8 @@ func TestGenerateService_DocComments(t *testing.T) {
 	contentStr := string(content)
 
 	// Verify service documentation
-	want := "/// Documentation for SecretManager service.\n///\n/// @Snippet(path: \"SecretManagerQuickstart\")\npublic class SecretManagerClient"
-	got := extractBlock(t, contentStr, "/// Documentation for SecretManager service.", "public class SecretManagerClient")
+	want := "/// Documentation for SecretManager service.\n///\n/// @Snippet(path: \"SecretManagerQuickstart\")\npublic final class SecretManagerClient: "
+	got := extractBlock(t, contentStr, "/// Documentation for SecretManager service.", "public final class SecretManagerClient: ")
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/sidekick/swift/generate_storage_test.go
+++ b/internal/sidekick/swift/generate_storage_test.go
@@ -275,7 +275,7 @@ func TestGenerateStorage_MultiModel(t *testing.T) {
 	if !strings.Contains(clientStr, "// Copyright 2026 Google LLC") {
 		t.Errorf("StorageControlClient.swift missing Copyright header:\n%s", clientStr)
 	}
-	if !strings.Contains(clientStr, "public class StorageControlClient: StorageControlProtocol {") {
+	if !strings.Contains(clientStr, "public final class StorageControlClient: StorageControlProtocol, Sendable {") {
 		t.Errorf("StorageControlClient.swift missing class declaration:\n%s", clientStr)
 	}
 	if !strings.Contains(clientStr, "private let storage: any Clients.StorageStub") ||

--- a/internal/sidekick/swift/generate_stub_test.go
+++ b/internal/sidekick/swift/generate_stub_test.go
@@ -81,8 +81,8 @@ func TestGenerateStub_Structure(t *testing.T) {
 	}
 	stubContentStr := string(stubContent)
 
-	got := extractBlock(t, stubContentStr, `  protocol ProtocolStub {`, "\n"+`  }`)
-	want := `  protocol ProtocolStub {
+	got := extractBlock(t, stubContentStr, `  protocol ProtocolStub: Sendable {`, "\n"+`  }`)
+	want := `  protocol ProtocolStub: Sendable {
     func getThing(
     request: SomeTestPackage.Request, options: GoogleCloudGax.RequestOptions
 ) async throws -> SomeTestPackage.Response
@@ -99,8 +99,8 @@ func TestGenerateStub_Structure(t *testing.T) {
 	}
 	transportContentStr := string(transportContent)
 
-	got = extractBlock(t, transportContentStr, `  class ProtocolTransport: `, `HTTPClient`)
-	want = `  class ProtocolTransport: ProtocolStub {
+	got = extractBlock(t, transportContentStr, `  final class ProtocolTransport: `, `HTTPClient`)
+	want = `  final class ProtocolTransport: ProtocolStub {
     let inner: GoogleCloudGax._HTTPClient`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -426,7 +426,7 @@ func TestGenerateStub_Grpc(t *testing.T) {
 		t.Fatal(err)
 	}
 	stubStr := string(stubContent)
-	if !strings.Contains(stubStr, "protocol StorageControlStub {") {
+	if !strings.Contains(stubStr, "protocol StorageControlStub: Sendable {") {
 		t.Errorf("stub file missing StorageControlStub protocol:\n%s", stubStr)
 	}
 	if !strings.Contains(stubStr, "func createFolder(") || !strings.Contains(stubStr, "func deleteFolder(") || !strings.Contains(stubStr, "func getOperation(") {
@@ -449,7 +449,7 @@ func TestGenerateStub_Grpc(t *testing.T) {
 	}
 
 	// Check gRPC Transport class definition and inner client
-	if !strings.Contains(transportStr, "class StorageControlTransport: StorageControlStub {") {
+	if !strings.Contains(transportStr, "final class StorageControlTransport: StorageControlStub {") {
 		t.Errorf("transport missing StorageControlTransport class declaration:\n%s", transportStr)
 	}
 	if !strings.Contains(transportStr, "let inner: GoogleCloudGaxGRPC._GRPCClient") {

--- a/internal/sidekick/swift/templates/common/service.swift.mustache
+++ b/internal/sidekick/swift/templates/common/service.swift.mustache
@@ -41,7 +41,7 @@ import GoogleCloudGax
 {{#Deprecated}}
 @available(*, deprecated)
 {{/Deprecated}}
-public class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol {
+public final class {{Codec.ClientName}}: Clients.{{Codec.StubPrefix}}Protocol, Sendable {
   let inner: any Clients.{{Codec.StubPrefix}}Stub
   {{#Codec.HasLROs}}
   let pollingErrorPolicy: GoogleCloudGax.PollingErrorPolicy

--- a/internal/sidekick/swift/templates/common/stub.swift.mustache
+++ b/internal/sidekick/swift/templates/common/stub.swift.mustache
@@ -30,7 +30,7 @@ import {{.}}
 import GoogleCloudGax
 
 extension Clients {
-  protocol {{Codec.StubPrefix}}Stub {
+  protocol {{Codec.StubPrefix}}Stub: Sendable {
     {{#Codec.Methods}}
     func {{> /templates/common/method_signature/request_options}}
     {{/Codec.Methods}}

--- a/internal/sidekick/swift/templates/grpc/transport.swift.mustache
+++ b/internal/sidekick/swift/templates/grpc/transport.swift.mustache
@@ -37,7 +37,7 @@ internal import GoogleCloudWktConvert
 internal import SwiftProtobuf
 
 extension Clients {
-  class {{Codec.StubPrefix}}Transport: {{Codec.StubPrefix}}Stub {
+  final class {{Codec.StubPrefix}}Transport: {{Codec.StubPrefix}}Stub {
     let inner: GoogleCloudGaxGRPC._GRPCClient
 
     public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {

--- a/internal/sidekick/swift/templates/http/transport.swift.mustache
+++ b/internal/sidekick/swift/templates/http/transport.swift.mustache
@@ -34,7 +34,7 @@ import {{.}}
 @_spi(GoogleCloudInternal) import GoogleCloudGax
 
 extension Clients {
-  class {{Codec.StubPrefix}}Transport: {{Codec.StubPrefix}}Stub {
+  final class {{Codec.StubPrefix}}Transport: {{Codec.StubPrefix}}Stub {
     let inner: GoogleCloudGax._HTTPClient
 
     public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {

--- a/internal/sidekick/swift/templates/storage/StorageControlClient.swift.mustache
+++ b/internal/sidekick/swift/templates/storage/StorageControlClient.swift.mustache
@@ -30,7 +30,7 @@ import {{.}}
 
 /// A client for Google Cloud Storage control-plane and administrative operations that unifies bucket lifecycle,
 /// IAM access control, object metadata, and control-plane features (folders, caches, intelligence).
-public class StorageControlClient: StorageControlProtocol {
+public final class StorageControlClient: StorageControlProtocol, Sendable {
   private let storage: any Clients.StorageStub
   private let control: any Clients.StorageControlStub
 


### PR DESCRIPTION
Mark the client type as `Sendable`, which in turn requires the class to be `final`. This requires the (internal to the package) stubs to be sendable too, which also means a number of classes are final.

Towards https://github.com/googleapis/google-cloud-swift/issues/515 and https://github.com/googleapis/google-cloud-swift/issues/525

The output is available at: https://github.com/googleapis/google-cloud-swift/pull/532 