### PR TITLE
feat(librarian): preserve YAML comments

### DIFF
--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -76,15 +76,74 @@ func Read[T any](path string) (*T, error) {
 	return Unmarshal[T](data)
 }
 
-// Write marshals a value to YAML, formats it with yamlfmt, adds a copyright header
-// and writes it to a file.
-func Write(path string, v any) error {
-	data, err := Marshal(v)
-	if err != nil {
-		return err
+// MarshalWithComments converts a value to formatted YAML, retaining comments
+// from the original YAML document where elements match.
+func MarshalWithComments(v any, original []byte) ([]byte, error) {
+	if len(original) == 0 {
+		return Marshal(v)
 	}
+	var origNode yaml.Node
+	if err := yaml.Unmarshal(original, &origNode); err != nil {
+		return Marshal(v)
+	}
+	var newNode yaml.Node
+	if n, ok := v.(*yaml.Node); ok {
+		if n.Kind == yaml.DocumentNode {
+			newNode = *n
+		} else {
+			newNode = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{n}}
+		}
+	} else if n, ok := v.(yaml.Node); ok {
+		if n.Kind == yaml.DocumentNode {
+			newNode = n
+		} else {
+			newNode = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{&n}}
+		}
+	} else {
+		data, err := yaml.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		if err := yaml.Unmarshal(data, &newNode); err != nil {
+			return nil, err
+		}
+	}
+	transferComments(&origNode, &newNode)
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&newNode); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return format(buf.Bytes())
+}
 
-	// Add # comment prefix to each line of the license header.
+// Write marshals a value to YAML, formats it with yamlfmt, adds or preserves
+// a copyright header and comments, and writes it to a file.
+func Write(path string, v any) error {
+	var data []byte
+	existing, err := os.ReadFile(path)
+	if err == nil && len(existing) > 0 {
+		data, err = MarshalWithComments(v, existing)
+		if err != nil {
+			return err
+		}
+	} else {
+		data, err = Marshal(v)
+		if err != nil {
+			return err
+		}
+	}
+	if !hasLicenseHeader(data) {
+		data = append([]byte(licenseHeader()), data...)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func licenseHeader() string {
 	var b strings.Builder
 	year := time.Now().Year()
 	for _, line := range license.Header(strconv.Itoa(year)) {
@@ -92,10 +151,132 @@ func Write(path string, v any) error {
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
-	header := b.String()
+	return b.String()
+}
 
-	data = append([]byte(header), data...)
-	return os.WriteFile(path, data, 0o644)
+func hasLicenseHeader(data []byte) bool {
+	return bytes.Contains(data, []byte("Licensed under the Apache License, Version 2.0"))
+}
+
+func transferComments(src, dst *yaml.Node) {
+	if src == nil || dst == nil {
+		return
+	}
+	if src.Kind == yaml.DocumentNode && dst.Kind == yaml.DocumentNode {
+		if dst.HeadComment == "" {
+			dst.HeadComment = src.HeadComment
+		}
+		if dst.FootComment == "" {
+			dst.FootComment = src.FootComment
+		}
+		if len(src.Content) > 0 && len(dst.Content) > 0 {
+			transferComments(src.Content[0], dst.Content[0])
+		}
+		return
+	}
+	if dst.HeadComment == "" {
+		dst.HeadComment = src.HeadComment
+	}
+	if dst.LineComment == "" {
+		dst.LineComment = src.LineComment
+	}
+	if dst.FootComment == "" {
+		dst.FootComment = src.FootComment
+	}
+	switch dst.Kind {
+	case yaml.MappingNode:
+		if src.Kind != yaml.MappingNode {
+			return
+		}
+		type pair struct {
+			key *yaml.Node
+			val *yaml.Node
+		}
+		srcMap := make(map[string]pair, len(src.Content)/2)
+		for i := 0; i+1 < len(src.Content); i += 2 {
+			srcMap[src.Content[i].Value] = pair{key: src.Content[i], val: src.Content[i+1]}
+		}
+		for i := 0; i+1 < len(dst.Content); i += 2 {
+			dk := dst.Content[i]
+			dv := dst.Content[i+1]
+			if sp, ok := srcMap[dk.Value]; ok {
+				if dk.HeadComment == "" {
+					dk.HeadComment = sp.key.HeadComment
+				}
+				if dk.LineComment == "" {
+					dk.LineComment = sp.key.LineComment
+				}
+				if dk.FootComment == "" {
+					dk.FootComment = sp.key.FootComment
+				}
+				transferComments(sp.val, dv)
+			}
+		}
+	case yaml.SequenceNode:
+		if src.Kind != yaml.SequenceNode {
+			return
+		}
+		matchedSrc := make(map[int]bool)
+		// First pass: match mappings by identifier.
+		for _, ditem := range dst.Content {
+			if ditem.Kind == yaml.MappingNode {
+				ident := nodeIdentifier(ditem)
+				if ident != "" {
+					for si, sitem := range src.Content {
+						if !matchedSrc[si] && sitem.Kind == yaml.MappingNode && nodeIdentifier(sitem) == ident {
+							matchedSrc[si] = true
+							transferComments(sitem, ditem)
+							break
+						}
+					}
+				}
+			}
+		}
+		// Second pass: match scalars by value.
+		for _, ditem := range dst.Content {
+			if ditem.Kind == yaml.ScalarNode {
+				for si, sitem := range src.Content {
+					if !matchedSrc[si] && sitem.Kind == yaml.ScalarNode && sitem.Value == ditem.Value {
+						matchedSrc[si] = true
+						transferComments(sitem, ditem)
+						break
+					}
+				}
+			}
+		}
+		// Third pass: match remaining items that do not have an identifier by position.
+		srcIdx := 0
+		for _, ditem := range dst.Content {
+			if ditem.Kind == yaml.MappingNode && nodeIdentifier(ditem) != "" {
+				continue
+			}
+			if ditem.HeadComment != "" || ditem.LineComment != "" {
+				continue
+			}
+			for srcIdx < len(src.Content) && (matchedSrc[srcIdx] || (src.Content[srcIdx].Kind == yaml.MappingNode && nodeIdentifier(src.Content[srcIdx]) != "")) {
+				srcIdx++
+			}
+			if srcIdx < len(src.Content) {
+				matchedSrc[srcIdx] = true
+				transferComments(src.Content[srcIdx], ditem)
+				srcIdx++
+			}
+		}
+	}
+}
+
+func nodeIdentifier(n *yaml.Node) string {
+	if n.Kind != yaml.MappingNode {
+		return ""
+	}
+	for _, idKey := range []string{"name", "path", "id"} {
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			if n.Content[i].Value == idKey && n.Content[i+1].Kind == yaml.ScalarNode {
+				return idKey + ":" + n.Content[i+1].Value
+			}
+		}
+	}
+	return ""
 }
 
 // Empty returns whether the given value serializes to an empty YAML object

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"go.yaml.in/yaml/v3"
 )
 
 type testConfig struct {
@@ -63,6 +64,180 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
+func TestMarshal_Comments(t *testing.T) {
+	const input = `# Header comment
+name: test # Inline comment
+# Version comment
+version: v1.0.0
+`
+	t.Run("struct drops comments", func(t *testing.T) {
+		cfg, err := Unmarshal[testConfig]([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := Marshal(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		const want = `name: test
+version: v1.0.0
+`
+		if diff := cmp.Diff(want, string(got)); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("yaml.Node preserves comments", func(t *testing.T) {
+		node, err := Unmarshal[yaml.Node]([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := Marshal(node)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(input, string(got)); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("yaml.Node preserves comments after mutation", func(t *testing.T) {
+		node, err := Unmarshal[yaml.Node]([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mapping := node.Content[0]
+		for i := 0; i < len(mapping.Content); i += 2 {
+			if mapping.Content[i].Value == "version" {
+				mapping.Content[i+1].Value = "v2.0.0"
+			}
+		}
+		got, err := Marshal(node)
+		if err != nil {
+			t.Fatal(err)
+		}
+		const want = `# Header comment
+name: test # Inline comment
+# Version comment
+version: v2.0.0
+`
+		if diff := cmp.Diff(want, string(got)); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMarshalWithComments(t *testing.T) {
+	type item struct {
+		Name string `yaml:"name"`
+		Path string `yaml:"path,omitempty"`
+	}
+	type itemConfig struct {
+		Items []item   `yaml:"items,omitempty"`
+		Roots []string `yaml:"roots,omitempty"`
+	}
+
+	for _, test := range []struct {
+		name     string
+		original string
+		value    any
+		want     string
+	}{
+		{
+			name: "struct with modified fields preserves comments",
+			original: `# Header comment
+name: test # Inline comment
+# Version comment
+version: v1.0.0
+`,
+			value: &testConfig{Name: "test", Version: "v2.0.0"},
+			want: `# Header comment
+name: test # Inline comment
+# Version comment
+version: v2.0.0
+`,
+		},
+		{
+			name: "reordered sequence items preserve comments",
+			original: `items:
+  - # Comment A
+    name: a # Inline A
+    path: path/a
+  - # Comment B
+    name: b
+    path: path/b
+`,
+			value: &itemConfig{
+				Items: []item{
+					{Name: "b", Path: "path/b"},
+					{Name: "a", Path: "path/a"},
+				},
+			},
+			want: `items:
+  - # Comment B
+    name: b
+    path: path/b
+  - # Comment A
+    name: a # Inline A
+    path: path/a
+`,
+		},
+		{
+			name: "added items do not inherit deleted item comments",
+			original: `items:
+  - # Comment old
+    name: old
+`,
+			value: &itemConfig{
+				Items: []item{
+					{Name: "new"},
+				},
+			},
+			want: `items:
+  - name: new
+`,
+		},
+		{
+			name: "scalar sequence items preserve comments",
+			original: `roots:
+  - googleapis # inline googleapis
+  - other
+`,
+			value: &itemConfig{
+				Roots: []string{"googleapis", "newroot"},
+			},
+			want: `roots:
+  - googleapis # inline googleapis
+  - newroot
+`,
+		},
+		{
+			name:     "empty original YAML",
+			original: "",
+			value:    &testConfig{Name: "test", Version: "v1.0.0"},
+			want: `name: test
+version: v1.0.0
+`,
+		},
+		{
+			name:     "invalid original YAML falls back to marshal",
+			original: "[invalid yaml",
+			value:    &testConfig{Name: "test", Version: "v1.0.0"},
+			want: `name: test
+version: v1.0.0
+`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := MarshalWithComments(test.value, []byte(test.original))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, string(got)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestReadWrite(t *testing.T) {
 	want := &testConfig{Name: "test", Version: "v1.0.0"}
 	path := filepath.Join(t.TempDir(), "test.yaml")
@@ -94,21 +269,73 @@ const copyright = `# Copyright %s Google LLC
 `
 
 func TestWrite(t *testing.T) {
-	// Construct expected header
 	header := fmt.Sprintf(copyright, strconv.Itoa(time.Now().Year()))
-	want := header + `name: test
+
+	for _, test := range []struct {
+		name       string
+		existing   string
+		value      any
+		want       string
+		writeTwice bool
+	}{
+		{
+			name:  "new file adds license header",
+			value: &testConfig{Name: "test", Version: "v1.0.0"},
+			want: header + `name: test
 version: v1.0.0
-`
-	path := filepath.Join(t.TempDir(), "test.yaml")
-	if err := Write(path, &testConfig{Name: "test", Version: "v1.0.0"}); err != nil {
-		t.Fatal(err)
-	}
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(want, string(got)); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+`,
+		},
+		{
+			name: "existing file preserves comments",
+			existing: header + `# Custom section comment
+name: test # Inline comment
+# Version comment
+version: v1.0.0
+`,
+			value: &testConfig{Name: "test", Version: "v2.0.0"},
+			want: header + `# Custom section comment
+name: test # Inline comment
+# Version comment
+version: v2.0.0
+`,
+			writeTwice: true,
+		},
+		{
+			name: "existing file without license header adds header",
+			existing: `# Custom comment
+name: test
+version: v1.0.0
+`,
+			value: &testConfig{Name: "test", Version: "v2.0.0"},
+			want: header + `# Custom comment
+name: test
+version: v2.0.0
+`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "test.yaml")
+			if test.existing != "" {
+				if err := os.WriteFile(path, []byte(test.existing), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := Write(path, test.value); err != nil {
+				t.Fatal(err)
+			}
+			if test.writeTwice {
+				if err := Write(path, test.value); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, string(got)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Preserve comments in YAML files serialized by `librarian` `internal/yaml` package.

The implementation is complex. When writing a file to disk, it attempts to merge the new content with the old, tarversing the `yaml` Nodes, applying the comment content to each node using properties like `name`, `id`, and `path` as keys for matching nodes - e.g. `name` for a `libraries` entry, `path` for an `apis` entry, etc. For comments on scalar values e.g. a `[]string` it matches based on value.

Fixes #6922