### PR TITLE
fix(rust): identfy new crates better

### DIFF
--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -164,7 +164,7 @@ func runSemverChecks(ctx context.Context, semverData semverData) error {
 
 // semverCheck runs semver checks for a specific crate.
 func semverCheck(ctx context.Context, semverData semverData, name string) error {
-	_, err := command.Output(ctx, command.Cargo, "info", name, "--registry", "crates-io")
+	err := command.Run(ctx, command.Cargo, "info", name, "--registry", "crates-io")
 	if err != nil {
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			if exitErr.ExitCode() == 101 && strings.Contains(err.Error(), "could not find") {

--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os/exec"
 	"runtime"
 	"slices"
 	"strings"
@@ -150,9 +151,9 @@ func publishCrates(ctx context.Context, params PublishParams, lastTag string, fi
 func runSemverChecks(ctx context.Context, semverData semverData) error {
 	group, ctx := errgroup.WithContext(ctx)
 	group.SetLimit(max(runtime.NumCPU()/semverCheckCPUDivisor, 1))
-	for name, manifest := range semverData.manifests {
+	for name := range semverData.manifests {
 		group.Go(func() error {
-			if err := semverCheck(ctx, semverData, name, manifest); err != nil {
+			if err := semverCheck(ctx, semverData, name); err != nil {
 				return fmt.Errorf("%s: %w: %v", name, errSemverCheck, err)
 			}
 			return nil
@@ -162,12 +163,17 @@ func runSemverChecks(ctx context.Context, semverData semverData) error {
 }
 
 // semverCheck runs semver checks for a specific crate.
-func semverCheck(ctx context.Context, semverData semverData, name string, manifest string) error {
-	if git.IsNewFile(ctx, command.Git, semverData.lastTag, manifest) {
-		// If the manifest is new, we can skip semver checks, since there is no previous version to compare against.
-		return nil
+func semverCheck(ctx context.Context, semverData semverData, name string) error {
+	_, err := command.Output(ctx, command.Cargo, "info", name, "--registry", "crates-io")
+	if err != nil {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			if exitErr.ExitCode() == 101 && strings.Contains(err.Error(), "could not find") {
+				// The crate was not found on crates.io, so we can skip the semver check.
+				return nil
+			}
+		}
+		return err
 	}
-	var err error
 	if semverData.verbose {
 		err = command.RunStreaming(ctx, command.Cargo, "semver-checks", "--all-features", "-p", name)
 	} else {

--- a/internal/librarian/rust/publish_test.go
+++ b/internal/librarian/rust/publish_test.go
@@ -458,7 +458,7 @@ func TestRunSemverChecks(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			script := `#!/bin/bash
-if [[ "$*" == *"fail-me"* ]]; then
+if [[ "$1" == "semver-checks" ]] && [[ "$*" == *"fail-me"* ]]; then
 	exit 1
 fi
 exit 0
@@ -483,6 +483,9 @@ func TestRunSemverChecks_Errors(t *testing.T) {
 	wantErr := errSemverCheck
 
 	script := `#!/bin/bash
+if [ "$1" == "info" ]; then
+	exit 0
+fi
 exit 1
 `
 	setupFakeCargoScript(t, script)
@@ -495,6 +498,46 @@ exit 1
 	}
 	if !errors.Is(err, wantErr) {
 		t.Errorf("runSemverChecks() error = %v, want to contain %v", err, wantErr)
+	}
+}
+
+func TestRunSemverChecks_CargoInfoCrateNotFoundSkips(t *testing.T) {
+	manifests := map[string]string{
+		"new-crate": "new/Cargo.toml",
+	}
+
+	// Exit code 101 with 'could not find' in stderr matches the crate not found error.
+	script := `#!/bin/bash
+echo "error: could not find 'new-crate' in registry" >&2
+exit 101
+`
+	setupFakeCargoScript(t, script)
+	sData := semverData{
+		manifests: manifests,
+	}
+	// Because the crate is not found, we should skip semver check and return nil error.
+	if err := runSemverChecks(t.Context(), sData); err != nil {
+		t.Errorf("runSemverChecks() expected nil error when cargo info fails with crate not found, got %v", err)
+	}
+}
+
+func TestRunSemverChecks_CargoInfoNetworkErrorDoesNotSkip(t *testing.T) {
+	manifests := map[string]string{
+		"existing-crate": "existing/Cargo.toml",
+	}
+
+	// Some other failure like connection timeout or lock failure shouldn't match "could not find".
+	script := `#!/bin/bash
+echo "error: failed to connect to registry" >&2
+exit 1
+`
+	setupFakeCargoScript(t, script)
+	sData := semverData{
+		manifests: manifests,
+	}
+	// Because of a network error, we should NOT skip, so we expect an error from cargo info.
+	if err := runSemverChecks(t.Context(), sData); err == nil {
+		t.Error("runSemverChecks() expected error when cargo info fails with network error, got nil")
 	}
 }
 


### PR DESCRIPTION
Find out a crate exists by checking `cargo info <crate> --registry crates-io` instead of checking if there is a new manifest file since the last release. This lets us add crates with `publish = false`, sit on them for a release, and publish them later.

Note that this change is also more accurate for crates that we are taking ownership of. e.g. `google-cloud-bigquery` is new to our repo, but there is a published `0.15.0` version we need to be semver compatible with. (We are, we bump the major)

Tested a dry run locally and it says:

```diff
--- a/internal/librarian/rust/publish.go
+++ b/internal/librarian/rust/publish.go
@@ -135,6 +135,7 @@ func publishCrates(ctx context.Context, params PublishParams, lastTag string, fi
                        return err
                }
        }
+       return fmt.Errorf("DEBUG")
        args := []string{"workspaces", "publish", "--skip-published", "--publish-interval=60", "--no-git-commit", "--from-git", "skip"}
        if params.DryRunKeepGoing {
                args = append(args, "--dry-run", "--keep-going")
@@ -169,11 +170,14 @@ func semverCheck(ctx context.Context, semverData semverData, name string) error
                if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
                        if exitErr.ExitCode() == 101 && strings.Contains(err.Error(), "could not find") {
                                // The crate was not found on crates.io, so we can skip the semver check.
+                               fmt.Println("SKIP: ", name)
                                return nil
                        }
                }
                return err
        }
+       fmt.Println("would check: ", name)
+       return nil
        if semverData.verbose {
                err = command.RunStreaming(ctx, command.Cargo, "semver-checks", "--all-features", "-p", name)
        } else {
```

and it correctly skips `google-cloud-bigquery-v2`:
```
SKIP:  google-cloud-bigquery-v2
```

Fixes #7124