### PR TITLE
fix(tool/cmd/migrate/php): preserve Datastore ReadOnly.php alias

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -38,8 +38,10 @@ import (
 var librarianPHPYAML []byte
 
 var protoMappings = map[string]string{
-	"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
-	"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
+	"//google/cloud/location:location_proto":     "google/cloud/location/locations.proto",
+	"//google/iam/v1:iam_policy_proto":           "google/iam/v1/iam_policy.proto",
+	"//google/longrunning:longrunning_php_proto": "google/longrunning/operations.proto",
+	"//google/longrunning:operations_proto":      "google/longrunning/operations.proto",
 }
 
 // protoPackageOverrides maps API paths to explicit proto_package overrides.
@@ -270,6 +272,9 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 			APIs:    apis,
 			Output:  name,
 		}
+		if name == "Datastore" {
+			lib.Keep = []string{"src/V1/TransactionOptions/ReadOnly.php"}
+		}
 		derivedComp, err := php.ComponentNameForLibrary(googleapisDir, lib)
 		if err != nil {
 			// If component name derivation fails (e.g. proto file missing or unresolvable in googleapis),
@@ -324,10 +329,6 @@ func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, string, error
 				// Identify common resources usage.
 				if strings.Contains(dep, "common_resources_proto") {
 					hasCommonResources = true
-					continue
-				}
-				// Ignore LROs since PHP does not compile LRO methods as mixins.
-				if strings.HasPrefix(dep, "//google/longrunning:") {
 					continue
 				}
 				// Ignore policy_proto as it only defines structs; the IAMPolicy service is in iam_policy_proto.

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -329,10 +329,10 @@ func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, string, error
 					hasCommonResources = true
 					continue
 				}
-					// Ignore LROs since PHP does not compile LRO methods as mixins.
-					if strings.HasPrefix(dep, "//google/longrunning:") {
-						continue
-					}
+				// Ignore LROs since PHP does not compile LRO methods as mixins.
+				if strings.HasPrefix(dep, "//google/longrunning:") {
+					continue
+				}
 				// Ignore policy_proto as it only defines structs; the IAMPolicy service is in iam_policy_proto.
 				if dep == "//google/iam/v1:policy_proto" {
 					continue

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -38,10 +38,8 @@ import (
 var librarianPHPYAML []byte
 
 var protoMappings = map[string]string{
-	"//google/cloud/location:location_proto":     "google/cloud/location/locations.proto",
-	"//google/iam/v1:iam_policy_proto":           "google/iam/v1/iam_policy.proto",
-	"//google/longrunning:longrunning_php_proto": "google/longrunning/operations.proto",
-	"//google/longrunning:operations_proto":      "google/longrunning/operations.proto",
+	"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
+	"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
 }
 
 // protoPackageOverrides maps API paths to explicit proto_package overrides.
@@ -331,6 +329,10 @@ func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, string, error
 					hasCommonResources = true
 					continue
 				}
+					// Ignore LROs since PHP does not compile LRO methods as mixins.
+					if strings.HasPrefix(dep, "//google/longrunning:") {
+						continue
+					}
 				// Ignore policy_proto as it only defines structs; the IAMPolicy service is in iam_policy_proto.
 				if dep == "//google/iam/v1:policy_proto" {
 					continue


### PR DESCRIPTION
This change modifies Librarian to preserve Datastore ReadOnly.php alias when generating librarian.yaml config.

Fixes https://github.com/googleapis/librarian/issues/7398