### PR TITLE
feat(tool/cmd/migrate/php): support longrunning operations in PHP

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -38,7 +38,7 @@ import (
 var librarianPHPYAML []byte
 
 var protoMappings = map[string]string{
-	"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
+	"//google/cloud/location:location_proto":     "google/cloud/location/locations.proto",
 	"//google/iam/v1:iam_policy_proto":           "google/iam/v1/iam_policy.proto",
 	"//google/longrunning:longrunning_php_proto": "google/longrunning/operations.proto",
 	"//google/longrunning:operations_proto":      "google/longrunning/operations.proto",

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -41,7 +41,6 @@ var protoMappings = map[string]string{
 	"//google/cloud/location:location_proto":     "google/cloud/location/locations.proto",
 	"//google/iam/v1:iam_policy_proto":           "google/iam/v1/iam_policy.proto",
 	"//google/longrunning:longrunning_php_proto": "google/longrunning/operations.proto",
-	"//google/longrunning:operations_proto":      "google/longrunning/operations.proto",
 }
 
 // protoPackageOverrides maps API paths to explicit proto_package overrides.

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -39,7 +39,9 @@ var librarianPHPYAML []byte
 
 var protoMappings = map[string]string{
 	"//google/cloud/location:location_proto": "google/cloud/location/locations.proto",
-	"//google/iam/v1:iam_policy_proto":       "google/iam/v1/iam_policy.proto",
+	"//google/iam/v1:iam_policy_proto":           "google/iam/v1/iam_policy.proto",
+	"//google/longrunning:longrunning_php_proto": "google/longrunning/operations.proto",
+	"//google/longrunning:operations_proto":      "google/longrunning/operations.proto",
 }
 
 // protoPackageOverrides maps API paths to explicit proto_package overrides.
@@ -324,10 +326,6 @@ func parsePHPBazel(googleapisDir, apiPath string) ([]string, bool, string, error
 				// Identify common resources usage.
 				if strings.Contains(dep, "common_resources_proto") {
 					hasCommonResources = true
-					continue
-				}
-				// Ignore LROs since PHP does not compile LRO methods as mixins.
-				if strings.HasPrefix(dep, "//google/longrunning:") {
 					continue
 				}
 				// Ignore policy_proto as it only defines structs; the IAMPolicy service is in iam_policy_proto.


### PR DESCRIPTION
This PR updates the migrate tool to allow generation of longrunning operation methods in PHP by mapping the LRO proto endpoints. This reverses previous hardcoded ignorance of LROs.

Ran `librarian generate --all` and the only LRO changes we found was for LongRunning,  but it fixes the diff in Dataform. I think this is OK since @JoeWang1127 shows a diff for LongRunning in the PHP Migration tracker.

Fixes #7369