### PR TITLE
fix(migrate): preserve ErrorReporting smoketest

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -270,6 +270,9 @@ func findPHPLibraries(repoPath string, googleapisDir string, globalDefaultCommon
 			APIs:    apis,
 			Output:  name,
 		}
+		if name == "ErrorReporting" {
+			lib.Keep = []string{"tests/System/V1beta1/ReportErrorsServiceSmokeTest.php"}
+		}
 		derivedComp, err := php.ComponentNameForLibrary(googleapisDir, lib)
 		if err != nil {
 			// If component name derivation fails (e.g. proto file missing or unresolvable in googleapis),


### PR DESCRIPTION
ErrorReporting is a hybrid library that contains a handwritten system test (`tests/System/V1beta1/ReportErrorsServiceSmokeTest.php`). The migration script was destroying the `keep` configuration for it, causing `librarian generate` to delete the file.

This PR adds `ErrorReporting` to the migration script `keep` exemptions so the file is preserved during generation.

Fixes #7400