### PR TITLE
feat(dart): enable client api version tracking

### DIFF
--- a/internal/librarian/dart/bump.go
+++ b/internal/librarian/dart/bump.go
@@ -19,8 +19,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -40,6 +42,7 @@ import (
 //     b. Use dart-apitool to see what the recommended next version is.
 //     c. If the version should be updated based:
 //     - Update the version in pubspec.yaml.
+//     - Update the version in lib/src/version.dart.
 //     - Update CHANGELOG.md.
 //     - Update the "dependencies:" section of each dependent package.
 //     - Update the version for the package in cfg.Default.Dart.Packages if the package
@@ -174,6 +177,10 @@ func maybeBumpLibrary(ctx context.Context, cloudDeps []string, newVersions map[s
 			return "", err
 		}
 
+		if err := updateVersionDart(packageDir, newVersion); err != nil {
+			return "", err
+		}
+
 		if err := updateChangelog(ctx, packageDir, newVersion, lastReleaseTagCommit, depsChanged); err != nil {
 			return "", err
 		}
@@ -292,4 +299,19 @@ func updateChangelog(ctx context.Context, packageDir, version, lastReleaseTagCom
 	}
 
 	return os.WriteFile(changelogPath, []byte(newTopOfFile+rest), 0644)
+}
+
+var versionDartRegex = regexp.MustCompile(`(const packageVersion = ["'])([^"']*)(["'])`)
+
+func updateVersionDart(packageDir, newVersion string) error {
+	versionPath := filepath.Join(packageDir, "lib", "src", "version.dart")
+	content, err := os.ReadFile(versionPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	result := versionDartRegex.ReplaceAllString(string(content), `${1}`+newVersion+`${3}`)
+	return os.WriteFile(versionPath, []byte(result), 0644)
 }

--- a/internal/librarian/dart/bump.go
+++ b/internal/librarian/dart/bump.go
@@ -300,7 +300,7 @@ func updateChangelog(ctx context.Context, packageDir, version, lastReleaseTagCom
 	return os.WriteFile(changelogPath, []byte(newTopOfFile+rest), 0644)
 }
 
-var versionRegex = regexp.MustCompile(`(const packageVersion = ["'])([^"']*)(["'])`)
+var versionRegex = regexp.MustCompile(`(const\s+packageVersion\s*=\s*["'])([^"']*)(["'])`)
 
 func updateLibraryVersion(packageDir, newVersion string) error {
 	versionPath := filepath.Join(packageDir, "lib", "src", "version.dart")

--- a/internal/librarian/dart/bump.go
+++ b/internal/librarian/dart/bump.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -177,7 +176,7 @@ func maybeBumpLibrary(ctx context.Context, cloudDeps []string, newVersions map[s
 			return "", err
 		}
 
-		if err := updateVersionDart(packageDir, newVersion); err != nil {
+		if err := updateLibraryVersion(packageDir, newVersion); err != nil {
 			return "", err
 		}
 
@@ -303,14 +302,14 @@ func updateChangelog(ctx context.Context, packageDir, version, lastReleaseTagCom
 
 var versionDartRegex = regexp.MustCompile(`(const packageVersion = ["'])([^"']*)(["'])`)
 
-func updateVersionDart(packageDir, newVersion string) error {
+func updateLibraryVersion(packageDir, newVersion string) error {
 	versionPath := filepath.Join(packageDir, "lib", "src", "version.dart")
 	content, err := os.ReadFile(versionPath)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
 		return err
+	}
+	if !versionDartRegex.Match(content) {
+		return fmt.Errorf("no version string found in %s", versionPath)
 	}
 	result := versionDartRegex.ReplaceAllString(string(content), `${1}`+newVersion+`${3}`)
 	return os.WriteFile(versionPath, []byte(result), 0644)

--- a/internal/librarian/dart/bump.go
+++ b/internal/librarian/dart/bump.go
@@ -300,7 +300,7 @@ func updateChangelog(ctx context.Context, packageDir, version, lastReleaseTagCom
 	return os.WriteFile(changelogPath, []byte(newTopOfFile+rest), 0644)
 }
 
-var versionDartRegex = regexp.MustCompile(`(const packageVersion = ["'])([^"']*)(["'])`)
+var versionRegex = regexp.MustCompile(`(const packageVersion = ["'])([^"']*)(["'])`)
 
 func updateLibraryVersion(packageDir, newVersion string) error {
 	versionPath := filepath.Join(packageDir, "lib", "src", "version.dart")
@@ -308,9 +308,9 @@ func updateLibraryVersion(packageDir, newVersion string) error {
 	if err != nil {
 		return err
 	}
-	if !versionDartRegex.Match(content) {
+	if !versionRegex.Match(content) {
 		return fmt.Errorf("no version string found in %s", versionPath)
 	}
-	result := versionDartRegex.ReplaceAllString(string(content), `${1}`+newVersion+`${3}`)
-	return os.WriteFile(versionPath, []byte(result), 0644)
+	result := versionRegex.ReplaceAll(content, []byte(`${1}`+newVersion+`${3}`))
+	return os.WriteFile(versionPath, result, 0644)
 }

--- a/internal/librarian/dart/bump_test.go
+++ b/internal/librarian/dart/bump_test.go
@@ -416,6 +416,139 @@ func TestBump_VersionMismatch(t *testing.T) {
 	}
 }
 
+func TestUpdateVersionDart(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		initial    string
+		newVersion string
+		want       string
+	}{
+		{
+			name: "double quotes",
+			initial: `// Copyright 2026 Google LLC
+
+/// The version of the a client library.
+const packageVersion = "1.0.0";
+`,
+			newVersion: "1.1.0",
+			want: `// Copyright 2026 Google LLC
+
+/// The version of the a client library.
+const packageVersion = "1.1.0";
+`,
+		},
+		{
+			name: "single quotes",
+			initial: `// Copyright 2026 Google LLC
+
+/// The version of the a client library.
+const packageVersion = '1.0.0';
+`,
+			newVersion: "1.1.0",
+			want: `// Copyright 2026 Google LLC
+
+/// The version of the a client library.
+const packageVersion = '1.1.0';
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			srcDir := filepath.Join(tempDir, "lib", "src")
+			if err := os.MkdirAll(srcDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			versionPath := filepath.Join(srcDir, "version.dart")
+			if err := os.WriteFile(versionPath, []byte(tc.initial), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := updateVersionDart(tempDir, tc.newVersion); err != nil {
+				t.Fatalf("updateVersionDart failed: %v", err)
+			}
+
+			content, err := os.ReadFile(versionPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := string(content); got != tc.want {
+				t.Errorf("version.dart content mismatch:\ngot:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateVersionDart_NotExist(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := updateVersionDart(tempDir, "1.1.0"); err != nil {
+		t.Fatalf("expected nil when file does not exist, got: %v", err)
+	}
+}
+
+func TestBump_WithVersionDart(t *testing.T) {
+	testhelper.RequireCommand(t, "dart")
+	testhelper.RequireCommand(t, "git")
+
+	inputDir, err := filepath.Abs("testdata/bump/input")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setupRepoFromDir(t, inputDir)
+	testhelper.RunGit(t, "tag", "a-v1.0.0")
+	testhelper.RunGit(t, "tag", "b-v1.0.0")
+	testhelper.RunGit(t, "tag", "c-v1.0.0")
+
+	versionPath := filepath.Join("generated", "a", "lib", "src", "version.dart")
+	if err := os.MkdirAll(filepath.Dir(versionPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	initialVersionContent := `/// The version of the a client library.
+const packageVersion = "1.0.0";
+`
+	if err := os.WriteFile(versionPath, []byte(initialVersionContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "feat: add version.dart")
+
+	// Now make a commit with changes to package a.
+	appendToFile(t, "generated/a/lib.dart", []byte("const a = 5;\n"))
+	testhelper.RunGit(t, "add", ".")
+	testhelper.RunGit(t, "commit", "-m", "feat: added new value", ".")
+
+	publishedVersions := map[string]string{"a": "1.0.0", "b": "1.0.0", "c": "1.0.0"}
+	setupMockPubdevServer(t, publishedVersions)
+
+	apiToolResponses := map[string]packageVersion{
+		"a": {needed: "1.1.0", old: "1.0.0"},
+		"b": {needed: "1.0.0", old: "1.0.0"},
+		"c": {needed: "1.0.0", old: "1.0.0"},
+	}
+	setupFakeApitool(t, apiToolResponses)
+
+	cfg, err := yaml.Read[config.Config]("librarian.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Bump(t.Context(), cfg, true, "", "")
+	if err != nil {
+		t.Fatalf("Bump failed: %v", err)
+	}
+
+	content, err := os.ReadFile(versionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantVersionContent := `/// The version of the a client library.
+const packageVersion = "1.1.0";
+`
+	if got := string(content); got != wantVersionContent {
+		t.Errorf("version.dart content mismatch:\ngot:\n%s\nwant:\n%s", got, wantVersionContent)
+	}
+}
+
 func setupRepoFromDir(t *testing.T, sourceDir string) {
 	t.Helper()
 

--- a/internal/librarian/dart/bump_test.go
+++ b/internal/librarian/dart/bump_test.go
@@ -464,7 +464,7 @@ const packageVersion = '1.1.0';
 			}
 
 			if err := updateLibraryVersion(tempDir, test.newVersion); err != nil {
-				t.Fatalf("updateVersionDart failed: %v", err)
+				t.Fatalf("updateLibraryVersion failed: %v", err)
 			}
 
 			content, err := os.ReadFile(versionPath)

--- a/internal/librarian/dart/bump_test.go
+++ b/internal/librarian/dart/bump_test.go
@@ -416,7 +416,7 @@ func TestBump_VersionMismatch(t *testing.T) {
 	}
 }
 
-func TestUpdateVersionDart(t *testing.T) {
+func TestUpdateLibraryVersion(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		initial    string
@@ -424,21 +424,21 @@ func TestUpdateVersionDart(t *testing.T) {
 		want       string
 	}{
 		{
-			name: "double quotes",
+			name: "prerelease",
 			initial: `// Copyright 2026 Google LLC
 
 /// The version of the a client library.
-const packageVersion = "1.0.0";
+const packageVersion = '0.9.0';
 `,
-			newVersion: "1.1.0",
+			newVersion: "0.9.1",
 			want: `// Copyright 2026 Google LLC
 
 /// The version of the a client library.
-const packageVersion = "1.1.0";
+const packageVersion = '0.9.1';
 `,
 		},
 		{
-			name: "single quotes",
+			name: "release",
 			initial: `// Copyright 2026 Google LLC
 
 /// The version of the a client library.
@@ -463,7 +463,7 @@ const packageVersion = '1.1.0';
 				t.Fatal(err)
 			}
 
-			if err := updateVersionDart(tempDir, tc.newVersion); err != nil {
+			if err := updateLibraryVersion(tempDir, tc.newVersion); err != nil {
 				t.Fatalf("updateVersionDart failed: %v", err)
 			}
 
@@ -478,74 +478,20 @@ const packageVersion = '1.1.0';
 	}
 }
 
-func TestUpdateVersionDart_NotExist(t *testing.T) {
+func TestUpdateLibraryVersion_NoMatch(t *testing.T) {
 	tempDir := t.TempDir()
-	if err := updateVersionDart(tempDir, "1.1.0"); err != nil {
-		t.Fatalf("expected nil when file does not exist, got: %v", err)
+	srcDir := filepath.Join(tempDir, "lib", "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
 	}
-}
-
-func TestBump_WithVersionDart(t *testing.T) {
-	testhelper.RequireCommand(t, "dart")
-	testhelper.RequireCommand(t, "git")
-
-	inputDir, err := filepath.Abs("testdata/bump/input")
-	if err != nil {
+	versionPath := filepath.Join(srcDir, "version.dart")
+	if err := os.WriteFile(versionPath, []byte("// no version here\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	setupRepoFromDir(t, inputDir)
-	testhelper.RunGit(t, "tag", "a-v1.0.0")
-	testhelper.RunGit(t, "tag", "b-v1.0.0")
-	testhelper.RunGit(t, "tag", "c-v1.0.0")
-
-	versionPath := filepath.Join("generated", "a", "lib", "src", "version.dart")
-	if err := os.MkdirAll(filepath.Dir(versionPath), 0755); err != nil {
-		t.Fatal(err)
-	}
-	initialVersionContent := `/// The version of the a client library.
-const packageVersion = "1.0.0";
-`
-	if err := os.WriteFile(versionPath, []byte(initialVersionContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-	testhelper.RunGit(t, "add", ".")
-	testhelper.RunGit(t, "commit", "-m", "feat: add version.dart")
-
-	// Now make a commit with changes to package a.
-	appendToFile(t, "generated/a/lib.dart", []byte("const a = 5;\n"))
-	testhelper.RunGit(t, "add", ".")
-	testhelper.RunGit(t, "commit", "-m", "feat: added new value", ".")
-
-	publishedVersions := map[string]string{"a": "1.0.0", "b": "1.0.0", "c": "1.0.0"}
-	setupMockPubdevServer(t, publishedVersions)
-
-	apiToolResponses := map[string]packageVersion{
-		"a": {needed: "1.1.0", old: "1.0.0"},
-		"b": {needed: "1.0.0", old: "1.0.0"},
-		"c": {needed: "1.0.0", old: "1.0.0"},
-	}
-	setupFakeApitool(t, apiToolResponses)
-
-	cfg, err := yaml.Read[config.Config]("librarian.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = Bump(t.Context(), cfg, true, "", "")
-	if err != nil {
-		t.Fatalf("Bump failed: %v", err)
-	}
-
-	content, err := os.ReadFile(versionPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wantVersionContent := `/// The version of the a client library.
-const packageVersion = "1.1.0";
-`
-	if got := string(content); got != wantVersionContent {
-		t.Errorf("version.dart content mismatch:\ngot:\n%s\nwant:\n%s", got, wantVersionContent)
+	err := updateLibraryVersion(tempDir, "1.1.0")
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 

--- a/internal/librarian/dart/bump_test.go
+++ b/internal/librarian/dart/bump_test.go
@@ -417,7 +417,7 @@ func TestBump_VersionMismatch(t *testing.T) {
 }
 
 func TestUpdateLibraryVersion(t *testing.T) {
-	for _, tc := range []struct {
+	for _, test := range []struct {
 		name       string
 		initial    string
 		newVersion string
@@ -452,18 +452,18 @@ const packageVersion = '1.1.0';
 `,
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			srcDir := filepath.Join(tempDir, "lib", "src")
 			if err := os.MkdirAll(srcDir, 0755); err != nil {
 				t.Fatal(err)
 			}
 			versionPath := filepath.Join(srcDir, "version.dart")
-			if err := os.WriteFile(versionPath, []byte(tc.initial), 0644); err != nil {
+			if err := os.WriteFile(versionPath, []byte(test.initial), 0644); err != nil {
 				t.Fatal(err)
 			}
 
-			if err := updateLibraryVersion(tempDir, tc.newVersion); err != nil {
+			if err := updateLibraryVersion(tempDir, test.newVersion); err != nil {
 				t.Fatalf("updateVersionDart failed: %v", err)
 			}
 
@@ -471,8 +471,8 @@ const packageVersion = '1.1.0';
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := string(content); got != tc.want {
-				t.Errorf("version.dart content mismatch:\ngot:\n%s\nwant:\n%s", got, tc.want)
+			if got := string(content); got != test.want {
+				t.Errorf("version.dart content mismatch:\ngot:\n%s\nwant:\n%s", got, test.want)
 			}
 		})
 	}

--- a/internal/librarian/dart/testdata/bump/api_change/golden_output/generated/a/lib/src/version.dart
+++ b/internal/librarian/dart/testdata/bump/api_change/golden_output/generated/a/lib/src/version.dart
@@ -1,0 +1,18 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: lines_longer_than_80_chars
+
+/// The version of the a client library.
+const packageVersion = '1.1.0';

--- a/internal/librarian/dart/testdata/bump/api_change/golden_output/generated/b/lib/src/version.dart
+++ b/internal/librarian/dart/testdata/bump/api_change/golden_output/generated/b/lib/src/version.dart
@@ -1,0 +1,18 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: lines_longer_than_80_chars
+
+/// The version of the b client library.
+const packageVersion = '1.0.1';

--- a/internal/librarian/dart/testdata/bump/api_change/golden_output/generated/c/lib/src/version.dart
+++ b/internal/librarian/dart/testdata/bump/api_change/golden_output/generated/c/lib/src/version.dart
@@ -1,0 +1,18 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: lines_longer_than_80_chars
+
+/// The version of the c client library.
+const packageVersion = '1.0.0';

--- a/internal/librarian/dart/testdata/bump/input/generated/a/lib/src/version.dart
+++ b/internal/librarian/dart/testdata/bump/input/generated/a/lib/src/version.dart
@@ -1,0 +1,18 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: lines_longer_than_80_chars
+
+/// The version of the a client library.
+const packageVersion = '1.0.0';

--- a/internal/librarian/dart/testdata/bump/input/generated/b/lib/src/version.dart
+++ b/internal/librarian/dart/testdata/bump/input/generated/b/lib/src/version.dart
@@ -1,0 +1,18 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: lines_longer_than_80_chars
+
+/// The version of the b client library.
+const packageVersion = '1.0.0';

--- a/internal/librarian/dart/testdata/bump/input/generated/c/lib/src/version.dart
+++ b/internal/librarian/dart/testdata/bump/input/generated/c/lib/src/version.dart
@@ -1,0 +1,18 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: lines_longer_than_80_chars
+
+/// The version of the c client library.
+const packageVersion = '1.0.0';

--- a/internal/sidekick/dart/generate_test.go
+++ b/internal/sidekick/dart/generate_test.go
@@ -76,6 +76,7 @@ func TestFromProtobuf(t *testing.T) {
 		"pubspec.yaml",
 		"lib/secretmanager.dart",
 		"lib/src/api.g.dart",
+		"lib/src/version.dart",
 		"lib/testing.dart",
 		"LICENSE",
 		"README.md",
@@ -103,6 +104,7 @@ README.md linguist-generated=true
 pubspec.yaml linguist-generated=true
 lib/secretmanager.dart linguist-generated=true
 lib/src/api.g.dart linguist-generated=true
+lib/src/version.dart linguist-generated=true
 lib/testing.dart linguist-generated=true
 skills/** linguist-generated=true
 `
@@ -147,6 +149,7 @@ func TestFromProtobuf_NoServices(t *testing.T) {
 		"pubspec.yaml",
 		"lib/type.dart",
 		"lib/src/api.g.dart",
+		"lib/src/version.dart",
 		"LICENSE",
 		"README.md",
 	} {
@@ -171,6 +174,7 @@ README.md linguist-generated=true
 pubspec.yaml linguist-generated=true
 lib/type.dart linguist-generated=true
 lib/src/api.g.dart linguist-generated=true
+lib/src/version.dart linguist-generated=true
 `
 	if diff := cmp.Diff(wantGitattributes, string(gitattributesContent)); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/sidekick/dart/templates/.gitattributes.mustache
+++ b/internal/sidekick/dart/templates/.gitattributes.mustache
@@ -19,6 +19,7 @@ README.md linguist-generated=true
 pubspec.yaml linguist-generated=true
 lib/{{Codec.MainFileNameWithExtension}} linguist-generated=true
 lib/src/api.g.dart linguist-generated=true
+lib/src/version.dart linguist-generated=true
 {{#HasServices}}
 lib/testing.dart linguist-generated=true
 skills/** linguist-generated=true

--- a/internal/sidekick/dart/templates/lib/src/api.g.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/src/api.g.dart.mustache
@@ -43,6 +43,10 @@ library;
 {{{.}}}
 {{/Codec.Imports}}
 
+{{#Codec.HasServices}}
+import 'version.dart';
+{{/Codec.HasServices}}
+
 {{#Codec.Exports}}
 {{{.}}};
 {{/Codec.Exports}}

--- a/internal/sidekick/dart/templates/lib/src/service.mustache
+++ b/internal/sidekick/dart/templates/lib/src/service.mustache
@@ -35,7 +35,8 @@ final class {{Codec.Name}} {
   /// local emulator.
   ///
   /// If [gcclVersion] is set then `gccl/<version>` will be included in the
-  /// `x-google-api-client` header.
+  /// `x-google-api-client` header. This argument is only meant for use by
+  /// hand-written official Google Cloud API clients.
   {{Codec.Name}}({required http.Client client, Uri? endPoint, String? gcclVersion})
       : _client = ServiceClient(client: client, gapicVersion: packageVersion, gcclVersion: gcclVersion),
         _endPoint =

--- a/internal/sidekick/dart/templates/lib/src/service.mustache
+++ b/internal/sidekick/dart/templates/lib/src/service.mustache
@@ -33,8 +33,11 @@ final class {{Codec.Name}} {
   /// used for all API requests. For example, `Uri.http('127.0.0.1:8080')`
   /// could be used to force the `Firestore` service to communicate with the
   /// local emulator.
-  {{Codec.Name}}({required http.Client client, Uri? endPoint})
-      : _client = ServiceClient(client: client),
+  ///
+  /// If [gcclVersion] is set then `gccl/<version>` will be included in the
+  /// `x-google-api-client` header.
+  {{Codec.Name}}({required http.Client client, Uri? endPoint, String? gcclVersion})
+      : _client = ServiceClient(client: client, gapicVersion: packageVersion, gcclVersion: gcclVersion),
         _endPoint =
             endPoint == null
                 ? Uri.https(_defaultHost, '')

--- a/internal/sidekick/dart/templates/lib/src/version.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/src/version.dart.mustache
@@ -19,6 +19,8 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.BoilerPlate}}
 
+// ignore_for_file: lines_longer_than_80_chars
+
 /// The version of the {{Codec.PackageName}} client library.
 {{#Codec.PackageVersion}}
 const packageVersion = '{{Codec.PackageVersion}}';

--- a/internal/sidekick/dart/templates/lib/src/version.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/src/version.dart.mustache
@@ -22,6 +22,4 @@ limitations under the License.
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the {{Codec.PackageName}} client library.
-{{#Codec.PackageVersion}}
 const packageVersion = '{{Codec.PackageVersion}}';
-{{/Codec.PackageVersion}}

--- a/internal/sidekick/dart/templates/lib/src/version.dart.mustache
+++ b/internal/sidekick/dart/templates/lib/src/version.dart.mustache
@@ -1,0 +1,25 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
+// Copyright {{Codec.CopyrightYear}} Google LLC
+{{#Codec.BoilerPlate}}
+//{{{.}}}
+{{/Codec.BoilerPlate}}
+
+/// The version of the {{Codec.PackageName}} client library.
+{{#Codec.PackageVersion}}
+const packageVersion = '{{Codec.PackageVersion}}';
+{{/Codec.PackageVersion}}


### PR DESCRIPTION
Causes generated clients to include their version number in the `x-google-api-client` header, e.g., `... gapic/5.0`.

Also allows a `gccl` tag to be injected in service constructors.

Example `version.dart`:

```dart
// Copyright 2025 Google LLC
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     https://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.
//
// Code generated by sidekick. DO NOT EDIT.

/// The version of the google_cloud_api client library.
const packageVersion = '0.5.4';
```

Change in `api.g.dart`:

```dart
  /// ...
  /// If [gcclVersion] is set then `gccl/<version>` will be included in the
  /// `x-google-api-client` header.
  CacheService({
    required http.Client client,
    Uri? endPoint,
    String? gcclVersion,
  }) : _client = ServiceClient(
         client: client,
         gapicVersion: packageVersion,
         gcclVersion: gcclVersion,
       ),
       _endPoint = endPoint == null
           ? Uri.https(_defaultHost, '')
           : Uri(
               scheme: endPoint.scheme,
               host: endPoint.host,
               port: endPoint.port,
             );
```
