### PR TITLE
feat(internal/librarian/ruby): support ruby-cloud-generic-endpoint option

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -510,6 +510,7 @@ This document describes the schema for the librarian.yaml.
 | `ruby-cloud-extra-dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
 | `ruby-cloud-factory-method-suffix` | string | Appends a suffix to client constructor helper methods. |
 | `ruby-cloud-gem-namespace` | string | Is the root Ruby namespace. |
+| `ruby-cloud-generic-endpoint` | bool | Specifies whether the client is for a generic endpoint service without a fixed default host or default credentials. |
 | `ruby-cloud-migration-version` | string | Specifies the gem version milestone at which the library was migrated to GAPIC, generating a migration section in the README file. |
 | `ruby-cloud-namespace-override` | string | Overrides token / segment replacements applied across all generated module & class paths. |
 | `ruby-cloud-path-override` | string | Overrides file/directory paths under lib/ and proto_docs/. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -898,6 +898,9 @@ type RubyCloudOpts struct {
 	// GemNamespace is the root Ruby namespace.
 	GemNamespace string `yaml:"ruby-cloud-gem-namespace,omitempty"`
 
+	// GenericEndpoint specifies whether the client is for a generic endpoint service without a fixed default host or default credentials.
+	GenericEndpoint bool `yaml:"ruby-cloud-generic-endpoint,omitempty"`
+
 	// MigrationVersion specifies the gem version milestone at which the library was migrated to GAPIC, generating a migration section in the README file.
 	MigrationVersion string `yaml:"ruby-cloud-migration-version,omitempty"`
 

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -192,6 +192,9 @@ func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir stri
 		if api.Ruby.RubyCloudOpts.GemNamespace != "" {
 			opts = append(opts, "ruby-cloud-gem-namespace="+api.Ruby.RubyCloudOpts.GemNamespace)
 		}
+		if api.Ruby.RubyCloudOpts.GenericEndpoint {
+			opts = append(opts, "ruby-cloud-generic-endpoint=true")
+		}
 		if api.Ruby.RubyCloudOpts.MigrationVersion != "" {
 			opts = append(opts, "ruby-cloud-migration-version="+api.Ruby.RubyCloudOpts.MigrationVersion)
 		}

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -152,6 +152,31 @@ func TestBuildGAPICOpts(t *testing.T) {
 			},
 		},
 		{
+			// The generic endpoint option is used for APIs like Grafeas (grafeas/v1), but tested here using Secret Manager testdata.
+			name: "ruby cloud opts with generic endpoint",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Ruby: &config.RubyAPI{
+					RubyCloudOpts: &config.RubyCloudOpts{
+						GenericEndpoint: true,
+					},
+				},
+			},
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+			},
+			want: []string{
+				"ruby-cloud-gem-name=google-cloud-secret_manager",
+				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
+				"ruby-cloud-generate-transports=grpc;rest",
+				"ruby-cloud-rest-numeric-enums=true",
+				"ruby-cloud-generic-endpoint=true",
+			},
+		},
+		{
 			name: "ruby cloud opts with all options",
 			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",
@@ -161,6 +186,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 						ExtraDependencies:   "google-cloud-core=~>1.6",
 						FactoryMethodSuffix: "service",
 						GemNamespace:        "Google::Cloud::SecretManager::V1",
+						GenericEndpoint:     true,
 						MigrationVersion:    "1.0",
 						NamespaceOverride:   "SecretManager=Secretmanager",
 						PathOverride:        "secret_manager=secretmanager",
@@ -186,6 +212,7 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"ruby-cloud-extra-dependencies=google-cloud-core=~>1.6",
 				"ruby-cloud-factory-method-suffix=service",
 				"ruby-cloud-gem-namespace=Google::Cloud::SecretManager::V1",
+				"ruby-cloud-generic-endpoint=true",
 				"ruby-cloud-migration-version=1.0",
 				"ruby-cloud-namespace-override=SecretManager=Secretmanager",
 				"ruby-cloud-path-override=secret_manager=secretmanager",


### PR DESCRIPTION
Support `ruby-cloud-generic-endpoint` in `librarian.yaml` and forward it to `gapic-generator-cloud` via `--ruby_cloud_opt`.

Fixes https://github.com/googleapis/librarian/issues/7401