### PR TITLE
fix(tool/cmd/migrate/php): preserve Logging smoketest

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -494,6 +494,8 @@ func specialCases(api *config.API) {
 
 func appendKeep(lib *config.Library) {
 	switch lib.Name {
+	case "logging":
+		lib.Keep = append(lib.Keep, "tests/System/V2/LoggingServiceV2SmokeTest.php")
 	case "bigtable":
 		lib.Keep = append(lib.Keep, "tests/Conformance/proxy/src/GPBMetadata/Google/Bigtable/Testproxy/TestProxy.php")
 		lib.Keep = append(lib.Keep, "tests/Conformance/proxy/src/Google/Bigtable/Testproxy/CheckAndMutateRowRequest.php")


### PR DESCRIPTION
Logging is a hybrid library that contains a handwritten system test (`tests/System/V2/LoggingServiceV2SmokeTest.php`). The migration script was dropping the `keep` configuration for it, causing `librarian generate logging` to accidentally delete the test file.

This PR adds `Logging` to the migration script `keep` exemptions so the file is preserved during generation.

Fixes #7409