### PR TITLE
feat(internal/sidekick/rust): support server-side streaming in grpc-client

### DIFF
--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -294,7 +294,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		}
 	}
 	hasBidiStreaming := codec.templateOverride == "" && len(bidiStreamingServices) > 0
-	hasServerStreaming := codec.templateOverride == "" && len(serverStreamingServices) > 0
+	hasServerStreaming := (codec.templateOverride == "" || codec.templateOverride == "templates/grpc-client") && len(serverStreamingServices) > 0
 	hasStreaming := hasBidiStreaming || hasServerStreaming
 	if hasStreaming {
 		for _, pkg := range codec.extraPackages {

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -756,6 +756,21 @@ func TestModelAnnotationsHasStreaming(t *testing.T) {
 			wantStreaming:        false,
 			wantRequiredPackages: []string{"gaxi.workspace       = true"},
 		},
+		{
+			name:    "grpc-client template override with server streaming method",
+			service: serverStreamingService,
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+				"template-override":                "templates/grpc-client",
+				"package:gaxi":                     "package=google-cloud-gax,used-if=services",
+				"package:prost":                    "package=prost,used-if=streaming",
+			},
+			wantBidi:             false,
+			wantServer:           true,
+			wantStreaming:        true,
+			wantGaxiFeatures:     []string{"_internal-grpc-client"},
+			wantRequiredPackages: []string{`gaxi                 = { workspace = true, features = ["_internal-grpc-client"] }`, "prost.workspace      = true"},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{test.service})

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -1579,7 +1579,7 @@ func (c *codec) hasBidiStreaming(model *api.API) bool {
 }
 
 func (c *codec) hasServerStreaming(model *api.API) bool {
-	if c.templateOverride != "" || !c.includeServerStreamingMethods {
+	if (c.templateOverride != "" && c.templateOverride != "templates/grpc-client") || !c.includeServerStreamingMethods {
 		return false
 	}
 	return slices.ContainsFunc(model.Services, (*api.Service).HasServerSideStreaming)

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -283,3 +283,94 @@ prost.workspace      = true
 		}
 	})
 }
+
+func TestGenerateGrpcClientServerStreaming(t *testing.T) {
+	outDir := t.TempDir()
+
+	request := api.NewTestMessage("ExpandRequest").WithPackage("test.v1")
+	request.Fields = []*api.Field{
+		{
+			Name:     "content",
+			JSONName: "content",
+			ID:       ".test.v1.ExpandRequest.content",
+			Typez:    api.TypezString,
+		},
+	}
+	response := api.NewTestMessage("EchoResponse").WithPackage("test.v1")
+
+	serverMethod := api.NewTestMethod("Expand").WithInput(request).WithOutput(response).WithServerSideStreaming()
+	serverMethod.PathInfo = &api.PathInfo{
+		Bindings: []*api.PathBinding{{Verb: "POST", PathTemplate: &api.PathTemplate{}}},
+	}
+	service := api.NewTestService("Echo").WithPackage("test.v1").WithMethods(serverMethod)
+
+	model := api.NewTestAPI([]*api.Message{request, response}, []*api.Enum{}, []*api.Service{service})
+	model.PackageName = "test.v1"
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: libconfig.SpecProtobuf,
+		Codec: map[string]string{
+			"template-override":                "templates/grpc-client",
+			"package:wkt":                      "source=google.protobuf,package=google-cloud-wkt",
+			"include-server-streaming-methods": "true",
+		},
+	}
+	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	files := make(map[string]string)
+	readFile := func(relPath string) string {
+		if content, ok := files[relPath]; ok {
+			return content
+		}
+		b, err := os.ReadFile(filepath.Join(outDir, relPath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[relPath] = string(b)
+		return files[relPath]
+	}
+
+	for _, test := range []struct {
+		name     string
+		file     string
+		startStr string
+		endStr   string
+		want     string
+	}{
+		{
+			name:     "grpc-client transport: execute_server_streaming call",
+			file:     "transport.rs",
+			startStr: "        self.inner\n            .execute_server_streaming::<",
+			endStr:   "&x_goog_request_params,\n            )\n            .await\n    }",
+			want: `        self.inner
+            .execute_server_streaming::<
+                crate::model::ExpandRequest,
+                crate::model::EchoResponse,
+                crate::test::v1::ExpandRequest,
+                crate::test::v1::EchoResponse,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			content := readFile(test.file)
+			got := extractBlock(t, content, test.startStr, test.endStr)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -102,6 +102,71 @@ impl {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     {{#Codec.Methods}}
+    {{#Codec.IsServerStreaming}}
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn {{Codec.Name}}(
+        &self,
+        req: {{InputType.Codec.QualifiedName}},
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "{{SourceService.Package}}.{{SourceService.Name}}",
+                "{{Name}}",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}"
+        );
+        {{!
+        AIP-4222 says:
+
+            For any given RPC, if the explicit routing headers annotation is
+            present, the code generators **must** use it and **ignore** any
+            routing headers that might be implicitly specified in the
+            google.api.http annotation.
+
+        So we only need to generate one of the two code paths.
+        }}
+        {{#HasRouting}}
+        {{> routinginfo}}
+        {{/HasRouting}}
+        {{^HasRouting}}
+        let x_goog_request_params = [
+            {{#PathInfo.Codec.UniqueParameters}}
+                {{{FieldAccessor}}}.map(|v| format!("{{FieldName}}={v}")),
+            {{/PathInfo.Codec.UniqueParameters}}
+            {{^PathInfo.Codec.UniqueParameters}}
+            ""; 0
+            {{/PathInfo.Codec.UniqueParameters}}
+        ]
+        .into_iter()
+        .flatten()
+        {{! TODO(#2548) - skip empty strings, and don't lead with a '&' }}
+        .fold(String::new(), |b, p| b + "&" + &p);
+        {{/HasRouting}}
+
+        self.inner
+            .execute_server_streaming::<
+                {{InputType.Codec.QualifiedName}},
+                {{OutputType.Codec.QualifiedName}},
+                crate::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
+                crate::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }
+
+    {{/Codec.IsServerStreaming}}
+    {{^Codec.IsServerStreaming}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -200,6 +265,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             .and_then(gaxi::grpc::to_gax_response::<TR, {{Codec.ReturnType}}>)
     }
 
+    {{/Codec.IsServerStreaming}}
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}
     fn get_polling_error_policy(


### PR DESCRIPTION
Add code generation support for server-side streaming RPC methods in Rust grpc-client templates. Generated code invokes execute_server_streaming on the gRPC transport client to manage prost message serialization and response streams.

Support include_server_streaming_methods for templates/grpc-client.

Prioritized over bidi streaming for ReadRows.