### PR TITLE
fix(tool/cmd/migrate/php): correctly map operations_proto for Dataform

### DIFF
--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -41,7 +41,7 @@ var protoMappings = map[string]string{
 	"//google/cloud/location:location_proto":     "google/cloud/location/locations.proto",
 	"//google/iam/v1:iam_policy_proto":           "google/iam/v1/iam_policy.proto",
 	"//google/longrunning:longrunning_php_proto": "google/longrunning/operations.proto",
-	"//google/longrunning:operations_proto": "google/longrunning/operations.proto",
+	"//google/longrunning:operations_proto":      "google/longrunning/operations.proto",
 }
 
 // protoPackageOverrides maps API paths to explicit proto_package overrides.

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -41,6 +41,7 @@ var protoMappings = map[string]string{
 	"//google/cloud/location:location_proto":     "google/cloud/location/locations.proto",
 	"//google/iam/v1:iam_policy_proto":           "google/iam/v1/iam_policy.proto",
 	"//google/longrunning:longrunning_php_proto": "google/longrunning/operations.proto",
+	"//google/longrunning:operations_proto": "google/longrunning/operations.proto",
 }
 
 // protoPackageOverrides maps API paths to explicit proto_package overrides.


### PR DESCRIPTION
Follow up to https://github.com/googleapis/librarian/pull/7397 - we also need to add the operations proto to fix the Dataform issue. Rerunning generate --all confirms there are no more diffs.

Fixes https://github.com/googleapis/librarian/issues/7369
