### PR TITLE
feat(sidekick/swift): default output uses `swift-*`

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -637,7 +637,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `name` | string | Is the module imported from the dependency.<br><br>Examples:<br>- to import `Logging` from the `swift-log` package, create a dependency: {name: "Logging", version: "1.14.0", url: "https://github.com/apple/swift-log"},<br>- to import `GoogleIamV1` from the `google-iam-v1` package. {name: "GoogleIamV1", path: "generated/google-iam-v1"} |
+| `name` | string | Is the module imported from the dependency.<br><br>Examples:<br>- to import `Logging` from the `swift-log` package, create a dependency: {name: "Logging", version: "1.14.0", url: "https://github.com/apple/swift-log"},<br>- to import `GoogleIamV1` from the `swift-google-iam-v1` package. {name: "GoogleIamV1", path: "generated/swift-google-iam-v1"} |
 | `path` | string | Configures the path for local (to the monorepo) packages.<br><br>For example, the authentication package definition will set this to `packages/auth`, which would generate the following snippet in the `Package.swift` files:<br><br>``` .package(path: "../../packages/auth") ``` |
 | `url` | string | Configures the `url:` parameter in the package definition.<br><br>For example, `https://github.com/apple/swift-protobuf` would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf") ``` |
 | `version` | string | Configures the minimum version for external package definitions.<br><br>For example, if the `swift-protobuf` package used `1.36.1`, then the codec would generate the following snippet in the `Package.swift` files:<br><br>``` .package(url: "https://github.com/apple/swift-protobuf", from: "1.36.1") ``` |

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -92,7 +92,7 @@ type SwiftDependency struct {
 	// - to import `Logging` from the `swift-log` package, create a dependency:
 	//     {name: "Logging", version: "1.14.0", url: "https://github.com/apple/swift-log"},
 	// - to import `GoogleIamV1` from the `google-iam-v1` package.
-	//     {name: "GoogleIamV1", path: "generated/google-iam-v1"}
+	//     {name: "GoogleIamV1", path: "generated/swift-google-iam-v1"}
 	Name string `yaml:"name"`
 	// Path configures the path for local (to the monorepo) packages.
 	//

--- a/internal/config/swift.go
+++ b/internal/config/swift.go
@@ -32,9 +32,11 @@ type SwiftPackage struct {
 	// LibraryNameOverride overrides the default library name.
 	//
 	// In Swift, each GAPIC package consists of a single product (the library),
-	// which contains a single target and module name. For example, the package for
-	// the google/cloud/secretmanager/v1 API is called google-cloud-secretmanager-v1, and
-	// contains a single product: `GoogleCloudSecretManagerV1`, which in turn contains a single target and module of the same name.
+	// which contains a single target and module name. For example, the package
+	// for the google/cloud/secretmanager/v1 API is called
+	// google-cloud-secretmanager-v1, and contains a single product:
+	// `GoogleCloudSecretManagerV1`, which in turn contains a single target and
+	// module of the same name.
 	//
 	// To use the library applications use this import:
 	//
@@ -43,7 +45,8 @@ type SwiftPackage struct {
 	// ```
 	//
 	// Normally the name is derived from:
-	// - If the Protobuf namespace overrides for PHP, Ruby, and C# are consistent, sidekick uses this name.
+	// - If the Protobuf namespace overrides for PHP, Ruby, and C# are
+	//   consistent, sidekick uses this name.
 	// - Otherwise, the name implied by the Protobuf package
 	// - Or the package set in the service config yaml file
 	LibraryNameOverride string `yaml:"library_name_override,omitempty"`
@@ -71,7 +74,8 @@ type SwiftPackage struct {
 	// other packages.
 	PackageNameOverride string `yaml:"package_name_override,omitempty"`
 
-	// NameOverrides contains codec-level overrides for service names (e.g., {".google.storage.v2.Storage": "StorageControl"}).
+	// NameOverrides contains codec-level overrides for service names (e.g.,
+	// {".google.storage.v2.Storage": "StorageControl"}).
 	NameOverrides map[string]string `yaml:"name_overrides,omitempty"`
 
 	// PerServiceTraits enables per-service compile-time flags.
@@ -91,7 +95,7 @@ type SwiftDependency struct {
 	// Examples:
 	// - to import `Logging` from the `swift-log` package, create a dependency:
 	//     {name: "Logging", version: "1.14.0", url: "https://github.com/apple/swift-log"},
-	// - to import `GoogleIamV1` from the `google-iam-v1` package.
+	// - to import `GoogleIamV1` from the `swift-google-iam-v1` package.
 	//     {name: "GoogleIamV1", path: "generated/swift-google-iam-v1"}
 	Name string `yaml:"name"`
 	// Path configures the path for local (to the monorepo) packages.

--- a/internal/librarian/swift/default_output.go
+++ b/internal/librarian/swift/default_output.go
@@ -23,5 +23,5 @@ import (
 // output directory.
 func DefaultOutput(api, defaultOutput string) string {
 	path := strings.ReplaceAll(strings.Trim(api, "/"), "/", "-")
-	return filepath.Join(defaultOutput, path)
+	return filepath.Join(defaultOutput, "swift-"+path)
 }

--- a/internal/librarian/swift/default_output_test.go
+++ b/internal/librarian/swift/default_output_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestDefaultOutput(t *testing.T) {
-	for _, tt := range []struct {
+	for _, test := range []struct {
 		name   string
 		api    string
 		defOut string
@@ -31,48 +31,48 @@ func TestDefaultOutput(t *testing.T) {
 			name:   "simple",
 			api:    "secretmanager",
 			defOut: "packages",
-			want:   "packages/secretmanager",
+			want:   "packages/swift-secretmanager",
 		},
 		{
 			name:   "empty default",
 			api:    "secretmanager",
 			defOut: "",
-			want:   "secretmanager",
+			want:   "swift-secretmanager",
 		},
 		{
 			name:   "nested default",
 			api:    "secretmanager",
 			defOut: "a/b/c",
-			want:   "a/b/c/secretmanager",
+			want:   "a/b/c/swift-secretmanager",
 		},
 		{
 			name:   "api path",
 			api:    "google/cloud/secretmanager/v1",
 			defOut: "generated",
-			want:   "generated/google-cloud-secretmanager-v1",
+			want:   "generated/swift-google-cloud-secretmanager-v1",
 		},
 		{
 			name:   "api path with trailing slash",
 			api:    "google/cloud/secretmanager/v1/",
 			defOut: "generated",
-			want:   "generated/google-cloud-secretmanager-v1",
+			want:   "generated/swift-google-cloud-secretmanager-v1",
 		},
 		{
 			name:   "api path with leading slash",
 			api:    "/google/cloud/secretmanager/v1",
 			defOut: "generated",
-			want:   "generated/google-cloud-secretmanager-v1",
+			want:   "generated/swift-google-cloud-secretmanager-v1",
 		},
 		{
 			name:   "api path with both leading and trailing slash (weird)",
 			api:    "/google/cloud/secretmanager/v1/",
 			defOut: "generated",
-			want:   "generated/google-cloud-secretmanager-v1",
+			want:   "generated/swift-google-cloud-secretmanager-v1",
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			got := DefaultOutput(tt.api, tt.defOut)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+		t.Run(test.name, func(t *testing.T) {
+			got := DefaultOutput(test.api, test.defOut)
+			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
We want the GitHub repositories to start with `swift-*`, and we want the directories to match the GitHub repository name.

Towards https://github.com/googleapis/google-cloud-swift/issues/544 
