### PR TITLE
chore(internal/librarian/php): remove obsolete TODO comments in tests

### DIFF
--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -144,8 +144,6 @@ func TestGenerate_GenerateGAPICFalse(t *testing.T) {
 	}
 }
 
-// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
-// once the install steps for the dev tool are ready.
 func TestGenerate_NewLibrary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow integration test")

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -205,8 +205,6 @@ cp %s SecretManager/owlbot.py
 	}
 }
 
-// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
-// once the install steps for the dev tool are ready.
 func TestGenerate_InitComponentError(t *testing.T) {
 	requirePHPGenerator(t)
 	googleapisDir := "../../testdata/googleapis"

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -402,8 +402,6 @@ func TestInitComponentIfMissing_Error(t *testing.T) {
 	}
 }
 
-// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
-// once the install steps for the dev tool are ready.
 func TestInitComponent(t *testing.T) {
 	ctx := t.Context()
 	repoRoot := t.TempDir()
@@ -442,8 +440,6 @@ echo "$@" > dev_output.txt
 	}
 }
 
-// TODO(https://github.com/googleapis/librarian/issues/6978): Revise this test
-// once the install steps for the dev tool are ready.
 func TestInitComponent_Error(t *testing.T) {
 	ctx := t.Context()
 	repoRoot := t.TempDir()


### PR DESCRIPTION
Obsolete TODO comments referencing dev tool installation are removed from PHP unit and integration tests.

For https://github.com/googleapis/librarian/issues/6978
