### PR TITLE
cleanup(rust): remove google_cloud_unstable_gapic_streaming

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -102,10 +102,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "client: method docstring and example",
 			file:     "src/client.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    ///\n    /// # Example",
+			startStr: "    ///\n    /// # Example",
 			endStr:   "        super::builder::protocol::Chat::new(self.inner.clone())\n    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    ///
+			want: `    ///
     /// # Example
     /// ` + "```" + `
     /// # use google_cloud_test_v1::client::Protocol;
@@ -135,7 +134,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			name:     "builder: struct docstring and example",
 			file:     "src/builder.rs",
 			startStr: "    /// The request builder for [Protocol::chat][crate::client::Protocol::chat] calls.\n    ///\n    /// # Example",
-			endStr:   "    #[cfg(google_cloud_unstable_gapic_streaming)]",
+			endStr:   "    #[derive(Clone, Debug)]",
 			want: `    /// The request builder for [Protocol::chat][crate::client::Protocol::chat] calls.
     ///
     /// # Example
@@ -160,7 +159,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
     ///   // ... details omitted ...
     /// }
     /// ` + "```" + `
-    #[cfg(google_cloud_unstable_gapic_streaming)]`,
+    #[derive(Clone, Debug)]`,
 		},
 		{
 			name:     "builder: struct definition",
@@ -187,10 +186,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "builder: request builder impl",
 			file:     "src/builder.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[doc(hidden)]\n    impl crate::RequestBuilder for Chat",
+			startStr: "    #[doc(hidden)]\n    impl crate::RequestBuilder for Chat",
 			endStr:   "\n    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    #[doc(hidden)]
+			want: `    #[doc(hidden)]
     impl crate::RequestBuilder for Chat {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
             &mut self.0.options
@@ -200,10 +198,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "stub: method signature and default body",
 			file:     "src/stub.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
+			startStr: "    fn chat(",
 			endStr:   "    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    fn chat(
+			want: `    fn chat(
         &self,
         _options: crate::RequestOptions,
     ) -> (
@@ -216,10 +213,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "stub dynamic: trait method",
 			file:     "src/stub/dynamic.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
+			startStr: "    fn chat(",
 			endStr:   ");",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    fn chat(
+			want: `    fn chat(
         &self,
         options: crate::RequestOptions,
     ) -> (
@@ -230,10 +226,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "stub dynamic: blanket forwarding impl",
 			file:     "src/stub/dynamic.rs",
-			startStr: "    /// Forwards the call to the implementation provided by `T`.\n    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
+			startStr: "    /// Forwards the call to the implementation provided by `T`.\n    fn chat(",
 			endStr:   "    }",
 			want: `    /// Forwards the call to the implementation provided by ` + "`T`." + `
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -247,10 +242,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "tracing: method wrapper",
 			file:     "src/tracing.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
+			startStr: "    fn chat(",
 			endStr:   "    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    fn chat(
+			want: `    fn chat(
         &self,
         options: crate::RequestOptions,
     ) -> (
@@ -263,10 +257,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "transport: method signature",
 			file:     "src/transport.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn chat(",
+			startStr: "    fn chat(",
 			endStr:   ") -> (",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    fn chat(
+			want: `    fn chat(
         &self,
         options: crate::RequestOptions,
     ) -> (`,

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -97,10 +97,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "client: method definition",
 			file:     "src/client.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    pub fn expand(&self) -> super::builder::echo::Expand",
+			startStr: "    pub fn expand(&self) -> super::builder::echo::Expand",
 			endStr:   "    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    pub fn expand(&self) -> super::builder::echo::Expand
+			want: `    pub fn expand(&self) -> super::builder::echo::Expand
     {
         super::builder::echo::Expand::new(self.inner.clone())
     }`,
@@ -108,9 +107,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "builder: struct definition",
 			file:     "src/builder.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[derive(Clone, Debug)]\n    pub struct Expand(",
+			startStr: "    #[derive(Clone, Debug)]\n    pub struct Expand(",
 			endStr:   ");",
-			want:     "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[derive(Clone, Debug)]\n    pub struct Expand(RequestBuilder<crate::model::ExpandRequest>);",
+			want:     "    #[derive(Clone, Debug)]\n    pub struct Expand(RequestBuilder<crate::model::ExpandRequest>);",
 		},
 		{
 			name:     "builder: send method",
@@ -127,10 +126,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "builder: RequestBuilder trait impl",
 			file:     "src/builder.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    #[doc(hidden)]\n    impl crate::RequestBuilder for Expand {",
+			startStr: "    #[doc(hidden)]\n    impl crate::RequestBuilder for Expand {",
 			endStr:   "        }\n    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    #[doc(hidden)]
+			want: `    #[doc(hidden)]
     impl crate::RequestBuilder for Expand {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
             &mut self.0.options
@@ -140,10 +138,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "stub: method signature",
 			file:     "src/stub.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    fn expand(",
+			startStr: "    fn expand(",
 			endStr:   "    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    fn expand(
+			want: `    fn expand(
         &self,
         _req: crate::model::ExpandRequest,
         _options: crate::RequestOptions,
@@ -156,10 +153,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "stub/dynamic: trait method",
 			file:     "src/stub/dynamic.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			startStr: "    async fn expand(",
 			endStr:   ">;",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn expand(
+			want: `    async fn expand(
         &self,
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,
@@ -170,10 +166,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "stub dynamic: blanket forwarding impl",
 			file:     "src/stub/dynamic.rs",
-			startStr: "    /// Forwards the call to the implementation provided by `T`.\n    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			startStr: "    /// Forwards the call to the implementation provided by `T`.\n    async fn expand(",
 			endStr:   "    }",
 			want: `    /// Forwards the call to the implementation provided by ` + "`T`." + `
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn expand(
         &self,
         req: crate::model::ExpandRequest,
@@ -187,10 +182,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "tracing: forwarder method",
 			file:     "src/tracing.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			startStr: "    async fn expand(",
 			endStr:   "    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn expand(
+			want: `    async fn expand(
         &self,
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,
@@ -201,10 +195,9 @@ func TestGenerateServerStreaming(t *testing.T) {
 		{
 			name:     "transport: method implementation",
 			file:     "src/transport.rs",
-			startStr: "    #[cfg(google_cloud_unstable_gapic_streaming)]\n    async fn expand(",
+			startStr: "    async fn expand(",
 			endStr:   "            .await\n    }",
-			want: `    #[cfg(google_cloud_unstable_gapic_streaming)]
-    async fn expand(
+			want: `    async fn expand(
         &self,
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -80,14 +80,12 @@ pub mod {{Codec.ModuleName}} {
     {{#Codec.HasBidiStreaming}}
 
     /// Common implementation for [crate::client::{{Codec.Name}}] bidi stream builders.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub(crate) struct BidiStreamBuilder {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
         options: crate::RequestOptions,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl BidiStreamBuilder {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>) -> Self {
             Self {
@@ -163,24 +161,14 @@ pub mod {{Codec.ModuleName}} {
     /// ```
     {{/Codec.InternalBuilders}}
     {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(BidiStreamBuilder);
     {{/Codec.IsBidiStreaming}}
     {{^Codec.IsBidiStreaming}}
-    {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsServerStreaming}}
     #[derive(Clone, Debug)]
     {{Codec.BuilderVisibility}} struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
     {{/Codec.IsBidiStreaming}}
 
-    {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsBidiStreaming}}
-    {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsServerStreaming}}
     impl {{Codec.BuilderName}} {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {
             Self(
@@ -686,12 +674,6 @@ pub mod {{Codec.ModuleName}} {
         {{/Codec.IsBidiStreaming}}
     }
 
-    {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsBidiStreaming}}
-    {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsServerStreaming}}
     #[doc(hidden)]
     impl crate::RequestBuilder for {{Codec.BuilderName}} {
         fn request_options(&mut self) -> &mut crate::RequestOptions {

--- a/internal/sidekick/rust/templates/crate/src/client.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/client.rs.mustache
@@ -128,12 +128,6 @@ impl {{Codec.Name}} {
     }
     {{#Codec.Methods}}
 
-    {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsBidiStreaming}}
-    {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {{/Codec.IsServerStreaming}}
     {{> /templates/common/client_method_preamble}}
     {{Codec.BuilderVisibility}} fn {{Codec.Name}}(&self) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
     {

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -126,7 +126,6 @@ pub(crate) mod tracing;
 pub(crate) mod transport;
 
 {{#Codec.HasStreaming}}
-#[cfg(google_cloud_unstable_gapic_streaming)]
 {{#Codec.PerServiceFeatures}}
 #[cfg(any(
 {{#Codec.StreamingServices}}

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -54,7 +54,6 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
 
     /// Implements [super::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}].
     {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
         _options: crate::RequestOptions,
@@ -66,7 +65,6 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     }
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
         _req: {{InputType.Codec.QualifiedName}},

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -27,7 +27,6 @@ limitations under the License.
 pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     {{#Codec.Methods}}
     {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
         options: crate::RequestOptions,
@@ -38,7 +37,6 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
 
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -88,7 +86,6 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
     {{#Codec.Methods}}
     /// Forwards the call to the implementation provided by `T`.
     {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
         options: crate::RequestOptions,
@@ -101,7 +98,6 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
 
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -65,7 +65,6 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
 
     {{#Codec.IsBidiStreaming}}
     {{! TODO(#6835) - add tracing for bidi streaming methods }}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
         options: crate::RequestOptions,
@@ -78,7 +77,6 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
     {{! TODO(#6835) - add tracing for server streaming methods }}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -36,7 +36,6 @@ use crate::Error;
 pub struct {{Codec.Name}} {
     inner: gaxi::http::ReqwestClient,
     {{#Codec.HasStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     grpc_inner: gaxi::grpc::Client,
     {{/Codec.HasStreaming}}
 }
@@ -54,7 +53,6 @@ impl std::fmt::Debug for {{Codec.Name}} {
         {{#Codec.HasStreaming}}
         let mut builder = f.debug_struct("{{Codec.Name}}");
         builder.field("inner", &self.inner);
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         builder.field("grpc_inner", &self.grpc_inner);
         builder.finish()
         {{/Codec.HasStreaming}}
@@ -91,7 +89,6 @@ impl {{Codec.Name}} {
         } else {
             inner
         };
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         let grpc_inner = if tracing_is_enabled {
             gaxi::grpc::Client::new_with_instrumentation(
                 config,
@@ -104,17 +101,14 @@ impl {{Codec.Name}} {
         };
         Ok(Self {
             inner,
-            #[cfg(google_cloud_unstable_gapic_streaming)]
             grpc_inner,
         })
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
         let inner = gaxi::http::ReqwestClient::new(config.clone(), crate::DEFAULT_HOST).await?;
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         let grpc_inner = gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self {
             inner,
-            #[cfg(google_cloud_unstable_gapic_streaming)]
             grpc_inner,
         })
         {{/Codec.DetailedTracingAttributes}}
@@ -128,7 +122,6 @@ impl {{Codec.Name}} {
 impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     {{#Codec.Methods}}
     {{#Codec.IsBidiStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn {{Codec.Name}}(
         &self,
         options: crate::RequestOptions,
@@ -168,7 +161,6 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
 
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -103,7 +103,6 @@ impl {{Codec.Name}} {
 impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     {{#Codec.Methods}}
     {{#Codec.IsServerStreaming}}
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},


### PR DESCRIPTION
Remove compiler flag now that we have stabilized the API.

For #6835 