### PR TITLE
fix(internal/librarian/java): validate required libraries google-cloud-java and google-cloud-pom-parent

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -620,7 +620,7 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 	cfg := sample.Config()
 	cfg.Language = config.LanguageJava
 	cfg.Default.Output = "output"
-	cfg.Libraries = []*config.Library{}
+	cfg.Libraries = []*config.Library{{Name: "google-cloud-java", Version: "1.0.0"}, {Name: "google-cloud-pom-parent", Version: "1.0.0"}}
 	cfg.Sources.Googleapis.Dir = googleapisDir
 	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 		t.Fatal(err)
@@ -652,6 +652,8 @@ func TestAddLibraryCommand_Java(t *testing.T) {
 				},
 			},
 		},
+		&config.Library{Name: "google-cloud-java", Version: "1.0.0"},
+		&config.Library{Name: "google-cloud-pom-parent", Version: "1.0.0"},
 	}
 	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -210,6 +210,10 @@ var (
 		"google/iam/v3":     true,
 		"google/iam/v3beta": true,
 	}
+	// errLibraryNotFound is returned when a required library is not found in librarian.yaml.
+	errLibraryNotFound = errors.New("library not found in librarian.yaml")
+	// errLibraryMissingVersion is returned when a required library is missing a version.
+	errLibraryMissingVersion = errors.New("library must have a version")
 )
 
 // Validate checks that the Java-specific configuration for a library and global config is
@@ -220,8 +224,10 @@ func Validate(cfg *config.Config) error {
 	if cfg.Default == nil || cfg.Default.Java == nil || cfg.Default.Java.LibrariesBOMVersion == "" {
 		errs = append(errs, errBOMVersionMissing)
 	}
-
 	pathCount := make(map[string]int)
+	if verifyErrs := verifyRequiredLibraries(cfg); len(verifyErrs) > 0 {
+		errs = append(errs, verifyErrs...)
+	}
 	for _, library := range cfg.Libraries {
 		if library.Version != "" {
 			if _, err := semver.Parse(library.Version); err != nil {
@@ -245,7 +251,6 @@ func Validate(cfg *config.Config) error {
 					errs = append(errs, fmt.Errorf("%s: %w", api.Path, ErrOmitCommonResourcesConflict))
 				}
 			}
-
 		}
 	}
 	for path, count := range pathCount {
@@ -307,4 +312,24 @@ func tidyReleasedVersion(library *config.Library) {
 	if err == nil && library.Java.ReleasedVersion == derived {
 		library.Java.ReleasedVersion = ""
 	}
+}
+
+func verifyRequiredLibraries(cfg *config.Config) []error {
+	var errs []error
+	seenLibs := make(map[string]bool)
+	for _, library := range cfg.Libraries {
+		switch library.Name {
+		case rootLibrary, parentPOM:
+			seenLibs[library.Name] = true
+			if library.Version == "" {
+				errs = append(errs, fmt.Errorf("%w: %s", errLibraryMissingVersion, library.Name))
+			}
+		}
+	}
+	for _, req := range []string{rootLibrary, parentPOM} {
+		if !seenLibs[req] {
+			errs = append(errs, fmt.Errorf("%w: %s", errLibraryNotFound, req))
+		}
+	}
+	return errs
 }

--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -314,21 +314,22 @@ func tidyReleasedVersion(library *config.Library) {
 	}
 }
 
+// verifyRequiredLibraries checks that the java configuration includes all mandatory java libraries.
 func verifyRequiredLibraries(cfg *config.Config) []error {
 	var errs []error
-	seenLibs := make(map[string]bool)
+	seenLibraries := make(map[string]bool)
 	for _, library := range cfg.Libraries {
 		switch library.Name {
 		case rootLibrary, parentPOM:
-			seenLibs[library.Name] = true
+			seenLibraries[library.Name] = true
 			if library.Version == "" {
 				errs = append(errs, fmt.Errorf("%w: %s", errLibraryMissingVersion, library.Name))
 			}
 		}
 	}
-	for _, req := range []string{rootLibrary, parentPOM} {
-		if !seenLibs[req] {
-			errs = append(errs, fmt.Errorf("%w: %s", errLibraryNotFound, req))
+	for _, requiredLibrary := range []string{rootLibrary, parentPOM} {
+		if !seenLibraries[requiredLibrary] {
+			errs = append(errs, fmt.Errorf("%w: %s", errLibraryNotFound, requiredLibrary))
 		}
 	}
 	return errs

--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -225,8 +225,8 @@ func Validate(cfg *config.Config) error {
 		errs = append(errs, errBOMVersionMissing)
 	}
 	pathCount := make(map[string]int)
-	if verifyErrs := verifyRequiredLibraries(cfg); len(verifyErrs) > 0 {
-		errs = append(errs, verifyErrs...)
+	if err := verifyRequiredLibraries(cfg); err != nil {
+		errs = append(errs, err)
 	}
 	for _, library := range cfg.Libraries {
 		if library.Version != "" {
@@ -315,22 +315,21 @@ func tidyReleasedVersion(library *config.Library) {
 }
 
 // verifyRequiredLibraries checks that the java configuration includes all mandatory java libraries.
-func verifyRequiredLibraries(cfg *config.Config) []error {
-	var errs []error
+func verifyRequiredLibraries(cfg *config.Config) error {
 	seenLibraries := make(map[string]bool)
 	for _, library := range cfg.Libraries {
 		switch library.Name {
 		case rootLibrary, parentPOM:
 			seenLibraries[library.Name] = true
 			if library.Version == "" {
-				errs = append(errs, fmt.Errorf("%w: %s", errLibraryMissingVersion, library.Name))
+				return fmt.Errorf("%w: %s", errLibraryMissingVersion, library.Name)
 			}
 		}
 	}
 	for _, requiredLibrary := range []string{rootLibrary, parentPOM} {
 		if !seenLibraries[requiredLibrary] {
-			errs = append(errs, fmt.Errorf("%w: %s", errLibraryNotFound, requiredLibrary))
+			return fmt.Errorf("%w: %s", errLibraryNotFound, requiredLibrary)
 		}
 	}
-	return errs
+	return nil
 }

--- a/internal/librarian/java/default_test.go
+++ b/internal/librarian/java/default_test.go
@@ -484,39 +484,68 @@ func TestTidy(t *testing.T) {
 func TestValidate(t *testing.T) {
 	for _, test := range []struct {
 		name string
-		lib  *config.Library
+		libs []*config.Library
 	}{
 		{
 			name: "valid java config",
-			lib: &config.Library{
-				Name: "secretmanager",
-				Java: &config.JavaModule{
-					ReleasedVersion: "1.2.3",
+			libs: []*config.Library{
+				{
+					Name: "secretmanager",
+					Java: &config.JavaModule{
+						ReleasedVersion: "1.2.3",
+					},
 				},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 		},
 		{
 			name: "skipped library does not require released_version",
-			lib: &config.Library{
-				Name:         "google-cloud-java",
-				SkipGenerate: true,
+			libs: []*config.Library{
+				{
+					Name:         "google-cloud-java",
+					Version:      "1.2.3",
+					SkipGenerate: true,
+				},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 		},
 		{
 			name: "valid java config with derivable released version",
-			lib: &config.Library{
-				Name:    "secretmanager",
-				Version: "1.2.0-SNAPSHOT",
+			libs: []*config.Library{
+				{
+					Name:    "secretmanager",
+					Version: "1.2.0-SNAPSHOT",
+				},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 		},
 		{
-			name: "skipped duplicate api paths",
-			lib: &config.Library{
-				Name: "iam",
-				APIs: []*config.API{
-					{Path: "google/iam/v1"},
-					{Path: "google/iam/v1"},
+			name: "valid java skipped duplicate api paths",
+			libs: []*config.Library{
+				{
+					Name: "secretmanager",
+					APIs: []*config.API{
+						{Path: "google/iam/v1"},
+						{Path: "google/iam/v1"},
+					},
 				},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
+			},
+		}, {
+			name: "skipped duplicate api paths",
+			libs: []*config.Library{
+				{
+					Name: "iam",
+					APIs: []*config.API{
+						{Path: "google/iam/v1"},
+						{Path: "google/iam/v1"},
+					},
+				},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 		},
 	} {
@@ -527,10 +556,10 @@ func TestValidate(t *testing.T) {
 						LibrariesBOMVersion: "1.2.3",
 					},
 				},
-				Libraries: []*config.Library{test.lib},
+				Libraries: test.libs,
 			}
 			if err := Validate(cfg); err != nil {
-				t.Errorf("Validate(%+v) error = %v, want nil", test.lib, err)
+				t.Errorf("Validate(%+v) error = %v, want nil", test.libs, err)
 			}
 		})
 	}
@@ -539,67 +568,103 @@ func TestValidate(t *testing.T) {
 func TestValidate_Error(t *testing.T) {
 	for _, test := range []struct {
 		name    string
-		lib     *config.Library
+		libs    []*config.Library
 		wantErr error
 	}{
 		{
 			name: "invalid version",
-			lib: &config.Library{
-				Name:    "secretmanager",
-				Version: "invalid-semver",
+			libs: []*config.Library{
+				{Name: "secretmanager", Version: "invalid-semver"},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 			wantErr: semver.ErrInvalidVersion,
 		},
 		{
 			name: "invalid version with skip generate",
-			lib: &config.Library{
-				Name:         "secretmanager",
-				Version:      "invalid-semver",
-				SkipGenerate: true,
+			libs: []*config.Library{
+				{Name: "secretmanager", Version: "invalid-semver", SkipGenerate: true},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 			wantErr: semver.ErrInvalidVersion,
 		},
 		{
 			name: "invalid released version",
-			lib: &config.Library{
-				Name: "secretmanager",
-				Java: &config.JavaModule{
-					ReleasedVersion: "invalid-semver",
-				},
+			libs: []*config.Library{
+				{Name: "secretmanager", Java: &config.JavaModule{ReleasedVersion: "invalid-semver"}},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 			wantErr: semver.ErrInvalidVersion,
 		},
 		{
 			name: "omit common resources conflict",
-			lib: &config.Library{
-				Name: "secretmanager",
-				Java: &config.JavaModule{
-					ReleasedVersion: "1.2.3",
-				},
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/conflict/v1",
-						Java: &config.JavaAPI{
-							OmitCommonResources: true,
-							AdditionalProtos: []*config.AdditionalProto{
-								{Path: "google/cloud/common_resources.proto"},
+			libs: []*config.Library{
+				{
+					Name: "secretmanager",
+					Java: &config.JavaModule{ReleasedVersion: "1.2.3"},
+					APIs: []*config.API{
+						{
+							Path: "google/cloud/conflict/v1",
+							Java: &config.JavaAPI{
+								OmitCommonResources: true,
+								AdditionalProtos: []*config.AdditionalProto{
+									{Path: "google/cloud/common_resources.proto"},
+								},
 							},
 						},
 					},
 				},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 			wantErr: ErrOmitCommonResourcesConflict,
 		},
 		{
 			name: "duplicate api path",
-			lib: &config.Library{
-				Name: "secretmanager",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-					{Path: "google/cloud/secretmanager/v1"},
+			libs: []*config.Library{
+				{
+					Name: "secretmanager",
+					APIs: []*config.API{
+						{Path: "google/cloud/secretmanager/v1"},
+						{Path: "google/cloud/secretmanager/v1"},
+					},
 				},
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 			wantErr: errDuplicateAPIPath,
+		},
+		{
+			name: "missing google-cloud-java",
+			libs: []*config.Library{
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
+			},
+			wantErr: errLibraryNotFound,
+		},
+		{
+			name: "missing google-cloud-pom-parent",
+			libs: []*config.Library{
+				{Name: "google-cloud-java", Version: "1.2.3"},
+			},
+			wantErr: errLibraryNotFound,
+		},
+		{
+			name: "missing google-cloud-java version",
+			libs: []*config.Library{
+				{Name: "google-cloud-java"},
+				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
+			},
+			wantErr: errLibraryMissingVersion,
+		},
+		{
+			name: "missing google-cloud-pom-parent version",
+			libs: []*config.Library{
+				{Name: "google-cloud-java", Version: "1.2.3"},
+				{Name: "google-cloud-pom-parent"},
+			},
+			wantErr: errLibraryMissingVersion,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -609,7 +674,7 @@ func TestValidate_Error(t *testing.T) {
 						LibrariesBOMVersion: "1.2.3",
 					},
 				},
-				Libraries: []*config.Library{test.lib},
+				Libraries: test.libs,
 			}
 			err := Validate(cfg)
 			if !errors.Is(err, test.wantErr) {
@@ -720,25 +785,19 @@ func TestDeriveLastReleasedVersion_Error(t *testing.T) {
 }
 
 func TestValidate_GlobalConfig(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		def  *config.Default
-	}{
-		{
-			name: "valid bom version",
-			def: &config.Default{
-				Java: &config.JavaDefault{
-					LibrariesBOMVersion: "1.2.3",
-				},
+	cfg := &config.Config{
+		Default: &config.Default{
+			Java: &config.JavaDefault{
+				LibrariesBOMVersion: "1.2.3",
 			},
 		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			cfg := &config.Config{Default: test.def}
-			if err := Validate(cfg); err != nil {
-				t.Fatal(err)
-			}
-		})
+		Libraries: []*config.Library{
+			{Name: "google-cloud-java", Version: "1.2.3"},
+			{Name: "google-cloud-pom-parent", Version: "1.2.3"},
+		},
+	}
+	if err := Validate(cfg); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -764,7 +823,13 @@ func TestValidate_GlobalConfigError(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := &config.Config{Default: test.def}
+			cfg := &config.Config{
+				Default: test.def,
+				Libraries: []*config.Library{
+					{Name: "google-cloud-java", Version: "1.2.3"},
+					{Name: "google-cloud-pom-parent", Version: "1.2.3"},
+				},
+			}
 			got := Validate(cfg)
 			if !errors.Is(got, test.wantErr) {
 				t.Errorf("Validate() error = %v, wantErr %v", got, test.wantErr)

--- a/internal/librarian/java/default_test.go
+++ b/internal/librarian/java/default_test.go
@@ -483,12 +483,12 @@ func TestTidy(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	for _, test := range []struct {
-		name string
-		libs []*config.Library
+		name      string
+		libraries []*config.Library
 	}{
 		{
 			name: "valid java config",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{
 					Name: "secretmanager",
 					Java: &config.JavaModule{
@@ -501,7 +501,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "skipped library does not require released_version",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{
 					Name:         "google-cloud-java",
 					Version:      "1.2.3",
@@ -512,7 +512,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "valid java config with derivable released version",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{
 					Name:    "secretmanager",
 					Version: "1.2.0-SNAPSHOT",
@@ -523,7 +523,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "valid java skipped duplicate api paths",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{
 					Name: "secretmanager",
 					APIs: []*config.API{
@@ -536,7 +536,7 @@ func TestValidate(t *testing.T) {
 			},
 		}, {
 			name: "skipped duplicate api paths",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{
 					Name: "iam",
 					APIs: []*config.API{
@@ -556,10 +556,10 @@ func TestValidate(t *testing.T) {
 						LibrariesBOMVersion: "1.2.3",
 					},
 				},
-				Libraries: test.libs,
+				Libraries: test.libraries,
 			}
 			if err := Validate(cfg); err != nil {
-				t.Errorf("Validate(%+v) error = %v, want nil", test.libs, err)
+				t.Error(err)
 			}
 		})
 	}
@@ -567,13 +567,14 @@ func TestValidate(t *testing.T) {
 
 func TestValidate_Error(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		libs    []*config.Library
-		wantErr error
+		name          string
+		libraries     []*config.Library
+		wantErr       error
+		wantErrString string
 	}{
 		{
 			name: "invalid version",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{Name: "secretmanager", Version: "invalid-semver"},
 				{Name: "google-cloud-java", Version: "1.2.3"},
 				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
@@ -582,7 +583,7 @@ func TestValidate_Error(t *testing.T) {
 		},
 		{
 			name: "invalid version with skip generate",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{Name: "secretmanager", Version: "invalid-semver", SkipGenerate: true},
 				{Name: "google-cloud-java", Version: "1.2.3"},
 				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
@@ -591,7 +592,7 @@ func TestValidate_Error(t *testing.T) {
 		},
 		{
 			name: "invalid released version",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{Name: "secretmanager", Java: &config.JavaModule{ReleasedVersion: "invalid-semver"}},
 				{Name: "google-cloud-java", Version: "1.2.3"},
 				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
@@ -600,7 +601,7 @@ func TestValidate_Error(t *testing.T) {
 		},
 		{
 			name: "omit common resources conflict",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{
 					Name: "secretmanager",
 					Java: &config.JavaModule{ReleasedVersion: "1.2.3"},
@@ -623,7 +624,7 @@ func TestValidate_Error(t *testing.T) {
 		},
 		{
 			name: "duplicate api path",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{
 					Name: "secretmanager",
 					APIs: []*config.API{
@@ -638,29 +639,35 @@ func TestValidate_Error(t *testing.T) {
 		},
 		{
 			name: "missing google-cloud-java",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 			wantErr: errLibraryNotFound,
 		},
 		{
 			name: "missing google-cloud-pom-parent",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{Name: "google-cloud-java", Version: "1.2.3"},
 			},
 			wantErr: errLibraryNotFound,
 		},
 		{
 			name: "missing google-cloud-java version",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{Name: "google-cloud-java"},
 				{Name: "google-cloud-pom-parent", Version: "1.2.3"},
 			},
 			wantErr: errLibraryMissingVersion,
 		},
 		{
+			name:          "missing both required libraries",
+			libraries:     []*config.Library{},
+			wantErr:       errLibraryNotFound,
+			wantErrString: "library not found in librarian.yaml: google-cloud-java\nlibrary not found in librarian.yaml: google-cloud-pom-parent",
+		},
+		{
 			name: "missing google-cloud-pom-parent version",
-			libs: []*config.Library{
+			libraries: []*config.Library{
 				{Name: "google-cloud-java", Version: "1.2.3"},
 				{Name: "google-cloud-pom-parent"},
 			},
@@ -674,11 +681,14 @@ func TestValidate_Error(t *testing.T) {
 						LibrariesBOMVersion: "1.2.3",
 					},
 				},
-				Libraries: test.libs,
+				Libraries: test.libraries,
 			}
 			err := Validate(cfg)
 			if !errors.Is(err, test.wantErr) {
 				t.Errorf("Validate() error = %v, want %v", err, test.wantErr)
+			}
+			if test.wantErrString != "" && err != nil && err.Error() != test.wantErrString {
+				t.Errorf("Validate() error string = %q, want %q", err.Error(), test.wantErrString)
 			}
 		})
 	}

--- a/internal/librarian/java/default_test.go
+++ b/internal/librarian/java/default_test.go
@@ -660,10 +660,9 @@ func TestValidate_Error(t *testing.T) {
 			wantErr: errLibraryMissingVersion,
 		},
 		{
-			name:          "missing both required libraries",
-			libraries:     []*config.Library{},
-			wantErr:       errLibraryNotFound,
-			wantErrString: "library not found in librarian.yaml: google-cloud-java\nlibrary not found in librarian.yaml: google-cloud-pom-parent",
+			name:      "missing both required libraries",
+			libraries: []*config.Library{},
+			wantErr:   errLibraryNotFound,
 		},
 		{
 			name: "missing google-cloud-pom-parent version",

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -636,6 +636,9 @@ func TestTidy_DerivableOutput(t *testing.T) {
 				Sources:   googleapisSource,
 				Libraries: []*config.Library{lib},
 			}
+			if test.language == config.LanguageJava {
+				cfg.Libraries = append(cfg.Libraries, &config.Library{Name: "google-cloud-java", Version: "1.0.0"}, &config.Library{Name: "google-cloud-pom-parent", Version: "1.0.0"})
+			}
 			if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
 				t.Fatal(err)
 			}
@@ -643,7 +646,7 @@ func TestTidy_DerivableOutput(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(got.Libraries) != 1 {
+			if len(got.Libraries) == 0 {
 				t.Fatalf("expected 1 library, got %d", len(got.Libraries))
 			}
 			if got.Libraries[0].Output != "" {
@@ -685,7 +688,7 @@ func TestTidy_DerivableAPIPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got.Libraries) != 1 {
+	if len(got.Libraries) == 0 {
 		t.Fatalf("expected 1 library, got %d", len(got.Libraries))
 	}
 	if len(got.Libraries[0].APIs) != 0 {
@@ -725,7 +728,7 @@ func TestTidy_DerivableRoots(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got.Libraries) != 1 {
+	if len(got.Libraries) == 0 {
 		t.Fatalf("expected 1 library, got %d", len(got.Libraries))
 	}
 	if got.Libraries[0].Roots != nil {
@@ -769,7 +772,8 @@ func TestTidy_UnusedSections(t *testing.T) {
 		{
 			name: "maven preserved",
 			cfg: &config.Config{
-				Language: config.LanguageJava,
+				Language:  config.LanguageJava,
+				Libraries: []*config.Library{{Name: "google-cloud-java", Version: "1.0.0"}, {Name: "google-cloud-pom-parent", Version: "1.0.0"}},
 				Sources: &config.Sources{
 					Googleapis: &config.Source{Commit: "commit"},
 				},

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -646,8 +646,12 @@ func TestTidy_DerivableOutput(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(got.Libraries) == 0 {
-				t.Fatalf("expected 1 library, got %d", len(got.Libraries))
+			expectedLen := 1
+			if test.language == config.LanguageJava {
+				expectedLen = 3
+			}
+			if len(got.Libraries) != expectedLen {
+				t.Fatalf("expected %d library, got %d", expectedLen, len(got.Libraries))
 			}
 			if got.Libraries[0].Output != "" {
 				t.Errorf("expected output to be empty, got %q", got.Libraries[0].Output)
@@ -688,7 +692,7 @@ func TestTidy_DerivableAPIPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got.Libraries) == 0 {
+	if len(got.Libraries) != 1 {
 		t.Fatalf("expected 1 library, got %d", len(got.Libraries))
 	}
 	if len(got.Libraries[0].APIs) != 0 {
@@ -728,7 +732,7 @@ func TestTidy_DerivableRoots(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got.Libraries) == 0 {
+	if len(got.Libraries) != 1 {
 		t.Fatalf("expected 1 library, got %d", len(got.Libraries))
 	}
 	if got.Libraries[0].Roots != nil {


### PR DESCRIPTION
The postgenerate step generates repo level pom.xml files, that sources versions of google-cloud-java and google-cloud-pom-parent from the library list. These two libraries and their version are required. Added a check within the tidy validate step to enforce this.

Fixes #6615