### PR TITLE
refactor(internal/librarian): decouple Java duplicate path validation from top-level tidy step

### DIFF
--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -248,7 +248,7 @@ func Validate(cfg *config.Config) error {
 
 		}
 	}
-	
+
 	for path, count := range pathCount {
 		if count > 1 && !javaSkipDuplicatePaths[path] {
 			errs = append(errs, fmt.Errorf("%w: %s (appears %d times)", errDuplicateAPIPath, path, count))

--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -196,6 +196,20 @@ var (
 	ErrCannotDeriveReleasedVersion = errors.New("cannot derive released version")
 	// errBOMVersionMissing is returned when libraries_bom_version is not set.
 	errBOMVersionMissing = errors.New("libraries bom version not found in config")
+	// errDuplicateAPIPath is returned when there are duplicate API paths.
+	errDuplicateAPIPath = errors.New("duplicate api path")
+
+	// javaSkipDuplicatePaths lists special API paths that are allowed to appear in multiple
+	// libraries in Java without triggering the duplicate API path error.
+	// These are paths are duplicated in java because their generated code splits
+	// between java-iam and java-iam-policy.
+	javaSkipDuplicatePaths = map[string]bool{
+		"google/iam/v1":     true,
+		"google/iam/v2":     true,
+		"google/iam/v2beta": true,
+		"google/iam/v3":     true,
+		"google/iam/v3beta": true,
+	}
 )
 
 // Validate checks that the Java-specific configuration for a library and global config is
@@ -207,6 +221,7 @@ func Validate(cfg *config.Config) error {
 		errs = append(errs, errBOMVersionMissing)
 	}
 
+	pathCount := make(map[string]int)
 	for _, library := range cfg.Libraries {
 		if library.Version != "" {
 			if _, err := semver.Parse(library.Version); err != nil {
@@ -219,6 +234,9 @@ func Validate(cfg *config.Config) error {
 			}
 		}
 		for _, api := range library.APIs {
+			if api.Path != "" {
+				pathCount[api.Path]++
+			}
 			if api.Java == nil || !api.Java.OmitCommonResources {
 				continue
 			}
@@ -230,6 +248,13 @@ func Validate(cfg *config.Config) error {
 
 		}
 	}
+	
+	for path, count := range pathCount {
+		if count > 1 && !javaSkipDuplicatePaths[path] {
+			errs = append(errs, fmt.Errorf("%w: %s (appears %d times)", errDuplicateAPIPath, path, count))
+		}
+	}
+
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}

--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -248,13 +248,11 @@ func Validate(cfg *config.Config) error {
 
 		}
 	}
-
 	for path, count := range pathCount {
 		if count > 1 && !javaSkipDuplicatePaths[path] {
 			errs = append(errs, fmt.Errorf("%w: %s (appears %d times)", errDuplicateAPIPath, path, count))
 		}
 	}
-
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}

--- a/internal/librarian/java/default_test.go
+++ b/internal/librarian/java/default_test.go
@@ -509,6 +509,16 @@ func TestValidate(t *testing.T) {
 				Version: "1.2.0-SNAPSHOT",
 			},
 		},
+		{
+			name: "skipped duplicate api paths",
+			lib: &config.Library{
+				Name: "iam",
+				APIs: []*config.API{
+					{Path: "google/iam/v1"},
+					{Path: "google/iam/v1"},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := &config.Config{
@@ -579,6 +589,17 @@ func TestValidate_Error(t *testing.T) {
 				},
 			},
 			wantErr: ErrOmitCommonResourcesConflict,
+		},
+		{
+			name: "duplicate api path",
+			lib: &config.Library{
+				Name: "secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			wantErr: errDuplicateAPIPath,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -40,17 +40,6 @@ var (
 	errDuplicateAPIPath      = errors.New("duplicate api path")
 	errNoGoogleapiSourceInfo = errors.New("googleapis source not configured in librarian.yaml")
 
-	// javaSkipDuplicatePaths lists special API paths that are allowed to appear in multiple
-	// libraries in Java without triggering the duplicate API path error.
-	// These are paths are duplicated in java because their generated code splits
-	// between java-iam and java-iam-policy.
-	javaSkipDuplicatePaths = map[string]bool{
-		"google/iam/v1":     true,
-		"google/iam/v2":     true,
-		"google/iam/v2beta": true,
-		"google/iam/v3":     true,
-		"google/iam/v3beta": true,
-	}
 )
 
 func tidyCommand() *cli.Command {
@@ -156,9 +145,6 @@ func validateLibraries(cfg *config.Config) error {
 		}
 		for _, ch := range lib.APIs {
 			if ch.Path != "" {
-				if cfg.Language == config.LanguageJava && javaSkipDuplicatePaths[ch.Path] {
-					continue
-				}
 				pathCount[ch.Path]++
 			}
 		}
@@ -171,7 +157,9 @@ func validateLibraries(cfg *config.Config) error {
 	for path, count := range pathCount {
 		// Relax unique API path validation for Ruby because wrapper libraries share
 		// API paths with the versioned libraries they wrap.
-		if count > 1 && cfg.Language != config.LanguageRuby {
+		// Relax unique API path validation for Java here and validate in Java
+		// language validation because some specific paths are intentionally duplicated.
+		if count > 1 && cfg.Language != config.LanguageRuby && cfg.Language != config.LanguageJava {
 			errs = append(errs, fmt.Errorf("%w: %s (appears %d times)", errDuplicateAPIPath, path, count))
 		}
 	}

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -39,7 +39,6 @@ var (
 	errDuplicateLibraryName  = errors.New("duplicate library name")
 	errDuplicateAPIPath      = errors.New("duplicate api path")
 	errNoGoogleapiSourceInfo = errors.New("googleapis source not configured in librarian.yaml")
-
 )
 
 func tidyCommand() *cli.Command {

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -43,29 +43,6 @@ func TestValidateLibraries(t *testing.T) {
 			},
 		},
 		{
-			name: "skipped duplicate api paths",
-			cfg: &config.Config{
-				Language: config.LanguageJava,
-				Default: &config.Default{
-					Java: &config.JavaDefault{
-						LibrariesBOMVersion: "1.2.3",
-					},
-				},
-				Libraries: []*config.Library{
-					{
-						Name: "lib1",
-						APIs: []*config.API{{Path: "google/iam/v1"}},
-						Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
-					},
-					{
-						Name: "lib2",
-						APIs: []*config.API{{Path: "google/iam/v1"}},
-						Java: &config.JavaModule{ReleasedVersion: "1.0.0"},
-					},
-				},
-			},
-		},
-		{
 			name: "allowed duplicate api paths for ruby",
 			cfg: &config.Config{
 				Language: config.LanguageRuby,


### PR DESCRIPTION
Removed the Java-specific `javaSkipDuplicatePaths` logic from the top-level `validateLibraries` step and moved it directly to the Java-specific validation step (`java.Validate`). This improves encapsulation and prevents unrelated tests from failing due to strict language-specific constraints.

Fixes #6707