### PR TITLE
test(php): remove unnecessary composer command requirement

### DIFF
--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -154,7 +154,6 @@ func TestInstall(t *testing.T) {
 }
 
 func TestInstall_Error(t *testing.T) {
-	testhelper.RequireCommand(t, "composer")
 	for _, test := range []struct {
 		name    string
 		tools   *config.Tools

--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -183,6 +183,12 @@ func TestInstall_Error(t *testing.T) {
 					},
 				},
 			},
+			setup: func(t *testing.T) {
+				bin := t.TempDir()
+				testhelper.WriteExecutable(t, filepath.Join(bin, "composer"), "#!/bin/sh\nexit 0\n")
+				testhelper.WriteExecutable(t, filepath.Join(bin, "php"), "#!/bin/sh\nexit 0\n")
+				t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+			},
 			wantErr: composer.ErrMissingRepo,
 		},
 		{

--- a/internal/tool/composer/composer_test.go
+++ b/internal/tool/composer/composer_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestInstall(t *testing.T) {
-	testhelper.RequireCommand(t, "composer")
 	cache := t.TempDir()
 	t.Setenv("LIBRARIAN_CACHE", cache)
 	repoDir := filepath.Join(cache, "github.com/googleapis/gapic-generator-php@1.0.0")
@@ -79,7 +78,6 @@ func TestInstall_Error(t *testing.T) {
 }
 
 func TestInstall_NoEntrypoint(t *testing.T) {
-	testhelper.RequireCommand(t, "composer")
 	cache := t.TempDir()
 	t.Setenv("LIBRARIAN_CACHE", cache)
 	repoDir := filepath.Join(cache, "github.com/googleapis/google-cloud-php@1.0.0")
@@ -253,7 +251,6 @@ func TestVerify_Error(t *testing.T) {
 }
 
 func TestInstall_LocalPath(t *testing.T) {
-	testhelper.RequireCommand(t, "composer")
 	bin := t.TempDir()
 	// Create a dummy composer executable that just exits 0 to simulate success.
 	testhelper.WriteExecutable(t, filepath.Join(bin, "composer"), "#!/bin/sh\nexit 0\n")
@@ -287,7 +284,6 @@ func TestInstall_LocalPath(t *testing.T) {
 }
 
 func TestInstall_LocalPath_Error(t *testing.T) {
-	testhelper.RequireCommand(t, "composer")
 	bin := t.TempDir()
 	// Create a dummy composer executable that exits 1 to simulate failure.
 	testhelper.WriteExecutable(t, filepath.Join(bin, "composer"), "#!/bin/sh\nexit 1\n")


### PR DESCRIPTION
The `composer` and `php` commands are fully mocked in the test cases by writing fake executables to a temporary directory and prepending it to `PATH`. Therefore, requiring the real commands on the host system is unnecessary and causes the tests to be skipped on environments without them.

This PR removes the false host dependency on `composer`. It also adds explicit mocks for `composer` and `php` to the "missing repo URL" test case so that it bypasses the `checkRequiredCommands()` path validation properly instead of failing on environments missing these tools.

Fixes https://github.com/googleapis/librarian/issues/7102