### PR TITLE
feat(rust): support default streaming configuration and explicit overrides

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -545,8 +545,8 @@ This document describes the schema for the librarian.yaml.
 | `routing_required` | bool | Indicates whether routing is required. |
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
-| `include_bidi_streaming_methods` | bool | Indicates whether to include gRPC bi-directional streaming methods. |
-| `include_server_streaming_methods` | bool | Indicates whether to include gRPC server-side streaming methods. |
+| `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
+| `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
 | `post_process_protos` | string | Indicates whether to post-process protos. |
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |
 | `pagination_overrides` | list of [RustPaginationOverride](#rustpaginationoverride-configuration) | Contains overrides for pagination configuration. |
@@ -565,6 +565,8 @@ This document describes the schema for the librarian.yaml.
 | `detailed_tracing_attributes` | bool (optional) | Indicates whether to include detailed tracing attributes. |
 | `lro_stub_options` | bool (optional) | Indicates whether to include LRO poller options in generated stub traits. |
 | `resource_name_heuristic` | bool (optional) | Indicates whether to apply heuristics to identify and generate resource names. |
+| `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
+| `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
 
 ## RustDocumentationOverride Configuration
 
@@ -590,8 +592,8 @@ This document describes the schema for the librarian.yaml.
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_list` | yaml.StringSlice | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
-| `include_bidi_streaming_methods` | bool | Indicates whether to include gRPC bi-directional streaming methods. |
-| `include_server_streaming_methods` | bool | Indicates whether to include gRPC server-side streaming methods. |
+| `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
+| `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
 | `internal_builders` | bool | Indicates whether generated builders should be internal to the crate. |
 | `module_path` | string | Is the Rust module path for converters (e.g., "crate::generated::gapic::model"). |
 | `module_roots` | map[string]string |  |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -545,8 +545,6 @@ This document describes the schema for the librarian.yaml.
 | `routing_required` | bool | Indicates whether routing is required. |
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
-| `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
-| `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
 | `post_process_protos` | string | Indicates whether to post-process protos. |
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |
 | `pagination_overrides` | list of [RustPaginationOverride](#rustpaginationoverride-configuration) | Contains overrides for pagination configuration. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -121,6 +121,14 @@ type RustDefault struct {
 
 	// ResourceNameHeuristic indicates whether to apply heuristics to identify and generate resource names.
 	ResourceNameHeuristic *bool `yaml:"resource_name_heuristic,omitempty"`
+
+	// IncludeBidiStreamingMethods indicates whether to include gRPC bi-directional streaming
+	// methods.
+	IncludeBidiStreamingMethods *bool `yaml:"include_bidi_streaming_methods,omitempty"`
+
+	// IncludeServerStreamingMethods indicates whether to include gRPC server-side streaming
+	// methods.
+	IncludeServerStreamingMethods *bool `yaml:"include_server_streaming_methods,omitempty"`
 }
 
 // RustModule defines a generation target within a veneer crate.
@@ -169,11 +177,11 @@ type RustModule struct {
 
 	// IncludeBidiStreamingMethods indicates whether to include gRPC bi-directional streaming
 	// methods.
-	IncludeBidiStreamingMethods bool `yaml:"include_bidi_streaming_methods,omitempty"`
+	IncludeBidiStreamingMethods *bool `yaml:"include_bidi_streaming_methods,omitempty"`
 
 	// IncludeServerStreamingMethods indicates whether to include gRPC server-side streaming
 	// methods.
-	IncludeServerStreamingMethods bool `yaml:"include_server_streaming_methods,omitempty"`
+	IncludeServerStreamingMethods *bool `yaml:"include_server_streaming_methods,omitempty"`
 
 	// InternalBuilders indicates whether generated builders should be internal to the crate.
 	InternalBuilders bool `yaml:"internal_builders,omitempty"`
@@ -273,14 +281,6 @@ type RustCrate struct {
 	// IncludeStreamingMethods indicates whether to include gRPC streaming
 	// methods.
 	IncludeStreamingMethods bool `yaml:"include_streaming_methods,omitempty"`
-
-	// IncludeBidiStreamingMethods indicates whether to include gRPC bi-directional streaming
-	// methods.
-	IncludeBidiStreamingMethods bool `yaml:"include_bidi_streaming_methods,omitempty"`
-
-	// IncludeServerStreamingMethods indicates whether to include gRPC server-side streaming
-	// methods.
-	IncludeServerStreamingMethods bool `yaml:"include_server_streaming_methods,omitempty"`
 
 	// PostProcessProtos indicates whether to post-process protos.
 	PostProcessProtos string `yaml:"post_process_protos,omitempty"`

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -143,12 +143,24 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Rust.GenerateRpcSamples == "" {
 		lib.Rust.GenerateRpcSamples = d.Rust.GenerateRpcSamples
 	}
+	if lib.Rust.IncludeBidiStreamingMethods == nil {
+		lib.Rust.IncludeBidiStreamingMethods = d.Rust.IncludeBidiStreamingMethods
+	}
+	if lib.Rust.IncludeServerStreamingMethods == nil {
+		lib.Rust.IncludeServerStreamingMethods = d.Rust.IncludeServerStreamingMethods
+	}
 	for _, mod := range lib.Rust.Modules {
 		if mod.GenerateSetterSamples == "" {
 			mod.GenerateSetterSamples = lib.Rust.GenerateSetterSamples
 		}
 		if mod.GenerateRpcSamples == "" {
 			mod.GenerateRpcSamples = lib.Rust.GenerateRpcSamples
+		}
+		if mod.IncludeBidiStreamingMethods == nil {
+			mod.IncludeBidiStreamingMethods = lib.Rust.IncludeBidiStreamingMethods
+		}
+		if mod.IncludeServerStreamingMethods == nil {
+			mod.IncludeServerStreamingMethods = lib.Rust.IncludeServerStreamingMethods
 		}
 	}
 	return lib
@@ -821,6 +833,12 @@ func mergeRust(dst, src *config.RustCrate) *config.RustCrate {
 	}
 	if src.IncludeStreamingMethods {
 		res.IncludeStreamingMethods = src.IncludeStreamingMethods
+	}
+	if src.IncludeBidiStreamingMethods != nil {
+		res.IncludeBidiStreamingMethods = src.IncludeBidiStreamingMethods
+	}
+	if src.IncludeServerStreamingMethods != nil {
+		res.IncludeServerStreamingMethods = src.IncludeServerStreamingMethods
 	}
 	if src.PostProcessProtos != "" {
 		res.PostProcessProtos = src.PostProcessProtos

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -135,10 +135,10 @@ func buildCodec(library *config.Library, releaseLevel string) map[string]string 
 	if rust.IncludeStreamingMethods {
 		codec["include-streaming-methods"] = "true"
 	}
-	if rust.IncludeBidiStreamingMethods {
+	if rust.IncludeBidiStreamingMethods != nil && *rust.IncludeBidiStreamingMethods {
 		codec["include-bidi-streaming-methods"] = "true"
 	}
-	if rust.IncludeServerStreamingMethods {
+	if rust.IncludeServerStreamingMethods != nil && *rust.IncludeServerStreamingMethods {
 		codec["include-server-streaming-methods"] = "true"
 	}
 	if rust.PerServiceFeatures {
@@ -321,10 +321,10 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	if module.IncludeStreamingMethods {
 		codec["include-streaming-methods"] = "true"
 	}
-	if module.IncludeBidiStreamingMethods {
+	if module.IncludeBidiStreamingMethods != nil && *module.IncludeBidiStreamingMethods {
 		codec["include-bidi-streaming-methods"] = "true"
 	}
-	if module.IncludeServerStreamingMethods {
+	if module.IncludeServerStreamingMethods != nil && *module.IncludeServerStreamingMethods {
 		codec["include-server-streaming-methods"] = "true"
 	}
 	detailedTracingAttributes := library.Rust != nil && library.Rust.DetailedTracingAttributes != nil && *library.Rust.DetailedTracingAttributes

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -35,8 +35,8 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 	if library.Rust == nil || library.Rust.TemplateOverride != "" {
 		return nil
 	}
-	includeBidi := library.Rust.IncludeBidiStreamingMethods
-	includeServer := library.Rust.IncludeServerStreamingMethods
+	includeBidi := library.Rust.IncludeBidiStreamingMethods != nil && *library.Rust.IncludeBidiStreamingMethods
+	includeServer := library.Rust.IncludeServerStreamingMethods != nil && *library.Rust.IncludeServerStreamingMethods
 	if !includeBidi && !includeServer {
 		return nil
 	}

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -103,9 +103,11 @@ func TestGenerateProstHybrid(t *testing.T) {
 			lib := &config.Library{
 				Name: "test-package",
 				Rust: &config.RustCrate{
-					IncludeBidiStreamingMethods:   test.includeBidiStreamingMethods,
-					IncludeServerStreamingMethods: test.includeServerStreamingMethods,
-					TemplateOverride:              test.templateOverride,
+					RustDefault: config.RustDefault{
+						IncludeBidiStreamingMethods:   &test.includeBidiStreamingMethods,
+						IncludeServerStreamingMethods: &test.includeServerStreamingMethods,
+					},
+					TemplateOverride: test.templateOverride,
 				},
 			}
 			absSpecSource, err := filepath.Abs("../../testdata/googleapis/google/type")


### PR DESCRIPTION
Add include_bidi_streaming_methods and include_server_streaming_methods to RustDefault and update them to pointer booleans across the Rust configuration structs.

This allows bi-directional and server-side streaming to be configured globally under default.rust in librarian.yaml, while allowing individual libraries or modules to explicitly disable streaming with false overrides. False was ambiguous because it could be unset or explicitly turned off. This will assist with enabling these globally.