### PR TITLE
fix(internal/sidekick/rust): support boxed oneof fields in to_proto

### DIFF
--- a/internal/sidekick/rust/generate_convert_test.go
+++ b/internal/sidekick/rust/generate_convert_test.go
@@ -192,3 +192,57 @@ impl gaxi::prost::FromProto<crate::model::MessageWithSkippedAny> for MessageWith
 		})
 	}
 }
+
+func TestGenerateConvertOneOf(t *testing.T) {
+	typeSchemaMsg := api.NewTestMessage("TypeSchema")
+	inlineSchemaMsg := api.NewTestMessage("InlineSchema").WithFields(
+		api.NewTestField("items").WithMessageType(typeSchemaMsg).WithOptional(),
+	)
+	refSchemaMsg := api.NewTestMessage("ReferenceSchema").WithFields(
+		api.NewTestField("tool").WithType(api.TypezString),
+	)
+	typeSchemaMsg.WithOneOfs(
+		api.NewTestOneOf("schema").WithFields(
+			api.NewTestField("inline_schema").WithMessageType(inlineSchemaMsg),
+			api.NewTestField("reference_schema").WithMessageType(refSchemaMsg),
+			api.NewTestField("name").WithType(api.TypezString),
+		),
+	)
+
+	outDir := t.TempDir()
+	model := api.NewTestAPI([]*api.Message{typeSchemaMsg, inlineSchemaMsg, refSchemaMsg}, nil, nil)
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: libconfig.SpecProtobuf,
+		Codec: map[string]string{
+			"package:wkt":       "source=google.protobuf,package=google-cloud-wkt",
+			"template-override": "templates/convert-prost",
+		},
+	}
+	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := os.ReadFile(filepath.Join(outDir, "convert.rs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantToProto := `impl gaxi::prost::ToProto<type_schema::Schema> for crate::model::type_schema::Schema {
+    type Output = type_schema::Schema;
+    fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
+        match self {
+            Self::InlineSchema(v) => Ok(Self::Output::InlineSchema(std::boxed::Box::new((*v).to_proto()?))),
+            Self::ReferenceSchema(v) => Ok(Self::Output::ReferenceSchema((*v).to_proto()?)),
+            Self::Name(v) => Ok(Self::Output::Name(v.to_proto()?)),
+        }
+    }
+}`
+	gotToProto := extractBlock(t, string(contents), "impl gaxi::prost::ToProto<type_schema::Schema>", "\n        }\n    }\n}")
+	if diff := cmp.Diff(wantToProto, gotToProto); diff != "" {
+		t.Errorf("mismatch ToProto (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/rust/templates/convert-prost/oneof.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/oneof.mustache
@@ -20,22 +20,7 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
         match self {
             {{#Fields}}
-            {{^Codec.IsBoxed}}
-            {{^Codec.MapToBoxed}}
-            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(v.to_proto()?)),
-            {{/Codec.MapToBoxed}}
-            {{#Codec.MapToBoxed}}
-            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(std::boxed::Box::new(v.to_proto()?))),
-            {{/Codec.MapToBoxed}}
-            {{/Codec.IsBoxed}}
-            {{#Codec.IsBoxed}}
-            {{^Codec.MapToBoxed}}
-            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}((*v).to_proto()?)),
-            {{/Codec.MapToBoxed}}
-            {{#Codec.MapToBoxed}}
-            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(std::boxed::Box::new((*v).to_proto()?))),
-            {{/Codec.MapToBoxed}}
-            {{/Codec.IsBoxed}}
+            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}({{#Codec.MapToBoxed}}std::boxed::Box::new({{/Codec.MapToBoxed}}{{#Codec.IsBoxed}}(*v){{/Codec.IsBoxed}}{{^Codec.IsBoxed}}v{{/Codec.IsBoxed}}.to_proto()?{{#Codec.MapToBoxed}}){{/Codec.MapToBoxed}})),
             {{/Fields}}
         }
     }

--- a/internal/sidekick/rust/templates/convert-prost/oneof.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/oneof.mustache
@@ -21,10 +21,20 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
         match self {
             {{#Fields}}
             {{^Codec.IsBoxed}}
+            {{^Codec.MapToBoxed}}
             Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(v.to_proto()?)),
+            {{/Codec.MapToBoxed}}
+            {{#Codec.MapToBoxed}}
+            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(std::boxed::Box::new(v.to_proto()?))),
+            {{/Codec.MapToBoxed}}
             {{/Codec.IsBoxed}}
             {{#Codec.IsBoxed}}
+            {{^Codec.MapToBoxed}}
             Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}((*v).to_proto()?)),
+            {{/Codec.MapToBoxed}}
+            {{#Codec.MapToBoxed}}
+            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(std::boxed::Box::new((*v).to_proto()?))),
+            {{/Codec.MapToBoxed}}
             {{/Codec.IsBoxed}}
             {{/Fields}}
         }


### PR DESCRIPTION
When converting oneofs from the model to Prost types in convert.rs, recursive oneof variants are boxed by prost-build (MapToBoxed = true). Previously, to_proto directly passed (*v).to_proto()? to the Prost oneof variant constructor, failing with a type mismatch because the Prost variant expects a Box<T>.

Update the oneof template to wrap (*v).to_proto()? in std::boxed::Box::new(...) when Codec.MapToBoxed is true.

Fixes googleapis/google-cloud-rust#6567