### PR TITLE
fix(internal/sidekick/rust): avoid clippy warnings in bidi-only services

### DIFF
--- a/internal/sidekick/rust/annotate_service.go
+++ b/internal/sidekick/rust/annotate_service.go
@@ -80,6 +80,24 @@ func (s *serviceAnnotations) HasLROs() bool {
 	return slices.IndexFunc(s.Methods, func(m *api.Method) bool { return m.DiscoveryLro != nil }) != -1
 }
 
+// NeedsRequestBuilder returns true if the service has at least one method that uses RequestBuilder
+// (i.e. methods that are not bidirectional streaming, such as unary or server-streaming methods).
+func (s *serviceAnnotations) NeedsRequestBuilder() bool {
+	return slices.ContainsFunc(s.Methods, func(m *api.Method) bool {
+		ann, ok := m.Codec.(*methodAnnotation)
+		return !ok || !ann.IsBidiStreaming()
+	})
+}
+
+// NeedsBidiStreamBuilder returns true if the service has at least one method that uses BidiStreamBuilder
+// (i.e. bidirectional streaming methods).
+func (s *serviceAnnotations) NeedsBidiStreamBuilder() bool {
+	return slices.ContainsFunc(s.Methods, func(m *api.Method) bool {
+		ann, ok := m.Codec.(*methodAnnotation)
+		return ok && ann.IsBidiStreaming()
+	})
+}
+
 // MaximumAPIVersion returns the highest (in alphanumeric order) APIVersion of
 // all the methods in the service.
 func (s *serviceAnnotations) MaximumAPIVersion() string {

--- a/internal/sidekick/rust/annotate_service_test.go
+++ b/internal/sidekick/rust/annotate_service_test.go
@@ -581,7 +581,7 @@ func TestServiceAnnotationsMethodKinds(t *testing.T) {
 			options: map[string]string{
 				"include-server-streaming-methods": "true",
 			},
-			wantRequestBuilder:   true,
+			wantRequestBuilder:    true,
 			wantBidiStreamBuilder: false,
 		},
 		{
@@ -591,7 +591,7 @@ func TestServiceAnnotationsMethodKinds(t *testing.T) {
 				"include-bidi-streaming-methods":   "true",
 				"include-server-streaming-methods": "true",
 			},
-			wantRequestBuilder:   true,
+			wantRequestBuilder:    true,
 			wantBidiStreamBuilder: true,
 		},
 		{

--- a/internal/sidekick/rust/annotate_service_test.go
+++ b/internal/sidekick/rust/annotate_service_test.go
@@ -543,3 +543,82 @@ func TestServiceAnnotationsStreaming(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceAnnotationsMethodKinds(t *testing.T) {
+	msg := api.NewTestMessage("Request").WithPackage("test.v1")
+	bidiMethod := api.NewTestMethod("Chat").WithInput(msg).WithOutput(msg).WithBidiStreaming().WithPathTemplate(&api.PathTemplate{})
+	serverMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg).WithServerSideStreaming().WithPathTemplate(&api.PathTemplate{})
+	unaryMethod := api.NewTestMethod("Get").WithInput(msg).WithOutput(msg).WithVerb("GET").WithPathTemplate(&api.PathTemplate{})
+
+	for _, test := range []struct {
+		name                  string
+		methods               []*api.Method
+		options               map[string]string
+		wantRequestBuilder    bool
+		wantBidiStreamBuilder bool
+	}{
+		{
+			name:    "bidi only with bidi enabled",
+			methods: []*api.Method{bidiMethod},
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			wantRequestBuilder:    false,
+			wantBidiStreamBuilder: true,
+		},
+		{
+			name:    "bidi and unary with bidi enabled",
+			methods: []*api.Method{bidiMethod, unaryMethod},
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			wantRequestBuilder:    true,
+			wantBidiStreamBuilder: true,
+		},
+		{
+			name:    "server streaming only with server enabled",
+			methods: []*api.Method{serverMethod},
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+			},
+			wantRequestBuilder:   true,
+			wantBidiStreamBuilder: false,
+		},
+		{
+			name:    "server streaming and bidi with both enabled",
+			methods: []*api.Method{serverMethod, bidiMethod},
+			options: map[string]string{
+				"include-bidi-streaming-methods":   "true",
+				"include-server-streaming-methods": "true",
+			},
+			wantRequestBuilder:   true,
+			wantBidiStreamBuilder: true,
+		},
+		{
+			name:                  "unary only",
+			methods:               []*api.Method{unaryMethod},
+			options:               map[string]string{},
+			wantRequestBuilder:    true,
+			wantBidiStreamBuilder: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service := api.NewTestService("TestService").WithPackage("test.v1").WithMethods(test.methods...)
+			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{service})
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
+			codec := newTestCodec(t, libconfig.SpecProtobuf, "", test.options)
+			if _, err := annotateModel(model, codec); err != nil {
+				t.Fatal(err)
+			}
+			serviceAnn := service.Codec.(*serviceAnnotations)
+			if got := serviceAnn.NeedsRequestBuilder(); got != test.wantRequestBuilder {
+				t.Errorf("serviceAnnotations.NeedsRequestBuilder() = %v, want %v", got, test.wantRequestBuilder)
+			}
+			if got := serviceAnn.NeedsBidiStreamBuilder(); got != test.wantBidiStreamBuilder {
+				t.Errorf("serviceAnnotations.NeedsBidiStreamBuilder() = %v, want %v", got, test.wantBidiStreamBuilder)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -73,6 +73,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			"package:prost-types":            "package=prost-types,used-if=streaming",
 			"include-bidi-streaming-methods": "true",
 			"generate-rpc-samples":           "true",
+			"detailed-tracing-attributes":     "true",
 		},
 	}
 	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
@@ -302,6 +303,19 @@ prost.workspace      = true
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+
+	builderContent := readFile("src/builder.rs")
+	if strings.Contains(builderContent, "use crate::Result;") {
+		t.Errorf("src/builder.rs should not contain 'use crate::Result;' for bidi-only service")
+	}
+	if strings.Contains(builderContent, "struct RequestBuilder<") {
+		t.Errorf("src/builder.rs should not contain 'struct RequestBuilder<' for bidi-only service")
+	}
+
+	tracingContent := readFile("src/tracing.rs")
+	if !strings.Contains(tracingContent, "#[allow(dead_code)]\n    duration: gaxi::observability::DurationMetric,") {
+		t.Errorf("src/tracing.rs should contain '#[allow(dead_code)]\\n    duration: gaxi::observability::DurationMetric,'")
 	}
 }
 

--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -73,7 +73,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			"package:prost-types":            "package=prost-types,used-if=streaming",
 			"include-bidi-streaming-methods": "true",
 			"generate-rpc-samples":           "true",
-			"detailed-tracing-attributes":     "true",
+			"detailed-tracing-attributes":    "true",
 		},
 	}
 	if err := Generate(t.Context(), model, outDir, cfg); err != nil {

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -68,6 +68,7 @@ func TestGenerateServerStreaming(t *testing.T) {
 			"package:prost":                    "package=prost,used-if=streaming",
 			"package:prost-types":              "package=prost-types,used-if=streaming",
 			"include-server-streaming-methods": "true",
+			"detailed-tracing-attributes":      "true",
 		},
 	}
 	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
@@ -273,6 +274,26 @@ prost.workspace      = true
 		builderContent := readFile("src/builder.rs")
 		if strings.Contains(builderContent, "auto_populate") {
 			t.Errorf("expected builder.rs not to contain auto_populate helper for server streaming method")
+		}
+	})
+
+	t.Run("builder: contains use crate::Result and RequestBuilder for server streaming", func(t *testing.T) {
+		builderContent := readFile("src/builder.rs")
+		if !strings.Contains(builderContent, "use crate::Result;") {
+			t.Errorf("expected builder.rs to contain 'use crate::Result;' for server-streaming method")
+		}
+		if !strings.Contains(builderContent, "pub(crate) struct RequestBuilder<") {
+			t.Errorf("expected builder.rs to contain 'pub(crate) struct RequestBuilder<' for server-streaming method")
+		}
+		if strings.Contains(builderContent, "BidiStreamBuilder") {
+			t.Errorf("expected builder.rs not to contain 'BidiStreamBuilder' for server-streaming only service")
+		}
+	})
+
+	t.Run("tracing: contains allow(dead_code) on duration for server-streaming only service", func(t *testing.T) {
+		tracingContent := readFile("src/tracing.rs")
+		if !strings.Contains(tracingContent, "#[allow(dead_code)]\n    duration: gaxi::observability::DurationMetric,") {
+			t.Errorf("expected tracing.rs to contain allow(dead_code) on duration metric")
 		}
 	})
 }

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -25,7 +25,9 @@ limitations under the License.
 #[cfg_attr(docsrs, doc(cfg(feature = "{{Codec.FeatureName}}")))]
 {{/Codec.PerServiceFeatures}}
 pub mod {{Codec.ModuleName}} {
+    {{#Codec.NeedsRequestBuilder}}
     use crate::Result;
+    {{/Codec.NeedsRequestBuilder}}
     {{^Codec.HasVeneer}}
 
     /// A builder for [{{Codec.Name}}][crate::client::{{Codec.Name}}].
@@ -58,6 +60,7 @@ pub mod {{Codec.ModuleName}} {
         }
     }
     {{/Codec.HasVeneer}}
+    {{#Codec.NeedsRequestBuilder}}
 
     /// Common implementation for [crate::client::{{Codec.Name}}] request builders.
     #[derive(Clone, Debug)]
@@ -77,7 +80,8 @@ pub mod {{Codec.ModuleName}} {
             }
         }
     }
-    {{#Codec.HasBidiStreaming}}
+    {{/Codec.NeedsRequestBuilder}}
+    {{#Codec.NeedsBidiStreamBuilder}}
 
     /// Common implementation for [crate::client::{{Codec.Name}}] bidi stream builders.
     #[derive(Clone, Debug)]
@@ -94,7 +98,7 @@ pub mod {{Codec.ModuleName}} {
             }
         }
     }
-    {{/Codec.HasBidiStreaming}}
+    {{/Codec.NeedsBidiStreamBuilder}}
 
     {{#Codec.Methods}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.NameNoMangling}}] calls.

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -21,6 +21,7 @@ limitations under the License.
 {{#Codec.PerServiceFeatures}}
 #[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
 {{/Codec.PerServiceFeatures}}
+#[allow(unused_imports)]
 use crate::Result;
 
 {{/Codec.HasServices}}
@@ -35,6 +36,8 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     inner: T,
     {{#Codec.DetailedTracingAttributes}}
     {{! Use a fully qualified name to avoid conflicts with any client called `DurationMetric` }}
+    {{! TODO(#6835) - remove `allow(dead_code)` when duration is used in streaming RPCs }}
+    #[allow(dead_code)]
     duration: gaxi::observability::DurationMetric,
     {{/Codec.DetailedTracingAttributes}}
 }

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -21,7 +21,9 @@ limitations under the License.
 {{#Codec.PerServiceFeatures}}
 #[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
 {{/Codec.PerServiceFeatures}}
+{{#Codec.HasBidiStreaming}}
 #[allow(unused_imports)]
+{{/Codec.HasBidiStreaming}}
 use crate::Result;
 
 {{/Codec.HasServices}}
@@ -36,8 +38,10 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
     inner: T,
     {{#Codec.DetailedTracingAttributes}}
     {{! Use a fully qualified name to avoid conflicts with any client called `DurationMetric` }}
+    {{#Codec.HasStreaming}}
     {{! TODO(#6835) - remove `allow(dead_code)` when duration is used in streaming RPCs }}
     #[allow(dead_code)]
+    {{/Codec.HasStreaming}}
     duration: gaxi::observability::DurationMetric,
     {{/Codec.DetailedTracingAttributes}}
 }

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -22,6 +22,7 @@ limitations under the License.
 {{#Codec.PerServiceFeatures}}
 #[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
 {{/Codec.PerServiceFeatures}}
+#[allow(unused_imports)]
 use crate::Result;
 #[allow(unused_imports)]
 use crate::Error;

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -22,7 +22,9 @@ limitations under the License.
 {{#Codec.PerServiceFeatures}}
 #[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
 {{/Codec.PerServiceFeatures}}
+{{#Codec.HasBidiStreaming}}
 #[allow(unused_imports)]
+{{/Codec.HasBidiStreaming}}
 use crate::Result;
 #[allow(unused_imports)]
 use crate::Error;

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -22,6 +22,7 @@ limitations under the License.
 {{#Codec.PerServiceFeatures}}
 #[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
 {{/Codec.PerServiceFeatures}}
+#[allow(unused_imports)]
 use crate::Result;
 #[allow(unused_imports)]
 use crate::Error;

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -22,7 +22,9 @@ limitations under the License.
 {{#Codec.PerServiceFeatures}}
 #[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
 {{/Codec.PerServiceFeatures}}
+{{#Codec.HasBidiStreaming}}
 #[allow(unused_imports)]
+{{/Codec.HasBidiStreaming}}
 use crate::Result;
 #[allow(unused_imports)]
 use crate::Error;


### PR DESCRIPTION
Services that contain only bidirectional streaming RPCs (such as Tether in apigeeconnect) triggered several clippy warnings during compilation: unused import crate::Result, unused struct RequestBuilder, and unread field duration in tracing.rs.

Add helper methods NeedsRequestBuilder and NeedsBidiStreamBuilder to serviceAnnotations and gate the unused items in builder.rs.mustache. In tracing.rs.mustache, add allow(dead_code) with a TODO to duration field, and allow unused imports on Result. In transport.rs.mustache, allow unused imports on Result.

Fixes googleapis/google-cloud-rust#6568