### PR TITLE
feat(sidekick/rust): support grpc_rust client generation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -577,6 +577,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `grpc_rust` | bool | Indicates whether to use GrpcRustClient for gRPC transport when google_cloud_unstable_grpc_rust is enabled. |
 | `disabled_rustdoc_warnings` | yaml.StringSlice | Specifies rustdoc lints to disable. An empty slice explicitly enables all warnings. |
 | `detailed_tracing_attributes` | bool (optional) | Indicates whether to include detailed tracing attributes. This overrides the crate-level setting. |
 | `lro_stub_options` | bool (optional) | Indicates whether to include LRO poller options in generated stub traits. This overrides the crate-level setting. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -127,6 +127,8 @@ type RustDefault struct {
 // Each module specifies what proto source to use, which template to apply,
 // and where to output the generated code.
 type RustModule struct {
+	// GrpcRust indicates whether to use GrpcRustClient for gRPC transport when google_cloud_unstable_grpc_rust is enabled.
+	GrpcRust bool `yaml:"grpc_rust,omitempty"`
 	// DisabledRustdocWarnings specifies rustdoc lints to disable. An empty slice explicitly enables all warnings.
 	DisabledRustdocWarnings yaml.StringSlice `yaml:"disabled_rustdoc_warnings,omitempty"`
 

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -368,5 +368,8 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	if module.InternalBuilders {
 		codec["internal-builders"] = "true"
 	}
+	if module.GrpcRust {
+		codec["grpc-rust"] = "true"
+	}
 	return codec
 }

--- a/internal/librarian/rust/codec_test.go
+++ b/internal/librarian/rust/codec_test.go
@@ -1301,6 +1301,16 @@ func TestBuildModuleCodec(t *testing.T) {
 			},
 		},
 		{
+			name:    "with GrpcRust",
+			library: &config.Library{},
+			module: &config.RustModule{
+				GrpcRust: true,
+			},
+			want: map[string]string{
+				"grpc-rust": "true",
+			},
+		},
+		{
 			name: "all fields set",
 			library: &config.Library{
 				Name:          "google-cloud-example",
@@ -1335,6 +1345,7 @@ func TestBuildModuleCodec(t *testing.T) {
 				DisabledRustdocWarnings:   []string{"w1", "w2"},
 				RootName:                  "my-root",
 				InternalBuilders:          true,
+				GrpcRust:                  true,
 			},
 			want: map[string]string{
 				"package-name-override":       "google-cloud-example",
@@ -1356,6 +1367,7 @@ func TestBuildModuleCodec(t *testing.T) {
 				"template-override":           "templates/grpc-client",
 				"root-name":                   "my-root",
 				"internal-builders":           "true",
+				"grpc-rust":                   "true",
 			},
 		},
 	} {

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -103,6 +103,8 @@ type modelAnnotations struct {
 	LroStubOptions bool
 	// If true, the generated builders's visibility should be restricted to the crate.
 	InternalBuilders bool
+	// If true, use GrpcRustClient for gRPC transport when google_cloud_unstable_grpc_rust is enabled.
+	UseGrpcRust bool
 	// The service to use for the package-level quickstart sample.
 	// Rust generation may decide not to generate some services,
 	// e.g. if the methods have no bindings. On occasion the service
@@ -354,6 +356,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		DetailedTracingAttributes: codec.detailedTracingAttributes,
 		LroStubOptions:            codec.lroStubOptions,
 		InternalBuilders:          codec.internalBuilders,
+		UseGrpcRust:               codec.grpcRust,
 		QuickstartService:         quickstartService,
 	}
 

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -188,6 +188,44 @@ func TestInternalBuildersAnnotation(t *testing.T) {
 	}
 }
 
+func TestUseGrpcRustAnnotation(t *testing.T) {
+	for _, test := range []struct {
+		Options map[string]string
+		Want    bool
+	}{
+		{
+			Options: map[string]string{},
+			Want:    false,
+		},
+		{
+			Options: map[string]string{
+				"grpc-rust": "true",
+			},
+			Want: true,
+		},
+		{
+			Options: map[string]string{
+				"grpc-rust": "false",
+			},
+			Want: false,
+		},
+	} {
+		model := newTestAnnotateModelAPI()
+		codec := newTestCodec(t, libconfig.SpecProtobuf, "", test.Options)
+		got, err := annotateModel(model, codec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.UseGrpcRust != test.Want {
+			t.Errorf("mismatch in UseGrpcRust, want=%v, got=%v", test.Want, got.UseGrpcRust)
+		}
+		svcAnn := model.Services[0].Codec.(*serviceAnnotations)
+		if svcAnn.UseGrpcRust != test.Want {
+			t.Errorf("mismatch in service UseGrpcRust, want=%v, got=%v", test.Want, svcAnn.UseGrpcRust)
+		}
+	}
+}
+
 func TestQuickstartServiceAnnotation(t *testing.T) {
 	t.Run("survives filtering", func(t *testing.T) {
 		model := newTestAnnotateModelAPI()

--- a/internal/sidekick/rust/annotate_service.go
+++ b/internal/sidekick/rust/annotate_service.go
@@ -62,6 +62,8 @@ type serviceAnnotations struct {
 	HasServerStreaming bool
 	// If true, the service has at least one streaming RPC (bidirectional or server-side) in the API definition.
 	HasStreaming bool
+	// If true, use GrpcRustClient for gRPC transport when google_cloud_unstable_grpc_rust is enabled.
+	UseGrpcRust bool
 }
 
 // BuilderVisibility returns the visibility for client and request builders.
@@ -158,6 +160,7 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 		HasBidiStreaming:          hasBidiStreaming,
 		HasServerStreaming:        hasServerStreaming,
 		HasStreaming:              hasStreaming,
+		UseGrpcRust:               c.grpcRust,
 	}
 	s.Codec = ann
 	return ann, nil

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -212,6 +212,12 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `include-rpc-status-conversion` value %q to boolean: %w", definition, err)
 			}
 			codec.includeRpcStatusConversion = value
+		case key == "grpc-rust":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `grpc-rust` value %q to boolean: %w", definition, err)
+			}
+			codec.grpcRust = value
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -372,6 +378,8 @@ type codec struct {
 	internalBuilders bool
 	// Overrides the default heuristically selected service for the package-level quickstart.
 	quickstartServiceOverride string
+	// If true, use GrpcRustClient for gRPC transport when google_cloud_unstable_grpc_rust is enabled.
+	grpcRust bool
 }
 
 type systemParameter struct {

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -363,6 +363,15 @@ func TestParseOptions(t *testing.T) {
 		{
 			Format: libconfig.SpecProtobuf,
 			Options: map[string]string{
+				"grpc-rust": "true",
+			},
+			Update: func(c *codec) {
+				c.grpcRust = true
+			},
+		},
+		{
+			Format: libconfig.SpecProtobuf,
+			Options: map[string]string{
 				"quickstart-service-override": "OverriddenService",
 			},
 			Update: func(c *codec) {
@@ -412,6 +421,7 @@ func TestParseOptionsErrors(t *testing.T) {
 		{Options: map[string]string{"generate-setter-samples": ""}},
 		{Options: map[string]string{"generate-rpc-samples": ""}},
 		{Options: map[string]string{"internal-builders": ""}},
+		{Options: map[string]string{"grpc-rust": ""}},
 		{Options: map[string]string{"--invalid--": ""}},
 	} {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -51,19 +51,42 @@ mod info {
         });
 }
 
+{{#Codec.UseGrpcRust}}
+{{#Codec.PerServiceFeatures}}
+#[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
+{{/Codec.PerServiceFeatures}}
+#[cfg(google_cloud_unstable_grpc_rust)]
+type GrpcClient = gaxi::grpc::GrpcRustClient;
+{{#Codec.PerServiceFeatures}}
+#[cfg(any({{#Codec.Services}}feature = "{{Codec.FeatureName}}",{{/Codec.Services}}))]
+{{/Codec.PerServiceFeatures}}
+#[cfg(not(google_cloud_unstable_grpc_rust))]
+type GrpcClient = gaxi::grpc::Client;
+{{/Codec.UseGrpcRust}}
+
 {{/Codec.HasServices}}
 {{#Codec.Services}}
-/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using a Tonic-generated client.
+/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using a {{^Codec.UseGrpcRust}}Tonic-generated{{/Codec.UseGrpcRust}}{{#Codec.UseGrpcRust}}gRPC{{/Codec.UseGrpcRust}} client.
 {{#Codec.PerServiceFeatures}}
 #[cfg(feature = "{{Codec.FeatureName}}")]
 {{/Codec.PerServiceFeatures}}
 #[derive(Clone)]
 pub struct {{Codec.Name}} {
     {{^Codec.ExtendGrpcTransport}}
+    {{#Codec.UseGrpcRust}}
+    inner: GrpcClient,
+    {{/Codec.UseGrpcRust}}
+    {{^Codec.UseGrpcRust}}
     inner: gaxi::grpc::Client,
+    {{/Codec.UseGrpcRust}}
     {{/Codec.ExtendGrpcTransport}}
     {{#Codec.ExtendGrpcTransport}}
+    {{#Codec.UseGrpcRust}}
+    pub(crate) inner: GrpcClient,
+    {{/Codec.UseGrpcRust}}
+    {{^Codec.UseGrpcRust}}
     pub(crate) inner: gaxi::grpc::Client,
+    {{/Codec.UseGrpcRust}}
     {{/Codec.ExtendGrpcTransport}}
 }
 
@@ -85,13 +108,28 @@ impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         {{#Codec.DetailedTracingAttributes}}
         let inner = if gaxi::options::tracing_enabled(&config) {
+            {{#Codec.UseGrpcRust}}
+            GrpcClient::new_with_instrumentation(config, DEFAULT_HOST, &super::tracing::info::INSTRUMENTATION_CLIENT_INFO).await?
+            {{/Codec.UseGrpcRust}}
+            {{^Codec.UseGrpcRust}}
             gaxi::grpc::Client::new_with_instrumentation(config, DEFAULT_HOST, &super::tracing::info::INSTRUMENTATION_CLIENT_INFO).await?
+            {{/Codec.UseGrpcRust}}
         } else {
+            {{#Codec.UseGrpcRust}}
+            GrpcClient::new(config, DEFAULT_HOST).await?
+            {{/Codec.UseGrpcRust}}
+            {{^Codec.UseGrpcRust}}
             gaxi::grpc::Client::new(config, DEFAULT_HOST).await?
+            {{/Codec.UseGrpcRust}}
         };
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
+        {{#Codec.UseGrpcRust}}
+        let inner = GrpcClient::new(config, DEFAULT_HOST).await?;
+        {{/Codec.UseGrpcRust}}
+        {{^Codec.UseGrpcRust}}
         let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
+        {{/Codec.UseGrpcRust}}
         {{/Codec.DetailedTracingAttributes}}
         Ok(Self { inner })
     }


### PR DESCRIPTION
For https://github.com/googleapis/google-cloud-rust/issues/5991

Add code generation support for `google-cloud-storage` to use `GrpcRustClient` - a gRPC transport written using Google's `grpc_rust` library) - when `google_cloud_unstable_grpc_rust` is enabled.

- Add GrpcRust boolean option to RustModule configuration and codec.
- Update transport.rs.mustache to generate conditional GrpcClient type aliases.
- Add unit test coverage in codec_test.go and annotate_model_test.go.