### PR TITLE
feat(internal/librarian/python): add tool installation directory helper

### DIFF
--- a/internal/librarian/debug.go
+++ b/internal/librarian/debug.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/librarian/internal/librarian/golang"
 	"github.com/googleapis/librarian/internal/librarian/java"
 	"github.com/googleapis/librarian/internal/librarian/nodejs"
+	"github.com/googleapis/librarian/internal/librarian/python"
 	"github.com/googleapis/librarian/internal/librarian/ruby"
 	"github.com/googleapis/librarian/internal/librarian/swift"
 	"github.com/urfave/cli/v3"
@@ -62,6 +63,7 @@ func runEnv(w io.Writer) error {
 	goToolsDir := dirOrErr(golang.InstallDir())
 	javaToolsDir := dirOrErr(java.InstallDir())
 	nodejsToolsDir := dirOrErr(nodejs.InstallDir())
+	pythonToolsDir := dirOrErr(python.InstallDir())
 	rubyToolsDir := dirOrErr(ruby.InstallDir())
 	swiftToolsDir := dirOrErr(swift.InstallDir())
 	var b strings.Builder
@@ -72,6 +74,7 @@ func runEnv(w io.Writer) error {
 	fmt.Fprintf(&b, "  golang: %s\n", goToolsDir)
 	fmt.Fprintf(&b, "  java: %s\n", javaToolsDir)
 	fmt.Fprintf(&b, "  nodejs: %s\n", nodejsToolsDir)
+	fmt.Fprintf(&b, "  python: %s\n", pythonToolsDir)
 	fmt.Fprintf(&b, "  ruby: %s\n", rubyToolsDir)
 	fmt.Fprintf(&b, "  swift: %s\n", swiftToolsDir)
 	_, err := io.WriteString(w, b.String())

--- a/internal/librarian/debug_test.go
+++ b/internal/librarian/debug_test.go
@@ -38,6 +38,7 @@ func TestRunEnv(t *testing.T) {
 		fmt.Sprintf("golang: %s", filepath.Join(binDir, "go_tools")),
 		fmt.Sprintf("java: %s", filepath.Join(binDir, "java_tools")),
 		fmt.Sprintf("nodejs: %s", filepath.Join(binDir, "nodejs_tools")),
+		fmt.Sprintf("python: %s", filepath.Join(binDir, "python_tools")),
 		fmt.Sprintf("ruby: %s", filepath.Join(binDir, "ruby_tools")),
 		fmt.Sprintf("swift: %s", filepath.Join(binDir, "swift_tools")),
 	}

--- a/internal/librarian/debug_test.go
+++ b/internal/librarian/debug_test.go
@@ -66,6 +66,7 @@ func TestRunEnv_Error(t *testing.T) {
 		"golang: <error:",
 		"java: <error:",
 		"nodejs: <error:",
+		"python: <error:",
 		"ruby: <error:",
 		"swift: <error:",
 	}

--- a/internal/librarian/python/install.go
+++ b/internal/librarian/python/install.go
@@ -17,10 +17,15 @@ package python
 import (
 	"context"
 	"errors"
+	"fmt"
+	"path/filepath"
 
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/tool/pip"
 )
+
+const toolsDir = "python_tools"
 
 var (
 	// ErrNoToolsSpecified indicates no pip tools were provided in the configuration.
@@ -33,4 +38,17 @@ func Install(ctx context.Context, tools *config.Tools) error {
 		return ErrNoToolsSpecified
 	}
 	return pip.Install(ctx, tools.Pip)
+}
+
+// InstallDir gets the directory where tools should be installed.
+func InstallDir() (string, error) {
+	dir, err := cache.BinDirectory()
+	if err != nil {
+		return "", err
+	}
+	absDir, err := filepath.Abs(filepath.Join(dir, toolsDir))
+	if err != nil {
+		return "", fmt.Errorf("failed to get install directory: %w", err)
+	}
+	return absDir, nil
 }

--- a/internal/librarian/python/install_test.go
+++ b/internal/librarian/python/install_test.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/testhelper"
 	"github.com/googleapis/librarian/internal/tool/pip"
@@ -84,6 +86,39 @@ func TestInstall_Error(t *testing.T) {
 			err := Install(t.Context(), test.tools)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("Install() error = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestInstallDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, test := range []struct {
+		name           string
+		librarianBin   string
+		librarianCache string
+		want           string
+	}{
+		{
+			name:         "LIBRARIAN_BIN is set",
+			librarianBin: tmpDir,
+			want:         filepath.Join(tmpDir, "python_tools"),
+		},
+		{
+			name:           "LIBRARIAN_CACHE is set",
+			librarianCache: tmpDir,
+			want:           filepath.Join(tmpDir, "bin", "python_tools"),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(cache.EnvLibrarianBin, test.librarianBin)
+			t.Setenv(cache.EnvLibrarianCache, test.librarianCache)
+			got, err := InstallDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Add an InstallDir function to the `internal/librarian/python` package to determine where Python tools should be installed within Librarian's cached binary directory.

Expose the Python tools directory in the debug env command output and add corresponding unit tests for directory resolution.

A follow up PR will download synthtool template into python tool directory.

For #7424