### PR TITLE
build(.github): add include_pnpm and include_python flags to setup-librarian action

### DIFF
--- a/.github/actions/setup-librarian/action.yaml
+++ b/.github/actions/setup-librarian/action.yaml
@@ -53,4 +53,4 @@ runs:
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       if: ${{ inputs.include_python == 'true' }}
       with:
-        python-version: "3.12"
+        python-version: "3.14"

--- a/.github/actions/setup-librarian/action.yaml
+++ b/.github/actions/setup-librarian/action.yaml
@@ -41,16 +41,16 @@ runs:
         go install ./cmd/librarian
       shell: bash
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-      if: inputs.include_pnpm == 'true'
+      if: ${{ inputs.include_pnpm == 'true' }}
       with:
         node-version: "22"
     - name: "Set up pnpm via corepack"
-      if: inputs.include_pnpm == 'true'
+      if: ${{ inputs.include_pnpm == 'true' }}
       run: |
         corepack enable pnpm
         corepack prepare pnpm@7.32.2 --activate
       shell: bash
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-      if: inputs.include_python == 'true'
+      if: ${{ inputs.include_python == 'true' }}
       with:
-        python-version: "3.14"
+        python-version: "3.12"

--- a/.github/actions/setup-librarian/action.yaml
+++ b/.github/actions/setup-librarian/action.yaml
@@ -13,6 +13,13 @@
 # limitations under the License.
 name: Setup Librarian
 description: Set up Go with build caching, install protoc and Go tools.
+inputs:
+  include_pnpm:
+    description: 'Whether to include Node.js and pnpm setup'
+    default: 'false'
+  include_python:
+    description: 'Whether to include Python setup'
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -33,3 +40,17 @@ runs:
         go install tool
         go install ./cmd/librarian
       shell: bash
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      if: inputs.include_pnpm == 'true'
+      with:
+        node-version: "22"
+    - name: "Set up pnpm via corepack"
+      if: inputs.include_pnpm == 'true'
+      run: |
+        corepack enable pnpm
+        corepack prepare pnpm@7.32.2 --activate
+      shell: bash
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      if: inputs.include_python == 'true'
+      with:
+        python-version: "3.14"

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -42,13 +42,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "22"
-      - name: "Set up pnpm via corepack"
-        run: |
-          corepack enable pnpm
-          corepack prepare pnpm@7.32.2 --activate
+          include_pnpm: 'true'
       - name: "Install Node.js dependencies (resolve cache paths)"
         id: tool-paths
         run: |

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -30,13 +30,9 @@ jobs:
           php-version: '8.2'
           extensions: mbstring, xml, bcmath
       - uses: ./.github/actions/setup-librarian
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "22"
-      - name: "Set up pnpm via corepack"
-        run: |
-          corepack enable pnpm
-          corepack prepare pnpm@7.32.2 --activate
+          include_pnpm: 'true'
+          include_python: 'true'
       - name: Setup test configuration
         run: |
           cp ./tool/cmd/migrate/librarian_php.yaml librarian.yaml

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -25,9 +25,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.14"
+          include_python: 'true'
       - name: Install pandoc
         run: |
           set -e


### PR DESCRIPTION
This allows the nodejs, php, and python workflows to avoid duplicating the Node.js/pnpm and Python installation steps. It also helps operationalize in case we need to add more cross-language runtimes/dependencies in the future.

Fixes https://github.com/googleapis/librarian/issues/7042