### PR TITLE
feat(internal/librarian/rust): support allow_streaming_any_types config

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -591,7 +591,6 @@ This document describes the schema for the librarian.yaml.
 | `included_ids` | list of string | Is a list of proto IDs to include in generation. |
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_list` | yaml.StringSlice | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
-| `allow_streaming_any_types` | list of string | Is a list of protobuf field/message IDs with google.protobuf.Any permitted in streaming RPCs (their fields will be dropped in prost conversion). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
 | `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
 | `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -566,6 +566,7 @@ This document describes the schema for the librarian.yaml.
 | `resource_name_heuristic` | bool (optional) | Indicates whether to apply heuristics to identify and generate resource names. |
 | `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
 | `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
+| `allow_streaming_any_types` | list of string | Is a list of protobuf field/message IDs with google.protobuf.Any permitted in streaming RPCs (their fields will be dropped in prost conversion). |
 
 ## RustDocumentationOverride Configuration
 
@@ -590,6 +591,7 @@ This document describes the schema for the librarian.yaml.
 | `included_ids` | list of string | Is a list of proto IDs to include in generation. |
 | `include_grpc_only_methods` | bool | Indicates whether to include gRPC-only methods. |
 | `include_list` | yaml.StringSlice | Is a list of proto files to include (e.g., "date.proto", "expr.proto"). |
+| `allow_streaming_any_types` | list of string | Is a list of protobuf field/message IDs with google.protobuf.Any permitted in streaming RPCs (their fields will be dropped in prost conversion). |
 | `include_streaming_methods` | bool | Indicates whether to include gRPC streaming methods. |
 | `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
 | `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -129,6 +129,10 @@ type RustDefault struct {
 	// IncludeServerStreamingMethods indicates whether to include gRPC server-side streaming
 	// methods.
 	IncludeServerStreamingMethods *bool `yaml:"include_server_streaming_methods,omitempty"`
+
+	// AllowStreamingAnyTypes is a list of protobuf field/message IDs with google.protobuf.Any
+	// permitted in streaming RPCs (their fields will be dropped in prost conversion).
+	AllowStreamingAnyTypes []string `yaml:"allow_streaming_any_types,omitempty"`
 }
 
 // RustModule defines a generation target within a veneer crate.
@@ -170,6 +174,10 @@ type RustModule struct {
 
 	// IncludeList is a list of proto files to include (e.g., "date.proto", "expr.proto").
 	IncludeList yaml.StringSlice `yaml:"include_list,omitempty"`
+
+	// AllowStreamingAnyTypes is a list of protobuf field/message IDs with google.protobuf.Any
+	// permitted in streaming RPCs (their fields will be dropped in prost conversion).
+	AllowStreamingAnyTypes []string `yaml:"allow_streaming_any_types,omitempty"`
 
 	// IncludeStreamingMethods indicates whether to include gRPC streaming
 	// methods.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -175,10 +175,6 @@ type RustModule struct {
 	// IncludeList is a list of proto files to include (e.g., "date.proto", "expr.proto").
 	IncludeList yaml.StringSlice `yaml:"include_list,omitempty"`
 
-	// AllowStreamingAnyTypes is a list of protobuf field/message IDs with google.protobuf.Any
-	// permitted in streaming RPCs (their fields will be dropped in prost conversion).
-	AllowStreamingAnyTypes []string `yaml:"allow_streaming_any_types,omitempty"`
-
 	// IncludeStreamingMethods indicates whether to include gRPC streaming
 	// methods.
 	IncludeStreamingMethods bool `yaml:"include_streaming_methods,omitempty"`

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -149,6 +149,9 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Rust.IncludeServerStreamingMethods == nil {
 		lib.Rust.IncludeServerStreamingMethods = d.Rust.IncludeServerStreamingMethods
 	}
+	if len(lib.Rust.AllowStreamingAnyTypes) == 0 && d.Rust != nil {
+		lib.Rust.AllowStreamingAnyTypes = d.Rust.AllowStreamingAnyTypes
+	}
 	for _, mod := range lib.Rust.Modules {
 		if mod.GenerateSetterSamples == "" {
 			mod.GenerateSetterSamples = lib.Rust.GenerateSetterSamples
@@ -161,6 +164,9 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 		}
 		if mod.IncludeServerStreamingMethods == nil {
 			mod.IncludeServerStreamingMethods = lib.Rust.IncludeServerStreamingMethods
+		}
+		if len(mod.AllowStreamingAnyTypes) == 0 {
+			mod.AllowStreamingAnyTypes = lib.Rust.AllowStreamingAnyTypes
 		}
 	}
 	return lib
@@ -839,6 +845,9 @@ func mergeRust(dst, src *config.RustCrate) *config.RustCrate {
 	}
 	if src.IncludeServerStreamingMethods != nil {
 		res.IncludeServerStreamingMethods = src.IncludeServerStreamingMethods
+	}
+	if len(src.AllowStreamingAnyTypes) > 0 {
+		res.AllowStreamingAnyTypes = src.AllowStreamingAnyTypes
 	}
 	if src.PostProcessProtos != "" {
 		res.PostProcessProtos = src.PostProcessProtos

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -165,9 +165,6 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 		if mod.IncludeServerStreamingMethods == nil {
 			mod.IncludeServerStreamingMethods = lib.Rust.IncludeServerStreamingMethods
 		}
-		if len(mod.AllowStreamingAnyTypes) == 0 {
-			mod.AllowStreamingAnyTypes = lib.Rust.AllowStreamingAnyTypes
-		}
 	}
 	return lib
 }

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -47,7 +47,7 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 		return nil
 	}
 
-	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToStreaming(model, includeBidi, includeServer)
+	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToStreaming(model, includeBidi, includeServer, library.Rust.AllowStreamingAnyTypes)
 	if err != nil {
 		return err
 	}
@@ -83,8 +83,8 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 // enabled bidirectional and server-side streaming RPC types for prost conversion generation. It also returns
 // a sorted slice of all non-WKT unused type IDs to exclude via prost_build extern_path,
 // and a boolean indicating whether google.rpc.Status is referenced in the streaming path.
-// Errors if Any is encountered in the streaming reachability path.
-func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool) (*api.API, []string, bool, error) {
+// Errors if Any is encountered in the streaming reachability path unless explicitly allowed via allowStreamingAnyTypes.
+func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool, allowStreamingAnyTypes []string) (*api.API, []string, bool, error) {
 	type streamingTypeItem struct {
 		id       string
 		rpc      string
@@ -177,14 +177,23 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 		}
 		visited[item.id] = true
 
-		anyError := func(path string) error {
+		anyError := func(path string, fieldID string) error {
+			if fieldID != "" && !isAnyType(fieldID) {
+				return fmt.Errorf("cannot generate prost conversion for streaming RPC %q: type google.protobuf.Any is unsupported (path: %s)\n"+
+					"To resolve this, allow dropping this Any field in prost conversion by adding it to allow_streaming_any_types in librarian.yaml:\n"+
+					"    rust:\n"+
+					"      allow_streaming_any_types:\n"+
+					"        - %s\n"+
+					"Or skip the RPC method by adding it to skipped_ids in librarian.yaml (e.g. skipped_ids: [%s])",
+					item.rpc, path, fieldID, item.methodID)
+			}
 			return fmt.Errorf("cannot generate prost conversion for streaming RPC %q: type google.protobuf.Any is unsupported (path: %s)\n"+
 				"To resolve this, add the RPC method ID to skipped_ids in librarian.yaml (e.g. skipped_ids: [%s])",
 				item.rpc, path, item.methodID)
 		}
 
 		if isAnyType(item.id) {
-			return nil, nil, false, anyError(item.path)
+			return nil, nil, false, anyError(item.path, item.id)
 		}
 
 		msg := model.Message(item.id)
@@ -201,7 +210,11 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 			for _, f := range msg.Fields {
 				fieldPath := item.path + "." + f.Name
 				if isAnyType(f.TypezID) {
-					return nil, nil, false, anyError(fieldPath)
+					if matchesAllowedAnyField(f.ID, allowStreamingAnyTypes) || matchesAllowedAnyField(fieldPath, allowStreamingAnyTypes) {
+						f.SkipProtoConversion = true
+						continue
+					}
+					return nil, nil, false, anyError(fieldPath, f.ID)
 				}
 				if f.Typez == api.TypezMessage && f.TypezID != "" {
 					queue = append(queue, streamingTypeItem{
@@ -219,7 +232,11 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 				for _, f := range o.Fields {
 					fieldPath := item.path + "." + o.Name + "." + f.Name
 					if isAnyType(f.TypezID) {
-						return nil, nil, false, anyError(fieldPath)
+						if matchesAllowedAnyField(f.ID, allowStreamingAnyTypes) || matchesAllowedAnyField(fieldPath, allowStreamingAnyTypes) {
+							f.SkipProtoConversion = true
+							continue
+						}
+						return nil, nil, false, anyError(fieldPath, f.ID)
 					}
 					if f.Typez == api.TypezMessage && f.TypezID != "" {
 						queue = append(queue, streamingTypeItem{
@@ -320,6 +337,16 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 	slices.Sort(unusedTypes)
 
 	return &hybridModel, slices.Compact(unusedTypes), hasGoogleRpcStatus, nil
+}
+
+func matchesAllowedAnyField(id string, allowStreamingAnyTypes []string) bool {
+	idTrimmed := strings.TrimPrefix(id, ".")
+	for _, allowed := range allowStreamingAnyTypes {
+		if strings.TrimPrefix(allowed, ".") == idTrimmed {
+			return true
+		}
+	}
+	return false
 }
 
 func isAnyType(id string) bool {

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -17,6 +17,7 @@ package rust
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -155,7 +156,7 @@ func TestFilterModelToStreaming(t *testing.T) {
 	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
 	model := api.NewTestAPI([]*api.Message{streamingMsg, unusedMsg}, []*api.Enum{}, []*api.Service{bidiService})
 
-	filtered, unused, _, err := filterModelToStreaming(model, true, true)
+	filtered, unused, _, err := filterModelToStreaming(model, true, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -191,7 +192,7 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{streamMsg, unaryReq, childData}, []*api.Enum{}, []*api.Service{bidiService, unaryService})
 
-	filtered, _, _, err := filterModelToStreaming(model, true, true)
+	filtered, _, _, err := filterModelToStreaming(model, true, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,7 +239,7 @@ func TestFilterModelToStreamingExternalTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	filtered, _, _, err := filterModelToStreaming(model, true, true)
+	filtered, _, _, err := filterModelToStreaming(model, true, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -268,12 +269,48 @@ func TestFilterModelToStreamingAnyError(t *testing.T) {
 
 	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
 
-	_, _, _, err := filterModelToStreaming(anyModel, true, true)
+	_, _, _, err := filterModelToStreaming(anyModel, true, true, nil)
 	if err == nil {
 		t.Fatal("expected error for google.protobuf.Any, got nil")
 	}
-	if !strings.Contains(err.Error(), "skipped_ids") {
-		t.Errorf("expected error to contain recommendation 'skipped_ids', got: %v", err)
+	if !strings.Contains(err.Error(), "allow_streaming_any_types") {
+		t.Errorf("expected error to contain recommendation 'allow_streaming_any_types', got: %v", err)
+	}
+}
+
+func TestFilterModelToStreamingAllowedAny(t *testing.T) {
+	// Verify allowing specific Any field path succeeds and drops the field from conversion
+	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(
+		api.NewTestField("details").WithType(api.TypezMessage).WithTypezID(".google.protobuf.Any"),
+		api.NewTestField("name").WithType(api.TypezString),
+	)
+	chatAnyMethod := api.NewTestMethod("ChatAny").WithInput(anyMsg).WithOutput(anyMsg).WithBidiStreaming()
+	anyService := api.NewTestService("AnyService").WithPackage("google.test.v1").WithMethods(chatAnyMethod)
+
+	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
+
+	filtered, _, _, err := filterModelToStreaming(anyModel, true, true, []string{".google.test.v1.AnyReq.details"})
+	if err != nil {
+		t.Fatalf("expected success with allowStreamingAnyTypes, got error: %v", err)
+	}
+
+	msg := filtered.Message(anyMsg.ID)
+	if msg == nil {
+		t.Fatalf("expected message %s in filtered model", anyMsg.ID)
+	}
+	if !msg.HasSkippedProtoConversionFields() {
+		t.Errorf("expected msg.HasSkippedProtoConversionFields() to be true")
+	}
+	if len(msg.Fields) != 2 {
+		t.Errorf("expected msg.Fields to retain all 2 fields, got: %v", msg.Fields)
+	}
+	detailsField := slices.IndexFunc(msg.Fields, func(f *api.Field) bool { return f.Name == "details" })
+	if detailsField == -1 || !msg.Fields[detailsField].SkipProtoConversion {
+		t.Errorf("expected 'details' field to have SkipProtoConversion == true")
+	}
+	nameField := slices.IndexFunc(msg.Fields, func(f *api.Field) bool { return f.Name == "name" })
+	if nameField == -1 || msg.Fields[nameField].SkipProtoConversion {
+		t.Errorf("expected 'name' field to have SkipProtoConversion == false")
 	}
 }
 
@@ -310,7 +347,7 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 	statusModel := api.NewTestAPI([]*api.Message{reqMsg}, []*api.Enum{}, []*api.Service{statusService})
 	statusModel.AddMessage(statusMsg)
 
-	filtered, unused, hasStatus, err := filterModelToStreaming(statusModel, true, true)
+	filtered, unused, hasStatus, err := filterModelToStreaming(statusModel, true, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error for google.rpc.Status: %v", err)
 	}
@@ -357,7 +394,7 @@ func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{parent, child, sibling, streamReq}, []*api.Enum{}, []*api.Service{bidiService})
 
-	_, unusedTypes, _, err := filterModelToStreaming(model, true, false)
+	_, unusedTypes, _, err := filterModelToStreaming(model, true, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -385,7 +422,7 @@ func TestFilterModelToStreamingServerStreaming(t *testing.T) {
 	serverService := api.NewTestService("EchoService").WithPackage("google.test.v1").WithMethods(expandMethod)
 	model := api.NewTestAPI([]*api.Message{reqMsg, respMsg, unusedMsg}, []*api.Enum{}, []*api.Service{serverService})
 
-	filtered, unused, _, err := filterModelToStreaming(model, false, true)
+	filtered, unused, _, err := filterModelToStreaming(model, false, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -442,7 +479,7 @@ func TestFilterModelToStreamingIsolation(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			filtered, unused, _, err := filterModelToStreaming(model, test.includeBidi, test.includeServer)
+			filtered, unused, _, err := filterModelToStreaming(model, test.includeBidi, test.includeServer, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/sidekick/api/field.go
+++ b/internal/sidekick/api/field.go
@@ -55,6 +55,9 @@ type Field struct {
 	// containing message. That triggers slightly different code generation for
 	// some languages.
 	Recursive bool
+	// SkipProtoConversion is true if this field should be omitted from
+	// proto/prost conversion (e.g. allowed Any fields in streaming RPCs).
+	SkipProtoConversion bool
 	// AutoPopulated is true if the field is eligible to be auto-populated,
 	// per the requirements in AIP-4235.
 	//

--- a/internal/sidekick/api/message.go
+++ b/internal/sidekick/api/message.go
@@ -80,3 +80,13 @@ func (m *Message) HasFields() bool {
 func (m *Message) HasSkippedFields() bool {
 	return len(m.SkippedFields) != 0
 }
+
+// HasSkippedProtoConversionFields returns true if any field in the message has SkipProtoConversion = true.
+func (m *Message) HasSkippedProtoConversionFields() bool {
+	for _, f := range m.Fields {
+		if f.SkipProtoConversion {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sidekick/api/test.go
+++ b/internal/sidekick/api/test.go
@@ -407,6 +407,18 @@ func (f *Field) WithMessageType(msg *Message) *Field {
 	return f
 }
 
+// WithTypezID sets the field's TypezID.
+func (f *Field) WithTypezID(id string) *Field {
+	f.TypezID = id
+	return f
+}
+
+// WithSkipProtoConversion marks the field as skipping proto conversion.
+func (f *Field) WithSkipProtoConversion() *Field {
+	f.SkipProtoConversion = true
+	return f
+}
+
 // WithResourceReference sets the resource reference on a field.
 func (f *Field) WithResourceReference(refType string) *Field {
 	f.ResourceReference = &ResourceReference{Type: refType}

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -163,10 +163,6 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		if err := codec.annotateEnum(e, model, true); err != nil {
 			return nil, err
 		}
-		// ExternalEnums (e.g. google.type.Date) are populated for convert-prost generation in hybrid crates.
-		// Override ProstRelativeName so ToProto and FromProto resolve to crate::prost::<pkg>::<TypeName>.
-		ann := e.Codec.(*enumAnnotation)
-		ann.ProstRelativeName = "crate::prost::" + packageToModuleName(e.Package) + "::" + prostEnumRelativePath(e)
 	}
 	for _, m := range model.Messages {
 		if err := codec.annotateMessage(m, model, true); err != nil {
@@ -177,10 +173,6 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		if err := codec.annotateMessage(m, model, true); err != nil {
 			return nil, err
 		}
-		// ExternalMessages (e.g. google.type.LatLng) are populated for convert-prost generation in hybrid crates.
-		// Override ProstRelativeName so ToProto and FromProto resolve to crate::prost::<pkg>::<TypeName>.
-		ann := m.Codec.(*messageAnnotation)
-		ann.ProstRelativeName = "crate::prost::" + packageToModuleName(m.Package) + "::" + prostMessageRelativePath(m)
 	}
 	// External enums and messages get only basic annotations
 	// used for sample generation.
@@ -232,6 +224,21 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		}
 		if _, err := codec.annotateService(s); err != nil {
 			return nil, err
+		}
+	}
+
+	// ExternalEnums (e.g. google.type.Date) and ExternalMessages (e.g. google.api.HttpBody)
+	// are populated for convert-prost generation in hybrid crates.
+	// Override ProstRelativeName after all method annotations so ToProto and FromProto
+	// resolve to crate::prost::<pkg>::<TypeName>.
+	for _, e := range model.ExternalEnums {
+		if ann, ok := e.Codec.(*enumAnnotation); ok {
+			ann.ProstRelativeName = "crate::prost::" + packageToModuleName(e.Package) + "::" + prostEnumRelativePath(e)
+		}
+	}
+	for _, m := range model.ExternalMessages {
+		if ann, ok := m.Codec.(*messageAnnotation); ok {
+			ann.ProstRelativeName = "crate::prost::" + packageToModuleName(m.Package) + "::" + prostMessageRelativePath(m)
 		}
 	}
 

--- a/internal/sidekick/rust/generate_convert_test.go
+++ b/internal/sidekick/rust/generate_convert_test.go
@@ -247,9 +247,13 @@ func TestGenerateConvertAcronyms(t *testing.T) {
 
 	extDnsConfigMsg := api.NewTestMessage("DNSConfig").WithPackage("google.type")
 
+	dnsMethod := api.NewTestMethod("GetDNS").WithInput(extDnsConfigMsg).WithOutput(extDnsConfigMsg)
+	dnsService := api.NewTestService("DNSService").WithPackage("test.v1").WithMethods(dnsMethod)
+
 	outDir := t.TempDir()
-	model := api.NewTestAPI([]*api.Message{vertexAiSearchMsg, dataStoreSpecMsg, retrievalMsg}, []*api.Enum{ipVersionEnum, nestedEnum}, nil)
+	model := api.NewTestAPI([]*api.Message{vertexAiSearchMsg, dataStoreSpecMsg, retrievalMsg}, []*api.Enum{ipVersionEnum, nestedEnum}, []*api.Service{dnsService})
 	model.ExternalMessages = []*api.Message{extDnsConfigMsg}
+	model.AddMessage(extDnsConfigMsg)
 	if err := api.CrossReference(model); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sidekick/rust/generate_convert_test.go
+++ b/internal/sidekick/rust/generate_convert_test.go
@@ -374,3 +374,48 @@ func TestGenerateConvertAcronyms(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateConvertOneOfWithSkippedProtoConversion(t *testing.T) {
+	typeSchemaMsg := api.NewTestMessage("TypeSchema").WithOneOfs(
+		api.NewTestOneOf("schema").WithFields(
+			api.NewTestField("name").WithType(api.TypezString),
+			api.NewTestField("details").WithType(api.TypezString).WithSkipProtoConversion(),
+		),
+	)
+
+	outDir := t.TempDir()
+	model := api.NewTestAPI([]*api.Message{typeSchemaMsg}, nil, nil)
+	if err := api.CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &parser.ModelConfig{
+		SpecificationFormat: libconfig.SpecProtobuf,
+		Codec: map[string]string{
+			"package:wkt":       "source=google.protobuf,package=google-cloud-wkt",
+			"template-override": "templates/convert-prost",
+		},
+	}
+	if err := Generate(t.Context(), model, outDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := os.ReadFile(filepath.Join(outDir, "convert.rs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantToProto := `impl gaxi::prost::ToProto<type_schema::Schema> for crate::model::type_schema::Schema {
+    type Output = type_schema::Schema;
+    fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
+        match self {
+            Self::Name(v) => Ok(Self::Output::Name(v.to_proto()?)),
+            Self::Details(_) => Ok(Self::Output::Details(std::default::Default::default())),
+        }
+    }
+}`
+	gotToProto := extractBlock(t, string(contents), "impl gaxi::prost::ToProto<type_schema::Schema>", "\n        }\n    }\n}")
+	if diff := cmp.Diff(wantToProto, gotToProto); diff != "" {
+		t.Errorf("mismatch ToProto (-want +got):\n%s", diff)
+	}
+}

--- a/internal/sidekick/rust/templates/convert-prost/message.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/message.mustache
@@ -30,6 +30,7 @@ impl gaxi::prost::ToProto<{{Codec.ProstRelativeName}}> for {{Codec.QualifiedName
     fn to_proto(self) -> std::result::Result<{{Codec.ProstRelativeName}}, gaxi::prost::ConvertError> {
         Ok(Self::Output {
             {{#Codec.BasicFields}}
+            {{^SkipProtoConversion}}
             {{#Singular}}
             {{^Optional}}
             {{Codec.FieldName}}: self.{{Codec.FieldName}}.to_proto()?,
@@ -57,13 +58,19 @@ impl gaxi::prost::ToProto<{{Codec.ProstRelativeName}}> for {{Codec.QualifiedName
                     gaxi::prost::pair_transpose(k.to_proto(), v.to_proto())
                 }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?,
             {{/Map}}
+            {{/SkipProtoConversion}}
             {{/Codec.BasicFields}}
             {{#OneOfs}}
             {{Codec.FieldName}}: self.{{Codec.FieldName}}.map(|v| v.to_proto()).transpose()?,
             {{/OneOfs}}
+            {{#HasSkippedProtoConversionFields}}
+            ..Self::Output::default()
+            {{/HasSkippedProtoConversionFields}}
+            {{^HasSkippedProtoConversionFields}}
             {{#HasSkippedFields}}
             ..Self::Output::default()
             {{/HasSkippedFields}}
+            {{/HasSkippedProtoConversionFields}}
         })
     }
 }
@@ -74,6 +81,7 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.ProstRelativeNa
         Ok(
             {{Codec.QualifiedName}}::new()
                 {{#Codec.BasicFields}}
+                {{^SkipProtoConversion}}
                 {{#Singular}}
                 {{^Optional}}
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}})
@@ -113,6 +121,7 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.ProstRelativeNa
                     }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
                 {{/Codec.ValueType.IsEnum}}
                 {{/Map}}
+                {{/SkipProtoConversion}}
                 {{/Codec.BasicFields}}
                 {{#OneOfs}}
                 .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()).transpose()?)

--- a/internal/sidekick/rust/templates/convert-prost/oneof.mustache
+++ b/internal/sidekick/rust/templates/convert-prost/oneof.mustache
@@ -20,7 +20,12 @@ impl gaxi::prost::ToProto<{{Codec.ProstRelativeName}}> for {{Codec.QualifiedName
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
         match self {
             {{#Fields}}
+            {{^SkipProtoConversion}}
             Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.ProstBranchName}}({{#Codec.MapToBoxed}}std::boxed::Box::new({{/Codec.MapToBoxed}}{{#Codec.IsBoxed}}(*v){{/Codec.IsBoxed}}{{^Codec.IsBoxed}}v{{/Codec.IsBoxed}}.to_proto()?{{#Codec.MapToBoxed}}){{/Codec.MapToBoxed}})),
+            {{/SkipProtoConversion}}
+            {{#SkipProtoConversion}}
+            Self::{{Codec.BranchName}}(_) => Ok(Self::Output::{{Codec.ProstBranchName}}(std::default::Default::default())),
+            {{/SkipProtoConversion}}
             {{/Fields}}
         }
     }
@@ -32,6 +37,7 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.ProstRelativeNa
         use {{Codec.QualifiedName}} as T;
         match self {
             {{#Fields}}
+            {{^SkipProtoConversion}}
             {{^IsEnum}}
             {{^Codec.IsBoxed}}
             Self::{{Codec.ProstBranchName}}(v) => Ok(T::{{Codec.BranchName}}(v.cnv()?)),
@@ -43,6 +49,10 @@ impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.ProstRelativeNa
             {{#IsEnum}}
             Self::{{Codec.ProstBranchName}}(v) => Ok(T::{{Codec.BranchName}}(v.into())),
             {{/IsEnum}}
+            {{/SkipProtoConversion}}
+            {{#SkipProtoConversion}}
+            Self::{{Codec.BranchName}}(_) => Ok(T::{{Codec.BranchName}}(std::default::Default::default())),
+            {{/SkipProtoConversion}}
             {{/Fields}}
         }
     }


### PR DESCRIPTION
Add allow_streaming_any_types configuration to Rust options in librarian.yaml to allow dropping specific google.protobuf.Any fields from prost conversions in streaming RPCs.

When generating prost conversions for streaming RPCs, encountering Any fields in the reachability traversal will fail unless the specific field ID is listed under allow_streaming_any_types. Matching fields are marked with SkipProtoConversion and omitted from message and oneof prost conversions so that the rest of the streaming RPCs and messages can be generated.

This can be expanded to support configuring the types that we could generate, or it can be made so this occurs by defualt.

For googleapis/google-cloud-rust#6566