### PR TITLE
feat(internal/librarian/php): allow skipping gRPC service config

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -460,7 +460,7 @@ This document describes the schema for the librarian.yaml.
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `samples` | bool (optional) | Determines whether to generate samples for the API. Default to true when omitted. |
-| `skip_grpc_config` | bool | Indicates whether to skip the generation of gRPC configuration. Default to false. TODO(https://github.com/googleapis/librarian/issues/7436): Remove this config once Bigtable uses GRPC service config. |
+| `skip_grpc_service_config` | bool | Indicates whether to skip the generation of gRPC service config. Default to false. TODO(https://github.com/googleapis/librarian/issues/7436): Remove this config once Bigtable uses GRPC service config. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -460,6 +460,7 @@ This document describes the schema for the librarian.yaml.
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `samples` | bool (optional) | Determines whether to generate samples for the API. Default to true when omitted. |
+| `skip_grpc_config` | bool |  |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -460,7 +460,7 @@ This document describes the schema for the librarian.yaml.
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `samples` | bool (optional) | Determines whether to generate samples for the API. Default to true when omitted. |
-| `skip_grpc_config` | bool | Indicates whether to skip the generation of gRPC configuration. Default to false. |
+| `skip_grpc_config` | bool | Indicates whether to skip the generation of gRPC configuration. Default to false. TODO(https://github.com/googleapis/librarian/issues/7436): Remove this config once Bigtable uses GRPC service config. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -460,7 +460,7 @@ This document describes the schema for the librarian.yaml.
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `samples` | bool (optional) | Determines whether to generate samples for the API. Default to true when omitted. |
-| `skip_grpc_config` | bool |  |
+| `skip_grpc_config` | bool | Indicates whether to skip the generation of gRPC configuration. Default to false. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -873,6 +873,9 @@ type PHPAPI struct {
 	// Default to true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
 
+
+	SkipGRPCConfig bool `yaml:"skip_grpc_config,omitempty"`
+
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.
 	StagingSubdir string `yaml:"staging_subdir,omitempty"`
 }

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -873,11 +873,11 @@ type PHPAPI struct {
 	// Default to true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
 
-	// SkipGRPCConfig indicates whether to skip the generation of gRPC configuration.
+	// SkipGRPCServiceConfig indicates whether to skip the generation of gRPC service config.
 	// Default to false.
 	// TODO(https://github.com/googleapis/librarian/issues/7436): Remove this config once
 	// Bigtable uses GRPC service config.
-	SkipGRPCConfig bool `yaml:"skip_grpc_config,omitempty"`
+	SkipGRPCServiceConfig bool `yaml:"skip_grpc_service_config,omitempty"`
 
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.
 	StagingSubdir string `yaml:"staging_subdir,omitempty"`

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -875,6 +875,8 @@ type PHPAPI struct {
 
 	// SkipGRPCConfig indicates whether to skip the generation of gRPC configuration.
 	// Default to false.
+	// TODO(https://github.com/googleapis/librarian/issues/7436): Remove this config once
+	// Bigtable uses GRPC service config.
 	SkipGRPCConfig bool `yaml:"skip_grpc_config,omitempty"`
 
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -873,7 +873,8 @@ type PHPAPI struct {
 	// Default to true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
 
-
+	// SkipGRPCConfig indicates whether to skip the generation of gRPC configuration.
+	// Default to false.
 	SkipGRPCConfig bool `yaml:"skip_grpc_config,omitempty"`
 
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -170,7 +170,7 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 	if err != nil {
 		return err
 	}
-	grpcConfigAbsPath, err := grpcServiceConfigPath(params.api, googleapisDir)
+	grpcSrvConfigAbsPath, err := grpcServiceConfigPath(params.api, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 	if err != nil {
 		return err
 	}
-	opts := gapicOpts(params.api, apiMetadata, grpcConfigAbsPath, serviceYamlAbsPath, gapicYamlAbsPath)
+	opts := gapicOpts(params.api, apiMetadata, grpcSrvConfigAbsPath, serviceYamlAbsPath, gapicYamlAbsPath)
 	additionalProtos := params.api.PHP.AdditionalProtos
 	includeCommonResources := *params.api.PHP.CommonResources
 	gapicProtos, err := gatherGAPICProtos(googleapisDir, params.api.Path, additionalProtos, params.api.PHP.ExcludedProtos, includeCommonResources)
@@ -209,18 +209,18 @@ func shouldGenerateGAPIC(api *config.API) bool {
 }
 
 func grpcServiceConfigPath(api *config.API, googleapisDir string) (string, error) {
-	if api.PHP.SkipGRPCConfig {
+	if api.PHP.SkipGRPCServiceConfig {
 		return "", nil
 	}
-	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
+	grpcServiceConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
 	if err != nil {
 		return "", err
 	}
-	grpcConfigAbsPath, err := absConfigPath(googleapisDir, grpcConfigPath)
+	grpcServiceConfigAbsPath, err := absConfigPath(googleapisDir, grpcServiceConfigPath)
 	if err != nil {
 		return "", err
 	}
-	return grpcConfigAbsPath, nil
+	return grpcServiceConfigAbsPath, nil
 }
 
 func generateProto(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, protoZipPath string) error {
@@ -324,7 +324,7 @@ func absConfigPath(baseDir, configPath string) (string, error) {
 	return filepath.Abs(filepath.Join(baseDir, configPath))
 }
 
-func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPath, serviceYamlAbsPath, gapicYamlAbsPath string) []string {
+func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcSrvConfigAbsPath, serviceYamlAbsPath, gapicYamlAbsPath string) []string {
 	transport := serviceconfig.GRPCRest
 	if apiMetadata != nil {
 		transport = apiMetadata.Transport(config.LanguagePhp)
@@ -337,8 +337,8 @@ func gapicOpts(api *config.API, apiMetadata *serviceconfig.API, grpcConfigAbsPat
 		opts = append(opts, "generate-snippets")
 	}
 
-	if grpcConfigAbsPath != "" {
-		opts = append(opts, "grpc_service_config="+grpcConfigAbsPath)
+	if grpcSrvConfigAbsPath != "" {
+		opts = append(opts, "grpc_service_config="+grpcSrvConfigAbsPath)
 	}
 	if serviceYamlAbsPath != "" {
 		opts = append(opts, "service_yaml="+serviceYamlAbsPath)

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -166,15 +166,11 @@ func generateGAPIC(ctx context.Context, params *generateAPIParams, pc *config.Pr
 	if !shouldGenerateGAPIC(params.api) {
 		return nil
 	}
-	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, params.api.Path)
-	if err != nil {
-		return err
-	}
 	apiMetadata, err := serviceconfig.Find(googleapisDir, params.api.Path, config.LanguagePhp)
 	if err != nil {
 		return err
 	}
-	grpcConfigAbsPath, err := absConfigPath(googleapisDir, grpcConfigPath)
+	grpcConfigAbsPath, err := grpcServiceConfigPath(params.api, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -210,6 +206,21 @@ func shouldGenerateGAPIC(api *config.API) bool {
 		return *api.PHP.GenerateGAPIC
 	}
 	return true
+}
+
+func grpcServiceConfigPath(api *config.API, googleapisDir string) (string, error) {
+	if api.PHP.SkipGRPCConfig {
+		return "", nil
+	}
+	grpcConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
+	if err != nil {
+		return "", err
+	}
+	grpcConfigAbsPath, err := absConfigPath(googleapisDir, grpcConfigPath)
+	if err != nil {
+		return "", err
+	}
+	return grpcConfigAbsPath, nil
 }
 
 func generateProto(ctx context.Context, params *generateAPIParams, pc *config.Protoc, googleapisDir, protoZipPath string) error {

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -805,11 +805,11 @@ func TestGRPCServiceConfigPath(t *testing.T) {
 			},
 		},
 		{
-			name: "skip grpc config",
+			name: "skip grpc service config",
 			api: &config.API{
 				Path: "google/cloud/secretmanager/v1",
 				PHP: &config.PHPAPI{
-					SkipGRPCConfig: true,
+					SkipGRPCServiceConfig: true,
 				},
 			},
 		},

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -777,3 +777,55 @@ func TestShouldGenerateSamples(t *testing.T) {
 		})
 	}
 }
+
+func TestGRPCServiceConfigPath(t *testing.T) {
+	googleapisDir := "../../testdata/googleapis"
+	absGoogleapis, err := filepath.Abs(googleapisDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name     string
+		api      *config.API
+		wantFile string
+	}{
+		{
+			name: "grpc config found",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				PHP:  &config.PHPAPI{},
+			},
+			wantFile: "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json",
+		},
+		{
+			name: "grpc config not found",
+			api: &config.API{
+				Path: "google/apps/meet/v2",
+				PHP:  &config.PHPAPI{},
+			},
+		},
+		{
+			name: "skip grpc config",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				PHP: &config.PHPAPI{
+					SkipGRPCConfig: true,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := grpcServiceConfigPath(test.api, absGoogleapis)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var want string
+			if test.wantFile != "" {
+				want = filepath.Join(absGoogleapis, test.wantFile)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/tool/cmd/migrate/php.go
+++ b/tool/cmd/migrate/php.go
@@ -391,12 +391,18 @@ func normalizeStagingSubdir(apiPath, stagingDir string) string {
 // Apply special case rules to the API config.
 func specialCases(api *config.API) {
 	switch api.Path {
+	case "google/bigtable/v2":
+		if api.PHP == nil {
+			api.PHP = &config.PHPAPI{}
+		}
+		api.PHP.SkipGRPCServiceConfig = true
 	case "google/bigtable/admin/v2":
 		if api.PHP == nil {
 			api.PHP = &config.PHPAPI{}
 		}
 		api.PHP.GapicYAML = "google/bigtable/admin/v2/bigtableadmin_gapic.yaml"
 		api.PHP.StagingSubdir = "Admin/v2"
+		api.PHP.SkipGRPCServiceConfig = true
 	case "google/cloud/aiplatform/v1":
 		if api.PHP == nil {
 			api.PHP = &config.PHPAPI{}


### PR DESCRIPTION
A `skip_grpc_config` option is added to the PHP API configuration, allowing APIs to selectively skip configuring a gRPC service config during GAPIC client generation.

When skip_grpc_config is true, grpcServiceConfigPath returns an empty path, preventing the grpc_service_config flag from being passed during protoc execution even if a matching config file exists in the API directory.

Fixes #7405
