### PR TITLE
impl(internal/sidekick/rust): rename return type for streaming responses

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -178,7 +178,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
             self,
         ) -> (
             google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-            google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+            google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
         ) {
             (*self.0.stub).chat(self.0.options)
         }`,
@@ -205,9 +205,9 @@ func TestGenerateBidiStreaming(t *testing.T) {
         _options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     ) {
-        gaxi::unimplemented::unimplemented_bidi_stub()
+        gaxi::unimplemented::unimplemented_bidi_stub_tmp()
     }`,
 		},
 		{
@@ -220,7 +220,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     );`,
 		},
 		{
@@ -234,7 +234,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     ) {
         T::chat(self, options)
     }`,
@@ -249,7 +249,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     ) {
         self.inner.chat(options)
     }`,
@@ -267,10 +267,10 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "transport: execute_bidi_streaming call",
 			file:     "src/transport.rs",
-			startStr: "        self.grpc_inner\n            .execute_bidi_streaming::<",
+			startStr: "        self.grpc_inner\n            .execute_bidi_streaming_tmp::<",
 			endStr:   "x_goog_request_params,\n            )\n    }",
 			want: `        self.grpc_inner
-            .execute_bidi_streaming::<
+            .execute_bidi_streaming_tmp::<
                 crate::model::Request,
                 crate::model::Response,
                 crate::prost::test::v1::Request,
@@ -399,7 +399,7 @@ func TestGenerateGrpcClientBidiStreaming(t *testing.T) {
             self,
         ) -> (
             google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-            google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+            google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
         ) {
             (*self.0.stub).chat(self.0.options)
         }
@@ -425,9 +425,9 @@ func TestGenerateGrpcClientBidiStreaming(t *testing.T) {
         _options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     ) {
-        gaxi::unimplemented::unimplemented_bidi_stub()
+        gaxi::unimplemented::unimplemented_bidi_stub_tmp()
     }`,
 		},
 		{
@@ -440,7 +440,7 @@ func TestGenerateGrpcClientBidiStreaming(t *testing.T) {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     );`,
 		},
 		{
@@ -453,7 +453,7 @@ func TestGenerateGrpcClientBidiStreaming(t *testing.T) {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::Response>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     ) {
         self.inner.chat(options)
     }`,
@@ -461,10 +461,10 @@ func TestGenerateGrpcClientBidiStreaming(t *testing.T) {
 		{
 			name:     "grpc-client transport: execute_bidi_streaming call",
 			file:     "transport.rs",
-			startStr: "        self.inner\n            .execute_bidi_streaming::<",
+			startStr: "        self.inner\n            .execute_bidi_streaming_tmp::<",
 			endStr:   "x_goog_request_params,\n            )\n    }",
 			want: `        self.inner
-            .execute_bidi_streaming::<
+            .execute_bidi_streaming_tmp::<
                 crate::model::Request,
                 crate::model::Response,
                 crate::test::v1::Request,

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -119,7 +119,7 @@ func TestGenerateServerStreaming(t *testing.T) {
 			want: `        /// Initiates the server stream.
         pub async fn send(
             self,
-        ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+        ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::EchoResponse>> {
             (*self.0.stub).expand(self.0.request, self.0.options).await
         }`,
 		},
@@ -145,9 +145,9 @@ func TestGenerateServerStreaming(t *testing.T) {
         _req: crate::model::ExpandRequest,
         _options: crate::RequestOptions,
     ) -> impl std::future::Future<Output = crate::Result<
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::EchoResponse>,
     >> + Send {
-        gaxi::unimplemented::unimplemented_server_streaming_stub()
+        gaxi::unimplemented::unimplemented_server_streaming_stub_tmp()
     }`,
 		},
 		{
@@ -160,7 +160,7 @@ func TestGenerateServerStreaming(t *testing.T) {
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,
     ) -> crate::Result<
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::EchoResponse>,
     >;`,
 		},
 		{
@@ -174,7 +174,7 @@ func TestGenerateServerStreaming(t *testing.T) {
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,
     ) -> crate::Result<
-        google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
+        google_cloud_gax::streaming::ResponseStream<crate::model::EchoResponse>,
     > {
         T::expand(self, req, options).await
     }`,
@@ -188,7 +188,7 @@ func TestGenerateServerStreaming(t *testing.T) {
         &self,
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,
-    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::EchoResponse>> {
         self.inner.expand(req, options).await
     }`,
 		},
@@ -201,7 +201,7 @@ func TestGenerateServerStreaming(t *testing.T) {
         &self,
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,
-    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::EchoResponse>> {
         let x_goog_request_params = [
             None::<String>; 0
         ]
@@ -222,7 +222,7 @@ func TestGenerateServerStreaming(t *testing.T) {
         );
 
         self.grpc_inner
-            .execute_server_streaming::<
+            .execute_server_streaming_tmp::<
                 crate::model::ExpandRequest,
                 crate::model::EchoResponse,
                 crate::prost::test::v1::ExpandRequest,
@@ -338,10 +338,10 @@ func TestGenerateGrpcClientServerStreaming(t *testing.T) {
 		{
 			name:     "grpc-client transport: execute_server_streaming call",
 			file:     "transport.rs",
-			startStr: "        self.inner\n            .execute_server_streaming::<",
+			startStr: "        self.inner\n            .execute_server_streaming_tmp::<",
 			endStr:   "&x_goog_request_params,\n            )\n            .await\n    }",
 			want: `        self.inner
-            .execute_server_streaming::<
+            .execute_server_streaming_tmp::<
                 crate::model::ExpandRequest,
                 crate::model::EchoResponse,
                 crate::test::v1::ExpandRequest,

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -197,7 +197,7 @@ pub mod {{Codec.ModuleName}} {
             self,
         ) -> (
             google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
-            google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+            google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
         ) {
             (*self.0.stub).{{Codec.Name}}(self.0.options)
         }
@@ -206,7 +206,7 @@ pub mod {{Codec.ModuleName}} {
         /// Initiates the server stream.
         pub async fn send(
             self,
-        ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+        ) -> Result<google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>> {
             (*self.0.stub).{{Codec.Name}}(self.0.request, self.0.options).await
         }
         {{/Codec.IsServerStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -59,9 +59,9 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         _options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     ) {
-        gaxi::unimplemented::unimplemented_bidi_stub()
+        gaxi::unimplemented::unimplemented_bidi_stub_tmp()
     }
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
@@ -70,9 +70,9 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         _req: {{InputType.Codec.QualifiedName}},
         _options: crate::RequestOptions,
     ) -> impl std::future::Future<Output = crate::Result<
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     >> + Send {
-        gaxi::unimplemented::unimplemented_server_streaming_stub()
+        gaxi::unimplemented::unimplemented_server_streaming_stub_tmp()
     }
     {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub/dynamic.rs.mustache
@@ -32,7 +32,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     );
 
     {{/Codec.IsBidiStreaming}}
@@ -42,7 +42,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         req: {{InputType.Codec.QualifiedName}},
         options: crate::RequestOptions,
     ) -> crate::Result<
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     >;
 
     {{/Codec.IsServerStreaming}}
@@ -91,7 +91,7 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     ) {
         T::{{Codec.Name}}(self, options)
     }
@@ -103,7 +103,7 @@ impl<T: super::{{Codec.Name}}> {{Codec.Name}} for T {
         req: {{InputType.Codec.QualifiedName}},
         options: crate::RequestOptions,
     ) -> crate::Result<
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     > {
         T::{{Codec.Name}}(self, req, options).await
     }

--- a/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/tracing.rs.mustache
@@ -70,7 +70,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     ) {
         self.inner.{{Codec.Name}}(options)
     }
@@ -81,7 +81,7 @@ where T: super::stub::{{Codec.Name}} + std::fmt::Debug + Send + Sync {
         &self,
         req: {{InputType.Codec.QualifiedName}},
         options: crate::RequestOptions,
-    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>> {
         self.inner.{{Codec.Name}}(req, options).await
     }
     {{/Codec.IsServerStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -127,7 +127,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     ) {
         {{! TODO(#6835) - support explicit routing parameters for bidirectional streaming RPCs }}
         let x_goog_request_params = "";
@@ -145,7 +145,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
 
         self.grpc_inner
-            .execute_bidi_streaming::<
+            .execute_bidi_streaming_tmp::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
@@ -165,7 +165,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         &self,
         req: {{InputType.Codec.QualifiedName}},
         options: crate::RequestOptions,
-    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>> {
         {{!
         AIP-4222 says:
 
@@ -206,7 +206,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
 
         self.grpc_inner
-            .execute_server_streaming::<
+            .execute_server_streaming_tmp::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -108,7 +108,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         options: crate::RequestOptions,
     ) -> (
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
-        google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>,
+        google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     ) {
         {{! TODO(#6835) - support explicit routing parameters for bidirectional streaming RPCs }}
         let x_goog_request_params = "";
@@ -126,7 +126,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
 
         self.inner
-            .execute_bidi_streaming::<
+            .execute_bidi_streaming_tmp::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
@@ -146,7 +146,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         &self,
         req: {{InputType.Codec.QualifiedName}},
         options: crate::RequestOptions,
-    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<{{OutputType.Codec.QualifiedName}}>> {
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>> {
         let extensions = {
             let mut e = gaxi::grpc::tonic::Extensions::new();
             e.insert(gaxi::grpc::tonic::GrpcMethod::new(
@@ -187,7 +187,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{/HasRouting}}
 
         self.inner
-            .execute_server_streaming::<
+            .execute_server_streaming_tmp::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},


### PR DESCRIPTION
For googleapis/google-cloud-rust#6581