### PR TITLE
cleanup(internal/sidekick/rust): switch back to standard execute helper

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -207,7 +207,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     ) {
-        gaxi::unimplemented::unimplemented_bidi_stub_tmp()
+        gaxi::unimplemented::unimplemented_bidi_stub()
     }`,
 		},
 		{
@@ -267,10 +267,10 @@ func TestGenerateBidiStreaming(t *testing.T) {
 		{
 			name:     "transport: execute_bidi_streaming call",
 			file:     "src/transport.rs",
-			startStr: "        self.grpc_inner\n            .execute_bidi_streaming_tmp::<",
+			startStr: "        self.grpc_inner\n            .execute_bidi_streaming::<",
 			endStr:   "x_goog_request_params,\n            )\n    }",
 			want: `        self.grpc_inner
-            .execute_bidi_streaming_tmp::<
+            .execute_bidi_streaming::<
                 crate::model::Request,
                 crate::model::Response,
                 crate::prost::test::v1::Request,
@@ -427,7 +427,7 @@ func TestGenerateGrpcClientBidiStreaming(t *testing.T) {
         google_cloud_gax::streaming::RequestSender<crate::model::Request>,
         google_cloud_gax::streaming::ResponseStream<crate::model::Response>,
     ) {
-        gaxi::unimplemented::unimplemented_bidi_stub_tmp()
+        gaxi::unimplemented::unimplemented_bidi_stub()
     }`,
 		},
 		{
@@ -461,10 +461,10 @@ func TestGenerateGrpcClientBidiStreaming(t *testing.T) {
 		{
 			name:     "grpc-client transport: execute_bidi_streaming call",
 			file:     "transport.rs",
-			startStr: "        self.inner\n            .execute_bidi_streaming_tmp::<",
+			startStr: "        self.inner\n            .execute_bidi_streaming::<",
 			endStr:   "x_goog_request_params,\n            )\n    }",
 			want: `        self.inner
-            .execute_bidi_streaming_tmp::<
+            .execute_bidi_streaming::<
                 crate::model::Request,
                 crate::model::Response,
                 crate::test::v1::Request,

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -147,7 +147,7 @@ func TestGenerateServerStreaming(t *testing.T) {
     ) -> impl std::future::Future<Output = crate::Result<
         google_cloud_gax::streaming::ResponseStream<crate::model::EchoResponse>,
     >> + Send {
-        gaxi::unimplemented::unimplemented_server_streaming_stub_tmp()
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
     }`,
 		},
 		{
@@ -222,7 +222,7 @@ func TestGenerateServerStreaming(t *testing.T) {
         );
 
         self.grpc_inner
-            .execute_server_streaming_tmp::<
+            .execute_server_streaming::<
                 crate::model::ExpandRequest,
                 crate::model::EchoResponse,
                 crate::prost::test::v1::ExpandRequest,
@@ -338,10 +338,10 @@ func TestGenerateGrpcClientServerStreaming(t *testing.T) {
 		{
 			name:     "grpc-client transport: execute_server_streaming call",
 			file:     "transport.rs",
-			startStr: "        self.inner\n            .execute_server_streaming_tmp::<",
+			startStr: "        self.inner\n            .execute_server_streaming::<",
 			endStr:   "&x_goog_request_params,\n            )\n            .await\n    }",
 			want: `        self.inner
-            .execute_server_streaming_tmp::<
+            .execute_server_streaming::<
                 crate::model::ExpandRequest,
                 crate::model::EchoResponse,
                 crate::test::v1::ExpandRequest,

--- a/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/stub.rs.mustache
@@ -61,7 +61,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
         google_cloud_gax::streaming::RequestSender<{{InputType.Codec.QualifiedName}}>,
         google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     ) {
-        gaxi::unimplemented::unimplemented_bidi_stub_tmp()
+        gaxi::unimplemented::unimplemented_bidi_stub()
     }
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
@@ -72,7 +72,7 @@ pub trait {{Codec.Name}}: std::fmt::Debug + Send + Sync {
     ) -> impl std::future::Future<Output = crate::Result<
         google_cloud_gax::streaming::ResponseStream<{{OutputType.Codec.QualifiedName}}>,
     >> + Send {
-        gaxi::unimplemented::unimplemented_server_streaming_stub_tmp()
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
     }
     {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -145,7 +145,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
 
         self.grpc_inner
-            .execute_bidi_streaming_tmp::<
+            .execute_bidi_streaming::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
@@ -206,7 +206,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
 
         self.grpc_inner
-            .execute_server_streaming_tmp::<
+            .execute_server_streaming::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::prost::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -126,7 +126,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         );
 
         self.inner
-            .execute_bidi_streaming_tmp::<
+            .execute_bidi_streaming::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},
@@ -187,7 +187,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{/HasRouting}}
 
         self.inner
-            .execute_server_streaming_tmp::<
+            .execute_server_streaming::<
                 {{InputType.Codec.QualifiedName}},
                 {{OutputType.Codec.QualifiedName}},
                 crate::{{InputType.Codec.PackageModuleName}}::{{InputType.Codec.Name}},


### PR DESCRIPTION
For googleapis/google-cloud-rust#6581