### PR TITLE
test(internal/librarian/nodejs): add unit tests for compileProtosArgs

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -409,13 +409,10 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 }
 
 func compileProtosArgs(library *config.Library) []string {
-	protoDir := "src"
-	compileArgs := []string{"--no-comments"}
 	if library.Nodejs != nil && library.Nodejs.ESM {
-		protoDir = "esm/src"
-		compileArgs = append(compileArgs, "--esm")
+		return []string{"esm/src", "--no-comments", "--esm"}
 	}
-	return append([]string{protoDir}, compileArgs...)
+	return []string{"src", "--no-comments"}
 }
 
 // movePackageFromStaging moves the generated code for a single package from

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -361,14 +361,7 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 	if err := copyMissingProtos(googleapisDir, outDir); err != nil {
 		return fmt.Errorf("failed to copy missing protos: %w", err)
 	}
-	protoDir := "src"
-	compileArgs := []string{"--no-comments"}
-	if library.Nodejs != nil && library.Nodejs.ESM {
-		protoDir = "esm/src"
-		compileArgs = append(compileArgs, "--esm")
-	}
-	runArgs := append([]string{protoDir}, compileArgs...)
-
+	runArgs := compileProtosArgs(library)
 	toolsEnv, err := getToolsEnv()
 	if err != nil {
 		return err
@@ -413,6 +406,16 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 		return fmt.Errorf("failed to remove %s: %w", cloudCommonResourcesProto, err)
 	}
 	return nil
+}
+
+func compileProtosArgs(library *config.Library) []string {
+	protoDir := "src"
+	compileArgs := []string{"--no-comments"}
+	if library.Nodejs != nil && library.Nodejs.ESM {
+		protoDir = "esm/src"
+		compileArgs = append(compileArgs, "--esm")
+	}
+	return append([]string{protoDir}, compileArgs...)
 }
 
 // movePackageFromStaging moves the generated code for a single package from

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -203,6 +203,45 @@ func TestDefaultOutput(t *testing.T) {
 	}
 }
 
+func TestCompileProtosArgs(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lib  *config.Library
+		want []string
+	}{
+		{
+			name: "nil nodejs config",
+			lib:  &config.Library{},
+			want: []string{"src", "--no-comments"},
+		},
+		{
+			name: "non-esm nodejs config",
+			lib: &config.Library{
+				Nodejs: &config.NodejsPackage{
+					ESM: false,
+				},
+			},
+			want: []string{"src", "--no-comments"},
+		},
+		{
+			name: "esm nodejs config",
+			lib: &config.Library{
+				Nodejs: &config.NodejsPackage{
+					ESM: true,
+				},
+			},
+			want: []string{"esm/src", "--no-comments", "--esm"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := compileProtosArgs(test.lib)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestBuildGeneratorArgs(t *testing.T) {
 	absGoogleapisDir, err := filepath.Abs(googleapisDir)
 	if err != nil {


### PR DESCRIPTION
Extract argument construction for compileProtos into helper function `compileProtosArgs` and add unit tests covering standard, non-ESM, and ESM configurations.

For #4664
