### PR TITLE
chore(internal/librarian/nodejs): remove redundant linter file cleanup

### DIFF
--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -402,10 +402,6 @@ func runPostProcessor(ctx context.Context, cfg *config.Config, library *config.L
 			return fmt.Errorf("failed to generate README.md: %w", err)
 		}
 	}
-	if err := removeRedundantLinterFiles(library, outDir); err != nil {
-		return fmt.Errorf("failed to remove redundant linter files: %w", err)
-	}
-
 	// Remove google/cloud/common_resources.proto from the protos directory.
 	// We don't need it in the repo (it isn't in googleapis-gen) and we don't
 	// want it to be in the diff.
@@ -464,39 +460,6 @@ func movePackageFromStaging(ctx context.Context, library *config.Library, repoRo
 	}
 	if err := os.RemoveAll(stagingDir); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to remove package staging: %w", err)
-	}
-	return nil
-}
-
-// TODO(https://github.com/googleapis/google-cloud-node/issues/8286): gapic-generator-typescript
-// unconditionally generates redundant linter configuration files (.eslintignore, .eslintrc.json, etc.).
-// This post-processing cleanup function removes them unless explicitly kept in librarian.yaml.
-// Once gapic-generator-typescript is updated to stop generating them, this function must be removed.
-func removeRedundantLinterFiles(library *config.Library, outDir string) error {
-	keepSet := make(map[string]bool)
-	for _, k := range library.Keep {
-		keepSet[filepath.Clean(k)] = true
-	}
-
-	linterFiles := []string{
-		".eslintignore",
-		".eslintrc.json",
-		".prettierignore",
-		".prettierrc.js",
-		".prettierrc.cjs",
-	}
-
-	for _, lf := range linterFiles {
-		if keepSet[lf] {
-			continue
-		}
-		path := filepath.Join(outDir, lf)
-		if err := os.Remove(path); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				continue
-			}
-			return fmt.Errorf("failed to remove redundant linter file %s: %w", path, err)
-		}
 	}
 	return nil
 }

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1633,68 +1633,6 @@ func TestInjectV1SmallExports(t *testing.T) {
 	}
 }
 
-func TestRemoveRedundantLinterFiles(t *testing.T) {
-	for _, test := range []struct {
-		name  string
-		keep  []string
-		files []string
-		want  []string
-	}{
-		{
-			name:  "removes all redundant linter files when keep is empty",
-			keep:  []string{},
-			files: []string{".eslintignore", ".eslintrc.json", ".prettierignore", ".prettierrc.js", ".prettierrc.cjs", "package.json", "README.md"},
-			want:  []string{"README.md", "package.json"},
-		},
-		{
-			name:  "preserves explicitly kept linter files",
-			keep:  []string{".eslintignore", ".eslintrc.json"},
-			files: []string{".eslintignore", ".eslintrc.json", ".prettierignore", ".prettierrc.js", "package.json", "README.md"},
-			want:  []string{".eslintignore", ".eslintrc.json", "README.md", "package.json"},
-		},
-		{
-			name:  "skips missing linter files without error",
-			keep:  []string{},
-			files: []string{"package.json", "README.md"},
-			want:  []string{"README.md", "package.json"},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			outDir := t.TempDir()
-			for _, f := range test.files {
-				path := filepath.Join(outDir, f)
-				if err := os.WriteFile(path, []byte("content"), 0o644); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			library := &config.Library{
-				Keep: test.keep,
-			}
-
-			if err := removeRedundantLinterFiles(library, outDir); err != nil {
-				t.Fatal(err)
-			}
-
-			var got []string
-			entries, err := os.ReadDir(outDir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			for _, entry := range entries {
-				got = append(got, entry.Name())
-			}
-
-			slices.Sort(got)
-			slices.Sort(test.want)
-
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestResolveDefaultVersion(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
Remove `removeRedundantLinterFiles` and its unit tests from the Node.js post-processing pipeline now that gapic-generator-typescript no longer generates redundant package-level linter configuration files.

Test `librarian generate --all` against up-to-date google-cloud-node without any change.
