### PR TITLE
fix(internal/librarian/ruby): do not pass grpc options for rest-only transport

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -94,11 +94,11 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err != nil {
 		return err
 	}
-	gapicOpts, err := buildGAPICOpts(api, library, googleapisDir)
+	serviceConfig, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
 	if err != nil {
 		return err
 	}
-	serviceConfig, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
+	gapicOpts, err := buildGAPICOpts(api, library, googleapisDir, serviceConfig)
 	if err != nil {
 		return err
 	}
@@ -138,11 +138,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	return nil
 }
 
-func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir string) ([]string, error) {
-	sc, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
-	if err != nil {
-		return nil, err
-	}
+func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir string, serviceConfig *serviceconfig.API) ([]string, error) {
 	gc, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
 	if err != nil {
 		return nil, err
@@ -150,21 +146,21 @@ func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir stri
 	opts := []string{
 		"ruby-cloud-gem-name=" + library.Name,
 	}
-	if sc != nil && sc.ServiceConfig != "" {
-		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, sc.ServiceConfig))
+	if serviceConfig != nil && serviceConfig.ServiceConfig != "" {
+		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, serviceConfig.ServiceConfig))
 	}
-	if sc != nil && sc.Description != "" {
-		desc := escapeRubyCloudOptValue(strings.Join(strings.Fields(sc.Description), " "))
+	if serviceConfig != nil && serviceConfig.Description != "" {
+		desc := escapeRubyCloudOptValue(strings.Join(strings.Fields(serviceConfig.Description), " "))
 		opts = append(opts, "ruby-cloud-description="+desc, "ruby-cloud-summary="+desc)
 	}
 	if gc != "" {
 		opts = append(opts, "grpc-service-config="+filepath.Join(googleapisDir, gc))
 	}
-	if trans := transport(sc); trans != "" {
+	if trans := transport(serviceConfig); trans != "" {
 		transports := strings.ReplaceAll(string(trans), "+", ";")
 		opts = append(opts, "ruby-cloud-generate-transports="+transports)
 	}
-	if sc != nil && sc.HasRESTNumericEnums(config.LanguageRuby) {
+	if serviceConfig != nil && serviceConfig.HasRESTNumericEnums(config.LanguageRuby) {
 		opts = append(opts, "ruby-cloud-rest-numeric-enums=true")
 	}
 	if api.Ruby != nil && api.Ruby.RubyCloudOpts != nil {

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -98,6 +98,10 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	if err != nil {
 		return err
 	}
+	serviceConfig, err := serviceconfig.Find(googleapisDir, api.Path, config.LanguageRuby)
+	if err != nil {
+		return err
+	}
 	installDir, err := InstallDir()
 	if err != nil {
 		return err
@@ -111,23 +115,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	}
 	// A main client is a wrapper of a versioned client
 	isWrapper := library.Ruby != nil && len(library.Ruby.WrapperOf) > 0
-	args := []string{
-		"--experimental_allow_proto3_optional",
-		"-I=" + googleapisDir,
-		"--ruby_cloud_out=" + stagingDir,
-	}
-	if !isWrapper {
-		grpcPluginPath := filepath.Join(installDir, "bin", "grpc_tools_ruby_protoc_plugin")
-		args = append(args,
-			"--ruby_out="+libStagingDir,
-			"--grpc_out="+libStagingDir,
-			"--plugin=protoc-gen-grpc="+grpcPluginPath,
-		)
-	}
-	if len(gapicOpts) > 0 {
-		args = append(args, "--ruby_cloud_opt="+strings.Join(gapicOpts, ","))
-	}
-	args = append(args, protoFiles...)
+	args := buildProtocArgs(googleapisDir, stagingDir, libStagingDir, installDir, isWrapper, serviceConfig, gapicOpts, protoFiles)
 	env, err := toolsEnv()
 	if err != nil {
 		return err
@@ -225,9 +213,32 @@ func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir stri
 	return opts, nil
 }
 
-func transport(sc *serviceconfig.API) serviceconfig.Transport {
-	if sc != nil {
-		return sc.Transport(config.LanguageRuby)
+func buildProtocArgs(googleapisDir, stagingDir, libStagingDir, installDir string, isWrapper bool, serviceConfig *serviceconfig.API, gapicOpts, protoFiles []string) []string {
+	args := []string{
+		"--experimental_allow_proto3_optional",
+		"-I=" + googleapisDir,
+		"--ruby_cloud_out=" + stagingDir,
+	}
+	if !isWrapper {
+		args = append(args, "--ruby_out="+libStagingDir)
+		if trans := transport(serviceConfig); trans != serviceconfig.Rest {
+			grpcPluginPath := filepath.Join(installDir, "bin", "grpc_tools_ruby_protoc_plugin")
+			args = append(args,
+				"--grpc_out="+libStagingDir,
+				"--plugin=protoc-gen-grpc="+grpcPluginPath,
+			)
+		}
+	}
+	if len(gapicOpts) > 0 {
+		args = append(args, "--ruby_cloud_opt="+strings.Join(gapicOpts, ","))
+	}
+	args = append(args, protoFiles...)
+	return args
+}
+
+func transport(serviceConfig *serviceconfig.API) serviceconfig.Transport {
+	if serviceConfig != nil {
+		return serviceConfig.Transport(config.LanguageRuby)
 	}
 	return serviceconfig.GRPCRest
 }

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -246,7 +246,11 @@ func TestBuildGAPICOpts(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := buildGAPICOpts(test.api, test.library, googleapisDir)
+			serviceConfig, err := serviceconfig.Find(googleapisDir, test.api.Path, config.LanguageRuby)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := buildGAPICOpts(test.api, test.library, googleapisDir, serviceConfig)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -259,18 +263,18 @@ func TestBuildGAPICOpts(t *testing.T) {
 
 func TestTransport(t *testing.T) {
 	for _, test := range []struct {
-		name string
-		sc   *serviceconfig.API
-		want serviceconfig.Transport
+		name          string
+		serviceConfig *serviceconfig.API
+		want          serviceconfig.Transport
 	}{
 		{
-			name: "nil api",
-			sc:   nil,
-			want: serviceconfig.GRPCRest,
+			name:          "nil api",
+			serviceConfig: nil,
+			want:          serviceconfig.GRPCRest,
 		},
 		{
 			name: "rest only",
-			sc: &serviceconfig.API{
+			serviceConfig: &serviceconfig.API{
 				Transports: map[string]serviceconfig.Transport{
 					config.LanguageRuby: serviceconfig.Rest,
 				},
@@ -279,7 +283,7 @@ func TestTransport(t *testing.T) {
 		},
 		{
 			name: "rest and grpc",
-			sc: &serviceconfig.API{
+			serviceConfig: &serviceconfig.API{
 				Transports: map[string]serviceconfig.Transport{
 					config.LanguageRuby: serviceconfig.GRPCRest,
 				},
@@ -288,7 +292,7 @@ func TestTransport(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := transport(test.sc)
+			got := transport(test.serviceConfig)
 			if got != test.want {
 				t.Errorf("transport() = %v, want %v", got, test.want)
 			}

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -477,10 +477,12 @@ func setupDummyProtoc(t *testing.T) {
 	script := `#!/bin/sh
 rubyOut=""
 rubyCloudOut=""
+grpcOut=""
 for arg in "$@"; do
   case "$arg" in
     --ruby_cloud_out=*) rubyCloudOut="${arg#--ruby_cloud_out=}" ;;
     --ruby_out=*) rubyOut="${arg#--ruby_out=}" ;;
+    --grpc_out=*) grpcOut="${arg#--grpc_out=}" ;;
   esac
 done
 if [ -n "$rubyCloudOut" ]; then
@@ -510,6 +512,10 @@ if [ -n "$rubyOut" ]; then
         ;;
     esac
   done
+fi
+if [ -n "$grpcOut" ]; then
+  mkdir -p "$grpcOut/google/cloud/secret_manager"
+  touch "$grpcOut/google/cloud/secret_manager/v1_services_pb.rb"
 fi
 exit 0
 `
@@ -597,6 +603,10 @@ end
 	if _, err := os.Stat(wantPbFile); err != nil {
 		t.Errorf("expected generated pb file %s to exist: %v", wantPbFile, err)
 	}
+	wantServicesPbFile := filepath.Join(outDir, "lib", "google", "cloud", "secret_manager", "v1_services_pb.rb")
+	if _, err := os.Stat(wantServicesPbFile); err != nil {
+		t.Errorf("expected generated services pb file %s to exist: %v", wantServicesPbFile, err)
+	}
 	gotChangelog, err := os.ReadFile(changelogPath)
 	if err != nil {
 		t.Fatal(err)
@@ -650,9 +660,140 @@ func TestGenerateAPI(t *testing.T) {
 	if _, err := os.Stat(wantPbFile); err != nil {
 		t.Errorf("expected generated pb file %s to exist: %v", wantPbFile, err)
 	}
+	wantServicesPbFile := filepath.Join(stagingDir, "lib", "google", "cloud", "secret_manager", "v1_services_pb.rb")
+	if _, err := os.Stat(wantServicesPbFile); err != nil {
+		t.Errorf("expected generated services pb file %s to exist: %v", wantServicesPbFile, err)
+	}
 	unexpectedCommonPbFile := filepath.Join(stagingDir, "lib", "google", "cloud", "common_resources_pb.rb")
 	if _, err := os.Stat(unexpectedCommonPbFile); !errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("expected common_resources_pb.rb %s to be removed, but err = %v", unexpectedCommonPbFile, err)
+	}
+}
+
+func TestBuildProtocArgs(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		googleapisDir string
+		stagingDir    string
+		libStagingDir string
+		installDir    string
+		isWrapper     bool
+		serviceConfig *serviceconfig.API
+		gapicOpts     []string
+		protoFiles    []string
+		want          []string
+	}{
+		{
+			name:          "standard api defaults to grpc and rest",
+			googleapisDir: "/googleapis",
+			stagingDir:    "/staging",
+			libStagingDir: "/staging/lib",
+			installDir:    "/install",
+			isWrapper:     false,
+			serviceConfig: nil,
+			protoFiles:    []string{"/googleapis/google/cloud/secretmanager/v1/service.proto"},
+			want: []string{
+				"--experimental_allow_proto3_optional",
+				"-I=/googleapis",
+				"--ruby_cloud_out=/staging",
+				"--ruby_out=/staging/lib",
+				"--grpc_out=/staging/lib",
+				"--plugin=protoc-gen-grpc=/install/bin/grpc_tools_ruby_protoc_plugin",
+				"/googleapis/google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+		{
+			name:          "rest-only transport with all",
+			googleapisDir: "/googleapis",
+			stagingDir:    "/staging",
+			libStagingDir: "/staging/lib",
+			installDir:    "/install",
+			isWrapper:     false,
+			serviceConfig: &serviceconfig.API{
+				Transports: map[string]serviceconfig.Transport{
+					config.LanguageAll: serviceconfig.Rest,
+				},
+			},
+			gapicOpts:  []string{"ruby-cloud-gem-name=google-cloud-compute-v1"},
+			protoFiles: []string{"/googleapis/google/cloud/compute/v1/compute.proto"},
+			want: []string{
+				"--experimental_allow_proto3_optional",
+				"-I=/googleapis",
+				"--ruby_cloud_out=/staging",
+				"--ruby_out=/staging/lib",
+				"--ruby_cloud_opt=ruby-cloud-gem-name=google-cloud-compute-v1",
+				"/googleapis/google/cloud/compute/v1/compute.proto",
+			},
+		},
+		{
+			name:          "rest-only transport with ruby",
+			googleapisDir: "/googleapis",
+			stagingDir:    "/staging",
+			libStagingDir: "/staging/lib",
+			installDir:    "/install",
+			isWrapper:     false,
+			serviceConfig: &serviceconfig.API{
+				Transports: map[string]serviceconfig.Transport{
+					config.LanguageRuby: serviceconfig.Rest,
+				},
+			},
+			protoFiles: []string{"/googleapis/google/cloud/compute/v1/compute.proto"},
+			want: []string{
+				"--experimental_allow_proto3_optional",
+				"-I=/googleapis",
+				"--ruby_cloud_out=/staging",
+				"--ruby_out=/staging/lib",
+				"/googleapis/google/cloud/compute/v1/compute.proto",
+			},
+		},
+		{
+			name:          "grpc-only transport with ruby",
+			googleapisDir: "/googleapis",
+			stagingDir:    "/staging",
+			libStagingDir: "/staging/lib",
+			installDir:    "/install",
+			isWrapper:     false,
+			serviceConfig: &serviceconfig.API{
+				Transports: map[string]serviceconfig.Transport{
+					config.LanguageRuby: serviceconfig.GRPC,
+				},
+			},
+			protoFiles: []string{"/googleapis/google/cloud/secretmanager/v1/service.proto"},
+			want: []string{
+				"--experimental_allow_proto3_optional",
+				"-I=/googleapis",
+				"--ruby_cloud_out=/staging",
+				"--ruby_out=/staging/lib",
+				"--grpc_out=/staging/lib",
+				"--plugin=protoc-gen-grpc=/install/bin/grpc_tools_ruby_protoc_plugin",
+				"/googleapis/google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+		{
+			name:          "wrapper gem omits ruby_out and grpc_out",
+			googleapisDir: "/googleapis",
+			stagingDir:    "/staging",
+			libStagingDir: "/staging/lib",
+			installDir:    "/install",
+			isWrapper:     true,
+			serviceConfig: nil,
+			gapicOpts:     []string{"ruby-cloud-gem-name=google-cloud-secret_manager"},
+			protoFiles:    []string{"/googleapis/google/cloud/secretmanager/v1/service.proto"},
+			want: []string{
+				"--experimental_allow_proto3_optional",
+				"-I=/googleapis",
+				"--ruby_cloud_out=/staging",
+				"--ruby_cloud_opt=ruby-cloud-gem-name=google-cloud-secret_manager",
+				"/googleapis/google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildProtocArgs(test.googleapisDir, test.stagingDir, test.libStagingDir, test.installDir, test.isWrapper, test.serviceConfig, test.gapicOpts, test.protoFiles)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
When generating a Ruby client library whose transport configuration is
REST-only (such as Google Cloud Compute), protoc should only be invoked with
--ruby_out to generate protobuf message classes, and omit --grpc_out as well as
--plugin=protoc-gen-grpc.

Previously, librarian unconditionally passed --grpc_out and the gRPC plugin to
protoc for all non-wrapper libraries, resulting in unnecessary *_services_pb.rb
files being generated for REST-only libraries.

Affected Gems in google-cloud-ruby:
- google-ads-ad_manager-v1
- google-cloud-api_hub-v1
- google-cloud-compute-v1 (pending unskipping)
- google-cloud-ftp-v1
- google-cloud-gke_connect-gateway-v1
- google-cloud-gke_connect-gateway-v1beta1

Fixes https://github.com/googleapis/librarian/issues/7453
For https://github.com/googleapis/librarian/issues/7452