### PR TITLE
build(.github): avoid full checkout for integration tests on PRs

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Add Java tools to PATH
         run: echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       - name: Run librarian install
-        if: steps.cache-tools.outputs.cache-hit != 'true'
+        if: steps.cache-tools.outputs.cache-hit != 'true' && (matrix.task != 'integration' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         working-directory: google-cloud-java
         run: |
           librarian install

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -74,7 +74,7 @@ jobs:
           persist-credentials: false
       - name: Display Go version
         run: go version
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -66,7 +66,7 @@ jobs:
             # Note: If changing the target of the smoke test below, update this sparse checkout rule.
             java-secretmanager/
       - name: Checkout google-cloud-java (Full)
-        if: matrix.sparse == false
+        if: matrix.sparse == false && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: googleapis/google-cloud-java

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -76,7 +76,7 @@ jobs:
             ~/.cache/librarian
           key: nodejs-tools-v4-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-node/librarian.yaml') }}
       - name: "Install Node.js dependencies (run librarian install)"
-        if: steps.tools-cache.outputs.cache-hit != 'true' || (matrix.task == 'integration' && github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: (steps.tools-cache.outputs.cache-hit != 'true' || matrix.task == 'integration') && (matrix.task != 'integration' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         run: librarian -v install nodejs
         working-directory: google-cloud-node
       - name: Run tests

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -61,7 +61,7 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
       - name: "Checkout google-cloud-node (full)"
-        if: matrix.sparse == false
+        if: matrix.sparse == false && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: googleapis/google-cloud-node

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -55,7 +55,7 @@ jobs:
             # Note: If changing the target of the smoke test below, update this sparse checkout rule.
             google-cloud-asset-v1/
       - name: Checkout google-cloud-ruby (Full)
-        if: matrix.sparse == false
+        if: matrix.sparse == false && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: googleapis/google-cloud-ruby

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Add Ruby tools to PATH
         run: echo "$HOME/.cache/librarian/bin/ruby_tools/bin" >> $GITHUB_PATH
       - name: Run librarian install
-        if: steps.cache-tools.outputs.cache-hit != 'true'
+        if: steps.cache-tools.outputs.cache-hit != 'true' && (matrix.task != 'integration' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         working-directory: google-cloud-ruby
         run: |
           librarian install


### PR DESCRIPTION
This PR applies the `github.event_name == 'push' && github.ref == 'refs/heads/main'` condition to the full repository checkout steps in Java, Node.js, and Ruby workflows, preventing an expensive and unnecessary clone during PR builds since the actual integration test step is skipped. 

This is identical to the fix applied for Python in #7437 (specifically https://github.com/googleapis/librarian/pull/7437#discussion_r3896955505 - thanks @hj690!).

This also includes a small change to a comment in the java workflow. Zizmor was not happy that the sha didn't match the comment exactly, so I changed it in this PR given that the change is not code-related (only updates the comment).