### PR TITLE
build(.github): fix setup-java hash pin comment

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -74,7 +74,7 @@ jobs:
           persist-credentials: false
       - name: Display Go version
         run: go version
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: "17"
           distribution: "temurin"


### PR DESCRIPTION
Updates the comment to match the tag (v4.8.0) that the specific hash points to, satisfying Zizmor's ref-version-mismatch check.