### PR TITLE
chore(librarian): move add source fetch outside validate

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -112,7 +112,11 @@ func runAdd(ctx context.Context, cfg *config.Config, api, explicitLibraryName st
 	if explicitLibraryName != "" && cfg.Language != config.LanguageRuby {
 		return errNameOnlyForRuby
 	}
-	if err := validateAPIPathExistence(ctx, cfg, api); err != nil {
+	googleapisDir, err := fetchSource(ctx, cfg.Sources.Googleapis, googleapisRepo)
+	if err != nil {
+		return err
+	}
+	if err := validateAPIPathExistence(googleapisDir, api); err != nil {
 		return err
 	}
 	name, cfg, err := addLibrary(cfg, api, explicitLibraryName)
@@ -137,15 +141,10 @@ func runAdd(ctx context.Context, cfg *config.Config, api, explicitLibraryName st
 }
 
 // validateAPIPathExistence verifies that the given API path exists as a directory
-// in the configured googleapis source repository. It expects cfg.Sources.Googleapis
-// to be configured.
-func validateAPIPathExistence(ctx context.Context, cfg *config.Config, api string) error {
+// in the googleapis source directory.
+func validateAPIPathExistence(googleapisDir, api string) error {
 	if api == "" {
 		return fmt.Errorf("%w: %s", errAPINotFound, api)
-	}
-	googleapisDir, err := fetchSource(ctx, cfg.Sources.Googleapis, googleapisRepo)
-	if err != nil {
-		return err
 	}
 	fullPath := filepath.Join(googleapisDir, api)
 	// Ensure the path does not escape the source root and is not the root itself.

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -283,7 +283,7 @@ func TestValidateAPIPathExistence(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := validateAPIPathExistence(googleapisDir, "google/cloud/secretmanager/v1"); err != nil {
-		t.Fatalf("expected nil error, got %v", err)
+		t.Errorf("expected nil error, got %v", err)
 	}
 }
 
@@ -321,7 +321,7 @@ func TestValidateAPIPathExistence_Error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := validateAPIPathExistence(googleapisDir, test.apiPath)
 			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("expected error %v, got %v", test.wantErr, err)
+				t.Errorf("expected error %v, got %v", test.wantErr, err)
 			}
 		})
 	}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -253,21 +253,6 @@ func TestAddCommand_Error(t *testing.T) {
 			args:    []string{"google/cloud/nonexistent/v1"},
 			wantErr: errAPINotFound,
 		},
-		{
-			name:    "non-existent preview API",
-			args:    []string{"preview/google/cloud/nonexistent/v1"},
-			wantErr: errAPINotFound,
-		},
-		{
-			name:    "directory traversal API",
-			args:    []string{"../../etc"},
-			wantErr: errAPINotFound,
-		},
-		{
-			name:    "file path instead of directory",
-			args:    []string{"google/cloud/secretmanager/v1/secretmanager.proto"},
-			wantErr: errAPINotFound,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
@@ -287,6 +272,56 @@ func TestAddCommand_Error(t *testing.T) {
 			err := Run(t.Context(), args...)
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("want error %v, got %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateAPIPathExistence(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAPIPathExistence(googleapisDir, "google/cloud/secretmanager/v1"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestValidateAPIPathExistence_Error(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		apiPath string
+		wantErr error
+	}{
+		{
+			name:    "empty API path",
+			apiPath: "",
+			wantErr: errAPINotFound,
+		},
+		{
+			name:    "non-existent API",
+			apiPath: "google/cloud/nonexistent/v1",
+			wantErr: errAPINotFound,
+		},
+		{
+			name:    "directory traversal API",
+			apiPath: "../../etc",
+			wantErr: errAPINotFound,
+		},
+		{
+			name:    "file path instead of directory",
+			apiPath: "google/cloud/secretmanager/v1/secretmanager.proto",
+			wantErr: errAPINotFound,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateAPIPathExistence(googleapisDir, test.apiPath)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
Refactors the `source.goolgeapis` fetch code to happen prior to running API path validation. This allows us to start using the sources in language-specific `Add` implementations if necessary.

Refactors/adds tests that I suppose were missing from the original PR (likely just covered by containing `runAdd` tests).

Precursor for #7466