### PR TITLE
fix(internal/sidekick/rust): emit grpc client header for streaming apis

### DIFF
--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -279,7 +279,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
                 extensions,
                 path,
                 options,
-                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &crate::info::X_GOOG_API_CLIENT_GRPC_HEADER,
                 x_goog_request_params,
             )
     }`,

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -232,7 +232,7 @@ func TestGenerateServerStreaming(t *testing.T) {
                 path,
                 req,
                 options,
-                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &crate::info::X_GOOG_API_CLIENT_GRPC_HEADER,
                 &x_goog_request_params,
             )
             .await

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -164,6 +164,18 @@ pub(crate) mod info {
             };
             ac.rest_header_value()
         });
+{{#Codec.HasStreaming}}
+    #[allow(dead_code)]
+    pub(crate) static X_GOOG_API_CLIENT_GRPC_HEADER: std::sync::LazyLock<String> =
+        std::sync::LazyLock::new(|| {
+            let ac = gaxi::api_header::XGoogApiClient {
+                name: NAME,
+                version: VERSION,
+                library_type: gaxi::api_header::GAPIC,
+            };
+            ac.grpc_header_value()
+        });
+{{/Codec.HasStreaming}}
 }
 
 // Define some shortcuts for imported crates.

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -154,7 +154,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 extensions,
                 path,
                 options,
-                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &crate::info::X_GOOG_API_CLIENT_GRPC_HEADER,
                 x_goog_request_params,
             )
     }
@@ -216,7 +216,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 path,
                 req,
                 options,
-                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &crate::info::X_GOOG_API_CLIENT_GRPC_HEADER,
                 &x_goog_request_params,
             )
             .await


### PR DESCRIPTION
Streaming methods in Rust client crates execute over gRPC but previously sent the REST client header constant, which formats the telemetry header as rest/<version>-reqwest.

Define X_GOOG_API_CLIENT_GRPC_HEADER using ac.grpc_header_value() when streaming methods are generated, and pass this header to execute_bidi_streaming and execute_server_streaming so gRPC requests accurately identify as grpc/<version>-tonic.

For #6835 and For #7373 