### PR TITLE
feat(sidekick/swift): propagate `deprecated` tags

### DIFF
--- a/internal/sidekick/swift/templates/common/client_protocol.mustache
+++ b/internal/sidekick/swift/templates/common/client_protocol.mustache
@@ -97,19 +97,31 @@ extension Clients {
 }
 
 // Default implementations
+{{#Deprecated}}
+@available(*, deprecated)
+{{/Deprecated}}
 extension Clients.{{Codec.StubPrefix}}Protocol {
   {{#Codec.Methods}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/request}} {
     try await self.{{Codec.Name}}(request: request, options: .init())
   }
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/request_options}} {
     throw GoogleCloudGax.RequestError.unimplemented
   }
   {{#Codec.PlainRPC}}
   {{#Signatures}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
       {{> /templates/common/method_body/overload_fields}}
@@ -125,10 +137,16 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
   {{/Codec.PlainRPC}}
   {{#Codec.Pagination}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/pagination}} {
     try self.{{Codec.Name}}(byItem: byItem, options: .init())
   }
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/pagination_options}} {
     let listRpc = { (token: Swift.String) async throws -> {{Codec.ReturnType}} in
       throw GoogleCloudGax.RequestError.unimplemented
@@ -137,6 +155,9 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
   }
   {{#Signatures}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/pagination_overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
       {{> /templates/common/method_body/overload_fields}}
@@ -147,10 +168,16 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
   {{/Codec.Pagination}}
   {{#Codec.LRO}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/lro}} {
     try await self.{{Codec.Name}}(withPolling: withPolling, options: .init())
   }
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/lro_options}} {
     let poll = { () async throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.LRO.ReturnType}}>.State in
       throw GoogleCloudGax.RequestError.unimplemented
@@ -159,6 +186,9 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
   }
   {{#Signatures}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/lro_overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
       {{> /templates/common/method_body/overload_fields}}
@@ -169,10 +199,16 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
   {{/Codec.LRO}}
   {{#Codec.DiscoveryLRO}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/discovery_lro}} {
     try await self.{{Codec.Name}}(withPolling: withPolling, options: .init())
   }
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/discovery_lro_options}} {
     let poll = { () async throws -> GoogleCloudGax._PollableOperationImpl<{{Codec.DiscoveryLRO.ReturnType}}>.State in
       throw GoogleCloudGax.RequestError.unimplemented
@@ -181,6 +217,9 @@ extension Clients.{{Codec.StubPrefix}}Protocol {
   }
   {{#Signatures}}
 
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   public func {{> /templates/common/method_signature/discovery_lro_overload}} {
     let request = {{Method.InputType.Codec.ParameterTypeName}}().with {
       {{> /templates/common/method_body/overload_fields}}


### PR DESCRIPTION
If a method is deprecated, then the default implementations of the method should be marked as deprecated.

If a service is deprecated, then the extensions to the corresponding protocol should be marked as deprecated too.


Expected output at: https://github.com/googleapis/google-cloud-swift/pull/580
