### PR TITLE
docs(internal/sidekick/rust): add server streaming doc examples

### DIFF
--- a/internal/sidekick/api/xref.go
+++ b/internal/sidekick/api/xref.go
@@ -140,6 +140,9 @@ func findQuickstartMethod(s *Service) *Method {
 		func(m *Method) bool { return m.IsAIPStandardUpdate },
 		// Fallback for when no standard AIP method is available: any method that is not streaming.
 		func(m *Method) bool { return !m.ClientSideStreaming && !m.ServerSideStreaming },
+		// Fallback for streaming methods when no unary methods exist.
+		func(m *Method) bool { return !m.ClientSideStreaming && m.ServerSideStreaming },
+		func(m *Method) bool { return m.ClientSideStreaming && m.ServerSideStreaming },
 	}
 
 	strippedServiceName := strings.TrimSuffix(s.Name, "Service")

--- a/internal/sidekick/api/xref_test.go
+++ b/internal/sidekick/api/xref_test.go
@@ -2235,6 +2235,16 @@ func TestFindQuickstartMethod(t *testing.T) {
 			service: &Service{Name: "AccessPolicyService", Methods: []*Method{listOther, {Name: "ListPolicies", IsAIPStandardList: true, OutputType: &Message{Resource: &Resource{Singular: "accesspolicy"}}}}},
 			want:    &Method{Name: "ListPolicies", IsAIPStandardList: true, OutputType: &Message{Resource: &Resource{Singular: "accesspolicy"}}}, // matches singular 'accesspolicy'
 		},
+		{
+			name:    "fallback to server streaming method when no simple methods exist",
+			service: &Service{Name: "EchoService", Methods: []*Method{{Name: "Expand", ServerSideStreaming: true}}},
+			want:    &Method{Name: "Expand", ServerSideStreaming: true},
+		},
+		{
+			name:    "fallback to bidi streaming method when no unary or server streaming methods exist",
+			service: &Service{Name: "EchoService", Methods: []*Method{{Name: "Chat", ClientSideStreaming: true, ServerSideStreaming: true}}},
+			want:    &Method{Name: "Chat", ClientSideStreaming: true, ServerSideStreaming: true},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/sidekick/rust/generate_server_streaming_test.go
+++ b/internal/sidekick/rust/generate_server_streaming_test.go
@@ -68,6 +68,7 @@ func TestGenerateServerStreaming(t *testing.T) {
 			"package:prost":                    "package=prost,used-if=streaming",
 			"package:prost-types":              "package=prost-types,used-if=streaming",
 			"include-server-streaming-methods": "true",
+			"generate-rpc-samples":             "true",
 			"detailed-tracing-attributes":      "true",
 		},
 	}
@@ -96,6 +97,34 @@ func TestGenerateServerStreaming(t *testing.T) {
 		want     string
 	}{
 		{
+			name:     "client: method doc example",
+			file:     "src/client.rs",
+			startStr: "    ///\n    /// # Example",
+			endStr:   "        super::builder::echo::Expand::new(self.inner.clone())\n    }",
+			want: `    ///
+    /// # Example
+    /// ` + "```" + `
+    /// # use google_cloud_test_v1::client::Echo;
+    /// use google_cloud_test_v1::Result;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> Result<()> {
+    ///     let mut resp_stream = client.expand()
+    ///         /* set fields */
+    ///         .send().await?;
+    ///     while let Some(response) = resp_stream.next().await {
+    ///         let response = response?;
+    ///         println!("response {:?}", response);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ` + "```" + `
+    pub fn expand(&self) -> super::builder::echo::Expand
+    {
+        super::builder::echo::Expand::new(self.inner.clone())
+    }`,
+		},
+		{
 			name:     "client: method definition",
 			file:     "src/client.rs",
 			startStr: "    pub fn expand(&self) -> super::builder::echo::Expand",
@@ -104,6 +133,32 @@ func TestGenerateServerStreaming(t *testing.T) {
     {
         super::builder::echo::Expand::new(self.inner.clone())
     }`,
+		},
+		{
+			name:     "builder: doc example",
+			file:     "src/builder.rs",
+			startStr: "    /// The request builder for [Echo::expand][crate::client::Echo::expand] calls.\n    ///\n    /// # Example",
+			endStr:   "    #[derive(Clone, Debug)]",
+			want: `    /// The request builder for [Echo::expand][crate::client::Echo::expand] calls.
+    ///
+    /// # Example
+    /// ` + "```" + `
+    /// # use google_cloud_test_v1::builder::echo::Expand;
+    /// # async fn sample() -> google_cloud_test_v1::Result<()> {
+    /// let builder = prepare_request_builder();
+    /// let mut resp_stream = builder.send().await?;
+    /// while let Some(response) = resp_stream.next().await {
+    ///     let response = response?;
+    ///     println!("response {:?}", response);
+    /// }
+    /// # Ok(()) }
+    ///
+    /// fn prepare_request_builder() -> Expand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ` + "```" + `
+    #[derive(Clone, Debug)]`,
 		},
 		{
 			name:     "builder: struct definition",

--- a/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/client_method_sample.mustache
@@ -29,6 +29,21 @@ limitations under the License.
 /// }
 /// ```
 {{/IsStreaming}}
+{{#Codec.IsServerStreaming}}
+///
+/// # Example
+/// ```
+/// # use {{Service.Model.Codec.PackageNamespace}}::client::{{Service.Codec.Name}};
+{{> /templates/common/client_method_samples/use_statements}}
+/// use {{Service.Model.Codec.PackageNamespace}}::Result;
+/// async fn sample(
+{{> /templates/common/client_method_samples/parameters}}
+/// ) -> Result<()> {
+{{> /templates/common/client_method_samples/method_call}}
+///     Ok(())
+/// }
+/// ```
+{{/Codec.IsServerStreaming}}
 {{#Codec.IsBidiStreaming}}
 ///
 /// # Example

--- a/internal/sidekick/rust/templates/common/client_method_samples/method_call.mustache
+++ b/internal/sidekick/rust/templates/common/client_method_samples/method_call.mustache
@@ -13,6 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+{{#Codec.IsServerStreaming}}
+///     let mut resp_stream = client.{{Codec.Name}}()
+{{> /templates/common/client_method_samples/builder_fields}}
+///         .send().await?;
+///     while let Some(response) = resp_stream.next().await {
+///         let response = response?;
+///         println!("response {:?}", response);
+///     }
+{{/Codec.IsServerStreaming}}
 {{#Codec.IsBidiStreaming}}
 ///     let (sender, mut resp_stream) = client.{{Codec.Name}}()
 ///         .build();

--- a/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/builder.rs.mustache
@@ -128,7 +128,11 @@ pub mod {{Codec.ModuleName}} {
     {{/Codec.IsBidiStreaming}}
     {{#Codec.IsServerStreaming}}
     /// let builder = prepare_request_builder();
-    /// let mut receiver = builder.send().await?;
+    /// let mut resp_stream = builder.send().await?;
+    /// while let Some(response) = resp_stream.next().await {
+    ///     let response = response?;
+    ///     println!("response {:?}", response);
+    /// }
     {{/Codec.IsServerStreaming}}
     {{^Codec.IsBidiStreaming}}
     {{^Codec.IsServerStreaming}}


### PR DESCRIPTION
Add server streaming method and builder doc example templates for the Rust sidekick code generator.

Rename receiver to resp_stream and loop over responses in server streaming builder examples. Update quickstart method fallback to include server-side and bidirectional streaming methods when no unary methods exist. This applies to the Tether service in apigeeconnect-v1.