### PR TITLE
cleanup(rust): support grpc and http on a single template

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -531,6 +531,7 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | (embedded) | [RustDefault](#rustdefault-configuration) |  |
+| `default_unary_transport` | string | Specifies the default transport for unary RPC methods ("http" or "grpc"). Defaults to "http". When set to "grpc", unary methods default to gRPC. |
 | `modules` | list of [RustModule](#rustmodule-configuration) (optional) | Specifies generation targets for veneer crates. Each module defines a source proto path, output location, and template to use. |
 | `per_service_features` | bool | Enables per-service feature flags. |
 | `module_path` | string | Is the module path for the crate. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -239,6 +239,10 @@ type RustModule struct {
 type RustCrate struct {
 	RustDefault `yaml:",inline"`
 
+	// DefaultUnaryTransport specifies the default transport for unary RPC methods ("http" or "grpc").
+	// Defaults to "http". When set to "grpc", unary methods default to gRPC.
+	DefaultUnaryTransport string `yaml:"default_unary_transport,omitempty"`
+
 	// Modules specifies generation targets for veneer crates. Each module
 	// defines a source proto path, output location, and template to use.
 	Modules []*RustModule `yaml:"modules,omitempty"`

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -68,6 +68,9 @@ func libraryToModelConfig(library *config.Library, ch *config.API, srcs *sources
 	}
 
 	if library.Rust != nil {
+		if len(library.Rust.IncludedIds) > 0 {
+			modelCfg.Override.IncludedIDs = library.Rust.IncludedIds
+		}
 		if len(library.Rust.SkippedIds) > 0 {
 			modelCfg.Override.SkippedIDs = library.Rust.SkippedIds
 		}
@@ -170,6 +173,9 @@ func buildCodec(library *config.Library, releaseLevel string) map[string]string 
 	}
 	if rust.QuickstartServiceOverride != "" {
 		codec["quickstart-service-override"] = rust.QuickstartServiceOverride
+	}
+	if rust.DefaultUnaryTransport != "" {
+		codec["default-unary-transport"] = rust.DefaultUnaryTransport
 	}
 	return codec
 }

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -86,8 +86,10 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := sidekickrust.Generate(ctx, model, library.Output, modelConfig); err != nil {
 		return err
 	}
-	if err := generateProstHybrid(ctx, model, library, library.Output, modelConfig); err != nil {
-		return err
+	if rootTypeIDs := sidekickrust.GrpcRootTypeIDs(model); len(rootTypeIDs) > 0 {
+		if err := generateProstHybrid(ctx, model, rootTypeIDs, library, library.Output, modelConfig); err != nil {
+			return err
+		}
 	}
 	if needsRepoMetadata(model, library) {
 		repoMetadata, err := createRepoMetadata(cfg, library, sources)

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -17,6 +17,7 @@ package rust
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -31,23 +32,16 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/rust_prost"
 )
 
-func generateProstHybrid(ctx context.Context, model *api.API, library *config.Library, outdir string, modelConfig *parser.ModelConfig) error {
-	if library.Rust == nil || library.Rust.TemplateOverride != "" {
-		return nil
-	}
-	includeBidi := library.Rust.IncludeBidiStreamingMethods != nil && *library.Rust.IncludeBidiStreamingMethods
-	includeServer := library.Rust.IncludeServerStreamingMethods != nil && *library.Rust.IncludeServerStreamingMethods
-	if !includeBidi && !includeServer {
-		return nil
-	}
-	hasStreaming := slices.ContainsFunc(model.Services, func(s *api.Service) bool {
-		return (includeBidi && s.HasBidiStreaming()) || (includeServer && s.HasServerSideStreaming())
-	})
-	if !hasStreaming {
+func generateProstHybrid(ctx context.Context, model *api.API, rootTypeIDs []string, library *config.Library, outdir string, modelConfig *parser.ModelConfig) error {
+	if library.Rust == nil || library.Rust.TemplateOverride != "" || len(rootTypeIDs) == 0 {
 		return nil
 	}
 
-	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToStreaming(model, includeBidi, includeServer, library.Rust.AllowStreamingAnyTypes)
+	var allowStreamingAnyTypes []string
+	if library.Rust != nil {
+		allowStreamingAnyTypes = library.Rust.AllowStreamingAnyTypes
+	}
+	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToTypes(model, rootTypeIDs, allowStreamingAnyTypes)
 	if err != nil {
 		return err
 	}
@@ -79,54 +73,34 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 	return nil
 }
 
-// filterModelToStreaming constructs a hybrid api.API model containing only
-// enabled bidirectional and server-side streaming RPC types for prost conversion generation. It also returns
-// a sorted slice of all non-WKT unused type IDs to exclude via prost_build extern_path,
-// and a boolean indicating whether google.rpc.Status is referenced in the streaming path.
-// Errors if Any is encountered in the streaming reachability path unless explicitly allowed via allowStreamingAnyTypes.
-func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool, allowStreamingAnyTypes []string) (*api.API, []string, bool, error) {
-	type streamingTypeItem struct {
-		id       string
-		rpc      string
-		methodID string
-		path     string
+// filterModelToTypes constructs an api.API model containing only types reachable
+// from rootTypeIDs for prost conversion generation. It also returns a sorted slice
+// of all non-WKT unused type IDs to exclude via prost_build extern_path, and a boolean
+// indicating whether google.rpc.Status is referenced in the reachability path.
+// Errors if Any is encountered in the reachability path unless explicitly allowed via allowStreamingAnyTypes.
+func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyTypes []string) (*api.API, []string, bool, error) {
+	type typeItem struct {
+		id   string
+		path string
 	}
 
 	streamingMsgs := make(map[string]bool)
 	streamingEnums := make(map[string]bool)
-	var queue []streamingTypeItem
+	var queue []typeItem
 
-	// Collect initial input/output message types from all enabled bidirectional and server-side streaming RPCs.
-	for _, s := range model.Services {
-		for _, m := range s.Methods {
-			isBidi := m.ClientSideStreaming && m.ServerSideStreaming && includeBidi
-			isServer := !m.ClientSideStreaming && m.ServerSideStreaming && includeServer
-			if isBidi || isServer {
-				rpcName := s.Name + "." + m.Name
-				if m.InputTypeID != "" {
-					queue = append(queue, streamingTypeItem{
-						id:       m.InputTypeID,
-						rpc:      rpcName,
-						methodID: m.ID,
-						path:     m.InputTypeID,
-					})
-				}
-				if m.OutputTypeID != "" {
-					queue = append(queue, streamingTypeItem{
-						id:       m.OutputTypeID,
-						rpc:      rpcName,
-						methodID: m.ID,
-						path:     m.OutputTypeID,
-					})
-				}
-			}
+	for _, id := range rootTypeIDs {
+		if id != "" {
+			queue = append(queue, typeItem{
+				id:   id,
+				path: id,
+			})
 		}
 	}
 
 	// Discover all transitively reachable messages and enums.
 	visited := make(map[string]bool)
-	var enqueueMsg func(m *api.Message, rpc, methodID, path string)
-	var enqueueEnum func(e *api.Enum, rpc, methodID, path string)
+	var enqueueMsg func(m *api.Message, path string)
+	var enqueueEnum func(e *api.Enum, path string)
 
 	// enqueueMsg marks a message as used in streaming and enqueues it for field
 	// traversal. It recursively enqueues all parent ancestor messages to ensure:
@@ -135,38 +109,37 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 	// 2. Parent messages are enqueued for field traversal so their sibling field types
 	//    (e.g., Partition.SpatialPartition) are also included in streamingMsgs rather than
 	//    placed in unusedTypes, preventing missing type errors in convert.rs.
-	enqueueMsg = func(m *api.Message, rpc, methodID, path string) {
+	enqueueMsg = func(m *api.Message, path string) {
 		if m == nil {
 			return
 		}
 		if !streamingMsgs[m.ID] {
 			streamingMsgs[m.ID] = true
-			queue = append(queue, streamingTypeItem{
-				id:       m.ID,
-				rpc:      rpc,
-				methodID: methodID,
-				path:     path,
+			queue = append(queue, typeItem{
+				id:   m.ID,
+				path: path,
 			})
 		}
 		if m.Parent != nil {
-			enqueueMsg(m.Parent, rpc, methodID, path)
+			enqueueMsg(m.Parent, path)
 		}
 	}
 
 	// enqueueEnum marks an enum as used in streaming. If the enum is nested inside a message,
 	// it recursively enqueues parent ancestor messages to ensure they and their sibling field
 	// types are not placed in unusedTypes.
-	enqueueEnum = func(e *api.Enum, rpc, methodID, path string) {
+	enqueueEnum = func(e *api.Enum, path string) {
 		if e == nil {
 			return
 		}
 		streamingEnums[e.ID] = true
 		if e.Parent != nil {
-			enqueueMsg(e.Parent, rpc, methodID, path)
+			enqueueMsg(e.Parent, path)
 		}
 	}
 
 	hasGoogleRpcStatus := false
+	var unsupportedAnyFields []string
 
 	for len(queue) > 0 {
 		item := queue[0]
@@ -177,23 +150,9 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 		}
 		visited[item.id] = true
 
-		anyError := func(path string, fieldID string) error {
-			if fieldID != "" && !isAnyType(fieldID) {
-				return fmt.Errorf("cannot generate prost conversion for streaming RPC %q: type google.protobuf.Any is unsupported (path: %s)\n"+
-					"To resolve this, allow dropping this Any field in prost conversion by adding it to allow_streaming_any_types in librarian.yaml:\n"+
-					"    rust:\n"+
-					"      allow_streaming_any_types:\n"+
-					"        - %s\n"+
-					"Or skip the RPC method by adding it to skipped_ids in librarian.yaml (e.g. skipped_ids: [%s])",
-					item.rpc, path, fieldID, item.methodID)
-			}
-			return fmt.Errorf("cannot generate prost conversion for streaming RPC %q: type google.protobuf.Any is unsupported (path: %s)\n"+
-				"To resolve this, add the RPC method ID to skipped_ids in librarian.yaml (e.g. skipped_ids: [%s])",
-				item.rpc, path, item.methodID)
-		}
-
 		if isAnyType(item.id) {
-			return nil, nil, false, anyError(item.path, item.id)
+			unsupportedAnyFields = append(unsupportedAnyFields, item.id)
+			continue
 		}
 
 		msg := model.Message(item.id)
@@ -206,7 +165,7 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 				hasGoogleRpcStatus = true
 				continue
 			}
-			enqueueMsg(msg, item.rpc, item.methodID, item.path)
+			enqueueMsg(msg, item.path)
 			for _, f := range msg.Fields {
 				fieldPath := item.path + "." + f.Name
 				if isAnyType(f.TypezID) {
@@ -214,18 +173,17 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 						f.SkipProtoConversion = true
 						continue
 					}
-					return nil, nil, false, anyError(fieldPath, f.ID)
+					unsupportedAnyFields = append(unsupportedAnyFields, f.ID)
+					continue
 				}
 				if f.Typez == api.TypezMessage && f.TypezID != "" {
-					queue = append(queue, streamingTypeItem{
-						id:       f.TypezID,
-						rpc:      item.rpc,
-						methodID: item.methodID,
-						path:     fieldPath,
+					queue = append(queue, typeItem{
+						id:   f.TypezID,
+						path: fieldPath,
 					})
 				}
 				if f.Typez == api.TypezEnum && f.TypezID != "" {
-					enqueueEnum(model.Enum(f.TypezID), item.rpc, item.methodID, fieldPath)
+					enqueueEnum(model.Enum(f.TypezID), fieldPath)
 				}
 			}
 			for _, o := range msg.OneOfs {
@@ -236,18 +194,17 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 							f.SkipProtoConversion = true
 							continue
 						}
-						return nil, nil, false, anyError(fieldPath, f.ID)
+						unsupportedAnyFields = append(unsupportedAnyFields, f.ID)
+						continue
 					}
 					if f.Typez == api.TypezMessage && f.TypezID != "" {
-						queue = append(queue, streamingTypeItem{
-							id:       f.TypezID,
-							rpc:      item.rpc,
-							methodID: item.methodID,
-							path:     fieldPath,
+						queue = append(queue, typeItem{
+							id:   f.TypezID,
+							path: fieldPath,
 						})
 					}
 					if f.Typez == api.TypezEnum && f.TypezID != "" {
-						enqueueEnum(model.Enum(f.TypezID), item.rpc, item.methodID, fieldPath)
+						enqueueEnum(model.Enum(f.TypezID), fieldPath)
 					}
 				}
 			}
@@ -255,8 +212,26 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 
 		enum := model.Enum(item.id)
 		if enum != nil {
-			enqueueEnum(enum, item.rpc, item.methodID, item.path)
+			enqueueEnum(enum, item.path)
 		}
+	}
+
+	slices.Sort(unsupportedAnyFields)
+	unsupportedAnyFields = slices.Compact(unsupportedAnyFields)
+
+	if len(unsupportedAnyFields) > 0 {
+		var b strings.Builder
+		b.WriteString("cannot generate prost conversion: type google.protobuf.Any is unsupported:\n")
+		for _, f := range unsupportedAnyFields {
+			fmt.Fprintf(&b, "  - %s\n", f)
+		}
+		b.WriteString("\nTo resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+			"    rust:\n" +
+			"      allow_streaming_any_types:\n")
+		for _, f := range unsupportedAnyFields {
+			fmt.Fprintf(&b, "        - %s\n", f)
+		}
+		return nil, nil, false, errors.New(b.String())
 	}
 
 	// Collect external top-level messages (e.g. google.type.LatLng) referenced by streaming RPCs.
@@ -285,17 +260,12 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 
 	// Construct hybridModel for prost conversion code generation.
 	hybridModel := api.API{
-		Name:        model.Name,
-		PackageName: model.PackageName,
-		Title:       model.Title,
-		Description: model.Description,
-		Revision:    model.Revision,
-		// Services, Messages, and Enums slices are filtered to only streaming types so convert.rs
-		// only contains conversion implementations for streaming RPCs.
-		// Filtering model.Messages and model.Enums preserves their original deterministic file order.
-		Services: language.FilterSlice(model.Services, func(s *api.Service) bool {
-			return (includeBidi && s.HasBidiStreaming()) || (includeServer && s.HasServerSideStreaming())
-		}),
+		Name:                model.Name,
+		PackageName:         model.PackageName,
+		Title:               model.Title,
+		Description:         model.Description,
+		Revision:            model.Revision,
+		Services:            model.Services,
 		Messages:            language.FilterSlice(model.Messages, func(m *api.Message) bool { return streamingMsgs[m.ID] }),
 		ExternalMessages:    externalMessages,
 		Enums:               language.FilterSlice(model.Enums, func(e *api.Enum) bool { return streamingEnums[e.ID] }),
@@ -310,8 +280,8 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 			hybridModel.AddMethod(m)
 		}
 	}
-	// Populate messageByID and enumByID with ALL package messages and enums (not just
-	// streaming types). This avoids aliasing model.messageByID while allowing model
+	// Populate messageByID and enumByID with ALL package messages and enums.
+	// This avoids aliasing model.messageByID while allowing model
 	// annotation to resolve field types across the entire package.
 	for m := range model.AllMessages() {
 		hybridModel.AddMessage(m)

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sidekick/api"
 	"github.com/googleapis/librarian/internal/sidekick/parser"
+	sidekickrust "github.com/googleapis/librarian/internal/sidekick/rust"
 	"github.com/googleapis/librarian/internal/sources"
 	"github.com/googleapis/librarian/internal/testhelper"
 )
@@ -118,15 +119,34 @@ func TestGenerateProstHybrid(t *testing.T) {
 			srcs := &sources.Sources{
 				Googleapis: filepath.Dir(filepath.Dir(absSpecSource)),
 			}
-			err = generateProstHybrid(t.Context(), test.model, lib, outDir, &parser.ModelConfig{
+			codecMap := map[string]string{
+				"package-name-override": "google-cloud-test",
+				"package:g3-wkt":        "package=google-cloud-wkt,source=google.protobuf",
+			}
+			if test.includeBidiStreamingMethods {
+				codecMap["include-bidi-streaming-methods"] = "true"
+			}
+			if test.includeServerStreamingMethods {
+				codecMap["include-server-streaming-methods"] = "true"
+			}
+			test.model.Codec = nil
+			for _, s := range test.model.Services {
+				s.Codec = nil
+				for _, m := range s.Methods {
+					m.Codec = nil
+				}
+			}
+			modelConfig := &parser.ModelConfig{
 				SpecificationFormat: config.SpecProtobuf,
 				SpecificationSource: absSpecSource,
 				Source:              sources.NewSourceConfig(srcs, []string{"googleapis"}),
-				Codec: map[string]string{
-					"package-name-override": "google-cloud-test",
-					"package:g3-wkt":        "package=google-cloud-wkt,source=google.protobuf",
-				},
-			})
+				Codec:               codecMap,
+			}
+			if err := sidekickrust.AnnotateModel(test.model, modelConfig); err != nil {
+				t.Fatalf("unexpected error annotating model: %v", err)
+			}
+			rootTypeIDs := sidekickrust.GrpcRootTypeIDs(test.model)
+			err = generateProstHybrid(t.Context(), test.model, rootTypeIDs, lib, outDir, modelConfig)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -147,16 +167,13 @@ func TestGenerateProstHybrid(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreaming(t *testing.T) {
+func TestFilterModelToTypes(t *testing.T) {
 	streamingMsg := api.NewTestMessage("StreamMsg").WithPackage("google.test.v1")
 	unusedMsg := api.NewTestMessage("UnusedMsg").WithPackage("google.test.v1")
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamingMsg).WithOutput(streamingMsg).WithBidiStreaming()
+	model := api.NewTestAPI([]*api.Message{streamingMsg, unusedMsg}, []*api.Enum{}, []*api.Service{})
 
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
-	model := api.NewTestAPI([]*api.Message{streamingMsg, unusedMsg}, []*api.Enum{}, []*api.Service{bidiService})
-
-	filtered, unused, _, err := filterModelToStreaming(model, true, true, nil)
+	filtered, unused, _, err := filterModelToTypes(model, []string{streamingMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -173,7 +190,7 @@ func TestFilterModelToStreaming(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
+func TestFilterModelToTypesUnusedFieldLookup(t *testing.T) {
 	streamMsg := api.NewTestMessage("StreamMsg").WithPackage("google.test.v1")
 	childData := api.NewTestMessage("ChildData").WithPackage("google.test.v1")
 	unaryReq := api.NewTestMessage("UnaryReq").WithPackage("google.test.v1").WithFields(
@@ -184,22 +201,13 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 		},
 	)
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamMsg).WithOutput(streamMsg).WithBidiStreaming()
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
+	model := api.NewTestAPI([]*api.Message{streamMsg, unaryReq, childData}, []*api.Enum{}, []*api.Service{})
 
-	unaryMethod := api.NewTestMethod("UnaryMethod").WithInput(unaryReq).WithOutput(unaryReq)
-	unaryService := api.NewTestService("UnaryService").WithPackage("google.test.v1").WithMethods(unaryMethod)
-
-	model := api.NewTestAPI([]*api.Message{streamMsg, unaryReq, childData}, []*api.Enum{}, []*api.Service{bidiService, unaryService})
-
-	filtered, _, _, err := filterModelToStreaming(model, true, true, nil)
+	filtered, _, _, err := filterModelToTypes(model, []string{streamMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(filtered.Services) != 1 || filtered.Services[0].ID != bidiService.ID {
-		t.Errorf("got services %v, want [%s]", filtered.Services, bidiService.ID)
-	}
 	if len(filtered.Messages) != 1 || filtered.Messages[0].ID != streamMsg.ID {
 		t.Errorf("got messages %v, want [%s]", filtered.Messages, streamMsg.ID)
 	}
@@ -211,7 +219,7 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingExternalTypes(t *testing.T) {
+func TestFilterModelToTypesExternalTypes(t *testing.T) {
 	streamMsg := api.NewTestMessage("StreamMsg").WithPackage("google.test.v1")
 	externalMsg := api.NewTestMessage("LatLng").WithPackage("google.type")
 	externalEnum := &api.Enum{Name: "DayOfWeek", ID: ".google.type.DayOfWeek", Package: "google.type"}
@@ -229,17 +237,14 @@ func TestFilterModelToStreamingExternalTypes(t *testing.T) {
 		},
 	}
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamMsg).WithOutput(streamMsg).WithBidiStreaming()
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
-
-	model := api.NewTestAPI([]*api.Message{streamMsg}, []*api.Enum{}, []*api.Service{bidiService})
+	model := api.NewTestAPI([]*api.Message{streamMsg}, []*api.Enum{}, []*api.Service{})
 	model.AddMessage(externalMsg)
 	model.AddEnum(externalEnum)
 	if err := api.CrossReference(model); err != nil {
 		t.Fatal(err)
 	}
 
-	filtered, _, _, err := filterModelToStreaming(model, true, true, nil)
+	filtered, _, _, err := filterModelToTypes(model, []string{streamMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -255,41 +260,46 @@ func TestFilterModelToStreamingExternalTypes(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingAnyError(t *testing.T) {
-	// Verify google.protobuf.Any in streaming path returns error with recommendation
+func TestFilterModelToTypesAnyError(t *testing.T) {
 	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(
 		&api.Field{
 			Name:    "details",
 			TypezID: ".google.protobuf.Any",
 			Typez:   api.TypezMessage,
 		},
+		&api.Field{
+			Name:    "metadata",
+			TypezID: ".google.protobuf.Any",
+			Typez:   api.TypezMessage,
+		},
 	)
-	chatAnyMethod := api.NewTestMethod("ChatAny").WithInput(anyMsg).WithOutput(anyMsg).WithBidiStreaming()
-	anyService := api.NewTestService("AnyService").WithPackage("google.test.v1").WithMethods(chatAnyMethod)
 
-	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
+	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{})
 
-	_, _, _, err := filterModelToStreaming(anyModel, true, true, nil)
+	_, _, _, err := filterModelToTypes(anyModel, []string{anyMsg.ID}, nil)
 	if err == nil {
 		t.Fatal("expected error for google.protobuf.Any, got nil")
 	}
 	if !strings.Contains(err.Error(), "allow_streaming_any_types") {
 		t.Errorf("expected error to contain recommendation 'allow_streaming_any_types', got: %v", err)
 	}
+	if !strings.Contains(err.Error(), ".google.test.v1.AnyReq.details") {
+		t.Errorf("expected error to contain .google.test.v1.AnyReq.details, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), ".google.test.v1.AnyReq.metadata") {
+		t.Errorf("expected error to contain .google.test.v1.AnyReq.metadata, got: %v", err)
+	}
 }
 
-func TestFilterModelToStreamingAllowedAny(t *testing.T) {
-	// Verify allowing specific Any field path succeeds and drops the field from conversion
+func TestFilterModelToTypesAllowedAny(t *testing.T) {
 	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(
 		api.NewTestField("details").WithType(api.TypezMessage).WithTypezID(".google.protobuf.Any"),
 		api.NewTestField("name").WithType(api.TypezString),
 	)
-	chatAnyMethod := api.NewTestMethod("ChatAny").WithInput(anyMsg).WithOutput(anyMsg).WithBidiStreaming()
-	anyService := api.NewTestService("AnyService").WithPackage("google.test.v1").WithMethods(chatAnyMethod)
 
-	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
+	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{})
 
-	filtered, _, _, err := filterModelToStreaming(anyModel, true, true, []string{".google.test.v1.AnyReq.details"})
+	filtered, _, _, err := filterModelToTypes(anyModel, []string{anyMsg.ID}, []string{".google.test.v1.AnyReq.details"})
 	if err != nil {
 		t.Fatalf("expected success with allowStreamingAnyTypes, got error: %v", err)
 	}
@@ -314,8 +324,7 @@ func TestFilterModelToStreamingAllowedAny(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
-	// Verify google.rpc.Status in streaming path succeeds and does not error on Any details
+func TestFilterModelToTypesGoogleRpcStatus(t *testing.T) {
 	statusMsg := api.NewTestMessage("Status").WithPackage("google.rpc").WithFields(
 		&api.Field{
 			Name:  "code",
@@ -341,13 +350,10 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 		},
 	)
 
-	chatMethod := api.NewTestMethod("ChatStatus").WithInput(reqMsg).WithOutput(reqMsg).WithBidiStreaming()
-	statusService := api.NewTestService("StatusService").WithPackage("google.test.v1").WithMethods(chatMethod)
-
-	statusModel := api.NewTestAPI([]*api.Message{reqMsg}, []*api.Enum{}, []*api.Service{statusService})
+	statusModel := api.NewTestAPI([]*api.Message{reqMsg}, []*api.Enum{}, []*api.Service{})
 	statusModel.AddMessage(statusMsg)
 
-	filtered, unused, hasStatus, err := filterModelToStreaming(statusModel, true, true, nil)
+	filtered, unused, hasStatus, err := filterModelToTypes(statusModel, []string{reqMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error for google.rpc.Status: %v", err)
 	}
@@ -357,7 +363,7 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 	}
 
 	if !hasStatus {
-		t.Errorf("expected hasStatus boolean from filterModelToStreaming to be true, got false")
+		t.Errorf("expected hasStatus boolean from filterModelToTypes to be true, got false")
 	}
 
 	for _, u := range unused {
@@ -367,7 +373,7 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
+func TestFilterModelToTypesNestedTypeParentPreservation(t *testing.T) {
 	parent := api.NewTestMessage("Parent").WithPackage("google.test.v1")
 	child := api.NewTestMessage("Child").WithPackage("google.test.v1")
 	sibling := api.NewTestMessage("Sibling").WithPackage("google.test.v1")
@@ -389,12 +395,9 @@ func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
 		},
 	)
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamReq).WithOutput(streamReq).WithBidiStreaming()
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
+	model := api.NewTestAPI([]*api.Message{parent, child, sibling, streamReq}, []*api.Enum{}, []*api.Service{})
 
-	model := api.NewTestAPI([]*api.Message{parent, child, sibling, streamReq}, []*api.Enum{}, []*api.Service{bidiService})
-
-	_, unusedTypes, _, err := filterModelToStreaming(model, true, false, nil)
+	_, unusedTypes, _, err := filterModelToTypes(model, []string{streamReq.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -412,74 +415,46 @@ func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingServerStreaming(t *testing.T) {
-	reqMsg := api.NewTestMessage("ExpandRequest").WithPackage("google.test.v1")
-	respMsg := api.NewTestMessage("EchoResponse").WithPackage("google.test.v1")
-	unusedMsg := api.NewTestMessage("UnusedMsg").WithPackage("google.test.v1")
-
-	expandMethod := api.NewTestMethod("Expand").WithInput(reqMsg).WithOutput(respMsg).WithServerSideStreaming()
-
-	serverService := api.NewTestService("EchoService").WithPackage("google.test.v1").WithMethods(expandMethod)
-	model := api.NewTestAPI([]*api.Message{reqMsg, respMsg, unusedMsg}, []*api.Enum{}, []*api.Service{serverService})
-
-	filtered, unused, _, err := filterModelToStreaming(model, false, true, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(filtered.Services) != 1 || filtered.Services[0].ID != serverService.ID {
-		t.Errorf("got services %v, want [%s]", filtered.Services, serverService.ID)
-	}
-	if len(filtered.Messages) != 2 {
-		t.Errorf("got messages %v, want [%s, %s]", filtered.Messages, reqMsg.ID, respMsg.ID)
-	}
-	if len(unused) != 1 || unused[0] != unusedMsg.ID {
-		t.Errorf("got unused %v, want [%s]", unused, unusedMsg.ID)
-	}
-}
-
-func TestFilterModelToStreamingIsolation(t *testing.T) {
-	bidiMsg := api.NewTestMessage("BidiMsg").WithPackage("google.test.v1")
-	serverReq := api.NewTestMessage("ServerReq").WithPackage("google.test.v1")
-	serverResp := api.NewTestMessage("ServerResp").WithPackage("google.test.v1")
-
-	bidiMethod := api.NewTestMethod("Chat").WithInput(bidiMsg).WithOutput(bidiMsg).WithBidiStreaming()
-	serverMethod := api.NewTestMethod("Expand").WithInput(serverReq).WithOutput(serverResp).WithServerSideStreaming()
-
-	service := api.NewTestService("MixedService").WithPackage("google.test.v1").WithMethods(bidiMethod, serverMethod)
-	model := api.NewTestAPI([]*api.Message{bidiMsg, serverReq, serverResp}, []*api.Enum{}, []*api.Service{service})
-
+func TestFilterModelToTypesMultipleRoots(t *testing.T) {
 	for _, test := range []struct {
-		name          string
-		includeBidi   bool
-		includeServer bool
-		wantMessages  []string
-		wantUnused    []string
+		name         string
+		rootTypeIDs  []string
+		wantMessages []string
+		wantUnused   []string
 	}{
 		{
-			name:          "server streaming only ignores bidi types",
-			includeBidi:   false,
-			includeServer: true,
-			wantMessages:  []string{serverReq.ID, serverResp.ID},
-			wantUnused:    []string{bidiMsg.ID},
+			name:         "single root only includes reachable types",
+			rootTypeIDs:  []string{".google.test.v1.MsgA"},
+			wantMessages: []string{".google.test.v1.MsgA"},
+			wantUnused:   []string{".google.test.v1.MsgB", ".google.test.v1.MsgC"},
 		},
 		{
-			name:          "bidi streaming only ignores server streaming types",
-			includeBidi:   true,
-			includeServer: false,
-			wantMessages:  []string{bidiMsg.ID},
-			wantUnused:    []string{serverReq.ID, serverResp.ID},
+			name:         "multiple roots include all reachable types",
+			rootTypeIDs:  []string{".google.test.v1.MsgA", ".google.test.v1.MsgB"},
+			wantMessages: []string{".google.test.v1.MsgA", ".google.test.v1.MsgB"},
+			wantUnused:   []string{".google.test.v1.MsgC"},
 		},
 		{
-			name:          "both streaming types enabled includes all types",
-			includeBidi:   true,
-			includeServer: true,
-			wantMessages:  []string{bidiMsg.ID, serverReq.ID, serverResp.ID},
-			wantUnused:    nil,
+			name:         "all roots includes all messages",
+			rootTypeIDs:  []string{".google.test.v1.MsgA", ".google.test.v1.MsgB", ".google.test.v1.MsgC"},
+			wantMessages: []string{".google.test.v1.MsgA", ".google.test.v1.MsgB", ".google.test.v1.MsgC"},
+			wantUnused:   nil,
+		},
+		{
+			name:         "empty roots includes no messages",
+			rootTypeIDs:  nil,
+			wantMessages: nil,
+			wantUnused:   []string{".google.test.v1.MsgA", ".google.test.v1.MsgB", ".google.test.v1.MsgC"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			filtered, unused, _, err := filterModelToStreaming(model, test.includeBidi, test.includeServer, nil)
+			msgA := api.NewTestMessage("MsgA").WithPackage("google.test.v1")
+			msgB := api.NewTestMessage("MsgB").WithPackage("google.test.v1")
+			msgC := api.NewTestMessage("MsgC").WithPackage("google.test.v1")
+
+			model := api.NewTestAPI([]*api.Message{msgA, msgB, msgC}, []*api.Enum{}, []*api.Service{})
+
+			filtered, unused, _, err := filterModelToTypes(model, test.rootTypeIDs, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -49,6 +49,17 @@ type methodAnnotation struct {
 	IsBigQueryInsertJob       bool
 	ClientSideStreaming       bool
 	ServerSideStreaming       bool
+	IsGrpc                    bool
+}
+
+// IsHttp returns true if the method is routed over HTTP transport.
+func (m *methodAnnotation) IsHttp() bool {
+	return !m.IsGrpc
+}
+
+// IsUnaryGrpc returns true if the method is a unary RPC routed over gRPC.
+func (m *methodAnnotation) IsUnaryGrpc() bool {
+	return m.IsGrpc && !m.ClientSideStreaming && !m.ServerSideStreaming
 }
 
 // IsBidiStreaming returns true if the method is a bidirectional streaming RPC.
@@ -347,6 +358,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		IsBigQueryInsertJob:       m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob",
 		ClientSideStreaming:       m.ClientSideStreaming,
 		ServerSideStreaming:       m.ServerSideStreaming,
+		IsGrpc:                    c.methodUsesGrpc(m),
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {
@@ -561,13 +573,15 @@ func makeClearAccessors(fields []string, m *api.Method) ([]string, error) {
 
 func (c *codec) annotatePathBinding(b *api.PathBinding, m *api.Method) (*pathBindingAnnotation, error) {
 	var subs []*bindingSubstitution
-	for _, s := range b.PathTemplate.Segments {
-		if s.Variable != nil {
-			sub, err := makeBindingSubstitution(s.Variable, m)
-			if err != nil {
-				return nil, err
+	if b.PathTemplate != nil {
+		for _, s := range b.PathTemplate.Segments {
+			if s.Variable != nil {
+				sub, err := makeBindingSubstitution(s.Variable, m)
+				if err != nil {
+					return nil, err
+				}
+				subs = append(subs, sub)
 			}
-			subs = append(subs, sub)
 		}
 	}
 	binding := &pathBindingAnnotation{
@@ -733,4 +747,19 @@ func isIdempotent(p *api.PathInfo) string {
 		}
 	}
 	return "true"
+}
+
+func (c *codec) methodUsesGrpc(m *api.Method) bool {
+	if !c.templateSupportsGrpc() {
+		return false
+	}
+	if c.defaultUnaryTransport == "grpc" {
+		return true
+	}
+	if m.ClientSideStreaming || m.ServerSideStreaming {
+		return (m.ClientSideStreaming && m.ServerSideStreaming && c.includeBidiStreamingMethods) ||
+			(!m.ClientSideStreaming && m.ServerSideStreaming && c.includeServerStreamingMethods) ||
+			c.includeStreamingMethods
+	}
+	return c.includeGrpcOnlyMethods && (m.PathInfo == nil || len(m.PathInfo.Bindings) == 0)
 }

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -414,7 +414,7 @@ func TestAnnotateMethodResourceNameTemplate(t *testing.T) {
 				"SystemParameters", "ReturnType", "PathInfo", "Attributes",
 				"RoutingRequired", "DetailedTracingAttributes",
 				"ResourceNameTemplateGrpc", "GrpcResourceNameArgs",
-				"InternalBuilders")); diff != "" {
+				"InternalBuilders", "IsGrpc")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 
@@ -607,6 +607,74 @@ func TestIsServerStreaming(t *testing.T) {
 			ann := &methodAnnotation{ClientSideStreaming: test.client, ServerSideStreaming: test.server}
 			if got := ann.IsServerStreaming(); got != test.want {
 				t.Errorf("methodAnnotation.IsServerStreaming() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsHttp(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		isGrpc bool
+		want   bool
+	}{
+		{"gRPC method", true, false},
+		{"HTTP method", false, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ann := &methodAnnotation{IsGrpc: test.isGrpc}
+			if got := ann.IsHttp(); got != test.want {
+				t.Errorf("methodAnnotation.IsHttp() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsUnaryGrpc(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		isGrpc bool
+		client bool
+		server bool
+		want   bool
+	}{
+		{"unary gRPC", true, false, false, true},
+		{"unary HTTP", false, false, false, false},
+		{"server-streaming gRPC", true, false, true, false},
+		{"bidi-streaming gRPC", true, true, true, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ann := &methodAnnotation{IsGrpc: test.isGrpc, ClientSideStreaming: test.client, ServerSideStreaming: test.server}
+			if got := ann.IsUnaryGrpc(); got != test.want {
+				t.Errorf("methodAnnotation.IsUnaryGrpc() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestMethodUsesGrpc(t *testing.T) {
+	unaryMethod := &api.Method{
+		ID:       ".test.Service.Unary",
+		PathInfo: &api.PathInfo{Bindings: []*api.PathBinding{{PathTemplate: &api.PathTemplate{}}}},
+	}
+	for _, test := range []struct {
+		name                  string
+		defaultUnaryTransport string
+		templateOverride      string
+		want                  bool
+	}{
+		{"default http", "", "", false},
+		{"explicit http", "http", "", false},
+		{"explicit grpc", "grpc", "", true},
+		{"template without grpc", "grpc", "templates/http-client", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := &codec{
+				defaultUnaryTransport: test.defaultUnaryTransport,
+				templateOverride:      test.templateOverride,
+			}
+			if got := c.methodUsesGrpc(unaryMethod); got != test.want {
+				t.Errorf("methodUsesGrpc() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -54,12 +54,11 @@ type modelAnnotations struct {
 	ExternPackages             []string
 	HasLROs                    bool
 	HasBidiStreaming           bool
-	HasServerStreaming         bool
 	HasStreaming               bool
+	HasGrpc                    bool
+	HasHttp                    bool
+	GrpcRootTypeIDs            []string
 	IncludeRpcStatusConversion bool
-	BidiStreamingServices      []*api.Service
-	ServerStreamingServices    []*api.Service
-	StreamingServices          []*api.Service
 	CopyrightYear              string
 	BoilerPlate                []string
 	DefaultHost                string
@@ -142,14 +141,50 @@ func (m *modelAnnotations) ReleaseLevelIsGA() bool {
 	return m.ReleaseLevel == "GA" || m.ReleaseLevel == "stable"
 }
 
+// GrpcServices returns the subset of services that have at least one gRPC method.
+func (m *modelAnnotations) GrpcServices() []*api.Service {
+	return language.FilterSlice(m.Services, func(s *api.Service) bool {
+		if ann, ok := s.Codec.(*serviceAnnotations); ok {
+			return ann.HasGrpc
+		}
+		return false
+	})
+}
+
+// GrpcRootTypeIDs returns the sorted and deduplicated input and output message type IDs
+// for all enabled gRPC methods in the model.
+func GrpcRootTypeIDs(model *api.API) []string {
+	if ann, ok := model.Codec.(*modelAnnotations); ok {
+		return ann.GrpcRootTypeIDs
+	}
+	return nil
+}
+
+// ModelHasGrpc returns true if the model is annotated and has at least one gRPC service.
+func ModelHasGrpc(model *api.API) bool {
+	if ann, ok := model.Codec.(*modelAnnotations); ok {
+		return ann.HasGrpc
+	}
+	return false
+}
+
 // annotateModel creates a struct used as input for Mustache templates.
 // Fields and methods defined in this struct directly correspond to Mustache
 // tags. For example, the Mustache tag {{#Services}} uses the
 // [Template.Services] field.
 func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	codec.hasServices = len(model.Services) > 0
+	for _, s := range model.Services {
+		if s.Model == nil {
+			s.Model = model
+		}
+		for _, m := range s.Methods {
+			if m.Model == nil {
+				m.Model = model
+			}
+		}
+	}
 
-	resolveUsedPackages(model, codec.extraPackages, codec.hasStreaming(model))
 	// Annotate enums and messages that we intend to generate. In the
 	// process we discover the external dependencies and trim the list of
 	// packages used by this API.
@@ -197,6 +232,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	for _, s := range model.Services {
 		for _, m := range s.Methods {
 			if !codec.generateMethod(m) {
+				m.Codec = nil
 				continue
 			}
 			if m.OperationInfo != nil || m.DiscoveryLro != nil || m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob" {
@@ -251,9 +287,6 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		slog.Warn("package has more than 15 services, consider enabling per-service features", "package", codec.packageName(model), "count", len(servicesSubset))
 	}
 
-	// Delay this until the Codec had a chance to compute what packages are
-	// used.
-	findUsedPackages(model, codec)
 	defaultHost := func() string {
 		if len(model.Services) > 0 {
 			return model.Services[0].DefaultHost
@@ -284,26 +317,40 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		}
 	}
 
-	var bidiStreamingServices []*api.Service
-	var serverStreamingServices []*api.Service
-	var streamingServices []*api.Service
+	hasBidiStreaming := false
+	hasStreaming := false
+	hasGrpc := false
+	hasHttp := false
+	var grpcRootTypeIDs []string
 	for _, s := range servicesSubset {
-		isBidi := codec.includeBidiStreamingMethods && s.HasBidiStreaming()
-		isServer := codec.includeServerStreamingMethods && s.HasServerSideStreaming()
-		if isBidi {
-			bidiStreamingServices = append(bidiStreamingServices, s)
-		}
-		if isServer {
-			serverStreamingServices = append(serverStreamingServices, s)
-		}
-		if isBidi || isServer {
-			streamingServices = append(streamingServices, s)
+		if sAnn, ok := s.Codec.(*serviceAnnotations); ok {
+			if sAnn.HasBidiStreaming {
+				hasBidiStreaming = true
+			}
+			if sAnn.HasStreaming {
+				hasStreaming = true
+			}
+			if sAnn.HasGrpc {
+				hasGrpc = true
+				for _, m := range s.Methods {
+					if mAnn, ok := m.Codec.(*methodAnnotation); ok && mAnn.IsGrpc {
+						if m.InputTypeID != "" {
+							grpcRootTypeIDs = append(grpcRootTypeIDs, m.InputTypeID)
+						}
+						if m.OutputTypeID != "" {
+							grpcRootTypeIDs = append(grpcRootTypeIDs, m.OutputTypeID)
+						}
+					}
+				}
+			}
+			if sAnn.HasHttp {
+				hasHttp = true
+			}
 		}
 	}
-	hasBidiStreaming := (codec.templateOverride == "" || codec.templateOverride == "templates/grpc-client") && len(bidiStreamingServices) > 0
-	hasServerStreaming := (codec.templateOverride == "" || codec.templateOverride == "templates/grpc-client") && len(serverStreamingServices) > 0
-	hasStreaming := hasBidiStreaming || hasServerStreaming
-	if hasStreaming {
+	slices.Sort(grpcRootTypeIDs)
+	grpcRootTypeIDs = slices.Compact(grpcRootTypeIDs)
+	if hasGrpc {
 		for _, pkg := range codec.extraPackages {
 			if pkg.name == gaxiPackageName {
 				if !slices.Contains(pkg.features, "_internal-grpc-client") {
@@ -312,6 +359,9 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 			}
 		}
 	}
+
+	resolveUsedPackages(model, codec.extraPackages, hasGrpc)
+	findUsedPackages(model, codec)
 
 	includeRpcStatusConversion := codec.includeRpcStatusConversion
 	if codecMap, ok := model.Codec.(map[string]string); ok && codecMap["include-rpc-status-conversion"] == "true" {
@@ -333,12 +383,11 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		ExternPackages:             externPackages(codec.extraPackages),
 		HasLROs:                    hasLROs,
 		HasBidiStreaming:           hasBidiStreaming,
-		HasServerStreaming:         hasServerStreaming,
 		HasStreaming:               hasStreaming,
+		HasGrpc:                    hasGrpc,
+		HasHttp:                    hasHttp,
+		GrpcRootTypeIDs:            grpcRootTypeIDs,
 		IncludeRpcStatusConversion: includeRpcStatusConversion,
-		BidiStreamingServices:      bidiStreamingServices,
-		ServerStreamingServices:    serverStreamingServices,
-		StreamingServices:          streamingServices,
 		CopyrightYear:              codec.generationYear,
 		BoilerPlate: append(license.HeaderBulk(),
 			"",

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -800,9 +800,6 @@ func TestModelAnnotationsHasStreaming(t *testing.T) {
 			if got.HasBidiStreaming != test.wantBidi {
 				t.Errorf("HasBidiStreaming = %v, want %v", got.HasBidiStreaming, test.wantBidi)
 			}
-			if got.HasServerStreaming != test.wantServer {
-				t.Errorf("HasServerStreaming = %v, want %v", got.HasServerStreaming, test.wantServer)
-			}
 			if got.HasStreaming != test.wantStreaming {
 				t.Errorf("HasStreaming = %v, want %v", got.HasStreaming, test.wantStreaming)
 			}
@@ -825,7 +822,7 @@ func TestModelAnnotationsHasStreaming(t *testing.T) {
 	}
 }
 
-func TestModelAnnotationsStreamingServices(t *testing.T) {
+func TestModelAnnotationsGrpcServices(t *testing.T) {
 	msg := api.NewTestMessage("Request").WithPackage("test.v1")
 
 	bidiMethod := api.NewTestMethod("Chat").WithInput(msg).WithOutput(msg).WithBidiStreaming()
@@ -855,20 +852,24 @@ func TestModelAnnotationsStreamingServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(got.BidiStreamingServices) != 1 {
-		t.Fatalf("expected 1 BidiStreamingService, got %d", len(got.BidiStreamingServices))
+	grpcServices := got.GrpcServices()
+	if len(grpcServices) != 2 {
+		t.Fatalf("expected 2 GrpcServices, got %d", len(grpcServices))
 	}
-	if got.BidiStreamingServices[0].Name != "BidiService" {
-		t.Errorf("expected BidiStreamingServices[0].Name == %q, got %q", "BidiService", got.BidiStreamingServices[0].Name)
+	if grpcServices[0].Name != "BidiService" {
+		t.Errorf("expected GrpcServices[0].Name == %q, got %q", "BidiService", grpcServices[0].Name)
 	}
-	if len(got.ServerStreamingServices) != 1 {
-		t.Fatalf("expected 1 ServerStreamingService, got %d", len(got.ServerStreamingServices))
+	if grpcServices[1].Name != "ServerService" {
+		t.Errorf("expected GrpcServices[1].Name == %q, got %q", "ServerService", grpcServices[1].Name)
 	}
-	if got.ServerStreamingServices[0].Name != "ServerService" {
-		t.Errorf("expected ServerStreamingServices[0].Name == %q, got %q", "ServerService", got.ServerStreamingServices[0].Name)
+	if !got.HasBidiStreaming {
+		t.Errorf("expected HasBidiStreaming == true")
 	}
-	if len(got.StreamingServices) != 2 {
-		t.Fatalf("expected 2 StreamingServices, got %d", len(got.StreamingServices))
+	if !got.HasStreaming {
+		t.Errorf("expected HasStreaming == true")
+	}
+	if !got.HasGrpc {
+		t.Errorf("expected HasGrpc == true")
 	}
 }
 

--- a/internal/sidekick/rust/annotate_service.go
+++ b/internal/sidekick/rust/annotate_service.go
@@ -62,6 +62,25 @@ type serviceAnnotations struct {
 	HasServerStreaming bool
 	// If true, the service has at least one streaming RPC (bidirectional or server-side) in the API definition.
 	HasStreaming bool
+	// If true, the service has at least one gRPC method.
+	HasGrpc bool
+	// If true, the service has at least one HTTP method.
+	HasHttp bool
+}
+
+// IsPureGrpc returns true if the service has gRPC methods and no HTTP methods.
+func (s *serviceAnnotations) IsPureGrpc() bool {
+	return s.HasGrpc && !s.HasHttp
+}
+
+// IsPureHttp returns true if the service has HTTP methods and no gRPC methods.
+func (s *serviceAnnotations) IsPureHttp() bool {
+	return s.HasHttp && !s.HasGrpc
+}
+
+// IsHybrid returns true if the service has both gRPC and HTTP methods.
+func (s *serviceAnnotations) IsHybrid() bool {
+	return s.HasGrpc && s.HasHttp
 }
 
 // BuilderVisibility returns the visibility for client and request builders.
@@ -129,8 +148,8 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 	// because we are incrementally adding streaming support (initializing transport
 	// stubs like grpc_inner first before generating streaming method implementations in
 	// subsequent steps).
-	hasBidiStreaming := c.includeBidiStreamingMethods && s.HasBidiStreaming()
-	hasServerStreaming := c.includeServerStreamingMethods && s.HasServerSideStreaming()
+	hasBidiStreaming := c.templateSupportsGrpc() && c.includeBidiStreamingMethods && s.HasBidiStreaming()
+	hasServerStreaming := c.templateSupportsGrpc() && c.includeServerStreamingMethods && s.HasServerSideStreaming()
 	hasStreaming := hasBidiStreaming || hasServerStreaming
 
 	// Some codecs skip some methods.
@@ -158,6 +177,19 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 	if err != nil {
 		return nil, err
 	}
+	hasGrpc := false
+	hasHttp := false
+	for _, m := range methods {
+		if ann, ok := m.Codec.(*methodAnnotation); ok {
+			if ann.IsGrpc {
+				hasGrpc = true
+			}
+			if ann.IsHttp() {
+				hasHttp = true
+			}
+		}
+	}
+
 	ann := &serviceAnnotations{
 		Name:                      toPascal(serviceName),
 		PackageModuleName:         packageToModuleName(s.Package),
@@ -176,6 +208,8 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 		HasBidiStreaming:          hasBidiStreaming,
 		HasServerStreaming:        hasServerStreaming,
 		HasStreaming:              hasStreaming,
+		HasGrpc:                   hasGrpc,
+		HasHttp:                   hasHttp,
 	}
 	s.Codec = ann
 	return ann, nil

--- a/internal/sidekick/rust/annotate_service_test.go
+++ b/internal/sidekick/rust/annotate_service_test.go
@@ -89,6 +89,7 @@ func TestServiceAnnotationsPerServiceFeatures(t *testing.T) {
 		ModuleName:         "resource_service",
 		PerServiceFeatures: true,
 		Incomplete:         true,
+		HasHttp:            true,
 	}
 	if diff := cmp.Diff(wantService, service.Codec, cmpopts.IgnoreFields(serviceAnnotations{}, "Methods")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -240,6 +241,7 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 		Name:              "LroService",
 		PackageModuleName: "test",
 		ModuleName:        "lro_service",
+		HasGrpc:           true,
 		LROTypes: []*api.Message{
 			metadata,
 			resource,
@@ -275,12 +277,13 @@ func TestServiceAnnotationsNameOverrides(t *testing.T) {
 		Name:       "Renamed",
 		ModuleName: "renamed",
 		Incomplete: true,
+		HasHttp:    true,
 	}
 	if diff := cmp.Diff(wantService, service.Codec, serviceFilter); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "NameNoMangling", "BuilderName", "Body", "PathInfo", "SystemParameters", "ReturnType")
+	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "NameNoMangling", "BuilderName", "Body", "PathInfo", "SystemParameters", "ReturnType", "IsGrpc")
 	wantMethod := &methodAnnotation{
 		ServiceNameToPascal: "Renamed",
 		ServiceNameToCamel:  "renamed",
@@ -312,6 +315,7 @@ func TestServiceAnnotations(t *testing.T) {
 		PackageModuleName: "test::v1",
 		ModuleName:        "resource_service",
 		Incomplete:        true,
+		HasHttp:           true,
 	}
 	if diff := cmp.Diff(wantService, service.Codec, cmpopts.IgnoreFields(serviceAnnotations{}, "Methods")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -618,6 +622,66 @@ func TestServiceAnnotationsMethodKinds(t *testing.T) {
 			}
 			if got := serviceAnn.NeedsBidiStreamBuilder(); got != test.wantBidiStreamBuilder {
 				t.Errorf("serviceAnnotations.NeedsBidiStreamBuilder() = %v, want %v", got, test.wantBidiStreamBuilder)
+			}
+		})
+	}
+}
+
+func TestServiceAnnotationsTransportHelpers(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		hasGrpc    bool
+		hasHttp    bool
+		isPureGrpc bool
+		isPureHttp bool
+		isHybrid   bool
+	}{
+		{
+			name:       "pure gRPC",
+			hasGrpc:    true,
+			hasHttp:    false,
+			isPureGrpc: true,
+			isPureHttp: false,
+			isHybrid:   false,
+		},
+		{
+			name:       "pure HTTP",
+			hasGrpc:    false,
+			hasHttp:    true,
+			isPureGrpc: false,
+			isPureHttp: true,
+			isHybrid:   false,
+		},
+		{
+			name:       "hybrid",
+			hasGrpc:    true,
+			hasHttp:    true,
+			isPureGrpc: false,
+			isPureHttp: false,
+			isHybrid:   true,
+		},
+		{
+			name:       "neither",
+			hasGrpc:    false,
+			hasHttp:    false,
+			isPureGrpc: false,
+			isPureHttp: false,
+			isHybrid:   false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ann := &serviceAnnotations{
+				HasGrpc: test.hasGrpc,
+				HasHttp: test.hasHttp,
+			}
+			if got := ann.IsPureGrpc(); got != test.isPureGrpc {
+				t.Errorf("IsPureGrpc() = %v, want %v", got, test.isPureGrpc)
+			}
+			if got := ann.IsPureHttp(); got != test.isPureHttp {
+				t.Errorf("IsPureHttp() = %v, want %v", got, test.isPureHttp)
+			}
+			if got := ann.IsHybrid(); got != test.isHybrid {
+				t.Errorf("IsHybrid() = %v, want %v", got, test.isHybrid)
 			}
 		})
 	}

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -212,6 +212,8 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 				return nil, fmt.Errorf("cannot convert `include-rpc-status-conversion` value %q to boolean: %w", definition, err)
 			}
 			codec.includeRpcStatusConversion = value
+		case key == "default-unary-transport" || key == "default-transport":
+			codec.defaultUnaryTransport = definition
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -319,6 +321,8 @@ type codec struct {
 	bytesUseUrlSafeAlphabet bool
 	// Overrides the template subdirectory.
 	templateOverride string
+	// Default transport for unary methods ("http" or "grpc").
+	defaultUnaryTransport string
 	// If true, this includes gRPC-only methods, such as methods without HTTP
 	// annotations.
 	includeGrpcOnlyMethods bool
@@ -399,7 +403,7 @@ type packagez struct {
 	usedIf []string
 }
 
-func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasStreaming bool) {
+func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasGrpc bool) {
 	hasServices := len(model.Services) > 0
 	hasLROs := false
 	hasAutoPopulation := false
@@ -434,7 +438,7 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasStreaming
 				pkg.used = true
 				break
 			}
-			if namedFeature == "streaming" && hasStreaming {
+			if namedFeature == "streaming" && hasGrpc {
 				pkg.used = true
 				break
 			}
@@ -790,6 +794,9 @@ func bodyAccessor(m *api.Method) string {
 }
 
 func httpPathFmt(t *api.PathTemplate) string {
+	if t == nil {
+		return ""
+	}
 	fmt := ""
 	for _, segment := range t.Segments {
 		if segment.Literal != "" {
@@ -1605,7 +1612,7 @@ func (c *codec) generateMethod(m *api.Method) bool {
 		}
 		return c.includeStreamingMethods
 	}
-	if c.includeGrpcOnlyMethods {
+	if c.defaultUnaryTransport == "grpc" || c.includeGrpcOnlyMethods {
 		return true
 	}
 	if m.PathInfo == nil || len(m.PathInfo.Bindings) == 0 {
@@ -1614,22 +1621,15 @@ func (c *codec) generateMethod(m *api.Method) bool {
 	return m.PathInfo.Bindings[0].PathTemplate != nil
 }
 
+func (c *codec) templateSupportsGrpc() bool {
+	return c.templateOverride == "" || c.templateOverride == "templates/grpc-client"
+}
+
 func (c *codec) hasBidiStreaming(model *api.API) bool {
-	if (c.templateOverride != "" && c.templateOverride != "templates/grpc-client") || !c.includeBidiStreamingMethods {
+	if !c.templateSupportsGrpc() || !c.includeBidiStreamingMethods {
 		return false
 	}
 	return slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
-}
-
-func (c *codec) hasServerStreaming(model *api.API) bool {
-	if (c.templateOverride != "" && c.templateOverride != "templates/grpc-client") || !c.includeServerStreamingMethods {
-		return false
-	}
-	return slices.ContainsFunc(model.Services, (*api.Service).HasServerSideStreaming)
-}
-
-func (c *codec) hasStreaming(model *api.API) bool {
-	return c.hasBidiStreaming(model) || c.hasServerStreaming(model)
 }
 
 // escapeKeyword is the list of Rust keywords and reserved words can be found

--- a/internal/sidekick/rust/generate.go
+++ b/internal/sidekick/rust/generate.go
@@ -42,6 +42,16 @@ func Generate(ctx context.Context, model *api.API, outdir string, cfg *parser.Mo
 	return language.GenerateFromModel(outdir, model, provider, generatedFiles)
 }
 
+// AnnotateModel annotates the model for Rust generation.
+func AnnotateModel(model *api.API, cfg *parser.ModelConfig) error {
+	c, err := newCodec(cfg.SpecificationFormat, cfg.Codec)
+	if err != nil {
+		return err
+	}
+	_, err = annotateModel(model, c)
+	return err
+}
+
 // GenerateStorage generates Rust code for the storage service.
 func GenerateStorage(ctx context.Context, outdir string, storageModel *api.API, storageConfig *parser.ModelConfig, controlModel *api.API, controlConfig *parser.ModelConfig) error {
 	storageCodec, err := newCodec(storageConfig.SpecificationFormat, storageConfig.Codec)

--- a/internal/sidekick/rust/generate_bidi_streaming_test.go
+++ b/internal/sidekick/rust/generate_bidi_streaming_test.go
@@ -135,7 +135,7 @@ func TestGenerateBidiStreaming(t *testing.T) {
 			name:     "builder: struct docstring and example",
 			file:     "src/builder.rs",
 			startStr: "    /// The request builder for [Protocol::chat][crate::client::Protocol::chat] calls.\n    ///\n    /// # Example",
-			endStr:   "    #[derive(Clone, Debug)]",
+			endStr:   "    #[derive(Clone, Debug)]\n    pub struct Chat(BidiStreamBuilder);",
 			want: `    /// The request builder for [Protocol::chat][crate::client::Protocol::chat] calls.
     ///
     /// # Example
@@ -160,7 +160,8 @@ func TestGenerateBidiStreaming(t *testing.T) {
     ///   // ... details omitted ...
     /// }
     /// ` + "```" + `
-    #[derive(Clone, Debug)]`,
+    #[derive(Clone, Debug)]
+    pub struct Chat(BidiStreamBuilder);`,
 		},
 		{
 			name:     "builder: struct definition",

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -125,12 +125,12 @@ pub(crate) mod tracing;
 #[doc(hidden)]
 pub(crate) mod transport;
 
-{{#Codec.HasStreaming}}
+{{#Codec.HasGrpc}}
 {{#Codec.PerServiceFeatures}}
 #[cfg(any(
-{{#Codec.StreamingServices}}
+{{#Codec.GrpcServices}}
     feature = "{{Codec.FeatureName}}",
-{{/Codec.StreamingServices}}
+{{/Codec.GrpcServices}}
 ))]
 {{/Codec.PerServiceFeatures}}
 #[doc(hidden)]
@@ -141,7 +141,7 @@ pub(crate) mod transport;
 pub(crate) mod prost {
     include!("prost/includes.rs");
 }
-{{/Codec.HasStreaming}}
+{{/Codec.HasGrpc}}
 
 /// The default host used by the service.
 {{#Codec.PerServiceFeatures}}
@@ -155,6 +155,7 @@ const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}/";
 pub(crate) mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
+    {{#Codec.HasHttp}}
     pub(crate) static X_GOOG_API_CLIENT_HEADER: std::sync::LazyLock<String> =
         std::sync::LazyLock::new(|| {
             let ac = gaxi::api_header::XGoogApiClient {
@@ -164,8 +165,8 @@ pub(crate) mod info {
             };
             ac.rest_header_value()
         });
-{{#Codec.HasStreaming}}
-    #[allow(dead_code)]
+    {{/Codec.HasHttp}}
+    {{#Codec.HasGrpc}}
     pub(crate) static X_GOOG_API_CLIENT_GRPC_HEADER: std::sync::LazyLock<String> =
         std::sync::LazyLock::new(|| {
             let ac = gaxi::api_header::XGoogApiClient {
@@ -175,7 +176,7 @@ pub(crate) mod info {
             };
             ac.grpc_header_value()
         });
-{{/Codec.HasStreaming}}
+    {{/Codec.HasGrpc}}
 }
 
 // Define some shortcuts for imported crates.

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -31,16 +31,18 @@ use crate::Error;
 
 {{/Codec.HasServices}}
 {{#Codec.Services}}
-/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using a [gaxi::http::ReqwestClient].
+/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using {{#Codec.IsPureGrpc}}a [gaxi::grpc::Client]{{/Codec.IsPureGrpc}}{{#Codec.IsPureHttp}}a [gaxi::http::ReqwestClient]{{/Codec.IsPureHttp}}{{#Codec.IsHybrid}}a [gaxi::http::ReqwestClient] and a [gaxi::grpc::Client]{{/Codec.IsHybrid}}.
 {{#Codec.PerServiceFeatures}}
 #[cfg(feature = "{{Codec.FeatureName}}")]
 {{/Codec.PerServiceFeatures}}
 #[derive(Clone)]
 pub struct {{Codec.Name}} {
+    {{#Codec.HasHttp}}
     inner: gaxi::http::ReqwestClient,
-    {{#Codec.HasStreaming}}
+    {{/Codec.HasHttp}}
+    {{#Codec.HasGrpc}}
     grpc_inner: gaxi::grpc::Client,
-    {{/Codec.HasStreaming}}
+    {{/Codec.HasGrpc}}
 }
 
 {{#Codec.PerServiceFeatures}}
@@ -48,17 +50,14 @@ pub struct {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl std::fmt::Debug for {{Codec.Name}} {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        {{^Codec.HasStreaming}}
         f.debug_struct("{{Codec.Name}}")
+            {{#Codec.HasHttp}}
             .field("inner", &self.inner)
+            {{/Codec.HasHttp}}
+            {{#Codec.HasGrpc}}
+            .field("grpc_inner", &self.grpc_inner)
+            {{/Codec.HasGrpc}}
             .finish()
-        {{/Codec.HasStreaming}}
-        {{#Codec.HasStreaming}}
-        let mut builder = f.debug_struct("{{Codec.Name}}");
-        builder.field("inner", &self.inner);
-        builder.field("grpc_inner", &self.grpc_inner);
-        builder.finish()
-        {{/Codec.HasStreaming}}
     }
 }
 
@@ -67,31 +66,23 @@ impl std::fmt::Debug for {{Codec.Name}} {
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
-        {{^Codec.HasStreaming}}
+        {{#Codec.HasHttp}}
         {{#Codec.DetailedTracingAttributes}}
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
-        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
+        let inner = gaxi::http::ReqwestClient::new(config{{#Codec.HasGrpc}}.clone(){{/Codec.HasGrpc}}, crate::DEFAULT_HOST).await?;
         let inner = if tracing_is_enabled {
             inner.with_instrumentation(&super::tracing::info::INSTRUMENTATION_CLIENT_INFO)
         } else {
             inner
         };
-        Ok(Self { inner })
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
-        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
-        Ok(Self { inner })
+        let inner = gaxi::http::ReqwestClient::new(config{{#Codec.HasGrpc}}.clone(){{/Codec.HasGrpc}}, crate::DEFAULT_HOST).await?;
         {{/Codec.DetailedTracingAttributes}}
-        {{/Codec.HasStreaming}}
-        {{#Codec.HasStreaming}}
+        {{/Codec.HasHttp}}
+        {{#Codec.HasGrpc}}
         {{#Codec.DetailedTracingAttributes}}
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
-        let inner = gaxi::http::ReqwestClient::new(config.clone(), crate::DEFAULT_HOST).await?;
-        let inner = if tracing_is_enabled {
-            inner.with_instrumentation(&super::tracing::info::INSTRUMENTATION_CLIENT_INFO)
-        } else {
-            inner
-        };
         let grpc_inner = if tracing_is_enabled {
             gaxi::grpc::Client::new_with_instrumentation(
                 config,
@@ -102,20 +93,19 @@ impl {{Codec.Name}} {
         } else {
             gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?
         };
-        Ok(Self {
-            inner,
-            grpc_inner,
-        })
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
-        let inner = gaxi::http::ReqwestClient::new(config.clone(), crate::DEFAULT_HOST).await?;
         let grpc_inner = gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?;
-        Ok(Self {
-            inner,
-            grpc_inner,
-        })
         {{/Codec.DetailedTracingAttributes}}
-        {{/Codec.HasStreaming}}
+        {{/Codec.HasGrpc}}
+        Ok(Self {
+            {{#Codec.HasHttp}}
+            inner,
+            {{/Codec.HasHttp}}
+            {{#Codec.HasGrpc}}
+            grpc_inner,
+            {{/Codec.HasGrpc}}
+        })
     }
 }
 
@@ -226,8 +216,90 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     }
 
     {{/Codec.IsServerStreaming}}
-    {{^Codec.IsBidiStreaming}}
-    {{^Codec.IsServerStreaming}}
+    {{#Codec.IsUnaryGrpc}}
+    async fn {{Codec.Name}}(
+        &self,
+        req: {{InputType.Codec.QualifiedName}},
+        options: crate::RequestOptions,
+    ) -> Result<crate::Response<{{Codec.ReturnType}}>> {
+        use gaxi::prost::ToProto;
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "{{SourceService.Package}}.{{SourceService.Name}}",
+                "{{Name}}",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}"
+        );
+
+        {{#HasRouting}}
+        {{> /templates/grpc-client/routinginfo}}
+        {{/HasRouting}}
+        {{^HasRouting}}
+        let x_goog_request_params = [
+            {{#PathInfo.Codec.UniqueParameters}}
+                {{{FieldAccessor}}}.map(|v| format!("{{FieldName}}={v}")),
+            {{/PathInfo.Codec.UniqueParameters}}
+            {{^PathInfo.Codec.UniqueParameters}}
+            None::<String>; 0
+            {{/PathInfo.Codec.UniqueParameters}}
+        ]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+        {{/HasRouting}}
+
+        {{#ReturnsEmpty}}
+        type TR = ();
+        {{/ReturnsEmpty}}
+        {{^ReturnsEmpty}}
+        type TR = crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}};
+        {{/ReturnsEmpty}}
+        {{#Codec.DetailedTracingAttributes}}
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}");
+            {{#Codec.HasGrpcResourceNameArgs}}
+            let resource_name = (|| {
+                {{#Codec.ResourceNameTemplateGrpc}}
+                Some(format!(
+                    "{{{Codec.ResourceNameTemplateGrpc}}}",
+                    {{#Codec.GrpcResourceNameArgs}}
+                    {{{.}}}?,
+                    {{/Codec.GrpcResourceNameArgs}}
+                ))
+                {{/Codec.ResourceNameTemplateGrpc}}
+                {{^Codec.ResourceNameTemplateGrpc}}
+                Some(String::new())
+                {{/Codec.ResourceNameTemplateGrpc}}
+            })();
+            let attributes = if let Some(rn) = resource_name.filter(|s| !s.is_empty()) {
+                attributes.set_resource_name(rn)
+            } else {
+                attributes
+            };
+            {{/Codec.HasGrpcResourceNameArgs}}
+            recorder.on_client_request(attributes);
+        }
+        {{/Codec.DetailedTracingAttributes}}
+        self.grpc_inner
+            .execute(
+                extensions,
+                path,
+                req.to_proto().map_err(Error::deser)?,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_GRPC_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(gaxi::grpc::to_gax_response::<TR, {{Codec.ReturnType}}>)
+    }
+
+    {{/Codec.IsUnaryGrpc}}
+    {{#Codec.IsHttp}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -395,8 +467,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{/ReturnsEmpty}}
         {{/Codec.HasBindings}}
     }
-    {{/Codec.IsServerStreaming}}
-    {{/Codec.IsBidiStreaming}}
+    {{/Codec.IsHttp}}
 
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}
@@ -404,14 +475,24 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         &self,
         options: &crate::RequestOptions,
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_error_policy::PollingErrorPolicy> {
+        {{#Codec.HasHttp}}
         self.inner.get_polling_error_policy(options)
+        {{/Codec.HasHttp}}
+        {{^Codec.HasHttp}}
+        self.grpc_inner.get_polling_error_policy(options)
+        {{/Codec.HasHttp}}
     }
 
     fn get_polling_backoff_policy(
         &self,
         options: &crate::RequestOptions,
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy> {
+        {{#Codec.HasHttp}}
         self.inner.get_polling_backoff_policy(options)
+        {{/Codec.HasHttp}}
+        {{^Codec.HasHttp}}
+        self.grpc_inner.get_polling_backoff_policy(options)
+        {{/Codec.HasHttp}}
     }
     {{/Codec.HasLROs}}
 }


### PR DESCRIPTION
This change allows choosing the default transport for a crate, to switch unary methods from grpc to http and back, configuring the relevant internal client types.

This also more accurately encapsulates when we need to include things because we are using gRPC vs because they are streaming. 

For googleapis/google-cloud-rust#6470