### PR TITLE
refactor(internal/librarian/rust): generalize prost hybrid type filtering

### DIFF
--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -86,8 +86,10 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := sidekickrust.Generate(ctx, model, library.Output, modelConfig); err != nil {
 		return err
 	}
-	if err := generateProstHybrid(ctx, model, library, library.Output, modelConfig); err != nil {
-		return err
+	if rootTypeIDs := streamingRootTypeIDs(model, library); len(rootTypeIDs) > 0 {
+		if err := generateProstHybrid(ctx, model, rootTypeIDs, library, library.Output, modelConfig); err != nil {
+			return err
+		}
 	}
 	if needsRepoMetadata(model, library) {
 		repoMetadata, err := createRepoMetadata(cfg, library, sources)

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -102,8 +102,8 @@ func generateProstHybrid(ctx context.Context, model *api.API, rootTypeIDs []stri
 // from rootTypeIDs for prost conversion generation. It also returns a sorted slice
 // of all non-WKT unused type IDs to exclude via prost_build extern_path, and a boolean
 // indicating whether google.rpc.Status is referenced in the reachability path.
-// Errors if Any is encountered in the reachability path unless explicitly allowed via allowStreamingAnyTypes.
-func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyTypes []string) (*api.API, []string, bool, error) {
+// Errors if Any is encountered in the reachability path unless explicitly allowed via allowAnyTypes.
+func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []string) (*api.API, []string, bool, error) {
 	type typeItem struct {
 		id   string
 		path string
@@ -204,7 +204,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 			for _, f := range msg.Fields {
 				fieldPath := item.path + "." + f.Name
 				if isAnyType(f.TypezID) {
-					if matchesAllowedAnyField(f.ID, allowStreamingAnyTypes) || matchesAllowedAnyField(fieldPath, allowStreamingAnyTypes) {
+					if matchesAllowedAnyField(f.ID, allowAnyTypes) || matchesAllowedAnyField(fieldPath, allowAnyTypes) {
 						f.SkipProtoConversion = true
 						continue
 					}
@@ -224,7 +224,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 				for _, f := range o.Fields {
 					fieldPath := item.path + "." + o.Name + "." + f.Name
 					if isAnyType(f.TypezID) {
-						if matchesAllowedAnyField(f.ID, allowStreamingAnyTypes) || matchesAllowedAnyField(fieldPath, allowStreamingAnyTypes) {
+						if matchesAllowedAnyField(f.ID, allowAnyTypes) || matchesAllowedAnyField(fieldPath, allowAnyTypes) {
 							f.SkipProtoConversion = true
 							continue
 						}

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -109,8 +109,8 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 		path string
 	}
 
-	streamingMsgs := make(map[string]bool)
-	streamingEnums := make(map[string]bool)
+	reachableMsgs := make(map[string]bool)
+	reachableEnums := make(map[string]bool)
 	var queue []typeItem
 
 	for _, id := range rootTypeIDs {
@@ -132,14 +132,14 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 	// 1. Parent messages are not placed in unusedTypes (which would cause prost_build's
 	//    prefix-matching extern_path to hijack nested types like Partition.TemporalPartition).
 	// 2. Parent messages are enqueued for field traversal so their sibling field types
-	//    (e.g., Partition.SpatialPartition) are also included in streamingMsgs rather than
+	//    (e.g., Partition.SpatialPartition) are also included in reachableMsgs rather than
 	//    placed in unusedTypes, preventing missing type errors in convert.rs.
 	enqueueMsg = func(m *api.Message, path string) {
 		if m == nil {
 			return
 		}
-		if !streamingMsgs[m.ID] {
-			streamingMsgs[m.ID] = true
+		if !reachableMsgs[m.ID] {
+			reachableMsgs[m.ID] = true
 			queue = append(queue, typeItem{
 				id:   m.ID,
 				path: path,
@@ -157,7 +157,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 		if e == nil {
 			return
 		}
-		streamingEnums[e.ID] = true
+		reachableEnums[e.ID] = true
 		if e.Parent != nil {
 			enqueueMsg(e.Parent, path)
 		}
@@ -192,7 +192,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 
 		msg := model.Message(item.id)
 		if msg != nil {
-			streamingMsgs[msg.ID] = true
+			reachableMsgs[msg.ID] = true
 
 			// Shortcircuit search for google.rpc.Status to avoid inspecting its fields,
 			// which would otherwise error on Status.details (google.protobuf.Any).
@@ -254,7 +254,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 	// iteration order is randomized by the Go runtime.
 	var externalMessages []*api.Message
 	for m := range model.AllMessages() {
-		if m.ID != "" && streamingMsgs[m.ID] && !isWKT(m.ID) && m.ID != ".google.rpc.Status" && !m.IsMap && m.Parent == nil {
+		if m.ID != "" && reachableMsgs[m.ID] && !isWKT(m.ID) && m.ID != ".google.rpc.Status" && !m.IsMap && m.Parent == nil {
 			if m.Package != model.PackageName && m.Package != api.ReservedPackageName {
 				externalMessages = append(externalMessages, m)
 			}
@@ -265,7 +265,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 	// Collect external top-level enums referenced by roots.
 	var externalEnums []*api.Enum
 	for e := range model.AllEnums() {
-		if e.ID != "" && streamingEnums[e.ID] && !isWKT(e.ID) && e.Parent == nil {
+		if e.ID != "" && reachableEnums[e.ID] && !isWKT(e.ID) && e.Parent == nil {
 			if e.Package != model.PackageName && e.Package != api.ReservedPackageName {
 				externalEnums = append(externalEnums, e)
 			}
@@ -281,9 +281,9 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 		Description:         model.Description,
 		Revision:            model.Revision,
 		Services:            model.Services,
-		Messages:            language.FilterSlice(model.Messages, func(m *api.Message) bool { return streamingMsgs[m.ID] }),
+		Messages:            language.FilterSlice(model.Messages, func(m *api.Message) bool { return reachableMsgs[m.ID] }),
 		ExternalMessages:    externalMessages,
-		Enums:               language.FilterSlice(model.Enums, func(e *api.Enum) bool { return streamingEnums[e.ID] }),
+		Enums:               language.FilterSlice(model.Enums, func(e *api.Enum) bool { return reachableEnums[e.ID] }),
 		ExternalEnums:       externalEnums,
 		ResourceDefinitions: model.ResourceDefinitions,
 		QuickstartService:   model.QuickstartService,
@@ -310,12 +310,12 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyT
 
 	var unusedTypes []string
 	for m := range model.AllMessages() {
-		if m.ID != "" && !isWKT(m.ID) && !streamingMsgs[m.ID] {
+		if m.ID != "" && !isWKT(m.ID) && !reachableMsgs[m.ID] {
 			unusedTypes = append(unusedTypes, m.ID)
 		}
 	}
 	for e := range model.AllEnums() {
-		if e.ID != "" && !isWKT(e.ID) && !streamingEnums[e.ID] {
+		if e.ID != "" && !isWKT(e.ID) && !reachableEnums[e.ID] {
 			unusedTypes = append(unusedTypes, e.ID)
 		}
 	}

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -31,7 +31,9 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/rust_prost"
 )
 
-func generateProstHybrid(ctx context.Context, model *api.API, library *config.Library, outdir string, modelConfig *parser.ModelConfig) error {
+// streamingRootTypeIDs returns the root message type IDs for all enabled bidirectional
+// and server-side streaming RPCs in the library.
+func streamingRootTypeIDs(model *api.API, library *config.Library) []string {
 	if library.Rust == nil || library.Rust.TemplateOverride != "" {
 		return nil
 	}
@@ -40,14 +42,31 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 	if !includeBidi && !includeServer {
 		return nil
 	}
-	hasStreaming := slices.ContainsFunc(model.Services, func(s *api.Service) bool {
-		return (includeBidi && s.HasBidiStreaming()) || (includeServer && s.HasServerSideStreaming())
-	})
-	if !hasStreaming {
+	var rootTypeIDs []string
+	for _, s := range model.Services {
+		for _, m := range s.Methods {
+			isBidi := m.ClientSideStreaming && m.ServerSideStreaming && includeBidi
+			isServer := !m.ClientSideStreaming && m.ServerSideStreaming && includeServer
+			if isBidi || isServer {
+				if m.InputTypeID != "" {
+					rootTypeIDs = append(rootTypeIDs, m.InputTypeID)
+				}
+				if m.OutputTypeID != "" {
+					rootTypeIDs = append(rootTypeIDs, m.OutputTypeID)
+				}
+			}
+		}
+	}
+	slices.Sort(rootTypeIDs)
+	return slices.Compact(rootTypeIDs)
+}
+
+func generateProstHybrid(ctx context.Context, model *api.API, rootTypeIDs []string, library *config.Library, outdir string, modelConfig *parser.ModelConfig) error {
+	if library.Rust == nil || library.Rust.TemplateOverride != "" || len(rootTypeIDs) == 0 {
 		return nil
 	}
 
-	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToStreaming(model, includeBidi, includeServer, library.Rust.AllowStreamingAnyTypes)
+	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToTypes(model, rootTypeIDs, library.Rust.AllowStreamingAnyTypes)
 	if err != nil {
 		return err
 	}
@@ -79,90 +98,68 @@ func generateProstHybrid(ctx context.Context, model *api.API, library *config.Li
 	return nil
 }
 
-// filterModelToStreaming constructs a hybrid api.API model containing only
-// enabled bidirectional and server-side streaming RPC types for prost conversion generation. It also returns
-// a sorted slice of all non-WKT unused type IDs to exclude via prost_build extern_path,
-// and a boolean indicating whether google.rpc.Status is referenced in the streaming path.
-// Errors if Any is encountered in the streaming reachability path unless explicitly allowed via allowStreamingAnyTypes.
-func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool, allowStreamingAnyTypes []string) (*api.API, []string, bool, error) {
-	type streamingTypeItem struct {
-		id       string
-		rpc      string
-		methodID string
-		path     string
+// filterModelToTypes constructs an api.API model containing only types reachable
+// from rootTypeIDs for prost conversion generation. It also returns a sorted slice
+// of all non-WKT unused type IDs to exclude via prost_build extern_path, and a boolean
+// indicating whether google.rpc.Status is referenced in the reachability path.
+// Errors if Any is encountered in the reachability path unless explicitly allowed via allowStreamingAnyTypes.
+func filterModelToTypes(model *api.API, rootTypeIDs []string, allowStreamingAnyTypes []string) (*api.API, []string, bool, error) {
+	type typeItem struct {
+		id   string
+		path string
 	}
 
 	streamingMsgs := make(map[string]bool)
 	streamingEnums := make(map[string]bool)
-	var queue []streamingTypeItem
+	var queue []typeItem
 
-	// Collect initial input/output message types from all enabled bidirectional and server-side streaming RPCs.
-	for _, s := range model.Services {
-		for _, m := range s.Methods {
-			isBidi := m.ClientSideStreaming && m.ServerSideStreaming && includeBidi
-			isServer := !m.ClientSideStreaming && m.ServerSideStreaming && includeServer
-			if isBidi || isServer {
-				rpcName := s.Name + "." + m.Name
-				if m.InputTypeID != "" {
-					queue = append(queue, streamingTypeItem{
-						id:       m.InputTypeID,
-						rpc:      rpcName,
-						methodID: m.ID,
-						path:     m.InputTypeID,
-					})
-				}
-				if m.OutputTypeID != "" {
-					queue = append(queue, streamingTypeItem{
-						id:       m.OutputTypeID,
-						rpc:      rpcName,
-						methodID: m.ID,
-						path:     m.OutputTypeID,
-					})
-				}
-			}
+	for _, id := range rootTypeIDs {
+		if id != "" {
+			queue = append(queue, typeItem{
+				id:   id,
+				path: id,
+			})
 		}
 	}
 
 	// Discover all transitively reachable messages and enums.
 	visited := make(map[string]bool)
-	var enqueueMsg func(m *api.Message, rpc, methodID, path string)
-	var enqueueEnum func(e *api.Enum, rpc, methodID, path string)
+	var enqueueMsg func(m *api.Message, path string)
+	var enqueueEnum func(e *api.Enum, path string)
 
-	// enqueueMsg marks a message as used in streaming and enqueues it for field
+	// enqueueMsg marks a message as used and enqueues it for field
 	// traversal. It recursively enqueues all parent ancestor messages to ensure:
 	// 1. Parent messages are not placed in unusedTypes (which would cause prost_build's
 	//    prefix-matching extern_path to hijack nested types like Partition.TemporalPartition).
 	// 2. Parent messages are enqueued for field traversal so their sibling field types
 	//    (e.g., Partition.SpatialPartition) are also included in streamingMsgs rather than
 	//    placed in unusedTypes, preventing missing type errors in convert.rs.
-	enqueueMsg = func(m *api.Message, rpc, methodID, path string) {
+	enqueueMsg = func(m *api.Message, path string) {
 		if m == nil {
 			return
 		}
 		if !streamingMsgs[m.ID] {
 			streamingMsgs[m.ID] = true
-			queue = append(queue, streamingTypeItem{
-				id:       m.ID,
-				rpc:      rpc,
-				methodID: methodID,
-				path:     path,
+			queue = append(queue, typeItem{
+				id:   m.ID,
+				path: path,
 			})
 		}
 		if m.Parent != nil {
-			enqueueMsg(m.Parent, rpc, methodID, path)
+			enqueueMsg(m.Parent, path)
 		}
 	}
 
-	// enqueueEnum marks an enum as used in streaming. If the enum is nested inside a message,
+	// enqueueEnum marks an enum as used. If the enum is nested inside a message,
 	// it recursively enqueues parent ancestor messages to ensure they and their sibling field
 	// types are not placed in unusedTypes.
-	enqueueEnum = func(e *api.Enum, rpc, methodID, path string) {
+	enqueueEnum = func(e *api.Enum, path string) {
 		if e == nil {
 			return
 		}
 		streamingEnums[e.ID] = true
 		if e.Parent != nil {
-			enqueueMsg(e.Parent, rpc, methodID, path)
+			enqueueMsg(e.Parent, path)
 		}
 	}
 
@@ -179,17 +176,14 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 
 		anyError := func(path string, fieldID string) error {
 			if fieldID != "" && !isAnyType(fieldID) {
-				return fmt.Errorf("cannot generate prost conversion for streaming RPC %q: type google.protobuf.Any is unsupported (path: %s)\n"+
+				return fmt.Errorf("cannot generate prost conversion for streaming RPC: type google.protobuf.Any is unsupported (path: %s)\n"+
 					"To resolve this, allow dropping this Any field in prost conversion by adding it to allow_streaming_any_types in librarian.yaml:\n"+
 					"    rust:\n"+
 					"      allow_streaming_any_types:\n"+
-					"        - %s\n"+
-					"Or skip the RPC method by adding it to skipped_ids in librarian.yaml (e.g. skipped_ids: [%s])",
-					item.rpc, path, fieldID, item.methodID)
+					"        - %s",
+					path, fieldID)
 			}
-			return fmt.Errorf("cannot generate prost conversion for streaming RPC %q: type google.protobuf.Any is unsupported (path: %s)\n"+
-				"To resolve this, add the RPC method ID to skipped_ids in librarian.yaml (e.g. skipped_ids: [%s])",
-				item.rpc, path, item.methodID)
+			return fmt.Errorf("cannot generate prost conversion for streaming RPC: type google.protobuf.Any is unsupported (path: %s)", path)
 		}
 
 		if isAnyType(item.id) {
@@ -206,7 +200,7 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 				hasGoogleRpcStatus = true
 				continue
 			}
-			enqueueMsg(msg, item.rpc, item.methodID, item.path)
+			enqueueMsg(msg, item.path)
 			for _, f := range msg.Fields {
 				fieldPath := item.path + "." + f.Name
 				if isAnyType(f.TypezID) {
@@ -217,15 +211,13 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 					return nil, nil, false, anyError(fieldPath, f.ID)
 				}
 				if f.Typez == api.TypezMessage && f.TypezID != "" {
-					queue = append(queue, streamingTypeItem{
-						id:       f.TypezID,
-						rpc:      item.rpc,
-						methodID: item.methodID,
-						path:     fieldPath,
+					queue = append(queue, typeItem{
+						id:   f.TypezID,
+						path: fieldPath,
 					})
 				}
 				if f.Typez == api.TypezEnum && f.TypezID != "" {
-					enqueueEnum(model.Enum(f.TypezID), item.rpc, item.methodID, fieldPath)
+					enqueueEnum(model.Enum(f.TypezID), fieldPath)
 				}
 			}
 			for _, o := range msg.OneOfs {
@@ -239,15 +231,13 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 						return nil, nil, false, anyError(fieldPath, f.ID)
 					}
 					if f.Typez == api.TypezMessage && f.TypezID != "" {
-						queue = append(queue, streamingTypeItem{
-							id:       f.TypezID,
-							rpc:      item.rpc,
-							methodID: item.methodID,
-							path:     fieldPath,
+						queue = append(queue, typeItem{
+							id:   f.TypezID,
+							path: fieldPath,
 						})
 					}
 					if f.Typez == api.TypezEnum && f.TypezID != "" {
-						enqueueEnum(model.Enum(f.TypezID), item.rpc, item.methodID, fieldPath)
+						enqueueEnum(model.Enum(f.TypezID), fieldPath)
 					}
 				}
 			}
@@ -255,11 +245,11 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 
 		enum := model.Enum(item.id)
 		if enum != nil {
-			enqueueEnum(enum, item.rpc, item.methodID, item.path)
+			enqueueEnum(enum, item.path)
 		}
 	}
 
-	// Collect external top-level messages (e.g. google.type.LatLng) referenced by streaming RPCs.
+	// Collect external top-level messages (e.g. google.type.LatLng) referenced by roots.
 	// We sort external types by ID because model.AllMessages() iterates over a map whose
 	// iteration order is randomized by the Go runtime.
 	var externalMessages []*api.Message
@@ -272,7 +262,7 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 	}
 	slices.SortFunc(externalMessages, func(a, b *api.Message) int { return cmp.Compare(a.ID, b.ID) })
 
-	// Collect external top-level enums referenced by streaming RPCs.
+	// Collect external top-level enums referenced by roots.
 	var externalEnums []*api.Enum
 	for e := range model.AllEnums() {
 		if e.ID != "" && streamingEnums[e.ID] && !isWKT(e.ID) && e.Parent == nil {
@@ -285,17 +275,12 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 
 	// Construct hybridModel for prost conversion code generation.
 	hybridModel := api.API{
-		Name:        model.Name,
-		PackageName: model.PackageName,
-		Title:       model.Title,
-		Description: model.Description,
-		Revision:    model.Revision,
-		// Services, Messages, and Enums slices are filtered to only streaming types so convert.rs
-		// only contains conversion implementations for streaming RPCs.
-		// Filtering model.Messages and model.Enums preserves their original deterministic file order.
-		Services: language.FilterSlice(model.Services, func(s *api.Service) bool {
-			return (includeBidi && s.HasBidiStreaming()) || (includeServer && s.HasServerSideStreaming())
-		}),
+		Name:                model.Name,
+		PackageName:         model.PackageName,
+		Title:               model.Title,
+		Description:         model.Description,
+		Revision:            model.Revision,
+		Services:            model.Services,
 		Messages:            language.FilterSlice(model.Messages, func(m *api.Message) bool { return streamingMsgs[m.ID] }),
 		ExternalMessages:    externalMessages,
 		Enums:               language.FilterSlice(model.Enums, func(e *api.Enum) bool { return streamingEnums[e.ID] }),
@@ -310,8 +295,8 @@ func filterModelToStreaming(model *api.API, includeBidi bool, includeServer bool
 			hybridModel.AddMethod(m)
 		}
 	}
-	// Populate messageByID and enumByID with ALL package messages and enums (not just
-	// streaming types). This avoids aliasing model.messageByID while allowing model
+	// Populate messageByID and enumByID with ALL package messages and enums.
+	// This avoids aliasing model.messageByID while allowing model
 	// annotation to resolve field types across the entire package.
 	for m := range model.AllMessages() {
 		hybridModel.AddMessage(m)

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -118,7 +118,7 @@ func TestGenerateProstHybrid(t *testing.T) {
 			srcs := &sources.Sources{
 				Googleapis: filepath.Dir(filepath.Dir(absSpecSource)),
 			}
-			err = generateProstHybrid(t.Context(), test.model, lib, outDir, &parser.ModelConfig{
+			modelConfig := &parser.ModelConfig{
 				SpecificationFormat: config.SpecProtobuf,
 				SpecificationSource: absSpecSource,
 				Source:              sources.NewSourceConfig(srcs, []string{"googleapis"}),
@@ -126,7 +126,9 @@ func TestGenerateProstHybrid(t *testing.T) {
 					"package-name-override": "google-cloud-test",
 					"package:g3-wkt":        "package=google-cloud-wkt,source=google.protobuf",
 				},
-			})
+			}
+			rootTypeIDs := streamingRootTypeIDs(test.model, lib)
+			err = generateProstHybrid(t.Context(), test.model, rootTypeIDs, lib, outDir, modelConfig)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -147,16 +149,13 @@ func TestGenerateProstHybrid(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreaming(t *testing.T) {
+func TestFilterModelToTypes(t *testing.T) {
 	streamingMsg := api.NewTestMessage("StreamMsg").WithPackage("google.test.v1")
 	unusedMsg := api.NewTestMessage("UnusedMsg").WithPackage("google.test.v1")
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamingMsg).WithOutput(streamingMsg).WithBidiStreaming()
+	model := api.NewTestAPI([]*api.Message{streamingMsg, unusedMsg}, []*api.Enum{}, []*api.Service{})
 
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
-	model := api.NewTestAPI([]*api.Message{streamingMsg, unusedMsg}, []*api.Enum{}, []*api.Service{bidiService})
-
-	filtered, unused, _, err := filterModelToStreaming(model, true, true, nil)
+	filtered, unused, _, err := filterModelToTypes(model, []string{streamingMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -173,7 +172,7 @@ func TestFilterModelToStreaming(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
+func TestFilterModelToTypesUnusedFieldLookup(t *testing.T) {
 	streamMsg := api.NewTestMessage("StreamMsg").WithPackage("google.test.v1")
 	childData := api.NewTestMessage("ChildData").WithPackage("google.test.v1")
 	unaryReq := api.NewTestMessage("UnaryReq").WithPackage("google.test.v1").WithFields(
@@ -184,22 +183,13 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 		},
 	)
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamMsg).WithOutput(streamMsg).WithBidiStreaming()
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
+	model := api.NewTestAPI([]*api.Message{streamMsg, unaryReq, childData}, []*api.Enum{}, []*api.Service{})
 
-	unaryMethod := api.NewTestMethod("UnaryMethod").WithInput(unaryReq).WithOutput(unaryReq)
-	unaryService := api.NewTestService("UnaryService").WithPackage("google.test.v1").WithMethods(unaryMethod)
-
-	model := api.NewTestAPI([]*api.Message{streamMsg, unaryReq, childData}, []*api.Enum{}, []*api.Service{bidiService, unaryService})
-
-	filtered, _, _, err := filterModelToStreaming(model, true, true, nil)
+	filtered, _, _, err := filterModelToTypes(model, []string{streamMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(filtered.Services) != 1 || filtered.Services[0].ID != bidiService.ID {
-		t.Errorf("got services %v, want [%s]", filtered.Services, bidiService.ID)
-	}
 	if len(filtered.Messages) != 1 || filtered.Messages[0].ID != streamMsg.ID {
 		t.Errorf("got messages %v, want [%s]", filtered.Messages, streamMsg.ID)
 	}
@@ -211,7 +201,7 @@ func TestFilterModelToStreamingNonStreamingFieldLookup(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingExternalTypes(t *testing.T) {
+func TestFilterModelToTypesExternalTypes(t *testing.T) {
 	streamMsg := api.NewTestMessage("StreamMsg").WithPackage("google.test.v1")
 	externalMsg := api.NewTestMessage("LatLng").WithPackage("google.type")
 	externalEnum := &api.Enum{Name: "DayOfWeek", ID: ".google.type.DayOfWeek", Package: "google.type"}
@@ -229,17 +219,14 @@ func TestFilterModelToStreamingExternalTypes(t *testing.T) {
 		},
 	}
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamMsg).WithOutput(streamMsg).WithBidiStreaming()
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
-
-	model := api.NewTestAPI([]*api.Message{streamMsg}, []*api.Enum{}, []*api.Service{bidiService})
+	model := api.NewTestAPI([]*api.Message{streamMsg}, []*api.Enum{}, []*api.Service{})
 	model.AddMessage(externalMsg)
 	model.AddEnum(externalEnum)
 	if err := api.CrossReference(model); err != nil {
 		t.Fatal(err)
 	}
 
-	filtered, _, _, err := filterModelToStreaming(model, true, true, nil)
+	filtered, _, _, err := filterModelToTypes(model, []string{streamMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -255,8 +242,7 @@ func TestFilterModelToStreamingExternalTypes(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingAnyError(t *testing.T) {
-	// Verify google.protobuf.Any in streaming path returns error with recommendation
+func TestFilterModelToTypesAnyError(t *testing.T) {
 	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(
 		&api.Field{
 			Name:    "details",
@@ -264,32 +250,30 @@ func TestFilterModelToStreamingAnyError(t *testing.T) {
 			Typez:   api.TypezMessage,
 		},
 	)
-	chatAnyMethod := api.NewTestMethod("ChatAny").WithInput(anyMsg).WithOutput(anyMsg).WithBidiStreaming()
-	anyService := api.NewTestService("AnyService").WithPackage("google.test.v1").WithMethods(chatAnyMethod)
 
-	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
+	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{})
 
-	_, _, _, err := filterModelToStreaming(anyModel, true, true, nil)
+	_, _, _, err := filterModelToTypes(anyModel, []string{anyMsg.ID}, nil)
 	if err == nil {
 		t.Fatal("expected error for google.protobuf.Any, got nil")
 	}
 	if !strings.Contains(err.Error(), "allow_streaming_any_types") {
 		t.Errorf("expected error to contain recommendation 'allow_streaming_any_types', got: %v", err)
 	}
+	if !strings.Contains(err.Error(), ".google.test.v1.AnyReq.details") {
+		t.Errorf("expected error to contain .google.test.v1.AnyReq.details, got: %v", err)
+	}
 }
 
-func TestFilterModelToStreamingAllowedAny(t *testing.T) {
-	// Verify allowing specific Any field path succeeds and drops the field from conversion
+func TestFilterModelToTypesAllowedAny(t *testing.T) {
 	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(
 		api.NewTestField("details").WithType(api.TypezMessage).WithTypezID(".google.protobuf.Any"),
 		api.NewTestField("name").WithType(api.TypezString),
 	)
-	chatAnyMethod := api.NewTestMethod("ChatAny").WithInput(anyMsg).WithOutput(anyMsg).WithBidiStreaming()
-	anyService := api.NewTestService("AnyService").WithPackage("google.test.v1").WithMethods(chatAnyMethod)
 
-	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
+	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{})
 
-	filtered, _, _, err := filterModelToStreaming(anyModel, true, true, []string{".google.test.v1.AnyReq.details"})
+	filtered, _, _, err := filterModelToTypes(anyModel, []string{anyMsg.ID}, []string{".google.test.v1.AnyReq.details"})
 	if err != nil {
 		t.Fatalf("expected success with allowStreamingAnyTypes, got error: %v", err)
 	}
@@ -314,8 +298,7 @@ func TestFilterModelToStreamingAllowedAny(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
-	// Verify google.rpc.Status in streaming path succeeds and does not error on Any details
+func TestFilterModelToTypesGoogleRpcStatus(t *testing.T) {
 	statusMsg := api.NewTestMessage("Status").WithPackage("google.rpc").WithFields(
 		&api.Field{
 			Name:  "code",
@@ -341,13 +324,10 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 		},
 	)
 
-	chatMethod := api.NewTestMethod("ChatStatus").WithInput(reqMsg).WithOutput(reqMsg).WithBidiStreaming()
-	statusService := api.NewTestService("StatusService").WithPackage("google.test.v1").WithMethods(chatMethod)
-
-	statusModel := api.NewTestAPI([]*api.Message{reqMsg}, []*api.Enum{}, []*api.Service{statusService})
+	statusModel := api.NewTestAPI([]*api.Message{reqMsg}, []*api.Enum{}, []*api.Service{})
 	statusModel.AddMessage(statusMsg)
 
-	filtered, unused, hasStatus, err := filterModelToStreaming(statusModel, true, true, nil)
+	filtered, unused, hasStatus, err := filterModelToTypes(statusModel, []string{reqMsg.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error for google.rpc.Status: %v", err)
 	}
@@ -357,7 +337,7 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 	}
 
 	if !hasStatus {
-		t.Errorf("expected hasStatus boolean from filterModelToStreaming to be true, got false")
+		t.Errorf("expected hasStatus boolean from filterModelToTypes to be true, got false")
 	}
 
 	for _, u := range unused {
@@ -367,7 +347,7 @@ func TestFilterModelToStreamingGoogleRpcStatus(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
+func TestFilterModelToTypesNestedTypeParentPreservation(t *testing.T) {
 	parent := api.NewTestMessage("Parent").WithPackage("google.test.v1")
 	child := api.NewTestMessage("Child").WithPackage("google.test.v1")
 	sibling := api.NewTestMessage("Sibling").WithPackage("google.test.v1")
@@ -389,12 +369,9 @@ func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
 		},
 	)
 
-	chatMethod := api.NewTestMethod("Chat").WithInput(streamReq).WithOutput(streamReq).WithBidiStreaming()
-	bidiService := api.NewTestService("BidiService").WithPackage("google.test.v1").WithMethods(chatMethod)
+	model := api.NewTestAPI([]*api.Message{parent, child, sibling, streamReq}, []*api.Enum{}, []*api.Service{})
 
-	model := api.NewTestAPI([]*api.Message{parent, child, sibling, streamReq}, []*api.Enum{}, []*api.Service{bidiService})
-
-	_, unusedTypes, _, err := filterModelToStreaming(model, true, false, nil)
+	_, unusedTypes, _, err := filterModelToTypes(model, []string{streamReq.ID}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -412,74 +389,46 @@ func TestFilterModelToStreamingNestedTypeParentPreservation(t *testing.T) {
 	}
 }
 
-func TestFilterModelToStreamingServerStreaming(t *testing.T) {
-	reqMsg := api.NewTestMessage("ExpandRequest").WithPackage("google.test.v1")
-	respMsg := api.NewTestMessage("EchoResponse").WithPackage("google.test.v1")
-	unusedMsg := api.NewTestMessage("UnusedMsg").WithPackage("google.test.v1")
-
-	expandMethod := api.NewTestMethod("Expand").WithInput(reqMsg).WithOutput(respMsg).WithServerSideStreaming()
-
-	serverService := api.NewTestService("EchoService").WithPackage("google.test.v1").WithMethods(expandMethod)
-	model := api.NewTestAPI([]*api.Message{reqMsg, respMsg, unusedMsg}, []*api.Enum{}, []*api.Service{serverService})
-
-	filtered, unused, _, err := filterModelToStreaming(model, false, true, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(filtered.Services) != 1 || filtered.Services[0].ID != serverService.ID {
-		t.Errorf("got services %v, want [%s]", filtered.Services, serverService.ID)
-	}
-	if len(filtered.Messages) != 2 {
-		t.Errorf("got messages %v, want [%s, %s]", filtered.Messages, reqMsg.ID, respMsg.ID)
-	}
-	if len(unused) != 1 || unused[0] != unusedMsg.ID {
-		t.Errorf("got unused %v, want [%s]", unused, unusedMsg.ID)
-	}
-}
-
-func TestFilterModelToStreamingIsolation(t *testing.T) {
-	bidiMsg := api.NewTestMessage("BidiMsg").WithPackage("google.test.v1")
-	serverReq := api.NewTestMessage("ServerReq").WithPackage("google.test.v1")
-	serverResp := api.NewTestMessage("ServerResp").WithPackage("google.test.v1")
-
-	bidiMethod := api.NewTestMethod("Chat").WithInput(bidiMsg).WithOutput(bidiMsg).WithBidiStreaming()
-	serverMethod := api.NewTestMethod("Expand").WithInput(serverReq).WithOutput(serverResp).WithServerSideStreaming()
-
-	service := api.NewTestService("MixedService").WithPackage("google.test.v1").WithMethods(bidiMethod, serverMethod)
-	model := api.NewTestAPI([]*api.Message{bidiMsg, serverReq, serverResp}, []*api.Enum{}, []*api.Service{service})
-
+func TestFilterModelToTypesMultipleRoots(t *testing.T) {
 	for _, test := range []struct {
-		name          string
-		includeBidi   bool
-		includeServer bool
-		wantMessages  []string
-		wantUnused    []string
+		name         string
+		rootTypeIDs  []string
+		wantMessages []string
+		wantUnused   []string
 	}{
 		{
-			name:          "server streaming only ignores bidi types",
-			includeBidi:   false,
-			includeServer: true,
-			wantMessages:  []string{serverReq.ID, serverResp.ID},
-			wantUnused:    []string{bidiMsg.ID},
+			name:         "single root only includes reachable types",
+			rootTypeIDs:  []string{".google.test.v1.MsgA"},
+			wantMessages: []string{".google.test.v1.MsgA"},
+			wantUnused:   []string{".google.test.v1.MsgB", ".google.test.v1.MsgC"},
 		},
 		{
-			name:          "bidi streaming only ignores server streaming types",
-			includeBidi:   true,
-			includeServer: false,
-			wantMessages:  []string{bidiMsg.ID},
-			wantUnused:    []string{serverReq.ID, serverResp.ID},
+			name:         "multiple roots include all reachable types",
+			rootTypeIDs:  []string{".google.test.v1.MsgA", ".google.test.v1.MsgB"},
+			wantMessages: []string{".google.test.v1.MsgA", ".google.test.v1.MsgB"},
+			wantUnused:   []string{".google.test.v1.MsgC"},
 		},
 		{
-			name:          "both streaming types enabled includes all types",
-			includeBidi:   true,
-			includeServer: true,
-			wantMessages:  []string{bidiMsg.ID, serverReq.ID, serverResp.ID},
-			wantUnused:    nil,
+			name:         "all roots includes all messages",
+			rootTypeIDs:  []string{".google.test.v1.MsgA", ".google.test.v1.MsgB", ".google.test.v1.MsgC"},
+			wantMessages: []string{".google.test.v1.MsgA", ".google.test.v1.MsgB", ".google.test.v1.MsgC"},
+			wantUnused:   nil,
+		},
+		{
+			name:         "empty roots includes no messages",
+			rootTypeIDs:  nil,
+			wantMessages: nil,
+			wantUnused:   []string{".google.test.v1.MsgA", ".google.test.v1.MsgB", ".google.test.v1.MsgC"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			filtered, unused, _, err := filterModelToStreaming(model, test.includeBidi, test.includeServer, nil)
+			msgA := api.NewTestMessage("MsgA").WithPackage("google.test.v1")
+			msgB := api.NewTestMessage("MsgB").WithPackage("google.test.v1")
+			msgC := api.NewTestMessage("MsgC").WithPackage("google.test.v1")
+
+			model := api.NewTestAPI([]*api.Message{msgA, msgB, msgC}, []*api.Enum{}, []*api.Service{})
+
+			filtered, unused, _, err := filterModelToTypes(model, test.rootTypeIDs, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
Refactor filterModelToStreaming into filterModelToTypes to support arbitrary root type IDs for prost conversion generation. Traverse all transitively reachable messages and enums. Also removes the unused filtering of the Services.

In generate.go, determine root types for enabled streaming RPCs via streamingRootTypeIDs and pass them to generateProstHybrid.

We will be able to use this to specify any types that we need prost types and conversions for.