### PR TITLE
docs(internal/sidekick/rust): link to gaxi::grpc::Client in docs

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -31,7 +31,7 @@ use crate::Error;
 
 {{/Codec.HasServices}}
 {{#Codec.Services}}
-/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using a [gaxi::http::ReqwestClient].
+/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using a [gaxi::http::ReqwestClient]{{#Codec.HasStreaming}} and a [gaxi::grpc::Client]{{/Codec.HasStreaming}}.
 {{#Codec.PerServiceFeatures}}
 #[cfg(feature = "{{Codec.FeatureName}}")]
 {{/Codec.PerServiceFeatures}}


### PR DESCRIPTION
This is internal only documentation.