### PR TITLE
cleanup(internal/sidekick/rust): support pure grpc services in default crates

### DIFF
--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -49,11 +49,17 @@ type methodAnnotation struct {
 	IsBigQueryInsertJob       bool
 	ClientSideStreaming       bool
 	ServerSideStreaming       bool
+	IsGrpc                    bool
+}
+
+// IsHttp returns true if the method is routed over HTTP transport.
+func (m *methodAnnotation) IsHttp() bool {
+	return !m.IsGrpc
 }
 
 // IsBidiStreaming returns true if the method is a bidirectional streaming RPC.
 func (m *methodAnnotation) IsBidiStreaming() bool {
-	return m.ClientSideStreaming && m.ServerSideStreaming
+	return m.IsGrpc && m.ClientSideStreaming && m.ServerSideStreaming
 }
 
 // FullBody returns true if the HTTP body is configured as "*".
@@ -64,7 +70,7 @@ func (m *methodAnnotation) FullBody() bool {
 // IsServerStreaming returns true if the method is a server-side streaming RPC
 // and is not bidirectional.
 func (m *methodAnnotation) IsServerStreaming() bool {
-	return !m.ClientSideStreaming && m.ServerSideStreaming
+	return m.IsGrpc && !m.ClientSideStreaming && m.ServerSideStreaming
 }
 
 // HasGrpcResourceNameArgs returns true if the method has gRPC resource name arguments.
@@ -347,6 +353,7 @@ func (c *codec) annotateMethod(m *api.Method) (*methodAnnotation, error) {
 		IsBigQueryInsertJob:       m.ID == ".google.cloud.bigquery.v2.JobService.InsertJob",
 		ClientSideStreaming:       m.ClientSideStreaming,
 		ServerSideStreaming:       m.ServerSideStreaming,
+		IsGrpc:                    c.methodUsesGrpc(m),
 	}
 
 	if err := c.annotateResourceNameGeneration(m, annotation); err != nil {
@@ -733,4 +740,16 @@ func isIdempotent(p *api.PathInfo) string {
 		}
 	}
 	return "true"
+}
+
+func (c *codec) methodUsesGrpc(m *api.Method) bool {
+	if !c.templateSupportsGrpc() {
+		return false
+	}
+	if m.ClientSideStreaming || m.ServerSideStreaming {
+		return (m.ClientSideStreaming && m.ServerSideStreaming && c.includeBidiStreamingMethods) ||
+			(!m.ClientSideStreaming && m.ServerSideStreaming && c.includeServerStreamingMethods) ||
+			c.includeStreamingMethods
+	}
+	return false
 }

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -575,15 +575,21 @@ func TestIsBidiStreaming(t *testing.T) {
 		name   string
 		client bool
 		server bool
+		isGrpc bool
 		want   bool
 	}{
-		{"bidi streaming", true, true, true},
-		{"client-only streaming", true, false, false},
-		{"server-only streaming", false, true, false},
-		{"unary", false, false, false},
+		{"bidi streaming with gRPC", true, true, true, true},
+		{"bidi streaming without gRPC", true, true, false, false},
+		{"client-only streaming", true, false, true, false},
+		{"server-only streaming", false, true, true, false},
+		{"unary", false, false, true, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ann := &methodAnnotation{ClientSideStreaming: test.client, ServerSideStreaming: test.server}
+			ann := &methodAnnotation{
+				ClientSideStreaming: test.client,
+				ServerSideStreaming: test.server,
+				IsGrpc:              test.isGrpc,
+			}
 			if got := ann.IsBidiStreaming(); got != test.want {
 				t.Errorf("methodAnnotation.IsBidiStreaming() = %v, want %v", got, test.want)
 			}
@@ -596,17 +602,96 @@ func TestIsServerStreaming(t *testing.T) {
 		name   string
 		client bool
 		server bool
+		isGrpc bool
 		want   bool
 	}{
-		{"bidi streaming", true, true, false},
-		{"client-only streaming", true, false, false},
-		{"server-only streaming", false, true, true},
-		{"unary", false, false, false},
+		{"bidi streaming", true, true, true, false},
+		{"client-only streaming", true, false, true, false},
+		{"server-only streaming with gRPC", false, true, true, true},
+		{"server-only streaming without gRPC", false, true, false, false},
+		{"unary", false, false, true, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ann := &methodAnnotation{ClientSideStreaming: test.client, ServerSideStreaming: test.server}
+			ann := &methodAnnotation{
+				ClientSideStreaming: test.client,
+				ServerSideStreaming: test.server,
+				IsGrpc:              test.isGrpc,
+			}
 			if got := ann.IsServerStreaming(); got != test.want {
 				t.Errorf("methodAnnotation.IsServerStreaming() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsHttp(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		isGrpc bool
+		want   bool
+	}{
+		{"gRPC method", true, false},
+		{"HTTP method", false, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ann := &methodAnnotation{IsGrpc: test.isGrpc}
+			if got := ann.IsHttp(); got != test.want {
+				t.Errorf("methodAnnotation.IsHttp() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestMethodUsesGrpc(t *testing.T) {
+	msg := api.NewTestMessage("Message").WithPackage("test.v1")
+	unaryMethod := api.NewTestMethod("Unary").WithInput(msg).WithOutput(msg).WithPathTemplate(&api.PathTemplate{})
+	bidiMethod := api.NewTestMethod("Bidi").WithInput(msg).WithOutput(msg).WithBidiStreaming()
+	serverMethod := api.NewTestMethod("Server").WithInput(msg).WithOutput(msg).WithServerSideStreaming()
+
+	for _, test := range []struct {
+		name             string
+		method           *api.Method
+		templateOverride string
+		options          map[string]string
+		want             bool
+	}{
+		{
+			name:    "unary method defaults to HTTP",
+			method:  unaryMethod,
+			options: map[string]string{},
+			want:    false,
+		},
+		{
+			name:   "bidi streaming enabled",
+			method: bidiMethod,
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			want: true,
+		},
+		{
+			name:   "server streaming enabled",
+			method: serverMethod,
+			options: map[string]string{
+				"include-server-streaming-methods": "true",
+			},
+			want: true,
+		},
+		{
+			name:             "template without grpc ignores streaming",
+			method:           bidiMethod,
+			templateOverride: "templates/http-client",
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := newTestCodec(t, libconfig.SpecProtobuf, "", test.options)
+			c.templateOverride = test.templateOverride
+			if got := c.methodUsesGrpc(test.method); got != test.want {
+				t.Errorf("methodUsesGrpc() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -53,13 +53,7 @@ type modelAnnotations struct {
 	RequiredPackages           []string
 	ExternPackages             []string
 	HasLROs                    bool
-	HasBidiStreaming           bool
-	HasServerStreaming         bool
-	HasStreaming               bool
 	IncludeRpcStatusConversion bool
-	BidiStreamingServices      []*api.Service
-	ServerStreamingServices    []*api.Service
-	StreamingServices          []*api.Service
 	CopyrightYear              string
 	BoilerPlate                []string
 	DefaultHost                string
@@ -130,6 +124,26 @@ func (m *modelAnnotations) HasServices() bool {
 	return len(m.Services) > 0
 }
 
+// HasGrpc returns true if any service in the model has at least one gRPC method.
+func (m *modelAnnotations) HasGrpc() bool {
+	return slices.ContainsFunc(m.Services, func(s *api.Service) bool {
+		if ann, ok := s.Codec.(*serviceAnnotations); ok {
+			return ann.HasGrpc()
+		}
+		return false
+	})
+}
+
+// HasHttp returns true if any service in the model has at least one HTTP method.
+func (m *modelAnnotations) HasHttp() bool {
+	return slices.ContainsFunc(m.Services, func(s *api.Service) bool {
+		if ann, ok := s.Codec.(*serviceAnnotations); ok {
+			return ann.HasHttp()
+		}
+		return false
+	})
+}
+
 // IsGaxiCrate returns true if we handle references to `gaxi` traits from within the `gaxi` crate, by
 // injecting some ad-hoc code.
 func (m *modelAnnotations) IsGaxiCrate() bool {
@@ -140,6 +154,16 @@ func (m *modelAnnotations) IsGaxiCrate() bool {
 // is a GA library.
 func (m *modelAnnotations) ReleaseLevelIsGA() bool {
 	return m.ReleaseLevel == "GA" || m.ReleaseLevel == "stable"
+}
+
+// GrpcServices returns the subset of services that have at least one gRPC method.
+func (m *modelAnnotations) GrpcServices() []*api.Service {
+	return language.FilterSlice(m.Services, func(s *api.Service) bool {
+		if ann, ok := s.Codec.(*serviceAnnotations); ok {
+			return ann.HasGrpc()
+		}
+		return false
+	})
 }
 
 // annotateModel creates a struct used as input for Mustache templates.
@@ -284,26 +308,13 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		}
 	}
 
-	var bidiStreamingServices []*api.Service
-	var serverStreamingServices []*api.Service
-	var streamingServices []*api.Service
-	for _, s := range servicesSubset {
-		isBidi := codec.includeBidiStreamingMethods && s.HasBidiStreaming()
-		isServer := codec.includeServerStreamingMethods && s.HasServerSideStreaming()
-		if isBidi {
-			bidiStreamingServices = append(bidiStreamingServices, s)
+	hasGrpc := slices.ContainsFunc(servicesSubset, func(s *api.Service) bool {
+		if sAnn, ok := s.Codec.(*serviceAnnotations); ok {
+			return sAnn.HasGrpc()
 		}
-		if isServer {
-			serverStreamingServices = append(serverStreamingServices, s)
-		}
-		if isBidi || isServer {
-			streamingServices = append(streamingServices, s)
-		}
-	}
-	hasBidiStreaming := (codec.templateOverride == "" || codec.templateOverride == "templates/grpc-client") && len(bidiStreamingServices) > 0
-	hasServerStreaming := (codec.templateOverride == "" || codec.templateOverride == "templates/grpc-client") && len(serverStreamingServices) > 0
-	hasStreaming := hasBidiStreaming || hasServerStreaming
-	if hasStreaming {
+		return false
+	})
+	if hasGrpc {
 		for _, pkg := range codec.extraPackages {
 			if pkg.name == gaxiPackageName {
 				if !slices.Contains(pkg.features, "_internal-grpc-client") {
@@ -332,13 +343,7 @@ func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 		RequiredPackages:           requiredPackages(codec.extraPackages),
 		ExternPackages:             externPackages(codec.extraPackages),
 		HasLROs:                    hasLROs,
-		HasBidiStreaming:           hasBidiStreaming,
-		HasServerStreaming:         hasServerStreaming,
-		HasStreaming:               hasStreaming,
 		IncludeRpcStatusConversion: includeRpcStatusConversion,
-		BidiStreamingServices:      bidiStreamingServices,
-		ServerStreamingServices:    serverStreamingServices,
-		StreamingServices:          streamingServices,
 		CopyrightYear:              codec.generationYear,
 		BoilerPlate: append(license.HeaderBulk(),
 			"",

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -797,14 +797,12 @@ func TestModelAnnotationsHasStreaming(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got.HasBidiStreaming != test.wantBidi {
-				t.Errorf("HasBidiStreaming = %v, want %v", got.HasBidiStreaming, test.wantBidi)
+			sAnn := test.service.Codec.(*serviceAnnotations)
+			if sAnn.HasBidiStreaming() != test.wantBidi {
+				t.Errorf("HasBidiStreaming = %v, want %v", sAnn.HasBidiStreaming(), test.wantBidi)
 			}
-			if got.HasServerStreaming != test.wantServer {
-				t.Errorf("HasServerStreaming = %v, want %v", got.HasServerStreaming, test.wantServer)
-			}
-			if got.HasStreaming != test.wantStreaming {
-				t.Errorf("HasStreaming = %v, want %v", got.HasStreaming, test.wantStreaming)
+			if sAnn.HasStreaming() != test.wantStreaming {
+				t.Errorf("HasStreaming = %v, want %v", sAnn.HasStreaming(), test.wantStreaming)
 			}
 			if len(test.wantGaxiFeatures) > 0 {
 				idx := slices.IndexFunc(codec.extraPackages, func(pkg *packagez) bool {
@@ -825,19 +823,16 @@ func TestModelAnnotationsHasStreaming(t *testing.T) {
 	}
 }
 
-func TestModelAnnotationsStreamingServices(t *testing.T) {
+func TestModelAnnotationsGrpcServices(t *testing.T) {
 	msg := api.NewTestMessage("Request").WithPackage("test.v1")
 
-	bidiMethod := api.NewTestMethod("Chat").WithInput(msg).WithOutput(msg).WithBidiStreaming()
-	bidiMethod.PathInfo = &api.PathInfo{}
+	bidiMethod := api.NewTestMethod("Chat").WithInput(msg).WithOutput(msg).WithBidiStreaming().WithPathTemplate(&api.PathTemplate{})
 	bidiService := api.NewTestService("BidiService").WithPackage("test.v1").WithMethods(bidiMethod)
 
-	serverMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg).WithServerSideStreaming()
-	serverMethod.PathInfo = &api.PathInfo{}
+	serverMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg).WithServerSideStreaming().WithPathTemplate(&api.PathTemplate{})
 	serverService := api.NewTestService("ServerService").WithPackage("test.v1").WithMethods(serverMethod)
 
-	unaryMethod := api.NewTestMethod("Get").WithInput(msg).WithOutput(msg)
-	unaryMethod.PathInfo = &api.PathInfo{}
+	unaryMethod := api.NewTestMethod("Get").WithInput(msg).WithOutput(msg).WithVerb("GET").WithPathTemplate(&api.PathTemplate{})
 	unaryService := api.NewTestService("UnaryService").WithPackage("test.v1").WithMethods(unaryMethod)
 
 	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{bidiService, serverService, unaryService})
@@ -855,20 +850,21 @@ func TestModelAnnotationsStreamingServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(got.BidiStreamingServices) != 1 {
-		t.Fatalf("expected 1 BidiStreamingService, got %d", len(got.BidiStreamingServices))
+	grpcServices := got.GrpcServices()
+	if len(grpcServices) != 2 {
+		t.Fatalf("expected 2 GrpcServices, got %d", len(grpcServices))
 	}
-	if got.BidiStreamingServices[0].Name != "BidiService" {
-		t.Errorf("expected BidiStreamingServices[0].Name == %q, got %q", "BidiService", got.BidiStreamingServices[0].Name)
+	if grpcServices[0].Name != "BidiService" {
+		t.Errorf("expected GrpcServices[0].Name == %q, got %q", "BidiService", grpcServices[0].Name)
 	}
-	if len(got.ServerStreamingServices) != 1 {
-		t.Fatalf("expected 1 ServerStreamingService, got %d", len(got.ServerStreamingServices))
+	if grpcServices[1].Name != "ServerService" {
+		t.Errorf("expected GrpcServices[1].Name == %q, got %q", "ServerService", grpcServices[1].Name)
 	}
-	if got.ServerStreamingServices[0].Name != "ServerService" {
-		t.Errorf("expected ServerStreamingServices[0].Name == %q, got %q", "ServerService", got.ServerStreamingServices[0].Name)
+	if !got.HasGrpc() {
+		t.Errorf("expected HasGrpc() == true")
 	}
-	if len(got.StreamingServices) != 2 {
-		t.Fatalf("expected 2 StreamingServices, got %d", len(got.StreamingServices))
+	if !got.HasHttp() {
+		t.Errorf("expected HasHttp() == true")
 	}
 }
 

--- a/internal/sidekick/rust/annotate_service.go
+++ b/internal/sidekick/rust/annotate_service.go
@@ -56,12 +56,66 @@ type serviceAnnotations struct {
 	DetailedTracingAttributes bool
 	// If true, the generated builders's visibility should be restricted to the crate.
 	InternalBuilders bool
-	// If true, the service has at least one bidirectional streaming RPC in the API definition.
-	HasBidiStreaming bool
-	// If true, the service has at least one server-side streaming RPC in the API definition.
-	HasServerStreaming bool
-	// If true, the service has at least one streaming RPC (bidirectional or server-side) in the API definition.
-	HasStreaming bool
+}
+
+// HasGrpc returns true if the service has at least one generated gRPC method.
+func (s *serviceAnnotations) HasGrpc() bool {
+	return slices.ContainsFunc(s.Methods, func(m *api.Method) bool {
+		if ann, ok := m.Codec.(*methodAnnotation); ok {
+			return ann.IsGrpc
+		}
+		return false
+	})
+}
+
+// HasHttp returns true if the service has at least one generated HTTP method.
+func (s *serviceAnnotations) HasHttp() bool {
+	return slices.ContainsFunc(s.Methods, func(m *api.Method) bool {
+		if ann, ok := m.Codec.(*methodAnnotation); ok {
+			return ann.IsHttp()
+		}
+		return false
+	})
+}
+
+// HasBidiStreaming returns true if the service has at least one generated bidirectional streaming method.
+func (s *serviceAnnotations) HasBidiStreaming() bool {
+	return slices.ContainsFunc(s.Methods, func(m *api.Method) bool {
+		if ann, ok := m.Codec.(*methodAnnotation); ok {
+			return ann.IsBidiStreaming()
+		}
+		return false
+	})
+}
+
+// HasServerStreaming returns true if the service has at least one generated server streaming method.
+func (s *serviceAnnotations) HasServerStreaming() bool {
+	return slices.ContainsFunc(s.Methods, func(m *api.Method) bool {
+		if ann, ok := m.Codec.(*methodAnnotation); ok {
+			return ann.IsServerStreaming()
+		}
+		return false
+	})
+}
+
+// HasStreaming returns true if the service has at least one generated streaming method.
+func (s *serviceAnnotations) HasStreaming() bool {
+	return s.HasBidiStreaming() || s.HasServerStreaming()
+}
+
+// IsPureGrpc returns true if the service has gRPC methods and no HTTP methods.
+func (s *serviceAnnotations) IsPureGrpc() bool {
+	return s.HasGrpc() && !s.HasHttp()
+}
+
+// IsPureHttp returns true if the service has HTTP methods and no gRPC methods.
+func (s *serviceAnnotations) IsPureHttp() bool {
+	return s.HasHttp() && !s.HasGrpc()
+}
+
+// IsHybrid returns true if the service has both gRPC and HTTP methods.
+func (s *serviceAnnotations) IsHybrid() bool {
+	return s.HasGrpc() && s.HasHttp()
 }
 
 // BuilderVisibility returns the visibility for client and request builders.
@@ -124,15 +178,6 @@ func (a *serviceAnnotations) EnabledFeatures() []string {
 }
 
 func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
-	// Check if the service has bidirectional or server-side streaming RPCs in its API definition
-	// before methods are filtered by generateMethod. We check this before filtering
-	// because we are incrementally adding streaming support (initializing transport
-	// stubs like grpc_inner first before generating streaming method implementations in
-	// subsequent steps).
-	hasBidiStreaming := c.includeBidiStreamingMethods && s.HasBidiStreaming()
-	hasServerStreaming := c.includeServerStreamingMethods && s.HasServerSideStreaming()
-	hasStreaming := hasBidiStreaming || hasServerStreaming
-
 	// Some codecs skip some methods.
 	methods := language.FilterSlice(s.Methods, func(m *api.Method) bool {
 		return c.generateMethod(m)
@@ -173,9 +218,6 @@ func (c *codec) annotateService(s *api.Service) (*serviceAnnotations, error) {
 		Incomplete:                slices.ContainsFunc(s.Methods, func(m *api.Method) bool { return !c.generateMethod(m) }),
 		DetailedTracingAttributes: c.detailedTracingAttributes,
 		InternalBuilders:          c.internalBuilders,
-		HasBidiStreaming:          hasBidiStreaming,
-		HasServerStreaming:        hasServerStreaming,
-		HasStreaming:              hasStreaming,
 	}
 	s.Codec = ann
 	return ann, nil

--- a/internal/sidekick/rust/annotate_service_test.go
+++ b/internal/sidekick/rust/annotate_service_test.go
@@ -280,7 +280,7 @@ func TestServiceAnnotationsNameOverrides(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
-	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "NameNoMangling", "BuilderName", "Body", "PathInfo", "SystemParameters", "ReturnType")
+	methodFilter := cmpopts.IgnoreFields(methodAnnotation{}, "Name", "NameNoMangling", "BuilderName", "Body", "PathInfo", "SystemParameters", "ReturnType", "IsGrpc")
 	wantMethod := &methodAnnotation{
 		ServiceNameToPascal: "Renamed",
 		ServiceNameToCamel:  "renamed",
@@ -531,14 +531,14 @@ func TestServiceAnnotationsStreaming(t *testing.T) {
 			codec := newTestCodec(t, libconfig.SpecProtobuf, "", test.options)
 			annotateModel(model, codec)
 			serviceAnn := test.service.Codec.(*serviceAnnotations)
-			if got := serviceAnn.HasBidiStreaming; got != test.wantBidi {
-				t.Errorf("serviceAnnotations.HasBidiStreaming = %v, want %v", got, test.wantBidi)
+			if got := serviceAnn.HasBidiStreaming(); got != test.wantBidi {
+				t.Errorf("serviceAnnotations.HasBidiStreaming() = %v, want %v", got, test.wantBidi)
 			}
-			if got := serviceAnn.HasServerStreaming; got != test.wantServer {
-				t.Errorf("serviceAnnotations.HasServerStreaming = %v, want %v", got, test.wantServer)
+			if got := serviceAnn.HasServerStreaming(); got != test.wantServer {
+				t.Errorf("serviceAnnotations.HasServerStreaming() = %v, want %v", got, test.wantServer)
 			}
-			if got := serviceAnn.HasStreaming; got != test.wantStreaming {
-				t.Errorf("serviceAnnotations.HasStreaming = %v, want %v", got, test.wantStreaming)
+			if got := serviceAnn.HasStreaming(); got != test.wantStreaming {
+				t.Errorf("serviceAnnotations.HasStreaming() = %v, want %v", got, test.wantStreaming)
 			}
 		})
 	}
@@ -618,6 +618,80 @@ func TestServiceAnnotationsMethodKinds(t *testing.T) {
 			}
 			if got := serviceAnn.NeedsBidiStreamBuilder(); got != test.wantBidiStreamBuilder {
 				t.Errorf("serviceAnnotations.NeedsBidiStreamBuilder() = %v, want %v", got, test.wantBidiStreamBuilder)
+			}
+		})
+	}
+}
+
+func TestServiceAnnotationsClassification(t *testing.T) {
+	msg := api.NewTestMessage("Request").WithPackage("test.v1")
+	bidiMethod := api.NewTestMethod("Chat").WithInput(msg).WithOutput(msg).WithBidiStreaming().WithPathTemplate(&api.PathTemplate{})
+	unaryMethod := api.NewTestMethod("Get").WithInput(msg).WithOutput(msg).WithVerb("GET").WithPathTemplate(&api.PathTemplate{})
+
+	for _, test := range []struct {
+		name       string
+		methods    []*api.Method
+		options    map[string]string
+		isPureGrpc bool
+		isPureHttp bool
+		isHybrid   bool
+	}{
+		{
+			name:    "pure gRPC service with only streaming methods",
+			methods: []*api.Method{bidiMethod},
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			isPureGrpc: true,
+			isPureHttp: false,
+			isHybrid:   false,
+		},
+		{
+			name:       "pure HTTP service with only unary methods",
+			methods:    []*api.Method{unaryMethod},
+			options:    map[string]string{},
+			isPureGrpc: false,
+			isPureHttp: true,
+			isHybrid:   false,
+		},
+		{
+			name:    "hybrid service with unary and streaming methods",
+			methods: []*api.Method{unaryMethod, bidiMethod},
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			isPureGrpc: false,
+			isPureHttp: false,
+			isHybrid:   true,
+		},
+		{
+			name:       "disabled streaming method does not mark service as gRPC",
+			methods:    []*api.Method{bidiMethod},
+			options:    map[string]string{},
+			isPureGrpc: false,
+			isPureHttp: false,
+			isHybrid:   false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service := api.NewTestService("TestService").WithPackage("test.v1").WithMethods(test.methods...)
+			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{service})
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
+			codec := newTestCodec(t, libconfig.SpecProtobuf, "", test.options)
+			if _, err := annotateModel(model, codec); err != nil {
+				t.Fatal(err)
+			}
+			serviceAnn := service.Codec.(*serviceAnnotations)
+			if got := serviceAnn.IsPureGrpc(); got != test.isPureGrpc {
+				t.Errorf("serviceAnnotations.IsPureGrpc() = %v, want %v", got, test.isPureGrpc)
+			}
+			if got := serviceAnn.IsPureHttp(); got != test.isPureHttp {
+				t.Errorf("serviceAnnotations.IsPureHttp() = %v, want %v", got, test.isPureHttp)
+			}
+			if got := serviceAnn.IsHybrid(); got != test.isHybrid {
+				t.Errorf("serviceAnnotations.IsHybrid() = %v, want %v", got, test.isHybrid)
 			}
 		})
 	}

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -1614,15 +1614,19 @@ func (c *codec) generateMethod(m *api.Method) bool {
 	return m.PathInfo.Bindings[0].PathTemplate != nil
 }
 
+func (c *codec) templateSupportsGrpc() bool {
+	return c.templateOverride == "" || c.templateOverride == "templates/grpc-client"
+}
+
 func (c *codec) hasBidiStreaming(model *api.API) bool {
-	if (c.templateOverride != "" && c.templateOverride != "templates/grpc-client") || !c.includeBidiStreamingMethods {
+	if !c.templateSupportsGrpc() || !c.includeBidiStreamingMethods {
 		return false
 	}
 	return slices.ContainsFunc(model.Services, (*api.Service).HasBidiStreaming)
 }
 
 func (c *codec) hasServerStreaming(model *api.API) bool {
-	if (c.templateOverride != "" && c.templateOverride != "templates/grpc-client") || !c.includeServerStreamingMethods {
+	if !c.templateSupportsGrpc() || !c.includeServerStreamingMethods {
 		return false
 	}
 	return slices.ContainsFunc(model.Services, (*api.Service).HasServerSideStreaming)

--- a/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/lib.rs.mustache
@@ -125,12 +125,12 @@ pub(crate) mod tracing;
 #[doc(hidden)]
 pub(crate) mod transport;
 
-{{#Codec.HasStreaming}}
+{{#Codec.HasGrpc}}
 {{#Codec.PerServiceFeatures}}
 #[cfg(any(
-{{#Codec.StreamingServices}}
+{{#Codec.GrpcServices}}
     feature = "{{Codec.FeatureName}}",
-{{/Codec.StreamingServices}}
+{{/Codec.GrpcServices}}
 ))]
 {{/Codec.PerServiceFeatures}}
 #[doc(hidden)]
@@ -141,7 +141,7 @@ pub(crate) mod transport;
 pub(crate) mod prost {
     include!("prost/includes.rs");
 }
-{{/Codec.HasStreaming}}
+{{/Codec.HasGrpc}}
 
 /// The default host used by the service.
 {{#Codec.PerServiceFeatures}}
@@ -155,6 +155,7 @@ const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}/";
 pub(crate) mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
+    {{#Codec.HasHttp}}
     pub(crate) static X_GOOG_API_CLIENT_HEADER: std::sync::LazyLock<String> =
         std::sync::LazyLock::new(|| {
             let ac = gaxi::api_header::XGoogApiClient {
@@ -164,8 +165,8 @@ pub(crate) mod info {
             };
             ac.rest_header_value()
         });
-{{#Codec.HasStreaming}}
-    #[allow(dead_code)]
+    {{/Codec.HasHttp}}
+    {{#Codec.HasGrpc}}
     pub(crate) static X_GOOG_API_CLIENT_GRPC_HEADER: std::sync::LazyLock<String> =
         std::sync::LazyLock::new(|| {
             let ac = gaxi::api_header::XGoogApiClient {
@@ -175,7 +176,7 @@ pub(crate) mod info {
             };
             ac.grpc_header_value()
         });
-{{/Codec.HasStreaming}}
+    {{/Codec.HasGrpc}}
 }
 
 // Define some shortcuts for imported crates.

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -31,16 +31,18 @@ use crate::Error;
 
 {{/Codec.HasServices}}
 {{#Codec.Services}}
-/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using a [gaxi::http::ReqwestClient]{{#Codec.HasStreaming}} and a [gaxi::grpc::Client]{{/Codec.HasStreaming}}.
+/// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using {{#Codec.IsPureGrpc}}a [gaxi::grpc::Client]{{/Codec.IsPureGrpc}}{{#Codec.IsPureHttp}}a [gaxi::http::ReqwestClient]{{/Codec.IsPureHttp}}{{#Codec.IsHybrid}}a [gaxi::http::ReqwestClient] and a [gaxi::grpc::Client]{{/Codec.IsHybrid}}.
 {{#Codec.PerServiceFeatures}}
 #[cfg(feature = "{{Codec.FeatureName}}")]
 {{/Codec.PerServiceFeatures}}
 #[derive(Clone)]
 pub struct {{Codec.Name}} {
+    {{#Codec.HasHttp}}
     inner: gaxi::http::ReqwestClient,
-    {{#Codec.HasStreaming}}
+    {{/Codec.HasHttp}}
+    {{#Codec.HasGrpc}}
     grpc_inner: gaxi::grpc::Client,
-    {{/Codec.HasStreaming}}
+    {{/Codec.HasGrpc}}
 }
 
 {{#Codec.PerServiceFeatures}}
@@ -49,10 +51,12 @@ pub struct {{Codec.Name}} {
 impl std::fmt::Debug for {{Codec.Name}} {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         f.debug_struct("{{Codec.Name}}")
+            {{#Codec.HasHttp}}
             .field("inner", &self.inner)
-            {{#Codec.HasStreaming}}
+            {{/Codec.HasHttp}}
+            {{#Codec.HasGrpc}}
             .field("grpc_inner", &self.grpc_inner)
-            {{/Codec.HasStreaming}}
+            {{/Codec.HasGrpc}}
             .finish()
     }
 }
@@ -64,17 +68,21 @@ impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         {{#Codec.DetailedTracingAttributes}}
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
-        let inner = gaxi::http::ReqwestClient::new(config{{#Codec.HasStreaming}}.clone(){{/Codec.HasStreaming}}, crate::DEFAULT_HOST).await?;
+        {{#Codec.HasHttp}}
+        let inner = gaxi::http::ReqwestClient::new(config{{#Codec.HasGrpc}}.clone(){{/Codec.HasGrpc}}, crate::DEFAULT_HOST).await?;
         let inner = if tracing_is_enabled {
             inner.with_instrumentation(&super::tracing::info::INSTRUMENTATION_CLIENT_INFO)
         } else {
             inner
         };
+        {{/Codec.HasHttp}}
         {{/Codec.DetailedTracingAttributes}}
         {{^Codec.DetailedTracingAttributes}}
-        let inner = gaxi::http::ReqwestClient::new(config{{#Codec.HasStreaming}}.clone(){{/Codec.HasStreaming}}, crate::DEFAULT_HOST).await?;
+        {{#Codec.HasHttp}}
+        let inner = gaxi::http::ReqwestClient::new(config{{#Codec.HasGrpc}}.clone(){{/Codec.HasGrpc}}, crate::DEFAULT_HOST).await?;
+        {{/Codec.HasHttp}}
         {{/Codec.DetailedTracingAttributes}}
-        {{#Codec.HasStreaming}}
+        {{#Codec.HasGrpc}}
         {{#Codec.DetailedTracingAttributes}}
         let grpc_inner = if tracing_is_enabled {
             gaxi::grpc::Client::new_with_instrumentation(
@@ -90,16 +98,20 @@ impl {{Codec.Name}} {
         {{^Codec.DetailedTracingAttributes}}
         let grpc_inner = gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?;
         {{/Codec.DetailedTracingAttributes}}
-        {{/Codec.HasStreaming}}
-        {{^Codec.HasStreaming}}
+        {{/Codec.HasGrpc}}
+        {{#Codec.IsPureHttp}}
         Ok(Self { inner })
-        {{/Codec.HasStreaming}}
-        {{#Codec.HasStreaming}}
+        {{/Codec.IsPureHttp}}
+        {{^Codec.IsPureHttp}}
         Ok(Self {
+            {{#Codec.HasHttp}}
             inner,
+            {{/Codec.HasHttp}}
+            {{#Codec.HasGrpc}}
             grpc_inner,
+            {{/Codec.HasGrpc}}
         })
-        {{/Codec.HasStreaming}}
+        {{/Codec.IsPureHttp}}
     }
 }
 


### PR DESCRIPTION
Differentiate between gRPC-only, HTTP-only, and hybrid services in the default Rust crate template, and clarify where template generation depends on gRPC vs HTTP transport capabilities rather than streaming mechanics.

Previously, template logic often used streaming checks as a proxy for gRPC presence. This change clarifies those distinctions by checking for gRPC support where transport features are concerned (such as `grpc_inner`, `X_GOOG_API_CLIENT_GRPC_HEADER`, `mod prost`, and transport doc comments), while preserving streaming checks only where they genuinely relate to stream builder mechanics.

This allows services that only define gRPC methods (such as `apigeeconnect::v1::Tether`) to generate clean transport structs without instantiating or storing an unused `inner: gaxi::http::ReqwestClient`, while preserving the exact existing structure and zero diffs for pure HTTP services.

This also removes some service annotations to minimize chances for skew between the methods that exist in the current filtered service and the corresponding annotation.

For googleapis/google-cloud-rust#6470