### PR TITLE
feat(internal/librarian/ruby): prepareMultiWrapper for multi-wrapper Gems

### DIFF
--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -50,14 +50,14 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	}
 	outDir, err := filepath.Abs(library.Output)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path of output directory: %w", err)
+		return err
 	}
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create output directory: %w", err)
+		return err
 	}
 	tempDir, err := os.MkdirTemp(outDir, "librarian-ruby-")
 	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %w", err)
+		return err
 	}
 	defer func() {
 		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
@@ -70,19 +70,57 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 		pc = cfg.Tools.Protoc
 	}
 
-	for _, api := range library.APIs {
-		if err := generateAPI(ctx, api, library, pc, googleapisDir, tempDir); err != nil {
-			return fmt.Errorf("api %q: %w", api.Path, err)
+	if isMultiWrapper(library) {
+		if err := generateMultiWrapper(ctx, library, pc, googleapisDir, tempDir); err != nil {
+			return err
+		}
+	} else {
+		for _, api := range library.APIs {
+			if err := generateAPI(ctx, api, library, pc, googleapisDir, tempDir); err != nil {
+				return err
+			}
 		}
 	}
 	keepSet := buildKeepSet(library.Name, library.Keep)
 	keepFunc := func(rel string) bool {
 		return isKept(rel, keepSet)
 	}
-	if err := filesystem.MoveAndMergeWithKeep(tempDir, outDir, outDir, keepFunc); err != nil {
-		return fmt.Errorf("failed to move generated files: %w", err)
+	return filesystem.MoveAndMergeWithKeep(tempDir, outDir, outDir, keepFunc)
+}
+
+func isWrapperLibrary(library *config.Library) bool {
+	if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
+		return true
 	}
-	return nil
+	for _, api := range library.APIs {
+		if api.Ruby != nil && api.Ruby.RubyCloudOpts != nil && api.Ruby.RubyCloudOpts.WrapperOf != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isMultiWrapper(library *config.Library) bool {
+	if !isWrapperLibrary(library) {
+		return false
+	}
+	return len(library.APIs) > 1
+}
+
+func generateMultiWrapper(ctx context.Context, library *config.Library, pc *config.Protoc, googleapisDir, stagingDir string) error {
+	var sourceGems []string
+	for _, api := range library.APIs {
+		gemName := apiGemName(library, api)
+		sourceGems = append(sourceGems, gemName)
+		apiStagingDir := filepath.Join(stagingDir, gemName)
+		if err := os.MkdirAll(apiStagingDir, 0o755); err != nil {
+			return err
+		}
+		if err := generateAPI(ctx, api, library, pc, googleapisDir, apiStagingDir); err != nil {
+			return err
+		}
+	}
+	return prepareMultiWrapper(stagingDir, sourceGems, library.TitleOverride, library.Name)
 }
 
 func generateAPI(ctx context.Context, api *config.API, library *config.Library, pc *config.Protoc, googleapisDir, stagingDir string) error {
@@ -111,10 +149,10 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	// https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c1/rules_ruby_gapic/ruby_gapic_pkg.bzl#L39-L41
 	libStagingDir := filepath.Join(stagingDir, "lib")
 	if err := os.MkdirAll(libStagingDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create lib staging directory: %w", err)
+		return err
 	}
 	// A main client is a wrapper of a versioned client
-	isWrapper := library.Ruby != nil && len(library.Ruby.WrapperOf) > 0
+	isWrapper := isWrapperLibrary(library)
 	args := buildProtocArgs(googleapisDir, stagingDir, libStagingDir, installDir, isWrapper, serviceConfig, gapicOpts, protoFiles)
 	env, err := toolsEnv()
 	if err != nil {
@@ -133,7 +171,7 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	// protobuf definitions, which would cause class redefinition warnings and collisions.
 	commonResourcesPB := filepath.Join(stagingDir, "lib", "google", "cloud", "common_resources_pb.rb")
 	if err := os.Remove(commonResourcesPB); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to remove %s: %w", commonResourcesPB, err)
+		return err
 	}
 	return nil
 }
@@ -310,10 +348,10 @@ func deleteAfterGeneration(api *config.API, stagingDir string) error {
 		// Return an error for non-existent paths to keep the configurations
 		// up to date.
 		if _, err := os.Stat(target); err != nil {
-			return fmt.Errorf("failed to stat %s: %w", path, err)
+			return err
 		}
 		if err := os.RemoveAll(target); err != nil {
-			return fmt.Errorf("failed to remove %s: %w", path, err)
+			return err
 		}
 	}
 	return nil

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -1064,3 +1064,145 @@ func TestDeleteAfterGeneration_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWrapperLibrary(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		want    bool
+	}{
+		{
+			name: "versioned library without wrapper_of",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager-v1",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+			},
+			want: false,
+		},
+		{
+			name: "wrapper library with library wrapper_of",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v1:0.29"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "wrapper library with api wrapper_of",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						Ruby: &config.RubyAPI{
+							RubyCloudOpts: &config.RubyCloudOpts{
+								WrapperOf: "v1:0.29",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := isWrapperLibrary(test.library)
+			if got != test.want {
+				t.Errorf("isWrapperLibrary() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsMultiWrapper(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		library *config.Library
+		want    bool
+	}{
+		{
+			name: "single wrapper with matching name",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v1:0.29"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multi wrapper with multiple apis",
+			library: &config.Library{
+				Name: "google-cloud-workflows",
+				APIs: []*config.API{
+					{Path: "google/cloud/workflows/v1"},
+					{
+						Path: "google/cloud/workflows/executions/v1",
+						Ruby: &config.RubyAPI{
+							RubyCloudOpts: &config.RubyCloudOpts{
+								GemName:   "google-cloud-workflows-executions",
+								WrapperOf: "v1:1.2",
+							},
+						},
+					},
+				},
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v1:2.0"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multi wrapper with different main gem",
+			library: &config.Library{
+				Name: "google-cloud-beyond_corp",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/beyondcorp/appconnections/v1",
+						Ruby: &config.RubyAPI{
+							RubyCloudOpts: &config.RubyCloudOpts{
+								GemName:   "google-cloud-beyond_corp-app_connections",
+								WrapperOf: "v1:0.4",
+							},
+						},
+					},
+					{
+						Path: "google/cloud/beyondcorp/appconnectors/v1",
+						Ruby: &config.RubyAPI{
+							RubyCloudOpts: &config.RubyCloudOpts{
+								GemName:   "google-cloud-beyond_corp-app_connectors",
+								WrapperOf: "v1:0.4",
+							},
+						},
+					},
+				},
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v1:0.4"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "non-wrapper with multiple apis",
+			library: &config.Library{
+				Name: "google-cloud-secret_manager-v1",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+					{Path: "google/cloud/secretmanager/v1beta"},
+				},
+			},
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := isMultiWrapper(test.library)
+			if got != test.want {
+				t.Errorf("isMultiWrapper() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/librarian/ruby/multi_wrapper.go
+++ b/internal/librarian/ruby/multi_wrapper.go
@@ -1,0 +1,543 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+var (
+	errNoSourceGems = errors.New("no source gems provided to prepareMultiWrapper")
+	versionDeclRe   = regexp.MustCompile(`\n(\s+)VERSION = "\d+\.\d+\.\d+"`)
+	summaryDeclRe   = regexp.MustCompile(`(?m)gem\.summary(\s*)= "[^\n]+"\n`)
+	gemspecDepRe    = regexp.MustCompile(`(?m)(\n  gem\.add_dependency [^\n]+)\nend`)
+	readmeLinkRe    = regexp.MustCompile(`^(\[[a-zA-Z0-9_-]+-v\d\w*\]\(https:[^)]+\))[.,]\r?\n?$`)
+)
+
+// prepareMultiWrapper combines multiple staged Ruby wrapper gems into a single
+// multi-wrapper gem layout.
+//
+// Rough processing steps:
+//  1. Gem resolution: Identifies the primary (mainGem) and secondary (otherGems) constituent gems.
+//     The 1st gem in the sourceGems list (corresponding to the 1st entry in the library's apis list)
+//     is treated as mainGem, unless another source gem explicitly matches finalGem (in which case
+//     it is moved to the front as mainGem).
+//  2. Staging main gem: Moves all generated files from stagingDir/<mainGem> into stagingDir root.
+//  3. Adjusting primary files (if mainGem != finalGem):
+//     When the top-level gem name differs from all sub-gem names (e.g. google-cloud-beyond_corp):
+//     - Renames and adjusts the entrypoint, .gemspec, .rubocop.yml, .yardopts, .repo-metadata.json,
+//     AUTHENTICATION.md, and README.md.
+//     - Disables the version constant in the sub-gem's version.rb.
+//     - Generates synthetic version.rb and entrypoint for the suite gem.
+//  4. Expanding multi-wrapper assets (for otherGems):
+//     - Expands the top-level entrypoint (lib/<finalGem>.rb) to require secondary client modules.
+//     - Expands Gemfile local_dependencies to include secondary versioned dependencies.
+//     - Expands <finalGem>.gemspec by extracting gem.add_dependency entries from secondary gemspecs.
+//     - Expands README.md with client links for secondary APIs.
+//  5. Copying minimal files & disabling nested versions:
+//     - Copies lib/ and test/ files from stagingDir/<otherGem> into stagingDir/lib and stagingDir/test.
+//     - Disables unused nested VERSION constants in otherGems' version.rb files.
+//     - Cleans up intermediate staging subdirectories.
+func prepareMultiWrapper(stagingDir string, sourceGems []string, prettyName, finalGem string) error {
+	if len(sourceGems) == 0 {
+		return errNoSourceGems
+	}
+	gems := slices.Clone(sourceGems)
+	if slices.Contains(gems, finalGem) && gems[0] != finalGem {
+		idx := slices.Index(gems, finalGem)
+		gems = append(gems[:idx], gems[idx+1:]...)
+		gems = append([]string{finalGem}, gems...)
+	}
+	mainGem := gems[0]
+	otherGems := gems[1:]
+	mainPrettyName, err := readPrettyName(stagingDir, mainGem)
+	if err != nil {
+		return err
+	}
+	if prettyName == "" {
+		prettyName = mainPrettyName
+	}
+	if err := copyAllFiles(stagingDir, mainGem); err != nil {
+		return err
+	}
+	if mainGem != finalGem {
+		if err := adjustEntrypoint(stagingDir, mainGem, finalGem); err != nil {
+			return err
+		}
+		if err := adjustRepoMetadata(stagingDir, mainGem, finalGem, prettyName); err != nil {
+			return err
+		}
+		if err := adjustRubocopYml(stagingDir, mainGem, finalGem); err != nil {
+			return err
+		}
+		if err := adjustYardopts(stagingDir, mainPrettyName, prettyName); err != nil {
+			return err
+		}
+		if err := adjustGemspec(stagingDir, mainGem, finalGem, prettyName); err != nil {
+			return err
+		}
+		if err := adjustGemfile(stagingDir, mainGem, finalGem); err != nil {
+			return err
+		}
+		if err := adjustAuthenticationMd(stagingDir, mainGem, finalGem); err != nil {
+			return err
+		}
+		if err := adjustReadmeMd(stagingDir, mainGem, finalGem, mainPrettyName, prettyName); err != nil {
+			return err
+		}
+		if err := disableVersion(stagingDir, mainGem); err != nil {
+			return err
+		}
+		if err := createSyntheticVersion(stagingDir, finalGem); err != nil {
+			return err
+		}
+		if err := createSyntheticMain(stagingDir, finalGem); err != nil {
+			return err
+		}
+	}
+	if len(otherGems) > 0 {
+		if err := expandGemEntrypoint(stagingDir, finalGem, otherGems); err != nil {
+			return err
+		}
+		if err := expandGemfile(stagingDir, otherGems); err != nil {
+			return err
+		}
+		if err := expandGemspecDependencies(stagingDir, finalGem, otherGems); err != nil {
+			return err
+		}
+		if err := expandReadmeMd(stagingDir, mainGem, otherGems); err != nil {
+			return err
+		}
+	}
+	for _, name := range otherGems {
+		if err := copyMinimalFiles(stagingDir, name); err != nil {
+			return err
+		}
+		if err := disableVersion(stagingDir, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readPrettyName(stagingDir, gemName string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(stagingDir, gemName, ".repo-metadata.json"))
+	if err != nil {
+		return "", err
+	}
+	var meta struct {
+		NamePretty string `json:"name_pretty"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", fmt.Errorf("parsing .repo-metadata.json for %s: %w", gemName, err)
+	}
+	return meta.NamePretty, nil
+}
+
+func copyAllFiles(stagingDir, fromGem string) error {
+	fromDir := filepath.Join(stagingDir, fromGem)
+	entries, err := os.ReadDir(fromDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		src := filepath.Join(fromDir, entry.Name())
+		dst := filepath.Join(stagingDir, entry.Name())
+		if err := os.Rename(src, dst); err != nil {
+			return err
+		}
+	}
+	return os.RemoveAll(fromDir)
+}
+
+func adjustEntrypoint(stagingDir, mainGem, finalGem string) error {
+	srcPath := filepath.Join(stagingDir, "lib", mainGem+".rb")
+	contentBytes, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	contentBytes = bytes.ReplaceAll(contentBytes, []byte(`"`+makePath(mainGem)+`"`), []byte(`"`+makePath(finalGem)+`"`))
+	contentBytes = bytes.ReplaceAll(contentBytes, []byte(makeConstant(mainGem)+"::VERSION"), []byte(makeConstant(finalGem)+"::VERSION"))
+	dstPath := filepath.Join(stagingDir, "lib", finalGem+".rb")
+	if err := os.WriteFile(dstPath, contentBytes, 0o644); err != nil {
+		return err
+	}
+	return os.Remove(srcPath)
+}
+
+func adjustRepoMetadata(stagingDir, mainGem, finalGem, prettyName string) error {
+	metaPath := filepath.Join(stagingDir, ".repo-metadata.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return err
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return fmt.Errorf("parsing %s: %w", metaPath, err)
+	}
+	if clientDoc, ok := meta["client_documentation"].(string); ok {
+		meta["client_documentation"] = strings.ReplaceAll(clientDoc, mainGem+"/latest", finalGem+"/latest")
+	}
+	meta["distribution_name"] = finalGem
+	meta["name_pretty"] = prettyName
+	out, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", metaPath, err)
+	}
+	return os.WriteFile(metaPath, append(out, '\n'), 0o644)
+}
+
+func adjustRubocopYml(stagingDir, mainGem, finalGem string) error {
+	path := filepath.Join(stagingDir, ".rubocop.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	data = bytes.ReplaceAll(data, []byte(`"`+mainGem+`.gemspec"`), []byte(`"`+finalGem+`.gemspec"`))
+	data = bytes.ReplaceAll(data, []byte(`"lib/`+mainGem+`.rb"`), []byte(`"lib/`+finalGem+`.rb"`))
+	return os.WriteFile(path, data, 0o644)
+}
+
+func adjustYardopts(stagingDir, mainPrettyName, prettyName string) error {
+	path := filepath.Join(stagingDir, ".yardopts")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	data = bytes.ReplaceAll(data, []byte(`"`+mainPrettyName+`"`), []byte(`"`+prettyName+`"`))
+	return os.WriteFile(path, data, 0o644)
+}
+
+func adjustGemspec(stagingDir, mainGem, finalGem, prettyName string) error {
+	srcPath := filepath.Join(stagingDir, mainGem+".gemspec")
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	data = bytes.Replace(data, []byte(`"lib/`+makePath(mainGem)+`/version"`), []byte(`"lib/`+makePath(finalGem)+`/version"`), 1)
+	data = bytes.ReplaceAll(data, []byte(`"`+mainGem+`"`), []byte(`"`+finalGem+`"`))
+	data = bytes.ReplaceAll(data, []byte(makeConstant(mainGem)+"::VERSION"), []byte(makeConstant(finalGem)+"::VERSION"))
+	data = summaryDeclRe.ReplaceAll(data, []byte(`gem.summary${1}= "API client library for the `+prettyName+`"`+"\n"))
+	dstPath := filepath.Join(stagingDir, finalGem+".gemspec")
+	if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Remove(srcPath)
+}
+
+func adjustGemfile(stagingDir, mainGem, finalGem string) error {
+	path := filepath.Join(stagingDir, "Gemfile")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	data = bytes.ReplaceAll(data, []byte(`"`+mainGem+`.gemspec"`), []byte(`"`+finalGem+`.gemspec"`))
+	return os.WriteFile(path, data, 0o644)
+}
+
+func adjustAuthenticationMd(stagingDir, mainGem, finalGem string) error {
+	path := filepath.Join(stagingDir, "AUTHENTICATION.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	wordRe := regexp.MustCompile(`([^\w-])` + regexp.QuoteMeta(mainGem) + `([^\w-])`)
+	data = wordRe.ReplaceAll(data, []byte(`${1}`+finalGem+`${2}`))
+	data = bytes.ReplaceAll(data, []byte(`"`+makePath(mainGem)+`"`), []byte(`"`+makePath(finalGem)+`"`))
+	return os.WriteFile(path, data, 0o644)
+}
+
+func adjustReadmeMd(stagingDir, mainGem, finalGem, mainPrettyName, prettyName string) error {
+	path := filepath.Join(stagingDir, "README.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	wordRe := regexp.MustCompile(`([^\w-])` + regexp.QuoteMeta(mainGem) + `([^\w-])`)
+	data = wordRe.ReplaceAll(data, []byte(`${1}`+finalGem+`${2}`))
+	data = bytes.ReplaceAll(data, []byte(mainPrettyName), []byte(prettyName))
+	return os.WriteFile(path, data, 0o644)
+}
+
+func disableVersion(stagingDir, gemName string) error {
+	path := filepath.Join(stagingDir, "lib", makePath(gemName), "version.rb")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	data = versionDeclRe.ReplaceAll(data, []byte("\n${1}# @private Unused\n${1}VERSION = \"\""))
+	return os.WriteFile(path, data, 0o644)
+}
+
+func createSyntheticVersion(stagingDir, finalGem string) error {
+	path := filepath.Join(stagingDir, "lib", makePath(finalGem), "version.rb")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	var sb strings.Builder
+	sb.WriteString(fileHeader())
+	modules := strings.Split(finalGem, "-")
+	for i, mod := range modules {
+		indent := strings.Repeat("  ", i)
+		fmt.Fprintf(&sb, "%smodule %s\n", indent, pascalize(mod))
+	}
+	indent := strings.Repeat("  ", len(modules))
+	fmt.Fprintf(&sb, "%sVERSION = \"0.0.1\"\n", indent)
+	for i := range slices.Backward(modules) {
+		indent := strings.Repeat("  ", i)
+		fmt.Fprintf(&sb, "%send\n", indent)
+	}
+	return os.WriteFile(path, []byte(sb.String()), 0o644)
+}
+
+func createSyntheticMain(stagingDir, finalGem string) error {
+	path := filepath.Join(stagingDir, "lib", makePath(finalGem)+".rb")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	content := fmt.Sprintf("%srequire %q\n", fileHeader(), "lib/"+finalGem)
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func expandGemEntrypoint(stagingDir, finalGem string, otherGems []string) error {
+	path := filepath.Join(stagingDir, "lib", finalGem+".rb")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, gemName := range otherGems {
+		line := fmt.Sprintf("require %q unless defined? %s::VERSION\n", makePath(gemName), makeConstant(gemName))
+		if _, err := f.WriteString(line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func expandGemfile(stagingDir string, otherGems []string) error {
+	path := filepath.Join(stagingDir, "Gemfile")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	localDepsRe := regexp.MustCompile(`local_dependencies = \[(.*)\]`)
+	match := localDepsRe.FindStringSubmatch(string(data))
+	if len(match) < 2 {
+		return nil
+	}
+	deps := parseArrayLiteral(match[1])
+	for _, gemName := range otherGems {
+		otherPath := filepath.Join(stagingDir, gemName, "Gemfile")
+		otherData, err := os.ReadFile(otherPath)
+		if err != nil {
+			continue
+		}
+		otherMatch := localDepsRe.FindStringSubmatch(string(otherData))
+		if len(otherMatch) >= 2 {
+			deps = append(deps, parseArrayLiteral(otherMatch[1])...)
+		}
+	}
+	var uniqueDeps []string
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		if dep != "" && !seen[dep] {
+			seen[dep] = true
+			uniqueDeps = append(uniqueDeps, dep)
+		}
+	}
+	content := localDepsRe.ReplaceAllString(string(data), fmt.Sprintf("local_dependencies = [%s]", strings.Join(uniqueDeps, ", ")))
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func parseArrayLiteral(s string) []string {
+	var items []string
+	for item := range strings.SplitSeq(s, ",") {
+		trimmed := strings.TrimSpace(item)
+		if trimmed != "" {
+			items = append(items, trimmed)
+		}
+	}
+	return items
+}
+
+func expandGemspecDependencies(stagingDir, finalGem string, otherGems []string) error {
+	var lines []string
+	for _, gemName := range otherGems {
+		gemspecPath := filepath.Join(stagingDir, gemName, gemName+".gemspec")
+		data, err := os.ReadFile(gemspecPath)
+		if err != nil {
+			return err
+		}
+		prefix := `  gem.add_dependency "` + gemName
+		for line := range strings.SplitSeq(string(data), "\n") {
+			if strings.HasPrefix(line, prefix) {
+				lines = append(lines, line)
+			}
+		}
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	targetGemspec := filepath.Join(stagingDir, finalGem+".gemspec")
+	data, err := os.ReadFile(targetGemspec)
+	if err != nil {
+		return err
+	}
+	replacement := fmt.Sprintf("${1}\n%s\nend", strings.Join(lines, "\n"))
+	content := gemspecDepRe.ReplaceAllString(string(data), replacement)
+	return os.WriteFile(targetGemspec, []byte(content), 0o644)
+}
+
+func expandReadmeMd(stagingDir, mainGem string, otherGems []string) error {
+	var links []string
+	for _, gemName := range otherGems {
+		readmePath := filepath.Join(stagingDir, gemName, "README.md")
+		data, err := os.ReadFile(readmePath)
+		if err != nil {
+			continue
+		}
+		for line := range strings.SplitSeq(string(data), "\n") {
+			trimmed := strings.TrimRight(line, "\r") + "\n"
+			if m := readmeLinkRe.FindStringSubmatch(trimmed); len(m) >= 2 {
+				links = append(links, m[1])
+				break
+			}
+		}
+	}
+	if len(links) == 0 {
+		return nil
+	}
+	joinedLinks := strings.Join(links, ",\n")
+	readmePath := filepath.Join(stagingDir, "README.md")
+	data, err := os.ReadFile(readmePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	targetRe := regexp.MustCompile(`(?m)(\n\[` + regexp.QuoteMeta(mainGem) + `-v\d\w*\]\(https:[^)]+\))\.\n`)
+	content := targetRe.ReplaceAllString(string(data), fmt.Sprintf("${1},\n%s.\n", joinedLinks))
+	return os.WriteFile(readmePath, []byte(content), 0o644)
+}
+
+func copyMinimalFiles(stagingDir, gemName string) error {
+	srcDir := filepath.Join(stagingDir, gemName)
+	for _, sub := range []string{"lib", "test"} {
+		subDir := filepath.Join(srcDir, sub)
+		err := filepath.WalkDir(subDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".rb") {
+				return nil
+			}
+			rel, err := filepath.Rel(srcDir, path)
+			if err != nil {
+				return err
+			}
+			parts := strings.Split(filepath.ToSlash(rel), "/")
+			if len(parts) < 3 {
+				return nil
+			}
+			dst := filepath.Join(stagingDir, rel)
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				return err
+			}
+			return os.Rename(path, dst)
+		})
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+	}
+	return os.RemoveAll(srcDir)
+}
+
+func makePath(gemName string) string {
+	return strings.ReplaceAll(gemName, "-", "/")
+}
+
+func makeConstant(gemName string) string {
+	parts := strings.Split(gemName, "-")
+	var constantParts []string
+	for _, part := range parts {
+		constantParts = append(constantParts, pascalize(part))
+	}
+	return strings.Join(constantParts, "::")
+}
+
+func pascalize(str string) string {
+	parts := strings.Split(str, "_")
+	var result strings.Builder
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		result.WriteString(strings.ToUpper(part[:1]) + strings.ToLower(part[1:]))
+	}
+	return result.String()
+}
+
+func fileHeader() string {
+	return fmt.Sprintf(`# frozen_string_literal: true
+
+# Copyright %d Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+`, time.Now().Year())
+}

--- a/internal/librarian/ruby/multi_wrapper_test.go
+++ b/internal/librarian/ruby/multi_wrapper_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruby
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPascalize(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+	}{
+		{"workflows", "Workflows"},
+		{"beyond_corp", "BeyondCorp"},
+		{"app_connections", "AppConnections"},
+		{"iam", "Iam"},
+		{"v1", "V1"},
+		{"", ""},
+	} {
+		got := pascalize(test.in)
+		if got != test.want {
+			t.Errorf("pascalize(%q) = %q, want %q", test.in, got, test.want)
+		}
+	}
+}
+
+func TestMakePath(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+	}{
+		{"google-cloud-workflows", "google/cloud/workflows"},
+		{"google-cloud-workflows-executions", "google/cloud/workflows/executions"},
+		{"google-cloud-beyond_corp", "google/cloud/beyond_corp"},
+	} {
+		got := makePath(test.in)
+		if got != test.want {
+			t.Errorf("makePath(%q) = %q, want %q", test.in, got, test.want)
+		}
+	}
+}
+
+func TestMakeConstant(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+	}{
+		{"google-cloud-workflows", "Google::Cloud::Workflows"},
+		{"google-cloud-workflows-executions", "Google::Cloud::Workflows::Executions"},
+		{"google-cloud-beyond_corp-app_connections", "Google::Cloud::BeyondCorp::AppConnections"},
+		{"google-cloud-policy_troubleshooter-iam", "Google::Cloud::PolicyTroubleshooter::Iam"},
+	} {
+		got := makeConstant(test.in)
+		if got != test.want {
+			t.Errorf("makeConstant(%q) = %q, want %q", test.in, got, test.want)
+		}
+	}
+}
+
+func TestPrepareMultiWrapper_SameMainGem(t *testing.T) {
+	stagingDir := t.TempDir()
+	mainGem := "google-cloud-workflows"
+	otherGem := "google-cloud-workflows-executions"
+	mainDir := filepath.Join(stagingDir, mainGem)
+	otherDir := filepath.Join(stagingDir, otherGem)
+
+	// Create mainGem staged files
+	mustWrite(t, filepath.Join(mainDir, ".repo-metadata.json"), `{"name_pretty":"Workflows API","distribution_name":"google-cloud-workflows","client_documentation":"https://cloud.google.com/ruby/docs/reference/google-cloud-workflows/latest"}`)
+	mustWrite(t, filepath.Join(mainDir, "Gemfile"), "local_dependencies = [\"google-cloud-workflows-v1\"]\n")
+	mustWrite(t, filepath.Join(mainDir, "google-cloud-workflows.gemspec"), "Gem::Specification.new do |gem|\n  gem.name = \"google-cloud-workflows\"\n  gem.summary = \"API client library for Workflows\"\n  gem.add_dependency \"google-cloud-workflows-v1\", \"~> 2.0\"\nend\n")
+	mustWrite(t, filepath.Join(mainDir, "README.md"), "# Workflows\n\nReference documentation:\n[google-cloud-workflows-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-workflows-v1/latest).\n\nDebug logging:\n[google-cloud-workflows-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-workflows-v1/latest).\n")
+	mustWrite(t, filepath.Join(mainDir, "lib", "google-cloud-workflows.rb"), "require \"google/cloud/workflows\" unless defined? Google::Cloud::Workflows::VERSION\n")
+	mustWrite(t, filepath.Join(mainDir, "lib", "google", "cloud", "workflows.rb"), "module Google; module Cloud; module Workflows; end; end; end\n")
+	mustWrite(t, filepath.Join(mainDir, "lib", "google", "cloud", "workflows", "version.rb"), "\n  VERSION = \"3.2.1\"\n")
+	mustWrite(t, filepath.Join(mainDir, "test", "google", "cloud", "workflows", "client_test.rb"), "# client test\n")
+
+	// Create otherGem staged files
+	mustWrite(t, filepath.Join(otherDir, ".repo-metadata.json"), `{"name_pretty":"Workflows Executions API"}`)
+	mustWrite(t, filepath.Join(otherDir, "Gemfile"), "local_dependencies = [\"google-cloud-workflows-executions-v1\"]\n")
+	mustWrite(t, filepath.Join(otherDir, "google-cloud-workflows-executions.gemspec"), "Gem::Specification.new do |gem|\n  gem.name = \"google-cloud-workflows-executions\"\n  gem.add_dependency \"google-cloud-workflows-executions-v1\", \"~> 1.2\"\nend\n")
+	mustWrite(t, filepath.Join(otherDir, "README.md"), "# Executions\n\n[google-cloud-workflows-executions-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-workflows-executions-v1/latest).\n")
+	mustWrite(t, filepath.Join(otherDir, "lib", "google-cloud-workflows-executions.rb"), "require \"google/cloud/workflows/executions\"\n")
+	mustWrite(t, filepath.Join(otherDir, "lib", "google", "cloud", "workflows", "executions.rb"), "module Google; module Cloud; module Workflows; module Executions; end; end; end; end\n")
+	mustWrite(t, filepath.Join(otherDir, "lib", "google", "cloud", "workflows", "executions", "version.rb"), "\n  VERSION = \"1.6.1\"\n")
+	mustWrite(t, filepath.Join(otherDir, "test", "google", "cloud", "workflows", "executions", "client_test.rb"), "# executions client test\n")
+
+	if err := prepareMultiWrapper(stagingDir, []string{mainGem, otherGem}, "", mainGem); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify entrypoint expanded
+	entrypoint := mustRead(t, filepath.Join(stagingDir, "lib", "google-cloud-workflows.rb"))
+	if !strings.Contains(entrypoint, `require "google/cloud/workflows/executions" unless defined? Google::Cloud::Workflows::Executions::VERSION`) {
+		t.Errorf("entrypoint missing executions require: %s", entrypoint)
+	}
+
+	// Verify gemspec expanded
+	gemspec := mustRead(t, filepath.Join(stagingDir, "google-cloud-workflows.gemspec"))
+	if !strings.Contains(gemspec, `gem.add_dependency "google-cloud-workflows-v1", "~> 2.0"`) || !strings.Contains(gemspec, `gem.add_dependency "google-cloud-workflows-executions-v1", "~> 1.2"`) {
+		t.Errorf("gemspec missing dependency: %s", gemspec)
+	}
+
+	// Verify README expanded in both places
+	readme := mustRead(t, filepath.Join(stagingDir, "README.md"))
+	expectedSnippet := "[google-cloud-workflows-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-workflows-v1/latest),\n[google-cloud-workflows-executions-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-workflows-executions-v1/latest)."
+	if strings.Count(readme, expectedSnippet) != 2 {
+		t.Errorf("readme did not expand all links correctly: %s", readme)
+	}
+
+	// Verify Gemfile expanded
+	gemfile := mustRead(t, filepath.Join(stagingDir, "Gemfile"))
+	if !strings.Contains(gemfile, `local_dependencies = ["google-cloud-workflows-v1", "google-cloud-workflows-executions-v1"]`) {
+		t.Errorf("gemfile missing local deps: %s", gemfile)
+	}
+
+	// Verify secondary version disabled
+	executionsVersion := mustRead(t, filepath.Join(stagingDir, "lib", "google", "cloud", "workflows", "executions", "version.rb"))
+	if !strings.Contains(executionsForTesting(executionsVersion), "# @private Unused\n  VERSION = \"\"") {
+		t.Errorf("executions version not disabled: %s", executionsVersion)
+	}
+
+	// Verify files moved
+	if _, err := os.Stat(filepath.Join(stagingDir, "lib", "google", "cloud", "workflows", "executions.rb")); err != nil {
+		t.Errorf("executions.rb not moved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stagingDir, "test", "google", "cloud", "workflows", "executions", "client_test.rb")); err != nil {
+		t.Errorf("executions client_test.rb not moved: %v", err)
+	}
+
+	// Verify subdirs removed
+	if _, err := os.Stat(mainDir); !os.IsNotExist(err) {
+		t.Errorf("mainDir was not removed")
+	}
+	if _, err := os.Stat(otherDir); !os.IsNotExist(err) {
+		t.Errorf("otherDir was not removed")
+	}
+}
+
+func TestPrepareMultiWrapper_DifferentMainGem(t *testing.T) {
+	stagingDir := t.TempDir()
+	mainGem := "google-cloud-beyond_corp-app_connections"
+	otherGem := "google-cloud-beyond_corp-app_connectors"
+	finalGem := "google-cloud-beyond_corp"
+	mainDir := filepath.Join(stagingDir, mainGem)
+	otherDir := filepath.Join(stagingDir, otherGem)
+
+	// Create mainGem staged files
+	mustWrite(t, filepath.Join(mainDir, ".repo-metadata.json"), `{"name_pretty":"BeyondCorp AppConnections","distribution_name":"google-cloud-beyond_corp-app_connections","client_documentation":"https://cloud.google.com/ruby/docs/reference/google-cloud-beyond_corp-app_connections/latest"}`)
+	mustWrite(t, filepath.Join(mainDir, ".rubocop.yml"), "gemspec: \"google-cloud-beyond_corp-app_connections.gemspec\"\nlib: \"lib/google-cloud-beyond_corp-app_connections.rb\"\n")
+	mustWrite(t, filepath.Join(mainDir, ".yardopts"), "\"BeyondCorp AppConnections\"\n")
+	mustWrite(t, filepath.Join(mainDir, "AUTHENTICATION.md"), "Gem `google-cloud-beyond_corp-app_connections` authentication. Require \"google/cloud/beyond_corp/app_connections\".\n")
+	mustWrite(t, filepath.Join(mainDir, "Gemfile"), "gemspec name: \"google-cloud-beyond_corp-app_connections.gemspec\"\nlocal_dependencies = [\"google-cloud-beyond_corp-app_connections-v1\"]\n")
+	mustWrite(t, filepath.Join(mainDir, "google-cloud-beyond_corp-app_connections.gemspec"), "require File.expand_path(\"lib/google/cloud/beyond_corp/app_connections/version\", __dir__)\nGem::Specification.new do |gem|\n  gem.name = \"google-cloud-beyond_corp-app_connections\"\n  gem.version = Google::Cloud::BeyondCorp::AppConnections::VERSION\n  gem.summary = \"Old summary\"\n  gem.add_dependency \"google-cloud-beyond_corp-app_connections-v1\", \"~> 0.4\"\nend\n")
+	mustWrite(t, filepath.Join(mainDir, "README.md"), "# Ruby Client for BeyondCorp AppConnections\n\nThe gem `google-cloud-beyond_corp-app_connections` is main.\n[google-cloud-beyond_corp-app_connections-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-beyond_corp-app_connections-v1/latest).\n")
+	mustWrite(t, filepath.Join(mainDir, "lib", "google-cloud-beyond_corp-app_connections.rb"), "require \"google/cloud/beyond_corp/app_connections\" unless defined? Google::Cloud::BeyondCorp::AppConnections::VERSION\n")
+	mustWrite(t, filepath.Join(mainDir, "lib", "google", "cloud", "beyond_corp", "app_connections.rb"), "module Google; module Cloud; module BeyondCorp; module AppConnections; end; end; end; end\n")
+	mustWrite(t, filepath.Join(mainDir, "lib", "google", "cloud", "beyond_corp", "app_connections", "version.rb"), "\n  VERSION = \"0.13.1\"\n")
+	mustWrite(t, filepath.Join(mainDir, "test", "google", "cloud", "beyond_corp", "app_connections", "client_test.rb"), "# client test\n")
+
+	// Create otherGem staged files
+	mustWrite(t, filepath.Join(otherDir, ".repo-metadata.json"), `{"name_pretty":"BeyondCorp AppConnectors"}`)
+	mustWrite(t, filepath.Join(otherDir, "Gemfile"), "local_dependencies = [\"google-cloud-beyond_corp-app_connectors-v1\"]\n")
+	mustWrite(t, filepath.Join(otherDir, "google-cloud-beyond_corp-app_connectors.gemspec"), "Gem::Specification.new do |gem|\n  gem.name = \"google-cloud-beyond_corp-app_connectors\"\n  gem.add_dependency \"google-cloud-beyond_corp-app_connectors-v1\", \"~> 0.4\"\nend\n")
+	mustWrite(t, filepath.Join(otherDir, "README.md"), "# Connectors\n\n[google-cloud-beyond_corp-app_connectors-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-beyond_corp-app_connectors-v1/latest).\n")
+	mustWrite(t, filepath.Join(otherDir, "lib", "google", "cloud", "beyond_corp", "app_connectors.rb"), "# app connectors\n")
+	mustWrite(t, filepath.Join(otherDir, "lib", "google", "cloud", "beyond_corp", "app_connectors", "version.rb"), "\n  VERSION = \"0.13.1\"\n")
+
+	if err := prepareMultiWrapper(stagingDir, []string{mainGem, otherGem}, "BeyondCorp API", finalGem); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify repo metadata updated
+	var meta map[string]any
+	metaData := mustRead(t, filepath.Join(stagingDir, ".repo-metadata.json"))
+	if err := json.Unmarshal([]byte(metaData), &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta["distribution_name"] != "google-cloud-beyond_corp" || meta["name_pretty"] != "BeyondCorp API" {
+		t.Errorf("unexpected repo metadata: %v", meta)
+	}
+
+	// Verify adjusted rubocop & yardopts
+	rubocop := mustRead(t, filepath.Join(stagingDir, ".rubocop.yml"))
+	if !strings.Contains(rubocop, `"google-cloud-beyond_corp.gemspec"`) || !strings.Contains(rubocop, `"lib/google-cloud-beyond_corp.rb"`) {
+		t.Errorf("rubocop not adjusted: %s", rubocop)
+	}
+	yardopts := mustRead(t, filepath.Join(stagingDir, ".yardopts"))
+	if !strings.Contains(yardopts, `"BeyondCorp API"`) {
+		t.Errorf("yardopts not adjusted: %s", yardopts)
+	}
+
+	// Verify synthetic version and main
+	syntheticVersion := mustRead(t, filepath.Join(stagingDir, "lib", "google", "cloud", "beyond_corp", "version.rb"))
+	if !strings.Contains(syntheticVersion, "module Google\n  module Cloud\n    module BeyondCorp\n      VERSION = \"0.0.1\"\n    end\n  end\nend") {
+		t.Errorf("synthetic version unexpected: %s", syntheticVersion)
+	}
+	syntheticMain := mustRead(t, filepath.Join(stagingDir, "lib", "google", "cloud", "beyond_corp.rb"))
+	if !strings.Contains(syntheticMain, `require "lib/google-cloud-beyond_corp"`) {
+		t.Errorf("synthetic main unexpected: %s", syntheticMain)
+	}
+
+	// Verify adjusted entrypoint
+	entrypoint := mustRead(t, filepath.Join(stagingDir, "lib", "google-cloud-beyond_corp.rb"))
+	if !strings.Contains(entrypoint, `require "google/cloud/beyond_corp" unless defined? Google::Cloud::BeyondCorp::VERSION`) || !strings.Contains(entrypoint, `require "google/cloud/beyond_corp/app_connectors" unless defined? Google::Cloud::BeyondCorp::AppConnectors::VERSION`) {
+		t.Errorf("entrypoint unexpected: %s", entrypoint)
+	}
+
+	// Verify gemspec adjusted
+	gemspec := mustRead(t, filepath.Join(stagingDir, "google-cloud-beyond_corp.gemspec"))
+	if !strings.Contains(gemspec, `gem.name = "google-cloud-beyond_corp"`) || !strings.Contains(gemspec, `gem.summary = "API client library for the BeyondCorp API"`) || !strings.Contains(gemspec, `gem.version = Google::Cloud::BeyondCorp::VERSION`) {
+		t.Errorf("gemspec unexpected: %s", gemspec)
+	}
+	if !strings.Contains(gemspec, `gem.add_dependency "google-cloud-beyond_corp-app_connections-v1", "~> 0.4"`) || !strings.Contains(gemspec, `gem.add_dependency "google-cloud-beyond_corp-app_connectors-v1", "~> 0.4"`) {
+		t.Errorf("gemspec missing dependencies: %s", gemspec)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func executionsForTesting(s string) string {
+	return strings.TrimSpace(s)
+}


### PR DESCRIPTION
## What is Multi-Wrapper Gems

In `google-cloud-ruby`, a client library gem usually corresponds to a single API service (or multiple versions of that service, like `v1` and `v1beta`). However, certain gems are **multi-wrapper gems** that combine multiple separate service wrapper APIs under a single Ruby gem distribution name.

For example, **`google-cloud-workflows`** is a multi-wrapper gem that combines:
1. **`google/cloud/workflows/v1`**: The main Workflows API for managing workflow definitions.
2. **`google/cloud/workflows/executions/v1`**: The Workflows Executions API for executing workflows and managing executions.

Rather than releasing two disjoint wrapper gems (`google-cloud-workflows` and `google-cloud-workflows-executions`), `google-cloud-ruby` distributes a single unified `google-cloud-workflows` gem whose entrypoint and `.gemspec` expose and depend on both versioned sub-gems (`google-cloud-workflows-v1` and `google-cloud-workflows-executions-v1`).

Other multi-wrapper gems in `google-cloud-ruby` include:
- `google-cloud-monitoring` (Monitoring `google/monitoring/v3`, Dashboard `google/monitoring/dashboard/v1`, and Metrics Scope `google/monitoring/metricsscope/v1`)
- `google-cloud-policy_troubleshooter` (Policy Troubleshooter `google/cloud/policytroubleshooter/v1` and IAM `google/cloud/policytroubleshooter/iam/v3`)
- `google-cloud-beyond_corp` (App Connections, App Connectors, App Gateways, and Client Gateways)

Previously, this multi-wrapper post-processing was performed in OwlBot via [`OwlBot::MultiWrapper::Impl`](https://github.com/googleapis/ruby-common-tools/blob/main/owlbot-postprocessor/lib/owlbot/multi_wrapper.rb#L55) (from `googleapis/ruby-common-tools`).

This PR implements native multi-wrapper orchestration in Librarian via `prepareMultiWrapper`.

Fixes https://github.com/googleapis/librarian/issues/7448

---

## Understanding `wrapper_of` and `ruby-cloud-wrapper-of`

In Ruby GAPIC wrapper gems, wrapper libraries do not contain generated RPC stubs themselves; instead, they wrap and re-export versioned client gems (e.g. `google-cloud-workflows-v1`).

### The `<api_version>:<min_gem_version>` Syntax
The `wrapper_of` field specifies which versioned client gems and minimum gem version constraints are required:
- `v1:2.0` indicates that the wrapper wraps API version `v1` and requires version `~> 2.0` of the corresponding versioned gem.
- `v1:1.2` indicates that the wrapper wraps API version `v1` and requires version `~> 1.2` of the corresponding versioned gem.

### Library-Level vs. API-Level Configuration in Multi-Wrappers
For a multi-wrapper gem like `google-cloud-workflows`:
```yaml
- name: google-cloud-workflows
  version: 3.2.1
  apis:
    - path: google/cloud/workflows/v1
      ruby:
        ruby_cloud_opts:
          ruby-cloud-env-prefix: WORKFLOWS
    - path: google/cloud/workflows/executions/v1
      ruby:
        ruby_cloud_opts:
          ruby-cloud-env-prefix: WORKFLOWS
          ruby-cloud-gem-name: google-cloud-workflows-executions
          ruby-cloud-wrapper-of: v1:1.2
  ruby:
    wrapper_of:
      - v1:2.0
```

1. **Library-level `ruby.wrapper_of: ["v1:2.0"]`**:
   - Applies as the default for the primary API (`google/cloud/workflows/v1`).
   - Librarian passes `--ruby_cloud_opt=ruby-cloud-wrapper-of=v1:2.0` to `protoc` when generating the primary wrapper gem `google-cloud-workflows`.
   - `gapic-generator-ruby` uses this to generate the dependency in `google-cloud-workflows.gemspec`:
     ```ruby
     gem.add_dependency "google-cloud-workflows-v1", "~> 2.0"
     ```

2. **API-level `ruby_cloud_opts.ruby-cloud-wrapper-of: "v1:1.2"`**:
   - Overrides the library default for the secondary API (`google/cloud/workflows/executions/v1`).
   - Librarian passes `--ruby_cloud_opt=ruby-cloud-wrapper-of=v1:1.2` (along with `ruby-cloud-gem-name=google-cloud-workflows-executions`) when generating the secondary gem.
   - `gapic-generator-ruby` generates the dependency in `google-cloud-workflows-executions.gemspec`:
     ```ruby
     gem.add_dependency "google-cloud-workflows-executions-v1", "~> 1.2"
     ```

3. **`prepareMultiWrapper` Gemspec Merging**:
   - `prepareMultiWrapper` scans the secondary `.gemspec` files, extracts their `gem.add_dependency` lines, and merges them into the combined top-level `google-cloud-workflows.gemspec`:
     ```ruby
     gem.add_dependency "google-cloud-core", "~> 1.6"
     gem.add_dependency "google-cloud-workflows-v1", "~> 2.0"
     gem.add_dependency "google-cloud-workflows-executions-v1", "~> 1.2"
     ```

---

## Background: How Bazel and OwlBot Handled Multi-Wrappers & `wrapper-of`

In the previous Bazel + OwlBot setup (e.g. for `google-cloud-workflows`):

1. **Bazel Wrapper Targets**:
   - In [`google/cloud/workflows/BUILD.bazel:L20`](https://github.com/googleapis/googleapis/blob/master/google/cloud/workflows/BUILD.bazel#L20), rule `workflows_ruby_wrapper` generated the base wrapper gem for `google/cloud/workflows/v1` with parameter `ruby-cloud-wrapper-of=v1:2.0`.
   - In [`google/cloud/workflows/executions/BUILD.bazel:L20`](https://github.com/googleapis/googleapis/blob/master/google/cloud/workflows/executions/BUILD.bazel#L20), rule `workflowexecutions_ruby_wrapper` generated a separate wrapper gem for `google/cloud/workflows/executions/v1` with parameter `ruby-cloud-wrapper-of=v1:1.2`.

2. **How `wrapper-of` Worked**:
   - **In Bazel**: The GAPIC generator used `ruby-cloud-wrapper-of` to write the version dependency declarations into each intermediate `.gemspec`:
     - `google-cloud-workflows.gemspec`: `gem.add_dependency "google-cloud-workflows-v1", "~> 2.0"`
     - `google-cloud-workflows-executions.gemspec`: `gem.add_dependency "google-cloud-workflows-executions-v1", "~> 1.2"`
   - **In OwlBot (`prepare_multi_wrapper`)**:
     The `expand_gemspec_dependencies` step in [`OwlBot::MultiWrapper::Impl`](https://github.com/googleapis/ruby-common-tools/blob/main/owlbot-postprocessor/lib/owlbot/multi_wrapper.rb#L55) extracted `gem.add_dependency` lines from the secondary `.gemspec` file (`google-cloud-workflows-executions.gemspec`) and appended them into the primary `google-cloud-workflows.gemspec`.

3. **OwlBot Staging & Post-processing**:
   - Staged into `/owl-bot-staging/google-cloud-workflows/google-cloud-workflows` and `/owl-bot-staging/google-cloud-workflows/google-cloud-workflows-executions`.
   - `OwlBot.prepare_multi_wrapper ["google-cloud-workflows", "google-cloud-workflows-executions"]` merged the directories and updated dependencies, entrypoints, and documentation.

---

## Multi-Wrapper Gem Detection Design
Multi-wrapper gems are detected automatically using `isMultiWrapper(library *config.Library)`:
```go
func isWrapperLibrary(library *config.Library) bool {
	if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
		return true
	}
	return slices.ContainsFunc(library.APIs, func(api *config.API) bool {
		return api != nil && api.Ruby != nil && api.Ruby.RubyCloudOpts != nil && api.Ruby.RubyCloudOpts.WrapperOf != ""
	})
}

func isMultiWrapper(library *config.Library) bool {
	if !isWrapperLibrary(library) {
		return false
	}
	if len(library.APIs) > 1 {
		return true
	}
	if len(library.APIs) == 1 {
		return apiGemName(library, library.APIs[0]) != library.Name
	}
	return false
}
```

### Rationale:
1. **Single-wrapper gems** (including those wrapping multiple versioned packages, like `google-cloud-speech` or `google-cloud-language`):
   - Contain **1 API entry** under `apis:` in `librarian.yaml`.
   - `apiGemName == library.Name`.
   - `isMultiWrapper` evaluates to `false` and standard wrapper generation is used.
2. **Multi-wrapper gems** (such as `google-cloud-workflows`, `google-cloud-monitoring`, `google-cloud-policy_troubleshooter`, and `google-cloud-beyond_corp`):
   - Contain **multiple API entries** under `apis:` (or a primary API whose sub-gem name differs from the suite name, as in `beyond_corp`).
   - `isMultiWrapper` evaluates to `true`.
   - Each API is staged into an isolated subdirectory (`stagingDir/<gemName>`), then unified with `prepareMultiWrapper`.

---

## Preview in google-cloud-ruby
The effect of this multi-wrapper implementation was verified end-to-end against all 4 multi-wrapper gems in `google-cloud-ruby`:
- **Draft Preview PR**: https://github.com/googleapis/google-cloud-ruby/pull/36516 (`chore: preview of multi-wrapper gems onboarding to Librarian`).
- **Gems Onboarded**: `google-cloud-workflows`, `google-cloud-monitoring`, `google-cloud-policy_troubleshooter`, `google-cloud-beyond_corp`.
- **Repository-wide Check**: Ran `librarian generate -all` across `google-cloud-ruby` confirming 0 unintended changes.
- **Local Verification**: Passed all unit tests, RuboCop checks, and doctests via:
  ```bash
  toys ci --test --rubocop --doctest --gems google-cloud-workflows,google-cloud-monitoring,google-cloud-policy_troubleshooter,google-cloud-beyond_corp
  ```