### PR TITLE
fix(internal/sidekick/rust): skip doc links for omitted methods and services

### DIFF
--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -1329,7 +1329,7 @@ func (c *codec) tryDocLinkWithId(id string, model *api.API, scope string) (strin
 		return c.methodRustdocLink(me, model), nil
 	}
 	if s := model.Service(id); s != nil {
-		return c.serviceRustdocLink(s), nil
+		return c.serviceRustdocLink(s, model), nil
 	}
 	rdLink, err := c.tryFieldRustdocLink(id, model, scope)
 	if err != nil {
@@ -1432,14 +1432,24 @@ func (c *codec) methodRustdocLink(m *api.Method, model *api.API) string {
 	if s == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s::%s", c.serviceRustdocLink(s), toSnake(m.Name))
+	if !slices.Contains(s.Methods, m) {
+		return ""
+	}
+	serviceLink := c.serviceRustdocLink(s, model)
+	if serviceLink == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s::%s", serviceLink, toSnake(m.Name))
 }
 
-func (c *codec) serviceRustdocLink(s *api.Service) string {
+func (c *codec) serviceRustdocLink(s *api.Service, model *api.API) string {
 	mapped, ok := c.packageMapping[s.Package]
 	name := c.ServiceName(s)
 	if ok {
 		return fmt.Sprintf("%s::client::%s", mapped.name, toPascal(name))
+	}
+	if !slices.Contains(model.Services, s) {
+		return ""
 	}
 	return fmt.Sprintf("crate::client::%s", toPascal(name))
 }

--- a/internal/sidekick/rust/codec_test.go
+++ b/internal/sidekick/rust/codec_test.go
@@ -1698,6 +1698,98 @@ func TestFormatDocCommentsRelativeCrossLinks(t *testing.T) {
 	}
 }
 
+func TestFormatDocCommentsSkippedMethodsAndServices(t *testing.T) {
+	input := `
+[CreateFoo][test.v1.SomeService.CreateFoo]
+[SkippedMethod][test.v1.SomeService.SkippedMethod]
+[SkippedService][test.v1.SkippedService]
+[SkippedServiceMethod][test.v1.SkippedService.SomeMethod]
+`
+	want := []string{
+		"/// [CreateFoo][test.v1.SomeService.CreateFoo]",
+		"/// [SkippedMethod][test.v1.SomeService.SkippedMethod]",
+		"/// [SkippedService][test.v1.SkippedService]",
+		"/// [SkippedServiceMethod][test.v1.SkippedService.SomeMethod]",
+		"///",
+		"/// [test.v1.SomeService.CreateFoo]: crate::client::SomeService::create_foo",
+	}
+
+	createFoo := &api.Method{
+		Name: "CreateFoo",
+		ID:   ".test.v1.SomeService.CreateFoo",
+		PathInfo: &api.PathInfo{
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: (&api.PathTemplate{}).
+						WithLiteral("v1").
+						WithLiteral("foo"),
+				},
+			},
+		},
+	}
+	skippedMethod := &api.Method{
+		Name: "SkippedMethod",
+		ID:   ".test.v1.SomeService.SkippedMethod",
+		PathInfo: &api.PathInfo{
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: (&api.PathTemplate{}).
+						WithLiteral("v1").
+						WithLiteral("skipped"),
+				},
+			},
+		},
+	}
+	someService := &api.Service{
+		Name:    "SomeService",
+		ID:      ".test.v1.SomeService",
+		Package: "test.v1",
+		Methods: []*api.Method{createFoo}, // skippedMethod omitted from Methods
+	}
+	skippedServiceMethod := &api.Method{
+		Name: "SomeMethod",
+		ID:   ".test.v1.SkippedService.SomeMethod",
+		PathInfo: &api.PathInfo{
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: (&api.PathTemplate{}).
+						WithLiteral("v1").
+						WithLiteral("bar"),
+				},
+			},
+		},
+	}
+	skippedService := &api.Service{
+		Name:    "SkippedService",
+		ID:      ".test.v1.SkippedService",
+		Package: "test.v1",
+		Methods: []*api.Method{skippedServiceMethod},
+	}
+
+	// Model has someService in model.Services, but skippedService is omitted from model.Services
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{someService})
+	model.AddMethod(createFoo)
+	model.AddMethod(skippedMethod)
+	model.AddMethod(skippedServiceMethod)
+	model.AddService(someService)
+	model.AddService(skippedService)
+
+	c := &codec{
+		modulePath: "crate::model",
+	}
+
+	got, err := c.formatDocComments(input, "test-only-ID", model, []string{"test.v1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestFormatDocCommentsSetextHeadings(t *testing.T) {
 	for _, test := range []struct {
 		name  string


### PR DESCRIPTION
Do not generate intra-doc link definitions for methods that have been pruned from a service (via `included_ids` or `skipped_ids`), or services that have been pruned from the model.

Previously, `methodRustdocLink` looked up methods in the global ID map and only checked streaming/gRPC flags via `generateMethod(m)` without verifying whether the method survived model element pruning in `s.Methods`. This caused broken intra-doc links to non-existent methods (such as `crate::client::StorageControl::read_object` when `Storage.ReadObject` was omitted).