### PR TITLE
feat(internal/librarian/ruby): ruby-cloud-gem-name for multi-wrapper Gems

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -510,6 +510,7 @@ This document describes the schema for the librarian.yaml.
 | `ruby-cloud-env-prefix` | string | Is the environment variable prefix. |
 | `ruby-cloud-extra-dependencies` | string | Contains extra runtime dependencies to the .gemspec file. |
 | `ruby-cloud-factory-method-suffix` | string | Appends a suffix to client constructor helper methods. |
+| `ruby-cloud-gem-name` | string | Overrides the gem name for multi-wrapper sub-gem generation. |
 | `ruby-cloud-gem-namespace` | string | Is the root Ruby namespace. |
 | `ruby-cloud-generic-endpoint` | bool | Specifies whether the client is for a generic endpoint service without a fixed default host or default credentials. |
 | `ruby-cloud-migration-version` | string | Specifies the gem version milestone at which the library was migrated to GAPIC, generating a migration section in the README file. |
@@ -518,6 +519,7 @@ This document describes the schema for the librarian.yaml.
 | `ruby-cloud-service-override` | string | Overrides generated service class names when proto package service names don't match desired Ruby conventions. |
 | `ruby-cloud-title` | string | Overrides the gem title. |
 | `ruby-cloud-wrapper-gem-override` | string | Overrides a versioned client gem to a custom non-standard main wrapper gem name. |
+| `ruby-cloud-wrapper-of` | string | Overrides the wrapper-of option for multi-wrapper sub-gem generation. |
 | `ruby-cloud-yard-strict` | string | Enables or disables strict YARD syntax checks during generation. |
 
 ## RubyPackage Configuration

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -905,6 +905,9 @@ type RubyCloudOpts struct {
 	// FactoryMethodSuffix appends a suffix to client constructor helper methods.
 	FactoryMethodSuffix string `yaml:"ruby-cloud-factory-method-suffix,omitempty"`
 
+	// GemName overrides the gem name for multi-wrapper sub-gem generation.
+	GemName string `yaml:"ruby-cloud-gem-name,omitempty"`
+
 	// GemNamespace is the root Ruby namespace.
 	GemNamespace string `yaml:"ruby-cloud-gem-namespace,omitempty"`
 
@@ -930,6 +933,9 @@ type RubyCloudOpts struct {
 
 	// WrapperGemOverride overrides a versioned client gem to a custom non-standard main wrapper gem name.
 	WrapperGemOverride string `yaml:"ruby-cloud-wrapper-gem-override,omitempty"`
+
+	// WrapperOf overrides the wrapper-of option for multi-wrapper sub-gem generation.
+	WrapperOf string `yaml:"ruby-cloud-wrapper-of,omitempty"`
 
 	// YardStrict enables or disables strict YARD syntax checks during generation.
 	YardStrict string `yaml:"ruby-cloud-yard-strict,omitempty"`

--- a/internal/librarian/ruby/generate.go
+++ b/internal/librarian/ruby/generate.go
@@ -138,13 +138,21 @@ func generateAPI(ctx context.Context, api *config.API, library *config.Library, 
 	return nil
 }
 
+func apiGemName(library *config.Library, api *config.API) string {
+	if api.Ruby != nil && api.Ruby.RubyCloudOpts != nil && api.Ruby.RubyCloudOpts.GemName != "" {
+		return api.Ruby.RubyCloudOpts.GemName
+	}
+	return library.Name
+}
+
 func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir string, serviceConfig *serviceconfig.API) ([]string, error) {
 	gc, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
 	if err != nil {
 		return nil, err
 	}
+	gemName := apiGemName(library, api)
 	opts := []string{
-		"ruby-cloud-gem-name=" + library.Name,
+		"ruby-cloud-gem-name=" + gemName,
 	}
 	if serviceConfig != nil && serviceConfig.ServiceConfig != "" {
 		opts = append(opts, "service-yaml="+filepath.Join(googleapisDir, serviceConfig.ServiceConfig))
@@ -202,7 +210,9 @@ func buildGAPICOpts(api *config.API, library *config.Library, googleapisDir stri
 			opts = append(opts, "ruby-cloud-yard-strict="+api.Ruby.RubyCloudOpts.YardStrict)
 		}
 	}
-	if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
+	if api.Ruby != nil && api.Ruby.RubyCloudOpts != nil && api.Ruby.RubyCloudOpts.WrapperOf != "" {
+		opts = append(opts, "ruby-cloud-wrapper-of="+api.Ruby.RubyCloudOpts.WrapperOf)
+	} else if library.Ruby != nil && len(library.Ruby.WrapperOf) > 0 {
 		// This controls the dependency range declaration in the gemspec file.
 		opts = append(opts, "ruby-cloud-wrapper-of="+strings.Join(library.Ruby.WrapperOf, ";"))
 	}

--- a/internal/librarian/ruby/generate_test.go
+++ b/internal/librarian/ruby/generate_test.go
@@ -244,6 +244,34 @@ func TestBuildGAPICOpts(t *testing.T) {
 				"ruby-cloud-wrapper-of=v1:0.29",
 			},
 		},
+		{
+			name: "api with ruby-cloud-gem-name and ruby-cloud-wrapper-of overrides",
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Ruby: &config.RubyAPI{
+					RubyCloudOpts: &config.RubyCloudOpts{
+						GemName:   "google-cloud-secret_manager-custom",
+						WrapperOf: "v1:1.0",
+					},
+				},
+			},
+			library: &config.Library{
+				Name: "google-cloud-secret_manager",
+				Ruby: &config.RubyPackage{
+					WrapperOf: []string{"v1:0.29"},
+				},
+			},
+			want: []string{
+				"ruby-cloud-gem-name=google-cloud-secret_manager-custom",
+				"service-yaml=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_v1.yaml"),
+				"ruby-cloud-description=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"ruby-cloud-summary=Stores sensitive data such as API keys\\, passwords\\, and certificates. Provides convenience while improving security.",
+				"grpc-service-config=" + filepath.Join(googleapisDir, "google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json"),
+				"ruby-cloud-generate-transports=grpc;rest",
+				"ruby-cloud-rest-numeric-enums=true",
+				"ruby-cloud-wrapper-of=v1:1.0",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			serviceConfig, err := serviceconfig.Find(googleapisDir, test.api.Path, config.LanguageRuby)


### PR DESCRIPTION
## Summary
Adds support for `ruby-cloud-gem-name` and `ruby-cloud-wrapper-of` in `RubyCloudOpts` to allow overriding the gem name and wrapper version on a per-API basis.

## Need for this Field
In multi-wrapper Gems (such as `google-cloud-workflows`, `google-cloud-monitoring`, `google-cloud-policy_troubleshooter`, and `google-cloud-beyond_corp`), a top-level suite gem combines multiple distinct sub-wrapper gems (e.g. `google-cloud-workflows` and `google-cloud-workflows-executions`).

When generating code for each constituent API:
1. **GAPIC Code Generation**: `ruby-cloud-gem-name` instructs `gapic-generator-ruby` to generate the appropriate gem name, namespace (e.g. `Google::Cloud::Workflows::Executions`), and gemspec dependencies. Without this field, every API would default to the root library name (`google-cloud-workflows`), resulting in namespace collisions and gemspec misconfiguration.
2. **Staging Isolation**: When staging multiple wrapper APIs before unifying them, each sub-gem must be staged under its respective gem name directory.

This PR is part 1 of the multi-wrapper support (stacked with the `prepareMultiWrapper` implementation).