### PR TITLE
ci(.github): increase timeout of php integration test

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -107,7 +107,7 @@ jobs:
     name: Integration test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
Increase timeout of php integration test to 60 mins.

The latest run was timeout: https://github.com/googleapis/librarian/actions/runs/33681784522/job/100419820118