### PR TITLE
feat(internal/librarian/php): populate library output on add

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -119,7 +119,7 @@ func runAdd(ctx context.Context, cfg *config.Config, api, explicitLibraryName st
 	if err := validateAPIPathExistence(googleapisDir, api); err != nil {
 		return err
 	}
-	name, cfg, err := addLibrary(cfg, api, explicitLibraryName)
+	name, cfg, err := addLibrary(cfg, api, explicitLibraryName, googleapisDir)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func deriveLibraryName(language string, api string) string {
 // It returns the name of the new or updated library, the updated config, and an
 // error if the API cannot be added (e.g. because it already exists, or the new
 // API is a preview and there is no corresponding stable library).
-func addLibrary(cfg *config.Config, apiPath, explicitLibraryName string) (string, *config.Config, error) {
+func addLibrary(cfg *config.Config, apiPath, explicitLibraryName, googleapisDir string) (string, *config.Config, error) {
 	stablePath, isPreview := strings.CutPrefix(apiPath, "preview/")
 	api := &config.API{Path: stablePath}
 	existingLib := findExistingLibraryForAPI(cfg, stablePath, explicitLibraryName)
@@ -238,9 +238,9 @@ func addLibrary(cfg *config.Config, apiPath, explicitLibraryName string) (string
 		return addPreviewLibrary(cfg, existingLib, api)
 	}
 	if existingLib != nil {
-		return updateExistingLibrary(cfg, existingLib, api)
+		return updateExistingLibrary(cfg, existingLib, api, googleapisDir)
 	}
-	return addNewLibrary(cfg, api, explicitLibraryName)
+	return addNewLibrary(cfg, api, explicitLibraryName, googleapisDir)
 }
 
 // findExistingLibraryForAPI determines if an existing library in cfg is
@@ -292,7 +292,7 @@ func addPreviewLibrary(cfg *config.Config, lib *config.Library, api *config.API)
 }
 
 // addNewLibrary adds a new library to the config.
-func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName string) (string, *config.Config, error) {
+func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName, googleapisDir string) (string, *config.Config, error) {
 	name := explicitLibraryName
 	if name == "" {
 		name = deriveLibraryName(cfg.Language, api.Path)
@@ -324,7 +324,11 @@ func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName stri
 	case config.LanguageSwift:
 		lib = swift.Add(lib, cfg)
 	case config.LanguagePhp:
-		lib = php.Add(lib)
+		var err error
+		lib, err = php.Add(lib, googleapisDir)
+		if err != nil {
+			return "", nil, err
+		}
 	case config.LanguageRuby:
 		var err error
 		lib, err = ruby.Add(cfg, lib)
@@ -341,7 +345,7 @@ func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName stri
 	return name, cfg, nil
 }
 
-func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api *config.API) (string, *config.Config, error) {
+func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api *config.API, googleapisDir string) (string, *config.Config, error) {
 	if slices.ContainsFunc(existingLib.APIs, func(a *config.API) bool { return api.Path == a.Path }) {
 		return "", nil, fmt.Errorf("%w: %s in library %s", errAPIAlreadyExists, api.Path, existingLib.Name)
 	}
@@ -365,7 +369,11 @@ func updateExistingLibrary(cfg *config.Config, existingLib *config.Library, api 
 		}
 	case config.LanguagePhp:
 		existingLib.APIs = append(existingLib.APIs, api)
-		existingLib = php.Add(existingLib)
+		var err error
+		existingLib, err = php.Add(existingLib, googleapisDir)
+		if err != nil {
+			return "", nil, err
+		}
 	default:
 		return "", nil, fmt.Errorf("%w: %s", errLibraryAlreadyExists, existingLib.Name)
 	}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -362,7 +362,7 @@ func TestAddLibrary(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
 				t.Fatal(err)
 			}
-			gotName, cfg, err := addLibrary(cfg, test.apiPath, "")
+			gotName, cfg, err := addLibrary(cfg, test.apiPath, "", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -531,8 +531,59 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "update existing library (php)",
+			apiPath: "google/cloud/secretmanager/v1beta2",
+			cfg: &config.Config{
+				Language: config.LanguagePhp,
+				Libraries: []*config.Library{
+					{
+						Name:    "secretmanager",
+						Output:  "SecretManager",
+						Version: "1.2.3",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/secretmanager/v1",
+								PHP: &config.PHPAPI{
+									StagingSubdir: "v1",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantName: "secretmanager",
+			wantCfg: &config.Config{
+				Language: config.LanguagePhp,
+				Libraries: []*config.Library{
+					{
+						Name:    "secretmanager",
+						Output:  "SecretManager",
+						Version: "1.2.3",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/secretmanager/v1",
+								PHP: &config.PHPAPI{
+									StagingSubdir: "v1",
+								},
+							},
+							{
+								Path: "google/cloud/secretmanager/v1beta2",
+								PHP: &config.PHPAPI{
+									StagingSubdir: "v1beta2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			googleapisDir, err := filepath.Abs("../testdata/googleapis")
+			if err != nil {
+				t.Fatal(err)
+			}
 			tmpDir := t.TempDir()
 			t.Chdir(tmpDir)
 			if err := os.WriteFile(filepath.Join(tmpDir, "versions.txt"), nil, 0o644); err != nil {
@@ -541,7 +592,7 @@ func TestAddLibrary_ExistingLibrary(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
 				t.Fatal(err)
 			}
-			gotName, gotCfg, err := addLibrary(test.cfg, test.apiPath, "")
+			gotName, gotCfg, err := addLibrary(test.cfg, test.apiPath, "", googleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -590,7 +641,7 @@ func TestAddLibrary_ExistingLibrary_Error(t *testing.T) {
 			if err := yaml.Write(config.LibrarianYAML, test.cfg); err != nil {
 				t.Fatal(err)
 			}
-			_, _, err := addLibrary(test.cfg, test.apiPath, "")
+			_, _, err := addLibrary(test.cfg, test.apiPath, "", "")
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}
@@ -626,7 +677,7 @@ func TestAddLibrary_Preview(t *testing.T) {
 				Language:  config.LanguageGo,
 				Libraries: test.initialLibraries,
 			}
-			gotName, gotCfg, err := addLibrary(cfg, test.apiPath, "")
+			gotName, gotCfg, err := addLibrary(cfg, test.apiPath, "", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -680,7 +731,7 @@ func TestAddLibrary_Preview_Error(t *testing.T) {
 				Language:  config.LanguageGo,
 				Libraries: test.initialLibraries,
 			}
-			_, _, err := addLibrary(cfg, test.apiPath, "")
+			_, _, err := addLibrary(cfg, test.apiPath, "", "")
 			if !errors.Is(err, test.wantErr) {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
 			}
@@ -814,6 +865,7 @@ func TestAddLibraryCommand_Php(t *testing.T) {
 	wantLibraries := []*config.Library{
 		{
 			Name:          "developerconnect",
+			Output:        "DeveloperConnect",
 			Version:       "0.0.0",
 			CopyrightYear: strconv.Itoa(time.Now().Year()),
 			APIs: []*config.API{

--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -15,6 +15,7 @@
 package php
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -38,7 +39,7 @@ func DefaultLibraryName(apiPath string) string {
 }
 
 // Add populates PHP-specific default configuration for all APIs in the library.
-func Add(lib *config.Library) *config.Library {
+func Add(lib *config.Library, googleapisDir string) (*config.Library, error) {
 	if lib.Version == "" {
 		lib.Version = defaultVersion
 	}
@@ -50,5 +51,12 @@ func Add(lib *config.Library) *config.Library {
 			api.PHP.StagingSubdir = serviceconfig.ExtractVersion(api.Path)
 		}
 	}
-	return lib
+	if lib.Output == "" {
+		compName, err := ComponentNameForLibrary(googleapisDir, lib)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive component name for library %q: %w", lib.Name, err)
+		}
+		lib.Output = compName
+	}
+	return lib, nil
 }

--- a/internal/librarian/php/add_test.go
+++ b/internal/librarian/php/add_test.go
@@ -15,6 +15,7 @@
 package php
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -65,6 +66,7 @@ func TestDefaultLibraryName(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
+	googleapisDir := filepath.Join("..", "..", "testdata", "googleapis")
 	for _, test := range []struct {
 		name string
 		lib  *config.Library
@@ -74,16 +76,17 @@ func TestAdd(t *testing.T) {
 			name: "empty php config",
 			lib: &config.Library{
 				APIs: []*config.API{
-					{Path: "google/cloud/speech/v2"},
+					{Path: "google/cloud/secretmanager/v1"},
 				},
 			},
 			want: &config.Library{
+				Output:  "SecretManager",
 				Version: "0.0.0",
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/speech/v2",
+						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
-							StagingSubdir: "v2",
+							StagingSubdir: "v1",
 						},
 					},
 				},
@@ -94,7 +97,7 @@ func TestAdd(t *testing.T) {
 			lib: &config.Library{
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/speech/v2",
+						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
 							StagingSubdir: "custom_subdir",
 						},
@@ -102,10 +105,11 @@ func TestAdd(t *testing.T) {
 				},
 			},
 			want: &config.Library{
+				Output:  "SecretManager",
 				Version: "0.0.0",
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/speech/v2",
+						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
 							StagingSubdir: "custom_subdir",
 						},
@@ -118,16 +122,17 @@ func TestAdd(t *testing.T) {
 			lib: &config.Library{
 				Version: "1.2.3",
 				APIs: []*config.API{
-					{Path: "google/cloud/speech/v2"},
+					{Path: "google/cloud/secretmanager/v1"},
 				},
 			},
 			want: &config.Library{
+				Output:  "SecretManager",
 				Version: "1.2.3",
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/speech/v2",
+						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
-							StagingSubdir: "v2",
+							StagingSubdir: "v1",
 						},
 					},
 				},
@@ -137,23 +142,71 @@ func TestAdd(t *testing.T) {
 			name: "multiple APIs",
 			lib: &config.Library{
 				APIs: []*config.API{
-					{Path: "google/cloud/speech/v2"},
-					{Path: "google/cloud/speech/v2beta1"},
+					{Path: "google/cloud/secretmanager/v1"},
+					{Path: "google/cloud/secretmanager/v1beta2"},
 				},
 			},
 			want: &config.Library{
+				Output:  "SecretManager",
 				Version: "0.0.0",
 				APIs: []*config.API{
 					{
-						Path: "google/cloud/speech/v2",
+						Path: "google/cloud/secretmanager/v1",
 						PHP: &config.PHPAPI{
-							StagingSubdir: "v2",
+							StagingSubdir: "v1",
 						},
 					},
 					{
-						Path: "google/cloud/speech/v2beta1",
+						Path: "google/cloud/secretmanager/v1beta2",
 						PHP: &config.PHPAPI{
-							StagingSubdir: "v2beta1",
+							StagingSubdir: "v1beta2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "existing output preserved",
+			lib: &config.Library{
+				Output: "CustomOutput",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Output:  "CustomOutput",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "component name override",
+			lib: &config.Library{
+				PHP: &config.PHPPackage{
+					ComponentName: "CustomComponent",
+				},
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Output:  "CustomComponent",
+				Version: "0.0.0",
+				PHP: &config.PHPPackage{
+					ComponentName: "CustomComponent",
+				},
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+						PHP: &config.PHPAPI{
+							StagingSubdir: "v1",
 						},
 					},
 				},
@@ -161,10 +214,26 @@ func TestAdd(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := Add(test.lib)
+			got, err := Add(test.lib, googleapisDir)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("Add() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestAdd_Error(t *testing.T) {
+	googleapisDir := filepath.Join("..", "..", "testdata", "googleapis")
+	lib := &config.Library{
+		Name: "nonexistent",
+		APIs: []*config.API{
+			{Path: "google/cloud/nonexistent/v1"},
+		},
+	}
+	if _, err := Add(lib, googleapisDir); err == nil {
+		t.Errorf("Add() expected error, got nil")
 	}
 }


### PR DESCRIPTION
The PHP add interface is updated to accept the googleapis directory and populate the library output directory with the derived component name when onboarding a library.

Previously, librarian add did not have access to the googleapis directory, preventing it from deriving the component name from proto definitions. Newly onboarded PHP libraries were left without an output path in librarian.yaml, requiring manual adjustments before generation (for formatting specifically). With this change, add resolves the component name from the proto php_namespace option or an explicit component name override and records it in the library output.

For https://github.com/googleapis/librarian/issues/7389