### PR TITLE
chore(internal/librarian/php): unexport ComponentNameForLibrary

### DIFF
--- a/internal/librarian/php/add.go
+++ b/internal/librarian/php/add.go
@@ -52,7 +52,7 @@ func Add(lib *config.Library, googleapisDir string) (*config.Library, error) {
 		}
 	}
 	if lib.Output == "" {
-		compName, err := ComponentNameForLibrary(googleapisDir, lib)
+		compName, err := componentNameForLibrary(googleapisDir, lib)
 		if err != nil {
 			return nil, fmt.Errorf("failed to derive component name for library %q: %w", lib.Name, err)
 		}

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -96,12 +96,10 @@ func newInitParams(googleapisDir string, library *config.Library) (*initParams, 
 	}, nil
 }
 
-// ComponentNameForLibrary resolves the component name for a PHP library.
+// componentNameForLibrary resolves the component name for a PHP library.
 // If library.PHP.ComponentName is set, it is returned as an explicit override.
 // Otherwise, the component name is derived on the fly from the php_namespace of the library's primary API.
-// TODO(https://github.com/googleapis/librarian/issues/7213):
-// Unexport ComponentNameForLibrary when the migrate tool code is removed.
-func ComponentNameForLibrary(googleapisDir string, library *config.Library) (string, error) {
+func componentNameForLibrary(googleapisDir string, library *config.Library) (string, error) {
 	if library.PHP != nil && library.PHP.ComponentName != "" {
 		return library.PHP.ComponentName, nil
 	}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -549,7 +549,7 @@ func TestComponentNameForLibrary(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := ComponentNameForLibrary(googleapisDir, test.library)
+			got, err := componentNameForLibrary(googleapisDir, test.library)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Un-export function now that migrate tool is removed for php.

Fixes https://github.com/googleapis/librarian/issues/7213