### PR TITLE
chore(internal/librarian/php): remove .yamlfmt workaround

### DIFF
--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,9 +1,0 @@
-# The PHP generator (gapic-generator-php) has a preprocessor bug (fixYaml)
-# that incorrectly indents top-level keys if they immediately follow indented blocks.
-# The workaround requires keeping blank lines between top-level keys in
-# secretmanager_v1.yaml, which the default yamlfmt settings would otherwise strip.
-# We exclude the file here to prevent yamlfmt from formatting it.
-# TODO(https://github.com/googleapis/gapic-generator-php/issues/837): determine to remove
-# this workaround or adjust testdata to keep blank lines.
-exclude:
-  - "internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml"

--- a/internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
+++ b/internal/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
@@ -18,7 +18,6 @@ title: Secret Manager API
 apis:
   - name: google.cloud.location.Locations
   - name: google.cloud.secretmanager.v1.SecretManagerService
-
 documentation:
   summary: |-
     Stores sensitive data such as API keys, passwords, and certificates.
@@ -29,14 +28,12 @@ documentation:
       description: Gets information about a location.
     - selector: google.cloud.location.Locations.ListLocations
       description: Lists information about the supported locations for this service.
-
 http:
   rules:
     - selector: google.cloud.location.Locations.GetLocation
       get: '/v1/{name=projects/*/locations/*}'
     - selector: google.cloud.location.Locations.ListLocations
       get: '/v1/{name=projects/*}/locations'
-
 authentication:
   rules:
     - selector: google.cloud.location.Locations.GetLocation
@@ -51,7 +48,6 @@ authentication:
       oauth:
         canonical_scopes: |-
           https://www.googleapis.com/auth/cloud-platform
-
 publishing:
   new_issue_uri: https://issuetracker.google.com/issues/new?component=784854&template=1380926
   documentation_uri: https://cloud.google.com/secret-manager/docs/overview
@@ -94,5 +90,4 @@ publishing:
         common:
           destinations:
             - PACKAGE_MANAGER
-
   proto_reference_documentation_uri: https://cloud.google.com/secret-manager/docs/reference/rpc


### PR DESCRIPTION
The .yamlfmt configuration file is removed and secretmanager_v1.yaml is reformatted with yamlfmt.

The exclusion was originally added as a workaround for a bug https://github.com/googleapis/gapic-generator-php/issues/837. Now that is fixed so the workaround no longer necessary.