### PR TITLE
feat(internal/sidekick/rust): support default_transport configuration

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -572,6 +572,7 @@ This document describes the schema for the librarian.yaml.
 | `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
 | `allow_streaming_any_types` | list of string | Is a list of protobuf field/message IDs with google.protobuf.Any permitted in streaming RPCs (their fields will be dropped in prost conversion). |
 | `grpc_client` | string | Is the Rust type used for the inner gRPC client in generated transports. Defaults to "gaxi::grpc::Client". |
+| `default_transport` | string | Specifies the default transport protocol for unary methods ("grpc" or "http"). Defaults to "http". |
 
 ## RustDocumentationOverride Configuration
 
@@ -587,6 +588,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `grpc_client` | string | Is the Rust type used for the inner gRPC client in generated transports. This overrides the crate-level setting. Defaults to "gaxi::grpc::Client". |
 | `disabled_rustdoc_warnings` | yaml.StringSlice | Specifies rustdoc lints to disable. An empty slice explicitly enables all warnings. |
+| `default_transport` | string | Specifies the default transport protocol for unary methods ("grpc" or "http"). This overrides the crate-level setting. |
 | `detailed_tracing_attributes` | bool (optional) | Indicates whether to include detailed tracing attributes. This overrides the crate-level setting. |
 | `lro_stub_options` | bool (optional) | Indicates whether to include LRO poller options in generated stub traits. This overrides the crate-level setting. |
 | `documentation_overrides` | list of [RustDocumentationOverride](#rustdocumentationoverride-configuration) | Contains overrides for element documentation. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -137,6 +137,10 @@ type RustDefault struct {
 	// GrpcClient is the Rust type used for the inner gRPC client in generated transports.
 	// Defaults to "gaxi::grpc::Client".
 	GrpcClient string `yaml:"grpc_client,omitempty"`
+
+	// DefaultTransport specifies the default transport protocol for unary methods ("grpc" or "http").
+	// Defaults to "http".
+	DefaultTransport string `yaml:"default_transport,omitempty"`
 }
 
 // RustModule defines a generation target within a veneer crate.
@@ -149,6 +153,10 @@ type RustModule struct {
 
 	// DisabledRustdocWarnings specifies rustdoc lints to disable. An empty slice explicitly enables all warnings.
 	DisabledRustdocWarnings yaml.StringSlice `yaml:"disabled_rustdoc_warnings,omitempty"`
+
+	// DefaultTransport specifies the default transport protocol for unary methods ("grpc" or "http").
+	// This overrides the crate-level setting.
+	DefaultTransport string `yaml:"default_transport,omitempty"`
 
 	// DetailedTracingAttributes indicates whether to include detailed tracing attributes.
 	// This overrides the crate-level setting.

--- a/internal/librarian/rust/codec.go
+++ b/internal/librarian/rust/codec.go
@@ -68,6 +68,9 @@ func libraryToModelConfig(library *config.Library, ch *config.API, srcs *sources
 	}
 
 	if library.Rust != nil {
+		if len(library.Rust.IncludedIds) > 0 {
+			modelCfg.Override.IncludedIDs = library.Rust.IncludedIds
+		}
 		if len(library.Rust.SkippedIds) > 0 {
 			modelCfg.Override.SkippedIDs = library.Rust.SkippedIds
 		}
@@ -152,6 +155,9 @@ func buildCodec(library *config.Library, releaseLevel string) map[string]string 
 	}
 	if rust.LroStubOptions != nil && *rust.LroStubOptions {
 		codec["lro-stub-options"] = "true"
+	}
+	if rust.DefaultTransport != "" {
+		codec["default-transport"] = rust.DefaultTransport
 	}
 	if rust.HasVeneer {
 		codec["has-veneer"] = "true"
@@ -380,6 +386,16 @@ func buildModuleCodec(library *config.Library, module *config.RustModule) map[st
 	}
 	if grpcClient != "" {
 		codec["grpc-client"] = grpcClient
+	}
+	defaultTransport := ""
+	if library.Rust != nil && library.Rust.DefaultTransport != "" {
+		defaultTransport = library.Rust.DefaultTransport
+	}
+	if module.DefaultTransport != "" {
+		defaultTransport = module.DefaultTransport
+	}
+	if defaultTransport != "" {
+		codec["default-transport"] = defaultTransport
 	}
 	return codec
 }

--- a/internal/librarian/rust/generate.go
+++ b/internal/librarian/rust/generate.go
@@ -86,7 +86,7 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 	if err := sidekickrust.Generate(ctx, model, library.Output, modelConfig); err != nil {
 		return err
 	}
-	if rootTypeIDs := streamingRootTypeIDs(model, library); len(rootTypeIDs) > 0 {
+	if rootTypeIDs := sidekickrust.GrpcRootTypeIDs(model); len(rootTypeIDs) > 0 {
 		if err := generateProstHybrid(ctx, model, rootTypeIDs, library, library.Output, modelConfig); err != nil {
 			return err
 		}

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -32,36 +32,6 @@ import (
 	"github.com/googleapis/librarian/internal/sidekick/rust_prost"
 )
 
-// streamingRootTypeIDs returns the root message type IDs for all enabled bidirectional
-// and server-side streaming RPCs in the library.
-func streamingRootTypeIDs(model *api.API, library *config.Library) []string {
-	if library.Rust == nil || library.Rust.TemplateOverride != "" {
-		return nil
-	}
-	includeBidi := library.Rust.IncludeBidiStreamingMethods != nil && *library.Rust.IncludeBidiStreamingMethods
-	includeServer := library.Rust.IncludeServerStreamingMethods != nil && *library.Rust.IncludeServerStreamingMethods
-	if !includeBidi && !includeServer {
-		return nil
-	}
-	var rootTypeIDs []string
-	for _, s := range model.Services {
-		for _, m := range s.Methods {
-			isBidi := m.ClientSideStreaming && m.ServerSideStreaming && includeBidi
-			isServer := !m.ClientSideStreaming && m.ServerSideStreaming && includeServer
-			if isBidi || isServer {
-				if m.InputTypeID != "" {
-					rootTypeIDs = append(rootTypeIDs, m.InputTypeID)
-				}
-				if m.OutputTypeID != "" {
-					rootTypeIDs = append(rootTypeIDs, m.OutputTypeID)
-				}
-			}
-		}
-	}
-	slices.Sort(rootTypeIDs)
-	return slices.Compact(rootTypeIDs)
-}
-
 func generateProstHybrid(ctx context.Context, model *api.API, rootTypeIDs []string, library *config.Library, outdir string, modelConfig *parser.ModelConfig) error {
 	if library.Rust == nil || library.Rust.TemplateOverride != "" || len(rootTypeIDs) == 0 {
 		return nil

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -33,69 +33,32 @@ func TestGenerateProstHybrid(t *testing.T) {
 	testhelper.RequireCommand(t, "protoc")
 	testhelper.RequireCommand(t, "cargo")
 	msg := api.NewTestMessage("Request").WithPackage("google.cloud.test.v1")
-
-	chatMethod := api.NewTestMethod("Chat").WithInput(msg).WithOutput(msg).WithBidiStreaming()
-
-	bidiService := api.NewTestService("BidiService").WithPackage("google.cloud.test.v1").WithMethods(chatMethod)
-
-	getMethod := api.NewTestMethod("Get").WithInput(msg).WithOutput(msg)
-	nonBidiService := api.NewTestService("UnaryService").WithPackage("google.cloud.test.v1").WithMethods(getMethod)
-
-	bidiModel := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{bidiService})
-	if err := api.CrossReference(bidiModel); err != nil {
-		t.Fatal(err)
-	}
-
-	nonBidiModel := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{nonBidiService})
-	if err := api.CrossReference(nonBidiModel); err != nil {
-		t.Fatal(err)
-	}
-
-	expandMethod := api.NewTestMethod("Expand").WithInput(msg).WithOutput(msg).WithServerSideStreaming()
-	serverService := api.NewTestService("ServerService").WithPackage("google.cloud.test.v1").WithMethods(expandMethod)
-	serverStreamingModel := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{serverService})
-	if err := api.CrossReference(serverStreamingModel); err != nil {
+	model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
+	if err := api.CrossReference(model); err != nil {
 		t.Fatal(err)
 	}
 
 	for _, test := range []struct {
-		name                          string
-		model                         *api.API
-		includeBidiStreamingMethods   bool
-		includeServerStreamingMethods bool
-		templateOverride              string
-		wantProstDir                  bool
+		name             string
+		rootTypeIDs      []string
+		templateOverride string
+		wantProstDir     bool
 	}{
 		{
-			name:                        "feature disabled does not create prost dir",
-			model:                       bidiModel,
-			includeBidiStreamingMethods: false,
-			wantProstDir:                false,
+			name:         "empty rootTypeIDs does not create prost dir",
+			rootTypeIDs:  nil,
+			wantProstDir: false,
 		},
 		{
-			name:                        "model without bidi streaming does not create prost dir",
-			model:                       nonBidiModel,
-			includeBidiStreamingMethods: true,
-			wantProstDir:                false,
+			name:             "template override tonic does not create prost dir",
+			rootTypeIDs:      []string{msg.ID},
+			templateOverride: "tonic",
+			wantProstDir:     false,
 		},
 		{
-			name:                        "template override tonic does not create prost dir",
-			model:                       bidiModel,
-			includeBidiStreamingMethods: true,
-			templateOverride:            "tonic",
-			wantProstDir:                false,
-		},
-		{
-			name:                        "feature enabled creates prost dir",
-			model:                       bidiModel,
-			includeBidiStreamingMethods: true,
-			wantProstDir:                true,
-		},
-		{
-			name:                          "server streaming enabled creates prost dir",
-			model:                         serverStreamingModel,
-			includeServerStreamingMethods: true,
-			wantProstDir:                  true,
+			name:         "valid rootTypeIDs creates prost dir",
+			rootTypeIDs:  []string{msg.ID},
+			wantProstDir: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -103,10 +66,6 @@ func TestGenerateProstHybrid(t *testing.T) {
 			lib := &config.Library{
 				Name: "test-package",
 				Rust: &config.RustCrate{
-					RustDefault: config.RustDefault{
-						IncludeBidiStreamingMethods:   &test.includeBidiStreamingMethods,
-						IncludeServerStreamingMethods: &test.includeServerStreamingMethods,
-					},
 					TemplateOverride: test.templateOverride,
 				},
 			}
@@ -126,8 +85,7 @@ func TestGenerateProstHybrid(t *testing.T) {
 					"package:g3-wkt":        "package=google-cloud-wkt,source=google.protobuf",
 				},
 			}
-			rootTypeIDs := streamingRootTypeIDs(test.model, lib)
-			err = generateProstHybrid(t.Context(), test.model, rootTypeIDs, lib, outDir, modelConfig)
+			err = generateProstHybrid(t.Context(), model, test.rootTypeIDs, lib, outDir, modelConfig)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -57,6 +57,11 @@ func (m *methodAnnotation) IsHttp() bool {
 	return !m.IsGrpc
 }
 
+// IsUnaryGrpc returns true if the method is routed over unary gRPC.
+func (m *methodAnnotation) IsUnaryGrpc() bool {
+	return m.IsGrpc && !m.ClientSideStreaming && !m.ServerSideStreaming
+}
+
 // IsBidiStreaming returns true if the method is a bidirectional streaming RPC.
 func (m *methodAnnotation) IsBidiStreaming() bool {
 	return m.IsGrpc && m.ClientSideStreaming && m.ServerSideStreaming
@@ -587,10 +592,16 @@ func (c *codec) annotatePathBinding(b *api.PathBinding, m *api.Method) (*pathBin
 }
 
 func (c *codec) annotatePathInfo(m *api.Method) error {
+	if m.PathInfo == nil {
+		return nil
+	}
 	seen := make(map[string]bool)
 	var uniqueParameters []*bindingSubstitution
 
 	for _, b := range m.PathInfo.Bindings {
+		if b.PathTemplate == nil {
+			continue
+		}
 		ann, err := c.annotatePathBinding(b, m)
 		if err != nil {
 			return err
@@ -745,6 +756,9 @@ func isIdempotent(p *api.PathInfo) string {
 func (c *codec) methodUsesGrpc(m *api.Method) bool {
 	if !c.templateSupportsGrpc() {
 		return false
+	}
+	if c.defaultTransport == "grpc" {
+		return true
 	}
 	if m.ClientSideStreaming || m.ServerSideStreaming {
 		return (m.ClientSideStreaming && m.ServerSideStreaming && c.includeBidiStreamingMethods) ||

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -757,6 +757,10 @@ func (c *codec) methodUsesGrpc(m *api.Method) bool {
 	if !c.templateSupportsGrpc() {
 		return false
 	}
+	// TODO(googleapis/google-cloud-rust#6470): Support LROs on gRPC transport.
+	if m.OperationInfo != nil || m.IsLroPoller || isDiscoveryLro(m) {
+		return false
+	}
 	if c.defaultTransport == "grpc" {
 		return true
 	}

--- a/internal/sidekick/rust/annotate_method.go
+++ b/internal/sidekick/rust/annotate_method.go
@@ -757,8 +757,8 @@ func (c *codec) methodUsesGrpc(m *api.Method) bool {
 	if !c.templateSupportsGrpc() {
 		return false
 	}
-	// TODO(googleapis/google-cloud-rust#6470): Support LROs on gRPC transport.
-	if m.OperationInfo != nil || m.IsLroPoller || isDiscoveryLro(m) {
+	// TODO(googleapis/google-cloud-rust#6470): Support LROs on gRPC transport in default template.
+	if c.templateOverride != "templates/grpc-client" && (m.OperationInfo != nil || m.IsLroPoller || isDiscoveryLro(m)) {
 		return false
 	}
 	if c.defaultTransport == "grpc" {

--- a/internal/sidekick/rust/annotate_method_test.go
+++ b/internal/sidekick/rust/annotate_method_test.go
@@ -648,6 +648,8 @@ func TestMethodUsesGrpc(t *testing.T) {
 	bidiMethod := api.NewTestMethod("Bidi").WithInput(msg).WithOutput(msg).WithBidiStreaming()
 	serverMethod := api.NewTestMethod("Server").WithInput(msg).WithOutput(msg).WithServerSideStreaming()
 
+	lroMethod := api.NewTestMethod("Lro").WithInput(msg).WithOutput(msg).WithOperationInfo(&api.OperationInfo{ResponseTypeID: "test.v1.Message", MetadataTypeID: "test.v1.Message"})
+
 	for _, test := range []struct {
 		name             string
 		method           *api.Method
@@ -685,6 +687,23 @@ func TestMethodUsesGrpc(t *testing.T) {
 				"include-bidi-streaming-methods": "true",
 			},
 			want: false,
+		},
+		{
+			name:   "LRO method defaults to HTTP on default template with default_transport grpc",
+			method: lroMethod,
+			options: map[string]string{
+				"default-transport": "grpc",
+			},
+			want: false,
+		},
+		{
+			name:             "LRO method uses gRPC on grpc-client template",
+			method:           lroMethod,
+			templateOverride: "templates/grpc-client",
+			options: map[string]string{
+				"default-transport": "grpc",
+			},
+			want: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/sidekick/rust/annotate_model.go
+++ b/internal/sidekick/rust/annotate_model.go
@@ -168,6 +168,25 @@ func (m *modelAnnotations) GrpcServices() []*api.Service {
 	})
 }
 
+// GrpcRootTypeIDs returns the root message type IDs for all generated gRPC methods in the model.
+func GrpcRootTypeIDs(model *api.API) []string {
+	var rootTypeIDs []string
+	for _, s := range model.Services {
+		for _, m := range s.Methods {
+			if ann, ok := m.Codec.(*methodAnnotation); ok && ann.IsGrpc {
+				if m.InputTypeID != "" {
+					rootTypeIDs = append(rootTypeIDs, m.InputTypeID)
+				}
+				if m.OutputTypeID != "" {
+					rootTypeIDs = append(rootTypeIDs, m.OutputTypeID)
+				}
+			}
+		}
+	}
+	slices.Sort(rootTypeIDs)
+	return slices.Compact(rootTypeIDs)
+}
+
 // annotateModel creates a struct used as input for Mustache templates.
 // Fields and methods defined in this struct directly correspond to Mustache
 // tags. For example, the Mustache tag {{#Services}} uses the
@@ -175,7 +194,7 @@ func (m *modelAnnotations) GrpcServices() []*api.Service {
 func annotateModel(model *api.API, codec *codec) (*modelAnnotations, error) {
 	codec.hasServices = len(model.Services) > 0
 
-	resolveUsedPackages(model, codec.extraPackages, codec.hasStreaming(model))
+	resolveUsedPackages(model, codec.extraPackages, codec.hasGrpc(model))
 	// Annotate enums and messages that we intend to generate. In the
 	// process we discover the external dependencies and trim the list of
 	// packages used by this API.

--- a/internal/sidekick/rust/annotate_model_test.go
+++ b/internal/sidekick/rust/annotate_model_test.go
@@ -940,3 +940,70 @@ func TestExternalTypesAnnotations(t *testing.T) {
 		t.Errorf("enumAnn.ProstRelativeName = %q, want %q", enumAnn.ProstRelativeName, want)
 	}
 }
+
+func TestGrpcRootTypeIDs(t *testing.T) {
+	req := api.NewTestMessage("Req").WithPackage("google.cloud.test.v1")
+	resp := api.NewTestMessage("Resp").WithPackage("google.cloud.test.v1")
+
+	unaryMethod := api.NewTestMethod("Unary").WithInput(req).WithOutput(resp)
+	unaryMethod.PathInfo = &api.PathInfo{
+		Bindings: []*api.PathBinding{
+			{Verb: "GET", PathTemplate: &api.PathTemplate{}},
+		},
+	}
+	streamMethod := api.NewTestMethod("Stream").WithInput(req).WithOutput(resp).WithBidiStreaming()
+
+	for _, test := range []struct {
+		name    string
+		methods []*api.Method
+		options map[string]string
+		want    []string
+	}{
+		{
+			name:    "unary method with default http returns no grpc root types",
+			methods: []*api.Method{unaryMethod},
+			options: map[string]string{},
+			want:    nil,
+		},
+		{
+			name:    "unary method with default_transport grpc returns root types",
+			methods: []*api.Method{unaryMethod},
+			options: map[string]string{
+				"default-transport": "grpc",
+			},
+			want: []string{req.ID, resp.ID},
+		},
+		{
+			name:    "streaming method with include-bidi returns root types",
+			methods: []*api.Method{streamMethod},
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			want: []string{req.ID, resp.ID},
+		},
+		{
+			name:    "mixed methods with default http returns only streaming root types",
+			methods: []*api.Method{unaryMethod, streamMethod},
+			options: map[string]string{
+				"include-bidi-streaming-methods": "true",
+			},
+			want: []string{req.ID, resp.ID},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			svc := api.NewTestService("Service").WithPackage("google.cloud.test.v1").WithMethods(test.methods...)
+			model := api.NewTestAPI([]*api.Message{req, resp}, []*api.Enum{}, []*api.Service{svc})
+			if err := api.CrossReference(model); err != nil {
+				t.Fatal(err)
+			}
+			codec := newTestCodec(t, libconfig.SpecProtobuf, "", test.options)
+			if _, err := annotateModel(model, codec); err != nil {
+				t.Fatal(err)
+			}
+			got := GrpcRootTypeIDs(model)
+			if diff := cmp.Diff(test.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/sidekick/rust/annotate_service_test.go
+++ b/internal/sidekick/rust/annotate_service_test.go
@@ -676,6 +676,27 @@ func TestServiceAnnotationsClassification(t *testing.T) {
 			isPureHttp: false,
 			isHybrid:   false,
 		},
+		{
+			name:    "default transport grpc marks unary service as pure gRPC",
+			methods: []*api.Method{unaryMethod},
+			options: map[string]string{
+				"default-transport": "grpc",
+			},
+			isPureGrpc: true,
+			isPureHttp: false,
+			isHybrid:   false,
+		},
+		{
+			name:    "default transport grpc with streaming is pure gRPC",
+			methods: []*api.Method{unaryMethod, bidiMethod},
+			options: map[string]string{
+				"default-transport":              "grpc",
+				"include-bidi-streaming-methods": "true",
+			},
+			isPureGrpc: true,
+			isPureHttp: false,
+			isHybrid:   false,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			service := api.NewTestService("TestService").WithPackage("test.v1").WithMethods(test.methods...)

--- a/internal/sidekick/rust/codec.go
+++ b/internal/sidekick/rust/codec.go
@@ -215,6 +215,11 @@ func newCodec(specificationFormat string, options map[string]string) (*codec, er
 			codec.includeRpcStatusConversion = value
 		case key == "grpc-client":
 			codec.grpcClient = definition
+		case key == "default-transport":
+			if definition != "grpc" && definition != "http" {
+				return nil, fmt.Errorf("invalid `default-transport` value %q, expected \"grpc\" or \"http\"", definition)
+			}
+			codec.defaultTransport = definition
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -377,6 +382,8 @@ type codec struct {
 	quickstartServiceOverride string
 	// The Rust type used for the inner gRPC client in generated transports.
 	grpcClient string
+	// The default transport protocol for unary methods ("grpc" or "http").
+	defaultTransport string
 }
 
 type systemParameter struct {
@@ -404,7 +411,7 @@ type packagez struct {
 	usedIf []string
 }
 
-func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasStreaming bool) {
+func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasGrpc bool) {
 	hasServices := len(model.Services) > 0
 	hasLROs := false
 	hasAutoPopulation := false
@@ -439,7 +446,7 @@ func resolveUsedPackages(model *api.API, extraPackages []*packagez, hasStreaming
 				pkg.used = true
 				break
 			}
-			if namedFeature == "streaming" && hasStreaming {
+			if (namedFeature == "streaming" || namedFeature == "grpc") && hasGrpc {
 				pkg.used = true
 				break
 			}
@@ -1620,7 +1627,7 @@ func (c *codec) generateMethod(m *api.Method) bool {
 		}
 		return c.includeStreamingMethods
 	}
-	if c.includeGrpcOnlyMethods {
+	if c.includeGrpcOnlyMethods || c.defaultTransport == "grpc" {
 		return true
 	}
 	if m.PathInfo == nil || len(m.PathInfo.Bindings) == 0 {
@@ -1649,6 +1656,16 @@ func (c *codec) hasServerStreaming(model *api.API) bool {
 
 func (c *codec) hasStreaming(model *api.API) bool {
 	return c.hasBidiStreaming(model) || c.hasServerStreaming(model)
+}
+
+func (c *codec) hasGrpc(model *api.API) bool {
+	if !c.templateSupportsGrpc() {
+		return false
+	}
+	if c.defaultTransport == "grpc" {
+		return len(model.Services) > 0
+	}
+	return c.hasStreaming(model)
 }
 
 // escapeKeyword is the list of Rust keywords and reserved words can be found

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -222,8 +222,106 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
     }
 
     {{/Codec.IsServerStreaming}}
-    {{^Codec.IsBidiStreaming}}
-    {{^Codec.IsServerStreaming}}
+    {{#Codec.IsUnaryGrpc}}
+    async fn {{Codec.Name}}(
+        &self,
+        req: {{InputType.Codec.QualifiedName}},
+        options: crate::RequestOptions,
+    ) -> Result<crate::Response<{{Codec.ReturnType}}>> {
+        use gaxi::{prost::ToProto, grpc::tonic::{GrpcMethod, Extensions}};
+        let options = google_cloud_gax::options::internal::set_default_idempotency(
+            options,
+            {{! TODO(#2588) - resolve this in the model }}
+            {{#HasAutoPopulatedFields}}
+            true,
+            {{/HasAutoPopulatedFields}}
+            {{^HasAutoPopulatedFields}}
+            {{PathInfo.Codec.IsIdempotent}},
+            {{/HasAutoPopulatedFields}}
+        );
+        let extensions = {
+            let mut e = Extensions::new();
+            e.insert(GrpcMethod::new("{{SourceService.Package}}.{{SourceService.Name}}", "{{Name}}"));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}"
+        );
+        {{!
+        AIP-4222 says:
+
+            For any given RPC, if the explicit routing headers annotation is
+            present, the code generators **must** use it and **ignore** any
+            routing headers that might be implicitly specified in the
+            google.api.http annotation.
+
+        So we only need to generate one of the two code paths.
+        }}
+        {{#HasRouting}}
+        {{> /templates/grpc-client/routinginfo}}
+        {{/HasRouting}}
+        {{^HasRouting}}
+        let x_goog_request_params = [
+            {{#PathInfo.Codec.UniqueParameters}}
+                {{{FieldAccessor}}}.map(|v| format!("{{FieldName}}={v}")),
+            {{/PathInfo.Codec.UniqueParameters}}
+            {{^PathInfo.Codec.UniqueParameters}}
+            ""; 0
+            {{/PathInfo.Codec.UniqueParameters}}
+        ]
+        .into_iter()
+        .flatten()
+        {{! TODO(#2548) - skip empty strings, and don't lead with a '&' }}
+        .fold(String::new(), |b, p| b + "&" + &p);
+        {{/HasRouting}}
+
+        {{#ReturnsEmpty}}
+        type TR = ();
+        {{/ReturnsEmpty}}
+        {{^ReturnsEmpty}}
+        type TR = crate::prost::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.ProstRelativeName}};
+        {{/ReturnsEmpty}}
+        {{#Codec.DetailedTracingAttributes}}
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("{{SourceService.Package}}.{{SourceService.Name}}/{{Name}}");
+            {{#Codec.HasGrpcResourceNameArgs}}
+            let resource_name = (|| {
+                {{#Codec.ResourceNameTemplateGrpc}}
+                Some(format!(
+                    "{{{Codec.ResourceNameTemplateGrpc}}}",
+                    {{#Codec.GrpcResourceNameArgs}}
+                    {{{.}}}?,
+                    {{/Codec.GrpcResourceNameArgs}}
+                ))
+                {{/Codec.ResourceNameTemplateGrpc}}
+                {{^Codec.ResourceNameTemplateGrpc}}
+                Some(String::new())
+                {{/Codec.ResourceNameTemplateGrpc}}
+            })();
+            let attributes = if let Some(rn) = resource_name.filter(|s| !s.is_empty()) {
+                attributes.set_resource_name(rn)
+            } else {
+                attributes
+            };
+            {{/Codec.HasGrpcResourceNameArgs}}
+            recorder.on_client_request(attributes);
+        }
+        {{/Codec.DetailedTracingAttributes}}
+        self.grpc_inner
+            .execute(
+                extensions,
+                path,
+                req.to_proto().map_err(Error::deser)?,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_GRPC_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(gaxi::grpc::to_gax_response::<TR, {{Codec.ReturnType}}>)
+    }
+    {{/Codec.IsUnaryGrpc}}
+    {{#Codec.IsHttp}}
     async fn {{Codec.Name}}(
         &self,
         req: {{InputType.Codec.QualifiedName}},
@@ -391,8 +489,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{/ReturnsEmpty}}
         {{/Codec.HasBindings}}
     }
-    {{/Codec.IsServerStreaming}}
-    {{/Codec.IsBidiStreaming}}
+    {{/Codec.IsHttp}}
 
     {{/Codec.Methods}}
     {{#Codec.HasLROs}}
@@ -400,16 +497,77 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         &self,
         options: &crate::RequestOptions,
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_error_policy::PollingErrorPolicy> {
+        {{#Codec.HasHttp}}
         self.inner.get_polling_error_policy(options)
+        {{/Codec.HasHttp}}
+        {{^Codec.HasHttp}}
+        self.grpc_inner.get_polling_error_policy(options)
+        {{/Codec.HasHttp}}
     }
 
     fn get_polling_backoff_policy(
         &self,
         options: &crate::RequestOptions,
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy> {
+        {{#Codec.HasHttp}}
         self.inner.get_polling_backoff_policy(options)
+        {{/Codec.HasHttp}}
+        {{^Codec.HasHttp}}
+        self.grpc_inner.get_polling_backoff_policy(options)
+        {{/Codec.HasHttp}}
     }
     {{/Codec.HasLROs}}
 }
 
 {{/Codec.Services}}
+{{#Codec.HasLROs}}
+{{#Codec.HasGrpc}}
+use gaxi::prost::{ConvertError, FromProto, ToProto};
+/// Convert from our `wkt::Any` to a `prost_types::Any`
+///
+/// The encoded types considered for conversion are either metadata or result
+/// types for LROs in this service.
+pub(crate) fn lro_any_to_prost(
+    value: wkt::Any,
+) -> std::result::Result<prost_types::Any, ConvertError> {
+    match value.type_url().unwrap_or_default() {
+        "" => Ok(prost_types::Any::default()),
+{{#Codec.Services}}
+{{#Codec.LROTypes}}
+        "type.googleapis.com/{{Codec.SourceFQN}}" => value
+            .to_msg::<{{Codec.QualifiedName}}>()
+            .map_err(ConvertError::other)?
+            .to_proto()
+            .and_then(|prost_msg| {
+                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
+            }),
+{{/Codec.LROTypes}}
+{{/Codec.Services}}
+        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
+    }
+}
+
+/// Convert from a `prost_types::Any` to our `wkt::Any`
+///
+/// The encoded types considered for conversion are either metadata or result
+/// types for LROs in this service.
+pub(crate) fn lro_any_from_prost(
+    value: prost_types::Any,
+) -> std::result::Result<wkt::Any, ConvertError> {
+    match value.type_url.as_str() {
+        "" => Ok(wkt::Any::default()),
+{{#Codec.Services}}
+{{#Codec.LROTypes}}
+        "type.googleapis.com/{{Codec.SourceFQN}}" => value
+            .to_msg::<crate::prost::{{Codec.PackageModuleName}}::{{Codec.ProstRelativeName}}>()
+            .map_err(ConvertError::other)?
+            .cnv()
+            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
+{{/Codec.LROTypes}}
+{{/Codec.Services}}
+        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
+    }
+}
+{{/Codec.HasGrpc}}
+{{/Codec.HasLROs}}
+

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -236,7 +236,12 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             true,
             {{/HasAutoPopulatedFields}}
             {{^HasAutoPopulatedFields}}
+            {{#PathInfo}}
             {{PathInfo.Codec.IsIdempotent}},
+            {{/PathInfo}}
+            {{^PathInfo}}
+            false,
+            {{/PathInfo}}
             {{/HasAutoPopulatedFields}}
         );
         let extensions = {

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -271,7 +271,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 {{{FieldAccessor}}}.map(|v| format!("{{FieldName}}={v}")),
             {{/PathInfo.Codec.UniqueParameters}}
             {{^PathInfo.Codec.UniqueParameters}}
-            ""; 0
+            None::<String>; 0
             {{/PathInfo.Codec.UniqueParameters}}
         ]
         .into_iter()

--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -525,54 +525,5 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
 }
 
 {{/Codec.Services}}
-{{#Codec.HasLROs}}
-{{#Codec.HasGrpc}}
-use gaxi::prost::{ConvertError, FromProto, ToProto};
-/// Convert from our `wkt::Any` to a `prost_types::Any`
-///
-/// The encoded types considered for conversion are either metadata or result
-/// types for LROs in this service.
-pub(crate) fn lro_any_to_prost(
-    value: wkt::Any,
-) -> std::result::Result<prost_types::Any, ConvertError> {
-    match value.type_url().unwrap_or_default() {
-        "" => Ok(prost_types::Any::default()),
-{{#Codec.Services}}
-{{#Codec.LROTypes}}
-        "type.googleapis.com/{{Codec.SourceFQN}}" => value
-            .to_msg::<{{Codec.QualifiedName}}>()
-            .map_err(ConvertError::other)?
-            .to_proto()
-            .and_then(|prost_msg| {
-                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
-            }),
-{{/Codec.LROTypes}}
-{{/Codec.Services}}
-        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
-    }
-}
 
-/// Convert from a `prost_types::Any` to our `wkt::Any`
-///
-/// The encoded types considered for conversion are either metadata or result
-/// types for LROs in this service.
-pub(crate) fn lro_any_from_prost(
-    value: prost_types::Any,
-) -> std::result::Result<wkt::Any, ConvertError> {
-    match value.type_url.as_str() {
-        "" => Ok(wkt::Any::default()),
-{{#Codec.Services}}
-{{#Codec.LROTypes}}
-        "type.googleapis.com/{{Codec.SourceFQN}}" => value
-            .to_msg::<crate::prost::{{Codec.PackageModuleName}}::{{Codec.ProstRelativeName}}>()
-            .map_err(ConvertError::other)?
-            .cnv()
-            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
-{{/Codec.LROTypes}}
-{{/Codec.Services}}
-        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
-    }
-}
-{{/Codec.HasGrpc}}
-{{/Codec.HasLROs}}
 

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -222,7 +222,12 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             true,
             {{/HasAutoPopulatedFields}}
             {{^HasAutoPopulatedFields}}
+            {{#PathInfo}}
             {{PathInfo.Codec.IsIdempotent}},
+            {{/PathInfo}}
+            {{^PathInfo}}
+            false,
+            {{/PathInfo}}
             {{/HasAutoPopulatedFields}}
         );
         let extensions = {

--- a/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/grpc-client/transport.rs.mustache
@@ -180,7 +180,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 {{{FieldAccessor}}}.map(|v| format!("{{FieldName}}={v}")),
             {{/PathInfo.Codec.UniqueParameters}}
             {{^PathInfo.Codec.UniqueParameters}}
-            ""; 0
+            None::<String>; 0
             {{/PathInfo.Codec.UniqueParameters}}
         ]
         .into_iter()

--- a/internal/sidekick/rust/used_by_test.go
+++ b/internal/sidekick/rust/used_by_test.go
@@ -557,3 +557,77 @@ func TestFindUsedPackages_MapFields(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestUsedByGrpcWithDefaultTransport(t *testing.T) {
+	method := &api.Method{
+		Name: "GetResource",
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
+		"default-transport": "grpc",
+		"package:location":  "package=gcp-sdk-location,source=google.cloud.location",
+		"package:prost":     "used-if=streaming,package=prost",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveUsedPackages(model, c.extraPackages, c.hasGrpc(model))
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "prost",
+			packageName: "prost",
+			used:        true,
+			usedIf:      []string{"streaming"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUsedByGrpcNamedFeature(t *testing.T) {
+	method := &api.Method{
+		Name: "GetResource",
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(libconfig.SpecProtobuf, map[string]string{
+		"default-transport": "grpc",
+		"package:location":  "package=gcp-sdk-location,source=google.cloud.location",
+		"package:prost":     "used-if=grpc,package=prost",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveUsedPackages(model, c.extraPackages, c.hasGrpc(model))
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "prost",
+			packageName: "prost",
+			used:        true,
+			usedIf:      []string{"grpc"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Add the default_transport configuration option ("grpc" | "http") to RustDefault and RustModule in librarian config and sidekick codec.

When default_transport is set to "grpc", unary methods in default crate templates route through gRPC via self.grpc_inner.execute instead of HTTP REST. All request/response types for unary gRPC methods are included in prost hybrid generation and converted using ToProto/FromProto. For this PR, we skip LRO generation on the default template. This is incomplete in other ways, our grpc conversions can add references to external types, which we need to add to the Cargo.toml. For the most part, the intent is to support this for our veneers, which have a handwritten Cargo.toml and do not encounter this issue.

This also adds the librarian side changes to update the used by packages to reference "grpc" instead of "streaming".

For googleapis/google-cloud-rust#6470