### PR TITLE
cleanup(internal/librarian/rust): rename allow_grpc_any_fields configuration

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -570,7 +570,8 @@ This document describes the schema for the librarian.yaml.
 | `resource_name_heuristic` | bool (optional) | Indicates whether to apply heuristics to identify and generate resource names. |
 | `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
 | `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
-| `allow_streaming_any_types` | list of string | Is a list of protobuf field/message IDs with google.protobuf.Any permitted in streaming RPCs (their fields will be dropped in prost conversion). |
+| `allow_grpc_any_fields` | list of string | Is a list of protobuf field IDs with google.protobuf.Any permitted in gRPC/streaming RPCs (their fields will be dropped in prost conversion). |
+| `allow_streaming_any_types` | list of string | Is deprecated: use AllowGrpcAnyFields instead. |
 | `grpc_client` | string | Is the Rust type used for the inner gRPC client in generated transports. Defaults to "gaxi::grpc::Client". |
 
 ## RustDocumentationOverride Configuration

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -571,7 +571,7 @@ This document describes the schema for the librarian.yaml.
 | `include_bidi_streaming_methods` | bool (optional) | Indicates whether to include gRPC bi-directional streaming methods. |
 | `include_server_streaming_methods` | bool (optional) | Indicates whether to include gRPC server-side streaming methods. |
 | `allow_grpc_any_fields` | list of string | Is a list of protobuf field IDs with google.protobuf.Any permitted in gRPC/streaming RPCs (their fields will be dropped in prost conversion). |
-| `allow_streaming_any_types` | list of string | Is deprecated: use AllowGrpcAnyFields instead. |
+| `allow_streaming_any_types` | list of string | Is deprecated: use allow_grpc_any_fields instead. |
 | `grpc_client` | string | Is the Rust type used for the inner gRPC client in generated transports. Defaults to "gaxi::grpc::Client". |
 
 ## RustDocumentationOverride Configuration

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -134,7 +134,7 @@ type RustDefault struct {
 	// permitted in gRPC/streaming RPCs (their fields will be dropped in prost conversion).
 	AllowGrpcAnyFields []string `yaml:"allow_grpc_any_fields,omitempty"`
 
-	// AllowStreamingAnyTypes is deprecated: use AllowGrpcAnyFields instead.
+	// AllowStreamingAnyTypes is deprecated: use allow_grpc_any_fields instead.
 	AllowStreamingAnyTypes []string `yaml:"allow_streaming_any_types,omitempty"`
 
 	// GrpcClient is the Rust type used for the inner gRPC client in generated transports.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -130,8 +130,11 @@ type RustDefault struct {
 	// methods.
 	IncludeServerStreamingMethods *bool `yaml:"include_server_streaming_methods,omitempty"`
 
-	// AllowStreamingAnyTypes is a list of protobuf field/message IDs with google.protobuf.Any
-	// permitted in streaming RPCs (their fields will be dropped in prost conversion).
+	// AllowGrpcAnyFields is a list of protobuf field IDs with google.protobuf.Any
+	// permitted in gRPC/streaming RPCs (their fields will be dropped in prost conversion).
+	AllowGrpcAnyFields []string `yaml:"allow_grpc_any_fields,omitempty"`
+
+	// AllowStreamingAnyTypes is deprecated: use AllowGrpcAnyFields instead.
 	AllowStreamingAnyTypes []string `yaml:"allow_streaming_any_types,omitempty"`
 
 	// GrpcClient is the Rust type used for the inner gRPC client in generated transports.

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -149,6 +149,9 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Rust.IncludeServerStreamingMethods == nil {
 		lib.Rust.IncludeServerStreamingMethods = d.Rust.IncludeServerStreamingMethods
 	}
+	if len(lib.Rust.AllowGrpcAnyFields) == 0 && d.Rust != nil {
+		lib.Rust.AllowGrpcAnyFields = d.Rust.AllowGrpcAnyFields
+	}
 	if len(lib.Rust.AllowStreamingAnyTypes) == 0 && d.Rust != nil {
 		lib.Rust.AllowStreamingAnyTypes = d.Rust.AllowStreamingAnyTypes
 	}
@@ -839,6 +842,9 @@ func mergeRust(dst, src *config.RustCrate) *config.RustCrate {
 	}
 	if src.IncludeServerStreamingMethods != nil {
 		res.IncludeServerStreamingMethods = src.IncludeServerStreamingMethods
+	}
+	if len(src.AllowGrpcAnyFields) > 0 {
+		res.AllowGrpcAnyFields = src.AllowGrpcAnyFields
 	}
 	if len(src.AllowStreamingAnyTypes) > 0 {
 		res.AllowStreamingAnyTypes = src.AllowStreamingAnyTypes

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -149,10 +149,10 @@ func fillRust(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Rust.IncludeServerStreamingMethods == nil {
 		lib.Rust.IncludeServerStreamingMethods = d.Rust.IncludeServerStreamingMethods
 	}
-	if len(lib.Rust.AllowGrpcAnyFields) == 0 && d.Rust != nil {
+	if len(lib.Rust.AllowGrpcAnyFields) == 0 {
 		lib.Rust.AllowGrpcAnyFields = d.Rust.AllowGrpcAnyFields
 	}
-	if len(lib.Rust.AllowStreamingAnyTypes) == 0 && d.Rust != nil {
+	if len(lib.Rust.AllowStreamingAnyTypes) == 0 {
 		lib.Rust.AllowStreamingAnyTypes = d.Rust.AllowStreamingAnyTypes
 	}
 	for _, mod := range lib.Rust.Modules {

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -243,6 +243,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 			DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 			GenerateSetterSamples:   "true",
 			GenerateRpcSamples:      "true",
+			AllowGrpcAnyFields:      []string{".google.test.Any.field"},
 		},
 	}
 	for _, test := range []struct {
@@ -267,6 +268,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "true",
 						GenerateRpcSamples:      "true",
+						AllowGrpcAnyFields:      []string{".google.test.Any.field"},
 					},
 					Modules: []*config.RustModule{
 						{
@@ -301,6 +303,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "true",
 						GenerateRpcSamples:      "true",
+						AllowGrpcAnyFields:      []string{".google.test.Any.field"},
 					},
 				},
 			},
@@ -328,6 +331,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "false",
 						GenerateRpcSamples:      "false",
+						AllowGrpcAnyFields:      []string{".google.test.Any.field"},
 					},
 				},
 			},
@@ -351,6 +355,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 						DisabledRustdocWarnings: []string{"custom_warning"},
 						GenerateSetterSamples:   "true",
 						GenerateRpcSamples:      "true",
+						AllowGrpcAnyFields:      []string{".google.test.Any.field"},
 					},
 				},
 			},
@@ -377,6 +382,7 @@ func TestFillDefaults_Rust(t *testing.T) {
 						DisabledRustdocWarnings: []string{"broken_intra_doc_links"},
 						GenerateSetterSamples:   "true",
 						GenerateRpcSamples:      "true",
+						AllowGrpcAnyFields:      []string{".google.test.Any.field"},
 					},
 					Modules: []*config.RustModule{
 						{
@@ -1601,6 +1607,7 @@ func TestMergeRust(t *testing.T) {
 					GenerateRpcSamples:        "true",
 					DetailedTracingAttributes: &detailedTracing,
 					ResourceNameHeuristic:     &resourceHeuristic,
+					AllowGrpcAnyFields:        []string{".any.field"},
 				},
 				Modules:                   []*config.RustModule{{Output: "out"}},
 				PerServiceFeatures:        true,
@@ -1632,6 +1639,7 @@ func TestMergeRust(t *testing.T) {
 					GenerateRpcSamples:        "true",
 					DetailedTracingAttributes: &detailedTracing,
 					ResourceNameHeuristic:     &resourceHeuristic,
+					AllowGrpcAnyFields:        []string{".any.field"},
 				},
 				Modules:                   []*config.RustModule{{Output: "out"}},
 				PerServiceFeatures:        true,

--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -67,7 +67,8 @@ func generateProstHybrid(ctx context.Context, model *api.API, rootTypeIDs []stri
 		return nil
 	}
 
-	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToTypes(model, rootTypeIDs, library.Rust.AllowStreamingAnyTypes)
+	allowedAnyFields := append(slices.Clone(library.Rust.AllowGrpcAnyFields), library.Rust.AllowStreamingAnyTypes...)
+	hybridModel, unusedTypes, hasGoogleRpcStatus, err := filterModelToTypes(model, rootTypeIDs, allowedAnyFields)
 	if err != nil {
 		return err
 	}
@@ -103,8 +104,8 @@ func generateProstHybrid(ctx context.Context, model *api.API, rootTypeIDs []stri
 // from rootTypeIDs for prost conversion generation. It also returns a sorted slice
 // of all non-WKT unused type IDs to exclude via prost_build extern_path, and a boolean
 // indicating whether google.rpc.Status is referenced in the reachability path.
-// Errors if Any is encountered in the reachability path unless explicitly allowed via allowAnyTypes.
-func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []string) (*api.API, []string, bool, error) {
+// Errors if Any is encountered in the reachability path unless explicitly allowed via allowGrpcAnyFields.
+func filterModelToTypes(model *api.API, rootTypeIDs []string, allowGrpcAnyFields []string) (*api.API, []string, bool, error) {
 	type typeItem struct {
 		id   string
 		path string
@@ -194,7 +195,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 			for _, f := range msg.Fields {
 				fieldPath := item.path + "." + f.Name
 				if isAnyType(f.TypezID) {
-					if matchesAllowedAnyField(f.ID, allowAnyTypes) || matchesAllowedAnyField(fieldPath, allowAnyTypes) {
+					if matchesAllowedAnyField(f.ID, allowGrpcAnyFields) || matchesAllowedAnyField(fieldPath, allowGrpcAnyFields) {
 						f.SkipProtoConversion = true
 						continue
 					}
@@ -215,7 +216,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 				for _, f := range o.Fields {
 					fieldPath := item.path + "." + f.Name
 					if isAnyType(f.TypezID) {
-						if matchesAllowedAnyField(f.ID, allowAnyTypes) || matchesAllowedAnyField(fieldPath, allowAnyTypes) {
+						if matchesAllowedAnyField(f.ID, allowGrpcAnyFields) || matchesAllowedAnyField(fieldPath, allowGrpcAnyFields) {
 							f.SkipProtoConversion = true
 							continue
 						}
@@ -249,9 +250,9 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 		for _, f := range unsupportedAnyFields {
 			fmt.Fprintf(&sb, "  - %s\n", f)
 		}
-		sb.WriteString("\nTo resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n")
+		sb.WriteString("\nTo resolve this, allow dropping Any fields in prost conversion by adding them to allow_grpc_any_fields in librarian.yaml:\n")
 		sb.WriteString("    rust:\n")
-		sb.WriteString("      allow_streaming_any_types:\n")
+		sb.WriteString("      allow_grpc_any_fields:\n")
 		for _, f := range unsupportedAnyFields {
 			fmt.Fprintf(&sb, "        - %s\n", f)
 		}
@@ -333,9 +334,9 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 	return &hybridModel, slices.Compact(unusedTypes), hasGoogleRpcStatus, nil
 }
 
-func matchesAllowedAnyField(id string, allowStreamingAnyTypes []string) bool {
+func matchesAllowedAnyField(id string, allowGrpcAnyFields []string) bool {
 	idTrimmed := strings.TrimPrefix(id, ".")
-	for _, allowed := range allowStreamingAnyTypes {
+	for _, allowed := range allowGrpcAnyFields {
 		if strings.TrimPrefix(allowed, ".") == idTrimmed {
 			return true
 		}

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -258,9 +258,9 @@ func TestFilterModelToTypesAnyError(t *testing.T) {
 	}
 	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
 		"  - .google.test.v1.AnyReq.details\n\n" +
-		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_grpc_any_fields in librarian.yaml:\n" +
 		"    rust:\n" +
-		"      allow_streaming_any_types:\n" +
+		"      allow_grpc_any_fields:\n" +
 		"        - .google.test.v1.AnyReq.details"
 	if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
 		t.Errorf("error message mismatch (-want +got):\n%s", diff)
@@ -294,9 +294,9 @@ func TestFilterModelToStreamingMultipleAnyError(t *testing.T) {
 	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
 		"  - .google.test.v1.AnyReq.details\n" +
 		"  - .google.test.v1.AnyReq.metadata\n\n" +
-		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_grpc_any_fields in librarian.yaml:\n" +
 		"    rust:\n" +
-		"      allow_streaming_any_types:\n" +
+		"      allow_grpc_any_fields:\n" +
 		"        - .google.test.v1.AnyReq.details\n" +
 		"        - .google.test.v1.AnyReq.metadata"
 
@@ -331,9 +331,9 @@ func TestFilterModelToStreamingPartialAllowedAny(t *testing.T) {
 
 	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
 		"  - .google.test.v1.AnyReq.metadata\n\n" +
-		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_grpc_any_fields in librarian.yaml:\n" +
 		"    rust:\n" +
-		"      allow_streaming_any_types:\n" +
+		"      allow_grpc_any_fields:\n" +
 		"        - .google.test.v1.AnyReq.metadata"
 
 	if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
@@ -377,9 +377,9 @@ func TestFilterModelToStreamingNestedAndOneofAnyError(t *testing.T) {
 	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
 		"  - .google.test.v1.ParentReq.child.extra\n" +
 		"  - .google.test.v1.ParentReq.payload\n\n" +
-		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_grpc_any_fields in librarian.yaml:\n" +
 		"    rust:\n" +
-		"      allow_streaming_any_types:\n" +
+		"      allow_grpc_any_fields:\n" +
 		"        - .google.test.v1.ParentReq.child.extra\n" +
 		"        - .google.test.v1.ParentReq.payload"
 


### PR DESCRIPTION
Add allow_grpc_any_fields to Rust options in librarian.yaml to allow dropping specific google.protobuf.Any fields in prost conversions for gRPC/streaming RPCs.

Deprecate allow_streaming_any_types in favor of allow_grpc_any_fields, maintaining backwards compatibility during the transition.