### PR TITLE
fix(internal/librarian): update bulk release-please config for existing python libraries

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1322,11 +1322,16 @@ func TestAddLibraryCommand_Python_ExistingLibraryReleasePlease(t *testing.T) {
 	pkgs := gotBulkConfig["packages"].(map[string]any)
 	pkg := pkgs["packages/google-cloud-secretmanager"].(map[string]any)
 	extraFiles := pkg["extra-files"].([]any)
-	if !slices.ContainsFunc(extraFiles, func(elem any) bool {
-		s, ok := elem.(string)
-		return ok && s == "google/cloud/secretmanager_v1beta2/gapic_version.py"
-	}) {
-		t.Errorf("bulk config extra-files missing v1beta2 gapic_version.py, got: %v", extraFiles)
+	for _, want := range []string{
+		"google/cloud/secretmanager_v1/gapic_version.py",
+		"google/cloud/secretmanager_v1beta2/gapic_version.py",
+	} {
+		if !slices.ContainsFunc(extraFiles, func(elem any) bool {
+			s, ok := elem.(string)
+			return ok && s == want
+		}) {
+			t.Errorf("bulk config extra-files missing %s, got: %v", want, extraFiles)
+		}
 	}
 	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, individualConfigFile))
 	if err != nil {

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -1247,5 +1248,95 @@ func TestAddLibraryCommand_GoogleapisCache(t *testing.T) {
 	err = runAdd(t.Context(), cfg, "google/cloud/secretmanager/v1", "")
 	if err != nil {
 		t.Fatalf("expected runAdd to succeed with cached googleapis, got %v", err)
+	}
+}
+
+func TestAddLibraryCommand_Python_ExistingLibraryReleasePlease(t *testing.T) {
+	googleapisDir, err := filepath.Abs("../testdata/googleapis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	initialBulkManifest := `{"packages/google-cloud-secretmanager": "1.2.3"}`
+	initialBulkConfig := `{
+		"packages": {
+			"packages/google-cloud-secretmanager": {
+				"component": "google-cloud-secretmanager",
+				"extra-files": [
+					"google/cloud/secretmanager/gapic_version.py",
+					"google/cloud/secretmanager_v1/gapic_version.py",
+					{
+						"jsonpath": "$.clientLibrary.version",
+						"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
+						"type": "json"
+					}
+				]
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-bulk-manifest.json"), []byte(initialBulkManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "release-please-bulk-config.json"), []byte(initialBulkConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-individual-manifest.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "release-please-individual-config.json"), []byte(`{"packages": {}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := sample.Config()
+	cfg.Language = config.LanguagePython
+	cfg.Default.Output = "output"
+	cfg.Sources.Googleapis.Dir = googleapisDir
+	cfg.Libraries = []*config.Library{
+		{
+			Name:    "google-cloud-secretmanager",
+			Version: "1.2.3",
+			APIs: []*config.API{
+				{Path: "google/cloud/secretmanager/v1"},
+			},
+			Python: &config.PythonPackage{
+				DefaultVersion: "v1",
+			},
+		},
+	}
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Run(t.Context(), "librarian", "add", "google/cloud/secretmanager/v1beta2"); err != nil {
+		t.Fatal(err)
+	}
+
+	gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lib, err := FindLibrary(gotCfg, "google-cloud-secretmanager")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lib.APIs) != 2 {
+		t.Fatalf("expected 2 APIs in library, got %d", len(lib.APIs))
+	}
+	gotBulkConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-bulk-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgs := gotBulkConfig["packages"].(map[string]any)
+	pkg := pkgs["packages/google-cloud-secretmanager"].(map[string]any)
+	extraFiles := pkg["extra-files"].([]any)
+	if !slices.Contains(extraFiles, "google/cloud/secretmanager_v1beta2/gapic_version.py") {
+		t.Errorf("bulk config extra-files missing v1beta2 gapic_version.py, got: %v", extraFiles)
+	}
+	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-individual-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotIndConfig); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1258,7 +1258,6 @@ func TestAddLibraryCommand_Python_ExistingLibraryReleasePlease(t *testing.T) {
 	}
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	initialBulkManifest := `{"packages/google-cloud-secretmanager": "1.2.3"}`
 	initialBulkConfig := `{
 		"packages": {
 			"packages/google-cloud-secretmanager": {
@@ -1275,18 +1274,12 @@ func TestAddLibraryCommand_Python_ExistingLibraryReleasePlease(t *testing.T) {
 			}
 		}
 	}`
-	if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-bulk-manifest.json"), []byte(initialBulkManifest), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "release-please-bulk-config.json"), []byte(initialBulkConfig), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, ".release-please-individual-manifest.json"), []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "release-please-individual-config.json"), []byte(`{"packages": {}}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFiles(t, tmpDir, map[string]string{
+		bulkManifestFile:       `{"packages/google-cloud-secretmanager": "1.2.3"}`,
+		bulkConfigFile:         initialBulkConfig,
+		individualManifestFile: `{}`,
+		individualConfigFile:   `{"packages": {}}`,
+	})
 	cfg := sample.Config()
 	cfg.Language = config.LanguagePython
 	cfg.Default.Output = "output"
@@ -1322,7 +1315,7 @@ func TestAddLibraryCommand_Python_ExistingLibraryReleasePlease(t *testing.T) {
 	if len(lib.APIs) != 2 {
 		t.Fatalf("expected 2 APIs in library, got %d", len(lib.APIs))
 	}
-	gotBulkConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-bulk-config.json"))
+	gotBulkConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, bulkConfigFile))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1332,7 +1325,7 @@ func TestAddLibraryCommand_Python_ExistingLibraryReleasePlease(t *testing.T) {
 	if !slices.Contains(extraFiles, "google/cloud/secretmanager_v1beta2/gapic_version.py") {
 		t.Errorf("bulk config extra-files missing v1beta2 gapic_version.py, got: %v", extraFiles)
 	}
-	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, "release-please-individual-config.json"))
+	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, individualConfigFile))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -1322,7 +1322,10 @@ func TestAddLibraryCommand_Python_ExistingLibraryReleasePlease(t *testing.T) {
 	pkgs := gotBulkConfig["packages"].(map[string]any)
 	pkg := pkgs["packages/google-cloud-secretmanager"].(map[string]any)
 	extraFiles := pkg["extra-files"].([]any)
-	if !slices.Contains(extraFiles, "google/cloud/secretmanager_v1beta2/gapic_version.py") {
+	if !slices.ContainsFunc(extraFiles, func(elem any) bool {
+		s, ok := elem.(string)
+		return ok && s == "google/cloud/secretmanager_v1beta2/gapic_version.py"
+	}) {
 		t.Errorf("bulk config extra-files missing v1beta2 gapic_version.py, got: %v", extraFiles)
 	}
 	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmpDir, individualConfigFile))

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -47,7 +47,15 @@ type extraFile struct {
 }
 
 func hasReleasePleaseConfigs(dir string, cfg *config.Config) bool {
+	if cfg.Language == config.LanguagePython {
+		return hasReleasePleasePair(dir, individualManifestFile, individualConfigFile) ||
+			hasReleasePleasePair(dir, bulkManifestFile, bulkConfigFile)
+	}
 	manifestFile, configFile := releasePleaseFiles(cfg)
+	return hasReleasePleasePair(dir, manifestFile, configFile)
+}
+
+func hasReleasePleasePair(dir, manifestFile, configFile string) bool {
 	_, errM := os.Stat(filepath.Join(dir, manifestFile))
 	_, errC := os.Stat(filepath.Join(dir, configFile))
 	return !errors.Is(errM, fs.ErrNotExist) && !errors.Is(errC, fs.ErrNotExist)

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -46,38 +46,60 @@ type extraFile struct {
 	rawMap map[string]any
 }
 
-func hasReleasePleaseConfigs(dir string, cfg *config.Config) bool {
-	if cfg.Language == config.LanguagePython {
-		return hasReleasePleasePair(dir, individualManifestFile, individualConfigFile) ||
-			hasReleasePleasePair(dir, bulkManifestFile, bulkConfigFile)
-	}
-	manifestFile, configFile := releasePleaseFiles(cfg)
-	return hasReleasePleasePair(dir, manifestFile, configFile)
+type releasePleasePair struct {
+	manifestFile string
+	configFile   string
 }
 
-func hasReleasePleasePair(dir, manifestFile, configFile string) bool {
-	_, errM := os.Stat(filepath.Join(dir, manifestFile))
-	_, errC := os.Stat(filepath.Join(dir, configFile))
+func (p releasePleasePair) exists(dir string) bool {
+	if p.manifestFile == "" || p.configFile == "" {
+		return false
+	}
+	_, errM := os.Stat(filepath.Join(dir, p.manifestFile))
+	_, errC := os.Stat(filepath.Join(dir, p.configFile))
 	return !errors.Is(errM, fs.ErrNotExist) && !errors.Is(errC, fs.ErrNotExist)
 }
 
-// releasePleaseFiles returns the file names for the Release Please manifest file
-// and config file in this order, depending on the SDK language.
-func releasePleaseFiles(cfg *config.Config) (string, string) {
-	// google-cloud-node and google-cloud-ruby use the default Release Please files to add a new library.
-	// google-cloud-python uses the "-individual-" files initially for new libraries.
-	// google-cloud-go uses the "-bulk-" files.
-	manifestFile := bulkManifestFile
-	configFile := bulkConfigFile
+type releasePleaseConfigFiles struct {
+	bulk       releasePleasePair
+	individual releasePleasePair
+}
+
+func hasReleasePleaseConfigs(dir string, cfg *config.Config) bool {
+	files := releasePleaseFiles(cfg)
+	return files.bulk.exists(dir) || files.individual.exists(dir)
+}
+
+// releasePleaseFiles returns the Release Please manifest and config file pairs
+// for the given SDK language.
+func releasePleaseFiles(cfg *config.Config) releasePleaseConfigFiles {
 	switch cfg.Language {
 	case config.LanguagePython:
-		manifestFile = individualManifestFile
-		configFile = individualConfigFile
+		return releasePleaseConfigFiles{
+			bulk: releasePleasePair{
+				manifestFile: bulkManifestFile,
+				configFile:   bulkConfigFile,
+			},
+			individual: releasePleasePair{
+				manifestFile: individualManifestFile,
+				configFile:   individualConfigFile,
+			},
+		}
 	case config.LanguageNodejs, config.LanguageRuby:
-		manifestFile = defaultManifestFile
-		configFile = defaultConfigFile
+		return releasePleaseConfigFiles{
+			bulk: releasePleasePair{
+				manifestFile: defaultManifestFile,
+				configFile:   defaultConfigFile,
+			},
+		}
+	default:
+		return releasePleaseConfigFiles{
+			bulk: releasePleasePair{
+				manifestFile: bulkManifestFile,
+				configFile:   bulkConfigFile,
+			},
+		}
 	}
-	return manifestFile, configFile
 }
 
 // isTrackedInBulkConfig reports whether the package path is already tracked
@@ -104,15 +126,17 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 		return err
 	}
 
-	manifestFile, configFile := releasePleaseFiles(cfg)
+	files := releasePleaseFiles(cfg)
+	target := files.bulk
 	pkgPath := lib.Name
 	if cfg.Language == config.LanguagePython {
 		pkgPath = python.ReleasePleasePkgPrefix + lib.Name
-		if isTrackedInBulkConfig(dir, pkgPath) {
-			manifestFile = bulkManifestFile
-			configFile = bulkConfigFile
+		if !isTrackedInBulkConfig(dir, pkgPath) {
+			target = files.individual
 		}
 	}
+	manifestFile := target.manifestFile
+	configFile := target.configFile
 	manifestPath := filepath.Join(dir, manifestFile)
 	manifest, err := readJSONFile[map[string]string](manifestPath)
 	if err != nil {

--- a/internal/librarian/release_please.go
+++ b/internal/librarian/release_please.go
@@ -72,6 +72,21 @@ func releasePleaseFiles(cfg *config.Config) (string, string) {
 	return manifestFile, configFile
 }
 
+// isTrackedInBulkConfig reports whether the package path is already tracked
+// in the bulk release-please configuration file.
+func isTrackedInBulkConfig(dir, pkgPath string) bool {
+	bulkConfig, err := readJSONFile[map[string]any](filepath.Join(dir, bulkConfigFile))
+	if err != nil {
+		return false
+	}
+	pkgs, ok := bulkConfig["packages"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, exists := pkgs[pkgPath]
+	return exists
+}
+
 // syncToReleasePlease updates the release-please configuration files with the
 // onboarded library's package name, initial version, and language-specific
 // extra files to track for release version bumps.
@@ -82,6 +97,14 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 	}
 
 	manifestFile, configFile := releasePleaseFiles(cfg)
+	pkgPath := lib.Name
+	if cfg.Language == config.LanguagePython {
+		pkgPath = python.ReleasePleasePkgPrefix + lib.Name
+		if isTrackedInBulkConfig(dir, pkgPath) {
+			manifestFile = bulkManifestFile
+			configFile = bulkConfigFile
+		}
+	}
 	manifestPath := filepath.Join(dir, manifestFile)
 	manifest, err := readJSONFile[map[string]string](manifestPath)
 	if err != nil {
@@ -111,10 +134,8 @@ func syncToReleasePlease(dir string, cfg *config.Config, name string) error {
 	}
 
 	var extraFiles []any
-	pkgPath := lib.Name
 	switch cfg.Language {
 	case config.LanguagePython:
-		pkgPath = python.ReleasePleasePkgPrefix + lib.Name
 		extraFiles = python.ReleasePleaseExtraFiles(lib)
 	case config.LanguageGo:
 		extraFiles = golang.ReleasePleaseExtraFiles(lib)

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -18,12 +18,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
-	"github.com/googleapis/librarian/internal/librarian/python"
 )
 
 func TestHasReleasePleaseConfigs(t *testing.T) {
@@ -90,53 +88,17 @@ func TestHasReleasePleaseConfigs(t *testing.T) {
 			createManifest: true,
 			want:           true,
 		},
-		{
-			name:           "both missing (Python)",
-			language:       config.LanguagePython,
-			createConfig:   false,
-			createManifest: false,
-			want:           false,
-		},
-		{
-			name:           "config missing (Python)",
-			language:       config.LanguagePython,
-			createConfig:   false,
-			createManifest: true,
-			want:           false,
-		},
-		{
-			name:           "manifest missing (Python)",
-			language:       config.LanguagePython,
-			createConfig:   true,
-			createManifest: false,
-			want:           false,
-		},
-		{
-			name:           "both exist (Python)",
-			language:       config.LanguagePython,
-			createConfig:   true,
-			createManifest: true,
-			want:           true,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmp := t.TempDir()
-			files := releasePleaseFiles(
-				&config.Config{
-					Language: test.language,
-				},
-			)
-			target := files.bulk
-			if test.language == config.LanguagePython {
-				target = files.individual
-			}
+			files := releasePleaseFiles(&config.Config{Language: test.language})
 			if test.createConfig {
-				if err := os.WriteFile(filepath.Join(tmp, target.configFile), []byte("{}"), 0o644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmp, files.bulk.configFile), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
 			if test.createManifest {
-				if err := os.WriteFile(filepath.Join(tmp, target.manifestFile), []byte("{}"), 0o644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmp, files.bulk.manifestFile), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -148,41 +110,57 @@ func TestHasReleasePleaseConfigs(t *testing.T) {
 	}
 }
 
-func TestHasReleasePleaseConfigs_PythonBulk(t *testing.T) {
+func TestHasReleasePleaseConfigs_Python(t *testing.T) {
 	for _, test := range []struct {
-		name           string
-		createConfig   bool
-		createManifest bool
-		want           bool
+		name  string
+		files []string
+		want  bool
 	}{
 		{
-			name:           "both bulk exist",
-			createConfig:   true,
-			createManifest: true,
-			want:           true,
+			name:  "both individual exist",
+			files: []string{individualConfigFile, individualManifestFile},
+			want:  true,
 		},
 		{
-			name:           "bulk config missing",
-			createConfig:   false,
-			createManifest: true,
-			want:           false,
+			name:  "individual config missing",
+			files: []string{individualManifestFile},
+			want:  false,
 		},
 		{
-			name:           "bulk manifest missing",
-			createConfig:   true,
-			createManifest: false,
-			want:           false,
+			name:  "individual manifest missing",
+			files: []string{individualConfigFile},
+			want:  false,
+		},
+		{
+			name:  "both bulk exist",
+			files: []string{bulkConfigFile, bulkManifestFile},
+			want:  true,
+		},
+		{
+			name:  "bulk config missing",
+			files: []string{bulkManifestFile},
+			want:  false,
+		},
+		{
+			name:  "bulk manifest missing",
+			files: []string{bulkConfigFile},
+			want:  false,
+		},
+		{
+			name:  "all exist",
+			files: []string{bulkConfigFile, bulkManifestFile, individualConfigFile, individualManifestFile},
+			want:  true,
+		},
+		{
+			name:  "all missing",
+			files: nil,
+			want:  false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmp := t.TempDir()
-			if test.createConfig {
-				if err := os.WriteFile(filepath.Join(tmp, bulkConfigFile), []byte("{}"), 0o644); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if test.createManifest {
-				if err := os.WriteFile(filepath.Join(tmp, bulkManifestFile), []byte("{}"), 0o644); err != nil {
+			for _, file := range test.files {
+				if err := os.WriteFile(filepath.Join(tmp, file), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -247,91 +225,6 @@ func TestSyncToReleasePlease(t *testing.T) {
 			wantManifest: `{"packages/google-cloud-secretmanager":"1.0.0"}`,
 			wantConfig:   `{"packages":{"packages/google-cloud-secretmanager":{}}}`,
 		},
-
-		{
-			name:            "new python library",
-			language:        config.LanguagePython,
-			initialManifest: `{}`,
-			initialConfig:   `{"packages": {}}`,
-			library: &config.Library{
-				Name:    "google-cloud-secretmanager",
-				Version: "0.0.0",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			wantManifest: `{"packages/google-cloud-secretmanager":"0.0.0"}`,
-			wantConfig: `{
-				"packages": {
-					"packages/google-cloud-secretmanager": {
-						"component": "google-cloud-secretmanager",
-						"extra-files": [
-							"google/cloud/secretmanager/gapic_version.py",
-							"google/cloud/secretmanager_v1/gapic_version.py",
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
-								"type": "json"
-							}
-						]
-					}
-				}
-			}`,
-		},
-		{
-			name:            "update existing python library (merge, deduplicate, sort)",
-			language:        config.LanguagePython,
-			initialManifest: `{"packages/google-cloud-secretmanager":"1.0.0"}`,
-			initialConfig: `{
-				"packages": {
-					"packages/google-cloud-secretmanager": {
-						"component": "google-cloud-secretmanager",
-						"release-type": "python",
-						"extra-files": [
-							"google/cloud/secretmanager/gapic_version.py",
-							"google/cloud/secretmanager_v1/gapic_version.py",
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
-								"type": "json"
-							}
-						]
-					}
-				}
-			}`,
-			library: &config.Library{
-				Name:    "google-cloud-secretmanager",
-				Version: "1.0.0",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-					{Path: "google/cloud/secretmanager/v1beta1"},
-				},
-			},
-			wantManifest: `{"packages/google-cloud-secretmanager":"1.0.0"}`,
-			wantConfig: `{
-				"packages": {
-					"packages/google-cloud-secretmanager": {
-						"component": "google-cloud-secretmanager",
-						"release-type": "python",
-						"extra-files": [
-							"google/cloud/secretmanager/gapic_version.py",
-							"google/cloud/secretmanager_v1/gapic_version.py",
-							"google/cloud/secretmanager_v1beta1/gapic_version.py",
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
-								"type": "json"
-							},
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1beta1.json",
-								"type": "json"
-							}
-						]
-					}
-				}
-			}`,
-		},
 		{
 			name:            "preserve existing extra-files for go library",
 			language:        config.LanguageGo,
@@ -361,45 +254,6 @@ func TestSyncToReleasePlease(t *testing.T) {
 							{
 								"jsonpath": "$.clientLibrary.version",
 								"path": "examples/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json",
-								"type": "json"
-							}
-						]
-					}
-				}
-			}`,
-		},
-		{
-			name:            "replace existing string extra-files with map if same path",
-			language:        config.LanguagePython,
-			initialManifest: `{"packages/google-cloud-secretmanager":"1.0.0"}`,
-			initialConfig: `{
-				"packages": {
-					"packages/google-cloud-secretmanager": {
-						"component": "google-cloud-secretmanager",
-						"extra-files": [
-							"samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json"
-						]
-					}
-				}
-			}`,
-			library: &config.Library{
-				Name:    "google-cloud-secretmanager",
-				Version: "1.0.0",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			wantManifest: `{"packages/google-cloud-secretmanager":"1.0.0"}`,
-			wantConfig: `{
-				"packages": {
-					"packages/google-cloud-secretmanager": {
-						"component": "google-cloud-secretmanager",
-						"extra-files": [
-							"google/cloud/secretmanager/gapic_version.py",
-							"google/cloud/secretmanager_v1/gapic_version.py",
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
 								"type": "json"
 							}
 						]
@@ -481,12 +335,8 @@ func TestSyncToReleasePlease(t *testing.T) {
 					Language: test.language,
 				},
 			)
-			target := files.bulk
-			if test.language == config.LanguagePython {
-				target = files.individual
-			}
-			manifestPath := filepath.Join(tmp, target.manifestFile)
-			configPath := filepath.Join(tmp, target.configFile)
+			manifestPath := filepath.Join(tmp, files.bulk.manifestFile)
+			configPath := filepath.Join(tmp, files.bulk.configFile)
 			if err := os.WriteFile(manifestPath, []byte(test.initialManifest), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -646,7 +496,8 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 		files                map[string]string
 		wantModifiedConfig   string
 		wantUnmodifiedConfig string
-		wantExtraFiles       []string
+		wantManifest         string
+		wantConfig           string
 	}{
 		{
 			name: "updates bulk config when tracked in bulk",
@@ -676,10 +527,29 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			},
 			wantModifiedConfig:   bulkConfigFile,
 			wantUnmodifiedConfig: individualConfigFile,
-			wantExtraFiles: []string{
-				"google/cloud/biglake_hive_v1beta/gapic_version.py",
-				"google/cloud/biglake_hive_v1/gapic_version.py",
-			},
+			wantManifest:         `{"packages/google-cloud-biglake-hive": "0.3.2"}`,
+			wantConfig: `{
+				"packages": {
+					"packages/google-cloud-biglake-hive": {
+						"component": "google-cloud-biglake-hive",
+						"extra-files": [
+							"google/cloud/biglake_hive/gapic_version.py",
+							"google/cloud/biglake_hive_v1/gapic_version.py",
+							"google/cloud/biglake_hive_v1beta/gapic_version.py",
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.biglake.hive.v1.json",
+								"type": "json"
+							},
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.biglake.hive.v1beta.json",
+								"type": "json"
+							}
+						]
+					}
+				}
+			}`,
 		},
 		{
 			name: "updates individual config when tracked in individual",
@@ -709,10 +579,167 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			},
 			wantModifiedConfig:   individualConfigFile,
 			wantUnmodifiedConfig: bulkConfigFile,
-			wantExtraFiles: []string{
-				"google/cloud/newservice_v1/gapic_version.py",
-				"google/cloud/newservice_v1beta/gapic_version.py",
+			wantManifest:         `{"packages/google-cloud-newservice": "0.0.0"}`,
+			wantConfig: `{
+				"packages": {
+					"packages/google-cloud-newservice": {
+						"component": "google-cloud-newservice",
+						"extra-files": [
+							"google/cloud/newservice/gapic_version.py",
+							"google/cloud/newservice_v1/gapic_version.py",
+							"google/cloud/newservice_v1beta/gapic_version.py",
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.newservice.v1.json",
+								"type": "json"
+							},
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.newservice.v1beta.json",
+								"type": "json"
+							}
+						]
+					}
+				}
+			}`,
+		},
+		{
+			name: "new python library",
+			library: &config.Library{
+				Name:    "google-cloud-secretmanager",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
 			},
+			files: map[string]string{
+				bulkManifestFile:       `{}`,
+				bulkConfigFile:         `{"packages": {}}`,
+				individualManifestFile: `{}`,
+				individualConfigFile:   `{"packages": {}}`,
+			},
+			wantModifiedConfig:   individualConfigFile,
+			wantUnmodifiedConfig: bulkConfigFile,
+			wantManifest:         `{"packages/google-cloud-secretmanager":"0.0.0"}`,
+			wantConfig: `{
+				"packages": {
+					"packages/google-cloud-secretmanager": {
+						"component": "google-cloud-secretmanager",
+						"extra-files": [
+							"google/cloud/secretmanager/gapic_version.py",
+							"google/cloud/secretmanager_v1/gapic_version.py",
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
+								"type": "json"
+							}
+						]
+					}
+				}
+			}`,
+		},
+		{
+			name: "update existing python library (merge, deduplicate, sort)",
+			library: &config.Library{
+				Name:    "google-cloud-secretmanager",
+				Version: "1.0.0",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+					{Path: "google/cloud/secretmanager/v1beta1"},
+				},
+			},
+			files: map[string]string{
+				bulkManifestFile:       `{}`,
+				bulkConfigFile:         `{"packages": {}}`,
+				individualManifestFile: `{"packages/google-cloud-secretmanager":"1.0.0"}`,
+				individualConfigFile: `{
+					"packages": {
+						"packages/google-cloud-secretmanager": {
+							"component": "google-cloud-secretmanager",
+							"release-type": "python",
+							"extra-files": [
+								"google/cloud/secretmanager/gapic_version.py",
+								"google/cloud/secretmanager_v1/gapic_version.py",
+								{
+									"jsonpath": "$.clientLibrary.version",
+									"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
+									"type": "json"
+								}
+							]
+						}
+					}
+				}`,
+			},
+			wantModifiedConfig:   individualConfigFile,
+			wantUnmodifiedConfig: bulkConfigFile,
+			wantManifest:         `{"packages/google-cloud-secretmanager":"1.0.0"}`,
+			wantConfig: `{
+				"packages": {
+					"packages/google-cloud-secretmanager": {
+						"component": "google-cloud-secretmanager",
+						"release-type": "python",
+						"extra-files": [
+							"google/cloud/secretmanager/gapic_version.py",
+							"google/cloud/secretmanager_v1/gapic_version.py",
+							"google/cloud/secretmanager_v1beta1/gapic_version.py",
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
+								"type": "json"
+							},
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1beta1.json",
+								"type": "json"
+							}
+						]
+					}
+				}
+			}`,
+		},
+		{
+			name: "replace existing string extra-files with map if same path",
+			library: &config.Library{
+				Name:    "google-cloud-secretmanager",
+				Version: "1.0.0",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			files: map[string]string{
+				bulkManifestFile:       `{}`,
+				bulkConfigFile:         `{"packages": {}}`,
+				individualManifestFile: `{"packages/google-cloud-secretmanager":"1.0.0"}`,
+				individualConfigFile: `{
+					"packages": {
+						"packages/google-cloud-secretmanager": {
+							"component": "google-cloud-secretmanager",
+							"extra-files": [
+								"samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json"
+							]
+						}
+					}
+				}`,
+			},
+			wantModifiedConfig:   individualConfigFile,
+			wantUnmodifiedConfig: bulkConfigFile,
+			wantManifest:         `{"packages/google-cloud-secretmanager":"1.0.0"}`,
+			wantConfig: `{
+				"packages": {
+					"packages/google-cloud-secretmanager": {
+						"component": "google-cloud-secretmanager",
+						"extra-files": [
+							"google/cloud/secretmanager/gapic_version.py",
+							"google/cloud/secretmanager_v1/gapic_version.py",
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
+								"type": "json"
+							}
+						]
+					}
+				}
+			}`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -725,21 +752,41 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			if err := syncToReleasePlease(tmp, cfg, test.library.Name); err != nil {
 				t.Fatal(err)
 			}
-			gotModified, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantModifiedConfig))
+
+			manifestFile := individualManifestFile
+			if test.wantModifiedConfig == bulkConfigFile {
+				manifestFile = bulkManifestFile
+			}
+			gotManifestBytes, err := os.ReadFile(filepath.Join(tmp, manifestFile))
 			if err != nil {
 				t.Fatal(err)
 			}
-			pkgs := gotModified["packages"].(map[string]any)
-			pkg := pkgs[python.ReleasePleasePkgPrefix+test.library.Name].(map[string]any)
-			extraFiles := pkg["extra-files"].([]any)
-			for _, want := range test.wantExtraFiles {
-				if !slices.ContainsFunc(extraFiles, func(elem any) bool {
-					s, ok := elem.(string)
-					return ok && s == want
-				}) {
-					t.Errorf("extra-files does not contain %s, got: %v", want, extraFiles)
-				}
+			var gotManifest, wantManifest map[string]string
+			if err := json.Unmarshal(gotManifestBytes, &gotManifest); err != nil {
+				t.Fatal(err)
 			}
+			if err := json.Unmarshal([]byte(test.wantManifest), &wantManifest); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(wantManifest, gotManifest); diff != "" {
+				t.Errorf("manifest mismatch (-want +got):\n%s", diff)
+			}
+
+			gotConfigBytes, err := os.ReadFile(filepath.Join(tmp, test.wantModifiedConfig))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var gotConfig, wantConfig map[string]any
+			if err := json.Unmarshal(gotConfigBytes, &gotConfig); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(test.wantConfig), &wantConfig); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(wantConfig, gotConfig); diff != "" {
+				t.Errorf("config mismatch (-want +got):\n%s", diff)
+			}
+
 			gotUnmodified, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantUnmodifiedConfig))
 			if err != nil {
 				t.Fatal(err)

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -641,12 +641,12 @@ func TestSyncToReleasePlease_Errors(t *testing.T) {
 
 func TestSyncToReleasePlease_Python(t *testing.T) {
 	for _, test := range []struct {
-		name               string
-		library            *config.Library
-		files              map[string]string
-		wantModifiedConfig string
-		wantCleanConfig    string
-		wantExtraFile      string
+		name                 string
+		library              *config.Library
+		files                map[string]string
+		wantModifiedConfig   string
+		wantUnmodifiedConfig string
+		wantExtraFiles       []string
 	}{
 		{
 			name: "updates bulk config when tracked in bulk",
@@ -674,9 +674,12 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 				individualManifestFile: `{}`,
 				individualConfigFile:   `{"packages": {}}`,
 			},
-			wantModifiedConfig: bulkConfigFile,
-			wantCleanConfig:    individualConfigFile,
-			wantExtraFile:      "google/cloud/biglake_hive_v1/gapic_version.py",
+			wantModifiedConfig:   bulkConfigFile,
+			wantUnmodifiedConfig: individualConfigFile,
+			wantExtraFiles: []string{
+				"google/cloud/biglake_hive_v1beta/gapic_version.py",
+				"google/cloud/biglake_hive_v1/gapic_version.py",
+			},
 		},
 		{
 			name: "updates individual config when tracked in individual",
@@ -704,9 +707,12 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 					}
 				}`,
 			},
-			wantModifiedConfig: individualConfigFile,
-			wantCleanConfig:    bulkConfigFile,
-			wantExtraFile:      "google/cloud/newservice_v1beta/gapic_version.py",
+			wantModifiedConfig:   individualConfigFile,
+			wantUnmodifiedConfig: bulkConfigFile,
+			wantExtraFiles: []string{
+				"google/cloud/newservice_v1/gapic_version.py",
+				"google/cloud/newservice_v1beta/gapic_version.py",
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -719,7 +725,6 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			if err := syncToReleasePlease(tmp, cfg, test.library.Name); err != nil {
 				t.Fatal(err)
 			}
-
 			gotModified, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantModifiedConfig))
 			if err != nil {
 				t.Fatal(err)
@@ -727,17 +732,19 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			pkgs := gotModified["packages"].(map[string]any)
 			pkg := pkgs[python.ReleasePleasePkgPrefix+test.library.Name].(map[string]any)
 			extraFiles := pkg["extra-files"].([]any)
-			if !slices.ContainsFunc(extraFiles, func(elem any) bool {
-				s, ok := elem.(string)
-				return ok && s == test.wantExtraFile
-			}) {
-				t.Errorf("extra-files does not contain %s, got: %v", test.wantExtraFile, extraFiles)
+			for _, want := range test.wantExtraFiles {
+				if !slices.ContainsFunc(extraFiles, func(elem any) bool {
+					s, ok := elem.(string)
+					return ok && s == want
+				}) {
+					t.Errorf("extra-files does not contain %s, got: %v", want, extraFiles)
+				}
 			}
-			gotClean, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantCleanConfig))
+			gotUnmodified, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantUnmodifiedConfig))
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotClean); diff != "" {
+			if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotUnmodified); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -552,94 +552,7 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			}`,
 		},
 		{
-			name: "updates individual config when tracked in individual",
-			library: &config.Library{
-				Name:    "google-cloud-newservice",
-				Version: "0.0.0",
-				APIs: []*config.API{
-					{Path: "google/cloud/newservice/v1"},
-					{Path: "google/cloud/newservice/v1beta"},
-				},
-			},
-			files: map[string]string{
-				bulkManifestFile:       `{}`,
-				bulkConfigFile:         `{"packages": {}}`,
-				individualManifestFile: `{"packages/google-cloud-newservice": "0.0.0"}`,
-				individualConfigFile: `{
-					"packages": {
-						"packages/google-cloud-newservice": {
-							"component": "google-cloud-newservice",
-							"extra-files": [
-								"google/cloud/newservice/gapic_version.py",
-								"google/cloud/newservice_v1/gapic_version.py"
-							]
-						}
-					}
-				}`,
-			},
-			wantModifiedConfig:   individualConfigFile,
-			wantUnmodifiedConfig: bulkConfigFile,
-			wantManifest:         `{"packages/google-cloud-newservice": "0.0.0"}`,
-			wantConfig: `{
-				"packages": {
-					"packages/google-cloud-newservice": {
-						"component": "google-cloud-newservice",
-						"extra-files": [
-							"google/cloud/newservice/gapic_version.py",
-							"google/cloud/newservice_v1/gapic_version.py",
-							"google/cloud/newservice_v1beta/gapic_version.py",
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.newservice.v1.json",
-								"type": "json"
-							},
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.newservice.v1beta.json",
-								"type": "json"
-							}
-						]
-					}
-				}
-			}`,
-		},
-		{
-			name: "new python library",
-			library: &config.Library{
-				Name:    "google-cloud-secretmanager",
-				Version: "0.0.0",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			files: map[string]string{
-				bulkManifestFile:       `{}`,
-				bulkConfigFile:         `{"packages": {}}`,
-				individualManifestFile: `{}`,
-				individualConfigFile:   `{"packages": {}}`,
-			},
-			wantModifiedConfig:   individualConfigFile,
-			wantUnmodifiedConfig: bulkConfigFile,
-			wantManifest:         `{"packages/google-cloud-secretmanager":"0.0.0"}`,
-			wantConfig: `{
-				"packages": {
-					"packages/google-cloud-secretmanager": {
-						"component": "google-cloud-secretmanager",
-						"extra-files": [
-							"google/cloud/secretmanager/gapic_version.py",
-							"google/cloud/secretmanager_v1/gapic_version.py",
-							{
-								"jsonpath": "$.clientLibrary.version",
-								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
-								"type": "json"
-							}
-						]
-					}
-				}
-			}`,
-		},
-		{
-			name: "update existing python library (merge, deduplicate, sort)",
+			name: "updates individual config when tracked in individual (merge, deduplicate, sort)",
 			library: &config.Library{
 				Name:    "google-cloud-secretmanager",
 				Version: "1.0.0",
@@ -698,7 +611,7 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			}`,
 		},
 		{
-			name: "replace existing string extra-files with map if same path",
+			name: "updates individual config when tracked in individual (replaces string extra-files with structured map)",
 			library: &config.Library{
 				Name:    "google-cloud-secretmanager",
 				Version: "1.0.0",
@@ -724,6 +637,41 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			wantModifiedConfig:   individualConfigFile,
 			wantUnmodifiedConfig: bulkConfigFile,
 			wantManifest:         `{"packages/google-cloud-secretmanager":"1.0.0"}`,
+			wantConfig: `{
+				"packages": {
+					"packages/google-cloud-secretmanager": {
+						"component": "google-cloud-secretmanager",
+						"extra-files": [
+							"google/cloud/secretmanager/gapic_version.py",
+							"google/cloud/secretmanager_v1/gapic_version.py",
+							{
+								"jsonpath": "$.clientLibrary.version",
+								"path": "samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1.json",
+								"type": "json"
+							}
+						]
+					}
+				}
+			}`,
+		},
+		{
+			name: "new python library defaults to individual config",
+			library: &config.Library{
+				Name:    "google-cloud-secretmanager",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			files: map[string]string{
+				bulkManifestFile:       `{}`,
+				bulkConfigFile:         `{"packages": {}}`,
+				individualManifestFile: `{}`,
+				individualConfigFile:   `{"packages": {}}`,
+			},
+			wantModifiedConfig:   individualConfigFile,
+			wantUnmodifiedConfig: bulkConfigFile,
+			wantManifest:         `{"packages/google-cloud-secretmanager":"0.0.0"}`,
 			wantConfig: `{
 				"packages": {
 					"packages/google-cloud-secretmanager": {

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/librarian/internal/config"
+	"github.com/googleapis/librarian/internal/librarian/python"
 )
 
 func TestHasReleasePleaseConfigs(t *testing.T) {
@@ -584,12 +585,18 @@ func TestSyncToReleasePlease_Errors(t *testing.T) {
 	}
 }
 
-func TestSyncToReleasePlease_Python_UpdatesBulkConfigWhenTrackedInBulk(t *testing.T) {
-	tmp := t.TempDir()
-	cfg := &config.Config{
-		Language: config.LanguagePython,
-		Libraries: []*config.Library{
-			{
+func TestSyncToReleasePlease_Python(t *testing.T) {
+	for _, test := range []struct {
+		name               string
+		library            *config.Library
+		files              map[string]string
+		wantModifiedConfig string
+		wantCleanConfig    string
+		wantExtraFile      any
+	}{
+		{
+			name: "updates bulk config when tracked in bulk",
+			library: &config.Library{
 				Name:    "google-cloud-biglake-hive",
 				Version: "0.3.2",
 				APIs: []*config.API{
@@ -597,62 +604,29 @@ func TestSyncToReleasePlease_Python_UpdatesBulkConfigWhenTrackedInBulk(t *testin
 					{Path: "google/cloud/biglake/hive/v1beta"},
 				},
 			},
+			files: map[string]string{
+				bulkManifestFile: `{"packages/google-cloud-biglake-hive": "0.3.2"}`,
+				bulkConfigFile: `{
+					"packages": {
+						"packages/google-cloud-biglake-hive": {
+							"component": "google-cloud-biglake-hive",
+							"extra-files": [
+								"google/cloud/biglake/hive/gapic_version.py",
+								"google/cloud/biglake/hive_v1beta/gapic_version.py"
+							]
+						}
+					}
+				}`,
+				individualManifestFile: `{}`,
+				individualConfigFile:   `{"packages": {}}`,
+			},
+			wantModifiedConfig: bulkConfigFile,
+			wantCleanConfig:    individualConfigFile,
+			wantExtraFile:      "google/cloud/biglake/hive_v1/gapic_version.py",
 		},
-	}
-	initialBulkManifest := `{"packages/google-cloud-biglake-hive": "0.3.2"}`
-	initialBulkConfig := `{
-		"packages": {
-			"packages/google-cloud-biglake-hive": {
-				"component": "google-cloud-biglake-hive",
-				"extra-files": [
-					"google/cloud/biglake/hive/gapic_version.py",
-					"google/cloud/biglake/hive_v1beta/gapic_version.py"
-				]
-			}
-		}
-	}`
-	if err := os.WriteFile(filepath.Join(tmp, bulkManifestFile), []byte(initialBulkManifest), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, bulkConfigFile), []byte(initialBulkConfig), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, individualManifestFile), []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, individualConfigFile), []byte(`{"packages": {}}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := syncToReleasePlease(tmp, cfg, "google-cloud-biglake-hive"); err != nil {
-		t.Fatal(err)
-	}
-
-	gotBulkConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, bulkConfigFile))
-	if err != nil {
-		t.Fatal(err)
-	}
-	pkgs := gotBulkConfig["packages"].(map[string]any)
-	pkg := pkgs["packages/google-cloud-biglake-hive"].(map[string]any)
-	extraFiles := pkg["extra-files"].([]any)
-	if !slices.Contains(extraFiles, "google/cloud/biglake/hive_v1/gapic_version.py") {
-		t.Errorf("extra-files does not contain v1 gapic_version.py, got: %v", extraFiles)
-	}
-	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, individualConfigFile))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotIndConfig); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}
-
-func TestSyncToReleasePlease_Python_UpdatesIndividualConfigWhenTrackedInIndividual(t *testing.T) {
-	tmp := t.TempDir()
-	cfg := &config.Config{
-		Language: config.LanguagePython,
-		Libraries: []*config.Library{
-			{
+		{
+			name: "updates individual config when tracked in individual",
+			library: &config.Library{
 				Name:    "google-cloud-newservice",
 				Version: "0.0.0",
 				APIs: []*config.API{
@@ -660,52 +634,56 @@ func TestSyncToReleasePlease_Python_UpdatesIndividualConfigWhenTrackedInIndividu
 					{Path: "google/cloud/newservice/v1beta"},
 				},
 			},
+			files: map[string]string{
+				bulkManifestFile:       `{}`,
+				bulkConfigFile:         `{"packages": {}}`,
+				individualManifestFile: `{"packages/google-cloud-newservice": "0.0.0"}`,
+				individualConfigFile: `{
+					"packages": {
+						"packages/google-cloud-newservice": {
+							"component": "google-cloud-newservice",
+							"extra-files": [
+								"google/cloud/newservice/gapic_version.py",
+								"google/cloud/newservice_v1/gapic_version.py"
+							]
+						}
+					}
+				}`,
+			},
+			wantModifiedConfig: individualConfigFile,
+			wantCleanConfig:    bulkConfigFile,
+			wantExtraFile:      "google/cloud/newservice_v1beta/gapic_version.py",
 		},
-	}
-	initialIndConfig := `{
-		"packages": {
-			"packages/google-cloud-newservice": {
-				"component": "google-cloud-newservice",
-				"extra-files": [
-					"google/cloud/newservice/gapic_version.py",
-					"google/cloud/newservice_v1/gapic_version.py"
-				]
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			writeTestFiles(t, tmp, test.files)
+			cfg := &config.Config{
+				Language:  config.LanguagePython,
+				Libraries: []*config.Library{test.library},
 			}
-		}
-	}`
-	if err := os.WriteFile(filepath.Join(tmp, bulkManifestFile), []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, bulkConfigFile), []byte(`{"packages": {}}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, individualManifestFile), []byte(`{"packages/google-cloud-newservice": "0.0.0"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, individualConfigFile), []byte(initialIndConfig), 0o644); err != nil {
-		t.Fatal(err)
-	}
+			if err := syncToReleasePlease(tmp, cfg, test.library.Name); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := syncToReleasePlease(tmp, cfg, "google-cloud-newservice"); err != nil {
-		t.Fatal(err)
-	}
-
-	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, individualConfigFile))
-	if err != nil {
-		t.Fatal(err)
-	}
-	pkgs := gotIndConfig["packages"].(map[string]any)
-	pkg := pkgs["packages/google-cloud-newservice"].(map[string]any)
-	extraFiles := pkg["extra-files"].([]any)
-	if !slices.Contains(extraFiles, "google/cloud/newservice_v1beta/gapic_version.py") {
-		t.Errorf("extra-files does not contain v1beta gapic_version.py, got: %v", extraFiles)
-	}
-	gotBulkConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, bulkConfigFile))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotBulkConfig); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+			gotModified, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantModifiedConfig))
+			if err != nil {
+				t.Fatal(err)
+			}
+			pkgs := gotModified["packages"].(map[string]any)
+			pkg := pkgs[python.ReleasePleasePkgPrefix+test.library.Name].(map[string]any)
+			extraFiles := pkg["extra-files"].([]any)
+			if !slices.Contains(extraFiles, test.wantExtraFile) {
+				t.Errorf("extra-files does not contain %s, got: %v", test.wantExtraFile, extraFiles)
+			}
+			gotClean, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantCleanConfig))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotClean); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -757,5 +735,14 @@ func TestIsTrackedInBulkConfig(t *testing.T) {
 				t.Errorf("isTrackedInBulkConfig(%s, %s) = %t, want %t", tmp, test.pkgPath, got, test.want)
 			}
 		})
+	}
+}
+
+func writeTestFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -121,18 +121,22 @@ func TestHasReleasePleaseConfigs(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmp := t.TempDir()
-			manifestFile, configFile := releasePleaseFiles(
+			files := releasePleaseFiles(
 				&config.Config{
 					Language: test.language,
 				},
 			)
+			target := files.bulk
+			if test.language == config.LanguagePython {
+				target = files.individual
+			}
 			if test.createConfig {
-				if err := os.WriteFile(filepath.Join(tmp, configFile), []byte("{}"), 0o644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmp, target.configFile), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
 			if test.createManifest {
-				if err := os.WriteFile(filepath.Join(tmp, manifestFile), []byte("{}"), 0o644); err != nil {
+				if err := os.WriteFile(filepath.Join(tmp, target.manifestFile), []byte("{}"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -472,13 +476,17 @@ func TestSyncToReleasePlease(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tmp := t.TempDir()
-			manifestFile, configFile := releasePleaseFiles(
+			files := releasePleaseFiles(
 				&config.Config{
 					Language: test.language,
 				},
 			)
-			manifestPath := filepath.Join(tmp, manifestFile)
-			configPath := filepath.Join(tmp, configFile)
+			target := files.bulk
+			if test.language == config.LanguagePython {
+				target = files.individual
+			}
+			manifestPath := filepath.Join(tmp, target.manifestFile)
+			configPath := filepath.Join(tmp, target.configFile)
 			if err := os.WriteFile(manifestPath, []byte(test.initialManifest), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -614,9 +622,9 @@ func TestSyncToReleasePlease_Errors(t *testing.T) {
 				Language:  config.LanguagePython,
 				Libraries: []*config.Library{test.library},
 			}
-			manifestFile, configFile := releasePleaseFiles(cfg)
-			manifestPath := filepath.Join(tmp, manifestFile)
-			configPath := filepath.Join(tmp, configFile)
+			files := releasePleaseFiles(cfg)
+			manifestPath := filepath.Join(tmp, files.individual.manifestFile)
+			configPath := filepath.Join(tmp, files.individual.configFile)
 			if err := os.WriteFile(manifestPath, []byte("{}"), 0o644); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -578,6 +579,182 @@ func TestSyncToReleasePlease_Errors(t *testing.T) {
 			err := syncToReleasePlease(tmp, cfg, test.library.Name)
 			if err == nil {
 				t.Errorf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestSyncToReleasePlease_Python_UpdatesBulkConfigWhenTrackedInBulk(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		Language: config.LanguagePython,
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-biglake-hive",
+				Version: "0.3.2",
+				APIs: []*config.API{
+					{Path: "google/cloud/biglake/hive/v1"},
+					{Path: "google/cloud/biglake/hive/v1beta"},
+				},
+			},
+		},
+	}
+	initialBulkManifest := `{"packages/google-cloud-biglake-hive": "0.3.2"}`
+	initialBulkConfig := `{
+		"packages": {
+			"packages/google-cloud-biglake-hive": {
+				"component": "google-cloud-biglake-hive",
+				"extra-files": [
+					"google/cloud/biglake/hive/gapic_version.py",
+					"google/cloud/biglake/hive_v1beta/gapic_version.py"
+				]
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmp, bulkManifestFile), []byte(initialBulkManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, bulkConfigFile), []byte(initialBulkConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, individualManifestFile), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, individualConfigFile), []byte(`{"packages": {}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncToReleasePlease(tmp, cfg, "google-cloud-biglake-hive"); err != nil {
+		t.Fatal(err)
+	}
+
+	gotBulkConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, bulkConfigFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgs := gotBulkConfig["packages"].(map[string]any)
+	pkg := pkgs["packages/google-cloud-biglake-hive"].(map[string]any)
+	extraFiles := pkg["extra-files"].([]any)
+	if !slices.Contains(extraFiles, "google/cloud/biglake/hive_v1/gapic_version.py") {
+		t.Errorf("extra-files does not contain v1 gapic_version.py, got: %v", extraFiles)
+	}
+	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, individualConfigFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotIndConfig); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSyncToReleasePlease_Python_UpdatesIndividualConfigWhenTrackedInIndividual(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		Language: config.LanguagePython,
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-newservice",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/cloud/newservice/v1"},
+					{Path: "google/cloud/newservice/v1beta"},
+				},
+			},
+		},
+	}
+	initialIndConfig := `{
+		"packages": {
+			"packages/google-cloud-newservice": {
+				"component": "google-cloud-newservice",
+				"extra-files": [
+					"google/cloud/newservice/gapic_version.py",
+					"google/cloud/newservice_v1/gapic_version.py"
+				]
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmp, bulkManifestFile), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, bulkConfigFile), []byte(`{"packages": {}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, individualManifestFile), []byte(`{"packages/google-cloud-newservice": "0.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, individualConfigFile), []byte(initialIndConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncToReleasePlease(tmp, cfg, "google-cloud-newservice"); err != nil {
+		t.Fatal(err)
+	}
+
+	gotIndConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, individualConfigFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgs := gotIndConfig["packages"].(map[string]any)
+	pkg := pkgs["packages/google-cloud-newservice"].(map[string]any)
+	extraFiles := pkg["extra-files"].([]any)
+	if !slices.Contains(extraFiles, "google/cloud/newservice_v1beta/gapic_version.py") {
+		t.Errorf("extra-files does not contain v1beta gapic_version.py, got: %v", extraFiles)
+	}
+	gotBulkConfig, err := readJSONFile[map[string]any](filepath.Join(tmp, bulkConfigFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(map[string]any{"packages": map[string]any{}}, gotBulkConfig); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestIsTrackedInBulkConfig(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		configJSON string
+		writeFile  bool
+		pkgPath    string
+		want       bool
+	}{
+		{
+			name:       "package exists in bulk config",
+			configJSON: `{"packages": {"packages/google-cloud-foo": {}}}`,
+			writeFile:  true,
+			pkgPath:    "packages/google-cloud-foo",
+			want:       true,
+		},
+		{
+			name:       "package does not exist in bulk config",
+			configJSON: `{"packages": {"packages/google-cloud-other": {}}}`,
+			writeFile:  true,
+			pkgPath:    "packages/google-cloud-foo",
+			want:       false,
+		},
+		{
+			name:      "bulk config file does not exist",
+			writeFile: false,
+			pkgPath:   "packages/google-cloud-foo",
+			want:      false,
+		},
+		{
+			name:       "invalid packages field",
+			configJSON: `{"packages": "not-a-map"}`,
+			writeFile:  true,
+			pkgPath:    "packages/google-cloud-foo",
+			want:       false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			if test.writeFile {
+				if err := os.WriteFile(filepath.Join(tmp, bulkConfigFile), []byte(test.configJSON), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := isTrackedInBulkConfig(tmp, test.pkgPath)
+			if got != test.want {
+				t.Errorf("isTrackedInBulkConfig(%s, %s) = %t, want %t", tmp, test.pkgPath, got, test.want)
 			}
 		})
 	}

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -144,6 +144,52 @@ func TestHasReleasePleaseConfigs(t *testing.T) {
 	}
 }
 
+func TestHasReleasePleaseConfigs_PythonBulk(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		createConfig   bool
+		createManifest bool
+		want           bool
+	}{
+		{
+			name:           "both bulk exist",
+			createConfig:   true,
+			createManifest: true,
+			want:           true,
+		},
+		{
+			name:           "bulk config missing",
+			createConfig:   false,
+			createManifest: true,
+			want:           false,
+		},
+		{
+			name:           "bulk manifest missing",
+			createConfig:   true,
+			createManifest: false,
+			want:           false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			if test.createConfig {
+				if err := os.WriteFile(filepath.Join(tmp, bulkConfigFile), []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.createManifest {
+				if err := os.WriteFile(filepath.Join(tmp, bulkManifestFile), []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := hasReleasePleaseConfigs(tmp, &config.Config{Language: config.LanguagePython})
+			if got != test.want {
+				t.Errorf("hasReleasePleaseConfigs(%s, %s) = %t, want %t", tmp, config.LanguagePython, got, test.want)
+			}
+		})
+	}
+}
+
 func TestSyncToReleasePlease(t *testing.T) {
 	for _, test := range []struct {
 		name            string
@@ -611,8 +657,8 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 						"packages/google-cloud-biglake-hive": {
 							"component": "google-cloud-biglake-hive",
 							"extra-files": [
-								"google/cloud/biglake/hive/gapic_version.py",
-								"google/cloud/biglake/hive_v1beta/gapic_version.py"
+								"google/cloud/biglake_hive/gapic_version.py",
+								"google/cloud/biglake_hive_v1beta/gapic_version.py"
 							]
 						}
 					}
@@ -622,7 +668,7 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			},
 			wantModifiedConfig: bulkConfigFile,
 			wantCleanConfig:    individualConfigFile,
-			wantExtraFile:      "google/cloud/biglake/hive_v1/gapic_version.py",
+			wantExtraFile:      "google/cloud/biglake_hive_v1/gapic_version.py",
 		},
 		{
 			name: "updates individual config when tracked in individual",

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -500,7 +500,7 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 		wantConfig           string
 	}{
 		{
-			name: "updates bulk config when tracked in bulk",
+			name: "updates bulk config when tracked in bulk (merge, deduplicate, sort extra-files)",
 			library: &config.Library{
 				Name:    "google-cloud-biglake-hive",
 				Version: "0.3.2",

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -638,7 +638,7 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 		files              map[string]string
 		wantModifiedConfig string
 		wantCleanConfig    string
-		wantExtraFile      any
+		wantExtraFile      string
 	}{
 		{
 			name: "updates bulk config when tracked in bulk",
@@ -719,7 +719,10 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			pkgs := gotModified["packages"].(map[string]any)
 			pkg := pkgs[python.ReleasePleasePkgPrefix+test.library.Name].(map[string]any)
 			extraFiles := pkg["extra-files"].([]any)
-			if !slices.Contains(extraFiles, test.wantExtraFile) {
+			if !slices.ContainsFunc(extraFiles, func(elem any) bool {
+				s, ok := elem.(string)
+				return ok && s == test.wantExtraFile
+			}) {
 				t.Errorf("extra-files does not contain %s, got: %v", test.wantExtraFile, extraFiles)
 			}
 			gotClean, err := readJSONFile[map[string]any](filepath.Join(tmp, test.wantCleanConfig))

--- a/internal/librarian/release_please_test.go
+++ b/internal/librarian/release_please_test.go
@@ -552,7 +552,7 @@ func TestSyncToReleasePlease_Python(t *testing.T) {
 			}`,
 		},
 		{
-			name: "updates individual config when tracked in individual (merge, deduplicate, sort)",
+			name: "updates individual config when tracked in individual (merge, deduplicate, sort extra-files)",
 			library: &config.Library{
 				Name:    "google-cloud-secretmanager",
 				Version: "1.0.0",


### PR DESCRIPTION
When onboarding an API to an existing Python library with librarian add, syncToReleasePlease previously defaulted to the individual release-please configuration files. If the library has already graduated to bulk releases, its configuration lives in the bulk release-please files instead. Additionally, hasReleasePleaseConfigs only checked for the existence of individual files for Python, incorrectly skipping the sync if python repo only maintained bulk configuration (unlikely).
    
Check whether the Python library is already tracked in the bulk release-please configuration and update the bulk configuration when present. Brand new libraries and ungraduated individual libraries continue to target the individual release-please configuration.

Refactor releasePleaseFiles to return a releasePleaseConfigFiles struct containing both bulk and individual file pairs. This allows cleaner logic in `hasReleasePleaseConfigs` and `syncToReleasePlease`.
    
Fixes https://github.com/googleapis/librarian/issues/7499