### PR TITLE
fix(internal/librarian/rust): batch unsupported any field errors (#7479)

### DIFF
--- a/internal/librarian/rust/generate_prost_hybrid.go
+++ b/internal/librarian/rust/generate_prost_hybrid.go
@@ -17,6 +17,7 @@ package rust
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -164,6 +165,7 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 	}
 
 	hasGoogleRpcStatus := false
+	var unsupportedAnyFields []string
 
 	for len(queue) > 0 {
 		item := queue[0]
@@ -173,21 +175,9 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 			continue
 		}
 		visited[item.id] = true
-
-		anyError := func(path string, fieldID string) error {
-			if fieldID != "" && !isAnyType(fieldID) {
-				return fmt.Errorf("cannot generate prost conversion for streaming RPC: type google.protobuf.Any is unsupported (path: %s)\n"+
-					"To resolve this, allow dropping this Any field in prost conversion by adding it to allow_streaming_any_types in librarian.yaml:\n"+
-					"    rust:\n"+
-					"      allow_streaming_any_types:\n"+
-					"        - %s",
-					path, fieldID)
-			}
-			return fmt.Errorf("cannot generate prost conversion for streaming RPC: type google.protobuf.Any is unsupported (path: %s)", path)
-		}
-
 		if isAnyType(item.id) {
-			return nil, nil, false, anyError(item.path, item.id)
+			unsupportedAnyFields = append(unsupportedAnyFields, item.id)
+			continue
 		}
 
 		msg := model.Message(item.id)
@@ -208,7 +198,8 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 						f.SkipProtoConversion = true
 						continue
 					}
-					return nil, nil, false, anyError(fieldPath, f.ID)
+					unsupportedAnyFields = append(unsupportedAnyFields, fieldPath)
+					continue
 				}
 				if f.Typez == api.TypezMessage && f.TypezID != "" {
 					queue = append(queue, typeItem{
@@ -222,13 +213,14 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 			}
 			for _, o := range msg.OneOfs {
 				for _, f := range o.Fields {
-					fieldPath := item.path + "." + o.Name + "." + f.Name
+					fieldPath := item.path + "." + f.Name
 					if isAnyType(f.TypezID) {
 						if matchesAllowedAnyField(f.ID, allowAnyTypes) || matchesAllowedAnyField(fieldPath, allowAnyTypes) {
 							f.SkipProtoConversion = true
 							continue
 						}
-						return nil, nil, false, anyError(fieldPath, f.ID)
+						unsupportedAnyFields = append(unsupportedAnyFields, fieldPath)
+						continue
 					}
 					if f.Typez == api.TypezMessage && f.TypezID != "" {
 						queue = append(queue, typeItem{
@@ -247,6 +239,23 @@ func filterModelToTypes(model *api.API, rootTypeIDs []string, allowAnyTypes []st
 		if enum != nil {
 			enqueueEnum(enum, item.path)
 		}
+	}
+
+	if len(unsupportedAnyFields) > 0 {
+		slices.Sort(unsupportedAnyFields)
+		unsupportedAnyFields = slices.Compact(unsupportedAnyFields)
+		var sb strings.Builder
+		sb.WriteString("cannot generate prost conversion: type google.protobuf.Any is unsupported:\n")
+		for _, f := range unsupportedAnyFields {
+			fmt.Fprintf(&sb, "  - %s\n", f)
+		}
+		sb.WriteString("\nTo resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n")
+		sb.WriteString("    rust:\n")
+		sb.WriteString("      allow_streaming_any_types:\n")
+		for _, f := range unsupportedAnyFields {
+			fmt.Fprintf(&sb, "        - %s\n", f)
+		}
+		return nil, nil, false, errors.New(strings.TrimSuffix(sb.String(), "\n"))
 	}
 
 	// Collect external top-level messages (e.g. google.type.LatLng) referenced by roots.

--- a/internal/librarian/rust/generate_prost_hybrid_test.go
+++ b/internal/librarian/rust/generate_prost_hybrid_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -257,11 +256,135 @@ func TestFilterModelToTypesAnyError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for google.protobuf.Any, got nil")
 	}
-	if !strings.Contains(err.Error(), "allow_streaming_any_types") {
-		t.Errorf("expected error to contain recommendation 'allow_streaming_any_types', got: %v", err)
+	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
+		"  - .google.test.v1.AnyReq.details\n\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"    rust:\n" +
+		"      allow_streaming_any_types:\n" +
+		"        - .google.test.v1.AnyReq.details"
+	if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
+		t.Errorf("error message mismatch (-want +got):\n%s", diff)
 	}
-	if !strings.Contains(err.Error(), ".google.test.v1.AnyReq.details") {
-		t.Errorf("expected error to contain .google.test.v1.AnyReq.details, got: %v", err)
+}
+
+func TestFilterModelToStreamingMultipleAnyError(t *testing.T) {
+	// Verify multiple unsupported Any fields are batched into a single sorted error
+	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(
+		&api.Field{
+			Name:    "metadata",
+			TypezID: ".google.protobuf.Any",
+			Typez:   api.TypezMessage,
+		},
+		&api.Field{
+			Name:    "details",
+			TypezID: ".google.protobuf.Any",
+			Typez:   api.TypezMessage,
+		},
+	)
+	chatAnyMethod := api.NewTestMethod("ChatAny").WithInput(anyMsg).WithOutput(anyMsg).WithBidiStreaming()
+	anyService := api.NewTestService("AnyService").WithPackage("google.test.v1").WithMethods(chatAnyMethod)
+
+	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
+
+	_, _, _, err := filterModelToTypes(anyModel, []string{anyMsg.ID}, nil)
+	if err == nil {
+		t.Fatal("expected error for google.protobuf.Any, got nil")
+	}
+
+	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
+		"  - .google.test.v1.AnyReq.details\n" +
+		"  - .google.test.v1.AnyReq.metadata\n\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"    rust:\n" +
+		"      allow_streaming_any_types:\n" +
+		"        - .google.test.v1.AnyReq.details\n" +
+		"        - .google.test.v1.AnyReq.metadata"
+
+	if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
+		t.Errorf("error message mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFilterModelToStreamingPartialAllowedAny(t *testing.T) {
+	// Verify allowing one Any field still reports the remaining unallowed Any fields
+	anyMsg := api.NewTestMessage("AnyReq").WithPackage("google.test.v1").WithFields(
+		&api.Field{
+			Name:    "details",
+			TypezID: ".google.protobuf.Any",
+			Typez:   api.TypezMessage,
+		},
+		&api.Field{
+			Name:    "metadata",
+			TypezID: ".google.protobuf.Any",
+			Typez:   api.TypezMessage,
+		},
+	)
+	chatAnyMethod := api.NewTestMethod("ChatAny").WithInput(anyMsg).WithOutput(anyMsg).WithBidiStreaming()
+	anyService := api.NewTestService("AnyService").WithPackage("google.test.v1").WithMethods(chatAnyMethod)
+
+	anyModel := api.NewTestAPI([]*api.Message{anyMsg}, []*api.Enum{}, []*api.Service{anyService})
+
+	_, _, _, err := filterModelToTypes(anyModel, []string{anyMsg.ID}, []string{".google.test.v1.AnyReq.details"})
+	if err == nil {
+		t.Fatal("expected error for remaining google.protobuf.Any field, got nil")
+	}
+
+	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
+		"  - .google.test.v1.AnyReq.metadata\n\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"    rust:\n" +
+		"      allow_streaming_any_types:\n" +
+		"        - .google.test.v1.AnyReq.metadata"
+
+	if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
+		t.Errorf("error message mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFilterModelToStreamingNestedAndOneofAnyError(t *testing.T) {
+	// Verify Any fields in nested messages and oneofs are all discovered and reported
+	childMsg := api.NewTestMessage("ChildReq").WithPackage("google.test.v1").WithFields(
+		&api.Field{
+			Name:    "extra",
+			TypezID: ".google.protobuf.Any",
+			Typez:   api.TypezMessage,
+		},
+	)
+	oneofField := &api.Field{
+		Name:    "payload",
+		TypezID: ".google.protobuf.Any",
+		Typez:   api.TypezMessage,
+	}
+	oneof := api.NewTestOneOf("data").WithFields(oneofField)
+	parentMsg := api.NewTestMessage("ParentReq").WithPackage("google.test.v1").WithFields(
+		&api.Field{
+			Name:    "child",
+			TypezID: childMsg.ID,
+			Typez:   api.TypezMessage,
+		},
+	).WithOneOfs(oneof)
+
+	chatMethod := api.NewTestMethod("Chat").WithInput(parentMsg).WithOutput(parentMsg).WithBidiStreaming()
+	service := api.NewTestService("Service").WithPackage("google.test.v1").WithMethods(chatMethod)
+
+	model := api.NewTestAPI([]*api.Message{parentMsg, childMsg}, []*api.Enum{}, []*api.Service{service})
+
+	_, _, _, err := filterModelToTypes(model, []string{parentMsg.ID}, nil)
+	if err == nil {
+		t.Fatal("expected error for google.protobuf.Any, got nil")
+	}
+
+	wantErr := "cannot generate prost conversion: type google.protobuf.Any is unsupported:\n" +
+		"  - .google.test.v1.ParentReq.child.extra\n" +
+		"  - .google.test.v1.ParentReq.payload\n\n" +
+		"To resolve this, allow dropping Any fields in prost conversion by adding them to allow_streaming_any_types in librarian.yaml:\n" +
+		"    rust:\n" +
+		"      allow_streaming_any_types:\n" +
+		"        - .google.test.v1.ParentReq.child.extra\n" +
+		"        - .google.test.v1.ParentReq.payload"
+
+	if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
+		t.Errorf("error message mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -444,5 +567,27 @@ func TestFilterModelToTypesMultipleRoots(t *testing.T) {
 				t.Errorf("mismatch in unused messages (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestFilterModelToTypesCyclicRecursion(t *testing.T) {
+	// A message with a field referring back to itself or its parent should not infinite loop
+	parent := api.NewTestMessage("Node").WithPackage("google.test.v1")
+	parent.Fields = []*api.Field{
+		{
+			Name:    "child",
+			TypezID: parent.ID,
+			Typez:   api.TypezMessage,
+		},
+	}
+	model := api.NewTestAPI([]*api.Message{parent}, []*api.Enum{}, []*api.Service{})
+
+	filtered, _, _, err := filterModelToTypes(model, []string{parent.ID}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(filtered.Messages) != 1 {
+		t.Errorf("expected 1 parsed message, got %d", len(filtered.Messages))
 	}
 }


### PR DESCRIPTION
Collect all unsupported google.protobuf.Any field references encountered during streaming reachability traversal instead of returning immediately on the first error. Sort and deduplicate the offending fields, and format a descriptive error message with a librarian.yaml allow_streaming_any_types configuration snippet.

Forward work by @suzmue at #7479, adding back `visited[item.id] = true` and a unit test to confirm no cyclic recursion.