### PR TITLE
feat(sidekick/rust): move x-goog-api-client header handling

### DIFF
--- a/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
+++ b/internal/sidekick/rust/templates/crate/src/transport.rs.mustache
@@ -237,7 +237,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{#Codec.HasBindings}}
         use google_cloud_gax::error::binding::BindingError;
         use gaxi::path_parameter::PathMismatchBuilder;
-        use gaxi::http::reqwest::{Method, HeaderValue};
+        use gaxi::http::reqwest::Method;
         {{#Codec.HasBindingSubstitutions}}
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
@@ -372,16 +372,15 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{! TODO(#4156) - return idempotency from the above closure }}
             gaxi::http::default_idempotency(&method),
         );
-        let builder = builder
-                {{#Codec.SystemParameters}}
-                .query(&[("{{Name}}", "{{Value}}")])
-                {{/Codec.SystemParameters}}
-                .header("x-goog-api-client", HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
+        {{#Codec.SystemParameters}}
+        let builder = builder.query(&[("{{Name}}", "{{Value}}")]);
+        {{/Codec.SystemParameters}}
         let body = gaxi::http::handle_empty({{{Codec.Body}}}, &method);
         self.inner.execute(
             builder,
             body,
             options,
+            &crate::info::X_GOOG_API_CLIENT_HEADER,
         ).await
         {{#ReturnsEmpty}}
         .map(|r: crate::Response<{{OutputType.Codec.QualifiedName}}>| {


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-rust/issues/2138