### PR TITLE
feat(internal/testhelper): check managed protoc in RequireCommand

### DIFF
--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -21,8 +21,11 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/googleapis/librarian/internal/cache"
 	"github.com/googleapis/librarian/internal/command"
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/sample"
@@ -30,14 +33,33 @@ import (
 )
 
 // RequireCommand skips the test if the specified command is not found in PATH.
-// Use this to skip tests that depend on external tools like protoc, cargo, or
-// taplo, so that `go test ./...` will always pass on a fresh clone of the
-// repo.
+// For protoc, it also checks the librarian-managed install directory
+// (see [cache.BinDirectory]). Use this to skip tests that depend on external
+// tools like protoc, cargo, or taplo, so that `go test ./...` will always pass
+// on a fresh clone of the repo.
 func RequireCommand(t *testing.T, cmd string) {
 	t.Helper()
 	if _, err := exec.LookPath(cmd); err != nil {
+		if cmd == "protoc" && hasManagedProtoc() {
+			return
+		}
 		t.Skipf("skipping test because %s is not installed", cmd)
 	}
+}
+
+// hasManagedProtoc reports whether a librarian-managed protoc binary exists
+// under the cache bin directory.
+func hasManagedProtoc() bool {
+	binDir, err := cache.BinDirectory()
+	if err != nil {
+		return false
+	}
+	pattern := filepath.Join(binDir, "protoc", "v*", "bin", "protoc")
+	if runtime.GOOS == "windows" {
+		pattern += ".exe"
+	}
+	matches, err := filepath.Glob(pattern)
+	return err == nil && len(matches) > 0
 }
 
 const (

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -34,32 +34,51 @@ import (
 
 // RequireCommand skips the test if the specified command is not found in PATH.
 // For protoc, it also checks the librarian-managed install directory
-// (see [cache.BinDirectory]). Use this to skip tests that depend on external
-// tools like protoc, cargo, or taplo, so that `go test ./...` will always pass
-// on a fresh clone of the repo.
+// (see [cache.BinDirectory]) and adds its directory to PATH for the test. Use
+// this to skip tests that depend on external tools like protoc, cargo, or
+// taplo, so that `go test ./...` will always pass on a fresh clone of the
+// repo.
 func RequireCommand(t *testing.T, cmd string) {
 	t.Helper()
 	if _, err := exec.LookPath(cmd); err != nil {
-		if cmd == "protoc" && hasManagedProtoc() {
-			return
+		if cmd == "protoc" {
+			if protocPath, ok := findManagedProtoc(); ok {
+				t.Setenv("PATH", filepath.Dir(protocPath)+string(filepath.ListSeparator)+os.Getenv("PATH"))
+				return
+			}
 		}
 		t.Skipf("skipping test because %s is not installed", cmd)
 	}
 }
 
-// hasManagedProtoc reports whether a librarian-managed protoc binary exists
-// under the cache bin directory.
-func hasManagedProtoc() bool {
+// findManagedProtoc finds an executable librarian-managed protoc binary under
+// the cache bin directory, returning its path and true if found.
+func findManagedProtoc() (string, bool) {
 	binDir, err := cache.BinDirectory()
 	if err != nil {
-		return false
+		return "", false
 	}
-	pattern := filepath.Join(binDir, "protoc", "v*", "bin", "protoc")
+	absBinDir, err := filepath.Abs(binDir)
+	if err != nil {
+		return "", false
+	}
+	pattern := filepath.Join(absBinDir, "protoc", "v*", "bin", "protoc")
 	if runtime.GOOS == "windows" {
 		pattern += ".exe"
 	}
 	matches, err := filepath.Glob(pattern)
-	return err == nil && len(matches) > 0
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+	for _, match := range matches {
+		if fi, err := os.Stat(match); err == nil && !fi.IsDir() {
+			if runtime.GOOS != "windows" && fi.Mode()&0o111 == 0 {
+				continue
+			}
+			return match, true
+		}
+	}
+	return "", false
 }
 
 const (

--- a/internal/testhelper/testhelper_test.go
+++ b/internal/testhelper/testhelper_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelper
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/googleapis/librarian/internal/cache"
+)
+
+func TestHasManagedProtoc(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv(cache.EnvLibrarianBin, binDir)
+
+	if hasManagedProtoc() {
+		t.Fatal("expected false with empty bin directory")
+	}
+
+	protocBin := "protoc"
+	if runtime.GOOS == "windows" {
+		protocBin = "protoc.exe"
+	}
+	protocPath := filepath.Join(binDir, "protoc", "v33.2", "bin", protocBin)
+	if err := os.MkdirAll(filepath.Dir(protocPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(protocPath, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !hasManagedProtoc() {
+		t.Fatal("expected true with managed protoc binary present")
+	}
+}
+
+func TestRequireCommand_ManagedProtoc(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv(cache.EnvLibrarianBin, binDir)
+
+	protocBin := "protoc"
+	if runtime.GOOS == "windows" {
+		protocBin = "protoc.exe"
+	}
+	protocPath := filepath.Join(binDir, "protoc", "v33.2", "bin", protocBin)
+	if err := os.MkdirAll(filepath.Dir(protocPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(protocPath, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clear PATH so exec.LookPath won't find protoc.
+	t.Setenv("PATH", "")
+
+	// RequireCommand should not skip because managed protoc exists.
+	RequireCommand(t, "protoc")
+	if t.Skipped() {
+		t.Fatal("expected test not to be skipped when managed protoc exists")
+	}
+}

--- a/internal/testhelper/testhelper_test.go
+++ b/internal/testhelper/testhelper_test.go
@@ -16,6 +16,7 @@ package testhelper
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -23,11 +24,11 @@ import (
 	"github.com/googleapis/librarian/internal/cache"
 )
 
-func TestHasManagedProtoc(t *testing.T) {
+func TestFindManagedProtoc(t *testing.T) {
 	binDir := t.TempDir()
 	t.Setenv(cache.EnvLibrarianBin, binDir)
 
-	if hasManagedProtoc() {
+	if _, ok := findManagedProtoc(); ok {
 		t.Fatal("expected false with empty bin directory")
 	}
 
@@ -43,8 +44,12 @@ func TestHasManagedProtoc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !hasManagedProtoc() {
+	got, ok := findManagedProtoc()
+	if !ok {
 		t.Fatal("expected true with managed protoc binary present")
+	}
+	if got != protocPath {
+		t.Fatalf("expected %q, got %q", protocPath, got)
 	}
 }
 
@@ -64,12 +69,17 @@ func TestRequireCommand_ManagedProtoc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Clear PATH so exec.LookPath won't find protoc.
+	// Clear PATH so exec.LookPath won't find protoc initially.
 	t.Setenv("PATH", "")
 
-	// RequireCommand should not skip because managed protoc exists.
+	// RequireCommand should not skip because managed protoc exists,
+	// and it should prepend the managed binary's directory to PATH.
 	RequireCommand(t, "protoc")
 	if t.Skipped() {
 		t.Fatal("expected test not to be skipped when managed protoc exists")
+	}
+
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Fatalf("expected managed protoc to be on PATH: %v", err)
 	}
 }


### PR DESCRIPTION
RequireCommand now checks for a librarian-managed protoc binary in the cache bin directory before skipping tests when protoc is not on the system PATH. This allows tests relying on protoc to run without requiring a global protoc installation.

Fixes https://github.com/googleapis/librarian/issues/7493