### PR TITLE
feat(internal/librarian/swift): resolve dependency version from library declaration

### DIFF
--- a/internal/librarian/swift/generate.go
+++ b/internal/librarian/swift/generate.go
@@ -31,6 +31,7 @@ import (
 
 // Generate generates a Swift client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, src *sources.Sources) error {
+	ResolveDependencyVersions(cfg, library)
 	if IsMixedLibrary(library) {
 		return generateModule(ctx, cfg, library, src)
 	}

--- a/internal/librarian/swift/resolve_dependency.go
+++ b/internal/librarian/swift/resolve_dependency.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+	"github.com/iancoleman/strcase"
+)
+
+// ResolveDependencyVersions resolves missing versions for dependencies of a Swift library
+// using matching library declarations from the configuration.
+func ResolveDependencyVersions(cfg *config.Config, library *config.Library) {
+	if cfg == nil || library == nil || library.Swift == nil || len(library.Swift.Dependencies) == 0 {
+		return
+	}
+	for i := range library.Swift.Dependencies {
+		dep := &library.Swift.Dependencies[i]
+		if dep.Version != "" {
+			continue
+		}
+		target := findLibraryForDependency(cfg.Libraries, dep)
+		if target == nil {
+			continue
+		}
+		if target.Version != "" {
+			dep.Version = target.Version
+		} else if cfg.Default != nil && cfg.Default.Swift != nil && cfg.Default.Swift.DefaultVersion != "" {
+			dep.Version = cfg.Default.Swift.DefaultVersion
+		}
+	}
+}
+
+func findLibraryForDependency(libraries []*config.Library, dep *config.SwiftDependency) *config.Library {
+	for _, lib := range libraries {
+		if lib.Swift != nil && lib.Swift.LibraryNameOverride != "" && strings.EqualFold(lib.Swift.LibraryNameOverride, dep.Name) {
+			return lib
+		}
+	}
+	for _, lib := range libraries {
+		if lib.Name == dep.Name || strings.EqualFold(lib.Name, dep.Name) {
+			return lib
+		}
+		camel := strcase.ToCamel(lib.Name)
+		if camel == dep.Name || strings.EqualFold(camel, dep.Name) {
+			return lib
+		}
+	}
+	if dep.URL != "" {
+		repo := repoNameFromURL(dep.URL)
+		trimmedRepo := strings.TrimPrefix(repo, "swift-")
+		for _, lib := range libraries {
+			if lib.Name == repo || lib.Name == trimmedRepo {
+				return lib
+			}
+			if lib.Swift != nil && (strings.EqualFold(lib.Swift.LibraryNameOverride, repo) || strings.EqualFold(lib.Swift.LibraryNameOverride, trimmedRepo)) {
+				return lib
+			}
+			camelTrimmed := strcase.ToCamel(trimmedRepo)
+			if camelTrimmed == dep.Name || strings.EqualFold(camelTrimmed, dep.Name) {
+				return lib
+			}
+			if lib.Output != "" && (outputPathContains(lib.Output, repo) || outputPathContains(lib.Output, trimmedRepo)) {
+				return lib
+			}
+		}
+	}
+	if dep.Path != "" {
+		pathBase := filepath.Base(dep.Path)
+		trimmedPathBase := strings.TrimPrefix(pathBase, "swift-")
+		for _, lib := range libraries {
+			if lib.Name == pathBase || lib.Name == trimmedPathBase {
+				return lib
+			}
+			if lib.Output != "" && (filepath.Clean(lib.Output) == filepath.Clean(dep.Path) || strings.HasPrefix(lib.Output, dep.Path) || strings.HasPrefix(dep.Path, lib.Output)) {
+				return lib
+			}
+		}
+	}
+	if dep.ApiPackage != "" {
+		for _, lib := range libraries {
+			for _, api := range lib.APIs {
+				if strings.ReplaceAll(api.Path, "/", ".") == dep.ApiPackage {
+					return lib
+				}
+			}
+			if strings.ReplaceAll(lib.Name, "-", ".") == dep.ApiPackage {
+				return lib
+			}
+		}
+	}
+	return nil
+}
+
+func repoNameFromURL(rawURL string) string {
+	source := strings.TrimSuffix(rawURL, ".git")
+	source = strings.Trim(source, "/")
+	idx := strings.LastIndex(source, "/")
+	if idx == -1 {
+		return source
+	}
+	return source[idx+1:]
+}
+
+func outputPathContains(output, target string) bool {
+	clean := filepath.Clean(output)
+	return slices.Contains(strings.Split(clean, string(filepath.Separator)), target)
+}

--- a/internal/librarian/swift/resolve_dependency.go
+++ b/internal/librarian/swift/resolve_dependency.go
@@ -53,11 +53,11 @@ func findLibraryForDependency(libraries []*config.Library, dep *config.SwiftDepe
 		}
 	}
 	for _, lib := range libraries {
-		if lib.Name == dep.Name || strings.EqualFold(lib.Name, dep.Name) {
+		if strings.EqualFold(lib.Name, dep.Name) {
 			return lib
 		}
 		camel := strcase.ToCamel(lib.Name)
-		if camel == dep.Name || strings.EqualFold(camel, dep.Name) {
+		if strings.EqualFold(camel, dep.Name) {
 			return lib
 		}
 	}
@@ -72,7 +72,7 @@ func findLibraryForDependency(libraries []*config.Library, dep *config.SwiftDepe
 				return lib
 			}
 			camelTrimmed := strcase.ToCamel(trimmedRepo)
-			if camelTrimmed == dep.Name || strings.EqualFold(camelTrimmed, dep.Name) {
+			if strings.EqualFold(camelTrimmed, dep.Name) {
 				return lib
 			}
 			if lib.Output != "" && (outputPathContains(lib.Output, repo) || outputPathContains(lib.Output, trimmedRepo)) {
@@ -87,8 +87,13 @@ func findLibraryForDependency(libraries []*config.Library, dep *config.SwiftDepe
 			if lib.Name == pathBase || lib.Name == trimmedPathBase {
 				return lib
 			}
-			if lib.Output != "" && (filepath.Clean(lib.Output) == filepath.Clean(dep.Path) || strings.HasPrefix(lib.Output, dep.Path) || strings.HasPrefix(dep.Path, lib.Output)) {
-				return lib
+			if lib.Output != "" {
+				cleanOut := filepath.Clean(lib.Output)
+				cleanDep := filepath.Clean(dep.Path)
+				sep := string(filepath.Separator)
+				if cleanOut == cleanDep || strings.HasPrefix(cleanOut, cleanDep+sep) || strings.HasPrefix(cleanDep, cleanOut+sep) {
+					return lib
+				}
 			}
 		}
 	}

--- a/internal/librarian/swift/resolve_dependency_test.go
+++ b/internal/librarian/swift/resolve_dependency_test.go
@@ -259,6 +259,44 @@ func TestResolveDependencyVersions_MatchesByPath(t *testing.T) {
 	}
 }
 
+func TestResolveDependencyVersions_NoFalsePositivePathPrefix(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "kms-v11-lib",
+				Output:  "generated/swift-google-cloud-kms-v11",
+				Version: "0.2.0",
+			},
+			{
+				Name:    "kms-v1-lib",
+				Output:  "generated/swift-google-cloud-kms-v1",
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "KMSClient",
+						Path: "./generated/swift-google-cloud-kms-v1",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.1.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
 func TestResolveDependencyVersions_MatchesByApiPackage(t *testing.T) {
 	cfg := &config.Config{
 		Libraries: []*config.Library{

--- a/internal/librarian/swift/resolve_dependency_test.go
+++ b/internal/librarian/swift/resolve_dependency_test.go
@@ -1,0 +1,363 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swift
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestResolveDependencyVersions_NilGuards(t *testing.T) {
+	// None of these should panic.
+	ResolveDependencyVersions(nil, nil)
+	ResolveDependencyVersions(&config.Config{}, nil)
+	ResolveDependencyVersions(&config.Config{}, &config.Library{})
+	ResolveDependencyVersions(&config.Config{}, &config.Library{Swift: &config.SwiftPackage{}})
+}
+
+func TestResolveDependencyVersions_PreservesExplicitVersion(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-rpc",
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name:    "GoogleRpc",
+						URL:     "https://github.com/googleapis/swift-google-rpc",
+						Version: "1.0.0-explicit",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "1.0.0-explicit"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_MatchesByNameOverride(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-iam-v1",
+				Version: "0.1.0-preview",
+				Swift: &config.SwiftPackage{
+					LibraryNameOverride: "GoogleIAMV1",
+				},
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "GoogleIAMV1",
+						URL:  "https://github.com/googleapis/swift-google-iam-v1",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.1.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_MatchesByNameCamelCase(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-rpc",
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "GoogleRpc",
+						URL:  "https://github.com/googleapis/swift-google-rpc",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.1.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_MatchesByExactName(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-rpc",
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "google-rpc",
+						URL:  "https://github.com/googleapis/swift-google-rpc",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.1.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_MatchesByCaseInsensitiveCamelCase(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-longrunning",
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "GoogleLongRunning",
+						URL:  "https://github.com/googleapis/swift-google-longrunning",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.1.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_MatchesByURLRepoName(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-auth",
+				Output:  "packages/swift-google-auth/Sources/GoogleCloudAuth/generated",
+				Version: "0.0.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "CustomAuthName",
+						URL:  "https://github.com/googleapis/swift-google-auth.git",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.0.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_MatchesByPath(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-kms-v1",
+				Output:  "generated/swift-google-cloud-kms-v1",
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "KMSClient",
+						Path: "generated/swift-google-cloud-kms-v1",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.1.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_MatchesByApiPackage(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name: "custom-rpc",
+				APIs: []*config.API{
+					{Path: "google/rpc"},
+				},
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name:       "RPCClient",
+						ApiPackage: "google.rpc",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.1.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_FallbackToDefaultVersion(t *testing.T) {
+	cfg := &config.Config{
+		Default: &config.Default{
+			Swift: &config.SwiftDefault{
+				DefaultVersion: "0.0.0-preview",
+			},
+		},
+		Libraries: []*config.Library{
+			{
+				Name: "google-rpc",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "GoogleRpc",
+						URL:  "https://github.com/googleapis/swift-google-rpc",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := "0.0.0-preview"
+	if got != want {
+		t.Errorf("got version %q, want %q", got, want)
+	}
+}
+
+func TestResolveDependencyVersions_ExternalDependencyNoMatch(t *testing.T) {
+	cfg := &config.Config{
+		Libraries: []*config.Library{
+			{
+				Name:    "google-rpc",
+				Version: "0.1.0-preview",
+			},
+		},
+	}
+	library := &config.Library{
+		Name: "test-lib",
+		Swift: &config.SwiftPackage{
+			SwiftDefault: config.SwiftDefault{
+				Dependencies: []config.SwiftDependency{
+					{
+						Name: "SwiftProtobuf",
+						URL:  "https://github.com/apple/swift-protobuf",
+					},
+				},
+			},
+		},
+	}
+
+	ResolveDependencyVersions(cfg, library)
+
+	got := library.Swift.Dependencies[0].Version
+	want := ""
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/librarian/swift/resolve_dependency_test.go
+++ b/internal/librarian/swift/resolve_dependency_test.go
@@ -29,373 +29,228 @@ func TestResolveDependencyVersions_NilGuards(t *testing.T) {
 	ResolveDependencyVersions(&config.Config{}, &config.Library{Swift: &config.SwiftPackage{}})
 }
 
-func TestResolveDependencyVersions_PreservesExplicitVersion(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-rpc",
-				Version: "0.1.0-preview",
+func TestResolveDependencyVersions(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		libraries    []*config.Library
+		dependencies []config.SwiftDependency
+		defaultCfg   *config.Default
+		wantVersion  string
+	}{
+		{
+			name: "PreservesExplicitVersion",
+			libraries: []*config.Library{
+				{
+					Name:    "google-rpc",
+					Version: "0.1.0-preview",
+				},
 			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name:    "GoogleRpc",
+					URL:     "https://github.com/googleapis/swift-google-rpc",
+					Version: "1.0.0-explicit",
+				},
+			},
+			wantVersion: "1.0.0-explicit",
 		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name:    "GoogleRpc",
-						URL:     "https://github.com/googleapis/swift-google-rpc",
-						Version: "1.0.0-explicit",
+		{
+			name: "MatchesByNameOverride",
+			libraries: []*config.Library{
+				{
+					Name:    "google-iam-v1",
+					Version: "0.1.0-preview",
+					Swift: &config.SwiftPackage{
+						LibraryNameOverride: "GoogleIAMV1",
 					},
 				},
 			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "GoogleIAMV1",
+					URL:  "https://github.com/googleapis/swift-google-iam-v1",
+				},
+			},
+			wantVersion: "0.1.0-preview",
 		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "1.0.0-explicit"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_MatchesByNameOverride(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-iam-v1",
-				Version: "0.1.0-preview",
+		{
+			name: "MatchesByNameCamelCase",
+			libraries: []*config.Library{
+				{
+					Name:    "google-rpc",
+					Version: "0.1.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "GoogleRpc",
+					URL:  "https://github.com/googleapis/swift-google-rpc",
+				},
+			},
+			wantVersion: "0.1.0-preview",
+		},
+		{
+			name: "MatchesByExactName",
+			libraries: []*config.Library{
+				{
+					Name:    "google-rpc",
+					Version: "0.1.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "google-rpc",
+					URL:  "https://github.com/googleapis/swift-google-rpc",
+				},
+			},
+			wantVersion: "0.1.0-preview",
+		},
+		{
+			name: "MatchesByCaseInsensitiveCamelCase",
+			libraries: []*config.Library{
+				{
+					Name:    "google-longrunning",
+					Version: "0.1.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "GoogleLongRunning",
+					URL:  "https://github.com/googleapis/swift-google-longrunning",
+				},
+			},
+			wantVersion: "0.1.0-preview",
+		},
+		{
+			name: "MatchesByURLRepoName",
+			libraries: []*config.Library{
+				{
+					Name:    "google-cloud-auth",
+					Output:  "packages/swift-google-auth/Sources/GoogleCloudAuth/generated",
+					Version: "0.0.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "CustomAuthName",
+					URL:  "https://github.com/googleapis/swift-google-auth.git",
+				},
+			},
+			wantVersion: "0.0.0-preview",
+		},
+		{
+			name: "MatchesByPath",
+			libraries: []*config.Library{
+				{
+					Name:    "google-cloud-kms-v1",
+					Output:  "generated/swift-google-cloud-kms-v1",
+					Version: "0.1.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "KMSClient",
+					Path: "generated/swift-google-cloud-kms-v1",
+				},
+			},
+			wantVersion: "0.1.0-preview",
+		},
+		{
+			name: "NoFalsePositivePathPrefix",
+			libraries: []*config.Library{
+				{
+					Name:    "kms-v11-lib",
+					Output:  "generated/swift-google-cloud-kms-v11",
+					Version: "0.2.0",
+				},
+				{
+					Name:    "kms-v1-lib",
+					Output:  "generated/swift-google-cloud-kms-v1",
+					Version: "0.1.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "KMSClient",
+					Path: "./generated/swift-google-cloud-kms-v1",
+				},
+			},
+			wantVersion: "0.1.0-preview",
+		},
+		{
+			name: "MatchesByApiPackage",
+			libraries: []*config.Library{
+				{
+					Name: "custom-rpc",
+					APIs: []*config.API{
+						{Path: "google/rpc"},
+					},
+					Version: "0.1.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name:       "RPCClient",
+					ApiPackage: "google.rpc",
+				},
+			},
+			wantVersion: "0.1.0-preview",
+		},
+		{
+			name: "FallbackToDefaultVersion",
+			libraries: []*config.Library{
+				{
+					Name: "google-rpc",
+				},
+			},
+			defaultCfg: &config.Default{
+				Swift: &config.SwiftDefault{
+					DefaultVersion: "0.0.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "GoogleRpc",
+					URL:  "https://github.com/googleapis/swift-google-rpc",
+				},
+			},
+			wantVersion: "0.0.0-preview",
+		},
+		{
+			name: "ExternalDependencyNoMatch",
+			libraries: []*config.Library{
+				{
+					Name:    "google-rpc",
+					Version: "0.1.0-preview",
+				},
+			},
+			dependencies: []config.SwiftDependency{
+				{
+					Name: "SwiftProtobuf",
+					URL:  "https://github.com/apple/swift-protobuf",
+				},
+			},
+			wantVersion: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Libraries: test.libraries,
+				Default:   test.defaultCfg,
+			}
+			library := &config.Library{
+				Name: "test-lib",
 				Swift: &config.SwiftPackage{
-					LibraryNameOverride: "GoogleIAMV1",
-				},
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "GoogleIAMV1",
-						URL:  "https://github.com/googleapis/swift-google-iam-v1",
+					SwiftDefault: config.SwiftDefault{
+						Dependencies: test.dependencies,
 					},
 				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.1.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_MatchesByNameCamelCase(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-rpc",
-				Version: "0.1.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "GoogleRpc",
-						URL:  "https://github.com/googleapis/swift-google-rpc",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.1.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_MatchesByExactName(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-rpc",
-				Version: "0.1.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "google-rpc",
-						URL:  "https://github.com/googleapis/swift-google-rpc",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.1.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_MatchesByCaseInsensitiveCamelCase(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-longrunning",
-				Version: "0.1.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "GoogleLongRunning",
-						URL:  "https://github.com/googleapis/swift-google-longrunning",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.1.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_MatchesByURLRepoName(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-cloud-auth",
-				Output:  "packages/swift-google-auth/Sources/GoogleCloudAuth/generated",
-				Version: "0.0.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "CustomAuthName",
-						URL:  "https://github.com/googleapis/swift-google-auth.git",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.0.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_MatchesByPath(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-cloud-kms-v1",
-				Output:  "generated/swift-google-cloud-kms-v1",
-				Version: "0.1.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "KMSClient",
-						Path: "generated/swift-google-cloud-kms-v1",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.1.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_NoFalsePositivePathPrefix(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "kms-v11-lib",
-				Output:  "generated/swift-google-cloud-kms-v11",
-				Version: "0.2.0",
-			},
-			{
-				Name:    "kms-v1-lib",
-				Output:  "generated/swift-google-cloud-kms-v1",
-				Version: "0.1.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "KMSClient",
-						Path: "./generated/swift-google-cloud-kms-v1",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.1.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_MatchesByApiPackage(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name: "custom-rpc",
-				APIs: []*config.API{
-					{Path: "google/rpc"},
-				},
-				Version: "0.1.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name:       "RPCClient",
-						ApiPackage: "google.rpc",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.1.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_FallbackToDefaultVersion(t *testing.T) {
-	cfg := &config.Config{
-		Default: &config.Default{
-			Swift: &config.SwiftDefault{
-				DefaultVersion: "0.0.0-preview",
-			},
-		},
-		Libraries: []*config.Library{
-			{
-				Name: "google-rpc",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "GoogleRpc",
-						URL:  "https://github.com/googleapis/swift-google-rpc",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := "0.0.0-preview"
-	if got != want {
-		t.Errorf("got version %q, want %q", got, want)
-	}
-}
-
-func TestResolveDependencyVersions_ExternalDependencyNoMatch(t *testing.T) {
-	cfg := &config.Config{
-		Libraries: []*config.Library{
-			{
-				Name:    "google-rpc",
-				Version: "0.1.0-preview",
-			},
-		},
-	}
-	library := &config.Library{
-		Name: "test-lib",
-		Swift: &config.SwiftPackage{
-			SwiftDefault: config.SwiftDefault{
-				Dependencies: []config.SwiftDependency{
-					{
-						Name: "SwiftProtobuf",
-						URL:  "https://github.com/apple/swift-protobuf",
-					},
-				},
-			},
-		},
-	}
-
-	ResolveDependencyVersions(cfg, library)
-
-	got := library.Swift.Dependencies[0].Version
-	want := ""
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			ResolveDependencyVersions(cfg, library)
+			got := library.Swift.Dependencies[0].Version
+			if diff := cmp.Diff(test.wantVersion, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Read the dependency version from the matching library declaration in the configuration when generating Swift client libraries if version is not explicitly specified on the dependency.

Dependencies configured in default.swift.dependencies or at the library level often refer to other libraries managed within the same repository. When their version is omitted, Librarian resolves the version from the corresponding library definition in librarian.yaml, avoiding redundant version declarations.

For https://github.com/googleapis/google-cloud-swift/issues/696