### PR TITLE
feat(internal/config): add NodejsDefault with custom_scopes

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -132,7 +132,7 @@ This document describes the schema for the librarian.yaml.
 | `dotnet` | [DotnetPackage](#dotnetpackage-configuration) (optional) | Contains .NET-specific default configuration. |
 | `go` | [GoDefault](#godefault-configuration) (optional) | Contains Go-specific default configuration. |
 | `java` | [JavaDefault](#javadefault-configuration) (optional) | Contains Java-specific default configuration. |
-| `nodejs` | [NodejsPackage](#nodejspackage-configuration) (optional) | Contains Node.js-specific default configuration. |
+| `nodejs` | [NodejsDefault](#nodejsdefault-configuration) (optional) | Contains Node.js-specific default configuration. |
 | `php` | [PHPDefault](#phpdefault-configuration) (optional) | Contains PHP-specific default configuration. |
 | `rust` | [RustDefault](#rustdefault-configuration) (optional) | Contains Rust-specific default configuration. |
 | `python` | [PythonDefault](#pythondefault-configuration) (optional) | Contains Python-specific default configuration. |
@@ -430,6 +430,12 @@ This document describes the schema for the librarian.yaml.
 | `mixins` | string | Controls mixin behavior for this API (e.g., "none" to disable). When set, this overrides the package-level mixins setting. |
 | `omit_common_resources` | bool | Indicates whether to omit the default inclusion of google/cloud/common_resources.proto. |
 | `path` | string | Is the source path. |
+
+## NodejsDefault Configuration
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `custom_scopes` | map[string]string | Maps API path prefixes (e.g., "google/shopping/merchant") to their corresponding npm scope (e.g., "@google-shopping"). Use this to override default package name derivation for specific non-cloud API paths. |
 
 ## NodejsPackage Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -285,7 +285,7 @@ type Default struct {
 	Java *JavaDefault `yaml:"java,omitempty"`
 
 	// Nodejs contains Node.js-specific default configuration.
-	Nodejs *NodejsPackage `yaml:"nodejs,omitempty"`
+	Nodejs *NodejsDefault `yaml:"nodejs,omitempty"`
 
 	// PHP contains PHP-specific default configuration.
 	PHP *PHPDefault `yaml:"php,omitempty"`

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -774,6 +774,14 @@ type DotnetCsprojSnippets struct {
 	EmbeddedResources []string `yaml:"embedded_resources,omitempty"`
 }
 
+// NodejsDefault contains Node.js-specific default configuration.
+type NodejsDefault struct {
+	// CustomScopes maps API path prefixes (e.g., "google/shopping/merchant")
+	// to their corresponding npm scope (e.g., "@google-shopping").
+	// Use this to override default package name derivation for specific non-cloud API paths.
+	CustomScopes map[string]string `yaml:"custom_scopes,omitempty"`
+}
+
 // NodejsPackage contains Node.js-specific library configuration.
 type NodejsPackage struct {
 	// AdditionalProtos is a list of additional proto files to include in generation.


### PR DESCRIPTION
Add NodejsDefault struct to language configuration with `custom_scopes` mapping. Update Default.Nodejs from NodejsPackage (unused) to NodejsDefault.

For https://github.com/googleapis/librarian/issues/7496