### PR TITLE
feat(sidekick/swift): Storage Control retry policy

### DIFF
--- a/internal/sidekick/swift/generate_storage_test.go
+++ b/internal/sidekick/swift/generate_storage_test.go
@@ -286,6 +286,9 @@ func TestGenerateStorage_MultiModel(t *testing.T) {
 		!strings.Contains(clientStr, `withDefaultEndpoint: "https://storage.googleapis.com"`) {
 		t.Errorf("StorageControlClient.swift missing shared _GRPCClient initialization:\n%s", clientStr)
 	}
+	if !strings.Contains(clientStr, "options.retryPolicy = StorageBaseRetryPolicy.defaultPolicy") {
+		t.Errorf("StorageControlClient.swift missing StorageBaseRetryPolicy default initialization:\n%s", clientStr)
+	}
 	if !strings.Contains(clientStr, "var storageStub: any Clients.StorageStub = Clients.StorageTransport(sharedGrpcClient)") ||
 		!strings.Contains(clientStr, "var controlStub: any Clients.StorageControlStub = Clients.StorageControlTransport(sharedGrpcClient)") {
 		t.Errorf("StorageControlClient.swift missing transport initialization with shared gRPC client:\n%s", clientStr)

--- a/internal/sidekick/swift/templates/storage/StorageControlClient.swift.mustache
+++ b/internal/sidekick/swift/templates/storage/StorageControlClient.swift.mustache
@@ -36,6 +36,10 @@ public final class StorageControlClient: StorageControlProtocol, Sendable {
 
   /// Creates a new `StorageControlClient` using the given client options.
   public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {
+    var options = options
+    if options.retryPolicy == nil {
+      options.retryPolicy = StorageBaseRetryPolicy.defaultPolicy
+    }
     let sharedGrpcClient = try GoogleCloudGaxGRPC._GRPCClient(
       from: options,
       withDefaultEndpoint: "https://{{Codec.DefaultHost}}"


### PR DESCRIPTION
Configure `StorageControlClient` to set
`StorageBaseRetryPolicy.defaultPolicy` as the retry policy.

Towards https://github.com/googleapis/google-cloud-swift/issues/529 
