### PR TITLE
refactor(internal/config): remove component_name from PHPPackage

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -478,7 +478,6 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `component_name` | string | Overrides the derived component name used for output/staging. |
 
 ## PythonDefault Configuration
 

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -160,7 +160,6 @@ This document describes the schema for the librarian.yaml.
 | `go` | [GoModule](#gomodule-configuration) (optional) | Contains Go-specific library configuration. |
 | `java` | [JavaModule](#javamodule-configuration) (optional) | Contains Java-specific library configuration. |
 | `nodejs` | [NodejsPackage](#nodejspackage-configuration) (optional) | Contains Node.js-specific library configuration. |
-| `php` | [PHPPackage](#phppackage-configuration) (optional) | Contains PHP-specific library configuration. |
 | `python` | [PythonPackage](#pythonpackage-configuration) (optional) | Contains Python-specific library configuration. |
 | `ruby` | [RubyPackage](#rubypackage-configuration) (optional) | Contains Ruby-specific library configuration. |
 | `rust` | [RustCrate](#rustcrate-configuration) (optional) | Contains Rust-specific library configuration. |
@@ -473,11 +472,6 @@ This document describes the schema for the librarian.yaml.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `common_resources` | bool (optional) | Indicates whether to include common resources in generation. Must be configured either globally or per-API. |
-
-## PHPPackage Configuration
-
-| Field | Type | Description |
-| :--- | :--- | :--- |
 
 ## PythonDefault Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -385,9 +385,6 @@ type Library struct {
 	// Nodejs contains Node.js-specific library configuration.
 	Nodejs *NodejsPackage `yaml:"nodejs,omitempty"`
 
-	// PHP contains PHP-specific library configuration.
-	PHP *PHPPackage `yaml:"php,omitempty"`
-
 	// Python contains Python-specific library configuration.
 	Python *PythonPackage `yaml:"python,omitempty"`
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -854,9 +854,6 @@ type PHPDefault struct {
 	CommonResources *bool `yaml:"common_resources,omitempty"`
 }
 
-// PHPPackage contains PHP-specific library configuration.
-type PHPPackage struct{}
-
 // PHPAPI represents configuration for a single API within a PHP package.
 type PHPAPI struct {
 	// AdditionalProtos is a list of additional proto files to include in generation.

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -855,10 +855,7 @@ type PHPDefault struct {
 }
 
 // PHPPackage contains PHP-specific library configuration.
-type PHPPackage struct {
-	// ComponentName overrides the derived component name used for output/staging.
-	ComponentName string `yaml:"component_name,omitempty"`
-}
+type PHPPackage struct{}
 
 // PHPAPI represents configuration for a single API within a PHP package.
 type PHPAPI struct {

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -448,8 +448,6 @@ func ResolvePreview(lib *config.Library, language string) *config.Library {
 		res.Python = mergePython(res.Python, p.Python)
 	case config.LanguageRust:
 		res.Rust = mergeRust(res.Rust, p.Rust)
-	case config.LanguagePhp:
-		res.PHP = mergePHP(res.PHP, p.PHP)
 	case config.LanguageRuby:
 		res.Ruby = mergeRuby(res.Ruby, p.Ruby)
 	case config.LanguageSwift:
@@ -926,16 +924,5 @@ func mergeSwift(dst, src *config.SwiftPackage) *config.SwiftPackage {
 		res.DefaultTraits = src.DefaultTraits
 	}
 	res.Discovery = mergeCommonDiscovery(res.Discovery, src.Discovery)
-	return &res
-}
-
-func mergePHP(dst, src *config.PHPPackage) *config.PHPPackage {
-	if src == nil {
-		return dst
-	}
-	if dst == nil {
-		return src
-	}
-	res := *dst
 	return &res
 }

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -1704,41 +1704,6 @@ func TestMergeRust(t *testing.T) {
 	}
 }
 
-func TestMergePHP(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		dst  *config.PHPPackage
-		src  *config.PHPPackage
-		want *config.PHPPackage
-	}{
-		{
-			name: "nil src returns dst",
-			dst:  &config.PHPPackage{},
-			src:  nil,
-			want: &config.PHPPackage{},
-		},
-		{
-			name: "nil dst returns src",
-			dst:  nil,
-			src:  &config.PHPPackage{},
-			want: &config.PHPPackage{},
-		},
-		{
-			name: "both non-nil",
-			dst:  &config.PHPPackage{},
-			src:  &config.PHPPackage{},
-			want: &config.PHPPackage{},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got := mergePHP(test.dst, test.src)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestMergeRuby(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/internal/librarian/php/add_test.go
+++ b/internal/librarian/php/add_test.go
@@ -186,32 +186,6 @@ func TestAdd(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "component name override",
-			lib: &config.Library{
-				PHP: &config.PHPPackage{
-					ComponentName: "CustomComponent",
-				},
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			want: &config.Library{
-				Output:  "CustomComponent",
-				Version: "0.0.0",
-				PHP: &config.PHPPackage{
-					ComponentName: "CustomComponent",
-				},
-				APIs: []*config.API{
-					{
-						Path: "google/cloud/secretmanager/v1",
-						PHP: &config.PHPAPI{
-							StagingSubdir: "v1",
-						},
-					},
-				},
-			},
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := Add(test.lib, googleapisDir)

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -273,9 +273,6 @@ func TestGenerate_StatError(t *testing.T) {
 	library := &config.Library{
 		Name:   "secretmanager",
 		Output: nestedDir,
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager/nested",
-		},
 		APIs: []*config.API{
 			{
 				Path: "google/cloud/secretmanager/v1",
@@ -372,9 +369,6 @@ func TestGenerate_Error(t *testing.T) {
 			lib: &config.Library{
 				Name:   "SecretManager",
 				Output: "SecretManager",
-				PHP: &config.PHPPackage{
-					ComponentName: "SecretManager",
-				},
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/secretmanager/v1",

--- a/internal/librarian/php/init.go
+++ b/internal/librarian/php/init.go
@@ -93,12 +93,8 @@ func newInitParams(googleapisDir string, library *config.Library) (*initParams, 
 }
 
 // componentNameForLibrary resolves the component name for a PHP library.
-// If library.PHP.ComponentName is set, it is returned as an explicit override.
-// Otherwise, the component name is derived on the fly from the php_namespace of the library's primary API.
+// The component name is derived on the fly from the php_namespace of the library's primary API.
 func componentNameForLibrary(googleapisDir string, library *config.Library) (string, error) {
-	if library.PHP != nil && library.PHP.ComponentName != "" {
-		return library.PHP.ComponentName, nil
-	}
 	if len(library.APIs) == 0 {
 		return "", fmt.Errorf("%w: %q", errNoAPIs, library.Name)
 	}
@@ -106,7 +102,7 @@ func componentNameForLibrary(googleapisDir string, library *config.Library) (str
 	if err != nil {
 		return "", err
 	}
-	return componentName(library, ns), nil
+	return componentName(ns), nil
 }
 
 // namespace reads the php_namespace option from the first .proto file in the API directory.
@@ -143,10 +139,7 @@ func namespace(googleapisDir, apiPath string) (string, error) {
 }
 
 // componentName returns the component name from a namespace.
-func componentName(library *config.Library, namespace string) string {
-	if library.PHP != nil && library.PHP.ComponentName != "" {
-		return library.PHP.ComponentName
-	}
+func componentName(namespace string) string {
 	if comp, ok := strings.CutPrefix(namespace, `Google\Cloud\`); ok {
 		return comp
 	}

--- a/internal/librarian/php/init_test.go
+++ b/internal/librarian/php/init_test.go
@@ -135,41 +135,27 @@ func TestNamespace_Error(t *testing.T) {
 func TestComponentName(t *testing.T) {
 	for _, test := range []struct {
 		name      string
-		library   *config.Library
 		namespace string
 		want      string
 	}{
 		{
 			name:      "google cloud component",
-			library:   &config.Library{},
 			namespace: `Google\Cloud\SecretManager`,
 			want:      "SecretManager",
 		},
 		{
 			name:      "google ads",
-			library:   &config.Library{},
 			namespace: `Google\Ads\GoogleAds`,
 			want:      "AdsGoogleAds",
 		},
 		{
 			name:      "google shopping",
-			library:   &config.Library{},
 			namespace: `Google\Shopping\Merchant\Conversions`,
 			want:      "ShoppingMerchantConversions",
 		},
-		{
-			name: "component name override",
-			library: &config.Library{
-				PHP: &config.PHPPackage{
-					ComponentName: "CustomComponentName",
-				},
-			},
-			namespace: `Google\Cloud\SecretManager`,
-			want:      "CustomComponentName",
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := componentName(test.library, test.namespace)
+			got := componentName(test.namespace)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -291,13 +277,10 @@ func TestInitComponentIfMissing(t *testing.T) {
 			wantInit:      true,
 		},
 		{
-			name: "new component with component name override",
+			name: "new component with custom output",
 			library: &config.Library{
 				Name:   "secretmanager",
 				Output: "CustomSecretManager",
-				PHP: &config.PHPPackage{
-					ComponentName: "CustomSecretManager",
-				},
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
@@ -374,9 +357,6 @@ func TestInitComponentIfMissing_Error(t *testing.T) {
 			library: &config.Library{
 				Name:   "secretmanager",
 				Output: "unreadable/SecretManager",
-				PHP: &config.PHPPackage{
-					ComponentName: "unreadable/SecretManager",
-				},
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
@@ -527,43 +507,18 @@ func TestProtoPackage(t *testing.T) {
 
 func TestComponentNameForLibrary(t *testing.T) {
 	googleapisDir := filepath.Join("..", "..", "testdata", "googleapis")
-	for _, test := range []struct {
-		name    string
-		library *config.Library
-		want    string
-	}{
-		{
-			name: "derived from proto namespace",
-			library: &config.Library{
-				Name: "SecretManager",
-				APIs: []*config.API{
-					{Path: "google/cloud/secretmanager/v1"},
-				},
-			},
-			want: "SecretManager",
+	library := &config.Library{
+		Name: "SecretManager",
+		APIs: []*config.API{
+			{Path: "google/cloud/secretmanager/v1"},
 		},
-		{
-			name: "explicit config override",
-			library: &config.Library{
-				Name: "AccessContextManager",
-				PHP: &config.PHPPackage{
-					ComponentName: "AccessContextManager",
-				},
-				APIs: []*config.API{
-					{Path: "google/identity/accesscontextmanager/v1"},
-				},
-			},
-			want: "AccessContextManager",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := componentNameForLibrary(googleapisDir, test.library)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		})
+	}
+	got, err := componentNameForLibrary(googleapisDir, library)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SecretManager"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/librarian/php/postprocess_test.go
+++ b/internal/librarian/php/postprocess_test.go
@@ -36,9 +36,6 @@ func TestPostProcess_MissingOwlBot(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager",
-		},
 	}
 	err := postProcessLibrary(ctx, lib)
 	if !errors.Is(err, errOwlBotNotFound) {
@@ -80,9 +77,6 @@ func TestPostProcess_OwlBot(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager",
-		},
 	}
 	if err := postProcessLibrary(ctx, lib); err != nil {
 		t.Fatal(err)
@@ -110,9 +104,6 @@ func TestPostProcess_OwlBotError(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager",
-		},
 	}
 	err := postProcessLibrary(ctx, lib)
 	if _, ok := errors.AsType[*exec.ExitError](err); !ok {
@@ -142,9 +133,6 @@ func TestPostProcess_StatError(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: inaccessibleDir,
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager_inaccessible",
-		},
 	}
 	err := postProcessLibrary(ctx, lib)
 	if !errors.Is(err, os.ErrPermission) {
@@ -183,9 +171,6 @@ func TestPostProcess_CleanupError(t *testing.T) {
 	lib := &config.Library{
 		Name:   "SecretManager",
 		Output: destDir,
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager",
-		},
 	}
 	err := postProcessLibrary(ctx, lib)
 	if !errors.Is(err, os.ErrPermission) {
@@ -218,11 +203,8 @@ func TestPostProcess_PHPPostProcessor(t *testing.T) {
 				},
 			},
 		},
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager",
-		},
 	}
-	stagingSubdir := filepath.Join(repoRoot, owlBotStagingDir, lib.PHP.ComponentName, "SecretManager/v1")
+	stagingSubdir := filepath.Join(repoRoot, owlBotStagingDir, filepath.Base(lib.Output), "SecretManager/v1")
 	if err := os.MkdirAll(stagingSubdir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -265,11 +247,8 @@ func TestPostProcess_PHPPostProcessorError(t *testing.T) {
 				},
 			},
 		},
-		PHP: &config.PHPPackage{
-			ComponentName: "SecretManager",
-		},
 	}
-	stagingSubdir := filepath.Join(repoRoot, owlBotStagingDir, lib.PHP.ComponentName, "SecretManager/v1")
+	stagingSubdir := filepath.Join(repoRoot, owlBotStagingDir, filepath.Base(lib.Output), "SecretManager/v1")
 	if err := os.MkdirAll(stagingSubdir, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -41,15 +41,6 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			api.PHP = nil
 		}
 	}
-	if lib.PHP != nil {
-		empty, err := yaml.Empty(lib.PHP)
-		if err != nil {
-			return nil, err
-		}
-		if empty {
-			lib.PHP = nil
-		}
-	}
 	return lib, nil
 }
 


### PR DESCRIPTION
The legacy component_name field in PHPPackage is removed in favor of output in librarian.yaml. Component initialization, code generation, and post-processing now derive and use the output path directly from library.Output, aligning PHP with other supported languages.

All references and overrides for component_name in PHP generation and post-processing tests are removed.

Fixes https://github.com/googleapis/librarian/issues/7389