### PR TITLE
feat(internal/librarian/nodejs): derive package name from custom prefixes

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -312,7 +312,7 @@ func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName, goo
 			return "", nil, err
 		}
 	case config.LanguageNodejs:
-		lib = nodejs.Add(lib)
+		lib = nodejs.Add(cfg, lib)
 	case config.LanguagePython:
 		var err error
 		lib, err = python.Add(cfg, lib)

--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -887,6 +887,105 @@ func TestAddLibraryCommand_Php(t *testing.T) {
 	}
 }
 
+func TestAddLibraryCommand_Nodejs(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	googleapisDir := filepath.Join(tmpDir, "googleapis")
+	apiPath := "google/shopping/merchant/loyaltycustomers/v1"
+	if err := os.MkdirAll(filepath.Join(googleapisDir, apiPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := sample.Config()
+	cfg.Language = config.LanguageNodejs
+	cfg.Default.Nodejs = &config.NodejsDefault{
+		CustomScopes: map[string]string{
+			"google/shopping/merchant": "@google-shopping",
+		},
+	}
+	cfg.Default.Output = "packages"
+	cfg.Libraries = []*config.Library{}
+	cfg.Sources.Googleapis.Dir = googleapisDir
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+		t.Fatal(err)
+	}
+	err := runAdd(t.Context(), cfg, apiPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLibraries := []*config.Library{
+		{
+			Name:          "google-shopping-merchant-loyaltycustomers",
+			Version:       "0.0.0",
+			CopyrightYear: strconv.Itoa(time.Now().Year()),
+			Nodejs: &config.NodejsPackage{
+				PackageName: "@google-shopping/loyaltycustomers",
+			},
+			APIs: []*config.API{
+				{
+					Path: "google/shopping/merchant/loyaltycustomers/v1",
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAddLibraryCommand_Nodejs_TidyDefaultPackageName(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	googleapisDir := filepath.Join(tmpDir, "googleapis")
+	apiPath := "google/apps/meet/v2"
+	if err := os.MkdirAll(filepath.Join(googleapisDir, apiPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := sample.Config()
+	cfg.Language = config.LanguageNodejs
+	cfg.Default.Nodejs = &config.NodejsDefault{
+		CustomScopes: map[string]string{
+			"google/apps": "@google-apps",
+		},
+	}
+	cfg.Default.Output = "packages"
+	cfg.Libraries = []*config.Library{}
+	cfg.Sources.Googleapis.Dir = googleapisDir
+	if err := yaml.Write(config.LibrarianYAML, cfg); err != nil {
+		t.Fatal(err)
+	}
+	err := runAdd(t.Context(), cfg, apiPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotCfg, err := yaml.Read[config.Config](config.LibrarianYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLibraries := []*config.Library{
+		{
+			Name:          "google-apps-meet",
+			Version:       "0.0.0",
+			CopyrightYear: strconv.Itoa(time.Now().Year()),
+			APIs: []*config.API{
+				{
+					Path: "google/apps/meet/v2",
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(wantLibraries, gotCfg.Libraries); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestAddLibrary_Swift(t *testing.T) {
 	copyrightYear := strconv.Itoa(time.Now().Year())
 	for _, test := range []struct {

--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -60,6 +60,8 @@ func fillDefaults(lib *config.Library, d *config.Default) *config.Library {
 		return fillSwift(lib, d)
 	case d.PHP != nil:
 		return fillPHP(lib, d)
+	case d.Nodejs != nil:
+		return nodejs.FillDefaultNodejs(lib, d)
 	default:
 		return lib
 	}

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -696,6 +696,73 @@ func TestFillDefaults_PHP(t *testing.T) {
 	}
 }
 
+func TestFillDefaults_Nodejs(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		lib      *config.Library
+		defaults *config.NodejsDefault
+		want     *config.Library
+	}{
+		{
+			name: "custom_scopes populates package_name",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/shopping/merchant/loyaltycustomers/v1",
+					},
+				},
+			},
+			defaults: &config.NodejsDefault{
+				CustomScopes: map[string]string{
+					"google/shopping/merchant": "@google-shopping",
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/shopping/merchant/loyaltycustomers/v1",
+					},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-shopping/loyaltycustomers",
+				},
+			},
+		},
+		{
+			name: "cloud API leaves package_name empty",
+			lib: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+					},
+				},
+			},
+			defaults: &config.NodejsDefault{
+				CustomScopes: map[string]string{
+					"google/shopping/merchant": "@google-shopping",
+				},
+			},
+			want: &config.Library{
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/secretmanager/v1",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			defaults := &config.Default{
+				Nodejs: test.defaults,
+			}
+			got := fillDefaults(test.lib, defaults)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestApplyDefaults(t *testing.T) {
 	for _, test := range []struct {
 		name        string

--- a/internal/librarian/nodejs/add.go
+++ b/internal/librarian/nodejs/add.go
@@ -15,7 +15,10 @@
 package nodejs
 
 import (
+	"fmt"
+	"log"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/librarian/internal/config"
@@ -25,9 +28,97 @@ import (
 const defaultVersion = "0.0.0"
 
 // Add initializes Node.js-specific configuration for a library.
-func Add(lib *config.Library) *config.Library {
+func Add(cfg *config.Config, lib *config.Library) *config.Library {
 	lib.Version = defaultVersion
+	var d *config.Default
+	if cfg != nil {
+		d = cfg.Default
+	}
+	lib = FillDefaultNodejs(lib, d)
+	if len(lib.APIs) > 0 {
+		apiPath := lib.APIs[0].Path
+		if !strings.HasPrefix(apiPath, "google/cloud/") && (lib.Nodejs == nil || lib.Nodejs.PackageName == "") {
+			log.Printf("WARNING: unrecognized non-cloud API path %q. Please manually configure nodejs.package_name in librarian.yaml.", apiPath)
+		}
+	}
 	return lib
+}
+
+// FillDefaultNodejs populates empty Node.js-specific fields in lib from [config.Default],
+// specifically from [config.NodejsDefault].
+func FillDefaultNodejs(lib *config.Library, d *config.Default) *config.Library {
+	if lib == nil {
+		return nil
+	}
+	fillPackageNameIfEmpty(lib, d)
+	return lib
+}
+
+func fillPackageNameIfEmpty(lib *config.Library, d *config.Default) {
+	if lib.Nodejs != nil && lib.Nodejs.PackageName != "" {
+		return
+	}
+	if d == nil || d.Nodejs == nil || len(d.Nodejs.CustomScopes) == 0 {
+		return
+	}
+	for _, api := range lib.APIs {
+		if pkgName := derivePackageNameFromCustomScopes(api.Path, d.Nodejs.CustomScopes); pkgName != "" {
+			if lib.Nodejs == nil {
+				lib.Nodejs = &config.NodejsPackage{}
+			}
+			lib.Nodejs.PackageName = pkgName
+			return
+		}
+	}
+}
+
+func derivePackageNameFromCustomScopes(apiPath string, customScopes map[string]string) string {
+	if apiPath == "" || len(customScopes) == 0 {
+		return ""
+	}
+	pathWithoutVersion := apiPath
+	if v := serviceconfig.ExtractVersion(apiPath); v != "" {
+		pathWithoutVersion = strings.TrimSuffix(strings.TrimSuffix(apiPath, v), "/")
+	}
+	prefixes := make([]string, 0, len(customScopes))
+	for p := range customScopes {
+		prefixes = append(prefixes, p)
+	}
+	slices.SortFunc(prefixes, func(a, b string) int {
+		if len(a) != len(b) {
+			return len(b) - len(a)
+		}
+		return strings.Compare(a, b)
+	})
+	for _, prefix := range prefixes {
+		normPrefix := strings.Trim(prefix, "/")
+		var remainder string
+		if pathWithoutVersion == normPrefix {
+			remainder = ""
+		} else if rem, ok := strings.CutPrefix(pathWithoutVersion, normPrefix+"/"); ok {
+			remainder = rem
+		} else {
+			continue
+		}
+		scope := strings.TrimSpace(customScopes[prefix])
+		if scope == "" {
+			continue
+		}
+		if !strings.HasPrefix(scope, "@") {
+			scope = "@" + scope
+		}
+		if strings.Contains(scope, "/") {
+			if remainder == "" {
+				return scope
+			}
+			return fmt.Sprintf("%s-%s", scope, strings.ReplaceAll(remainder, "/", "-"))
+		}
+		if remainder != "" {
+			return fmt.Sprintf("%s/%s", scope, strings.ReplaceAll(remainder, "/", "-"))
+		}
+		return fmt.Sprintf("%s/%s", scope, filepath.Base(normPrefix))
+	}
+	return ""
 }
 
 // DefaultLibraryName derives a library name from an API path by stripping

--- a/internal/librarian/nodejs/add_test.go
+++ b/internal/librarian/nodejs/add_test.go
@@ -35,9 +35,169 @@ func TestAdd(t *testing.T) {
 			{Path: "google/cloud/secretmanager/v1"},
 		},
 	}
-	got := Add(in)
+	got := Add(nil, in)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAdd_CustomScopes(t *testing.T) {
+	cfg := &config.Config{
+		Default: &config.Default{
+			Nodejs: &config.NodejsDefault{
+				CustomScopes: map[string]string{
+					"google/shopping/merchant": "@google-shopping",
+					"google/shopping":          "@google-shopping",
+					"google/maps":              "googlemaps",
+					"google/chat":              "@google-apps/chat",
+					"google/apps":              "@google-apps",
+				},
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name string
+		in   *config.Library
+		want *config.Library
+	}{
+		{
+			name: "cloud API leaves package name empty",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-cloud-secretmanager",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+		},
+		{
+			name: "nested custom organization strips prefix and derives package name",
+			in: &config.Library{
+				Name: "google-shopping-merchant-loyaltycustomers",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-shopping-merchant-loyaltycustomers",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-shopping/loyaltycustomers",
+				},
+			},
+		},
+		{
+			name: "prefix without leading @ is normalized",
+			in: &config.Library{
+				Name: "google-maps-routing",
+				APIs: []*config.API{
+					{Path: "google/maps/routing/v2"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-maps-routing",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/maps/routing/v2"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@googlemaps/routing",
+				},
+			},
+		},
+		{
+			name: "org containing slash returns exact package name when remainder empty",
+			in: &config.Library{
+				Name: "google-chat",
+				APIs: []*config.API{
+					{Path: "google/chat/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-chat",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/chat/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-apps/chat",
+				},
+			},
+		},
+		{
+			name: "general prefix derives package name from remainder",
+			in: &config.Library{
+				Name: "google-apps-meet",
+				APIs: []*config.API{
+					{Path: "google/apps/meet/v2"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-apps-meet",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/apps/meet/v2"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-apps/meet",
+				},
+			},
+		},
+		{
+			name: "unrecognized non-cloud API leaves package name empty",
+			in: &config.Library{
+				Name: "google-unrecognized-api",
+				APIs: []*config.API{
+					{Path: "google/unrecognized/api/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-unrecognized-api",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/unrecognized/api/v1"},
+				},
+			},
+		},
+		{
+			name: "preserves explicitly configured package name",
+			in: &config.Library{
+				Name: "google-shopping-merchant-loyaltycustomers",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@custom/override",
+				},
+			},
+			want: &config.Library{
+				Name:    "google-shopping-merchant-loyaltycustomers",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@custom/override",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Add(cfg, test.in)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/librarian/nodejs/tidy.go
+++ b/internal/librarian/nodejs/tidy.go
@@ -24,6 +24,9 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 	if lib.Nodejs == nil {
 		return lib, nil
 	}
+	if lib.Nodejs.PackageName == derivePackageNameFromLibraryName(lib.Name) {
+		lib.Nodejs.PackageName = ""
+	}
 	empty, err := yaml.Empty(lib.Nodejs)
 	if err != nil {
 		return nil, err

--- a/internal/librarian/nodejs/tidy_test.go
+++ b/internal/librarian/nodejs/tidy_test.go
@@ -61,6 +61,33 @@ func TestTidy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "default derived package_name is tidied away",
+			lib: &config.Library{
+				Name: "google-cloud-secretmanager",
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-cloud/secretmanager",
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager",
+			},
+		},
+		{
+			name: "custom package_name is kept",
+			lib: &config.Library{
+				Name: "google-shopping-merchant-loyaltycustomers",
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-shopping/loyaltycustomers",
+				},
+			},
+			want: &config.Library{
+				Name: "google-shopping-merchant-loyaltycustomers",
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-shopping/loyaltycustomers",
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := Tidy(test.lib)


### PR DESCRIPTION
Derive default Node.js package names for non-cloud APIs during `librarian add` using custom package prefixes configured in librarian.yaml. A shared prefix matcher in serviceconfig resolves API paths by matching exact paths or iteratively stripping path segments, enabling Node.js to construct package names for scoped packages, scoped prefixes with hyphenated suffixes, and exact package names without manual configuration.

The configuration field is renamed from custom_scopes to custom_package_prefixes to reflect that configured values can represent full or partial package prefixes in addition to bare npm scopes. Shared prefix matching is also adopted in Java group ID resolution to standardize prefix lookup behavior across languages.

Here is the expected addition to google-cloud-node/librarian.yaml to take advantage of this feat:
```
+  nodejs:
+    custom_scopes:
+      google/ads: "@google-ads"
+      google/ai: "@google-ai"
+      google/analytics: "@google-analytics"
+      google/apps: "@google-apps"
+      google/area120: "@google/area120"
+      google/chat: "@google-apps/chat"
+      google/developers: "@google/developer"
+      google/maps: "@googlemaps"
+      google/maps/isochrones: "@google-maps/isochrones"
+      google/marketingplatform: "@google-ads/marketing-platform"
+      google/shopping: "@google-shopping"
+      google/shopping/merchant: "@google-shopping"
```

For https://github.com/googleapis/librarian/issues/7496
