### PR TITLE
refactor(internal/serviceconfig): add MatchPrefix helper and migrate Java

### DIFF
--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/googleapis/librarian/internal/config"
 	"github.com/googleapis/librarian/internal/semver"
+	"github.com/googleapis/librarian/internal/serviceconfig"
 	"github.com/googleapis/librarian/internal/yaml"
 )
 
@@ -101,15 +102,13 @@ func FillDefaultJava(lib *config.Library, d *config.Default) *config.Library {
 // It matches the library's API paths against the custom group ID prefixes in default
 // and assigns the first matching group ID.
 func fillGroupIDIfEmpty(lib *config.Library, d *config.Default) {
-	if lib.Java.GroupID != "" || d == nil || d.Java == nil || d.Java.CustomGroupIDs == nil {
+	if lib.Java.GroupID != "" || d == nil || d.Java == nil || len(d.Java.CustomGroupIDs) == 0 {
 		return
 	}
 	for _, api := range lib.APIs {
-		for apiPrefix, groupID := range d.Java.CustomGroupIDs {
-			if api.Path == apiPrefix || strings.HasPrefix(api.Path, apiPrefix+"/") {
-				lib.Java.GroupID = groupID
-				return
-			}
+		if groupID, _, ok := serviceconfig.MatchPrefix(api.Path, d.Java.CustomGroupIDs); ok {
+			lib.Java.GroupID = groupID
+			return
 		}
 	}
 }

--- a/internal/serviceconfig/prefix.go
+++ b/internal/serviceconfig/prefix.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceconfig
+
+import (
+	"strings"
+)
+
+// MatchPrefix finds the longest matching prefix for apiPath in prefixes.
+// It strips any API version, checks the exact path, and walks up parent paths.
+//
+// Returns the mapped value, remainder path, and true if found.
+func MatchPrefix(apiPath string, prefixes map[string]string) (value, remainder string, ok bool) {
+	if apiPath == "" || len(prefixes) == 0 {
+		return "", "", false
+	}
+	path := strings.Trim(apiPath, "/")
+	if val, ok := prefixes[path]; ok {
+		return val, "", true
+	}
+	if v := ExtractVersion(path); v != "" {
+		path = strings.TrimSuffix(strings.TrimSuffix(path, v), "/")
+	}
+	for curr := path; curr != ""; {
+		if val, ok := prefixes[curr]; ok {
+			return val, strings.TrimPrefix(path[len(curr):], "/"), true
+		}
+		idx := strings.LastIndex(curr, "/")
+		if idx == -1 {
+			break
+		}
+		curr = curr[:idx]
+	}
+	return "", "", false
+}

--- a/internal/serviceconfig/prefix_test.go
+++ b/internal/serviceconfig/prefix_test.go
@@ -26,7 +26,6 @@ func TestMatchPrefix(t *testing.T) {
 		Remainder string
 		OK        bool
 	}
-
 	prefixes := map[string]string{
 		"google/shopping/merchant": "@google-shopping",
 		"google/shopping":          "@google-shopping",
@@ -35,7 +34,6 @@ func TestMatchPrefix(t *testing.T) {
 		"google/chat":              "@google-apps",
 		"google/area120":           "@google/area120",
 	}
-
 	for _, test := range []struct {
 		name     string
 		apiPath  string

--- a/internal/serviceconfig/prefix_test.go
+++ b/internal/serviceconfig/prefix_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceconfig
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMatchPrefix(t *testing.T) {
+	type result struct {
+		Value     string
+		Remainder string
+		OK        bool
+	}
+
+	prefixes := map[string]string{
+		"google/shopping/merchant": "@google-shopping",
+		"google/shopping":          "@google-shopping",
+		"google/maps/isochrones":   "@google-maps",
+		"google/maps":              "@googlemaps",
+		"google/chat":              "@google-apps",
+		"google/area120":           "@google/area120",
+	}
+
+	for _, test := range []struct {
+		name     string
+		apiPath  string
+		prefixes map[string]string
+		want     result
+	}{
+		{
+			name:     "empty apiPath",
+			apiPath:  "",
+			prefixes: prefixes,
+			want:     result{},
+		},
+		{
+			name:     "nil prefixes",
+			apiPath:  "google/shopping/v1",
+			prefixes: nil,
+			want:     result{},
+		},
+		{
+			name:     "empty prefixes",
+			apiPath:  "google/shopping/v1",
+			prefixes: map[string]string{},
+			want:     result{},
+		},
+		{
+			name:     "nested prefix matches longest prefix",
+			apiPath:  "google/shopping/merchant/accounts/v1",
+			prefixes: prefixes,
+			want:     result{Value: "@google-shopping", Remainder: "accounts", OK: true},
+		},
+		{
+			name:     "fallback to shorter prefix when nested prefix does not match",
+			apiPath:  "google/shopping/css/v1",
+			prefixes: prefixes,
+			want:     result{Value: "@google-shopping", Remainder: "css", OK: true},
+		},
+		{
+			name:     "exact match without remainder",
+			apiPath:  "google/chat/v1",
+			prefixes: prefixes,
+			want:     result{Value: "@google-apps", Remainder: "", OK: true},
+		},
+		{
+			name:     "specific sub-path override",
+			apiPath:  "google/maps/isochrones/v1",
+			prefixes: prefixes,
+			want:     result{Value: "@google-maps", Remainder: "", OK: true},
+		},
+		{
+			name:     "general prefix with remainder",
+			apiPath:  "google/maps/routing/v2",
+			prefixes: prefixes,
+			want:     result{Value: "@googlemaps", Remainder: "routing", OK: true},
+		},
+		{
+			name:     "multi-level remainder",
+			apiPath:  "google/maps/fleetengine/delivery/v1",
+			prefixes: prefixes,
+			want:     result{Value: "@googlemaps", Remainder: "fleetengine/delivery", OK: true},
+		},
+		{
+			name:     "exact match including version",
+			apiPath:  "google/exact/v1",
+			prefixes: map[string]string{"google/exact/v1": "com.google.exact"},
+			want:     result{Value: "com.google.exact", Remainder: "", OK: true},
+		},
+		{
+			name:     "no matching prefix",
+			apiPath:  "google/cloud/secretmanager/v1",
+			prefixes: prefixes,
+			want:     result{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			val, rem, ok := MatchPrefix(test.apiPath, test.prefixes)
+			got := result{Value: val, Remainder: rem, OK: ok}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a shared MatchPrefix function to internal/serviceconfig that matches an API path against a map of prefixes by checking exact matches and walking up parent path segments.

Migrate Java group ID resolution in internal/librarian/java to use the shared prefix matcher, prepare for node to use the same prefix lookup behavior. By replacing map iteration with hierarchical path lookups, this eliminates non-deterministic prefix matching in Java and guarantees that more specific sub-paths always take precedence.

For https://github.com/googleapis/librarian/issues/7496