### PR TITLE
feat(internal/config): rename custom_scopes to custom_package_prefixes

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -435,7 +435,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `custom_scopes` | map[string]string | Maps API path prefixes (e.g., "google/shopping/merchant") to their corresponding npm scope (e.g., "@google-shopping"). Use this to override default package name derivation for specific non-cloud API paths. |
+| `custom_package_prefixes` | map[string]string | Maps API path prefixes to their npm package prefixes. Values can be:<br>- An npm scope (e.g., "google/shopping/merchant": "@google-shopping"): the remainder path becomes the package name (e.g., "@google-shopping/accounts").<br>- An npm scope with a partial package name (e.g., "google/area120": "@google/area120"): the remainder path is appended with a hyphen (e.g., "@google/area120-tables").<br>- An npm scope with a full package name (e.g., "google/chat": "@google-apps/chat"): used as-is when there is no remainder path (e.g., "@google-apps/chat"). |
 
 ## NodejsPackage Configuration
 

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -776,10 +776,15 @@ type DotnetCsprojSnippets struct {
 
 // NodejsDefault contains Node.js-specific default configuration.
 type NodejsDefault struct {
-	// CustomScopes maps API path prefixes (e.g., "google/shopping/merchant")
-	// to their corresponding npm scope (e.g., "@google-shopping").
-	// Use this to override default package name derivation for specific non-cloud API paths.
-	CustomScopes map[string]string `yaml:"custom_scopes,omitempty"`
+	// CustomPackagePrefixes maps API path prefixes to their npm package prefixes.
+	// Values can be:
+	//   - An npm scope (e.g., "google/shopping/merchant": "@google-shopping"):
+	//     the remainder path becomes the package name (e.g., "@google-shopping/accounts").
+	//   - An npm scope with a partial package name (e.g., "google/area120": "@google/area120"):
+	//     the remainder path is appended with a hyphen (e.g., "@google/area120-tables").
+	//   - An npm scope with a full package name (e.g., "google/chat": "@google-apps/chat"):
+	//     used as-is when there is no remainder path (e.g., "@google-apps/chat").
+	CustomPackagePrefixes map[string]string `yaml:"custom_package_prefixes,omitempty"`
 }
 
 // NodejsPackage contains Node.js-specific library configuration.


### PR DESCRIPTION
The Node.js default configuration field is renamed from custom_scopes to custom_package_prefixes in librarian.yaml and internal/config. The new name reflects that configured values can represent npm scopes, scopes with partial package names, or full package names rather than bare npm scopes alone.

This accounts for three historical package naming patterns in google-cloud-node: 
 - bare npm scopes where the remainder path forms the package name (such as @google-shopping/accounts from google/shopping/merchant), 
 - shared scopes with partial package prefixes where subpaths append with a hyphen (such as @google/developer-knowledge from google/developers/knowledge or @google/area120-tables from google/area120),
 - and exact leaf package names used as-is without a remainder (such as @google-apps/chat from google/chat).

Here is the expected addition to google-cloud-node/librarian.yaml after all PRs for #7496 are ready:
```
+  nodejs:
+    custom_scopes:
+      google/ads: "@google-ads"
+      google/ai: "@google-ai"
+      google/analytics: "@google-analytics"
+      google/apps: "@google-apps"
+      google/area120: "@google/area120"
+      google/chat: "@google-apps/chat"
+      google/developers: "@google/developer"
+      google/maps: "@googlemaps"
+      google/maps/isochrones: "@google-maps/isochrones"
+      google/marketingplatform: "@google-ads/marketing-platform"
+      google/shopping: "@google-shopping"
+      google/shopping/merchant: "@google-shopping"
```


For https://github.com/googleapis/librarian/issues/7496
