### PR TITLE
feat(swift): add convenience methods without options to StorageControlProtocol

### DIFF
--- a/internal/sidekick/swift/generate_storage_test.go
+++ b/internal/sidekick/swift/generate_storage_test.go
@@ -263,6 +263,19 @@ func TestGenerateStorage_MultiModel(t *testing.T) {
 	if !strings.Contains(protocolStr, "import GoogleIAMV1") {
 		t.Errorf("StorageControlProtocol.swift missing import GoogleIAMV1:\n%s", protocolStr)
 	}
+	if !strings.Contains(protocolStr, "func createBucket(request: CreateBucketRequest) async throws") {
+		t.Errorf("StorageControlProtocol.swift missing convenience overload without options:\n%s", protocolStr)
+	}
+	if !strings.Contains(protocolStr, "byItem: ListBucketsRequest") ||
+		!strings.Contains(protocolStr, "try self.listBuckets(byItem: byItem, options: .init())") {
+		t.Errorf("StorageControlProtocol.swift missing paginated convenience overload without options:\n%s", protocolStr)
+	}
+	if !strings.Contains(protocolStr, "extension StorageControlProtocol {") {
+		t.Errorf("StorageControlProtocol.swift missing StorageControlProtocol extension:\n%s", protocolStr)
+	}
+	if !strings.Contains(protocolStr, "try await self.createBucket(request: request, options: .init())") {
+		t.Errorf("StorageControlProtocol.swift missing default implementation forwarding to options:\n%s", protocolStr)
+	}
 
 	// 2. Verify StorageControlClient.swift in Control/
 	clientPath := filepath.Join(outDir, "Control", "StorageControlClient.swift")

--- a/internal/sidekick/swift/templates/storage/StorageControlProtocol.swift.mustache
+++ b/internal/sidekick/swift/templates/storage/StorageControlProtocol.swift.mustache
@@ -38,8 +38,24 @@ public protocol StorageControlProtocol {
   {{#Deprecated}}
   @available(*, deprecated)
   {{/Deprecated}}
+  func {{> /templates/common/method_signature/request}}
+
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   func {{> /templates/common/method_signature/request_options}}
   {{#Codec.Pagination}}
+
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  func {{> /templates/common/method_signature/pagination}}
 
   {{#Codec.DocLines}}
   /// {{{.}}}
@@ -60,8 +76,24 @@ public protocol StorageControlProtocol {
   {{#Deprecated}}
   @available(*, deprecated)
   {{/Deprecated}}
+  func {{> /templates/common/method_signature/request}}
+
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
   func {{> /templates/common/method_signature/request_options}}
   {{#Codec.Pagination}}
+
+  {{#Codec.DocLines}}
+  /// {{{.}}}
+  {{/Codec.DocLines}}
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  func {{> /templates/common/method_signature/pagination}}
 
   {{#Codec.DocLines}}
   /// {{{.}}}
@@ -74,3 +106,82 @@ public protocol StorageControlProtocol {
   {{/Codec.Methods}}
   {{/Codec.Control.Services}}
 }
+
+// Default implementations
+extension StorageControlProtocol {
+  {{#Codec.Storage.Services}}
+  {{#Codec.Methods}}
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/request}} {
+    try await self.{{Codec.Name}}(request: request, options: .init())
+  }
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/request_options}} {
+    throw GoogleCloudGax.RequestError.unimplemented
+  }
+  {{#Codec.Pagination}}
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/pagination}} {
+    try self.{{Codec.Name}}(byItem: byItem, options: .init())
+  }
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/pagination_options}} {
+    let listRpc = { (token: Swift.String) async throws -> {{Codec.ReturnType}} in
+      throw GoogleCloudGax.RequestError.unimplemented
+    }
+    return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
+  }
+  {{/Codec.Pagination}}
+  {{/Codec.Methods}}
+  {{/Codec.Storage.Services}}
+  {{#Codec.Control.Services}}
+  {{#Codec.Methods}}
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/request}} {
+    try await self.{{Codec.Name}}(request: request, options: .init())
+  }
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/request_options}} {
+    throw GoogleCloudGax.RequestError.unimplemented
+  }
+  {{#Codec.Pagination}}
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/pagination}} {
+    try self.{{Codec.Name}}(byItem: byItem, options: .init())
+  }
+
+  {{#Deprecated}}
+  @available(*, deprecated)
+  {{/Deprecated}}
+  public func {{> /templates/common/method_signature/pagination_options}} {
+    let listRpc = { (token: Swift.String) async throws -> {{Codec.ReturnType}} in
+      throw GoogleCloudGax.RequestError.unimplemented
+    }
+    return GoogleCloudGax.PaginatedResponseSequence(listRpc: listRpc)
+  }
+  {{/Codec.Pagination}}
+  {{/Codec.Methods}}
+  {{/Codec.Control.Services}}
+}
+

--- a/internal/sidekick/swift/templates/storage/StorageControlProtocol.swift.mustache
+++ b/internal/sidekick/swift/templates/storage/StorageControlProtocol.swift.mustache
@@ -107,7 +107,6 @@ public protocol StorageControlProtocol {
   {{/Codec.Control.Services}}
 }
 
-// Default implementations
 extension StorageControlProtocol {
   {{#Codec.Storage.Services}}
   {{#Codec.Methods}}


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-swift/issues/581

generates https://github.com/googleapis/google-cloud-swift/pull/787 