### PR TITLE
feat(internal/config): add comment field to configuration schema

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -18,6 +18,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `comment` | string | Is an optional comment explaining configuration choices. |
 | `conformance` | [Source](#source-configuration) (optional) | Is the path to the `conformance-tests` repository, used as include directory for `protoc`. |
 | `discovery` | [Source](#source-configuration) (optional) | Is the discovery-artifact-manager repository configuration. |
 | `googleapis` | [Source](#source-configuration) (optional) | Is the googleapis repository configuration. |
@@ -37,6 +38,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| `comment` | string | Is an optional comment explaining configuration choices. |
 | `cargo` | list of [CargoTool](#cargotool-configuration) (optional) | Defines tools to install via cargo. |
 | `composer` | list of [ComposerTool](#composertool-configuration) (optional) | Defines tools to install via Composer. |
 | `go` | list of [GoTool](#gotool-configuration) (optional) | Defines tools to install via go. |
@@ -144,6 +146,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `name` | string | Is the library name, such as "secretmanager" or "storage". |
 | `version` | string | Is the library version. |
+| `comment` | string | Is an optional comment explaining configuration choices. |
 | `preview` | [Library](#library-configuration) (optional) | Signifies that this API has a preview variant, and it contains overrides specific to the preview API variant. This is merged with the containing [Library], preferring those [Library.Preview] values that are set over their counterpart in the containing configuration.<br><br>The most common overrides are [Library.Version] and [Library.APIs], with the former containing a pre-release version based on the containing version of the stable client, and the latter being a subset of APIs, typically omitting alpha and beta paths.<br><br>The [Library.Output] may be a different location and derived on a per-language basis, but will not be serialized in the configuration.<br><br>Important: The boolean fields [Library.SkipRelease] and [Library.SkipGenerate] set in the containing config will always be applied to the Preview library as well, because previews are related to the stable library and should be managed identically. |
 | `apis` | list of [API](#api-configuration) (optional) | API specifies which googleapis API to generate from (for generated libraries). |
 | `copyright_year` | string | Is the copyright year for the library. |

--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -18,7 +18,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `comment` | string | Is an optional comment explaining configuration choices. |
+| `comment` | string | Is an optional comment explaining configuration choices. It supports UTF-8 text. Multiline comments are supported, but may be reformatted when tidying. |
 | `conformance` | [Source](#source-configuration) (optional) | Is the path to the `conformance-tests` repository, used as include directory for `protoc`. |
 | `discovery` | [Source](#source-configuration) (optional) | Is the discovery-artifact-manager repository configuration. |
 | `googleapis` | [Source](#source-configuration) (optional) | Is the googleapis repository configuration. |
@@ -38,7 +38,7 @@ This document describes the schema for the librarian.yaml.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `comment` | string | Is an optional comment explaining configuration choices. |
+| `comment` | string | Is an optional comment explaining configuration choices. It supports UTF-8 text. Multiline comments are supported, but may be reformatted when tidying. |
 | `cargo` | list of [CargoTool](#cargotool-configuration) (optional) | Defines tools to install via cargo. |
 | `composer` | list of [ComposerTool](#composertool-configuration) (optional) | Defines tools to install via Composer. |
 | `go` | list of [GoTool](#gotool-configuration) (optional) | Defines tools to install via go. |
@@ -146,7 +146,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `name` | string | Is the library name, such as "secretmanager" or "storage". |
 | `version` | string | Is the library version. |
-| `comment` | string | Is an optional comment explaining configuration choices. |
+| `comment` | string | Is an optional comment explaining configuration choices. It supports UTF-8 text. Multiline comments are supported, but may be reformatted when tidying.<br><br>For example, it can be used in pair with [Library.SkipGenerate] to record a reason or link to a bug:<br><br>skip_generate: true comment: "Generation is skipped due to https://github.com/googleapis/librarian/issues/1234" |
 | `preview` | [Library](#library-configuration) (optional) | Signifies that this API has a preview variant, and it contains overrides specific to the preview API variant. This is merged with the containing [Library], preferring those [Library.Preview] values that are set over their counterpart in the containing configuration.<br><br>The most common overrides are [Library.Version] and [Library.APIs], with the former containing a pre-release version based on the containing version of the stable client, and the latter being a subset of APIs, typically omitting alpha and beta paths.<br><br>The [Library.Output] may be a different location and derived on a per-language basis, but will not be serialized in the configuration.<br><br>Important: The boolean fields [Library.SkipRelease] and [Library.SkipGenerate] set in the containing config will always be applied to the Preview library as well, because previews are related to the stable library and should be managed identically. |
 | `apis` | list of [API](#api-configuration) (optional) | API specifies which googleapis API to generate from (for generated libraries). |
 | `copyright_year` | string | Is the copyright year for the library. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,8 @@ type Config struct {
 // Sources references external source repositories.
 type Sources struct {
 	// Comment is an optional comment explaining configuration choices.
+	// It supports UTF-8 text. Multiline comments are supported, but may
+	// be reformatted when tidying.
 	Comment string `yaml:"comment,omitempty"`
 
 	// Conformance is the path to the `conformance-tests` repository, used as include directory for `protoc`.
@@ -98,6 +100,8 @@ type Source struct {
 // Tools defines required tools.
 type Tools struct {
 	// Comment is an optional comment explaining configuration choices.
+	// It supports UTF-8 text. Multiline comments are supported, but may
+	// be reformatted when tidying.
 	Comment string `yaml:"comment,omitempty"`
 
 	// Cargo defines tools to install via cargo.
@@ -319,6 +323,14 @@ type Library struct {
 	Version string `yaml:"version,omitempty"`
 
 	// Comment is an optional comment explaining configuration choices.
+	// It supports UTF-8 text. Multiline comments are supported, but may
+	// be reformatted when tidying.
+	//
+	// For example, it can be used in pair with [Library.SkipGenerate] to record
+	// a reason or link to a bug:
+	//
+	//	skip_generate: true
+	//	comment: "Generation is skipped due to https://github.com/googleapis/librarian/issues/1234"
 	Comment string `yaml:"comment,omitempty"`
 
 	// Preview signifies that this API has a preview variant, and it contains

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,9 @@ type Config struct {
 
 // Sources references external source repositories.
 type Sources struct {
+	// Comment is an optional comment explaining configuration choices.
+	Comment string `yaml:"comment,omitempty"`
+
 	// Conformance is the path to the `conformance-tests` repository, used as include directory for `protoc`.
 	Conformance *Source `yaml:"conformance,omitempty"`
 
@@ -94,6 +97,9 @@ type Source struct {
 
 // Tools defines required tools.
 type Tools struct {
+	// Comment is an optional comment explaining configuration choices.
+	Comment string `yaml:"comment,omitempty"`
+
 	// Cargo defines tools to install via cargo.
 	Cargo []*CargoTool `yaml:"cargo,omitempty"`
 
@@ -311,6 +317,9 @@ type Library struct {
 
 	// Version is the library version.
 	Version string `yaml:"version,omitempty"`
+
+	// Comment is an optional comment explaining configuration choices.
+	Comment string `yaml:"comment,omitempty"`
 
 	// Preview signifies that this API has a preview variant, and it contains
 	// overrides specific to the preview API variant. This is merged with the

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -215,7 +215,8 @@ func tidyLanguageConfig(lib *config.Library, cfg *config.Config) (*config.Librar
 
 // isToolsEmpty returns true if the tools configuration is empty.
 func isToolsEmpty(tools *config.Tools) bool {
-	return len(tools.Cargo) == 0 &&
+	return tools.Comment == "" &&
+		len(tools.Cargo) == 0 &&
 		len(tools.Composer) == 0 &&
 		len(tools.Go) == 0 &&
 		len(tools.Maven) == 0 &&

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -843,19 +843,6 @@ func TestTidy_UnusedSections(t *testing.T) {
 			},
 			wantDefault: nil,
 		},
-		{
-			name: "tools with comment preserved",
-			cfg: &config.Config{
-				Language: config.LanguageRust,
-				Sources: &config.Sources{
-					Googleapis: &config.Source{Commit: "commit"},
-				},
-				Tools:   &config.Tools{Comment: "custom tools comment"},
-				Default: &config.Default{},
-			},
-			wantTools:   &config.Tools{Comment: "custom tools comment"},
-			wantDefault: nil,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -960,7 +947,7 @@ func TestTidy_PreservesComments(t *testing.T) {
 			{
 				Name:    "google-cloud-storage",
 				Version: "1.0.0",
-				Comment: "special casing storage because of size",
+				Comment: "special comment about storage config",
 				APIs: []*config.API{
 					{
 						Path: "google/cloud/storage/v1",

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -843,6 +843,19 @@ func TestTidy_UnusedSections(t *testing.T) {
 			},
 			wantDefault: nil,
 		},
+		{
+			name: "tools with comment preserved",
+			cfg: &config.Config{
+				Language: config.LanguageRust,
+				Sources: &config.Sources{
+					Googleapis: &config.Source{Commit: "commit"},
+				},
+				Tools:   &config.Tools{Comment: "custom tools comment"},
+				Default: &config.Default{},
+			},
+			wantTools:   &config.Tools{Comment: "custom tools comment"},
+			wantDefault: nil,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -917,5 +930,53 @@ func TestTidy_SkipGenerate(t *testing.T) {
 	}
 	if !cfg.Libraries[0].SkipGenerate {
 		t.Errorf("expected skip_generate to be true for mixed library, got false")
+	}
+}
+
+func TestTidy_PreservesComments(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		Language: config.LanguageRust,
+		Sources: &config.Sources{
+			Comment: "sources comment",
+			Googleapis: &config.Source{
+				Commit: "94ccedca05acb0bb60780789e93371c9e4100ddc",
+				SHA256: "fff40946e897d96bbdccd566cb993048a87029b7e08eacee3fe99eac792721ba",
+			},
+		},
+		Tools: &config.Tools{
+			Comment: "tools comment",
+			Cargo: []*config.CargoTool{
+				{
+					Name:    "taplo",
+					Version: "1.0",
+				},
+			},
+		},
+		Default: &config.Default{
+			Output: "src/generated",
+		},
+		Libraries: []*config.Library{
+			{
+				Name:    "google-cloud-storage",
+				Version: "1.0.0",
+				Comment: "special casing storage because of size",
+				APIs: []*config.API{
+					{
+						Path: "google/cloud/storage/v1",
+					},
+				},
+			},
+		},
+	}
+	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(cfg, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/librarian/tidy_test.go
+++ b/internal/librarian/tidy_test.go
@@ -921,49 +921,100 @@ func TestTidy_SkipGenerate(t *testing.T) {
 }
 
 func TestTidy_PreservesComments(t *testing.T) {
-	tempDir := t.TempDir()
-	cfg := &config.Config{
-		Language: config.LanguageRust,
-		Sources: &config.Sources{
-			Comment: "sources comment",
-			Googleapis: &config.Source{
-				Commit: "94ccedca05acb0bb60780789e93371c9e4100ddc",
-				SHA256: "fff40946e897d96bbdccd566cb993048a87029b7e08eacee3fe99eac792721ba",
-			},
-		},
-		Tools: &config.Tools{
-			Comment: "tools comment",
-			Cargo: []*config.CargoTool{
-				{
-					Name:    "taplo",
-					Version: "1.0",
+	for _, test := range []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{
+			name: "single-line comments",
+			cfg: &config.Config{
+				Language: config.LanguageRust,
+				Sources: &config.Sources{
+					Comment: "sources comment",
+					Googleapis: &config.Source{
+						Commit: "94ccedca05acb0bb60780789e93371c9e4100ddc",
+						SHA256: "fff40946e897d96bbdccd566cb993048a87029b7e08eacee3fe99eac792721ba",
+					},
 				},
-			},
-		},
-		Default: &config.Default{
-			Output: "src/generated",
-		},
-		Libraries: []*config.Library{
-			{
-				Name:    "google-cloud-storage",
-				Version: "1.0.0",
-				Comment: "special comment about storage config",
-				APIs: []*config.API{
+				Tools: &config.Tools{
+					Comment: "tools comment",
+					Cargo: []*config.CargoTool{
+						{
+							Name:    "taplo",
+							Version: "1.0",
+						},
+					},
+				},
+				Default: &config.Default{
+					Output: "src/generated",
+				},
+				Libraries: []*config.Library{
 					{
-						Path: "google/cloud/storage/v1",
+						Name:    "google-cloud-storage",
+						Version: "1.0.0",
+						Comment: "special comment about storage config",
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/storage/v1",
+							},
+						},
 					},
 				},
 			},
 		},
-	}
-	if err := RunTidyOnConfig(t.Context(), tempDir, cfg); err != nil {
-		t.Fatal(err)
-	}
-	got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(cfg, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+		{
+			name: "multiline long comments",
+			cfg: &config.Config{
+				Language: config.LanguageRust,
+				Sources: &config.Sources{
+					Comment: "Line 1: sources comment explaining repository choices in detail.\nLine 2: additional context on why this specific commit is pinned and how updates are managed.\n",
+					Googleapis: &config.Source{
+						Commit: "94ccedca05acb0bb60780789e93371c9e4100ddc",
+						SHA256: "fff40946e897d96bbdccd566cb993048a87029b7e08eacee3fe99eac792721ba",
+					},
+				},
+				Tools: &config.Tools{
+					Comment: `Line 1: tools comment explaining required toolchain versions and rationale.
+Line 2: more details regarding tool versions and installation procedures.`,
+					Cargo: []*config.CargoTool{
+						{
+							Name:    "taplo",
+							Version: "1.0",
+						},
+					},
+				},
+				Default: &config.Default{
+					Output: "src/generated",
+				},
+				Libraries: []*config.Library{
+					{
+						Name:    "google-cloud-storage",
+						Version: "1.0.0",
+						Comment: `Line 1: this library requires a long multiline comment to describe its complex configuration requirements in full detail.
+Line 2: additional instructions and context for this client library across multiple lines of documentation.
+Line 3: third line with UTF-8 characters: café, résumé, åäö, 中文.`,
+						APIs: []*config.API{
+							{
+								Path: "google/cloud/storage/v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			if err := RunTidyOnConfig(t.Context(), tempDir, test.cfg); err != nil {
+				t.Fatal(err)
+			}
+			got, err := yaml.Read[config.Config](filepath.Join(tempDir, config.LibrarianYAML))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.cfg, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add an optional comment field to the Library, Sources, and Tools configurationstructs in internal/config. This allows repository maintainers to document configuration decisions and comments directly in librarian.yaml without comments being stripped during tidy and formatting operations.


Fix https://github.com/googleapis/librarian/issues/6922