### PR TITLE
refactor(internal/yaml): add ClearIfEmpty helper and migrate tidy

### DIFF
--- a/internal/librarian/java/default.go
+++ b/internal/librarian/java/default.go
@@ -125,12 +125,9 @@ func Tidy(library *config.Library) (*config.Library, error) {
 			library.Java.GroupID = ""
 		}
 		tidyReleasedVersion(library)
-		empty, err := yaml.Empty(library.Java)
-		if err != nil {
+		var err error
+		if library.Java, err = yaml.ClearIfEmpty(library.Java); err != nil {
 			return nil, err
-		}
-		if empty {
-			library.Java = nil
 		}
 	}
 	for _, api := range library.APIs {
@@ -155,12 +152,9 @@ func Tidy(library *config.Library) (*config.Library, error) {
 		api.Java.AdditionalProtos = slices.DeleteFunc(api.Java.AdditionalProtos, func(p *config.AdditionalProto) bool {
 			return p == nil || p.Path == ""
 		})
-		empty, err := yaml.Empty(api.Java)
-		if err != nil {
+		var err error
+		if api.Java, err = yaml.ClearIfEmpty(api.Java); err != nil {
 			return nil, err
-		}
-		if empty {
-			api.Java = nil
 		}
 	}
 	return library, nil

--- a/internal/librarian/nodejs/tidy.go
+++ b/internal/librarian/nodejs/tidy.go
@@ -21,15 +21,9 @@ import (
 
 // Tidy tidies configuration for a library.
 func Tidy(lib *config.Library) (*config.Library, error) {
-	if lib.Nodejs == nil {
-		return lib, nil
-	}
-	empty, err := yaml.Empty(lib.Nodejs)
-	if err != nil {
+	var err error
+	if lib.Nodejs, err = yaml.ClearIfEmpty(lib.Nodejs); err != nil {
 		return nil, err
-	}
-	if empty {
-		lib.Nodejs = nil
 	}
 	return lib, nil
 }

--- a/internal/librarian/php/tidy.go
+++ b/internal/librarian/php/tidy.go
@@ -33,12 +33,9 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			slices.Sort(api.PHP.AdditionalProtos)
 			api.PHP.AdditionalProtos = slices.Compact(api.PHP.AdditionalProtos)
 		}
-		empty, err := yaml.Empty(api.PHP)
-		if err != nil {
+		var err error
+		if api.PHP, err = yaml.ClearIfEmpty(api.PHP); err != nil {
 			return nil, err
-		}
-		if empty {
-			api.PHP = nil
 		}
 	}
 	return lib, nil

--- a/internal/librarian/ruby/tidy.go
+++ b/internal/librarian/ruby/tidy.go
@@ -28,7 +28,8 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 			return nil, err
 		}
 	}
-	if err := clearIfEmpty(&lib.Ruby); err != nil {
+	var err error
+	if lib.Ruby, err = yaml.ClearIfEmpty(lib.Ruby); err != nil {
 		return nil, err
 	}
 	return lib, nil
@@ -39,10 +40,11 @@ func tidyAPI(api *config.API) error {
 		return nil
 	}
 	api.Ruby.AdditionalProtos = tidyAdditionalProtos(api.Ruby.AdditionalProtos)
-	if err := clearIfEmpty(&api.Ruby.RubyCloudOpts); err != nil {
+	var err error
+	if api.Ruby.RubyCloudOpts, err = yaml.ClearIfEmpty(api.Ruby.RubyCloudOpts); err != nil {
 		return err
 	}
-	if err := clearIfEmpty(&api.Ruby); err != nil {
+	if api.Ruby, err = yaml.ClearIfEmpty(api.Ruby); err != nil {
 		return err
 	}
 	return nil
@@ -54,21 +56,4 @@ func tidyAdditionalProtos(protos []string) []string {
 	}
 	slices.Sort(protos)
 	return slices.Compact(protos)
-}
-
-// clearIfEmpty sets the value pointed to by v to its zero value if it serializes
-// to an empty YAML document. This is useful for removing empty optional fields
-// from the configuration.
-func clearIfEmpty[T any](v *T) error {
-	if v == nil {
-		return nil
-	}
-	empty, err := yaml.Empty(*v)
-	if err != nil {
-		return err
-	}
-	if empty {
-		*v = *new(T)
-	}
-	return nil
 }

--- a/internal/librarian/rust/tidy.go
+++ b/internal/librarian/rust/tidy.go
@@ -27,12 +27,9 @@ func Tidy(lib *config.Library) (*config.Library, error) {
 		lib.Rust.Modules = slices.DeleteFunc(lib.Rust.Modules, isEmptyModule)
 	}
 
-	empty, err := yaml.Empty(lib.Rust)
-	if err != nil {
+	var err error
+	if lib.Rust, err = yaml.ClearIfEmpty(lib.Rust); err != nil {
 		return nil, err
-	}
-	if empty {
-		lib.Rust = nil
 	}
 
 	return lib, nil

--- a/internal/librarian/tidy.go
+++ b/internal/librarian/tidy.go
@@ -78,7 +78,9 @@ func RunTidyOnConfig(ctx context.Context, repoDir string, cfg *config.Config) er
 	if cfg.Libraries, err = tidyLibraries(cfg); err != nil {
 		return err
 	}
-	cfg = tidyConfig(cfg)
+	if cfg, err = tidyConfig(cfg); err != nil {
+		return err
+	}
 	return yaml.Write(filepath.Join(repoDir, config.LibrarianYAML), formatConfig(cfg))
 }
 
@@ -213,44 +215,16 @@ func tidyLanguageConfig(lib *config.Library, cfg *config.Config) (*config.Librar
 	return lib, nil
 }
 
-// isToolsEmpty returns true if the tools configuration is empty.
-func isToolsEmpty(tools *config.Tools) bool {
-	return len(tools.Cargo) == 0 &&
-		len(tools.Composer) == 0 &&
-		len(tools.Go) == 0 &&
-		len(tools.Maven) == 0 &&
-		len(tools.Pip) == 0 &&
-		len(tools.PNPM) == 0 &&
-		len(tools.Gem) == 0 &&
-		tools.Protoc == nil
-}
-
-// isDefaultEmpty returns true if the default configuration is empty.
-// Note that this will not remove {default: language: {}} because we have
-// not yet encountered this edge case.
-func isDefaultEmpty(defaults *config.Default) bool {
-	return len(defaults.Keep) == 0 &&
-		defaults.Output == "" &&
-		defaults.TagFormat == "" &&
-		defaults.Dotnet == nil &&
-		defaults.Dart == nil &&
-		defaults.Java == nil &&
-		defaults.Nodejs == nil &&
-		defaults.Rust == nil &&
-		defaults.Python == nil &&
-		defaults.Swift == nil &&
-		defaults.PHP == nil
-}
-
 // tidyConfig removes unused sections from the configuration.
-func tidyConfig(cfg *config.Config) *config.Config {
-	if cfg.Tools != nil && isToolsEmpty(cfg.Tools) {
-		cfg.Tools = nil
+func tidyConfig(cfg *config.Config) (*config.Config, error) {
+	var err error
+	if cfg.Tools, err = yaml.ClearIfEmpty(cfg.Tools); err != nil {
+		return nil, err
 	}
-	if cfg.Default != nil && isDefaultEmpty(cfg.Default) {
-		cfg.Default = nil
+	if cfg.Default, err = yaml.ClearIfEmpty(cfg.Default); err != nil {
+		return nil, err
 	}
-	return cfg
+	return cfg, nil
 }
 
 func formatConfig(cfg *config.Config) *config.Config {

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -108,6 +108,22 @@ func Empty(v any) (bool, error) {
 	return string(data) == "{}\n", nil
 }
 
+// ClearIfEmpty returns nil if v is nil or serializes to an empty YAML object.
+// Otherwise it returns v.
+func ClearIfEmpty[T any](v *T) (*T, error) {
+	if v == nil {
+		return nil, nil
+	}
+	empty, err := Empty(v)
+	if err != nil {
+		return nil, err
+	}
+	if empty {
+		return nil, nil
+	}
+	return v, nil
+}
+
 // format runs yamlfmt on the given YAML content and returns the formatted output.
 func format(data []byte) ([]byte, error) {
 	factory := &basic.BasicFormatterFactory{}

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -98,9 +98,9 @@ func Write(path string, v any) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
-// Empty returns whether the given value serializes to an empty YAML object
+// empty returns whether the given value serializes to an empty YAML object
 // (i.e. "{}" with a line break).
-func Empty(v any) (bool, error) {
+func empty(v any) (bool, error) {
 	data, err := Marshal(v)
 	if err != nil {
 		return false, err
@@ -114,7 +114,7 @@ func ClearIfEmpty[T any](v *T) (*T, error) {
 	if v == nil {
 		return nil, nil
 	}
-	empty, err := Empty(v)
+	empty, err := empty(v)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -173,3 +173,37 @@ func TestEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestClearIfEmpty(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value *testConfig
+		want  *testConfig
+	}{
+		{
+			name:  "nil",
+			value: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty",
+			value: &testConfig{},
+			want:  nil,
+		},
+		{
+			name:  "not empty",
+			value: &testConfig{Name: "librarian"},
+			want:  &testConfig{Name: "librarian"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ClearIfEmpty(test.value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -163,7 +163,7 @@ func TestEmpty(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Empty(test.value)
+			got, err := empty(test.value)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Add a generic ClearIfEmpty helper function to the internal/yaml package that returns nil if a struct pointer is nil or serializes to an empty YAML object, or returns the pointer unchanged otherwise.

Migrate tidy routines across librarian and the language packages (Java, Node.js, PHP, Ruby, and Rust) to use `yaml.ClearIfEmpty`. This removes the manual struct-field checks in `isToolsEmpty` and `isDefaultEmpty`, removes Ruby's local `clearIfEmpty` helper, and eliminates repetitive empty-check boilerplate.

Fixes https://github.com/googleapis/librarian/issues/7540