### PR TITLE
fix(internal/librarian/ruby): omit copyright_year from librarian.yaml

### DIFF
--- a/internal/librarian/add_test.go
+++ b/internal/librarian/add_test.go
@@ -980,7 +980,7 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			wantFinalLibraries: []*config.Library{
 				{
 					Name:          "google-cloud-secret_manager-v1",
-					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					CopyrightYear: "",
 					Version:       "0.0.1",
 					APIs: []*config.API{
 						{Path: "google/cloud/secretmanager/v1"},
@@ -1024,7 +1024,7 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			wantFinalLibraries: []*config.Library{
 				{
 					Name:          "google-cloud-secret_manager",
-					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					CopyrightYear: "",
 					Version:       "0.0.1",
 					APIs: []*config.API{
 						{Path: "google/cloud/secretmanager/v1"},
@@ -1065,7 +1065,7 @@ func TestAddLibraryCommand_Ruby(t *testing.T) {
 			wantFinalLibraries: []*config.Library{
 				{
 					Name:          "google-cloud-secretmanager-v1",
-					CopyrightYear: strconv.Itoa(time.Now().Year()),
+					CopyrightYear: "",
 					Version:       "0.0.1",
 					APIs: []*config.API{
 						{Path: "google/cloud/secretmanager/v1"},

--- a/internal/librarian/ruby/add.go
+++ b/internal/librarian/ruby/add.go
@@ -34,6 +34,9 @@ var (
 // Add initializes a new Ruby library configuration.
 func Add(cfg *config.Config, lib *config.Library) (*config.Library, error) {
 	lib.Version = defaultVersion
+	// Ruby generation does not require copyright_year in librarian.yaml,
+	// so we reset it here to avoid redundancy in librarian.yaml.
+	lib.CopyrightYear = ""
 	newLib, err := addWrapper(cfg, lib)
 	if err != nil {
 		return nil, err
@@ -55,7 +58,7 @@ func addWrapper(cfg *config.Config, lib *config.Library) (*config.Library, error
 	if err != nil {
 		return nil, err
 	}
-	configureWrapper(lib, versionedAPI)
+	lib = configureWrapper(lib, versionedAPI)
 	return lib, nil
 }
 
@@ -73,9 +76,11 @@ func searchVersionedAPI(cfg *config.Config, apiPath string) (string, error) {
 }
 
 // configureWrapper configures the library to be a main client.
-func configureWrapper(lib *config.Library, versionedAPI string) {
+func configureWrapper(lib *config.Library, versionedAPI string) *config.Library {
 	lib.APIs = []*config.API{{Path: versionedAPI}}
-	lib.Ruby = &config.RubyPackage{
-		WrapperOf: []string{fmt.Sprintf("%s:0.0", filepath.Base(versionedAPI))},
+	if lib.Ruby == nil {
+		lib.Ruby = &config.RubyPackage{}
 	}
+	lib.Ruby.WrapperOf = []string{fmt.Sprintf("%s:0.0", filepath.Base(versionedAPI))}
+	return lib
 }

--- a/internal/librarian/ruby/add_test.go
+++ b/internal/librarian/ruby/add_test.go
@@ -31,14 +31,16 @@ func TestAdd(t *testing.T) {
 		{
 			name: "default library name",
 			in: &config.Library{
-				Name: "google-cloud-secretmanager-v1",
+				Name:          "google-cloud-secretmanager-v1",
+				CopyrightYear: "2026",
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},
 			},
 			want: &config.Library{
-				Name:    "google-cloud-secretmanager-v1",
-				Version: "0.0.1",
+				Name:          "google-cloud-secretmanager-v1",
+				CopyrightYear: "",
+				Version:       "0.0.1",
 				APIs: []*config.API{
 					{Path: "google/cloud/secretmanager/v1"},
 				},


### PR DESCRIPTION
Ruby client generation does not require `copyright_year` declarations in `librarian.yaml`. This PR clears `CopyrightYear` for Ruby libraries (similar to Java in `internal/librarian/java/add.go`) to omit redundant `copyright_year` declarations.

I used this enhancement in https://github.com/googleapis/google-cloud-ruby/pull/36544.

For https://github.com/googleapis/librarian/issues/6635.