### PR TITLE
test(internal/librarian/php): relax TestInstall permission assertion for umask compatibility

### DIFF
--- a/internal/librarian/php/install_test.go
+++ b/internal/librarian/php/install_test.go
@@ -132,8 +132,8 @@ func TestInstall(t *testing.T) {
 				info, err := os.Stat(postProcessorPath)
 				if err != nil {
 					t.Error(err)
-				} else if info.Mode().Perm() != 0o755 {
-					t.Errorf("php-post-processor wrapper file has permissions %v, want 0755", info.Mode().Perm())
+				} else if perm := info.Mode().Perm(); perm&0o700 != 0o700 {
+					t.Errorf("php-post-processor wrapper permissions = %04o, want at least 0700", perm)
 				}
 			},
 		},


### PR DESCRIPTION
In internal/librarian/php/install_test.go, TestInstall asserted exact 0755 permissions for the php-post-processor wrapper. On systems with a restrictive umask (such as 0027), files created with mode 0755 receive 0750 permissions, causing test failures locally.

Update the test assertion to verify owner read/write/execute permissions (0700) rather than requiring exact 0755 permissions.

Fixes https://github.com/googleapis/librarian/issues/7543