### PR TITLE
test(internal/librarian/dart): require jq command for semver tests

### DIFF
--- a/internal/librarian/dart/publish_test.go
+++ b/internal/librarian/dart/publish_test.go
@@ -209,6 +209,7 @@ func TestPublishErrorGreaterPublishedVersion(t *testing.T) {
 
 func TestPublishSemverFailure(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
+	testhelper.RequireCommand(t, "jq")
 
 	publishedVersions := map[string]string{
 		"a": "0.9.0",
@@ -252,6 +253,7 @@ func TestPublishSemverFailure(t *testing.T) {
 
 func TestPublishSemverSkipByFlag(t *testing.T) {
 	testhelper.RequireCommand(t, "git")
+	testhelper.RequireCommand(t, "jq")
 
 	publishedVersions := map[string]string{
 		"a": "0.9.0",


### PR DESCRIPTION
Require the jq command in TestPublishSemverFailure and TestPublishSemverSkipByFlag so they skip gracefully when jq is not installed on the host system. The mock dart-apitool script executed in these tests invokes jq to parse mock error messages, without jq installed, the script fails to parse the error and exits with code 0, causing the test assertions to fail unexpectedly.

Run into this test failure on my local that do not have jq.