### PR TITLE
fix(rust): avoid use conflicts in setter samples

### DIFF
--- a/internal/sidekick/rust/annotate_field.go
+++ b/internal/sidekick/rust/annotate_field.go
@@ -268,7 +268,10 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 
 		if targetType != nil {
 			fieldFqName, err := c.fullyQualifiedMessageName(targetType, model.PackageName)
-			if err == nil && unqualifiedRustName(fieldFqName) == parentRustName {
+			if err != nil {
+				return nil, err
+			}
+			if unqualifiedRustName(fieldFqName) == parentRustName {
 				isNameConflict = true
 			}
 		}

--- a/internal/sidekick/rust/annotate_field.go
+++ b/internal/sidekick/rust/annotate_field.go
@@ -256,15 +256,29 @@ func (c *codec) annotateField(field *api.Field, message *api.Message, model *api
 	ann.FieldTypeIsParentType = (field.MessageType == message || // Single or repeated field whose type is the same as the containing type.
 		// Map field whose value type is the same as the containing type.
 		(ann.ValueField != nil && ann.ValueField.MessageType == message))
-	if !ann.FieldTypeIsParentType && // When the type of the field is the same as the containing type we don't import twice. No alias needed.
-		// Single or repeated field whose type's unqualified name is the same as the containing message's.
-		((field.MessageType != nil && field.MessageType.Name == message.Name) ||
-			// Map field whose type's unqualified name is the same as the containing message's.
-			(ann.ValueField != nil && ann.ValueField.MessageType != nil && ann.ValueField.MessageType.Name == message.Name)) {
-		ann.AliasInExamples = toPascal(field.Name)
-		if ann.AliasInExamples == toPascal(message.Name) {
-			// The field name was the same as the type name so we still have to disambiguate.
-			ann.AliasInExamples = fmt.Sprintf("%sField", ann.AliasInExamples)
+	if !ann.FieldTypeIsParentType {
+		parentRustName := unqualifiedRustName(fqMessageName)
+		var isNameConflict bool
+		var targetType *api.Message
+		if ann.ValueField != nil && ann.ValueField.MessageType != nil {
+			targetType = ann.ValueField.MessageType
+		} else {
+			targetType = field.MessageType
+		}
+
+		if targetType != nil {
+			fieldFqName, err := c.fullyQualifiedMessageName(targetType, model.PackageName)
+			if err == nil && unqualifiedRustName(fieldFqName) == parentRustName {
+				isNameConflict = true
+			}
+		}
+
+		if isNameConflict {
+			ann.AliasInExamples = toPascal(field.Name)
+			if ann.AliasInExamples == parentRustName {
+				// The field name was the same as the type name so we still have to disambiguate.
+				ann.AliasInExamples = fmt.Sprintf("%sField", ann.AliasInExamples)
+			}
 		}
 	}
 
@@ -327,4 +341,9 @@ func mapToBoxed(field *api.Field, message *api.Message, model *api.API) bool {
 
 	visited := make(map[string]bool)
 	return check(field.TypezID, message.ID, visited)
+}
+
+func unqualifiedRustName(qualifiedName string) string {
+	parts := strings.Split(qualifiedName, "::")
+	return parts[len(parts)-1]
 }

--- a/internal/sidekick/rust/annotate_field_test.go
+++ b/internal/sidekick/rust/annotate_field_test.go
@@ -1139,3 +1139,53 @@ func TestJsonNameAnnotations(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestFieldNameConflictWithNestedMessage(t *testing.T) {
+	// Top-level message: google.cloud.compute.v1.CapacityHistoryRequest
+	topLevelMsg := &api.Message{
+		Name:    "CapacityHistoryRequest",
+		Package: "test.v1",
+		ID:      ".test.v1.CapacityHistoryRequest",
+	}
+
+	// Message: google.cloud.compute.v1.Advice
+	adviceMsg := &api.Message{
+		Name:    "Advice",
+		Package: "test.v1",
+		ID:      ".test.v1.Advice",
+	}
+
+	// Nested message: google.cloud.compute.v1.Advice.CapacityHistoryRequest
+	nestedMsg := &api.Message{
+		Name:    "CapacityHistoryRequest",
+		Package: "test.v1",
+		ID:      ".test.v1.Advice.CapacityHistoryRequest",
+		Parent:  adviceMsg,
+	}
+
+	// The "body" field of nestedMsg whose type is topLevelMsg
+	bodyField := &api.Field{
+		Name:     "body",
+		JSONName: "body",
+		ID:       ".test.v1.Advice.CapacityHistoryRequest.body",
+		Typez:    api.TypezMessage,
+		TypezID:  ".test.v1.CapacityHistoryRequest",
+	}
+	nestedMsg.Fields = []*api.Field{bodyField}
+
+	model := api.NewTestAPI([]*api.Message{topLevelMsg, adviceMsg, nestedMsg}, []*api.Enum{}, []*api.Service{})
+	api.CrossReference(model)
+	codec := newTestCodec(t, libconfig.SpecProtobuf, "test", map[string]string{
+		"generate-setter-samples": "true",
+	})
+	annotateModel(model, codec)
+
+	gotFA, ok := bodyField.Codec.(*fieldAnnotations)
+	if !ok {
+		t.Fatalf("bodyField.Codec is not *fieldAnnotations")
+	}
+
+	if gotFA.AliasInExamples == "" {
+		t.Errorf("AliasInExamples is empty; it should be set to disambiguate from containing message of same unqualified name")
+	}
+}

--- a/internal/sidekick/rust/annotate_field_test.go
+++ b/internal/sidekick/rust/annotate_field_test.go
@@ -1185,7 +1185,8 @@ func TestFieldNameConflictWithNestedMessage(t *testing.T) {
 		t.Fatalf("bodyField.Codec is not *fieldAnnotations")
 	}
 
-	if gotFA.AliasInExamples == "" {
-		t.Errorf("AliasInExamples is empty; it should be set to disambiguate from containing message of same unqualified name")
+	wantAlias := "Body"
+	if gotFA.AliasInExamples != wantAlias {
+		t.Errorf("mismatch in AliasInExamples, want %s, got %s", wantAlias, gotFA.AliasInExamples)
 	}
 }


### PR DESCRIPTION
Deal with nested messages that have the same name as parent messages in setter samples. Luckily there is already a hook to define aliases in the samples.

Unblocks https://github.com/googleapis/google-cloud-rust/issues/6758

The effect of this PR can be seen in: https://github.com/googleapis/google-cloud-rust/pull/6771/changes/2886e7ed2fc1fe3761d4d0283d6818dca1bcea0b