### PR TITLE
refactor(internal/config): remove skip_grpc_service_config from PHPAPI

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -464,7 +464,6 @@ This document describes the schema for the librarian.yaml.
 | `generate_gapic` | bool (optional) | Indicates whether to generate the GAPIC client surface. Defaults to true. |
 | `proto_package` | string | Overrides the derived proto package for the API. |
 | `samples` | bool (optional) | Determines whether to generate samples for the API. Default to true when omitted. |
-| `skip_grpc_service_config` | bool | Indicates whether to skip the generation of gRPC service config. Default to false. TODO(https://github.com/googleapis/librarian/issues/7436): Remove this config once Bigtable uses GRPC service config. |
 | `staging_subdir` | string | Is the subdirectory in staging where the generated files should be placed. |
 
 ## PHPDefault Configuration

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -906,12 +906,6 @@ type PHPAPI struct {
 	// Default to true when omitted.
 	Samples *bool `yaml:"samples,omitempty"`
 
-	// SkipGRPCServiceConfig indicates whether to skip the generation of gRPC service config.
-	// Default to false.
-	// TODO(https://github.com/googleapis/librarian/issues/7436): Remove this config once
-	// Bigtable uses GRPC service config.
-	SkipGRPCServiceConfig bool `yaml:"skip_grpc_service_config,omitempty"`
-
 	// StagingSubdir is the subdirectory in staging where the generated files should be placed.
 	StagingSubdir string `yaml:"staging_subdir,omitempty"`
 }

--- a/internal/librarian/php/generate.go
+++ b/internal/librarian/php/generate.go
@@ -214,9 +214,6 @@ func shouldGenerateGAPIC(api *config.API) bool {
 }
 
 func grpcServiceConfigPath(api *config.API, googleapisDir string) (string, error) {
-	if api.PHP.SkipGRPCServiceConfig {
-		return "", nil
-	}
 	grpcServiceConfigPath, err := serviceconfig.FindGRPCServiceConfig(googleapisDir, api.Path)
 	if err != nil {
 		return "", err

--- a/internal/librarian/php/generate_test.go
+++ b/internal/librarian/php/generate_test.go
@@ -816,15 +816,6 @@ func TestGRPCServiceConfigPath(t *testing.T) {
 				PHP:  &config.PHPAPI{},
 			},
 		},
-		{
-			name: "skip grpc service config",
-			api: &config.API{
-				Path: "google/cloud/secretmanager/v1",
-				PHP: &config.PHPAPI{
-					SkipGRPCServiceConfig: true,
-				},
-			},
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := grpcServiceConfigPath(test.api, absGoogleapis)


### PR DESCRIPTION
The `skip_grpc_service_config` option is removed from PHPAPI and the configuration schema. Bigtable now supports gRPC service configuration, so this temporary workaround is no longer needed.

This config is removed in google-cloud-php via https://github.com/googleapis/google-cloud-php/pull/9625.

Code generation in internal/librarian/php now unconditionally searches for gRPC service config files, and the corresponding unit tests in generate_test.go have been updated.

Fixes https://github.com/googleapis/librarian/issues/7436