### PR TITLE
build(.github/workflows): separate go integration test into standalone job

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -54,7 +54,7 @@ jobs:
         run: librarian generate secretmanager
   integration-test:
     name: Integration test
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -19,36 +19,30 @@ jobs:
   build-and-test:
     name: ${{ matrix.job-name }}
     runs-on: ubuntu-24.04
-    # Presubmit jobs must complete within 5 minutes. Integration might take longer.
-    timeout-minutes: ${{ matrix.timeout }}
-    # Skip integration test unless it's a push to main
+    # Presubmit jobs must complete within 5 minutes.
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
         include:
           - job-name: 'Unit Tests'
             task: 'unit-test'
-            timeout: 5
           - job-name: 'Smoke Test'
             task: 'smoke-test'
-            timeout: 5
-          - job-name: 'Integration Test'
-            task: 'integration'
-            timeout: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
       - name: Checkout google-cloud-go
-        if: matrix.task != 'unit-test'
+        if: matrix.task == 'smoke-test'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: googleapis/google-cloud-go
           path: google-cloud-go
           persist-credentials: false
       - name: Run librarian install
-        if: matrix.task != 'unit-test'
+        if: matrix.task == 'smoke-test'
         working-directory: google-cloud-go
         run: librarian install
       - name: Run Unit Tests
@@ -58,8 +52,26 @@ jobs:
         if: matrix.task == 'smoke-test'
         working-directory: google-cloud-go
         run: librarian generate secretmanager
-      - name: Run librarian generate all (integration test)
-        if: matrix.task == 'integration' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+  integration-test:
+    name: Integration test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-librarian
+      - name: Checkout google-cloud-go
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: googleapis/google-cloud-go
+          path: google-cloud-go
+          persist-credentials: false
+      - name: Run librarian install
+        working-directory: google-cloud-go
+        run: librarian install
+      - name: Generate all libraries
         working-directory: google-cloud-go
         run: librarian generate --all
   create-issue-on-failure:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -54,7 +54,7 @@ jobs:
         run: librarian generate secretmanager
   integration-test:
     name: Integration test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Move the Go integration test out of the build-and-test presubmit matrix into a dedicated integration-test job that only runs on pushes to main.

Previously, including the integration test in the presubmit matrix resulted in an extra matrix job scheduled during presubmit runs on pull requests that did not execute generation. Removing it from the matrix simplifies the presubmit timeout to five minutes.

For #7484
