### PR TITLE
ci(.github): add shared build-monitor action and workflow

### DIFF
--- a/.github/actions/build-monitor/action.yaml
+++ b/.github/actions/build-monitor/action.yaml
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: 'Build Monitor'
+description: 'Monitors Google Cloud Build check suites and GitHub Actions workflow runs, creating or updating issues on failure'
+inputs:
+  target_branch:
+    description: "The target branch to monitor for failures (default: main)."
+    required: false
+    default: "main"
+  team_mention:
+    description: "A team or user to mention in a follow-up comment when a new issue is created."
+    required: false
+    default: ""
+  issue_title:
+    description: "The title of the issue to create or search for."
+    required: false
+    default: ""
+  labels:
+    description: "Comma-separated list of labels to apply to the issue."
+    required: false
+    default: ":rotating_light: critical"
+  assignee:
+    description: "The GitHub username to assign the issue to. Defaults to commit author or actor."
+    required: false
+    default: ""
+  check_suite_app_name:
+    description: "The GitHub App name to filter on for check_suite events (default: Google Cloud Build)."
+    required: false
+    default: "Google Cloud Build"
+  workflow_run_event:
+    description: "The trigger event to filter on for workflow_run events (default: push)."
+    required: false
+    default: "push"
+  repo:
+    description: "The target repository in owner/repo format."
+    required: false
+    default: ${{ github.repository }}
+runs:
+  using: "composite"
+  steps:
+    - name: Monitor build and report failure
+      shell: bash
+      run: bash "${{ github.action_path }}/build-monitor.sh"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ inputs.repo }}
+        TARGET_BRANCH: ${{ inputs.target_branch }}
+        TEAM_MENTION: ${{ inputs.team_mention }}
+        INPUT_ISSUE_TITLE: ${{ inputs.issue_title }}
+        ISSUE_LABELS: ${{ inputs.labels }}
+        INPUT_ASSIGNEE: ${{ inputs.assignee }}
+        CHECK_SUITE_APP_NAME: ${{ inputs.check_suite_app_name }}
+        WORKFLOW_RUN_EVENT: ${{ inputs.workflow_run_event }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_ACTION: ${{ github.event.action }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_SHA: ${{ github.sha }}
+        CHECK_SUITE_ID: ${{ github.event.check_suite.id }}
+        CHECK_SUITE_HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
+        CHECK_SUITE_HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+        CHECK_SUITE_APP_NAME_ACTUAL: ${{ github.event.check_suite.app.name }}
+        CHECK_SUITE_APP_SLUG: ${{ github.event.check_suite.app.slug }}
+        CHECK_SUITE_CONCLUSION: ${{ github.event.check_suite.conclusion }}
+        CHECK_SUITE_URL: ${{ github.event.check_suite.url }}
+        CHECK_SUITE_PULL_REQUESTS: ${{ toJson(github.event.check_suite.pull_requests) }}
+        WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+        WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        WORKFLOW_RUN_EVENT_ACTUAL: ${{ github.event.workflow_run.event }}
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        WORKFLOW_RUN_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        WORKFLOW_RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}
+        WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}

--- a/.github/actions/build-monitor/build-monitor.sh
+++ b/.github/actions/build-monitor/build-monitor.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+GH_REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
+CHECK_SUITE_APP_NAME="${CHECK_SUITE_APP_NAME:-Google Cloud Build}"
+WORKFLOW_RUN_EVENT="${WORKFLOW_RUN_EVENT:-push}"
+ISSUE_LABELS="${ISSUE_LABELS-:rotating_light: critical}"
+EVENT_NAME="${EVENT_NAME:-}"
+EVENT_ACTION="${EVENT_ACTION:-}"
+
+if [[ -z "$GH_REPO" ]]; then
+  echo "Error: GH_REPO (or GITHUB_REPOSITORY) is required." >&2
+  exit 1
+fi
+
+# Prevent execution on forks when target repo is specified
+if [[ -n "${GITHUB_REPOSITORY:-}" && "$GITHUB_REPOSITORY" != "$GH_REPO" ]]; then
+  echo "Current repository '$GITHUB_REPOSITORY' does not match target repo '$GH_REPO'. Skipping."
+  exit 0
+fi
+
+# Ensure only completed events are processed
+if [[ -n "$EVENT_ACTION" && "$EVENT_ACTION" != "completed" ]]; then
+  echo "Event action '$EVENT_ACTION' is not completed. Skipping."
+  exit 0
+fi
+
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | tr ' _' '--' | tr -cd '[:alnum:]-'
+}
+
+COMMIT_SHA=""
+BODY=""
+
+case "$EVENT_NAME" in
+  check_suite)
+    # Validate conclusion
+    case "${CHECK_SUITE_CONCLUSION:-}" in
+      failure|timed_out|cancelled)
+        ;;
+      *)
+        echo "Check suite conclusion '${CHECK_SUITE_CONCLUSION:-}' is not a failure. Skipping."
+        exit 0
+        ;;
+    esac
+
+    # Validate target branch
+    if [[ "${CHECK_SUITE_HEAD_BRANCH:-}" != "$TARGET_BRANCH" ]]; then
+      echo "Check suite branch '${CHECK_SUITE_HEAD_BRANCH:-}' does not match target branch '$TARGET_BRANCH'. Skipping."
+      exit 0
+    fi
+
+    # Validate app name or slug
+    APP_NAME_ACTUAL="${CHECK_SUITE_APP_NAME_ACTUAL:-}"
+    APP_SLUG_ACTUAL="${CHECK_SUITE_APP_SLUG:-}"
+    EXPECTED_SLUG=$(slugify "$CHECK_SUITE_APP_NAME")
+    ACTUAL_NAME_SLUG=$(slugify "$APP_NAME_ACTUAL")
+    if [[ "$APP_NAME_ACTUAL" != "$CHECK_SUITE_APP_NAME" && "$APP_SLUG_ACTUAL" != "$EXPECTED_SLUG" && "$ACTUAL_NAME_SLUG" != "$EXPECTED_SLUG" ]]; then
+      echo "Check suite app '$APP_NAME_ACTUAL' (slug: '$APP_SLUG_ACTUAL') does not match expected app '$CHECK_SUITE_APP_NAME'. Skipping."
+      exit 0
+    fi
+
+    # Security check: Filter out check suites that belong to open pull requests or PRs from forks
+    if [[ -n "${CHECK_SUITE_PULL_REQUESTS:-}" && "$CHECK_SUITE_PULL_REQUESTS" != "[]" ]]; then
+      IS_OPEN_OR_FORK_PR=$(echo "$CHECK_SUITE_PULL_REQUESTS" | jq -r --arg repo "$GH_REPO" '
+        [ .[]? | select(.state == "open" or .head.repo.full_name != $repo) ] | length > 0
+      ' 2>/dev/null || echo "false")
+      if [[ "$IS_OPEN_OR_FORK_PR" == "true" ]]; then
+        echo "Check suite is associated with an active pull request or fork. Skipping."
+        exit 0
+      fi
+    fi
+
+    COMMIT_SHA="${CHECK_SUITE_HEAD_SHA:-}"
+
+    # Extract failed check runs from the check suite
+    FAILED_BUILDS=""
+    if [[ -n "${CHECK_SUITE_ID:-}" ]]; then
+      CHECK_RUNS_JSON=""
+      if RUNS_OUT=$(gh api "repos/$GH_REPO/check-suites/$CHECK_SUITE_ID/check-runs" --paginate 2>/dev/null); then
+        CHECK_RUNS_JSON="$RUNS_OUT"
+      fi
+
+      if [[ -n "$CHECK_RUNS_JSON" ]]; then
+        FAILED_RUNS=$(echo "$CHECK_RUNS_JSON" | jq -c '.check_runs[]? | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled") | {name: .name, url: (.details_url // .html_url // "")}' 2>/dev/null || true)
+        if [[ -n "$FAILED_RUNS" ]]; then
+          while IFS= read -r run_item; do
+            if [[ -n "$run_item" ]]; then
+              name=$(echo "$run_item" | jq -r '.name' 2>/dev/null || true)
+              url=$(echo "$run_item" | jq -r '.url' 2>/dev/null || true)
+              if [[ -n "$name" ]]; then
+                if [[ -n "$url" ]]; then
+                  FAILED_BUILDS="$FAILED_BUILDS"$'\n'"- [\`$name\`]($url)"
+                else
+                  FAILED_BUILDS="$FAILED_BUILDS"$'\n'"- \`$name\`"
+                fi
+              fi
+            fi
+          done < <(echo "$FAILED_RUNS")
+        fi
+      fi
+    fi
+
+    if [[ -z "$FAILED_BUILDS" ]]; then
+      CHECK_FALLBACK_URL="https://github.com/$GH_REPO/commit/$COMMIT_SHA/checks"
+      FAILED_BUILDS=$'\n'"- [Check Suite Logs]($CHECK_FALLBACK_URL)"
+    fi
+
+    BODY="**Failure in $CHECK_SUITE_APP_NAME on \`$TARGET_BRANCH\`:**
+
+**Failed Builds:**$FAILED_BUILDS
+
+**Commit:** $COMMIT_SHA"
+    ;;
+
+  workflow_run)
+    # Validate conclusion
+    case "${WORKFLOW_RUN_CONCLUSION:-}" in
+      failure|timed_out|cancelled|startup_failure)
+        ;;
+      *)
+        echo "Workflow run conclusion '${WORKFLOW_RUN_CONCLUSION:-}' is not a failure. Skipping."
+        exit 0
+        ;;
+    esac
+
+    # Validate target branch
+    if [[ "${WORKFLOW_RUN_HEAD_BRANCH:-}" != "$TARGET_BRANCH" ]]; then
+      echo "Workflow run branch '${WORKFLOW_RUN_HEAD_BRANCH:-}' does not match target branch '$TARGET_BRANCH'. Skipping."
+      exit 0
+    fi
+
+    # Validate triggering event (must be push by default to ignore pull_request runs)
+    if [[ "${WORKFLOW_RUN_EVENT_ACTUAL:-}" != "$WORKFLOW_RUN_EVENT" ]]; then
+      echo "Workflow run triggering event '${WORKFLOW_RUN_EVENT_ACTUAL:-}' does not match expected event '$WORKFLOW_RUN_EVENT'. Skipping."
+      exit 0
+    fi
+
+    # Validate repository to prevent triggers from fork workflow runs
+    if [[ -n "${WORKFLOW_RUN_HEAD_REPO:-}" && "$WORKFLOW_RUN_HEAD_REPO" != "$GH_REPO" ]]; then
+      echo "Workflow run repository '$WORKFLOW_RUN_HEAD_REPO' does not match target repo '$GH_REPO'. Skipping."
+      exit 0
+    fi
+
+    # Security check: Filter out workflow runs that belong to open pull requests
+    if [[ -n "${WORKFLOW_RUN_PULL_REQUESTS:-}" && "$WORKFLOW_RUN_PULL_REQUESTS" != "[]" ]]; then
+      IS_OPEN_PR=$(echo "$WORKFLOW_RUN_PULL_REQUESTS" | jq -r '
+        [ .[]? | select(.state == "open") ] | length > 0
+      ' 2>/dev/null || echo "false")
+      if [[ "$IS_OPEN_PR" == "true" ]]; then
+        echo "Workflow run is associated with an active pull request. Skipping."
+        exit 0
+      fi
+    fi
+
+    COMMIT_SHA="${WORKFLOW_RUN_HEAD_SHA:-}"
+
+    # Extract failed jobs from the workflow run
+    FAILED_JOBS=""
+    if [[ -n "${WORKFLOW_RUN_ID:-}" ]]; then
+      JOBS_JSON=""
+      if JOBS_OUT=$(gh api "repos/$GH_REPO/actions/runs/$WORKFLOW_RUN_ID/jobs" --paginate 2>/dev/null); then
+        JOBS_JSON="$JOBS_OUT"
+      fi
+
+      if [[ -n "$JOBS_JSON" ]]; then
+        FAILED_ITEMS=$(echo "$JOBS_JSON" | jq -c '.jobs[]? | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled" or .conclusion == "startup_failure") | {name: .name, url: (.html_url // "")}' 2>/dev/null || true)
+        if [[ -n "$FAILED_ITEMS" ]]; then
+          while IFS= read -r item; do
+            if [[ -n "$item" ]]; then
+              name=$(echo "$item" | jq -r '.name' 2>/dev/null || true)
+              url=$(echo "$item" | jq -r '.url' 2>/dev/null || true)
+              if [[ -n "$name" ]]; then
+                if [[ -n "$url" ]]; then
+                  FAILED_JOBS="$FAILED_JOBS"$'\n'"- [\`$name\`]($url)"
+                else
+                  FAILED_JOBS="$FAILED_JOBS"$'\n'"- \`$name\`"
+                fi
+              fi
+            fi
+          done < <(echo "$FAILED_ITEMS")
+        fi
+      fi
+    fi
+
+    if [[ -z "$FAILED_JOBS" ]]; then
+      if [[ -n "${WORKFLOW_RUN_URL:-}" ]]; then
+        FAILED_JOBS=$'\n'"- [Workflow Run Logs]($WORKFLOW_RUN_URL)"
+      else
+        FAILED_JOBS=$'\n'"- Workflow run failed (details url unavailable)"
+      fi
+    fi
+
+    WORKFLOW_NAME="${WORKFLOW_RUN_NAME:-GitHub Actions}"
+    WORKFLOW_URL="${WORKFLOW_RUN_URL:-}"
+    if [[ -n "$WORKFLOW_URL" ]]; then
+      WORKFLOW_TEXT="**Workflow:** $WORKFLOW_NAME ([Run Logs]($WORKFLOW_URL))"
+    else
+      WORKFLOW_TEXT="**Workflow:** $WORKFLOW_NAME"
+    fi
+
+    BODY="**Failure in GitHub Actions on \`$TARGET_BRANCH\`:**
+
+$WORKFLOW_TEXT
+
+**Failed Jobs:**$FAILED_JOBS
+
+**Commit:** $COMMIT_SHA"
+    ;;
+
+  push|workflow_dispatch)
+    COMMIT_SHA="${GITHUB_SHA:-}"
+    RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/$GH_REPO/actions/runs/${GITHUB_RUN_ID:-}"
+    BODY="**CI failure on \`$TARGET_BRANCH\`:**
+
+**Workflow Run:** $RUN_URL
+
+**Commit:** $COMMIT_SHA"
+    ;;
+
+  *)
+    echo "Event '$EVENT_NAME' is not monitored. Skipping."
+    exit 0
+    ;;
+esac
+
+# Find associated Pull Requests
+PR_TEXT=""
+if [[ -n "$COMMIT_SHA" ]]; then
+  PRS=""
+  if PRS_OUT=$(gh api "repos/$GH_REPO/commits/$COMMIT_SHA/pulls" 2>/dev/null); then
+    PRS=$(echo "$PRS_OUT" | jq -r '.[]? | .number // empty' 2>/dev/null || true)
+  fi
+  if [[ -n "$PRS" ]]; then
+    for pr in $(echo "$PRS" | tr ' ' '\n' | sort -u -n); do
+      if [[ -n "$pr" && "$pr" != "null" ]]; then
+        PR_TEXT="$PR_TEXT"$'\n'"- #$pr"
+      fi
+    done
+  fi
+fi
+
+# Fall back to merged pull requests from event payload if commit PRs query was empty
+if [[ -z "$PR_TEXT" ]]; then
+  PAYLOAD_PRS="${CHECK_SUITE_PULL_REQUESTS:-${WORKFLOW_RUN_PULL_REQUESTS:-}}"
+  if [[ -n "$PAYLOAD_PRS" && "$PAYLOAD_PRS" != "[]" ]]; then
+    PRS=$(echo "$PAYLOAD_PRS" | jq -r '.[]? | .number // empty' 2>/dev/null || true)
+    if [[ -n "$PRS" ]]; then
+      for pr in $(echo "$PRS" | tr ' ' '\n' | sort -u -n); do
+        if [[ -n "$pr" && "$pr" != "null" ]]; then
+          PR_TEXT="$PR_TEXT"$'\n'"- #$pr"
+        fi
+      done
+    fi
+  fi
+fi
+
+if [[ -n "$PR_TEXT" ]]; then
+  BODY="$BODY
+
+**Associated Pull Requests:**$PR_TEXT"
+fi
+
+# Determine issue title
+if [[ -n "${INPUT_ISSUE_TITLE:-}" ]]; then
+  TITLE="$INPUT_ISSUE_TITLE"
+else
+  REPO_NAME="${GH_REPO##*/}"
+  TITLE="$REPO_NAME: Post-merge build failure on $TARGET_BRANCH"
+fi
+
+# Check for existing open issue with the exact same title (prevent partial token match)
+EXISTING_ISSUE=""
+if ISSUES_OUT=$(gh issue list --repo "$GH_REPO" --search "\"$TITLE\" in:title" --state open --json number,title 2>/dev/null); then
+  EXISTING_ISSUE=$(echo "$ISSUES_OUT" | jq -r --arg title "$TITLE" '[.[]? | select(.title == $title)][0].number // empty' 2>/dev/null || true)
+fi
+
+if [[ -n "$EXISTING_ISSUE" && "$EXISTING_ISSUE" != "null" ]]; then
+  echo "Found existing open issue #$EXISTING_ISSUE. Adding comment."
+  COMMENT_BODY="The build failed again on \`$TARGET_BRANCH\`.
+
+$BODY"
+  gh issue comment "$EXISTING_ISSUE" --repo "$GH_REPO" --body "$COMMENT_BODY"
+  exit 0
+fi
+
+echo "No open issue found with title '$TITLE'. Creating new issue."
+
+# Resolve assignee: explicitly provided -> commit author -> workflow run actor -> event actor
+ASSIGNEE="${INPUT_ASSIGNEE:-}"
+if [[ -z "$ASSIGNEE" && -n "$COMMIT_SHA" ]]; then
+  COMMIT_AUTHOR=""
+  if COMMIT_OUT=$(gh api "repos/$GH_REPO/commits/$COMMIT_SHA" 2>/dev/null); then
+    COMMIT_AUTHOR=$(echo "$COMMIT_OUT" | jq -r '.author.login // empty' 2>/dev/null || true)
+  fi
+  if [[ -n "$COMMIT_AUTHOR" && ! "$COMMIT_AUTHOR" =~ \[bot\]$ ]]; then
+    ASSIGNEE="$COMMIT_AUTHOR"
+  fi
+fi
+if [[ -z "$ASSIGNEE" && -n "${WORKFLOW_RUN_ACTOR:-}" && ! "$WORKFLOW_RUN_ACTOR" =~ \[bot\]$ ]]; then
+  ASSIGNEE="$WORKFLOW_RUN_ACTOR"
+fi
+if [[ -z "$ASSIGNEE" && -n "${GITHUB_ACTOR:-}" && ! "$GITHUB_ACTOR" =~ \[bot\]$ ]]; then
+  ASSIGNEE="$GITHUB_ACTOR"
+fi
+
+create_issue() {
+  local target_assignee="$1"
+  local target_labels="$2"
+  local cmd=(gh issue create --title "$TITLE" --body "$BODY" --repo "$GH_REPO")
+  if [[ -n "$target_labels" ]]; then
+    cmd+=(--label "$target_labels")
+  fi
+  if [[ -n "$target_assignee" ]]; then
+    cmd+=(--assignee "$target_assignee")
+  fi
+  "${cmd[@]}"
+}
+
+ISSUE_LINK=""
+
+# Tier 1: Try with assignee and labels
+if [[ -n "$ASSIGNEE" ]]; then
+  echo "Attempting to create issue assigned to $ASSIGNEE..."
+  ISSUE_LINK=$(create_issue "$ASSIGNEE" "$ISSUE_LABELS" 2>/dev/null || true)
+fi
+
+# Tier 2: Retry without assignee (e.g. assignee is not a repo collaborator)
+if [[ -z "$ISSUE_LINK" && -n "$ISSUE_LABELS" ]]; then
+  echo "Attempting to create issue without assignee..."
+  ISSUE_LINK=$(create_issue "" "$ISSUE_LABELS" 2>/dev/null || true)
+fi
+
+# Tier 3: Retry without labels (e.g. label does not exist in repository)
+if [[ -z "$ISSUE_LINK" ]]; then
+  echo "Attempting to create issue without label..."
+  ISSUE_LINK=$(create_issue "" "" 2>/dev/null || true)
+fi
+
+if [[ -z "$ISSUE_LINK" ]]; then
+  echo "Error: Failed to create issue in $GH_REPO." >&2
+  exit 1
+fi
+
+ISSUE_LINK=$(echo "$ISSUE_LINK" | tr -d '[:space:]')
+echo "Created issue: $ISSUE_LINK"
+
+if [[ -n "${TEAM_MENTION:-}" ]]; then
+  ISSUE_NUM="${ISSUE_LINK##*/}"
+  echo "Adding team mention comment for $TEAM_MENTION..."
+  gh issue comment "$ISSUE_NUM" --repo "$GH_REPO" --body "$TEAM_MENTION A critical issue has been created, please respond immediately."
+fi

--- a/.github/actions/build-monitor/build-monitor_test.sh
+++ b/.github/actions/build-monitor/build-monitor_test.sh
@@ -1,0 +1,558 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONITOR_SCRIPT="$SCRIPT_DIR/build-monitor.sh"
+
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+MOCK_BIN="$TEST_TMP/bin"
+mkdir -p "$MOCK_BIN"
+MOCK_LOG="$TEST_TMP/gh_calls.log"
+
+# Create mock gh CLI
+cat << 'EOF' > "$MOCK_BIN/gh"
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="${TEST_GH_LOG:-/dev/null}"
+echo "$@" >> "$LOG_FILE"
+
+case "${1:-}" in
+  issue)
+    subcmd="${2:-}"
+    case "$subcmd" in
+      list)
+        if [[ -n "${MOCK_EXISTING_ISSUE:-}" ]]; then
+          echo "$MOCK_EXISTING_ISSUE"
+        else
+          echo "[]"
+        fi
+        exit 0
+        ;;
+      create)
+        # Check if we should simulate assignee failure
+        if [[ "${FAIL_ON_ASSIGNEE:-false}" == "true" ]] && [[ "$*" =~ --assignee ]]; then
+          echo "GraphQL error: could not add assignee" >&2
+          exit 1
+        fi
+        # Check if we should simulate label failure
+        if [[ "${FAIL_ON_LABEL:-false}" == "true" ]] && [[ "$*" =~ --label ]]; then
+          echo "GraphQL error: label not found" >&2
+          exit 1
+        fi
+        echo "https://github.com/${GH_REPO:-test/repo}/issues/42"
+        exit 0
+        ;;
+      comment)
+        exit 0
+        ;;
+      *)
+        echo "Unknown gh issue command: $subcmd" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  api)
+    endpoint="${2:-}"
+    case "$endpoint" in
+      *check-suites/*/check-runs*)
+        cat << 'JSON'
+{
+  "check_runs": [
+    {
+      "name": "build-docker-image",
+      "conclusion": "failure",
+      "details_url": "https://console.cloud.google.com/cloud-build/builds/12345"
+    }
+  ]
+}
+JSON
+        exit 0
+        ;;
+      *actions/runs/*/jobs*)
+        cat << 'JSON'
+{
+  "jobs": [
+    {
+      "name": "Integration Tests",
+      "conclusion": "failure",
+      "html_url": "https://github.com/test/repo/actions/runs/1/job/2"
+    }
+  ]
+}
+JSON
+        exit 0
+        ;;
+      *commits/*/pulls*)
+        cat << 'JSON'
+[
+  {
+    "number": 101,
+    "html_url": "https://github.com/test/repo/pull/101"
+  }
+]
+JSON
+        exit 0
+        ;;
+      *commits/*)
+        if [[ "${MOCK_COMMIT_AUTHOR_BOT:-false}" == "true" ]]; then
+          cat << 'JSON'
+{
+  "author": {
+    "login": "release-please[bot]"
+  }
+}
+JSON
+        else
+          cat << 'JSON'
+{
+  "author": {
+    "login": "octocat"
+  }
+}
+JSON
+        fi
+        exit 0
+        ;;
+      *)
+        echo "{}"
+        exit 0
+        ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+
+chmod +x "$MOCK_BIN/gh"
+export PATH="$MOCK_BIN:$PATH"
+export TEST_GH_LOG="$MOCK_LOG"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+  local test_name="$1"
+  shift
+  echo -n "Running $test_name... "
+  rm -f "$MOCK_LOG"
+  touch "$MOCK_LOG"
+  if "$@"; then
+    echo "PASSED"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "FAILED"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# Test 1: check_suite conclusion=success should skip
+test_check_suite_success() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="success" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+  ! grep -q "issue comment" "$MOCK_LOG"
+}
+
+# Test 2: check_suite branch != main should skip
+test_check_suite_wrong_branch() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="feat/something" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 3: check_suite wrong app should skip
+test_check_suite_wrong_app() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Dependabot" \
+    CHECK_SUITE_APP_SLUG="dependabot" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 4: check_suite slug matching should succeed
+test_check_suite_slug_match() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google-Cloud-Build" \
+    CHECK_SUITE_APP_SLUG="google-cloud-build" \
+    CHECK_SUITE_ID="123" \
+    CHECK_SUITE_HEAD_SHA="abcdef123456" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Created issue" ]]
+  grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 5: check_suite wrong head repo should skip
+test_check_suite_fork_repo() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    GITHUB_REPOSITORY="fork-user/test-repo" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 6: check_suite with active open PR should skip
+test_check_suite_open_pr_skip() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    CHECK_SUITE_PULL_REQUESTS='[{"number":50,"state":"open","head":{"repo":{"full_name":"googleapis/test-repo"}}}]' \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 7: check_suite with PR from fork repo should skip
+test_check_suite_fork_pr_skip() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    CHECK_SUITE_PULL_REQUESTS='[{"number":50,"state":"closed","head":{"repo":{"full_name":"attacker/test-repo"}}}]' \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 8: check_suite non-completed action should skip
+test_check_suite_non_completed_action() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="requested" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 9: check_suite failure on main creates new issue and posts comment
+test_check_suite_failure_new_issue() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    CHECK_SUITE_ID="123" \
+    CHECK_SUITE_HEAD_SHA="abcdef123456" \
+    GH_REPO="googleapis/test-repo" \
+    TEAM_MENTION="@googleapis/cloud-sdk-rust-team" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Created issue" ]]
+  grep -q "issue create" "$MOCK_LOG"
+  grep -q "issue comment 42" "$MOCK_LOG"
+}
+
+# Test 10: check_suite failure on main updates existing open issue
+test_check_suite_failure_existing_issue() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    CHECK_SUITE_ID="123" \
+    CHECK_SUITE_HEAD_SHA="abcdef123456" \
+    GH_REPO="googleapis/test-repo" \
+    MOCK_EXISTING_ISSUE='[{"number":77,"title":"test-repo: Post-merge build failure on main"}]' \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Found existing open issue #77" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+  grep -q "issue comment 77" "$MOCK_LOG"
+}
+
+# Test 11: check_suite exact title match prevents commenting on partial match
+test_check_suite_exact_title_match_only() {
+  output=$(EVENT_NAME="check_suite" \
+    EVENT_ACTION="completed" \
+    CHECK_SUITE_CONCLUSION="failure" \
+    CHECK_SUITE_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    CHECK_SUITE_APP_NAME="Google Cloud Build" \
+    CHECK_SUITE_APP_NAME_ACTUAL="Google Cloud Build" \
+    CHECK_SUITE_ID="123" \
+    CHECK_SUITE_HEAD_SHA="abcdef123456" \
+    GH_REPO="googleapis/test-repo" \
+    MOCK_EXISTING_ISSUE='[{"number":77,"title":"test-repo: Post-merge build failure on main (old/different)"}]' \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Created issue" ]]
+  grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 12: workflow_run conclusion=success should skip
+test_workflow_run_success() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="success" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 13: workflow_run wrong branch should skip
+test_workflow_run_wrong_branch() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="feat/something" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 14: workflow_run pull_request event should skip
+test_workflow_run_pr_event() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="pull_request" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 15: workflow_run fork head repo should skip
+test_workflow_run_fork_head_repo() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    WORKFLOW_RUN_HEAD_REPO="fork-user/test-repo" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 16: workflow_run non-completed action should skip
+test_workflow_run_non_completed_action() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="in_progress" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 17: workflow_run failure creates issue
+test_workflow_run_failure() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    WORKFLOW_RUN_ID="999" \
+    WORKFLOW_RUN_NAME="CI" \
+    WORKFLOW_RUN_HEAD_SHA="11223344" \
+    WORKFLOW_RUN_URL="https://github.com/test/repo/actions/runs/999" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Created issue" ]]
+  grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 18: workflow_run assigns WORKFLOW_RUN_ACTOR when commit author is a bot
+test_workflow_run_actor_assignee() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    WORKFLOW_RUN_ID="999" \
+    WORKFLOW_RUN_HEAD_SHA="11223344" \
+    WORKFLOW_RUN_ACTOR="human-dev" \
+    MOCK_COMMIT_AUTHOR_BOT="true" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Attempting to create issue assigned to human-dev" ]]
+  grep -q "issue create" "$MOCK_LOG"
+  grep -q -- "--assignee human-dev" "$MOCK_LOG"
+}
+
+# Test 19: assignee retry fallback
+test_assignee_retry_fallback() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    WORKFLOW_RUN_ID="999" \
+    GH_REPO="googleapis/test-repo" \
+    INPUT_ASSIGNEE="external-contributor" \
+    FAIL_ON_ASSIGNEE="true" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Attempting to create issue without assignee" ]]
+  grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 20: label retry fallback when label doesn't exist in repo
+test_label_retry_fallback() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    WORKFLOW_RUN_ID="999" \
+    GH_REPO="googleapis/test-repo" \
+    ISSUE_LABELS="nonexistent-label" \
+    FAIL_ON_LABEL="true" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Attempting to create issue without label" ]]
+  grep -q "issue create" "$MOCK_LOG"
+}
+
+# Test 21: empty labels does not pass --label flag
+test_empty_labels_input() {
+  output=$(EVENT_NAME="workflow_run" \
+    EVENT_ACTION="completed" \
+    WORKFLOW_RUN_CONCLUSION="failure" \
+    WORKFLOW_RUN_HEAD_BRANCH="main" \
+    TARGET_BRANCH="main" \
+    WORKFLOW_RUN_EVENT="push" \
+    WORKFLOW_RUN_EVENT_ACTUAL="push" \
+    WORKFLOW_RUN_ID="999" \
+    GH_REPO="googleapis/test-repo" \
+    ISSUE_LABELS="" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Created issue" ]]
+  ! grep -q -- "--label" "$MOCK_LOG"
+}
+
+# Test 22: unsupported event should skip
+test_unsupported_event() {
+  output=$(EVENT_NAME="pull_request" \
+    GH_REPO="googleapis/test-repo" \
+    bash "$MONITOR_SCRIPT")
+  [[ "$output" =~ "Skipping" ]]
+  ! grep -q "issue create" "$MOCK_LOG"
+}
+
+run_test "check_suite_success" test_check_suite_success
+run_test "check_suite_wrong_branch" test_check_suite_wrong_branch
+run_test "check_suite_wrong_app" test_check_suite_wrong_app
+run_test "check_suite_slug_match" test_check_suite_slug_match
+run_test "check_suite_fork_repo" test_check_suite_fork_repo
+run_test "check_suite_open_pr_skip" test_check_suite_open_pr_skip
+run_test "check_suite_fork_pr_skip" test_check_suite_fork_pr_skip
+run_test "check_suite_non_completed_action" test_check_suite_non_completed_action
+run_test "check_suite_failure_new_issue" test_check_suite_failure_new_issue
+run_test "check_suite_failure_existing_issue" test_check_suite_failure_existing_issue
+run_test "check_suite_exact_title_match_only" test_check_suite_exact_title_match_only
+run_test "workflow_run_success" test_workflow_run_success
+run_test "workflow_run_wrong_branch" test_workflow_run_wrong_branch
+run_test "workflow_run_pr_event" test_workflow_run_pr_event
+run_test "workflow_run_fork_head_repo" test_workflow_run_fork_head_repo
+run_test "workflow_run_non_completed_action" test_workflow_run_non_completed_action
+run_test "workflow_run_failure" test_workflow_run_failure
+run_test "workflow_run_actor_assignee" test_workflow_run_actor_assignee
+run_test "assignee_retry_fallback" test_assignee_retry_fallback
+run_test "label_retry_fallback" test_label_retry_fallback
+run_test "empty_labels_input" test_empty_labels_input
+run_test "unsupported_event" test_unsupported_event
+
+echo ""
+echo "=== Test Summary ==="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+  exit 1
+fi

--- a/.github/workflows/build-monitor.yaml
+++ b/.github/workflows/build-monitor.yaml
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Build Monitor
+on:
+  workflow_call:
+    inputs:
+      target_branch:
+        description: "The target branch to monitor for failures (default: main)."
+        required: false
+        type: string
+        default: "main"
+      team_mention:
+        description: "A team or user to mention in a follow-up comment when a new issue is created."
+        required: false
+        type: string
+        default: ""
+      issue_title:
+        description: "The title of the issue to create or search for."
+        required: false
+        type: string
+        default: ""
+      labels:
+        description: "Comma-separated list of labels to apply to the issue."
+        required: false
+        type: string
+        default: ":rotating_light: critical"
+      assignee:
+        description: "The GitHub user to assign the issue to."
+        required: false
+        type: string
+        default: ""
+      check_suite_app_name:
+        description: "The GitHub App name to filter on for check_suite events (default: Google Cloud Build)."
+        required: false
+        type: string
+        default: "Google Cloud Build"
+      workflow_run_event:
+        description: "The trigger event to filter on for workflow_run events (default: push)."
+        required: false
+        type: string
+        default: "push"
+      repo:
+        description: "The target repository in owner/repo format (default: caller repository)."
+        required: false
+        type: string
+        default: ""
+      librarian_ref:
+        description: "The ref of googleapis/librarian to checkout (default: main)."
+        required: false
+        type: string
+        default: "main"
+permissions:
+  contents: read
+  issues: write
+  checks: read
+  actions: read
+  pull-requests: read
+jobs:
+  build-monitor:
+    runs-on: ubuntu-24.04
+    # Strict event filtering to prevent unnecessary runner jobs or unwanted triggers.
+    # Note: In GitHub Actions expressions, '&&' and '||' return booleans, so comparisons
+    # must be evaluated explicitly against string values rather than using JavaScript-style
+    # value fallbacks like '(inputs.target_branch || "main")'.
+    if: (github.event_name == 'check_suite' && (github.event.action == 'completed' || github.event.action == '') && (github.event.check_suite.head_branch == inputs.target_branch || (inputs.target_branch == '' && github.event.check_suite.head_branch == 'main')) && (github.event.check_suite.app.name == inputs.check_suite_app_name || (inputs.check_suite_app_name == '' && github.event.check_suite.app.name == 'Google Cloud Build')) && (github.event.check_suite.conclusion == 'failure' || github.event.check_suite.conclusion == 'timed_out' || github.event.check_suite.conclusion == 'cancelled')) || (github.event_name == 'workflow_run' && (github.event.action == 'completed' || github.event.action == '') && github.event.workflow_run.head_repository.full_name == github.repository && (github.event.workflow_run.head_branch == inputs.target_branch || (inputs.target_branch == '' && github.event.workflow_run.head_branch == 'main')) && (github.event.workflow_run.event == inputs.workflow_run_event || (inputs.workflow_run_event == '' && github.event.workflow_run.event == 'push')) && (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out' || github.event.workflow_run.conclusion == 'cancelled' || github.event.workflow_run.conclusion == 'startup_failure'))
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: googleapis/librarian
+          ref: ${{ inputs.librarian_ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/build-monitor
+        with:
+          target_branch: ${{ inputs.target_branch }}
+          team_mention: ${{ inputs.team_mention }}
+          issue_title: ${{ inputs.issue_title }}
+          labels: ${{ inputs.labels }}
+          assignee: ${{ inputs.assignee }}
+          check_suite_app_name: ${{ inputs.check_suite_app_name }}
+          workflow_run_event: ${{ inputs.workflow_run_event }}
+          repo: ${{ inputs.repo }}


### PR DESCRIPTION
Add a reusable composite action and workflow to monitor post-merge build failures on `main` across Google Cloud Build and GitHub Actions.

It extracts failed targets, console logs, and triggering PRs to open or update an issue with team mentions, while ignoring pre-submit PR builds and fork events.