### PR TITLE
build(.github/workflows): split ruby integration test into standalone job

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -75,7 +75,7 @@ jobs:
         working-directory: google-cloud-go
         run: librarian generate --all
   create-issue-on-failure:
-    needs: [build-and-test, integration-test]
+    needs: [build-and-test]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -75,7 +75,7 @@ jobs:
         working-directory: google-cloud-go
         run: librarian generate --all
   create-issue-on-failure:
-    needs: [build-and-test]
+    needs: [build-and-test, integration-test]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -19,31 +19,22 @@ jobs:
   build-and-test:
     name: ${{ matrix.job-name }}
     runs-on: ubuntu-24.04
-    # Presubmit jobs must complete within 5 minutes. Integration might take longer.
-    timeout-minutes: ${{ matrix.timeout }}
+    # Presubmit jobs must complete within 5 minutes.
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
         include:
           - job-name: 'Unit Tests'
             task: 'unit-test'
-            timeout: 5
-            sparse: true
           - job-name: 'Smoke Test'
             task: 'smoke-test'
-            timeout: 5
-            sparse: true
-          - job-name: 'Integration Test'
-            task: 'integration'
-            timeout: 120
-            sparse: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-librarian
       - name: Checkout google-cloud-ruby (Sparse)
-        if: matrix.sparse == true
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: googleapis/google-cloud-ruby
@@ -54,15 +45,6 @@ jobs:
             librarian.yaml
             # Note: If changing the target of the smoke test below, update this sparse checkout rule.
             google-cloud-asset-v1/
-      - name: Checkout google-cloud-ruby (Full)
-        if: matrix.sparse == false && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: googleapis/google-cloud-ruby
-          path: google-cloud-ruby
-          persist-credentials: false
-      - name: Display Go version
-        run: go version
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: '4.0'
@@ -77,23 +59,57 @@ jobs:
       - name: Add Ruby tools to PATH
         run: echo "$HOME/.cache/librarian/bin/ruby_tools/bin" >> $GITHUB_PATH
       - name: Run librarian install
-        if: steps.cache-tools.outputs.cache-hit != 'true' && (matrix.task != 'integration' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+        if: steps.cache-tools.outputs.cache-hit != 'true'
         working-directory: google-cloud-ruby
         run: |
           librarian install
       - name: Verify tools
         run: |
-          protoc --version
           gem --version
       - name: Run internal/librarian/ruby tests and check coverage
         if: matrix.task == 'unit-test'
         run: go run ./tool/cmd/coverage ./internal/librarian/ruby
       - name: Generate a single library (smoke test)
-        if: matrix.task == 'smoke-test' && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: matrix.task == 'smoke-test'
         working-directory: google-cloud-ruby
         run: librarian generate google-cloud-asset-v1
+  integration-test:
+    name: Integration test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-librarian
+      - name: Checkout google-cloud-ruby (Full)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: googleapis/google-cloud-ruby
+          path: google-cloud-ruby
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+      - name: Cache Librarian Tools
+        id: cache-tools
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/librarian
+          key: librarian-ruby-tools-v2-${{ runner.os }}-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-ruby/librarian.yaml') }}
+      - name: Add Ruby tools to PATH
+        run: echo "$HOME/.cache/librarian/bin/ruby_tools/bin" >> $GITHUB_PATH
+      - name: Run librarian install
+        if: steps.cache-tools.outputs.cache-hit != 'true'
+        working-directory: google-cloud-ruby
+        run: |
+          librarian install
+      - name: Verify tools
+        run: |
+          gem --version
       - name: Run librarian generate all (integration test)
-        if: matrix.task == 'integration' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: google-cloud-ruby
         run: librarian generate --all
   create-issue-on-failure:

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -113,7 +113,7 @@ jobs:
         working-directory: google-cloud-ruby
         run: librarian generate --all
   create-issue-on-failure:
-    needs: [build-and-test]
+    needs: [build-and-test, integration-test]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -75,6 +75,7 @@ jobs:
         run: librarian generate google-cloud-asset-v1
   integration-test:
     name: Integration test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
Move the Ruby integration test out of the build-and-test presubmit matrix into a dedicated integration-test job.

Previously, including the integration test in the presubmit matrix resulted in an extra matrix job scheduled during presubmit runs on pull requests that did not execute generation. Removing it from the matrix simplifies the presubmit timeout to five minutes and eliminates conditional checkout steps.

For #7484