### PR TITLE
feat(internal/librarian/nodejs): derive package name from custom prefixes

### DIFF
--- a/internal/librarian/add.go
+++ b/internal/librarian/add.go
@@ -312,7 +312,7 @@ func addNewLibrary(cfg *config.Config, api *config.API, explicitLibraryName, goo
 			return "", nil, err
 		}
 	case config.LanguageNodejs:
-		lib = nodejs.Add(lib)
+		lib = nodejs.Add(cfg, lib)
 	case config.LanguagePython:
 		var err error
 		lib, err = python.Add(cfg, lib)

--- a/internal/librarian/nodejs/add.go
+++ b/internal/librarian/nodejs/add.go
@@ -29,7 +29,7 @@ const defaultVersion = "0.0.0"
 func Add(cfg *config.Config, lib *config.Library) *config.Library {
 	lib.Version = defaultVersion
 	if cfg != nil {
-		lib = fillDefault(lib, cfg.Default)
+		lib = populatePackageName(lib, cfg.Default)
 	}
 	apiPath := lib.APIs[0].Path
 	if !strings.HasPrefix(apiPath, "google/cloud/") && (lib.Nodejs == nil || lib.Nodejs.PackageName == "") {
@@ -38,9 +38,9 @@ func Add(cfg *config.Config, lib *config.Library) *config.Library {
 	return lib
 }
 
-// fillDefault populates empty Node.js-specific fields in lib from [config.Default],
-// specifically from [config.NodejsDefault].
-func fillDefault(lib *config.Library, d *config.Default) *config.Library {
+// populatePackageName sets the Node.js package name on lib if empty, deriving it
+// from custom_package_prefixes in [config.Default].
+func populatePackageName(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Nodejs != nil && lib.Nodejs.PackageName != "" {
 		return lib
 	}

--- a/internal/librarian/nodejs/add.go
+++ b/internal/librarian/nodejs/add.go
@@ -15,6 +15,7 @@
 package nodejs
 
 import (
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -25,9 +26,56 @@ import (
 const defaultVersion = "0.0.0"
 
 // Add initializes Node.js-specific configuration for a library.
-func Add(lib *config.Library) *config.Library {
+func Add(cfg *config.Config, lib *config.Library) *config.Library {
 	lib.Version = defaultVersion
+	if len(lib.APIs) == 0 {
+		return lib
+	}
+	if cfg != nil {
+		fillDefault(lib, cfg.Default)
+	}
+	apiPath := lib.APIs[0].Path
+	if !strings.HasPrefix(apiPath, "google/cloud/") && (lib.Nodejs == nil || lib.Nodejs.PackageName == "") {
+		slog.Warn("unrecognized non-cloud API path; please manually configure nodejs.package_name in librarian.yaml", "api", apiPath)
+	}
 	return lib
+}
+
+// fillDefault populates empty Node.js-specific fields in lib from [config.Default],
+// specifically from [config.NodejsDefault].
+func fillDefault(lib *config.Library, d *config.Default) *config.Library {
+	if lib.Nodejs != nil && lib.Nodejs.PackageName != "" {
+		return lib
+	}
+	if d == nil || d.Nodejs == nil || len(d.Nodejs.CustomPackagePrefixes) == 0 || len(lib.APIs) == 0 {
+		return lib
+	}
+	if pkgName := derivePackageNameFromCustomPackagePrefixes(lib.APIs[0].Path, d.Nodejs.CustomPackagePrefixes); pkgName != "" {
+		if lib.Nodejs == nil {
+			lib.Nodejs = &config.NodejsPackage{}
+		}
+		lib.Nodejs.PackageName = pkgName
+	}
+	return lib
+}
+
+func derivePackageNameFromCustomPackagePrefixes(apiPath string, customPackagePrefixes map[string]string) string {
+	scope, remainder, ok := serviceconfig.MatchPrefix(apiPath, customPackagePrefixes)
+	if !ok {
+		return ""
+	}
+	sub := strings.ReplaceAll(remainder, "/", "-")
+	switch {
+	case sub == "":
+		// Exact leaf API match (e.g. @google-apps/chat).
+		return scope
+	case strings.Contains(scope, "/"):
+		// Scope already has a slash; join with hyphen (e.g. @google/area120-tables).
+		return scope + "-" + sub
+	default:
+		// Standard scope; join with slash (e.g. @google-shopping/accounts).
+		return scope + "/" + sub
+	}
 }
 
 // DefaultLibraryName derives a library name from an API path by stripping

--- a/internal/librarian/nodejs/add.go
+++ b/internal/librarian/nodejs/add.go
@@ -28,9 +28,6 @@ const defaultVersion = "0.0.0"
 // Add initializes Node.js-specific configuration for a library.
 func Add(cfg *config.Config, lib *config.Library) *config.Library {
 	lib.Version = defaultVersion
-	if len(lib.APIs) == 0 {
-		return lib
-	}
 	if cfg != nil {
 		lib = fillDefault(lib, cfg.Default)
 	}
@@ -47,7 +44,7 @@ func fillDefault(lib *config.Library, d *config.Default) *config.Library {
 	if lib.Nodejs != nil && lib.Nodejs.PackageName != "" {
 		return lib
 	}
-	if d == nil || d.Nodejs == nil || len(d.Nodejs.CustomPackagePrefixes) == 0 || len(lib.APIs) == 0 {
+	if d == nil || d.Nodejs == nil || len(d.Nodejs.CustomPackagePrefixes) == 0 {
 		return lib
 	}
 	if pkgName := derivePackageNameFromCustomPackagePrefixes(lib.APIs[0].Path, d.Nodejs.CustomPackagePrefixes); pkgName != "" {

--- a/internal/librarian/nodejs/add.go
+++ b/internal/librarian/nodejs/add.go
@@ -32,7 +32,7 @@ func Add(cfg *config.Config, lib *config.Library) *config.Library {
 		return lib
 	}
 	if cfg != nil {
-		fillDefault(lib, cfg.Default)
+		lib = fillDefault(lib, cfg.Default)
 	}
 	apiPath := lib.APIs[0].Path
 	if !strings.HasPrefix(apiPath, "google/cloud/") && (lib.Nodejs == nil || lib.Nodejs.PackageName == "") {

--- a/internal/librarian/nodejs/add_test.go
+++ b/internal/librarian/nodejs/add_test.go
@@ -35,9 +35,168 @@ func TestAdd(t *testing.T) {
 			{Path: "google/cloud/secretmanager/v1"},
 		},
 	}
-	got := Add(in)
+	got := Add(nil, in)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAdd_CustomPackagePrefixes(t *testing.T) {
+	cfg := &config.Config{
+		Default: &config.Default{
+			Nodejs: &config.NodejsDefault{
+				CustomPackagePrefixes: map[string]string{
+					"google/shopping/merchant": "@google-shopping",
+					"google/shopping":          "@google-shopping",
+					"google/maps":              "@googlemaps",
+					"google/chat":              "@google-apps/chat",
+					"google/apps":              "@google-apps",
+				},
+			},
+		},
+	}
+	for _, test := range []struct {
+		name string
+		in   *config.Library
+		want *config.Library
+	}{
+		{
+			name: "cloud API leaves package name empty",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-cloud-secretmanager",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/cloud/secretmanager/v1"},
+				},
+			},
+		},
+		{
+			name: "nested custom organization strips prefix and derives package name",
+			in: &config.Library{
+				Name: "google-shopping-merchant-loyaltycustomers",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-shopping-merchant-loyaltycustomers",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-shopping/loyaltycustomers",
+				},
+			},
+		},
+		{
+			name: "general prefix with remainder derives package name",
+			in: &config.Library{
+				Name: "google-maps-routing",
+				APIs: []*config.API{
+					{Path: "google/maps/routing/v2"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-maps-routing",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/maps/routing/v2"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@googlemaps/routing",
+				},
+			},
+		},
+		{
+			name: "org containing slash returns exact package name when remainder empty",
+			in: &config.Library{
+				Name: "google-chat",
+				APIs: []*config.API{
+					{Path: "google/chat/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-chat",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/chat/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-apps/chat",
+				},
+			},
+		},
+		{
+			name: "general prefix derives package name from remainder",
+			in: &config.Library{
+				Name: "google-apps-meet",
+				APIs: []*config.API{
+					{Path: "google/apps/meet/v2"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-apps-meet",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/apps/meet/v2"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-apps/meet",
+				},
+			},
+		},
+		{
+			name: "unrecognized non-cloud API leaves package name empty",
+			in: &config.Library{
+				Name: "google-unrecognized-api",
+				APIs: []*config.API{
+					{Path: "google/unrecognized/api/v1"},
+				},
+			},
+			want: &config.Library{
+				Name:    "google-unrecognized-api",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/unrecognized/api/v1"},
+				},
+			},
+		},
+		{
+			name: "preserves explicitly configured package name",
+			in: &config.Library{
+				Name: "google-shopping-merchant-loyaltycustomers",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@custom/override",
+				},
+			},
+			want: &config.Library{
+				Name:    "google-shopping-merchant-loyaltycustomers",
+				Version: "0.0.0",
+				APIs: []*config.API{
+					{Path: "google/shopping/merchant/loyaltycustomers/v1"},
+				},
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@custom/override",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Add(cfg, test.in)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Derive default Node.js package names for non-cloud APIs during library addition using custom_package_prefixes configured in librarian.yaml. Node.js constructs package names for bare scopes, scoped prefixes with hyphenated suffixes, and exact leaf package names without manual configuration.

Unrecognized non-cloud APIs log a structured warning prompting the user to manually configure package_name. 

For https://github.com/googleapis/librarian/issues/7496