### PR TITLE
fix(.github/workflows): trigger issue creation on go integration failure

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -75,7 +75,7 @@ jobs:
         working-directory: google-cloud-go
         run: librarian generate --all
   create-issue-on-failure:
-    needs: [build-and-test]
+    needs: [build-and-test, integration-test]
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Update the create-issue-on-failure job in the Go workflow to include integration-test in its needs list.

For #7484
