### PR TITLE
cleanup(sidekick/swift): remove HasConvertedFields

### DIFF
--- a/internal/sidekick/swift/annotate_message.go
+++ b/internal/sidekick/swift/annotate_message.go
@@ -34,11 +34,6 @@ type messageAnnotations struct {
 	TypeURL             string
 	CustomSerialization bool
 
-	// HasConvertedFields is true if any field or oneof in the message emits code in
-	// toProto(). This prevents the Swift compiler warning "variable 'proto' was never mutated"
-	// for empty messages by emitting "let" instead of "var" in convert_message.mustache.
-	HasConvertedFields bool
-
 	IsPaginatedResponse bool
 	PageableItemField   string
 	PageableItemType    string
@@ -151,7 +146,6 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 	if len(message.Fields) != 0 {
 		sampleField = camelCase(message.Fields[0].Name)
 	}
-	hasConvertedFields := len(message.Fields) > 0
 	parameterTypeName, err := c.messageTypeName(message)
 	if err != nil {
 		return err
@@ -162,7 +156,6 @@ func (c *codec) annotateMessage(message *api.Message, model *modelAnnotations) e
 		Model:               model,
 		TypeURL:             typeURLPrefix + strings.TrimPrefix(message.ID, "."),
 		CustomSerialization: len(message.OneOfs) > 0,
-		HasConvertedFields:  hasConvertedFields,
 		DependsOn:           map[string]*Dependency{},
 		SampleField:         sampleField,
 		ParameterTypeName:   parameterTypeName,

--- a/internal/sidekick/swift/annotate_message_test.go
+++ b/internal/sidekick/swift/annotate_message_test.go
@@ -172,7 +172,7 @@ func TestAnnotateMessage(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
+			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.wantImports, test.message.Codec.(*messageAnnotations).MessageImports()); diff != "" {
@@ -395,7 +395,7 @@ func TestAnnotateMessage_Discovery(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
+			if diff := cmp.Diff(test.want, test.message.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -454,7 +454,7 @@ func TestAnnotateMessage_DiscoveryRequests(t *testing.T) {
 			if err := codec.annotateModel(); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(test.want, test.request.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
+			if diff := cmp.Diff(test.want, test.request.Codec, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -534,7 +534,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		ProtoTypeName:     "Google_Cloud_Secretmanager_V1_ListSecretsRequest",
 		ModulePath:        "",
 	}
-	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
+	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantRequestImports := []*dependencyImport{{Module: "GoogleCloudWKT"}}
@@ -555,7 +555,7 @@ func TestAnnotateMessage_Pagination(t *testing.T) {
 		ProtoTypeName:       "Google_Cloud_Secretmanager_V1_ListSecretsResponse",
 		ModulePath:          "",
 	}
-	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
+	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantResponseImports := []*dependencyImport{{Module: "GoogleCloudGax"}, {Module: "GoogleCloudWKT"}}
@@ -610,7 +610,7 @@ func TestAnnotateMessage_RecursiveNested(t *testing.T) {
 		ProtoTypeName:     "Google_Cloud_Secretmanager_V1_OuterMessage",
 		ModulePath:        "",
 	}
-	if diff := cmp.Diff(wantOuter, gotOuter, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "HasConvertedFields")); diff != "" {
+	if diff := cmp.Diff(wantOuter, gotOuter, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 
@@ -696,81 +696,6 @@ func TestAnnotateMessage_PlaceholderGating(t *testing.T) {
 
 			if !ann.IsGated() {
 				t.Error("expected IsGated() to be true")
-			}
-		})
-	}
-}
-
-func TestAnnotateMessage_HasConvertedFields(t *testing.T) {
-	for _, test := range []struct {
-		name   string
-		fields []*api.Field
-		want   bool
-	}{
-		{
-			name:   "empty_message",
-			fields: []*api.Field{},
-			want:   false,
-		},
-		{
-			name: "singular_field",
-			fields: []*api.Field{
-				{Name: "field1", ID: "1", Typez: api.TypezString},
-			},
-			want: true,
-		},
-		{
-			name: "repeated_field",
-			fields: []*api.Field{
-				{Name: "field1", ID: "1", Typez: api.TypezString, Repeated: true},
-			},
-			want: true,
-		},
-		{
-			name: "map_field",
-			fields: []*api.Field{
-				{Name: "field1", ID: "1", Typez: api.TypezString, Map: true},
-			},
-			want: true,
-		},
-		{
-			name: "oneof_field",
-			fields: []*api.Field{
-				{Name: "field1", ID: "1", Typez: api.TypezString, IsOneOf: true},
-			},
-			want: true,
-		},
-		{
-			name: "map_and_repeated_fields",
-			fields: []*api.Field{
-				{Name: "labels", ID: "1", Typez: api.TypezString, Map: true},
-				{Name: "names", ID: "2", Typez: api.TypezString, Repeated: true},
-			},
-			want: true,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			msg := &api.Message{
-				Name:    "TestMessage",
-				ID:      ".test.TestMessage",
-				Package: "test",
-				Fields:  test.fields,
-			}
-			for _, f := range msg.Fields {
-				f.Parent = msg
-			}
-			model := api.NewTestAPI([]*api.Message{msg}, []*api.Enum{}, []*api.Service{})
-			model.PackageName = "test"
-			codec := newTestCodec(t, model, nil)
-			if err := codec.annotateModel(); err != nil {
-				t.Fatal(err)
-			}
-			ann, ok := msg.Codec.(*messageAnnotations)
-			if !ok {
-				t.Fatalf("expected msg.Codec to be *messageAnnotations, got %T", msg.Codec)
-			}
-			if ann.HasConvertedFields != test.want {
-				t.Errorf("HasConvertedFields = %v, want %v", ann.HasConvertedFields, test.want)
 			}
 		})
 	}

--- a/internal/sidekick/swift/annotate_method_test.go
+++ b/internal/sidekick/swift/annotate_method_test.go
@@ -365,7 +365,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		SampleField:       "pageSize",
 		ParameterTypeName: "ListRequest",
 	}
-	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath", "HasConvertedFields")); diff != "" {
+	if diff := cmp.Diff(wantRequest, gotRequest, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	wantRequestImports := []*dependencyImport{{Module: "GoogleCloudWKT"}}
@@ -384,7 +384,7 @@ func TestAnnotateMethod_Pagination(t *testing.T) {
 		SampleField:         "items",
 		ParameterTypeName:   "ListResponse",
 	}
-	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath", "HasConvertedFields")); diff != "" {
+	if diff := cmp.Diff(wantResponse, gotResponse, cmpopts.IgnoreFields(messageAnnotations{}, "Model", "DependsOn", "ProtoTypeName", "ModulePath")); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	// Response type is a paginated response which depends on gax

--- a/internal/sidekick/swift/templates/convert/convert_message.mustache
+++ b/internal/sidekick/swift/templates/convert/convert_message.mustache
@@ -109,12 +109,12 @@ extension {{Codec.ParameterTypeName}} {
   }
 
   internal func toProto() throws -> ProtoType {
-    {{#Codec.HasConvertedFields}}
+    {{#HasFields}}
     var proto = ProtoType()
-    {{/Codec.HasConvertedFields}}
-    {{^Codec.HasConvertedFields}}
+    {{/HasFields}}
+    {{^HasFields}}
     let proto = ProtoType()
-    {{/Codec.HasConvertedFields}}
+    {{/HasFields}}
     {{#Fields}}
     {{^IsOneOf}}
     {{#Singular}}


### PR DESCRIPTION
This field may have been used in the past, but it looks unused now. Both the true and false variants output the same code in the templates.