### PR TITLE
feat(sidekick/swift): rename DocC landing page

### DIFF
--- a/internal/sidekick/swift/generate.go
+++ b/internal/sidekick/swift/generate.go
@@ -100,7 +100,7 @@ func (c *codec) swiftFilename(basename string) string {
 }
 
 func (c *codec) generateDocc(outdir string, model *api.API, provider language.TemplateProvider) error {
-	output := filepath.Join("Sources", c.LibraryName, c.LibraryName+".docc", c.LibraryName+".md")
+	output := filepath.Join("Sources", c.LibraryName, c.LibraryName+".docc", "Index.md")
 	template := "templates/docc/landing_page.md.mustache"
 	generated := language.GeneratedFile{
 		TemplatePath: template,

--- a/internal/sidekick/swift/generate_landing_page_test.go
+++ b/internal/sidekick/swift/generate_landing_page_test.go
@@ -55,10 +55,13 @@ func TestGenerateLandingPage(t *testing.T) {
 		if err := Generate(t.Context(), model, outDir, library, nil); err != nil {
 			t.Fatal(err)
 		}
-		landing := filepath.Join(outDir, "Sources", "Test", "Test.docc", "Test.md")
+		landing := filepath.Join(outDir, "Sources", "Test", "Test.docc", "Index.md")
 		contentBytes, err := os.ReadFile(landing)
 		if err != nil {
 			t.Fatal(err)
+		}
+		if _, err := os.Stat(filepath.Join(outDir, "Sources", "Test", "Test.docc", "Test.md")); !os.IsNotExist(err) {
+			t.Errorf("expected Test.md to not exist, got %v", err)
 		}
 		content := string(contentBytes)
 


### PR DESCRIPTION
Use `Index.md` instead of the module name. The module name is very long and puts us closer to the maximum path name under Windows.

Towards https://github.com/googleapis/google-cloud-swift/issues/803 