### PR TITLE
feat(sidekick/swift): use `setBody()` helper

### DIFF
--- a/internal/sidekick/swift/templates/http/transport.swift.mustache
+++ b/internal/sidekick/swift/templates/http/transport.swift.mustache
@@ -92,11 +92,11 @@ extension Clients {
       req.addHeader(name: GoogleCloudGax._HeaderNames.apiClient, value: Clients.clientHeader)
       {{#Codec.HasBody}}
       {{#Codec.IsBodyWildcard}}
-      req.setBody(data: try JSONEncoder().encode(request), ofContentType: "application/json")
+      try req.setBody(json: request)
       {{/Codec.IsBodyWildcard}}
       {{^Codec.IsBodyWildcard}}
       if let body = request.{{Codec.BodyField}} {
-        req.setBody(data: try JSONEncoder().encode(body), ofContentType: "application/json")
+        try req.setBody(json: body)
       }
       {{/Codec.IsBodyWildcard}}
       {{/Codec.HasBody}}


### PR DESCRIPTION
Update transport.swift.mustache use `req.setBody(json:)` instead of manual JSONEncoder encoding.

This delegates request JSON serialization to _HTTPClientRequest in GoogleCloudGax. We can then enforce all the ProtoJSON rules in a single place. In this iteration, we want to fix the serialization of floats that are not numbers (such as `NaN` or `Infinity`).

Towards https://github.com/googleapis/google-cloud-swift/issues/796

For expected changes see: https://github.com/googleapis/google-cloud-swift/pull/819
