### PR TITLE
build(.github/workflows): separate node.js integration test into own job

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -19,24 +19,16 @@ jobs:
   build-and-test:
     name: ${{ matrix.job-name }}
     runs-on: ubuntu-24.04
-    # Presubmit jobs must complete within 5 minutes. Integration might take longer.
-    timeout-minutes: ${{ matrix.timeout }}
+    # Presubmit jobs must complete within 5 minutes.
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
         include:
           - job-name: 'Unit Tests'
             task: 'unit-test'
-            timeout: 5
-            sparse: true
           - job-name: 'Smoke Test'
             task: 'smoke-test'
-            timeout: 5
-            sparse: true
-          - job-name: 'Integration Test'
-            task: 'integration'
-            timeout: 60
-            sparse: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -49,7 +41,6 @@ jobs:
         run: |
           echo "npm=$(npm config get prefix)" >> "$GITHUB_OUTPUT"
       - name: "Checkout google-cloud-node (sparse)"
-        if: matrix.sparse
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3        
         with:
           repository: googleapis/google-cloud-node
@@ -60,8 +51,41 @@ jobs:
             google-cloud-secretmanager
           sparse-checkout-cone-mode: false
           persist-credentials: false
+      - name: "Install Node.js dependencies (restore cache)"
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: tools-cache
+        with:
+          path: |
+            ${{ steps.tool-paths.outputs.npm }}
+            ~/.cache/librarian
+          key: nodejs-tools-v4-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-node/librarian.yaml') }}
+      - name: "Install Node.js dependencies (run librarian install)"
+        if: steps.tools-cache.outputs.cache-hit != 'true'
+        run: librarian -v install nodejs
+        working-directory: google-cloud-node
+      - name: Run tests
+        if: matrix.task == 'unit-test'
+        run: go run ./tool/cmd/coverage ./internal/librarian/nodejs
+      - name: Generate a single library (smoke test)
+        if: matrix.task == 'smoke-test'
+        working-directory: google-cloud-node
+        run: librarian generate google-cloud-secretmanager
+  integration-test:
+    name: Integration test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-librarian
+        with:
+          include_pnpm: 'true'
+      - name: "Install Node.js dependencies (resolve cache paths)"
+        id: tool-paths
+        run: |
+          echo "npm=$(npm config get prefix)" >> "$GITHUB_OUTPUT"
       - name: "Checkout google-cloud-node (full)"
-        if: matrix.sparse == false && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: googleapis/google-cloud-node
@@ -76,22 +100,14 @@ jobs:
             ~/.cache/librarian
           key: nodejs-tools-v4-${{ hashFiles('internal/config/**/*.go') }}-${{ hashFiles('google-cloud-node/librarian.yaml') }}
       - name: "Install Node.js dependencies (run librarian install)"
-        if: (steps.tools-cache.outputs.cache-hit != 'true' || matrix.task == 'integration') && (matrix.task != 'integration' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+        if: steps.tools-cache.outputs.cache-hit != 'true'
         run: librarian -v install nodejs
         working-directory: google-cloud-node
-      - name: Run tests
-        if: matrix.task == 'unit-test'
-        run: go run ./tool/cmd/coverage ./internal/librarian/nodejs
-      - name: Generate a single library (smoke test)
-        if: matrix.task == 'smoke-test' && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
-        working-directory: google-cloud-node
-        run: librarian generate google-cloud-secretmanager
-      - name: Run librarian generate all (integration test)
-        if: matrix.task == 'integration' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Generate all libraries (integration test)
         working-directory: google-cloud-node
         run: librarian generate --all
   create-issue-on-failure:
-    needs: [build-and-test]
+    needs: [build-and-test, integration-test]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -72,6 +72,7 @@ jobs:
         run: librarian generate google-cloud-secretmanager
   integration-test:
     name: Integration test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Move the Node.js integration test out of the build-and-test presubmit matrix into a dedicated integration-test job.

Previously, including the integration test in the presubmit matrix resulted in an extra matrix job scheduled during presubmit runs on pull requests that did not execute generation. Removing it from the matrix simplifies the presubmit timeout to five minutes and eliminates conditional checkout steps. Also update create-issue-on-failure to monitor both jobs.

Fixes #7484
