### PR TITLE
fix(sidekick/swift): normalize monorepo root to forward slashes

### DIFF
--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -79,7 +79,7 @@ type codec struct {
 	// The package version (e.g. "1.2.3").
 	PackageVersion string
 
-	// The location of the monorepo, relative to the current directory. This
+	// The location of the monorepo, relative to the output directory. This
 	// always uses forward slashes, as it is interpolated into the generated
 	// Package.swift manifest.
 	//

--- a/internal/sidekick/swift/codec.go
+++ b/internal/sidekick/swift/codec.go
@@ -79,7 +79,9 @@ type codec struct {
 	// The package version (e.g. "1.2.3").
 	PackageVersion string
 
-	// The location of the monorepo, relative to the current directory.
+	// The location of the monorepo, relative to the current directory. This
+	// always uses forward slashes, as it is interpolated into the generated
+	// Package.swift manifest.
 	//
 	// Recall that sidekick only generates clients within a monorepo, so this
 	// always makes sense.
@@ -206,7 +208,7 @@ func newCodec(model *api.API, library *config.Library, module *config.SwiftModul
 		PackageName:        packageName,
 		PackageRepoName:    packageRepoName,
 		PackageVersion:     packageVersion,
-		MonorepoRoot:       rel,
+		MonorepoRoot:       filepath.ToSlash(rel),
 		ApiPackages:        map[string]*Dependency{},
 		DependenciesByName: map[string]*Dependency{},
 		UrlSafeForBytes:    library.SpecificationFormat == config.SpecDiscovery,


### PR DESCRIPTION
Fixes #7565.

`newCodec` assigns `MonorepoRoot` from `filepath.Rel`, which returns OS-native separators, and `Package.swift.mustache:58` interpolates it into a path literal. On Windows the generated dependency line becomes `.package(path: "..\../packages/gax")`.

`filepath.ToSlash` returns its argument unchanged when the separator is already `/` (`internal/filepathlite/path.go:176`), so Linux and macOS output does not change. The repo already uses this call in 27 non-test places for the same job.

Fail before, with only that assignment reverted:

```
--- FAIL: TestGeneratePackageSwift_WithDependencies (0.04s)
    generate_package_swift_test.go:79: mismatch (-want +got)
        - "/"
        + `\`
```

After, the whole package is `ok`.

`TestAddLicense`, `TestGoImports`, `TestGolangCILint`, `gofmt -l` and `go vet` pass. `TestYAMLFormat` fails on `.gemini/config.yaml` identically with and without this change.

Tested on Windows only.
