### PR TITLE
build(.github/workflows): remove redundant pandoc install from python CI

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -36,14 +36,6 @@ jobs:
       - uses: ./.github/actions/setup-librarian
         with:
           include_python: 'true'
-      - name: Install pandoc
-        run: |
-          set -e
-          curl -fsSL --retry 5 --retry-delay 15 -o /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/$VERSION/pandoc-$VERSION-linux-amd64.tar.gz
-          sudo tar -xvf /tmp/pandoc.tar.gz -C /usr/local --strip-components=1
-          pandoc --version
-        env:
-          VERSION: 3.8.2
       - name: "Checkout google-cloud-python (sparse)"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -78,14 +70,6 @@ jobs:
       - uses: ./.github/actions/setup-librarian
         with:
           include_python: 'true'
-      - name: Install pandoc
-        run: |
-          set -e
-          curl -fsSL --retry 5 --retry-delay 15 -o /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/$VERSION/pandoc-$VERSION-linux-amd64.tar.gz
-          sudo tar -xvf /tmp/pandoc.tar.gz -C /usr/local --strip-components=1
-          pandoc --version
-        env:
-          VERSION: 3.8.2
       - name: "Checkout google-cloud-python (full)"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
Remove the manual Pandoc installation steps from the build-and-test and integration-test jobs.

Now that google-cloud-python pins pypandoc-binary in librarian.yaml, running librarian install python provisions the bundled Pandoc binary automatically, making manual system installation unnecessary.

For https://github.com/googleapis/librarian/issues/5818