### PR TITLE
fix(sidekick/swift): serialize enums as strings in ProtoJSON

### DIFF
--- a/internal/sidekick/swift/generate_enum_swift_test.go
+++ b/internal/sidekick/swift/generate_enum_swift_test.go
@@ -101,6 +101,20 @@ func TestGenerateEnum_UniqueNumbers(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
+
+	gotEncode := extractBlock(t, string(contentsB), "public func encode(to encoder: Encoder) throws {", "\n  }")
+	wantEncode := `public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .test: return try container.encode("KIND_TEST")
+    case .otherTest: return try container.encode("KIND_OTHER_TEST")
+    case .unknownIntValue(let v): return try container.encode(v)
+    case .unknownStringValue(let v): return try container.encode(v)
+    }
+  }`
+	if diff := cmp.Diff(wantEncode, gotEncode); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestGenerateEnum_DocComments(t *testing.T) {

--- a/internal/sidekick/swift/templates/common/enum.mustache
+++ b/internal/sidekick/swift/templates/common/enum.mustache
@@ -118,7 +118,7 @@ public enum {{Codec.Name}}: Codable, Equatable, Sendable {
     var container = encoder.singleValueContainer()
     switch self {
     {{#UniqueNumberValues}}
-    case .{{Codec.CaseName}}: return try container.encode({{Number}})
+    case .{{Codec.CaseName}}: return try container.encode("{{Name}}")
     {{/UniqueNumberValues}}
     case .{{Codec.UnknownIntName}}(let v): return try container.encode(v)
     case .{{Codec.UnknownStringName}}(let v): return try container.encode(v)


### PR DESCRIPTION
Change Swift enum generation to serialize enum cases as their proto
string names instead of integer numbers, in conformance with the
Proto3 JSON specification.

References googleapis/google-cloud-swift#823

For the expected output, see https://github.com/googleapis/google-cloud-swift/pull/829 