### PR TITLE
cleanup(internal/postprocessing): remove duplicate method operation action

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -176,16 +176,16 @@ This document describes the schema for the librarian.yaml.
 | `replace_regex` | list of [ReplaceRegexConfig](#replaceregexconfig-configuration) | Contains regular expression replacement rules. |
 | `copy_file` | list of [CopyConfig](#copyconfig-configuration) | Contains file copy rules. |
 | `remove_file` | list of string | Contains glob patterns of files to remove. |
-| `method_operations` | list of [MethodOperation](#methodoperation-configuration) | Contains method-level operations (`delete`, `copy_and_rename`, `duplicate`, `deprecate`). |
+| `method_operations` | list of [MethodOperation](#methodoperation-configuration) | Contains method-level operations (`delete`, `copy_and_rename`, `deprecate`). |
 
 ## MethodOperation Configuration
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `path` | string | Specifies the relative file path to modify. |
-| `action` | string | Specifies the operation (`delete`, `copy_and_rename`, `duplicate`, or `deprecate`). |
+| `action` | string | Specifies the operation (`delete`, `copy_and_rename`, or `deprecate`). |
 | `func_name` | string | Specifies the target method name. |
-| `new_name` | string | Specifies the new method name for copy_and_rename or duplicate operations. |
+| `new_name` | string | Specifies the new method name for copy_and_rename operations. |
 | `deprecation_message` | string | Specifies the deprecation message for deprecate operations. |
 
 ## ReplaceConfig Configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -433,22 +433,22 @@ type Postprocess struct {
 	// RemoveFile contains glob patterns of files to remove.
 	RemoveFile []string `yaml:"remove_file,omitempty"`
 
-	// MethodOperations contains method-level operations (`delete`, `copy_and_rename`, `duplicate`, `deprecate`).
+	// MethodOperations contains method-level operations (`delete`, `copy_and_rename`, `deprecate`).
 	MethodOperations []MethodOperation `yaml:"method_operations,omitempty"`
 }
 
-// MethodOperation represents a method-level operation like delete, copy_and_rename, duplicate, or deprecate.
+// MethodOperation represents a method-level operation like delete, copy_and_rename, or deprecate.
 type MethodOperation struct {
 	// Path specifies the relative file path to modify.
 	Path string `yaml:"path"`
 
-	// Action specifies the operation (`delete`, `copy_and_rename`, `duplicate`, or `deprecate`).
+	// Action specifies the operation (`delete`, `copy_and_rename`, or `deprecate`).
 	Action string `yaml:"action"`
 
 	// FuncName specifies the target method name.
 	FuncName string `yaml:"func_name"`
 
-	// NewName specifies the new method name for copy_and_rename or duplicate operations.
+	// NewName specifies the new method name for copy_and_rename operations.
 	NewName string `yaml:"new_name,omitempty"`
 
 	// DeprecationMessage specifies the deprecation message for deprecate operations.

--- a/internal/postprocessing/fileops.go
+++ b/internal/postprocessing/fileops.go
@@ -194,7 +194,7 @@ func ApplyMethodOperations(outDir string, methodOperations []config.MethodOperat
 				if err := DeleteMethod(file, mo.FuncName, "java"); err != nil {
 					return fmt.Errorf("failed to delete method %q in %s: %w", mo.FuncName, file, err)
 				}
-			case "copy_and_rename", "duplicate":
+			case "copy_and_rename":
 				if err := DuplicateMethod(file, mo.FuncName, mo.NewName, "java"); err != nil {
 					return fmt.Errorf("failed to copy and rename method %q in %s: %w", mo.FuncName, file, err)
 				}

--- a/internal/postprocessing/fileops_test.go
+++ b/internal/postprocessing/fileops_test.go
@@ -785,20 +785,6 @@ func TestApplyMethodOperations(t *testing.T) {
 			},
 			ops: []config.MethodOperation{
 				{Path: "*.java", Action: "delete", FuncName: "public void toDelete()"},
-				{Path: "*.java", Action: "duplicate", FuncName: "public void newFunc()", NewName: "newFuncCopy"},
-				{Path: "*.java", Action: "deprecate", FuncName: "public void newFuncCopy()", DeprecationMessage: "Use newFunc instead."},
-			},
-			wantFiles: map[string]string{
-				"Test.java": "package com.example;\n\npublic class Test {\n\tpublic void newFunc() {}\n\n\t/**\n\t * @deprecated Use newFunc instead.\n\t */\n\t@Deprecated\n\tpublic void newFuncCopy() {}\n}",
-			},
-		},
-		{
-			name: "single file sequential operations with copy_and_rename",
-			files: map[string]string{
-				"Test.java": "package com.example;\n\npublic class Test {\n\tpublic void toDelete() {}\n\tpublic void newFunc() {}\n}",
-			},
-			ops: []config.MethodOperation{
-				{Path: "*.java", Action: "delete", FuncName: "public void toDelete()"},
 				{Path: "*.java", Action: "copy_and_rename", FuncName: "public void newFunc()", NewName: "newFuncCopy"},
 				{Path: "*.java", Action: "deprecate", FuncName: "public void newFuncCopy()", DeprecationMessage: "Use newFunc instead."},
 			},
@@ -859,6 +845,12 @@ func TestApplyMethodOperations_Error(t *testing.T) {
 			name:    "unsupported action",
 			files:   map[string]string{"Test.java": "public class Test {}"},
 			ops:     []config.MethodOperation{{Path: "*.java", Action: "invalid_action", FuncName: "public void foo()"}},
+			wantErr: errUnsupportedMethodAction,
+		},
+		{
+			name:    "removed duplicate action",
+			files:   map[string]string{"Test.java": "public class Test {}"},
+			ops:     []config.MethodOperation{{Path: "*.java", Action: "duplicate", FuncName: "public void foo()", NewName: "bar"}},
 			wantErr: errUnsupportedMethodAction,
 		},
 	} {


### PR DESCRIPTION
The duplicate action was an alias kept for backwards compatibility while google-cloud-java migrated its librarian.yaml to copy_and_rename. That migration is complete, so the alias is removed and duplicate is now rejected as an unsupported action.

Fixes https://github.com/googleapis/librarian/issues/7073