### PR TITLE
feat(sidekick/swift): pass request options to newRequest

### DIFF
--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -171,6 +171,16 @@ func TestGenerateService_Delegation(t *testing.T) {
 			t.Errorf("expected %q in IAM.swift, got:\n%s", want, contentStr)
 		}
 	}
+
+	transportFilename := filepath.Join(outDir, "Sources", "GoogleCloudTestV1", "IAM+Transport.swift")
+	transportContent, err := os.ReadFile(transportFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNewRequest := "var req = try await self.inner.newRequest(path: path, query: query, options: options)"
+	if !strings.Contains(string(transportContent), wantNewRequest) {
+		t.Errorf("expected %q in IAM+Transport.swift, got:\n%s", wantNewRequest, string(transportContent))
+	}
 }
 
 func TestGenerateService_SnippetFiles(t *testing.T) {

--- a/internal/sidekick/swift/generate_service_swift_test.go
+++ b/internal/sidekick/swift/generate_service_swift_test.go
@@ -178,7 +178,7 @@ func TestGenerateService_Delegation(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantNewRequest := "var req = try await self.inner.newRequest(path: path, query: query, options: options)"
-	if !strings.Contains(string(transportContent), wantNewRequest) {
+	if !bytes.Contains(transportContent, []byte(wantNewRequest)) {
 		t.Errorf("expected %q in IAM+Transport.swift, got:\n%s", wantNewRequest, string(transportContent))
 	}
 }

--- a/internal/sidekick/swift/templates/http/transport.swift.mustache
+++ b/internal/sidekick/swift/templates/http/transport.swift.mustache
@@ -87,7 +87,7 @@ extension Clients {
       query.append(contentsOf: try encoder.encode(request.{{Codec.Name}}, prefix: "{{JSONName}}"))
       {{/IsOneOf}}
       {{/Codec.QueryParams}}
-      var req = try await self.inner.newRequest(path: path, query: query)
+      var req = try await self.inner.newRequest(path: path, query: query, options: options)
       req.setMethod(.{{Codec.HTTPMethod}})
       req.addHeader(name: GoogleCloudGax._HeaderNames.apiClient, value: Clients.clientHeader)
       {{#Codec.HasBody}}


### PR DESCRIPTION
Allow passing request options to `newRequest`. This allows the transport to configure the `userProject` and other configured headers.

Towards https://github.com/googleapis/google-cloud-swift/issues/785