### PR TITLE
feat(internal/librarian/nodejs): support excluding protos from generation

### DIFF
--- a/doc/config-schema.md
+++ b/doc/config-schema.md
@@ -428,6 +428,7 @@ This document describes the schema for the librarian.yaml.
 | :--- | :--- | :--- |
 | `additional_protos` | list of string | Is a list of additional proto files to include in generation. |
 | `diregapic` | bool | Indicates whether generation uses DIREGAPIC (Discovery REST GAPICs). This is typically false. Used for the GCE (compute) client. |
+| `exclude_protos` | list of string | Is a list of proto files to exclude from generation. It expects the full path starting from the root of the googleapis directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto"). |
 | `mixins` | string | Controls mixin behavior for this API (e.g., "none" to disable). When set, this overrides the package-level mixins setting. |
 | `omit_common_resources` | bool | Indicates whether to omit the default inclusion of google/cloud/common_resources.proto. |
 | `path` | string | Is the source path. |

--- a/internal/config/language.go
+++ b/internal/config/language.go
@@ -848,6 +848,11 @@ type NodejsAPI struct {
 	// This is typically false. Used for the GCE (compute) client.
 	DIREGAPIC bool `yaml:"diregapic,omitempty"`
 
+	// ExcludeProtos is a list of proto files to exclude from generation.
+	// It expects the full path starting from the root of the googleapis
+	// directory (e.g., "google/cloud/aiplatform/v1/schema/io_format.proto").
+	ExcludeProtos []string `yaml:"exclude_protos,omitempty"`
+
 	// Mixins controls mixin behavior for this API (e.g., "none" to disable).
 	// When set, this overrides the package-level mixins setting.
 	Mixins string `yaml:"mixins,omitempty"`

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -195,6 +195,9 @@ func resolveNodejsAPI(library *config.Library, api *config.API) *config.NodejsAP
 	if library.Nodejs != nil {
 		protos = append(protos, library.Nodejs.AdditionalProtos...)
 	}
+	if api.Nodejs != nil {
+		protos = append(protos, api.Nodejs.AdditionalProtos...)
+	}
 	res.AdditionalProtos = unique(protos)
 	return res
 }

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -205,22 +205,22 @@ func resolveNodejsAPI(library *config.Library, api *config.API) *config.NodejsAP
 		}
 		res.OmitCommonResources = api.Nodejs.OmitCommonResources
 	}
-
 	var protos []string
 	if !omitCommon {
 		protos = append(protos, cloudCommonResourcesProto)
 	}
-
 	// Add package-level additional protos.
 	if library.Nodejs != nil {
 		protos = append(protos, library.Nodejs.AdditionalProtos...)
 	}
-
-	// Add API-level additional protos.
 	if api.Nodejs != nil {
 		protos = append(protos, api.Nodejs.AdditionalProtos...)
+		for _, excluded := range api.Nodejs.ExcludeProtos {
+			protos = slices.DeleteFunc(protos, func(p string) bool {
+				return p == excluded
+			})
+		}
 	}
-
 	res.AdditionalProtos = unique(protos)
 	return res
 }

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -218,7 +218,7 @@ func collectProtos(absGoogleapisDir string, nodejsAPI *config.NodejsAPI) ([]stri
 	apiDir := filepath.Join(absGoogleapisDir, nodejsAPI.Path)
 	protos, err := filepath.Glob(apiDir + "/*.proto")
 	if err != nil {
-		return nil, fmt.Errorf("failed to find protos: %w", err)
+		return nil, fmt.Errorf("ailed to match proto pattern: %w", err)
 	}
 	if len(protos) == 0 {
 		return nil, fmt.Errorf("no protos found in api %q", nodejsAPI.Path)

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -138,19 +138,15 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 	if _, err := requireCachedTool("gapic-node-processing"); err != nil {
 		return err
 	}
-
 	stagingDir := filepath.Join(params.repoRoot, "owl-bot-staging", params.library.Name, buildStagingSubdirName(params.apiIndex, params.api.Path))
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}
-
 	nodejsAPI := resolveNodejsAPI(params.library, params.api)
-
 	absGoogleapisDir, err := filepath.Abs(params.googleapisDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve googleapis directory path: %w", err)
 	}
-
 	apiDir := filepath.Join(absGoogleapisDir, params.api.Path)
 	protos, err := filepath.Glob(apiDir + "/*.proto")
 	if err != nil {
@@ -166,10 +162,11 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 		}
 		protos[index] = rel
 	}
-
 	// Add additional protos from configuration.
 	protos = append(protos, nodejsAPI.AdditionalProtos...)
-
+	protos = slices.DeleteFunc(protos, func(p string) bool {
+		return slices.Contains(nodejsAPI.ExcludeProtos, p)
+	})
 	args, err := buildGeneratorArgs(buildGeneratorArgsParams{
 		generatorPath: generatorPath,
 		protoc:        params.protoc,
@@ -212,14 +209,6 @@ func resolveNodejsAPI(library *config.Library, api *config.API) *config.NodejsAP
 	// Add package-level additional protos.
 	if library.Nodejs != nil {
 		protos = append(protos, library.Nodejs.AdditionalProtos...)
-	}
-	if api.Nodejs != nil {
-		protos = append(protos, api.Nodejs.AdditionalProtos...)
-		for _, excluded := range api.Nodejs.ExcludeProtos {
-			protos = slices.DeleteFunc(protos, func(p string) bool {
-				return p == excluded
-			})
-		}
 	}
 	res.AdditionalProtos = unique(protos)
 	return res

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -147,26 +147,10 @@ func generateAPI(ctx context.Context, params generateAPIParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve googleapis directory path: %w", err)
 	}
-	apiDir := filepath.Join(absGoogleapisDir, params.api.Path)
-	protos, err := filepath.Glob(apiDir + "/*.proto")
+	protos, err := collectProtos(absGoogleapisDir, nodejsAPI)
 	if err != nil {
-		return fmt.Errorf("failed to find protos: %w", err)
+		return err
 	}
-	if len(protos) == 0 {
-		return fmt.Errorf("no protos found in api %q", params.api.Path)
-	}
-	for index := range protos {
-		rel, err := filepath.Rel(absGoogleapisDir, protos[index])
-		if err != nil {
-			return fmt.Errorf("failed to make path %s relative: %w", protos[index], err)
-		}
-		protos[index] = rel
-	}
-	// Add additional protos from configuration.
-	protos = append(protos, nodejsAPI.AdditionalProtos...)
-	protos = slices.DeleteFunc(protos, func(p string) bool {
-		return slices.Contains(nodejsAPI.ExcludeProtos, p)
-	})
 	args, err := buildGeneratorArgs(buildGeneratorArgsParams{
 		generatorPath: generatorPath,
 		protoc:        params.protoc,
@@ -195,6 +179,7 @@ func resolveNodejsAPI(library *config.Library, api *config.API) *config.NodejsAP
 	}
 	omitCommon := false
 	if api.Nodejs != nil {
+		res.ExcludeProtos = append(res.ExcludeProtos, api.Nodejs.ExcludeProtos...)
 		omitCommon = api.Nodejs.OmitCommonResources
 		res.DIREGAPIC = api.Nodejs.DIREGAPIC
 		if api.Nodejs.Mixins != "" {
@@ -224,6 +209,29 @@ func unique(ss []string) []string {
 		}
 	}
 	return res
+}
+
+func collectProtos(absGoogleapisDir string, nodejsAPI *config.NodejsAPI) ([]string, error) {
+	apiDir := filepath.Join(absGoogleapisDir, nodejsAPI.Path)
+	protos, err := filepath.Glob(apiDir + "/*.proto")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find protos: %w", err)
+	}
+	if len(protos) == 0 {
+		return nil, fmt.Errorf("no protos found in api %q", nodejsAPI.Path)
+	}
+	for index := range protos {
+		rel, err := filepath.Rel(absGoogleapisDir, protos[index])
+		if err != nil {
+			return nil, fmt.Errorf("failed to make path %s relative: %w", protos[index], err)
+		}
+		protos[index] = rel
+	}
+	protos = append(protos, nodejsAPI.AdditionalProtos...)
+	protos = slices.DeleteFunc(protos, func(p string) bool {
+		return slices.Contains(nodejsAPI.ExcludeProtos, p)
+	})
+	return protos, nil
 }
 
 type buildGeneratorArgsParams struct {

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1624,40 +1624,6 @@ func TestResolveNodejsAPI(t *testing.T) {
 				AdditionalProtos:    []string{"pkg.proto", "dup.proto", "api.proto"},
 			},
 		},
-		{
-			name: "excludes package-level and api-level additional protos",
-			library: &config.Library{
-				Nodejs: &config.NodejsPackage{
-					AdditionalProtos: []string{"pkg1.proto", "pkg2.proto"},
-				},
-			},
-			api: &config.API{
-				Path: "google/cloud/secretmanager/v1",
-				Nodejs: &config.NodejsAPI{
-					AdditionalProtos: []string{"api1.proto", "api2.proto"},
-					ExcludeProtos:    []string{"pkg1.proto", "api2.proto"},
-				},
-			},
-			want: &config.NodejsAPI{
-				Path:             "google/cloud/secretmanager/v1",
-				AdditionalProtos: []string{cloudCommonResourcesProto, "pkg2.proto", "api1.proto"},
-			},
-		},
-		{
-			name:    "excludes non-matching proto is no-op",
-			library: &config.Library{},
-			api: &config.API{
-				Path: "google/cloud/secretmanager/v1",
-				Nodejs: &config.NodejsAPI{
-					AdditionalProtos: []string{"api.proto"},
-					ExcludeProtos:    []string{"nonexistent.proto"},
-				},
-			},
-			want: &config.NodejsAPI{
-				Path:             "google/cloud/secretmanager/v1",
-				AdditionalProtos: []string{cloudCommonResourcesProto, "api.proto"},
-			},
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := resolveNodejsAPI(test.library, test.api)

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1624,6 +1624,62 @@ func TestResolveNodejsAPI(t *testing.T) {
 				AdditionalProtos:    []string{"pkg.proto", "dup.proto", "api.proto"},
 			},
 		},
+		{
+			name:    "exclude protos preserved",
+			library: &config.Library{},
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Nodejs: &config.NodejsAPI{
+					ExcludeProtos: []string{"exclude1.proto", "exclude2.proto"},
+				},
+			},
+			want: &config.NodejsAPI{
+				Path:             "google/cloud/secretmanager/v1",
+				AdditionalProtos: []string{cloudCommonResourcesProto},
+				ExcludeProtos:    []string{"exclude1.proto", "exclude2.proto"},
+			},
+		},
+		{
+			name:    "mixins preserved",
+			library: &config.Library{},
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Nodejs: &config.NodejsAPI{
+					Mixins: "none",
+				},
+			},
+			want: &config.NodejsAPI{
+				Path:             "google/cloud/secretmanager/v1",
+				AdditionalProtos: []string{cloudCommonResourcesProto},
+				Mixins:           "none",
+			},
+		},
+		{
+			name: "package-level and api-level with all fields",
+			library: &config.Library{
+				Nodejs: &config.NodejsPackage{
+					AdditionalProtos: []string{"pkg.proto"},
+				},
+			},
+			api: &config.API{
+				Path: "google/cloud/compute/v1",
+				Nodejs: &config.NodejsAPI{
+					DIREGAPIC:           true,
+					Mixins:              "none",
+					OmitCommonResources: true,
+					AdditionalProtos:    []string{"api.proto"},
+					ExcludeProtos:       []string{"exclude.proto"},
+				},
+			},
+			want: &config.NodejsAPI{
+				Path:                "google/cloud/compute/v1",
+				DIREGAPIC:           true,
+				Mixins:              "none",
+				OmitCommonResources: true,
+				AdditionalProtos:    []string{"pkg.proto", "api.proto"},
+				ExcludeProtos:       []string{"exclude.proto"},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := resolveNodejsAPI(test.library, test.api)

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1690,6 +1690,93 @@ func TestResolveNodejsAPI(t *testing.T) {
 	}
 }
 
+func TestCollectProtos(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name       string
+		setupFiles []string
+		nodejsAPI  *config.NodejsAPI
+		want       []string
+	}{
+		{
+			name: "collects protos from api directory",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+			nodejsAPI: &config.NodejsAPI{
+				Path: "google/cloud/secretmanager/v1",
+			},
+			want: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+		{
+			name: "appends additional protos",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+			nodejsAPI: &config.NodejsAPI{
+				Path:             "google/cloud/secretmanager/v1",
+				AdditionalProtos: []string{"google/cloud/common_resources.proto"},
+			},
+			want: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+				"google/cloud/common_resources.proto",
+			},
+		},
+		{
+			name: "excludes protos from api directory",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/resources.proto",
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+			nodejsAPI: &config.NodejsAPI{
+				Path:          "google/cloud/secretmanager/v1",
+				ExcludeProtos: []string{"google/cloud/secretmanager/v1/resources.proto"},
+			},
+			want: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+		{
+			name: "excludes non-matching proto is no-op",
+			setupFiles: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+			nodejsAPI: &config.NodejsAPI{
+				Path:          "google/cloud/secretmanager/v1",
+				ExcludeProtos: []string{"nonexistent.proto"},
+			},
+			want: []string{
+				"google/cloud/secretmanager/v1/service.proto",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			googleapisDir := t.TempDir()
+			for _, file := range test.setupFiles {
+				path := filepath.Join(googleapisDir, file)
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte("syntax = \"proto3\";"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := collectProtos(googleapisDir, test.nodejsAPI)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestInjectV1SmallExports(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -1624,6 +1624,40 @@ func TestResolveNodejsAPI(t *testing.T) {
 				AdditionalProtos:    []string{"pkg.proto", "dup.proto", "api.proto"},
 			},
 		},
+		{
+			name: "excludes package-level and api-level additional protos",
+			library: &config.Library{
+				Nodejs: &config.NodejsPackage{
+					AdditionalProtos: []string{"pkg1.proto", "pkg2.proto"},
+				},
+			},
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Nodejs: &config.NodejsAPI{
+					AdditionalProtos: []string{"api1.proto", "api2.proto"},
+					ExcludeProtos:    []string{"pkg1.proto", "api2.proto"},
+				},
+			},
+			want: &config.NodejsAPI{
+				Path:             "google/cloud/secretmanager/v1",
+				AdditionalProtos: []string{cloudCommonResourcesProto, "pkg2.proto", "api1.proto"},
+			},
+		},
+		{
+			name:    "excludes non-matching proto is no-op",
+			library: &config.Library{},
+			api: &config.API{
+				Path: "google/cloud/secretmanager/v1",
+				Nodejs: &config.NodejsAPI{
+					AdditionalProtos: []string{"api.proto"},
+					ExcludeProtos:    []string{"nonexistent.proto"},
+				},
+			},
+			want: &config.NodejsAPI{
+				Path:             "google/cloud/secretmanager/v1",
+				AdditionalProtos: []string{cloudCommonResourcesProto, "api.proto"},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := resolveNodejsAPI(test.library, test.api)


### PR DESCRIPTION
An `exclude_protos` option is added to NodejsAPI configuration, allowing APIs to exclude specific proto files from generation.

We plan to use `proto.Gather` to collect protos for code generation. However, `aiplatform` excludes `google/cloud/aiplatform/v1beta1/schema/io_format.proto`, thus we need this configuration before further refactor.

This change let the nodejs configurations align with other languages.

For #7217