### PR TITLE
chore(internal/librarian/nodejs): derive package names in defaults

### DIFF
--- a/internal/librarian/library.go
+++ b/internal/librarian/library.go
@@ -379,6 +379,8 @@ func fillLibraryDefaults(language string, lib *config.Library) (*config.Library,
 		return php.Fill(lib), nil
 	case config.LanguagePython:
 		return python.Fill(lib)
+	case config.LanguageNodejs:
+		return nodejs.Fill(lib), nil
 	default:
 		return lib, nil
 	}

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -864,8 +864,12 @@ func TestApplyDefaults_Nodejs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Nodejs == nil || got.Nodejs.PackageName != "@google-cloud/secretmanager" {
-		t.Errorf("got package name %v, want %q", got.Nodejs, "@google-cloud/secretmanager")
+	if got.Nodejs == nil {
+		t.Error("got.Nodejs is nil")
+		return
+	}
+	if got.Nodejs.PackageName != "@google-cloud/secretmanager" {
+		t.Errorf("got package name %q, want %q", got.Nodejs.PackageName, "@google-cloud/secretmanager")
 	}
 }
 

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -865,7 +865,7 @@ func TestApplyDefaults_Nodejs(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got.Nodejs == nil {
-		t.Error("got.Nodejs is nil")
+		t.Fatal("got.Nodejs is nil")
 		return
 	}
 	if got.Nodejs.PackageName != "@google-cloud/secretmanager" {

--- a/internal/librarian/library_test.go
+++ b/internal/librarian/library_test.go
@@ -855,6 +855,20 @@ func TestApplyDefaults_Error(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_Nodejs(t *testing.T) {
+	lib := &config.Library{
+		Name: "google-cloud-secretmanager",
+		APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+	}
+	got, err := applyDefaults(config.LanguageNodejs, lib, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Nodejs == nil || got.Nodejs.PackageName != "@google-cloud/secretmanager" {
+		t.Errorf("got package name %v, want %q", got.Nodejs, "@google-cloud/secretmanager")
+	}
+}
+
 func TestCanDeriveAPIPath(t *testing.T) {
 	for _, test := range []struct {
 		name     string

--- a/internal/librarian/nodejs/default.go
+++ b/internal/librarian/nodejs/default.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"strings"
+
+	"github.com/googleapis/librarian/internal/config"
+)
+
+// Fill populates Node.js-specific default values for the library.
+// For standard Google Cloud libraries (prefixed with "google-cloud-"), it derives
+// the package name as "@google-cloud/<suffix>". Non-cloud packages are not filled
+// and must be populated during "librarian add" (via custom_package_prefixes) or
+// configured explicitly in librarian.yaml.
+func Fill(lib *config.Library) *config.Library {
+	if lib.Nodejs != nil && lib.Nodejs.PackageName != "" {
+		return lib
+	}
+	if suffix, ok := strings.CutPrefix(lib.Name, "google-cloud-"); ok && suffix != "" {
+		if lib.Nodejs == nil {
+			lib.Nodejs = &config.NodejsPackage{}
+		}
+		lib.Nodejs.PackageName = "@google-cloud/" + suffix
+	}
+	return lib
+}

--- a/internal/librarian/nodejs/default_test.go
+++ b/internal/librarian/nodejs/default_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/librarian/internal/config"
+)
+
+func TestFill(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   *config.Library
+		want *config.Library
+	}{
+		{
+			name: "cloud library derives package name",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager",
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager",
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@google-cloud/secretmanager",
+				},
+			},
+		},
+		{
+			name: "cloud library with existing nodejs config preserves other fields",
+			in: &config.Library{
+				Name: "google-cloud-monitoring",
+				Nodejs: &config.NodejsPackage{
+					DefaultVersion: "v1",
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-monitoring",
+				Nodejs: &config.NodejsPackage{
+					DefaultVersion: "v1",
+					PackageName:    "@google-cloud/monitoring",
+				},
+			},
+		},
+		{
+			name: "preserves explicit package name",
+			in: &config.Library{
+				Name: "google-cloud-secretmanager",
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@custom/override",
+				},
+			},
+			want: &config.Library{
+				Name: "google-cloud-secretmanager",
+				Nodejs: &config.NodejsPackage{
+					PackageName: "@custom/override",
+				},
+			},
+		},
+		{
+			name: "non-cloud library leaves package name empty",
+			in: &config.Library{
+				Name: "google-apps-meet",
+			},
+			want: &config.Library{
+				Name: "google-apps-meet",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Fill(test.in)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -41,6 +41,11 @@ const (
 	protosPathPrefix          = "protos/"
 )
 
+var (
+	errToolNotInstalled    = errors.New("tool not installed in librarian cache")
+	errPackageNameRequired = errors.New("nodejs.package_name is required; non-cloud libraries must be configured in librarian.yaml or populated during librarian add")
+)
+
 // IsMixedLibrary reports whether the library has handwritten code wrapping
 // generated or librarian-managed code.
 func IsMixedLibrary(lib *config.Library) bool {
@@ -95,11 +100,6 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 
 	return nil
 }
-
-var (
-	errToolNotInstalled    = errors.New("tool not installed in librarian cache")
-	errPackageNameRequired = errors.New("nodejs.package_name is required; non-cloud libraries must be configured in librarian.yaml or populated during librarian add")
-)
 
 func requireCachedTool(toolName string) (string, error) {
 	binDir, err := getBinDir()

--- a/internal/librarian/nodejs/generate.go
+++ b/internal/librarian/nodejs/generate.go
@@ -49,6 +49,9 @@ func IsMixedLibrary(lib *config.Library) bool {
 
 // Generate generates a Node.js client library.
 func Generate(ctx context.Context, cfg *config.Config, library *config.Library, srcs *sources.Sources) error {
+	if library.Nodejs == nil || library.Nodejs.PackageName == "" {
+		return fmt.Errorf("library %q: %w", library.Name, errPackageNameRequired)
+	}
 	googleapisDir := srcs.Googleapis
 	outdir, err := filepath.Abs(library.Output)
 	if err != nil {
@@ -94,7 +97,8 @@ func Generate(ctx context.Context, cfg *config.Config, library *config.Library, 
 }
 
 var (
-	errToolNotInstalled = errors.New("tool not installed in librarian cache")
+	errToolNotInstalled    = errors.New("tool not installed in librarian cache")
+	errPackageNameRequired = errors.New("nodejs.package_name is required; non-cloud libraries must be configured in librarian.yaml or populated during librarian add")
 )
 
 func requireCachedTool(toolName string) (string, error) {
@@ -279,7 +283,7 @@ func buildGeneratorArgs(params buildGeneratorArgsParams) ([]string, error) {
 		args = append(args, "--service-yaml", apiMetadata.ServiceConfig)
 	}
 
-	args = append(args, "--package-name", derivePackageName(params.library))
+	args = append(args, "--package-name", params.library.Nodejs.PackageName)
 	args = append(args, "--metadata")
 
 	// Only pass --transport for non-default values (default is grpc+rest).
@@ -616,31 +620,6 @@ func copySamplesFromStaging(stagingDir, outDir string) error {
 		}
 	}
 	return nil
-}
-
-// derivePackageName returns the npm package name for a library.
-// It uses nodejs.package_name if set, otherwise derives it by splitting the
-// library name on the second dash (e.g. "google-cloud-batch" → "@google-cloud/batch").
-func derivePackageName(library *config.Library) string {
-	if library.Nodejs != nil && library.Nodejs.PackageName != "" {
-		return library.Nodejs.PackageName
-	}
-	return derivePackageNameFromLibraryName(library.Name)
-}
-
-func derivePackageNameFromLibraryName(name string) string {
-	firstDash := strings.Index(name, "-")
-	if firstDash < 0 {
-		return name
-	}
-	secondDash := strings.Index(name[firstDash+1:], "-")
-	if secondDash < 0 {
-		return name
-	}
-	secondDash += firstDash + 1
-	scope := name[:secondDash]
-	pkg := name[secondDash+1:]
-	return fmt.Sprintf("@%s/%s", scope, pkg)
 }
 
 // DefaultOutput returns the output path for a library.

--- a/internal/librarian/nodejs/generate_test.go
+++ b/internal/librarian/nodejs/generate_test.go
@@ -77,70 +77,33 @@ func TestIsMixedLibrary(t *testing.T) {
 	}
 }
 
-func TestDerivePackageName(t *testing.T) {
+func TestGenerate_MissingPackageName(t *testing.T) {
+	cfg := &config.Config{
+		Language: config.LanguageNodejs,
+		Repo:     "googleapis/google-cloud-node",
+	}
 	for _, test := range []struct {
 		name string
 		lib  *config.Library
-		want string
 	}{
-		{
-			name: "explicit package name",
-			lib: &config.Library{
-				Name: "google-cloud-accessapproval",
-				Nodejs: &config.NodejsPackage{
-					PackageName: "@google-cloud/access-approval",
-				},
-			},
-			want: "@google-cloud/access-approval",
-		},
-		{
-			name: "derived from library name",
-			lib: &config.Library{
-				Name: "google-cloud-batch",
-			},
-			want: "@google-cloud/batch",
-		},
-		{
-			name: "derived with multi-segment suffix",
-			lib: &config.Library{
-				Name: "google-cloud-video-transcoder",
-			},
-			want: "@google-cloud/video-transcoder",
-		},
 		{
 			name: "nil nodejs config",
 			lib: &config.Library{
-				Name: "google-cloud-speech",
+				Name: "google-unrecognized-api",
 			},
-			want: "@google-cloud/speech",
 		},
 		{
-			name: "empty package name in config",
+			name: "empty package name in nodejs config",
 			lib: &config.Library{
-				Name:   "google-cloud-monitoring",
+				Name:   "google-unrecognized-api",
 				Nodejs: &config.NodejsPackage{},
 			},
-			want: "@google-cloud/monitoring",
-		},
-		{
-			name: "no second dash",
-			lib: &config.Library{
-				Name: "google",
-			},
-			want: "google",
-		},
-		{
-			name: "only one dash",
-			lib: &config.Library{
-				Name: "google-cloud",
-			},
-			want: "google-cloud",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got := derivePackageName(test.lib)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
+			err := Generate(t.Context(), cfg, test.lib, nil)
+			if !errors.Is(err, errPackageNameRequired) {
+				t.Errorf("got error %v, want %v", err, errPackageNameRequired)
 			}
 		})
 	}
@@ -473,12 +436,13 @@ func TestBuildGeneratorArgs(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			nodejsAPI := resolveNodejsAPI(test.library, test.api)
+			lib := Fill(test.library)
+			nodejsAPI := resolveNodejsAPI(lib, test.api)
 			got, err := buildGeneratorArgs(buildGeneratorArgsParams{
 				generatorPath: "gapic-generator-typescript",
 				protoc:        defaultProtoc,
 				api:           test.api,
-				library:       test.library,
+				library:       lib,
 				googleapisDir: absGoogleapisDir,
 				stagingDir:    "staging",
 				nodejsAPI:     nodejsAPI,
@@ -500,7 +464,7 @@ func TestBuildGeneratorArgs_SystemProtocFallback(t *testing.T) {
 	}
 	fakeSystemProtoc := createFakeSystemExecutable(t, "protoc")
 	api := &config.API{Path: "google/cloud/secretmanager/v1"}
-	library := &config.Library{Name: "google-cloud-secretmanager"}
+	library := Fill(&config.Library{Name: "google-cloud-secretmanager"})
 	nodejsAPI := resolveNodejsAPI(library, api)
 
 	for _, test := range []struct {
@@ -544,7 +508,7 @@ func TestBuildGeneratorArgs_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 	api := &config.API{Path: "google/cloud/secretmanager/v1"}
-	library := &config.Library{Name: "google-cloud-secretmanager"}
+	library := Fill(&config.Library{Name: "google-cloud-secretmanager"})
 	nodejsAPI := resolveNodejsAPI(library, api)
 
 	for _, test := range []struct {
@@ -598,7 +562,7 @@ func TestGenerateAPI(t *testing.T) {
 	err = generateAPI(t.Context(), generateAPIParams{
 		apiIndex:      0,
 		api:           &config.API{Path: "google/cloud/secretmanager/v1"},
-		library:       &config.Library{Name: "google-cloud-secretmanager", Output: outDir},
+		library:       Fill(&config.Library{Name: "google-cloud-secretmanager", Output: outDir}),
 		googleapisDir: absGoogleapisDir,
 		repoRoot:      repoRoot,
 		protoc:        &config.Protoc{Version: "33.2"},
@@ -625,13 +589,13 @@ func TestGenerateAPI_MultipleVersions(t *testing.T) {
 	}
 
 	repoRoot := t.TempDir()
-	library := &config.Library{
+	library := Fill(&config.Library{
 		Name: "google-cloud-secretmanager",
 		APIs: []*config.API{
 			{Path: "google/cloud/secretmanager/v1"},
 			{Path: "google/cloud/secretmanager/v1beta2"},
 		},
-	}
+	})
 	outDir := filepath.Join(repoRoot, "packages", library.Name)
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -1053,7 +1017,7 @@ func TestGenerate(t *testing.T) {
 		},
 	}
 	for _, library := range libraries {
-		if err := Generate(t.Context(), cfg, library, &sources.Sources{Googleapis: absGoogleapisDir}); err != nil {
+		if err := Generate(t.Context(), cfg, Fill(library), &sources.Sources{Googleapis: absGoogleapisDir}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1235,10 +1199,10 @@ func TestGenerateAPI_NoProtos(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	library := &config.Library{
+	library := Fill(&config.Library{
 		Name:   "google-cloud-emptyapi",
 		Output: filepath.Join(repoRoot, "packages", "google-cloud-emptyapi"),
-	}
+	})
 	if err := generateAPI(t.Context(), generateAPIParams{
 		apiIndex:      0,
 		api:           &config.API{Path: apiPath},
@@ -1370,7 +1334,7 @@ func TestWriteRepoMetadata(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outDir := t.TempDir()
-			if err := writeRepoMetadata(cfg, test.library, absGoogleapisDir, outDir); err != nil {
+			if err := writeRepoMetadata(cfg, Fill(test.library), absGoogleapisDir, outDir); err != nil {
 				t.Fatal(err)
 			}
 			got, err := repometadata.Read(outDir)
@@ -1387,7 +1351,7 @@ func TestWriteRepoMetadata(t *testing.T) {
 
 func TestWriteRepoMetadata_NoAPIs(t *testing.T) {
 	cfg := &config.Config{Language: config.LanguageNodejs}
-	library := &config.Library{Name: "google-cloud-test"}
+	library := Fill(&config.Library{Name: "google-cloud-test"})
 	if err := writeRepoMetadata(cfg, library, "", t.TempDir()); err != nil {
 		t.Errorf("expected nil error for library with no APIs, got: %v", err)
 	}

--- a/internal/librarian/nodejs/readme_test.go
+++ b/internal/librarian/nodejs/readme_test.go
@@ -124,8 +124,9 @@ func TestGenerateReadme_Error(t *testing.T) {
 		{
 			name: "output is not a directory",
 			library: &config.Library{
-				Name: "google-cloud-secretmanager",
-				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Name:   "google-cloud-secretmanager",
+				APIs:   []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Nodejs: &config.NodejsPackage{PackageName: "@google-cloud/secretmanager"},
 			},
 			googleapisDir: absGoogleapisDir,
 			output: func(t *testing.T) string {
@@ -141,8 +142,9 @@ func TestGenerateReadme_Error(t *testing.T) {
 		{
 			name: "permission denied creating readme",
 			library: &config.Library{
-				Name: "google-cloud-secretmanager",
-				APIs: []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Name:   "google-cloud-secretmanager",
+				APIs:   []*config.API{{Path: "google/cloud/secretmanager/v1"}},
+				Nodejs: &config.NodejsPackage{PackageName: "@google-cloud/secretmanager"},
 			},
 			googleapisDir: absGoogleapisDir,
 			output: func(t *testing.T) string {

--- a/internal/librarian/nodejs/repometadata.go
+++ b/internal/librarian/nodejs/repometadata.go
@@ -27,7 +27,7 @@ func generateRepoMetadata(cfg *config.Config, library *config.Library, googleapi
 	if err != nil {
 		return nil, err
 	}
-	metadata.DistributionName = derivePackageName(library)
+	metadata.DistributionName = library.Nodejs.PackageName
 	metadata.LibraryType = repometadata.GAPICAutoLibraryType
 	metadata.DefaultVersion = resolveDefaultVersion(library)
 

--- a/internal/librarian/nodejs/repometadata_test.go
+++ b/internal/librarian/nodejs/repometadata_test.go
@@ -99,7 +99,7 @@ func TestGenerateRepoMetadata(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := generateRepoMetadata(cfg, test.library, absGoogleapisDir)
+			got, err := generateRepoMetadata(cfg, Fill(test.library), absGoogleapisDir)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Derives standard Node.js package names (@google-cloud/<suffix>) during defaults resolution instead of during generator argument construction. The generator now requires nodejs.package_name to be set and fails fast with an explanatory error when it is missing.

Non-cloud APIs and custom scopes are populated during library onboarding via custom package prefixes or configured explicitly in librarian.yaml. Moving derivation upstream establishes a single source of truth for the entire generation pipeline and removes redundant runtime guesswork.

Fixes https://github.com/googleapis/librarian/issues/7558